### PR TITLE
feat(settings): AI client selection with dynamic detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 evaluations/
 v1/
 docs/
+src/tmp/

--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -79,6 +79,8 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
                 dimensions=payload.get("dimensions") or "",
                 numerical=bool(payload.get("numerical")),
                 reports_dir=_reports_dir(),
+                ai_cmd=payload.get("aiCmd") or None,
+                ai_model=payload.get("aiModel") or None,
             )
         except FileNotFoundError as exc:
             body, status = _error(str(exc), 400, "INVALID_INPUT")
@@ -100,6 +102,14 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
             body, status = _error("Job not found or not running", 404, "NOT_FOUND")
             return jsonify(body), status
         return jsonify({"ok": True})
+
+    @app.get("/api/ai-clients")
+    def ai_clients():
+        return jsonify(provider.get_ai_clients())
+
+    @app.get("/api/ai-clients/<client_id>/models")
+    def client_models(client_id: str):
+        return jsonify(provider.get_client_models(client_id))
 
     @app.get("/api/browse")
     def browse():

--- a/src/codecompass/action_provider.py
+++ b/src/codecompass/action_provider.py
@@ -20,7 +20,7 @@ class ActionProvider:
     def get_violations(self, reports_dir: str, project: str, run_id: str):
         raise NotImplementedError
 
-    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str):
+    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str, ai_cmd: str | None = None, ai_model: str | None = None):
         raise NotImplementedError
 
     def get_evaluation_status(self, job_id: str):
@@ -30,4 +30,10 @@ class ActionProvider:
         raise NotImplementedError
 
     def browse_repo(self, path: str | None):
+        raise NotImplementedError
+
+    def get_ai_clients(self):
+        raise NotImplementedError
+
+    def get_client_models(self, client_id: str):
         raise NotImplementedError

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import os
 from pathlib import Path
+import shutil
 import sys
 from typing import Any
 
@@ -671,7 +672,7 @@ class FilesystemActionProvider(ActionProvider):
             return _parse_eval_markdown(content, project, run_id, dimension)
         return None
 
-    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str):
+    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str, ai_cmd: str | None = None, ai_model: str | None = None):
         repo_path = Path(repo)
         if not is_repo_url(repo) and not repo_path.exists():
             raise FileNotFoundError(f"Repository not found: {repo}")
@@ -695,8 +696,14 @@ class FilesystemActionProvider(ActionProvider):
         info_dir.mkdir(parents=True, exist_ok=True)
         (info_dir / "repository_info.json").write_text(json.dumps(info))
 
+        env = dict(os.environ)
+        if ai_cmd:
+            env["AI_CMD"] = ai_cmd
+        if ai_model:
+            env["AI_MODEL"] = ai_model
+
         cwd = str(Path.cwd()) if is_repo_url(repo) else str(repo_path.resolve())
-        return self._jobs.start_job(cmd, cwd=cwd, env=dict(os.environ))
+        return self._jobs.start_job(cmd, cwd=cwd, env=env)
 
     def get_evaluation_status(self, job_id: str):
         return self._jobs.get_job(job_id)
@@ -739,6 +746,67 @@ class FilesystemActionProvider(ActionProvider):
         summary["files"] = files
         summary.pop("byFile", None)
         return summary
+
+    def get_ai_clients(self):
+        candidates = [
+            {"id": "claude", "label": "Claude"},
+            {"id": "codex", "label": "Codex"},
+            {"id": "copilot", "label": "Copilot"},
+        ]
+        return {"clients": [c for c in candidates if shutil.which(c["id"])]}
+
+    def get_client_models(self, client_id: str):
+        if client_id == "claude":
+            return self._get_claude_models()
+        import subprocess
+        if not shutil.which(client_id):
+            return {"models": []}
+        try:
+            result = subprocess.run(
+                [client_id, "/models"],
+                capture_output=True,
+                text=True,
+                timeout=8,
+            )
+            output = result.stdout if result.returncode == 0 else ""
+        except (subprocess.TimeoutExpired, OSError):
+            return {"models": []}
+        models = []
+        for line in output.splitlines():
+            token = line.strip().split()[0] if line.strip() else ""
+            if token and token[0] not in ("#", "=", "-", "[", "("):
+                models.append(token)
+        return {"models": models}
+
+    def _get_claude_models(self):
+        import json
+        import urllib.request
+        # Try direct API call when ANTHROPIC_API_KEY is available
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if api_key:
+            try:
+                req = urllib.request.Request(
+                    "https://api.anthropic.com/v1/models",
+                    headers={
+                        "x-api-key": api_key,
+                        "anthropic-version": "2023-06-01",
+                    },
+                )
+                with urllib.request.urlopen(req, timeout=8) as resp:
+                    data = json.loads(resp.read())
+                models = [m["id"] for m in data.get("data", []) if m.get("id")]
+                if models:
+                    return {"models": models}
+            except Exception:
+                pass
+        # Fall back to a curated list of current models.
+        # Claude Code uses OAuth (web login) — there's no way to call /v1/models
+        # without an API key, so we maintain this list manually.
+        return {"models": [
+            "claude-opus-4-5",
+            "claude-sonnet-4-5",
+            "claude-haiku-4-5",
+        ]}
 
     def browse_repo(self, path: str | None):
         target = Path(path) if path else Path.home()

--- a/src/codecompass/evaluate/lib/ai_cli_provider.py
+++ b/src/codecompass/evaluate/lib/ai_cli_provider.py
@@ -5,3 +5,7 @@ import os
 
 def get_ai_cmd() -> str:
     return os.environ.get("AI_CMD", "claude")
+
+
+def get_ai_model() -> str | None:
+    return os.environ.get("AI_MODEL") or None

--- a/src/codecompass/evaluate/lib/analysis.py
+++ b/src/codecompass/evaluate/lib/analysis.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from codecompass.evaluate.lib.ai_cli_provider import get_ai_cmd
+from codecompass.evaluate.lib.ai_cli_provider import get_ai_cmd, get_ai_model
 from codecompass.evaluate.lib.common import log_error, log_info, log_success, log_warning
 
 
@@ -179,14 +179,12 @@ def run_analysis_phase(
 ) -> None:
     """Run the AI analysis phase, capturing stream-json output to stream_file."""
     cmd = get_ai_cmd()
+    model = get_ai_model()
     analysis_tools = "Bash,Glob,Grep,Read"
 
-    args = [
-        cmd, "--print",
-        "--output-format", "stream-json",
-        "--verbose",
-        "--tools", analysis_tools,
-    ]
+    args = [cmd, "--print", "--output-format", "stream-json", "--verbose", "--tools", analysis_tools]
+    if model:
+        args.extend(["--model", model])
     if not deep_unrestricted and analysis_budget:
         args.extend(["--max-budget-usd", str(analysis_budget)])
     args.extend(["-p", prompt])
@@ -242,7 +240,11 @@ def run_scoring_phase(
         log_info(f"{dimension_tag} Scoring (with insufficient evidence — scores will reflect this)...")
 
     cmd = get_ai_cmd()
-    args = [cmd, "--print", "--tools", "", "-p", scoring_prompt]
+    model = get_ai_model()
+    args = [cmd, "--print", "--tools", ""]
+    if model:
+        args.extend(["--model", model])
+    args.extend(["-p", scoring_prompt])
 
     with open(eval_file, "w") as out:
         result = subprocess.run(

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { listProjects } from './api/index.js';
+import { listProjects, getAiClients } from './api/index.js';
 import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import RunNavigator from './features/dashboard/components/RunNavigator.jsx';
@@ -13,6 +13,7 @@ import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
 import PrincipleDetailPage from './features/explorer/components/PrincipleDetailPage.jsx';
 import EvalPrincipleDetailPage from './features/explorer/components/EvalPrincipleDetailPage.jsx';
 import { formatRunId } from './utils/formatters.js';
+
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -218,9 +219,38 @@ export default function App() {
   }
 
   // -------------------------------------------------------------------------
+  // AI settings
+  // -------------------------------------------------------------------------
+  const [aiCmd, setAiCmd] = useState(localStorage.getItem('cc-ai-cmd') || '');
+  const [availableClients, setAvailableClients] = useState(null);
+
+  useEffect(() => {
+    if (activePage.page !== 'settings' || availableClients !== null) return;
+    getAiClients()
+      .then((data) => {
+        const clients = data.clients || [];
+        setAvailableClients(clients);
+        if (aiCmd && !clients.some((c) => c.id === aiCmd)) {
+          setAiCmd('');
+          localStorage.removeItem('cc-ai-cmd');
+        }
+      })
+      .catch(() => setAvailableClients([]));
+  }, [activePage]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function applyAiCmd(value) {
+    setAiCmd(value);
+    localStorage.setItem('cc-ai-cmd', value);
+  }
+
+  // -------------------------------------------------------------------------
   // Evaluation
   // -------------------------------------------------------------------------
   const { job, jobError, startEvaluation, clearJob, cancelEvaluation } = useEvaluation();
+
+  function handleStartEvaluation(payload) {
+    startEvaluation({ ...payload, aiCmd: aiCmd || undefined });
+  }
 
   function handleEvalDismiss(action) {
     if (action === 'view') {
@@ -340,7 +370,7 @@ export default function App() {
               {!job && selectedProject && (
                 <ReEvaluateCard
                   project={selectedProject}
-                  onStart={startEvaluation}
+                  onStart={handleStartEvaluation}
                   disabled={false}
                 />
               )}
@@ -350,7 +380,7 @@ export default function App() {
                   <div className="panel-header">
                     <h3>Evaluate a Repository</h3>
                   </div>
-                  <EvaluationForm onStart={startEvaluation} disabled={false} />
+                  <EvaluationForm onStart={handleStartEvaluation} disabled={false} />
                 </div>
               )}
 
@@ -403,11 +433,25 @@ export default function App() {
         return (
           <div className="settings-page">
             <div className="settings-header">
-              <h1 className="settings-title">Settings</h1>
+              <div className="settings-header-content">
+                <div className="settings-page-icon">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                  </svg>
+                </div>
+                <div>
+                  <h1 className="settings-title">Settings</h1>
+                  <p className="settings-subtitle">Manage your CodeCompass preferences</p>
+                </div>
+              </div>
             </div>
+
             <div className="settings-body">
-              <section className="settings-section">
-                <h2 className="settings-section-title">Appearance</h2>
+              <section className="panel settings-section">
+                <div className="panel-header">
+                  <h2 className="settings-section-title">Appearance</h2>
+                </div>
                 <div className="settings-row">
                   <div className="settings-row-label">
                     <span className="settings-label">Theme</span>
@@ -430,6 +474,69 @@ export default function App() {
                     ))}
                   </div>
                 </div>
+              </section>
+
+              <section className="panel settings-section">
+                <div className="panel-header">
+                  <h2 className="settings-section-title">Analysis</h2>
+                  <p className="settings-section-description">Configure the AI client used when running evaluations</p>
+                </div>
+                <div className={`settings-row${!aiCmd ? ' settings-row--last' : ''}`}>
+                  <div className="settings-row-label">
+                    <span className="settings-label">Client</span>
+                    <span className="settings-description">CLI tool used to run the analysis</span>
+                  </div>
+                  {availableClients === null ? (
+                    <span className="settings-description">Detecting…</span>
+                  ) : availableClients.length > 0 ? (
+                    <div className="theme-toggle">
+                      {availableClients.map(({ id, label }) => (
+                        <button
+                          key={id}
+                          type="button"
+                          className={`theme-toggle-btn${aiCmd === id ? ' active' : ''}`}
+                          onClick={() => applyAiCmd(id)}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                {availableClients !== null && availableClients.length === 0 && (
+                  <div className="settings-row settings-row--last settings-install-guide">
+                    <div className="settings-row-label">
+                      <span className="settings-label">No AI client detected</span>
+                      <span className="settings-description">
+                        Install one of the supported CLI tools and restart CodeCompass.
+                      </span>
+                    </div>
+                    <div className="settings-install-options">
+                      <div className="settings-install-item">
+                        <span className="settings-install-name">Claude</span>
+                        <code className="settings-install-cmd">npm i -g @anthropic-ai/claude-code</code>
+                      </div>
+                      <div className="settings-install-item">
+                        <span className="settings-install-name">Codex</span>
+                        <code className="settings-install-cmd">npm i -g @openai/codex</code>
+                      </div>
+                      <div className="settings-install-item">
+                        <span className="settings-install-name">Copilot</span>
+                        <code className="settings-install-cmd">gh extension install github/gh-copilot</code>
+                      </div>
+                    </div>
+                  </div>
+                )}
+                {aiCmd && (
+                  <div className="settings-row settings-row--last">
+                    <div className="settings-row-label">
+                      <span className="settings-label">Model</span>
+                      <span className="settings-description">
+                        Uses your client's default model. Run <code>{aiCmd} --help</code> to see how to change it.
+                      </span>
+                    </div>
+                  </div>
+                )}
               </section>
             </div>
           </div>

--- a/ui/web/src/api/index.js
+++ b/ui/web/src/api/index.js
@@ -61,3 +61,11 @@ export function browseDirectory(dirPath = '') {
   const q = dirPath ? `?path=${encodeURIComponent(dirPath)}` : '';
   return request(`/browse${q}`);
 }
+
+export function getAiClients() {
+  return request('/ai-clients');
+}
+
+export function getClientModels(clientId) {
+  return request(`/ai-clients/${encodeURIComponent(clientId)}/models`);
+}

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -826,65 +826,204 @@ textarea:focus {
 }
 
 .settings-header {
-  padding: var(--space-6) var(--space-8) var(--space-4);
+  padding: var(--space-8) var(--space-8) var(--space-6);
   border-bottom: 1px solid var(--color-border);
+}
+
+.settings-header-content {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  max-width: 760px;
+}
+
+.settings-page-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--color-accent-soft);
+  border-radius: var(--radius-lg);
+  color: var(--color-accent);
+  flex-shrink: 0;
 }
 
 .settings-title {
-  font-size: var(--text-2xl);
+  font-size: var(--text-lg);
   font-weight: var(--weight-semibold);
   color: var(--color-text);
+  margin: 0 0 2px 0;
+}
+
+.settings-subtitle {
   margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
 }
 
 .settings-body {
-  padding: var(--space-6) var(--space-8);
+  padding: var(--space-8);
   display: flex;
   flex-direction: column;
-  gap: var(--space-8);
-  max-width: 640px;
+  gap: var(--space-5);
+  max-width: 760px;
 }
 
+/* Card: zero out .panel's default padding; rows carry their own */
 .settings-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4);
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Section header: override .panel-header from evaluation.css */
+.settings-section .panel-header {
+  padding: var(--space-4) var(--space-6);
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
 }
 
 .settings-section-title {
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.07em;
   margin: 0;
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-section-description {
+  margin: var(--space-1) 0 0 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 
 .settings-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-3) 0;
+  gap: var(--space-8);
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-row--last {
+  border-bottom: none;
 }
 
 .settings-row-label {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+  padding-top: 2px;
 }
 
 .settings-label {
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
   color: var(--color-text);
+  line-height: 1.4;
 }
 
 .settings-description {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.settings-description code {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+  color: var(--color-text);
+}
+
+.settings-install-guide {
+  align-items: flex-start;
+  gap: var(--space-6);
+}
+
+.settings-install-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.settings-install-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-install-name {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  width: 52px;
+  flex-shrink: 0;
+}
+
+.settings-install-cmd {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+/* Shared field base for controls on the right side of a row */
+.settings-select,
+.settings-input {
+  width: auto;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  min-width: 200px;
+  flex-shrink: 0;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.settings-select {
+  appearance: none;
+  padding-right: var(--space-8);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239a9490' stroke-width='2.5'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--space-3) center;
+  cursor: pointer;
+}
+
+.settings-input {
+  cursor: text;
+}
+
+.settings-input::placeholder {
+  color: var(--color-text-subtle);
+}
+
+.settings-select:focus,
+.settings-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+
+.settings-select:hover,
+.settings-input:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
 }
 
 /* ─── Theme toggle ─── */


### PR DESCRIPTION
## Summary

- **Client detection**: `GET /api/ai-clients` uses `shutil.which` to detect installed CLI tools (`claude`, `codex`, `copilot`) and returns only the ones actually present on the system
- **Dynamic model list**: `GET /api/ai-clients/<id>/models` runs `<client> /models` to retrieve real model lists; `claude` falls back to `ANTHROPIC_API_KEY` → Anthropic API when the CLI doesn't support `/models`
- **AI passthrough**: selected `aiCmd` is forwarded to `start_evaluation` and injected as `AI_CMD` env var into the evaluation subprocess, picked up by analysis and scoring phases
- **Settings UX**: segmented toggle shows only installed clients; progressive disclosure reveals model info row only after a client is selected; install instructions (`npm`/`gh` commands) are shown when no clients are detected
- **Settings styling**: uppercase category headers, top-aligned rows, `settings-input` class (no chevron), install guide with monospace command blocks

## Test plan

- [x] Open Settings with no AI clients installed → install instructions shown for Claude, Codex, Copilot
- [x] Open Settings with one or more clients installed → only available clients appear in the toggle
- [x] Select a client → model row appears with correct `--help` hint
- [x] Start an evaluation with a client selected → `AI_CMD` is set in subprocess env and that client is used
- [x] Start an evaluation with no client selected → evaluation runs with default client