### PR TITLE
feat(repo-handler): copy local repos to tmp and strip gitignored files

### DIFF
--- a/src/codecompass/evaluate/lib/repo_handler.py
+++ b/src/codecompass/evaluate/lib/repo_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 import subprocess
 
@@ -8,16 +9,45 @@ def is_repo_url(repo_input: str) -> bool:
     return repo_input.startswith(("http://", "https://", "git@"))
 
 
+def _strip_gitignored(src_repo: Path, dest: Path) -> None:
+    """Remove files/dirs from dest that are gitignored in src_repo."""
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "--directory"],
+        cwd=str(src_repo),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return
+    for rel in result.stdout.splitlines():
+        rel = rel.strip().rstrip("/")
+        if not rel:
+            continue
+        target = dest / rel
+        if target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+        elif target.is_file():
+            target.unlink(missing_ok=True)
+
+
 def prepare_repository(repo_input: str) -> str:
     repo_root = Path(__file__).resolve().parents[3]
+    tmp_base = repo_root / "tmp"
+    tmp_base.mkdir(parents=True, exist_ok=True)
+
     if is_repo_url(repo_input):
         repo_name = repo_input.split("/")[-1].replace(".git", "")
-        dest = repo_root / "tmp" / repo_name
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest = tmp_base / repo_name
         subprocess.run(["git", "clone", repo_input, str(dest)], check=True)
         return str(dest.resolve())
 
     local_path = Path(repo_input).resolve()
     if not local_path.exists():
         raise FileNotFoundError(f"Local path {local_path} does not exist")
-    return str(local_path)
+
+    dest = tmp_base / local_path.name
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(str(local_path), str(dest), ignore=shutil.ignore_patterns(".git"))
+    _strip_gitignored(local_path, dest)
+    return str(dest.resolve())

--- a/tests/test_evaluate_repo_handler.py
+++ b/tests/test_evaluate_repo_handler.py
@@ -12,10 +12,40 @@ def test_is_repo_url():
     assert not is_repo_url("/local/path/to/repo")
 
 
-def test_prepare_repository_local(tmp_path: Path):
-    repo = tmp_path / "repo"
+def test_prepare_repository_local_copies_to_tmp(tmp_path: Path, monkeypatch):
+    # Set up a fake local repo with some files and a gitignored file
+    repo = tmp_path / "my-repo"
     repo.mkdir()
-    assert prepare_repository(str(repo)) == str(repo.resolve())
+    (repo / "main.py").write_text("print('hello')")
+    (repo / "secret.env").write_text("SECRET=abc")
+    (repo / ".gitignore").write_text("secret.env\n")
+
+    def fake_git(cmd, cwd, capture_output, text):
+        # Simulate `git ls-files --others --ignored ...` returning secret.env
+        class R:
+            returncode = 0
+            stdout = "secret.env\n"
+        return R()
+
+    monkeypatch.setattr("subprocess.run", fake_git)
+
+    dest = prepare_repository(str(repo))
+    dest_path = Path(dest)
+
+    # Should be copied to tmp/, not the original path
+    assert dest_path != repo.resolve()
+    assert dest_path.name == "my-repo"
+    assert (dest_path / "main.py").exists()
+    assert (dest_path / ".gitignore").exists()
+    # Gitignored file should be stripped
+    assert not (dest_path / "secret.env").exists()
+    # .git dir should not be copied
+    assert not (dest_path / ".git").exists()
+
+
+def test_prepare_repository_local_missing_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        prepare_repository(str(tmp_path / "nonexistent"))
 
 
 def test_prepare_repository_url_creates_tmp(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

- `prepare_repository` now copies local repos to `tmp/<repo_name>` instead of using the original path directly
- After copying, strips all files/dirs matching `.gitignore` patterns using `git ls-files --others --ignored --exclude-standard --directory`
- `.git` dir is excluded from the copy
- Brings local repo behaviour in line with remote — `git clone` already excludes gitignored files, now local repos match

## Test plan

- [x] Start an evaluation on a local repo — verify it runs from a copy under `tmp/`, not the original path
- [x] Confirm gitignored files (e.g. `node_modules/`, `.env`) are absent from the copy
- [x] Confirm `.gitignore` itself is still present in the copy
- [x] Confirm tracked source files are untouched
- [x] Run `pytest tests/test_evaluate_repo_handler.py` — all 4 tests pass