### PR TITLE
Feat/UI persistent header navigation

### DIFF
--- a/reports/repo/repository_info.json
+++ b/reports/repo/repository_info.json
@@ -1,1 +1,0 @@
-{"name": "repo", "discipline": null, "location": "local", "path": "/private/var/folders/kr/l0dm7skx5pn9b6zcfp5r_mmw0000gn/T/pytest-of-victor/pytest-212/test_start_evaluation_always_p0/repo"}

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -410,12 +410,46 @@ def _parse_eval_from_json(json_path: Path, project: str, run_id: str, dimension:
         }
     )
 
+    # Build per-principle detail by grouping top-level violations and compliance
+    principle_map: dict[str, Any] = {}
+    for p in data.get("principles", []):
+        name = p.get("name", "")
+        principle_map[name] = {
+            "name": name,
+            "score": p.get("score"),
+            "grade": p.get("grade"),
+            "violations": [],
+            "compliance": [],
+            "justification": "",
+            "recommendations": [],
+            "metrics": None,
+        }
+    for v in data.get("violations", []):
+        key = v.get("principle", "")
+        if key not in principle_map:
+            principle_map[key] = {"name": key, "score": None, "grade": None, "violations": [], "compliance": [], "justification": "", "recommendations": [], "metrics": None}
+        f = v.get("file")
+        line = v.get("line")
+        principle_map[key]["violations"].append({
+            "code": v.get("snippet", ""),
+            "severity": v.get("severity", "minor"),
+            "file": f"{f}:{line}" if f and line else f,
+            "reason": v.get("reason", ""),
+        })
+    for c in data.get("compliance", []):
+        key = c.get("principle", "")
+        if key not in principle_map:
+            principle_map[key] = {"name": key, "score": None, "grade": None, "violations": [], "compliance": [], "justification": "", "recommendations": [], "metrics": None}
+        principle_map[key]["compliance"].append(c.get("snippet") or c.get("reason") or "")
+
     return {
         "dimension": dimension,
         "runId": run_id,
         "project": project,
         "principleGrades": principle_grades,
-        "principles": [],
+        "principles": list(principle_map.values()),
+        "violations": data.get("violations", []),
+        "compliance": data.get("compliance", []),
         "priorityRemediation": {"critical": [], "major": [], "minor": []},
         "rawContent": None,
     }

--- a/src/codecompass/dashboard/runner.py
+++ b/src/codecompass/dashboard/runner.py
@@ -53,6 +53,25 @@ def _npm_build(path: Path) -> None:
     subprocess.run(["npm", "run", "build"], cwd=str(path), check=True)
 
 
+def _sources_newer_than_dist(web_root: Path, dist_index: Path) -> bool:
+    """Return True if any tracked source file is newer than dist/index.html."""
+    if not dist_index.exists():
+        return True
+    dist_mtime = dist_index.stat().st_mtime
+    watch_dirs = [web_root / "src", web_root / "public"]
+    watch_files = [web_root / "package.json", web_root / "vite.config.js"]
+    for f in watch_files:
+        if f.exists() and f.stat().st_mtime > dist_mtime:
+            return True
+    for d in watch_dirs:
+        if not d.exists():
+            continue
+        for f in d.rglob("*"):
+            if f.is_file() and f.stat().st_mtime > dist_mtime:
+                return True
+    return False
+
+
 def _is_port_open(host: str, port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         return sock.connect_ex((host, port)) == 0
@@ -185,9 +204,12 @@ def run_dashboard(config: DashboardConfig) -> int:
         _npm_install(repo_root / "ui/server")
 
     if not config.no_build:
-        if config.reinstall or not (static_dist / "index.html").exists():
+        dist_index = static_dist / "index.html"
+        if config.reinstall or _sources_newer_than_dist(repo_root / "ui/web", dist_index):
             log_info("Building web UI (ui/web)...")
             _npm_build(repo_root / "ui/web")
+        else:
+            log_info("Web UI is up to date, skipping build.")
 
     config = DashboardConfig(
         port=config.port,

--- a/ui/server/src/app.js
+++ b/ui/server/src/app.js
@@ -64,6 +64,17 @@ export function createApp(options = {}) {
   app.use(cors());
   app.use(express.json({ limit: '1mb' }));
 
+  // Routes handled by the Node server regardless of whether an action API is present
+  app.get('/api/projects/:project/info', (req, res) => {
+    try {
+      const infoPath = path.join(reportsRoot, req.params.project, 'repository_info.json');
+      const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+      res.json(info);
+    } catch {
+      res.status(404).json({ error: 'Repository info not found' });
+    }
+  });
+
   if (actionApiBase) {
     app.use('/api', (req, res) => proxyToActionApi(req, res, actionApiBase));
   } else {

--- a/ui/server/src/parsers/evalParser.js
+++ b/ui/server/src/parsers/evalParser.js
@@ -154,12 +154,49 @@ function parseFromJson(jsonPath, project, runId, dimension) {
     },
   ];
 
+  // Build per-principle detail by grouping top-level violations and compliance
+  const principleMap = {};
+  for (const p of data.principles ?? []) {
+    principleMap[p.name] = {
+      name:            p.name,
+      score:           p.score ?? null,
+      grade:           p.grade ?? null,
+      violations:      [],
+      compliance:      [],
+      justification:   '',
+      recommendations: [],
+      metrics:         null,
+    };
+  }
+  for (const v of data.violations ?? []) {
+    const key = v.principle;
+    if (!principleMap[key]) {
+      principleMap[key] = { name: key, score: null, grade: null, violations: [], compliance: [], justification: '', recommendations: [], metrics: null };
+    }
+    principleMap[key].violations.push({
+      code:     v.snippet || '',
+      severity: v.severity || 'minor',
+      file:     v.file ? (v.line ? `${v.file}:${v.line}` : v.file) : null,
+      reason:   v.reason || '',
+    });
+  }
+  for (const c of data.compliance ?? []) {
+    const key = c.principle;
+    if (!principleMap[key]) {
+      principleMap[key] = { name: key, score: null, grade: null, violations: [], compliance: [], justification: '', recommendations: [], metrics: null };
+    }
+    principleMap[key].compliance.push(c.snippet || c.reason || '');
+  }
+  const principles = Object.values(principleMap);
+
   return {
     dimension,
     runId,
     project,
     principleGrades,
-    principles:          [],
+    principles,
+    violations:          data.violations ?? [],
+    compliance:          data.compliance ?? [],
     priorityRemediation: { critical: [], major: [], minor: [] },
     rawContent:          null,
   };

--- a/ui/server/src/parsers/reportParser.js
+++ b/ui/server/src/parsers/reportParser.js
@@ -451,10 +451,11 @@ function readEvidenceFile(evidencePath) {
       dimension: dimName,
       sourceFileCount: data.source_file_count ?? null,
       date: data.date ?? null,
-      discipline: data.discipline ?? null
+      discipline: data.discipline ?? null,
+      repository: data.repository ?? null
     };
   } catch {
-    return { dimension: dimName, sourceFileCount: null, date: null, discipline: null };
+    return { dimension: dimName, sourceFileCount: null, date: null, discipline: null, repository: null };
   }
 }
 
@@ -499,7 +500,8 @@ function loadRunDimensions(reportsRoot, project, runId) {
     ...d,
     sourceFileCount: evidenceMap.get(d.dimension)?.sourceFileCount ?? null,
     evidenceDate: evidenceMap.get(d.dimension)?.date ?? null,
-    discipline: evidenceMap.get(d.dimension)?.discipline ?? null
+    discipline: evidenceMap.get(d.dimension)?.discipline ?? null,
+    repository: evidenceMap.get(d.dimension)?.repository ?? null
   }));
 
   dimensions.sort((a, b) => a.dimension.localeCompare(b.dimension));

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -1,40 +1,60 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { listProjects } from './api/index.js';
+import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
+import RunNavigator from './features/dashboard/components/RunNavigator.jsx';
 import { useEvaluation } from './features/evaluation/hooks/useEvaluation.js';
 import EvaluationForm from './features/evaluation/components/EvaluationForm.jsx';
 import EvaluationStatus from './features/evaluation/components/EvaluationStatus.jsx';
 import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
+import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
 import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
 import PrincipleDetailPage from './features/explorer/components/PrincipleDetailPage.jsx';
 import EvalPrincipleDetailPage from './features/explorer/components/EvalPrincipleDetailPage.jsx';
+import { formatRunId } from './utils/formatters.js';
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+const ICON_OVERVIEW = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+const ICON_EVALUATE = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M12 2L2 7l10 5 10-5-10-5z" />
+    <path d="M2 17l10 5 10-5" />
+    <path d="M2 12l10 5 10-5" />
+  </svg>
+);
+
+const ICON_SETTINGS = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
 
 export default function App() {
   // -------------------------------------------------------------------------
-  // Nav stack state
+  // Nav stack
   // -------------------------------------------------------------------------
   const [navStack, setNavStack] = useState([{ page: 'overview' }]);
 
-  function navPush(entry) {
-    setNavStack((prev) => [...prev, entry]);
-  }
-
-  function navPop() {
-    setNavStack((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev));
-  }
-
-  function navGoTo(index) {
-    setNavStack((prev) => prev.slice(0, index + 1));
-  }
-
-  function navReset() {
-    setNavStack([{ page: 'overview' }]);
-  }
+  function navPush(entry) { setNavStack((prev) => [...prev, entry]); }
+  function navPop() { setNavStack((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev)); }
+  function navGoTo(index) { setNavStack((prev) => prev.slice(0, index + 1)); }
+  function navReset() { setNavStack([{ page: 'overview' }]); }
 
   const activePage = navStack[navStack.length - 1];
 
   // -------------------------------------------------------------------------
-  // Project / run selection state
+  // Project / run selection
   // -------------------------------------------------------------------------
   const [projects, setProjects] = useState([]);
   const [selectedProject, setSelectedProject] = useState('');
@@ -58,44 +78,136 @@ export default function App() {
     navReset();
   }
 
-  function handleRunChange(runId) {
-    setSelectedRun(runId);
+  function handleRunChange(runId) { setSelectedRun(runId); }
+
+  // -------------------------------------------------------------------------
+  // Dashboard data (shared across all pages)
+  // -------------------------------------------------------------------------
+  const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({
+    selectedProject,
+    selectedRun,
+  });
+
+  // -------------------------------------------------------------------------
+  // Run navigator state (lifted from DashboardPage)
+  // -------------------------------------------------------------------------
+  const [overviewRunIndex, setOverviewRunIndex] = useState(0);
+
+  useEffect(() => {
+    if (!availableRuns.length) return;
+    if (selectedRun === 'latest') {
+      setOverviewRunIndex(0);
+    } else {
+      const idx = availableRuns.findIndex((r) => r.runId === selectedRun);
+      if (idx >= 0) setOverviewRunIndex(idx);
+    }
+  }, [selectedRun, availableRuns]);
+
+  const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
+
+  function handleRunPrev() {
+    const idx = Math.min(overviewRunIndex + 1, availableRuns.length - 1);
+    setOverviewRunIndex(idx);
+    handleRunChange(availableRuns[idx]?.runId || 'latest');
+  }
+
+  function handleRunNext() {
+    const idx = Math.max(overviewRunIndex - 1, 0);
+    setOverviewRunIndex(idx);
+    handleRunChange(availableRuns[idx]?.runId || 'latest');
+  }
+
+  function handleRunLatest() {
+    setOverviewRunIndex(0);
+    handleRunChange(availableRuns[0]?.runId || 'latest');
+  }
+
+  function handleRunView() {
+    handleNavigate('run', { runId: currentOverviewRun });
   }
 
   // -------------------------------------------------------------------------
-  // Sidebar state
+  // Header meta (discipline, repository, source files)
   // -------------------------------------------------------------------------
-  const [sidebarExpanded, setSidebarExpanded] = useState(true);
+  const headerMeta = useMemo(() => {
+    const dims = accumulated?.dimensions || [];
+    if (dims.length === 0) return null;
+    const discipline = dims.find((d) => d.discipline)?.discipline ?? null;
+    const repository = dims.find((d) => d.repository)?.repository ?? null;
+    const totalFiles = dims.reduce((s, d) => s + (d.sourceFileCount || 0), 0);
+    return { discipline, repository, totalFiles: totalFiles || null };
+  }, [accumulated]);
 
   // -------------------------------------------------------------------------
-  // Evaluation feature state (hook lives here so it survives tab switches)
+  // Theme
+  // -------------------------------------------------------------------------
+  const [themePreference, setThemePreference] = useState(
+    localStorage.getItem('cc-theme') || 'system'
+  );
+
+  function applyTheme(value) {
+    setThemePreference(value);
+    if (value === 'system') {
+      localStorage.removeItem('cc-theme');
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      localStorage.setItem('cc-theme', value);
+      document.documentElement.setAttribute('data-theme', value);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Evaluation
   // -------------------------------------------------------------------------
   const { job, jobError, startEvaluation, clearJob } = useEvaluation();
 
   function handleEvalDismiss(action) {
     if (action === 'view') {
-      navPush({ page: 'overview' });
+      const project = job?.outputProject;
+      const runId = job?.outputRunId;
+      if (project) {
+        listProjects()
+          .then((data) => {
+            const list = data.projects || data || [];
+            setProjects(list);
+            setSelectedProject(project);
+            setSelectedRun(runId || 'latest');
+          })
+          .catch(() => {
+            setSelectedProject(project);
+            setSelectedRun(runId || 'latest');
+          });
+      }
+      navReset();
     }
     clearJob();
   }
 
-  // -------------------------------------------------------------------------
-  // Navigation handler passed to child features
-  // -------------------------------------------------------------------------
   function handleNavigate(page, params = {}) {
+    if (page === 'run' && params.runId) {
+      setSelectedRun(params.runId);
+    }
     navPush({ page, ...params });
   }
 
   // -------------------------------------------------------------------------
-  // Sidebar tab entries
+  // Active tab / header visibility
   // -------------------------------------------------------------------------
-  const NAV_TABS = [
-    { page: 'overview', label: 'Overview' },
-    { page: 'evaluate', label: 'Evaluate' },
-  ];
+  const activeTab = ['overview', 'evaluate', 'settings'].includes(activePage.page)
+    ? activePage.page
+    : 'overview';
+
+  // Show the project header on all data pages; hide it on evaluate and settings.
+  const showProjectHeader = activeTab === 'overview' && projects.length > 0 && !!selectedProject;
+
+  // Show the run navigator only on data pages with runs available.
+  const showRunNav = showProjectHeader && availableRuns.length > 0;
+
+  // "View run" button only on the top-level overview (not when already in run mode or inner pages).
+  const onViewRun = activePage.page === 'overview' ? handleRunView : undefined;
 
   // -------------------------------------------------------------------------
-  // Render active feature content
+  // Content renderer
   // -------------------------------------------------------------------------
   function renderContent() {
     const { page, ...params } = activePage;
@@ -107,93 +219,271 @@ export default function App() {
             selectedProject={selectedProject}
             selectedRun={selectedRun}
             projects={projects}
-            onProjectChange={handleProjectChange}
-            onRunChange={handleRunChange}
+            onNavigate={handleNavigate}
+            dashboard={dashboard}
+            accumulated={accumulated}
+            loading={loading}
+            error={error}
+            availableRuns={availableRuns}
+            overviewRunIndex={overviewRunIndex}
+          />
+        );
+
+      case 'run':
+        return (
+          <DashboardPage
+            selectedProject={selectedProject}
+            selectedRun={selectedRun}
+            projects={projects}
+            onNavigate={handleNavigate}
+            dashboard={dashboard}
+            accumulated={accumulated}
+            loading={loading}
+            error={error}
+            availableRuns={availableRuns}
+            overviewRunIndex={overviewRunIndex}
+            runMode={true}
+          />
+        );
+
+      case 'explorer':
+        return (
+          <ExplorerPage
+            project={selectedProject}
+            dimension={params.dimension}
+            runId={params.runId}
             onNavigate={handleNavigate}
           />
         );
 
       case 'evaluate':
         return (
-          <div className="evaluate-page">
-            <EvaluationForm
-              onStart={startEvaluation}
-              disabled={job?.status === 'running'}
-            />
-            {jobError && (
-              <div className="job-error-banner">{jobError}</div>
-            )}
-            <EvaluationStatus job={job} onDismiss={handleEvalDismiss} />
-          </div>
+          <section className="evaluate-screen">
+            <header className="evaluate-header">
+              <div className="evaluate-header-content">
+                <div className="evaluate-icon">
+                  <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                    <path d="M2 17l10 5 10-5" />
+                    <path d="M2 12l10 5 10-5" />
+                  </svg>
+                </div>
+                <div>
+                  <h1>Evaluate Repository</h1>
+                  <p className="evaluate-subtitle">Run a comprehensive code quality evaluation on any repository</p>
+                </div>
+              </div>
+            </header>
+
+            <div className="evaluate-content">
+              <div className="panel evaluate-panel">
+                <div className="panel-header">
+                  <h3>Repository Details</h3>
+                </div>
+                <EvaluationForm onStart={startEvaluation} disabled={job?.status === 'running'} />
+              </div>
+
+              {jobError && <div className="job-error-banner">{jobError}</div>}
+              <EvaluationStatus job={job} onDismiss={handleEvalDismiss} />
+
+              <div className="panel evaluate-help-panel">
+                <div className="panel-header">
+                  <h3>How It Works</h3>
+                </div>
+                <div className="help-steps">
+                  <div className="help-step">
+                    <div className="step-number">1</div>
+                    <div className="step-content">
+                      <h4>Provide Repository</h4>
+                      <p>Enter a GitHub URL, SSH path, or local filesystem path to the repository you want to evaluate.</p>
+                    </div>
+                  </div>
+                  <div className="help-step">
+                    <div className="step-number">2</div>
+                    <div className="step-content">
+                      <h4>Select Dimensions</h4>
+                      <p>Choose which quality dimensions to analyze. Each dimension covers different aspects of code quality.</p>
+                    </div>
+                  </div>
+                  <div className="help-step">
+                    <div className="step-number">3</div>
+                    <div className="step-content">
+                      <h4>Review Results</h4>
+                      <p>Once complete, view detailed findings, grades, and actionable recommendations in the Overview.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
         );
 
-      case 'file-detail':
+      case 'file':
         return <FileDetailPage file={params.file} />;
 
-      case 'principle-detail':
+      case 'principle':
         return <PrincipleDetailPage principle={params.principle} />;
 
+      case 'evalprinciple':
       case 'eval-principle-detail':
         return <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} />;
 
-      default:
+      case 'settings':
         return (
-          <div className="page-not-found">
-            <p>Page not found: {page}</p>
+          <div className="settings-page">
+            <div className="settings-header">
+              <h1 className="settings-title">Settings</h1>
+            </div>
+            <div className="settings-body">
+              <section className="settings-section">
+                <h2 className="settings-section-title">Appearance</h2>
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Theme</span>
+                    <span className="settings-description">Choose how CodeCompass looks to you</span>
+                  </div>
+                  <div className="theme-toggle">
+                    {[
+                      { value: 'system', label: 'System' },
+                      { value: 'light', label: 'Light' },
+                      { value: 'dark', label: 'Dark' },
+                    ].map(({ value, label }) => (
+                      <button
+                        key={value}
+                        type="button"
+                        className={`theme-toggle-btn${themePreference === value ? ' active' : ''}`}
+                        onClick={() => applyTheme(value)}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </div>
           </div>
         );
+
+      default:
+        return <div className="empty-state"><p>Page not found: {page}</p></div>;
     }
   }
 
   // -------------------------------------------------------------------------
   // Layout
   // -------------------------------------------------------------------------
-  const activeTab = ['overview', 'evaluate'].includes(activePage.page)
-    ? activePage.page
-    : 'overview';
-
   return (
-    <div className={`app-layout${sidebarExpanded ? '' : ' sidebar-collapsed'}`}>
+    <div className="app-shell">
       {/* Sidebar */}
       <aside className="sidebar">
-        <div className="sidebar-top">
-          <button
-            className="sidebar-toggle"
-            onClick={() => setSidebarExpanded((v) => !v)}
-            title={sidebarExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-            aria-label={sidebarExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-          >
-            {sidebarExpanded ? '‹' : '›'}
-          </button>
+        <div className="sidebar-header">
+          <div className="sidebar-brand-icon">CC</div>
+          <span className="sidebar-brand-text">CodeCompass</span>
         </div>
 
         <nav className="sidebar-nav">
-          {NAV_TABS.map(({ page, label }) => (
-            <button
-              key={page}
-              className={`sidebar-tab${activeTab === page ? ' active' : ''}`}
-              onClick={() => {
-                navReset();
-                setNavStack([{ page }]);
-              }}
-              title={label}
-              aria-label={label}
-            >
-              <span className="sidebar-tab-label">{label}</span>
-            </button>
-          ))}
+          <button
+            type="button"
+            className={`sidebar-nav-item${activeTab === 'overview' ? ' active' : ''}`}
+            onClick={() => setNavStack([{ page: 'overview' }])}
+            title="Overview"
+          >
+            {ICON_OVERVIEW}
+            <span className="sidebar-nav-label">Overview</span>
+          </button>
+
+          <button
+            type="button"
+            className={`sidebar-nav-item${activeTab === 'evaluate' ? ' active' : ''}`}
+            onClick={() => setNavStack([{ page: 'evaluate' }])}
+            title="Evaluate"
+          >
+            {ICON_EVALUATE}
+            <span className="sidebar-nav-label">Evaluate</span>
+          </button>
         </nav>
+
+        {/* Settings at bottom */}
+        <div className="sidebar-bottom-nav">
+          <button
+            type="button"
+            className={`sidebar-nav-item${activeTab === 'settings' ? ' active' : ''}`}
+            onClick={() => setNavStack([{ page: 'settings' }])}
+            title="Settings"
+          >
+            {ICON_SETTINGS}
+            <span className="sidebar-nav-label">Settings</span>
+          </button>
+        </div>
+
+        {/* Project selector */}
+        {projects.length > 0 && (
+          <div className="sidebar-project-section">
+            <p className="sidebar-project-label">Project</p>
+            <select
+              className="project-select-styled"
+              value={selectedProject}
+              disabled={projects.length === 0}
+              onChange={(e) => handleProjectChange(e.target.value)}
+            >
+              {projects.map((p) => {
+                const name = p.name || p;
+                return <option key={name} value={name}>{name}</option>;
+              })}
+            </select>
+          </div>
+        )}
       </aside>
 
       {/* Main content */}
-      <main className="main-content">
-        {navStack.length > 1 && (
-          <NavBreadcrumb
-            stack={navStack}
-            onBack={navPop}
-            onGoTo={navGoTo}
-          />
+      <main className="dashboard">
+        {/* Persistent project header — shown on all data pages */}
+        {showProjectHeader && (
+          <header className="content-header">
+            <div className="content-header-left">
+              <h1 className="content-project-name">{selectedProject}</h1>
+              {headerMeta && (
+                <div className="content-meta-row">
+                  {headerMeta.repository && (
+                    <span className="content-meta-chip">
+                      <span className="content-meta-chip-label">Repository</span>
+                      <span className="content-meta-chip-value">{headerMeta.repository}</span>
+                    </span>
+                  )}
+                  {headerMeta.discipline && (
+                    <span className="content-meta-chip">
+                      <span className="content-meta-chip-label">Discipline</span>
+                      <span className="content-meta-chip-value">{headerMeta.discipline}</span>
+                    </span>
+                  )}
+                  {headerMeta.totalFiles && (
+                    <span className="content-meta-chip">
+                      <span className="content-meta-chip-label">Source files</span>
+                      <span className="content-meta-chip-value">{headerMeta.totalFiles.toLocaleString()}</span>
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+            {showRunNav && (
+              <RunNavigator
+                currentRun={formatRunId(currentOverviewRun)}
+                isLatest={overviewRunIndex === 0}
+                isOldest={overviewRunIndex >= availableRuns.length - 1}
+                onPrev={handleRunPrev}
+                onNext={handleRunNext}
+                onLatest={handleRunLatest}
+                onView={onViewRun}
+              />
+            )}
+          </header>
         )}
+
+        {/* Breadcrumb — shown when navigating into sub-pages */}
+        {navStack.length > 1 && (
+          <NavBreadcrumb stack={navStack} onBack={navPop} onGoTo={navGoTo} />
+        )}
+
         {renderContent()}
       </main>
     </div>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -6,6 +6,7 @@ import RunNavigator from './features/dashboard/components/RunNavigator.jsx';
 import { useEvaluation } from './features/evaluation/hooks/useEvaluation.js';
 import EvaluationForm from './features/evaluation/components/EvaluationForm.jsx';
 import EvaluationStatus from './features/evaluation/components/EvaluationStatus.jsx';
+import ReEvaluateCard from './features/evaluation/components/ReEvaluateCard.jsx';
 import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
 import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
@@ -46,12 +47,70 @@ export default function App() {
   // -------------------------------------------------------------------------
   const [navStack, setNavStack] = useState([{ page: 'overview' }]);
 
-  function navPush(entry) { setNavStack((prev) => [...prev, entry]); }
-  function navPop() { setNavStack((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev)); }
-  function navGoTo(index) { setNavStack((prev) => prev.slice(0, index + 1)); }
-  function navReset() { setNavStack([{ page: 'overview' }]); }
+  // Initialize browser history state on mount
+  useEffect(() => {
+    window.history.replaceState({ navIndex: 0, entry: { page: 'overview' } }, '');
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Sync browser back/forward buttons with navStack
+  useEffect(() => {
+    function onPopState(e) {
+      const targetIndex = e.state?.navIndex ?? 0;
+      setNavStack((prev) => {
+        if (targetIndex < prev.length - 1) {
+          // Going back
+          return prev.slice(0, targetIndex + 1);
+        }
+        if (targetIndex >= prev.length && e.state?.entry) {
+          // Going forward — restore entry from history state
+          return [...prev.slice(0, targetIndex), e.state.entry];
+        }
+        return prev;
+      });
+    }
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  function navPush(entry) {
+    setNavStack((prev) => {
+      const next = [...prev, entry];
+      window.history.pushState({ navIndex: next.length - 1, entry }, '');
+      return next;
+    });
+  }
+
+  function navPop() {
+    window.history.back(); // popstate handler updates navStack
+  }
+
+  function navGoTo(index) {
+    const steps = navStack.length - 1 - index;
+    if (steps > 0) window.history.go(-steps); // popstate handler updates navStack
+  }
+
+  function navReset() {
+    setNavStack((prev) => {
+      const stepsBack = prev.length - 1;
+      if (stepsBack > 0) window.history.go(-stepsBack);
+      return [{ page: 'overview' }];
+    });
+  }
+
+  function navTab(page) {
+    setNavStack((prev) => {
+      const stepsBack = prev.length - 1;
+      if (stepsBack > 0) window.history.go(-stepsBack);
+      return [{ page }];
+    });
+  }
 
   const activePage = navStack[navStack.length - 1];
+
+  // Scroll to top on every navigation
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, [activePage]);
 
   // -------------------------------------------------------------------------
   // Project / run selection
@@ -67,6 +126,8 @@ export default function App() {
         setProjects(list);
         if (list.length > 0 && !selectedProject) {
           setSelectedProject(list[0].name || list[0]);
+        } else if (list.length === 0) {
+          navTab('evaluate');
         }
       })
       .catch(() => {});
@@ -276,9 +337,17 @@ export default function App() {
             </header>
 
             <div className="evaluate-content">
+              {selectedProject && (
+                <ReEvaluateCard
+                  project={selectedProject}
+                  onStart={startEvaluation}
+                  disabled={job?.status === 'running'}
+                />
+              )}
+
               <div className="panel evaluate-panel">
                 <div className="panel-header">
-                  <h3>Repository Details</h3>
+                  <h3>Evaluate a Repository</h3>
                 </div>
                 <EvaluationForm onStart={startEvaluation} disabled={job?.status === 'running'} />
               </div>
@@ -385,7 +454,7 @@ export default function App() {
           <button
             type="button"
             className={`sidebar-nav-item${activeTab === 'overview' ? ' active' : ''}`}
-            onClick={() => setNavStack([{ page: 'overview' }])}
+            onClick={() => navTab('overview')}
             title="Overview"
           >
             {ICON_OVERVIEW}
@@ -395,7 +464,7 @@ export default function App() {
           <button
             type="button"
             className={`sidebar-nav-item${activeTab === 'evaluate' ? ' active' : ''}`}
-            onClick={() => setNavStack([{ page: 'evaluate' }])}
+            onClick={() => navTab('evaluate')}
             title="Evaluate"
           >
             {ICON_EVALUATE}
@@ -408,7 +477,7 @@ export default function App() {
           <button
             type="button"
             className={`sidebar-nav-item${activeTab === 'settings' ? ' active' : ''}`}
-            onClick={() => setNavStack([{ page: 'settings' }])}
+            onClick={() => navTab('settings')}
             title="Settings"
           >
             {ICON_SETTINGS}

--- a/ui/web/src/api/index.js
+++ b/ui/web/src/api/index.js
@@ -22,6 +22,10 @@ export function listProjects() {
   return request('/projects');
 }
 
+export function getProjectInfo(project) {
+  return request(`/projects/${encodeURIComponent(project)}/info`);
+}
+
 export function getDashboard(project, run = 'latest') {
   const q = run ? `?run=${encodeURIComponent(run)}` : '';
   return request(`/projects/${encodeURIComponent(project)}/dashboard${q}`);

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -4,7 +4,8 @@ import DimensionViolationsRow from './DimensionViolationsRow.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from './ViolationsByPrincipleTable.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
-import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+import CopyButton from '../../../components/CopyButton.jsx';
+import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { formatRunId, gradeColorClass, mostFrequentGrade, splitScore } from '../../../utils/formatters.js';
 
 // ---------------------------------------------------------------------------
@@ -348,45 +349,93 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
     [dashboard]
   );
 
+  const runScoreDelta = useMemo(() => {
+    const prevScores = (dashboard?.dimensions || [])
+      .map((d) => parseFloat(d.previousScore))
+      .filter((v) => !isNaN(v));
+    if (prevScores.length === 0) return null;
+    const prevAvg = prevScores.reduce((a, b) => a + b, 0) / prevScores.length;
+    const currAvg = parseFloat(runSummary.numericAverage);
+    if (isNaN(currAvg)) return null;
+    return (currAvg - prevAvg).toFixed(1);
+  }, [dashboard, runSummary]);
+
+  const runUniquePrinciples = useMemo(() => {
+    const violations = (dashboard?.dimensions || []).flatMap((d) => d.violations || []);
+    return new Set(violations.map((v) => v.principle).filter(Boolean)).size;
+  }, [dashboard]);
+
   if (!dashboard) {
     return <p className="empty-state">Loading run data...</p>;
   }
 
   return (
     <>
-      <section className="overview-summary">
-        <h3 className="run-evaluation-title">{formatRunId(selectedRunId)}</h3>
-        <div className="overview-summary-row">
-          <article className="overview-stat-card overview-stat-grade">
-            <p className="overview-stat-label">Grade</p>
-            <p className="overview-stat-value big">{runSummary.overallGrade}</p>
-            {runSummary.numericAverage && (
-              <p className="overview-stat-sub">{runSummary.numericAverage}/10</p>
-            )}
-          </article>
-          <article className="overview-stat-card">
-            <p className="overview-stat-label">Violations</p>
-            <p className="overview-stat-value">{runSummary.totalViolations}</p>
-            <div className="overview-severity-row">
-              <span className="severity-badge severity-critical">
-                {runSummary.severity.critical} critical
-              </span>
-              <span className="severity-badge severity-major">
-                {runSummary.severity.major} major
-              </span>
-              <span className="severity-badge severity-minor">
-                {runSummary.severity.minor} minor
-              </span>
+      <section className="acc-eval-panel panel">
+        <div className="acc-eval-top">
+          <span className="acc-eval-date">{formatRunId(selectedRunId)}</span>
+          {(dashboard?.dimensions || []).some((d) => (d.violations?.length || 0) > 0) && (
+            <CopyButton
+              label="Fix plan"
+              onClick={() => {
+                const allViolations = (dashboard.dimensions || []).flatMap(
+                  (d) => (d.violations || []).map((v) => ({ ...v, dimension: d.dimension }))
+                );
+                navigator.clipboard.writeText(
+                  buildDimensionPlanFromViolations(formatRunId(selectedRunId), allViolations)
+                );
+              }}
+            />
+          )}
+        </div>
+
+        <div className="acc-eval-hero">
+          <span className={`acc-eval-grade-chip chip ${gradeColorClass(runSummary.overallGrade)}`}>
+            {runSummary.overallGrade || '—'}
+          </span>
+          <div className="acc-eval-score-row">
+            <span className="acc-eval-score">{runSummary.numericAverage || '—'}</span>
+            <span className="acc-eval-score-denom">/10</span>
+          </div>
+          {runScoreDelta !== null && (
+            <div className="acc-eval-trend">
+              <TrendBadge delta={runScoreDelta} showLabel={true} />
             </div>
-          </article>
-          <article className="overview-stat-card">
-            <p className="overview-stat-label">Compliance</p>
-            <p className="overview-stat-value">{runSummary.totalCompliance}</p>
-          </article>
-          <article className="overview-stat-card">
-            <p className="overview-stat-label">Dimensions</p>
-            <p className="overview-stat-value">{runSummary.dimensionCount}</p>
-          </article>
+          )}
+        </div>
+
+        <div className="acc-eval-stats-grid">
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Violations</span>
+            <span className="acc-eval-stat-value">{runSummary.totalViolations || 0}</span>
+            <div className="acc-eval-tags">
+              {(runSummary.severity?.critical || 0) > 0 && (
+                <span className="severity-tag critical">{runSummary.severity.critical} critical</span>
+              )}
+              {(runSummary.severity?.major || 0) > 0 && (
+                <span className="severity-tag major">{runSummary.severity.major} major</span>
+              )}
+              {(runSummary.severity?.minor || 0) > 0 && (
+                <span className="severity-tag minor">{runSummary.severity.minor} minor</span>
+              )}
+            </div>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Files Affected</span>
+            <span className="acc-eval-stat-value">{runTopFiles.length}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Principles</span>
+            <span className="acc-eval-stat-value">{runUniquePrinciples}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Compliant</span>
+            <span className="acc-eval-stat-value">{runSummary.totalCompliance || 0}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Dimensions</span>
+            <span className="acc-eval-stat-value">{runSummary.dimensionCount || 0}</span>
+          </div>
         </div>
       </section>
 

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -1,9 +1,6 @@
 import { useMemo, useState } from 'react';
-import { useDashboard } from '../hooks/useDashboard.js';
 import DimensionCard from './DimensionCard.jsx';
 import DimensionViolationsRow from './DimensionViolationsRow.jsx';
-import ProjectSelector from './ProjectSelector.jsx';
-import RunNavigator from './RunNavigator.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from './ViolationsByPrincipleTable.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
@@ -88,7 +85,6 @@ function AccumulatedOverviewPanel({
   const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? availableRuns[0]?.runId : currentOverviewRun;
 
-  // Derived accumulated stats
   const accumulatedTopFiles = useMemo(
     () => withDimensionsStr(buildTopOffendingFiles(accumulatedDimensions)),
     [accumulatedDimensions]
@@ -394,7 +390,6 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
         </div>
       </section>
 
-      {/* Dimension cards */}
       <div className="dimensions-header">
         <h3 className="dimensions-title">Dimensions Analyzed</h3>
       </div>
@@ -451,7 +446,6 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
         </div>
       </div>
 
-      {/* Violations by dimension */}
       {dimensionsWithViolations.length > 0 && (
         <>
           <div className="section-header">
@@ -474,7 +468,6 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
         </>
       )}
 
-      {/* Violations by file */}
       {runTopFiles.length > 0 && (
         <>
           <div className="section-header">
@@ -493,41 +486,29 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
 }
 
 // ---------------------------------------------------------------------------
-// DashboardPage
+// DashboardPage — body only, header is rendered by App.jsx
 // ---------------------------------------------------------------------------
 
-/**
- * Main dashboard view orchestrator.
- *
- * Props:
- *   selectedProject  - current project name (string)
- *   selectedRun      - current run ID or 'latest' (string)
- *   projects         - array of project objects ({ name }) for the project selector
- *   onProjectChange  - called with new project name when user switches projects
- *   onRunChange      - called with new run ID when user switches runs
- *   onNavigate       - called with (page, params) to push to the navigation stack
- */
 export default function DashboardPage({
   selectedProject,
   selectedRun,
   projects = [],
-  onProjectChange,
-  onRunChange,
   onNavigate,
+  runMode = false,
+  // Data from App-level useDashboard
+  dashboard,
+  accumulated,
+  loading,
+  error,
+  availableRuns = [],
+  overviewRunIndex = 0,
 }) {
-  const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({
-    selectedProject,
-    selectedRun,
-  });
-
-  // Dashboard-local UI state
   const [themePreference, setThemePreference] = useState(
     () => localStorage.getItem('cc-theme') ?? 'system'
   );
   const [showSettingsPanel, setShowSettingsPanel] = useState(false);
   const [compareMode, setCompareMode] = useState(false);
   const [focusedDimension, setFocusedDimension] = useState(null);
-  const [overviewRunIndex, setOverviewRunIndex] = useState(0);
 
   const applyTheme = (pref) => {
     setThemePreference(pref);
@@ -539,20 +520,14 @@ export default function DashboardPage({
     }
   };
 
-  // The current run displayed in the RunNavigator (index 0 = latest).
-  const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
-
-  // Accumulated dimensions (all dimensions, latest of each).
   const accumulatedDimensions = accumulated?.dimensions || [];
 
-  // Focused single-dimension view data.
   const focusedDimensionData = useMemo(() => {
     if (!focusedDimension) return null;
     return (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null;
   }, [focusedDimension, dashboard]);
 
-  // Handlers for navigating to explorer/file/principle detail pages.
   const handleDimensionCardClick = (item, runId) => {
     if (onNavigate) {
       onNavigate('explorer', { dimension: item.dimension, runId: runId || item.fromRunId });
@@ -566,42 +541,13 @@ export default function DashboardPage({
   };
 
   const handleFileClick = (fileObj) => {
-    if (onNavigate) {
-      onNavigate('file', { file: fileObj });
-    }
+    if (onNavigate) onNavigate('file', { file: fileObj });
   };
 
   const handlePrincipleClick = (principleObj) => {
-    if (onNavigate) {
-      onNavigate('principle', { principle: principleObj });
-    }
+    if (onNavigate) onNavigate('principle', { principle: principleObj });
   };
 
-  // RunNavigator handlers — navigate through the available runs list.
-  const handleRunPrev = () => {
-    const newIndex = Math.min(overviewRunIndex + 1, availableRuns.length - 1);
-    setOverviewRunIndex(newIndex);
-    if (onRunChange) onRunChange(availableRuns[newIndex]?.runId || 'latest');
-  };
-
-  const handleRunNext = () => {
-    const newIndex = Math.max(overviewRunIndex - 1, 0);
-    setOverviewRunIndex(newIndex);
-    if (onRunChange) onRunChange(availableRuns[newIndex]?.runId || 'latest');
-  };
-
-  const handleRunLatest = () => {
-    setOverviewRunIndex(0);
-    if (onRunChange) onRunChange(availableRuns[0]?.runId || 'latest');
-  };
-
-  const handleRunView = () => {
-    if (onNavigate) {
-      onNavigate('run', { runId: currentOverviewRun });
-    }
-  };
-
-  // Empty state when there are no projects.
   if (!projects || projects.length === 0) {
     return (
       <section className="empty-state">
@@ -613,84 +559,57 @@ export default function DashboardPage({
 
   return (
     <div className="dashboard-page">
-      {/* Project and run selectors */}
-      <ProjectSelector
-        projects={projects}
-        selectedProject={selectedProject}
-        selectedRun={selectedRunId}
-        runs={availableRuns}
-        onProjectChange={(project) => {
-          setOverviewRunIndex(0);
-          if (onProjectChange) onProjectChange(project);
-        }}
-        onRunChange={(run) => {
-          setOverviewRunIndex(
-            availableRuns.findIndex((r) => r.runId === run) || 0
-          );
-          if (onRunChange) onRunChange(run);
-        }}
-      />
-
-      {/* Run navigation */}
-      {availableRuns.length > 0 && (
-        <RunNavigator
-          currentRun={formatRunId(currentOverviewRun)}
-          isLatest={overviewRunIndex === 0}
-          isOldest={overviewRunIndex >= availableRuns.length - 1}
-          onPrev={handleRunPrev}
-          onNext={handleRunNext}
-          onLatest={handleRunLatest}
-          onView={handleRunView}
-        />
-      )}
-
-      {/* Error */}
       {error && <p className="inline-error">{error}</p>}
-
-      {/* Loading */}
       {loading && <p className="loading">Loading dashboard...</p>}
 
-      {/* Main content */}
-      {!loading && dashboard && accumulated && (
+      {!loading && dashboard && (
         <>
-          {/* Focused single dimension */}
-          {focusedDimension ? (
-            <div className="dimensions-panel">
-              <div className="dimensions-header">
-                <h3 className="dimensions-title">{focusedDimension}</h3>
-                <button
-                  type="button"
-                  className="btn-secondary"
-                  onClick={() => setFocusedDimension(null)}
-                >
-                  Show all
-                </button>
-              </div>
-              <DimensionCard
-                title={focusedDimension}
-                dimension={focusedDimensionData}
-                isSingleFocus={true}
-              />
-            </div>
-          ) : (
-            <AccumulatedOverviewPanel
-              accumulated={accumulated}
-              accumulatedDimensions={accumulatedDimensions}
-              availableRuns={availableRuns}
-              overviewRunIndex={overviewRunIndex}
-              onDimensionClick={handleAccumulatedDimensionClick}
+          {runMode ? (
+            <RunOverviewPanel
+              dashboard={dashboard}
+              selectedRunId={selectedRunId}
+              onDimensionClick={handleDimensionCardClick}
               onFileClick={handleFileClick}
-              onPrincipleClick={handlePrincipleClick}
             />
+          ) : accumulated ? (
+            <>
+              {focusedDimension ? (
+                <div className="dimensions-panel">
+                  <div className="dimensions-header">
+                    <h3 className="dimensions-title">{focusedDimension}</h3>
+                    <button
+                      type="button"
+                      className="btn-secondary"
+                      onClick={() => setFocusedDimension(null)}
+                    >
+                      Show all
+                    </button>
+                  </div>
+                  <DimensionCard
+                    title={focusedDimension}
+                    dimension={focusedDimensionData}
+                    isSingleFocus={true}
+                  />
+                </div>
+              ) : (
+                <AccumulatedOverviewPanel
+                  accumulated={accumulated}
+                  accumulatedDimensions={accumulatedDimensions}
+                  availableRuns={availableRuns}
+                  overviewRunIndex={overviewRunIndex}
+                  onDimensionClick={handleAccumulatedDimensionClick}
+                  onFileClick={handleFileClick}
+                  onPrincipleClick={handlePrincipleClick}
+                />
+              )}
+            </>
+          ) : (
+            <p className="empty-state">Loading accumulated data...</p>
           )}
         </>
       )}
 
-      {!loading && dashboard && !accumulated && (
-        <p className="empty-state">Loading accumulated data...</p>
-      )}
-
-      {/* Settings toggle button */}
+      {/* Settings toggle */}
       <button
         type="button"
         className="settings-panel-toggle"
@@ -698,27 +617,15 @@ export default function DashboardPage({
         title="Settings"
         aria-label="Toggle settings panel"
       >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
-        >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="3" />
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
         </svg>
       </button>
 
-      {/* Settings panel */}
       {showSettingsPanel && (
         <aside className="settings-panel panel">
           <h4 className="settings-panel-title">Settings</h4>
-
           <div className="settings-section">
             <p className="settings-label">Theme</p>
             <div className="theme-toggle-group">
@@ -734,7 +641,6 @@ export default function DashboardPage({
               ))}
             </div>
           </div>
-
           <div className="settings-section">
             <label className="settings-toggle-row">
               <span className="settings-label">Compare mode</span>

--- a/ui/web/src/features/dashboard/components/DimensionViolationsRow.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionViolationsRow.jsx
@@ -13,22 +13,25 @@ export default function DimensionViolationsRow({ dimension, onClick }) {
     if (counts[sev] !== undefined) counts[sev]++;
   });
   const total = violations.length;
+  const hasTags = counts.critical > 0 || counts.major > 0 || counts.minor > 0;
 
   return (
     <button className="dimension-violations-row" onClick={onClick}>
       <span className="dimension-name">{dimension.dimension}</span>
       <strong className="offending-file-total">{total}</strong>
-      <span className="offending-file-tags">
-        {counts.critical > 0 && (
-          <span className="severity-tag critical">{counts.critical} critical</span>
-        )}
-        {counts.major > 0 && (
-          <span className="severity-tag major">{counts.major} major</span>
-        )}
-        {counts.minor > 0 && (
-          <span className="severity-tag minor">{counts.minor} minor</span>
-        )}
-      </span>
+      {hasTags && (
+        <span className="offending-file-tags">
+          {counts.critical > 0 && (
+            <span className="severity-tag critical">{counts.critical} critical</span>
+          )}
+          {counts.major > 0 && (
+            <span className="severity-tag major">{counts.major} major</span>
+          )}
+          {counts.minor > 0 && (
+            <span className="severity-tag minor">{counts.minor} minor</span>
+          )}
+        </span>
+      )}
       <span className="row-arrow">›</span>
     </button>
   );

--- a/ui/web/src/features/dashboard/components/TopOffendingFilesTable.jsx
+++ b/ui/web/src/features/dashboard/components/TopOffendingFilesTable.jsx
@@ -19,10 +19,12 @@ const TopOffendingFilesTable = memo(function TopOffendingFilesTable({ files, onF
             onClick={onFileClick ? () => onFileClick(f) : undefined}
             title={f.file}
           >
-            <span className="offending-file-path">{f.file}</span>
-            {f.dimensionsStr && (
-              <span className="offending-file-dims">{f.dimensionsStr}</span>
-            )}
+            <div className="offending-file-info">
+              <span className="offending-file-path">{f.file}</span>
+              {f.dimensionsStr && (
+                <span className="offending-file-dims">{f.dimensionsStr}</span>
+              )}
+            </div>
             <strong className="offending-file-total">{f.total}</strong>
             <span className="offending-file-tags">
               {f.critical > 0 && (

--- a/ui/web/src/features/dashboard/components/ViolationsByPrincipleTable.jsx
+++ b/ui/web/src/features/dashboard/components/ViolationsByPrincipleTable.jsx
@@ -49,10 +49,12 @@ const ViolationsByPrincipleTable = memo(function ViolationsByPrincipleTable({ vi
             className={`offending-file-row${onPrincipleClick ? ' offending-file-row--clickable' : ''}`}
             onClick={onPrincipleClick ? () => onPrincipleClick(p) : undefined}
           >
-            <span className="offending-file-path">{p.principle}</span>
-            {p.dimensionsStr && (
-              <span className="offending-file-dims">{p.dimensionsStr}</span>
-            )}
+            <div className="offending-file-info">
+              <span className="offending-file-path">{p.principle}</span>
+              {p.dimensionsStr && (
+                <span className="offending-file-dims">{p.dimensionsStr}</span>
+              )}
+            </div>
             <strong className="offending-file-total">{p.total}</strong>
             <span className="offending-file-tags">
               {p.critical > 0 && <span className="severity-tag critical">{p.critical} critical</span>}

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -1,42 +1,10 @@
 import { useState } from 'react';
 import FolderBrowser from './FolderBrowser.jsx';
-
-const DISCIPLINE_OPTIONS = [
-  'backend_springboot_java',
-  'backend_springboot_kotlin',
-  'backend_typescript_lambdas',
-  'cli_bash',
-  'frontend_nextjs',
-  'frontend_react',
-  'infrastructure',
-  'mobile_android',
-  'mobile_ios',
-  'nodejs',
-];
-
-const DIMENSION_OPTIONS = [
-  { name: 'Affordability',   short: 'aff',  code: 'affordability' },
-  { name: 'Availability',    short: 'avl',  code: 'availability' },
-  { name: 'Configurability', short: 'cfg',  code: 'configurability' },
-  { name: 'Efficiency',      short: 'eff',  code: 'efficiency' },
-  { name: 'Evolvability',    short: 'evo',  code: 'evolvability' },
-  { name: 'Extensibility',   short: 'ext',  code: 'extensibility' },
-  { name: 'Flexibility',     short: 'flx',  code: 'flexibility' },
-  { name: 'Maintainability', short: 'mnt',  code: 'maintainability' },
-  { name: 'Performance',     short: 'perf', code: 'performance' },
-  { name: 'Recoverability',  short: 'rcv',  code: 'recoverability' },
-  { name: 'Resilience',      short: 'res',  code: 'resilience' },
-  { name: 'Robustness',      short: 'rob',  code: 'robustness' },
-  { name: 'Scalability',     short: 'scl',  code: 'scalability' },
-  { name: 'Simplicity',      short: 'sim',  code: 'simplicity' },
-  { name: 'Usability',       short: 'usx',  code: 'usability' },
-];
+import { DIMENSION_OPTIONS } from '../constants.js';
 
 export default function EvaluationForm({ onStart, disabled }) {
   const [repo, setRepo] = useState('');
-  const [discipline, setDiscipline] = useState('');
   const [selectedDimensions, setSelectedDimensions] = useState([]);
-  const [numerical, setNumerical] = useState(true);
   const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
 
   function toggleDimension(code) {
@@ -49,9 +17,8 @@ export default function EvaluationForm({ onStart, disabled }) {
     e.preventDefault();
     onStart({
       repo,
-      discipline: discipline || undefined,
       dimensions: selectedDimensions.join(','),
-      numerical,
+      numerical: true,
     });
     setRepo('');
   }
@@ -60,6 +27,8 @@ export default function EvaluationForm({ onStart, disabled }) {
     setRepo(path);
     setFolderBrowserOpen(false);
   }
+
+  const canSubmit = !disabled && !!repo && selectedDimensions.length > 0;
 
   return (
     <>
@@ -100,56 +69,43 @@ export default function EvaluationForm({ onStart, disabled }) {
           </div>
         </div>
 
-        <div className="form-group">
-          <label htmlFor="eval-form-discipline">Discipline (optional)</label>
-          <select
-            id="eval-form-discipline"
-            value={discipline}
-            onChange={(e) => setDiscipline(e.target.value)}
-          >
-            <option value="">— None —</option>
-            {DISCIPLINE_OPTIONS.map((d) => (
-              <option key={d} value={d}>{d}</option>
-            ))}
-          </select>
-        </div>
-
-        <div className="form-group">
-          <label>Dimensions to Evaluate</label>
-          <div className="dimension-grid">
-            {DIMENSION_OPTIONS.map((dim) => (
-              <button
-                key={dim.code}
-                type="button"
-                className={`dimension-chip-btn ${selectedDimensions.includes(dim.code) ? 'selected' : ''}`}
-                onClick={() => toggleDimension(dim.code)}
-              >
-                <span className="dim-code">{dim.short}</span>
-                <span className="dim-name">{dim.name}</span>
-              </button>
-            ))}
+        {repo && (
+          <div className="form-group">
+            <div className="dimension-label-row">
+              <label>Dimensions</label>
+              <div className="dimension-chip-actions">
+                <button
+                  type="button"
+                  className="dim-action-btn"
+                  onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.map((d) => d.code))}
+                >
+                  Select all
+                </button>
+                <button
+                  type="button"
+                  className="dim-action-btn"
+                  onClick={() => setSelectedDimensions([])}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+            <div className="dimension-grid">
+              {DIMENSION_OPTIONS.map((dim) => (
+                <button
+                  key={dim.code}
+                  type="button"
+                  className={`dimension-chip-btn${selectedDimensions.includes(dim.code) ? ' selected' : ''}`}
+                  onClick={() => toggleDimension(dim.code)}
+                >
+                  {dim.name}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="dimension-chip-actions">
-            <button type="button" onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.map((d) => d.code))}>
-              Select All
-            </button>
-            <button type="button" onClick={() => setSelectedDimensions([])}>
-              Clear
-            </button>
-          </div>
-        </div>
+        )}
 
-        <label className="checkbox-row" htmlFor="eval-form-numerical">
-          <input
-            id="eval-form-numerical"
-            type="checkbox"
-            checked={numerical}
-            onChange={(e) => setNumerical(e.target.checked)}
-          />
-          Enable numerical scoring (0-10 scale)
-        </label>
-
-        <button type="submit" className="evaluate-submit-btn" disabled={disabled}>
+        <button type="submit" className="evaluate-submit-btn" disabled={!canSubmit}>
           {disabled ? 'Running Evaluation...' : 'Start Evaluation'}
         </button>
       </form>

--- a/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import { getProjectInfo } from '../../../api/index.js';
+import { DIMENSION_OPTIONS } from '../constants.js';
+
+export default function ReEvaluateCard({ project, onStart, disabled }) {
+  const [info, setInfo] = useState(null);
+  const [selectedDimensions, setSelectedDimensions] = useState([]);
+
+  useEffect(() => {
+    if (!project) return;
+    setInfo(null);
+    getProjectInfo(project)
+      .then(setInfo)
+      .catch(() => setInfo(null));
+  }, [project]);
+
+  if (!info) return null;
+
+  function toggleDimension(code) {
+    setSelectedDimensions((prev) =>
+      prev.includes(code) ? prev.filter((d) => d !== code) : [...prev, code]
+    );
+  }
+
+  function handleStart() {
+    onStart({
+      repo: info.path,
+      dimensions: selectedDimensions.join(','),
+      numerical: true,
+    });
+  }
+
+  const canStart = !disabled && selectedDimensions.length > 0;
+
+  return (
+    <div className="panel evaluate-panel">
+      <div className="panel-header">
+        <h3>Re-evaluate <span className="re-eval-project-name">{project}</span></h3>
+      </div>
+
+      <div className="evaluate-form-large">
+        <div className="re-eval-repo-path">
+          <span className="re-eval-repo-label">{info.location === 'online' ? 'Remote' : 'Local'}</span>
+          <code>{info.path}</code>
+        </div>
+
+        <div className="form-group">
+          <div className="dimension-label-row">
+            <label>Dimensions</label>
+            <div className="dimension-chip-actions">
+              <button
+                type="button"
+                className="dim-action-btn"
+                onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.map((d) => d.code))}
+              >
+                Select all
+              </button>
+              <button
+                type="button"
+                className="dim-action-btn"
+                onClick={() => setSelectedDimensions([])}
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+          <div className="dimension-grid">
+            {DIMENSION_OPTIONS.map((dim) => (
+              <button
+                key={dim.code}
+                type="button"
+                className={`dimension-chip-btn${selectedDimensions.includes(dim.code) ? ' selected' : ''}`}
+                onClick={() => toggleDimension(dim.code)}
+              >
+                {dim.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className="evaluate-submit-btn"
+          disabled={!canStart}
+          onClick={handleStart}
+        >
+          {disabled ? 'Running Evaluation...' : `Re-evaluate ${project}`}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/features/evaluation/constants.js
+++ b/ui/web/src/features/evaluation/constants.js
@@ -1,0 +1,17 @@
+export const DIMENSION_OPTIONS = [
+  { name: 'Affordability',   code: 'affordability' },
+  { name: 'Availability',    code: 'availability' },
+  { name: 'Configurability', code: 'configurability' },
+  { name: 'Efficiency',      code: 'efficiency' },
+  { name: 'Evolvability',    code: 'evolvability' },
+  { name: 'Extensibility',   code: 'extensibility' },
+  { name: 'Flexibility',     code: 'flexibility' },
+  { name: 'Maintainability', code: 'maintainability' },
+  { name: 'Performance',     code: 'performance' },
+  { name: 'Recoverability',  code: 'recoverability' },
+  { name: 'Resilience',      code: 'resilience' },
+  { name: 'Robustness',      code: 'robustness' },
+  { name: 'Scalability',     code: 'scalability' },
+  { name: 'Simplicity',      code: 'simplicity' },
+  { name: 'Usability',       code: 'usability' },
+];

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -143,9 +143,6 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
 
   return (
     <>
-      <div className="section-header">
-        <h3 className="section-title file-detail-title">{principle}</h3>
-      </div>
       <section className="panel file-detail-summary-panel">
         <div className="file-detail-stats">
           {score && (
@@ -175,6 +172,10 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
           />
         )}
       </section>
+
+      <div className="section-header">
+        <h3 className="section-title file-detail-title">{principle}</h3>
+      </div>
 
       {principleData?.findings && (
         <p className="violation-context-desc" style={{ padding: '0 4px', marginBottom: '4px' }}>

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -144,38 +144,37 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
   return (
     <>
       <section className="panel file-detail-summary-panel">
-        <div className="file-detail-stats">
-          {score && (
-            <>
-              <span className="file-detail-stat"><strong>{score}</strong></span>
-              <span className="file-detail-stat-sep">·</span>
-            </>
-          )}
-          <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
+        <h3 className="file-detail-title">{principle}</h3>
+        <div className="file-detail-stats-row">
+          <div className="file-detail-stats">
+            {score && (
+              <>
+                <span className="file-detail-stat"><strong>{score}</strong></span>
+                <span className="file-detail-stat-sep">·</span>
+              </>
+            )}
+            <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
+            {violations.length > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat"><strong>{violations.length}</strong> violations</span>
+              </>
+            )}
+            {compliance.length > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat"><strong>{compliance.length}</strong> compliant</span>
+              </>
+            )}
+          </div>
           {violations.length > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat"><strong>{violations.length}</strong> violations</span>
-            </>
-          )}
-          {compliance.length > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat"><strong>{compliance.length}</strong> compliant</span>
-            </>
+            <CopyButton
+              label="Principle fix plan"
+              onClick={() => navigator.clipboard.writeText(buildPrinciplePlanText())}
+            />
           )}
         </div>
-        {violations.length > 0 && (
-          <CopyButton
-            label="Principle fix plan"
-            onClick={() => navigator.clipboard.writeText(buildPrinciplePlanText())}
-          />
-        )}
       </section>
-
-      <div className="section-header">
-        <h3 className="section-title file-detail-title">{principle}</h3>
-      </div>
 
       {principleData?.findings && (
         <p className="violation-context-desc" style={{ padding: '0 4px', marginBottom: '4px' }}>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useMemo } from 'react';
 import { getDimensionEval } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
+import CopyButton from '../../../components/CopyButton.jsx';
 import { gradeColorClass } from '../../../utils/formatters.js';
-import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 
 export default function ExplorerPage({ project, dimension, runId, onNavigate }) {
   const [evalData, setEvalData] = useState(null);
@@ -47,6 +48,25 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
     return buildTopOffendingFiles([{ dimension: evalData.dimension, violations: allViolations }]);
   }, [evalData, allViolations]);
 
+  const severityCounts = useMemo(() => {
+    const counts = { critical: 0, major: 0, minor: 0 };
+    allViolations.forEach((v) => {
+      const s = (v.severity || 'minor').toLowerCase();
+      if (counts[s] !== undefined) counts[s]++;
+    });
+    return counts;
+  }, [allViolations]);
+
+  const uniquePrinciples = useMemo(
+    () => new Set(allViolations.map((v) => v.principle).filter(Boolean)).size,
+    [allViolations]
+  );
+
+  const totalCompliant = useMemo(
+    () => (evalData?.principles || []).reduce((sum, p) => sum + (p.compliance?.length || 0), 0),
+    [evalData]
+  );
+
   if (loading) return <div className="loading">Loading…</div>;
   if (error) return <div className="inline-error">{error}</div>;
   if (!evalData) return <div className="empty-state"><h2>No data found</h2></div>;
@@ -65,47 +85,80 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
   }
 
   return (
-    <div className="dashboard">
-      {/* Header */}
-      <section className="panel eval-header-panel">
-        <div className="eval-header">
-          <div>
-            <p className="eval-project-label">{evalData.project}</p>
-            <h2 className="eval-dimension-title">{evalData.dimension}</h2>
+    <>
+      <section className="acc-eval-panel panel">
+        <div className="acc-eval-top">
+          <span className="acc-eval-label">{evalData.dimension}</span>
+          {allViolations.length > 0 && (
+            <CopyButton
+              label="Fix plan"
+              onClick={() => navigator.clipboard.writeText(
+                buildDimensionPlanFromViolations(evalData.dimension, allViolations)
+              )}
+            />
+          )}
+        </div>
+
+        <div className="acc-eval-hero">
+          <span className={`acc-eval-grade-chip chip ${gradeColorClass(overallGrade?.grade)}`}>
+            {overallGrade?.grade || '—'}
+          </span>
+          {overallGrade?.score && (
+            <div className="acc-eval-score-row">
+              <span className="acc-eval-score">{overallGrade.score}</span>
+            </div>
+          )}
+        </div>
+
+        <div className="acc-eval-stats-grid">
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Violations</span>
+            <span className="acc-eval-stat-value">{allViolations.length}</span>
+            <div className="acc-eval-tags">
+              {severityCounts.critical > 0 && (
+                <span className="severity-tag critical">{severityCounts.critical} critical</span>
+              )}
+              {severityCounts.major > 0 && (
+                <span className="severity-tag major">{severityCounts.major} major</span>
+              )}
+              {severityCounts.minor > 0 && (
+                <span className="severity-tag minor">{severityCounts.minor} minor</span>
+              )}
+            </div>
           </div>
-          <div className="eval-header-scores">
-            {overallGrade?.score && <span className="overall-score">{overallGrade.score}</span>}
-            <span className={`chip ${gradeColorClass(overallGrade?.grade)}`}>
-              {overallGrade?.grade || 'No grade'}
-            </span>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Files Affected</span>
+            <span className="acc-eval-stat-value">{topFiles.length}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Principles</span>
+            <span className="acc-eval-stat-value">{uniquePrinciples}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Compliant</span>
+            <span className="acc-eval-stat-value">{totalCompliant}</span>
           </div>
         </div>
-        <p className="eval-meta">{evalData.runId}</p>
       </section>
 
-      {/* Executive summary */}
+      {/* Principles list */}
       {principleGrades.length > 0 && (
-        <>
-          <div className="section-header">
-            <h3 className="section-title">Executive Summary</h3>
-          </div>
-          <section className="panel eval-summary-panel">
-            <ul className="exec-summary-list">
-              {principleGrades.map((pg) => (
-                <li
-                  key={pg.principle}
-                  className="exec-summary-row exec-summary-row--clickable"
-                  onClick={() => onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) })}
-                >
-                  <span className="exec-summary-principle">{pg.principle}</span>
-                  {pg.score && <span className="exec-summary-score">{pg.score}</span>}
-                  <span className={`chip small ${gradeColorClass(pg.grade)}`}>{pg.grade || '—'}</span>
-                  <span className="exec-summary-chevron">›</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        </>
+        <section className="panel eval-summary-panel">
+          <ul className="exec-summary-list">
+            {principleGrades.map((pg) => (
+              <li
+                key={pg.principle}
+                className="exec-summary-row exec-summary-row--clickable"
+                onClick={() => onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) })}
+              >
+                <span className="exec-summary-principle">{pg.principle}</span>
+                {pg.score && <span className="exec-summary-score">{pg.score}</span>}
+                <span className={`chip small ${gradeColorClass(pg.grade)}`}>{pg.grade || '—'}</span>
+                <span className="exec-summary-chevron">›</span>
+              </li>
+            ))}
+          </ul>
+        </section>
       )}
 
       {/* Violations by principle */}
@@ -140,6 +193,6 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
         </>
       )}
 
-    </div>
+    </>
   );
 }

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -1,0 +1,145 @@
+import { useState, useEffect, useMemo } from 'react';
+import { getDimensionEval } from '../../../api/index.js';
+import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
+import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
+import { gradeColorClass } from '../../../utils/formatters.js';
+import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+
+export default function ExplorerPage({ project, dimension, runId, onNavigate }) {
+  const [evalData, setEvalData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    getDimensionEval(project, runId, dimension)
+      .then((data) => { setEvalData(data); setLoading(false); })
+      .catch((err) => { setError(err.message); setLoading(false); });
+  }, [project, dimension, runId]);
+
+  // All hooks above conditional returns
+  const overallGrade = useMemo(() => (evalData?.principleGrades || []).find(
+    (pg) => pg.isOverall || pg.principle?.includes('Overall')
+  ), [evalData]);
+
+  const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter(
+    (pg) => !pg.isOverall && !pg.principle?.includes('Overall')
+  ), [evalData]);
+
+  // Top-level violations (original JSON format: {principle, file, line, severity, reason})
+  const allViolations = useMemo(() => {
+    if (!evalData) return [];
+    if (evalData.violations?.length > 0) return evalData.violations;
+    return (evalData.principles || []).flatMap((p) =>
+      (p.violations || []).map((v) => ({
+        principle: p.name,
+        file: v.file ? v.file.split(':')[0] : null,
+        line: v.line || null,
+        severity: v.severity || 'minor',
+        reason: v.reason || v.code || '',
+      }))
+    );
+  }, [evalData]);
+
+  // Files list via buildTopOffendingFiles (same format as overview)
+  const topFiles = useMemo(() => {
+    if (!evalData) return [];
+    return buildTopOffendingFiles([{ dimension: evalData.dimension, violations: allViolations }]);
+  }, [evalData, allViolations]);
+
+  if (loading) return <div className="loading">Loading…</div>;
+  if (error) return <div className="inline-error">{error}</div>;
+  if (!evalData) return <div className="empty-state"><h2>No data found</h2></div>;
+
+  function buildEvalPrincipal(principleId) {
+    const principleData = (evalData.principles || []).find((p) => p.name === principleId);
+    const pg = (evalData.principleGrades || []).find((p) => p.principle === principleId);
+    return {
+      principle: principleId,
+      score: pg?.score || null,
+      grade: pg?.grade || null,
+      principleData,
+      dimViolations: principleData?.violations || [],
+      dimCompliance: principleData?.compliance || [],
+    };
+  }
+
+  return (
+    <div className="dashboard">
+      {/* Header */}
+      <section className="panel eval-header-panel">
+        <div className="eval-header">
+          <div>
+            <p className="eval-project-label">{evalData.project}</p>
+            <h2 className="eval-dimension-title">{evalData.dimension}</h2>
+          </div>
+          <div className="eval-header-scores">
+            {overallGrade?.score && <span className="overall-score">{overallGrade.score}</span>}
+            <span className={`chip ${gradeColorClass(overallGrade?.grade)}`}>
+              {overallGrade?.grade || 'No grade'}
+            </span>
+          </div>
+        </div>
+        <p className="eval-meta">{evalData.runId}</p>
+      </section>
+
+      {/* Executive summary */}
+      {principleGrades.length > 0 && (
+        <>
+          <div className="section-header">
+            <h3 className="section-title">Executive Summary</h3>
+          </div>
+          <section className="panel eval-summary-panel">
+            <ul className="exec-summary-list">
+              {principleGrades.map((pg) => (
+                <li
+                  key={pg.principle}
+                  className="exec-summary-row exec-summary-row--clickable"
+                  onClick={() => onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) })}
+                >
+                  <span className="exec-summary-principle">{pg.principle}</span>
+                  {pg.score && <span className="exec-summary-score">{pg.score}</span>}
+                  <span className={`chip small ${gradeColorClass(pg.grade)}`}>{pg.grade || '—'}</span>
+                  <span className="exec-summary-chevron">›</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </>
+      )}
+
+      {/* Violations by principle */}
+      {allViolations.length > 0 && (
+        <>
+          <div className="section-header">
+            <h3 className="section-title">Violations by Principle</h3>
+            <span className="section-count">{allViolations.length} violations</span>
+          </div>
+          <section className="panel wide-panel offending-panel">
+            <ViolationsByPrincipleTable
+              violations={allViolations}
+              onPrincipleClick={(p) => onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(p.principle) })}
+            />
+          </section>
+        </>
+      )}
+
+      {/* Violations by file — same component as main overview */}
+      {topFiles.length > 0 && (
+        <>
+          <div className="section-header">
+            <h3 className="section-title">Violations by File</h3>
+            <span className="section-count">{topFiles.length} files</span>
+          </div>
+          <section className="panel wide-panel offending-panel">
+            <TopOffendingFilesTable
+              files={topFiles}
+              onFileClick={(f) => onNavigate && onNavigate('file', { file: f })}
+            />
+          </section>
+        </>
+      )}
+
+    </div>
+  );
+}

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -121,9 +121,6 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
 
   return (
     <>
-      <div className="section-header">
-        <h3 className="section-title file-detail-title">{file.file}</h3>
-      </div>
       <section className="panel file-detail-summary-panel">
         <div className="file-detail-stats">
           <span className="file-detail-stat">
@@ -157,6 +154,10 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
           onClick={() => navigator.clipboard.writeText(buildFilePlanText(file))}
         />
       </section>
+
+      <div className="section-header">
+        <h3 className="section-title file-detail-title">{file.file}</h3>
+      </div>
 
       {SEVERITY_ORDER.map((sev) => {
         const violations = file.violationsBySeverity?.[sev] || [];

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -122,42 +122,41 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
   return (
     <>
       <section className="panel file-detail-summary-panel">
-        <div className="file-detail-stats">
-          <span className="file-detail-stat">
-            <strong>{totalViolations}</strong> violations
-          </span>
-          <span className="file-detail-stat-sep">·</span>
-          <span className="file-detail-stat">
-            <strong>{dimensionsCount}</strong> {dimensionsCount === 1 ? 'dimension' : 'dimensions'}
-          </span>
-          {file.critical > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag critical">{file.critical} critical</span>
-            </>
-          )}
-          {file.major > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag major">{file.major} major</span>
-            </>
-          )}
-          {file.minor > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag minor">{file.minor} minor</span>
-            </>
-          )}
+        <h3 className="file-detail-title">{file.file}</h3>
+        <div className="file-detail-stats-row">
+          <div className="file-detail-stats">
+            <span className="file-detail-stat">
+              <strong>{totalViolations}</strong> violations
+            </span>
+            <span className="file-detail-stat-sep">·</span>
+            <span className="file-detail-stat">
+              <strong>{dimensionsCount}</strong> {dimensionsCount === 1 ? 'dimension' : 'dimensions'}
+            </span>
+            {file.critical > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag critical">{file.critical} critical</span>
+              </>
+            )}
+            {file.major > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag major">{file.major} major</span>
+              </>
+            )}
+            {file.minor > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag minor">{file.minor} minor</span>
+              </>
+            )}
+          </div>
+          <CopyButton
+            label="File fix plan"
+            onClick={() => navigator.clipboard.writeText(buildFilePlanText(file))}
+          />
         </div>
-        <CopyButton
-          label="File fix plan"
-          onClick={() => navigator.clipboard.writeText(buildFilePlanText(file))}
-        />
       </section>
-
-      <div className="section-header">
-        <h3 className="section-title file-detail-title">{file.file}</h3>
-      </div>
 
       {SEVERITY_ORDER.map((sev) => {
         const violations = file.violationsBySeverity?.[sev] || [];

--- a/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -128,33 +128,35 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ principle }) {
         <h3 className="section-title file-detail-title">{principle.principle}</h3>
       </div>
       <section className="panel file-detail-summary-panel">
-        <div className="file-detail-stats">
-          <span className="file-detail-stat">
-            <strong>{totalViolations}</strong> violations
-          </span>
-          {principle.critical > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag critical">{principle.critical} critical</span>
-            </>
-          )}
-          {principle.major > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag major">{principle.major} major</span>
-            </>
-          )}
-          {principle.minor > 0 && (
-            <>
-              <span className="file-detail-stat-sep">·</span>
-              <span className="file-detail-stat severity-tag minor">{principle.minor} minor</span>
-            </>
-          )}
+        <div className="file-detail-stats-row">
+          <div className="file-detail-stats">
+            <span className="file-detail-stat">
+              <strong>{totalViolations}</strong> violations
+            </span>
+            {principle.critical > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag critical">{principle.critical} critical</span>
+              </>
+            )}
+            {principle.major > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag major">{principle.major} major</span>
+              </>
+            )}
+            {principle.minor > 0 && (
+              <>
+                <span className="file-detail-stat-sep">·</span>
+                <span className="file-detail-stat severity-tag minor">{principle.minor} minor</span>
+              </>
+            )}
+          </div>
+          <CopyButton
+            label="Principle fix plan"
+            onClick={() => navigator.clipboard.writeText(buildPrinciplePlanText(principle))}
+          />
         </div>
-        <CopyButton
-          label="Principle fix plan"
-          onClick={() => navigator.clipboard.writeText(buildPrinciplePlanText(principle))}
-        />
       </section>
 
       {SEVERITY_ORDER.map((sev) => {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -449,6 +449,15 @@ textarea:focus {
   margin: var(--space-2) 0;
 }
 
+.job-error-banner {
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+}
+
 .no-data-cell {
   color: var(--color-text-muted);
   font-size: var(--text-sm);
@@ -595,6 +604,45 @@ textarea:focus {
   font-weight: var(--weight-semibold);
   color: var(--color-text);
   margin: 0;
+}
+
+.content-meta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.content-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  font-size: var(--text-xs);
+  line-height: 1;
+}
+
+.content-meta-chip-label {
+  padding: 4px var(--space-2);
+  background: var(--color-surface-alt);
+  color: var(--color-text-subtle);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-right: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.content-meta-chip-value {
+  padding: 4px var(--space-3);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+  font-family: var(--font-mono);
+  white-space: nowrap;
 }
 
 /* ── Panels ───────────────────────────────────────────── */

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -584,7 +584,7 @@ textarea:focus {
 
 .content-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   gap: var(--space-4);
   padding-bottom: var(--space-4);

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -354,6 +354,7 @@
 
 .dimension-violations-row .dimension-name {
   flex: 1;
+  min-width: 0;
   font-weight: 500;
   text-transform: capitalize;
   color: var(--color-text-muted);
@@ -409,7 +410,6 @@
 }
 
 .dimensions-panel {
-  margin-bottom: 28px;
   padding: 16px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -651,22 +651,24 @@
 .run-navigator .run-nav-action {
   display: inline-flex;
   align-items: center;
-  padding: 3px 10px;
+  padding: 4px 10px;
   background: transparent;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   font-family: var(--font-sans);
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
   color: var(--color-text-muted);
   white-space: nowrap;
   cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease;
+  line-height: 1;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
 }
 
 .run-navigator .run-nav-action:hover:not(:disabled) {
-  border-color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
   color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .run-navigator .run-nav-action:disabled {
@@ -680,15 +682,17 @@
   display: inline-flex;
   align-items: center;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
   overflow: hidden;
+  line-height: 1;
 }
 
 .run-navigator .run-nav-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 3px var(--space-2);
+  padding: 4px 7px;
   background: transparent;
   border: none;
   color: var(--color-text-muted);
@@ -711,11 +715,12 @@
 
 /* Date label inside the pager */
 .run-navigator .run-nav-label {
-  padding: 3px var(--space-3);
+  padding: 4px var(--space-3);
   border-left: 1px solid var(--color-border);
   border-right: 1px solid var(--color-border);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
   color: var(--color-text);
   white-space: nowrap;
   min-width: 9ch;
@@ -1286,7 +1291,6 @@
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
-  margin-left: auto;
 }
 
 .offending-file-total {
@@ -1297,27 +1301,26 @@
   text-align: right;
 }
 
+.offending-file-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.offending-file-info .offending-file-dims {
+  margin-top: 2px;
+}
+
 .offending-file-dims {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   font-size: 0.72rem;
   color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 28%;
-  pointer-events: none;
-}
-
-@media (max-width: 640px) {
-  .offending-file-dims {
-    display: none;
-  }
 }
 
 .offending-file-path {
-  flex: 1;
   min-width: 0;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.8rem;
@@ -1943,7 +1946,7 @@
 .dashboard-page {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-6);
 }
 
 /* ── Project selector (in main content area) ──────────── */

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -1937,3 +1937,280 @@
   padding: 9px 14px;
   font-size: 0.84rem;
 }
+
+/* ── Dashboard page wrapper ───────────────────────────── */
+
+.dashboard-page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* ── Project selector (in main content area) ──────────── */
+
+.project-selector {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-end;
+  flex-wrap: wrap;
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* Override sidebar-context hiding when inside .project-selector */
+.project-selector .sidebar-project-section,
+.project-selector .sidebar-run-section {
+  border-top: none;
+  padding: 0;
+  overflow: visible;
+}
+
+.project-selector .sidebar-project-label {
+  opacity: 1;
+}
+
+.project-selector .project-select-styled {
+  opacity: 1;
+  pointer-events: auto;
+  width: auto;
+  min-width: 180px;
+}
+
+/* ── Sidebar run section ──────────────────────────────── */
+
+.sidebar-run-section {
+  padding: var(--space-3);
+  border-top: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+/* ── Overview summary (run-specific view) ─────────────── */
+
+.overview-summary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.run-evaluation-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.overview-summary-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.overview-stat-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.overview-stat-card p {
+  margin: 0;
+}
+
+.overview-stat-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.overview-stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-stat-value.big,
+.big {
+  font-size: 3rem;
+}
+
+.overview-stat-sub {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.overview-stat-grade {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+}
+
+.overview-severity-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+/* ── Settings panel toggle (floating button) ──────────── */
+
+.settings-panel-toggle {
+  position: fixed;
+  bottom: var(--space-5);
+  right: var(--space-5);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+  transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
+  z-index: 100;
+}
+
+.settings-panel-toggle:hover {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  box-shadow: var(--shadow-lg);
+}
+
+.settings-panel-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0 0 var(--space-4) 0;
+}
+
+.settings-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+}
+
+.theme-toggle-group {
+  display: flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+/* ── DimensionCard missing classes ────────────────────── */
+
+.brand-overline {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 var(--space-1) 0;
+}
+
+.dim-score-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.dim-score-value {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.dim-score-denom {
+  font-size: 1.2rem;
+  color: var(--color-text-muted);
+  font-weight: var(--weight-medium);
+}
+
+.dim-filter-section {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.dim-principles-filter {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.file-filter-input {
+  max-width: 240px;
+}
+
+.principle-accordion-list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.dim-violations-section {
+  display: grid;
+  gap: var(--space-3);
+}
+
+/* ── Pill buttons (filter toggles) ───────────────────── */
+
+.pill-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+  text-transform: capitalize;
+}
+
+.pill-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-text);
+}
+
+.pill-btn.active {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+/* Severity-specific pill active colors */
+.severity-pill.critical.active {
+  background: color-mix(in srgb, var(--color-sev-critical-text) 15%, transparent);
+  border-color: var(--color-sev-critical-text);
+  color: var(--color-sev-critical-text);
+}
+
+.severity-pill.major.active {
+  background: color-mix(in srgb, var(--color-sev-major-text) 15%, transparent);
+  border-color: var(--color-sev-major-text);
+  color: var(--color-sev-major-text);
+}
+
+.severity-pill.minor.active {
+  background: color-mix(in srgb, var(--color-sev-minor-text) 15%, transparent);
+  border-color: var(--color-sev-minor-text);
+  color: var(--color-sev-minor-text);
+}

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -31,18 +31,6 @@
   padding: 24px;
 }
 
-.evaluate-panel h3 {
-  margin: 0 0 20px 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-.evaluate-form-large {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
 
 .form-group {
   display: flex;
@@ -83,6 +71,7 @@
   border: none;
   border-radius: var(--radius-lg);
   color: var(--color-bg);
+  font-family: var(--font-sans);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -314,74 +303,7 @@
   margin-top: 10px;
 }
 
-.dimension-chip-btn {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  padding: 12px 8px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.dimension-chip-btn:hover:not(:disabled) {
-  background: var(--color-surface-alt);
-  border-color: var(--color-accent);
-}
-
-.dimension-chip-btn.selected {
-  background: var(--color-accent-soft);
-  border-color: var(--color-accent);
-}
-
 .dimension-chip-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.dimension-chip-btn .dim-code {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.dimension-chip-btn.selected .dim-code {
-  color: var(--color-accent);
-}
-
-.dimension-chip-btn .dim-name {
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--color-text);
-}
-
-.dimension-actions {
-  display: flex;
-  gap: 12px;
-  margin-top: 12px;
-}
-
-.dim-action-btn {
-  padding: 8px 16px;
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  color: var(--color-text-muted);
-  font-size: 0.8rem;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.dim-action-btn:hover:not(:disabled) {
-  background: var(--color-surface);
-  color: var(--color-text);
-  border-color: var(--color-accent);
-}
-
-.dim-action-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -592,45 +514,120 @@
   color: var(--color-text);
 }
 
-/* Improve dimension grid */
+/* Re-evaluate card */
+.re-eval-project-name {
+  color: var(--color-accent);
+  font-weight: var(--weight-semibold);
+}
+
+.re-eval-repo-path {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 10px 14px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  min-width: 0;
+}
+
+.re-eval-repo-label {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.re-eval-repo-path code {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+/* Dimension label row: label left, actions right */
+.dimension-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dimension-label-row label {
+  margin-bottom: 0;
+}
+
+.dimension-chip-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.dim-action-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  line-height: 1;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.dim-action-btn:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+/* Dimension grid */
 .dimension-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 10px;
-  margin-top: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
 }
 
 .dimension-chip-btn {
-  padding: 14px 10px;
-  background: var(--color-bg);
-  border: 2px solid transparent;
-  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 10px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 150ms, background 150ms, color 150ms;
 }
 
 .dimension-chip-btn:hover:not(:disabled) {
   background: var(--color-surface-alt);
-  border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  color: var(--color-text);
 }
 
 .dimension-chip-btn.selected {
   background: var(--color-accent-soft);
   border-color: var(--color-accent);
-}
-
-.dimension-chip-btn .dim-code {
-  font-size: 0.75rem;
-  font-weight: 800;
-}
-
-.dimension-chip-btn .dim-name {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-muted);
-  margin-top: 2px;
-}
-
-.dimension-chip-btn.selected .dim-name {
-  color: var(--color-text);
+  color: var(--color-accent);
+  font-weight: var(--weight-semibold);
 }
 
 /* Improve submit button */
@@ -1197,17 +1194,7 @@
   opacity: 0.6;
 }
 
-@media (max-width: 1024px) {
-  .dimension-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
 @media (max-width: 640px) {
-  .dimension-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
   .evaluate-header-content {
     flex-direction: column;
     text-align: center;

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -458,3 +458,140 @@
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+/* ── Eval dimension page ──────────────────────────────── */
+
+.eval-header-panel {
+  padding: var(--space-4) var(--space-5);
+}
+
+.eval-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.eval-project-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 4px;
+}
+
+.eval-dimension-title {
+  font-size: 1.5rem;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  text-transform: capitalize;
+  margin: 0;
+}
+
+.eval-header-scores {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.overall-score {
+  font-size: 1.1rem;
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.eval-meta {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: var(--space-2) 0 0;
+}
+
+/* Executive summary list */
+.exec-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.exec-summary-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.exec-summary-row:last-child { border-bottom: none; }
+
+.exec-summary-row--clickable {
+  cursor: pointer;
+  transition: background 100ms ease;
+}
+
+.exec-summary-row--clickable:hover { background: var(--color-surface-alt); }
+
+.exec-summary-principle {
+  flex: 1;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.exec-summary-score {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.exec-summary-chevron {
+  color: var(--color-text-subtle);
+  font-size: 1rem;
+}
+
+/* Flat violations table */
+.violation-table {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.violation-table-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 1fr 2fr;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-sm);
+}
+
+.violation-table-row:last-child { border-bottom: none; }
+
+.violation-file {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  word-break: break-all;
+}
+
+.violation-principle {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.violation-reason {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.violation-table-row--clickable {
+  cursor: pointer;
+  transition: background 100ms ease;
+}
+
+.violation-table-row--clickable:hover {
+  background: var(--color-surface-alt);
+}

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -230,6 +230,12 @@
 .file-detail-summary-panel {
   padding: var(--space-4);
   display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.file-detail-stats-row {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);
@@ -249,6 +255,10 @@
 
 .file-detail-title {
   font-family: var(--font-mono);
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
   word-break: break-all;
 }
 
@@ -461,25 +471,13 @@
 
 /* ── Eval dimension page ──────────────────────────────── */
 
-.eval-header-panel {
-  padding: var(--space-4) var(--space-5);
-}
-
 .eval-header {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   justify-content: space-between;
   gap: var(--space-4);
   flex-wrap: wrap;
-}
-
-.eval-project-label {
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin: 0 0 4px;
+  margin-bottom: calc(-1 * var(--space-4));
 }
 
 .eval-dimension-title {
@@ -501,12 +499,6 @@
   font-weight: var(--weight-semibold);
   color: var(--color-text);
   font-variant-numeric: tabular-nums;
-}
-
-.eval-meta {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  margin: var(--space-2) 0 0;
 }
 
 /* Executive summary list */


### PR DESCRIPTION
## Summary

  - Add persistent project header with navigation breadcrumb across all views (dashboard, explorer, evaluation)
  - Add principle detail page and re-evaluate card in evaluation view
  - Implement smart frontend rebuild detection (auto-rebuilds when source files are newer than dist)

  ## Test Plan

  - [x] All 138 tests pass (\`pytest\`)
  - [x] Verify persistent header appears on dashboard, explorer, and evaluation pages
  - [x] Verify breadcrumb navigation works correctly
  - [x] Verify smart rebuild triggers on source file changes and skips when up to date