### PR TITLE
feat(evaluate): cancel evaluation + improved status panel

### DIFF
--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -93,6 +93,14 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
             return jsonify(body), status
         return jsonify(job)
 
+    @app.delete("/api/evaluations/<job_id>")
+    def cancel_evaluation(job_id: str):
+        ok = provider.cancel_evaluation(job_id)
+        if not ok:
+            body, status = _error("Job not found or not running", 404, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify({"ok": True})
+
     @app.get("/api/browse")
     def browse():
         path = request.args.get("path")

--- a/src/codecompass/action_provider.py
+++ b/src/codecompass/action_provider.py
@@ -26,5 +26,8 @@ class ActionProvider:
     def get_evaluation_status(self, job_id: str):
         raise NotImplementedError
 
+    def cancel_evaluation(self, job_id: str) -> bool:
+        raise NotImplementedError
+
     def browse_repo(self, path: str | None):
         raise NotImplementedError

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -701,6 +701,9 @@ class FilesystemActionProvider(ActionProvider):
     def get_evaluation_status(self, job_id: str):
         return self._jobs.get_job(job_id)
 
+    def cancel_evaluation(self, job_id: str) -> bool:
+        return self._jobs.cancel_job(job_id)
+
     def get_violations(self, reports_dir: str, project: str, run_id: str):
         dashboard = self.get_dashboard(reports_dir, project, run_id)
         summary = {

--- a/src/codecompass/action_provider_jobs.py
+++ b/src/codecompass/action_provider_jobs.py
@@ -44,6 +44,7 @@ class JobManager:
     def __init__(self, spawn_impl=None) -> None:
         self._spawn = spawn_impl or subprocess.Popen
         self._jobs: dict[str, Job] = {}
+        self._processes: dict[str, Any] = {}
         self._lock = threading.Lock()
 
     def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None) -> dict[str, Any]:
@@ -71,12 +72,25 @@ class JobManager:
 
         with self._lock:
             self._jobs[job_id] = job
+            self._processes[job_id] = process
 
         threading.Thread(target=self._consume_stream, args=(job_id, process.stdout), daemon=True).start()
         threading.Thread(target=self._consume_stream, args=(job_id, process.stderr), daemon=True).start()
         threading.Thread(target=self._monitor_process, args=(job_id, process), daemon=True).start()
 
         return job.to_dict()
+
+    def cancel_job(self, job_id: str) -> bool:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            process = self._processes.get(job_id)
+            if not job or job.status != "running":
+                return False
+            job.status = "cancelled"
+            job.ended_at = datetime.now(timezone.utc).isoformat()
+        if process:
+            process.terminate()
+        return True
 
     def get_job(self, job_id: str) -> dict[str, Any] | None:
         with self._lock:
@@ -110,8 +124,9 @@ class JobManager:
     def _monitor_process(self, job_id: str, process: Any) -> None:
         exit_code = process.wait()
         with self._lock:
+            self._processes.pop(job_id, None)
             job = self._jobs.get(job_id)
-            if not job:
+            if not job or job.status == "cancelled":
                 return
             job.exit_code = exit_code
             job.ended_at = datetime.now(timezone.utc).isoformat()

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -220,7 +220,7 @@ export default function App() {
   // -------------------------------------------------------------------------
   // Evaluation
   // -------------------------------------------------------------------------
-  const { job, jobError, startEvaluation, clearJob } = useEvaluation();
+  const { job, jobError, startEvaluation, clearJob, cancelEvaluation } = useEvaluation();
 
   function handleEvalDismiss(action) {
     if (action === 'view') {
@@ -337,23 +337,25 @@ export default function App() {
             </header>
 
             <div className="evaluate-content">
-              {selectedProject && (
+              {!job && selectedProject && (
                 <ReEvaluateCard
                   project={selectedProject}
                   onStart={startEvaluation}
-                  disabled={job?.status === 'running'}
+                  disabled={false}
                 />
               )}
 
-              <div className="panel evaluate-panel">
-                <div className="panel-header">
-                  <h3>Evaluate a Repository</h3>
+              {!job && (
+                <div className="panel evaluate-panel">
+                  <div className="panel-header">
+                    <h3>Evaluate a Repository</h3>
+                  </div>
+                  <EvaluationForm onStart={startEvaluation} disabled={false} />
                 </div>
-                <EvaluationForm onStart={startEvaluation} disabled={job?.status === 'running'} />
-              </div>
+              )}
 
               {jobError && <div className="job-error-banner">{jobError}</div>}
-              <EvaluationStatus job={job} onDismiss={handleEvalDismiss} />
+              <EvaluationStatus job={job} onDismiss={handleEvalDismiss} onCancel={cancelEvaluation} />
 
               <div className="panel evaluate-help-panel">
                 <div className="panel-header">

--- a/ui/web/src/api/index.js
+++ b/ui/web/src/api/index.js
@@ -42,6 +42,10 @@ export function getEvaluation(jobId) {
   return request(`/evaluations/${encodeURIComponent(jobId)}`);
 }
 
+export function cancelEvaluation(jobId) {
+  return request(`/evaluations/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
+}
+
 export function getAccumulated(project, asOfRun = null) {
   const q = asOfRun ? `?asOf=${encodeURIComponent(asOfRun)}` : '';
   return request(`/projects/${encodeURIComponent(project)}/accumulated${q}`);

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,6 +1,18 @@
 import { useEffect, useRef } from 'react';
 
-export default function EvaluationStatus({ job, onDismiss }) {
+function deriveProjectName(repo) {
+  if (!repo) return null;
+  return repo.replace(/\.git$/, '').split(/[/\\]/).filter(Boolean).pop() || null;
+}
+
+function statusTitle(status) {
+  if (status === 'running') return 'Evaluation in Progress';
+  if (status === 'done') return 'Evaluation Complete';
+  if (status === 'failed') return 'Evaluation Failed';
+  return 'Evaluation Cancelled';
+}
+
+export default function EvaluationStatus({ job, onDismiss, onCancel }) {
   const logViewerRef = useRef(null);
 
   useEffect(() => {
@@ -12,46 +24,62 @@ export default function EvaluationStatus({ job, onDismiss }) {
   if (!job) return null;
 
   const isRunning = job.status === 'running';
-  const isDone = job.status === 'completed';
+  const isDone = job.status === 'done';
+  const projectName = deriveProjectName(job.repo);
 
   return (
     <div className="panel evaluate-job-panel">
       <div className="job-header">
-        <h3>Evaluation Progress</h3>
+        <div className="job-header-left">
+          {isRunning && <span className="job-spinner" />}
+          <h3>{statusTitle(job.status)}</h3>
+        </div>
         <span className={`job-status-badge ${job.status}`}>{job.status}</span>
       </div>
 
-      <div className="job-info">
-        <div className="job-info-item">
-          <span className="job-info-label">Job ID</span>
-          <code>{job.jobId}</code>
+      <div className="job-meta">
+        {projectName && (
+          <div className="job-meta-item">
+            <span className="job-meta-label">Project</span>
+            <span className="job-meta-value">{projectName}</span>
+          </div>
+        )}
+        <div className="job-meta-item">
+          <span className="job-meta-label">Job ID</span>
+          <code className="job-meta-code job-meta-code--muted">{job.jobId}</code>
         </div>
         {job.repo && (
-          <div className="job-info-item">
-            <span className="job-info-label">Repository</span>
-            <code>{job.repo}</code>
+          <div className="job-meta-item job-meta-item--full">
+            <span className="job-meta-label">Repository</span>
+            <code className="job-meta-code">{job.repo}</code>
           </div>
         )}
       </div>
 
       <div className="console-output">
         <pre ref={logViewerRef}>
-          {job.logs?.length ? job.logs.join('\n') : 'Waiting for output...'}
+          {job.logs?.length ? job.logs.join('\n') : 'Waiting for output…'}
         </pre>
       </div>
 
-      {!isRunning && (
-        <div className="job-actions">
-          {isDone && (
-            <button className="view-results-btn" onClick={() => onDismiss('view')}>
-              View Results
-            </button>
-          )}
-          <button className="job-close-btn" onClick={() => onDismiss('close')}>
-            {isDone ? 'Dismiss' : 'Close'}
+      <div className="job-actions">
+        {isRunning ? (
+          <button className="job-cancel-btn" onClick={onCancel}>
+            Cancel
           </button>
-        </div>
-      )}
+        ) : (
+          <>
+            {isDone && (
+              <button className="view-results-btn" onClick={() => onDismiss('view')}>
+                View Results
+              </button>
+            )}
+            <button className="job-close-btn" onClick={() => onDismiss('close')}>
+              {isDone ? 'Dismiss' : 'Close'}
+            </button>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/ui/web/src/features/evaluation/hooks/useEvaluation.js
+++ b/ui/web/src/features/evaluation/hooks/useEvaluation.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { startEvaluation, getEvaluation } from '../../../api/index.js';
+import { startEvaluation, getEvaluation, cancelEvaluation } from '../../../api/index.js';
 
 export function useEvaluation() {
   const [job, setJob] = useState(null);
@@ -26,7 +26,7 @@ export function useEvaluation() {
     pollRef.current = setInterval(async () => {
       try {
         const updated = await getEvaluation(jobId);
-        setJob(updated);
+        setJob((prev) => ({ ...updated, repo: prev?.repo }));
         if (updated.status !== 'running') {
           stopPolling();
         }
@@ -41,7 +41,7 @@ export function useEvaluation() {
     setJobError('');
     try {
       const created = await startEvaluation(payload);
-      setJob(created);
+      setJob({ ...created, repo: payload.repo });
       startPolling(created.jobId);
     } catch (err) {
       setJobError(err.message);
@@ -54,5 +54,15 @@ export function useEvaluation() {
     stopPolling();
   }
 
-  return { job, jobError, startEvaluation: startEvaluationJob, clearJob };
+  async function cancelEvaluationJob() {
+    if (!job?.jobId) return;
+    try {
+      await cancelEvaluation(job.jobId);
+      clearJob();
+    } catch (err) {
+      setJobError(err.message);
+    }
+  }
+
+  return { job, jobError, startEvaluation: startEvaluationJob, clearJob, cancelEvaluation: cancelEvaluationJob };
 }

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -110,108 +110,224 @@
   margin-bottom: 20px;
 }
 
-.job-header h3 {
-  margin: 0;
+.job-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
+.job-header h3 {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+}
+
+/* Spinner shown while running */
+.job-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Status badge */
 .job-status-badge {
-  padding: 6px 14px;
+  padding: 4px 12px;
   border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .job-status-badge.pending {
-  background: rgba(255, 193, 7, 0.15);
-  color: #ffc107;
+  background: rgba(255, 193, 7, 0.12);
+  color: #d4a400;
 }
 
 .job-status-badge.running {
-  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   color: var(--color-accent);
   animation: pulse 2s infinite;
 }
 
+.job-status-badge.done,
 .job-status-badge.completed {
-  background: rgba(76, 175, 80, 0.15);
-  color: #4caf50;
+  background: color-mix(in srgb, var(--color-success) 12%, transparent);
+  color: var(--color-success);
 }
 
 .job-status-badge.failed {
-  background: rgba(255, 111, 111, 0.15);
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
   color: var(--color-danger);
+}
+
+.job-status-badge.cancelled {
+  background: color-mix(in srgb, var(--color-text-muted) 10%, transparent);
+  color: var(--color-text-muted);
 }
 
 @keyframes pulse {
   0%, 100% { opacity: 1; }
-  50% { opacity: 0.6; }
+  50% { opacity: 0.55; }
 }
 
-.job-info {
+/* Meta grid */
+.job-meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px 20px;
   margin-bottom: 20px;
   padding: 16px;
   background: var(--color-bg);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
 }
 
-.job-info-item {
+.job-meta-item {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-width: 0;
 }
 
-.job-info-label {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+.job-meta-item--full {
+  grid-column: 1 / -1;
 }
 
-.job-info-item code {
-  font-family: "SFMono-Regular", Consolas, monospace;
-  font-size: 0.85rem;
+.job-meta-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.job-meta-value {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--color-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
+.job-meta-code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.job-meta-code--muted {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+/* Console */
 .console-output {
-  background: #0a0e14;
+  background: #0d1117;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 16px;
-  max-height: 400px;
+  max-height: 420px;
   overflow-y: auto;
+}
+
+.console-output::-webkit-scrollbar {
+  width: 5px;
+}
+
+.console-output::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.console-output::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
 }
 
 .console-output pre {
   margin: 0;
-  font-family: "SFMono-Regular", Consolas, monospace;
+  font-family: var(--font-mono);
   font-size: 0.8rem;
-  line-height: 1.6;
+  line-height: 1.65;
   color: #8bc34a;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
+/* Action row */
 .job-actions {
   margin-top: 20px;
   display: flex;
-  gap: 12px;
+  gap: 10px;
 }
 
 .view-results-btn {
-  padding: 12px 24px;
+  padding: 10px 22px;
   background: var(--color-accent);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   color: var(--color-bg);
-  font-weight: 600;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   cursor: pointer;
-  transition: transform 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
 .view-results-btn:hover {
-  transform: translateY(-2px);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--color-accent) 35%, transparent);
+}
+
+.job-cancel-btn {
+  padding: 10px 22px;
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.job-cancel-btn:hover {
+  background: color-mix(in srgb, var(--color-danger) 18%, transparent);
+  border-color: var(--color-danger);
+}
+
+.job-close-btn {
+  padding: 10px 22px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.job-close-btn:hover {
+  background: var(--color-surface-alt);
+  border-color: color-mix(in srgb, var(--color-text-muted) 50%, transparent);
+  color: var(--color-text);
 }
 
 /* Help Panel */


### PR DESCRIPTION
## Summary

- Add `DELETE /api/evaluations/<job_id>` to kill running jobs (SIGTERM via `JobManager`)
- Cancel button in the UI kills the job and dismisses the panel in one action
- Evaluate and Re-evaluate panels hidden while a job is active; restored only after dismissal
- `EvaluationStatus` now shows a meta grid with project name, repo address, and job ID
- Meta grid persists across polling updates and all terminal states (done, failed, cancelled)
- Improved status badges, running spinner, console scrollbar, and button styles

## Test plan

- [x] Start an evaluation and verify both form panels collapse
- [x] Click Cancel — job should terminate and panel should dismiss immediately
- [x] Let a job complete — verify meta grid (project, repo, job ID) stays consistent
- [x] Let a job fail — verify meta grid still shows, Close button appears
- [x] Dismiss the status panel — verify form panels reappear
