### PR TITLE
feat: improve evaluation UX, fix repo copy, process management, and dimension filtering

### DIFF
--- a/config/disciplines.conf
+++ b/config/disciplines.conf
@@ -110,3 +110,13 @@ detect_file=package.json
 detect_priority=9
 detect_fallback=true
 suggested_topics=Node.js Best Practices,SOLID Principles,Error Handling Patterns,Security Practices,API Design Standards,TypeScript Standards
+
+[python_fullstack]
+language=python
+category=backend
+detect_file=pyproject.toml
+detect_file_alt=setup.py
+detect_dir=src
+detect_requires_file=src/**/*.py
+detect_priority=6
+suggested_topics=Python Code Standards,Python Architecture,Python Testing,LLM Pipeline Patterns

--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -29,6 +29,14 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
     def list_projects():
         return jsonify(provider.list_projects(_reports_dir()))
 
+    @app.get("/api/projects/<project>/info")
+    def project_info(project: str):
+        info = provider.get_project_info(_reports_dir(), project)
+        if not info:
+            body, status = _error("Project info not found", 404, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(info)
+
     @app.get("/api/projects/<project>/dashboard")
     def dashboard(project: str):
         run = request.args.get("run", "latest")

--- a/src/codecompass/action_provider.py
+++ b/src/codecompass/action_provider.py
@@ -5,6 +5,9 @@ class ActionProvider:
     def list_projects(self, reports_dir: str):
         raise NotImplementedError
 
+    def get_project_info(self, reports_dir: str, project: str):
+        raise NotImplementedError
+
     def get_dashboard(self, reports_dir: str, project: str, run: str):
         raise NotImplementedError
 

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -479,6 +479,49 @@ class FilesystemActionProvider(ActionProvider):
         projects.sort(key=lambda item: item["name"])
         return {"projects": projects}
 
+    def get_project_info(self, reports_dir: str, project: str):
+        info_path = Path(reports_dir) / project / "repository_info.json"
+        if not info_path.exists():
+            return None
+        try:
+            info = json.loads(info_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+        discipline = info.get("discipline")
+
+        # Discipline may be null for projects evaluated via CLI — infer it from
+        # the most recent evidence file, which always records the discipline.
+        if not discipline:
+            reports_root = Path(reports_dir)
+            for run in sorted(_safe_read_dir(reports_root / project), key=lambda e: e.name, reverse=True):
+                if not run.is_dir():
+                    continue
+                for ev in _safe_read_dir(reports_root / project / run.name / "evidence"):
+                    if ev.name.endswith("_evidence.json"):
+                        try:
+                            d = json.loads(Path(ev.path).read_text()).get("discipline")
+                            if d:
+                                discipline = d
+                        except Exception:
+                            pass
+                if discipline:
+                    break
+
+        available_dimensions: list[str] = []
+        if discipline:
+            try:
+                from codecompass.adapters.fs.evaluators_repository import FilesystemEvaluatorsRepository
+                from codecompass.config.paths import default_paths
+                from codecompass.evaluate.lib.dimensions import list_available_dimensions
+                paths = default_paths()
+                evaluators = FilesystemEvaluatorsRepository(root=paths.vroot)
+                available_dimensions = list_available_dimensions(evaluators, discipline)
+            except Exception:
+                pass
+
+        return {**info, "discipline": discipline, "availableDimensions": available_dimensions}
+
     def get_dashboard(self, reports_dir: str, project: str, run: str):
         reports_root = Path(reports_dir)
         runs = _list_runs(reports_root, project)
@@ -696,7 +739,7 @@ class FilesystemActionProvider(ActionProvider):
         info_dir.mkdir(parents=True, exist_ok=True)
         (info_dir / "repository_info.json").write_text(json.dumps(info))
 
-        env = dict(os.environ)
+        env = {**os.environ, "PYTHONUNBUFFERED": "1"}
         if ai_cmd:
             env["AI_CMD"] = ai_cmd
         if ai_model:

--- a/src/codecompass/cli.py
+++ b/src/codecompass/cli.py
@@ -56,6 +56,7 @@ def main(argv: list[str] | None = None) -> int:
             repo=repo,
             reports_dir=Path(args.evaluations),
             reports_defaulted=reports_defaulted,
+            dimensions=dimensions,
             version=getattr(args, "data_version", None),
         )
         return run_evaluate(config)

--- a/src/codecompass/dashboard/runner.py
+++ b/src/codecompass/dashboard/runner.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -99,6 +100,7 @@ def _spawn_action_api(port: int) -> subprocess.Popen:
     return subprocess.Popen(
         [sys.executable, "-m", "codecompass.action_api"],
         env=env,
+        start_new_session=True,
     )
 
 
@@ -185,6 +187,7 @@ def _start_ui_server(config: DashboardConfig, action_api_url: str) -> subprocess
             str(config.port),
         ],
         env=env,
+        start_new_session=True,
     )
 
 
@@ -246,9 +249,25 @@ def run_dashboard(config: DashboardConfig) -> int:
     if config.open_browser:
         webbrowser.open(f"http://localhost:{config.port}")
 
+    def _stop_children() -> None:
+        for proc in (process, action_api_process):
+            if proc and proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+    def _handle_tstp(signum, frame) -> None:
+        """Ctrl+Z: shut down cleanly instead of suspending."""
+        _stop_children()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTSTP, _handle_tstp)
+
     try:
         return process.wait()
+    except KeyboardInterrupt:
+        pass
     finally:
-        if action_api_process and action_api_process.poll() is None:
-            action_api_process.terminate()
-            action_api_process.wait()
+        _stop_children()

--- a/src/codecompass/evaluate/lib/analysis.py
+++ b/src/codecompass/evaluate/lib/analysis.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from codecompass.evaluate.lib.ai_cli_provider import get_ai_cmd, get_ai_model
-from codecompass.evaluate.lib.common import log_error, log_info, log_success, log_warning
+from codecompass.evaluate.lib.common import log_beat, log_error, log_info, log_success, log_warning
 
 
 # ---------------------------------------------------------------------------
@@ -108,12 +108,7 @@ def extract_jsonl_evidence(stream_file: str, jsonl_file: str, dimension: str) ->
             elif etype == "item.completed":
                 process_item_completed_event(data, out, stats)
 
-    events_summary = ", ".join(f"{k}:{v}" for k, v in sorted(event_types.items()))
-    log_info(
-        f"[{dimension}] Extraction: {stats['text_blocks']} text blocks, "
-        f"{stats['total_text_lines']} text lines scanned, "
-        f"{stats['jsonl_lines']} evidence lines found (events: {events_summary})"
-    )
+    pass  # evidence count is reported after assembly
 
 
 def is_stream_valid(stream_file: str) -> bool:
@@ -135,7 +130,7 @@ def is_stream_valid(stream_file: str) -> bool:
 def dump_debug_sample(stream_file: str, debug_stream: str, dimension_tag: str) -> None:
     """Save the stream file as a debug artifact and log a sample of it."""
     shutil.copy(stream_file, debug_stream)
-    log_warning(f"{dimension_tag} No evidence extracted — debug stream saved to {debug_stream}")
+    log_warning(f"No evidence extracted — debug stream saved to {Path(debug_stream).name}")
 
     with open(stream_file) as f:
         for line in f:
@@ -148,8 +143,8 @@ def dump_debug_sample(stream_file: str, debug_stream: str, dimension_tag: str) -
                 for block in d.get("message", {}).get("content", []):
                     if block.get("type") == "text":
                         text = block["text"]
-                        preview = text[:500].replace("\n", "\n    ")
-                        log_info(f"  [DEBUG] Sample text block ({len(text)} chars):\n    {preview}")
+                        preview = text[:400].replace("\n", "\n    ")
+                        log_info(f"  debug sample ({len(text)} chars):\n    {preview}")
                         return
 
             if d.get("type") == "item.completed":
@@ -157,11 +152,11 @@ def dump_debug_sample(stream_file: str, debug_stream: str, dimension_tag: str) -
                 if item.get("type") == "agent_message":
                     text = item.get("text", "")
                     if text:
-                        preview = text[:500].replace("\n", "\n    ")
-                        log_info(f"  [DEBUG] Sample agent_message text ({len(text)} chars):\n    {preview}")
+                        preview = text[:400].replace("\n", "\n    ")
+                        log_info(f"  debug sample ({len(text)} chars):\n    {preview}")
                         return
 
-    log_info("  [DEBUG] No assistant text blocks found in stream")
+    log_info("  debug: no assistant text blocks found in stream")
 
 
 # ---------------------------------------------------------------------------
@@ -193,8 +188,6 @@ def run_analysis_phase(
     if "CODEX_SANDBOX" not in env:
         env["CODEX_SANDBOX"] = "read-only"
 
-    log_info(f"{dimension_tag} Analyzing (this may take a while)...")
-
     stream_err_file = stream_file + ".err"
     heartbeat_interval = 60
     with open(stream_file, "w") as stream_out, open(stream_err_file, "w") as stream_err:
@@ -212,14 +205,9 @@ def run_analysis_phase(
                 process.wait(timeout=heartbeat_interval)
             except subprocess.TimeoutExpired:
                 elapsed += heartbeat_interval
-                stream_size = Path(stream_file).stat().st_size if Path(stream_file).exists() else 0
-                log_info(f"{dimension_tag} Still analyzing... ({elapsed}s elapsed, {stream_size} bytes captured)")
-
-    events = 0
-    if Path(stream_file).exists():
-        with open(stream_file) as f:
-            events = sum(1 for line in f if line.strip())
-    log_info(f"{dimension_tag} Analysis complete ({events} stream events captured).")
+                mins, secs = divmod(elapsed, 60)
+                elapsed_label = f"{mins}m {secs}s" if mins else f"{secs}s"
+                log_beat(f"{elapsed_label} elapsed")
 
 
 def run_scoring_phase(
@@ -234,10 +222,11 @@ def run_scoring_phase(
 
     Returns True on success, False on failure.
     """
+    from codecompass.evaluate.lib.common import log_step
     if has_evidence:
-        log_info(f"{dimension_tag} Scoring...")
+        log_step("Scoring")
     else:
-        log_info(f"{dimension_tag} Scoring (with insufficient evidence — scores will reflect this)...")
+        log_step("Scoring  (no evidence — scores will reflect this)")
 
     cmd = get_ai_cmd()
     model = get_ai_model()
@@ -257,10 +246,8 @@ def run_scoring_phase(
 
     eval_path = Path(eval_file)
     if result.returncode != 0 or not eval_path.exists() or eval_path.stat().st_size == 0:
-        log_error(f"{dimension_tag} Scoring failed (exit code: {result.returncode})")
+        log_error(f"Scoring failed (exit code: {result.returncode})")
         return False
 
-    with open(eval_file) as f:
-        line_count = sum(1 for _ in f)
-    log_success(f"{dimension_tag} Evaluation complete ({line_count} lines) -> {eval_path.name}")
+    log_success(eval_path.name)
     return True

--- a/src/codecompass/evaluate/lib/common.py
+++ b/src/codecompass/evaluate/lib/common.py
@@ -2,29 +2,68 @@ from __future__ import annotations
 
 import sys
 
+_OK   = "✓"
+_ERR  = "✗"
+_WARN = "!"
+_STEP = "→"
+_BEAT = "·"
+_THIN = "─"
+_BOLD = "━"
+_WIDTH = 48
+
+
+def log_step(message: str) -> None:
+    """In-progress phase indicator (→ message)."""
+    print(f"  {_STEP} {message}", flush=True)
+
 
 def log_info(message: str) -> str:
-    formatted = f"[INFO] {message}"
+    """Plain informational line, indented."""
+    formatted = f"  {message}"
     print(formatted, flush=True)
-    return formatted
-
-
-def log_error(message: str) -> str:
-    formatted = f"[ERROR] {message}"
-    print(formatted, file=sys.stderr)
-    return formatted
-
-
-def log_warning(message: str) -> str:
-    formatted = f"[WARNING] {message}"
-    print(formatted, file=sys.stderr)
     return formatted
 
 
 def log_success(message: str) -> str:
-    formatted = f"[SUCCESS] {message}"
+    formatted = f"  {_OK} {message}"
     print(formatted, flush=True)
     return formatted
+
+
+def log_warning(message: str) -> str:
+    formatted = f"  {_WARN} {message}"
+    print(formatted, file=sys.stderr, flush=True)
+    return formatted
+
+
+def log_error(message: str) -> str:
+    formatted = f"  {_ERR} {message}"
+    print(formatted, file=sys.stderr, flush=True)
+    return formatted
+
+
+def log_beat(message: str) -> None:
+    """Heartbeat / still-running indicator (· message)."""
+    print(f"  {_BEAT} {message}", flush=True)
+
+
+def log_divider(label: str = "", width: int = _WIDTH) -> None:
+    """Thin dimension section header: ─── [1/3] resilience ──────"""
+    if label:
+        inner = f" {label} "
+        dashes = max(1, width - len(inner) - 3)
+        print(f"\n  {_THIN * 3}{inner}{_THIN * dashes}", flush=True)
+    else:
+        print(f"\n  {_THIN * width}", flush=True)
+
+
+def log_banner(lines: list[str], width: int = _WIDTH) -> None:
+    """Bold border section (━ lines above and below)."""
+    border = _BOLD * width
+    print(f"\n{border}", flush=True)
+    for line in lines:
+        print(f"  {line}", flush=True)
+    print(border, flush=True)
 
 
 def fail_with_error(message: str) -> int:

--- a/src/codecompass/evaluate/lib/dimension_runner.py
+++ b/src/codecompass/evaluate/lib/dimension_runner.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from codecompass.evaluate.lib.common import log_error, log_info, log_success
+from codecompass.evaluate.lib.common import log_banner, log_divider, log_error, log_info, log_success
 from codecompass.evaluate.lib.evaluation import compute_prompt_hash, run_two_phase_dimension
 from codecompass.evaluate.lib.evaluator_renderer import (
     extract_analysis_context,
@@ -41,11 +41,11 @@ def run_dimensions(dimensions: list[str], ctx: DimensionRunContext) -> tuple[int
     """
     success = 0
     failed = 0
+    total = len(dimensions)
 
-    log_info(f"Starting sequential analysis of {len(dimensions)} dimensions...")
-
-    for dimension in dimensions:
-        mapping_file = ctx.evaluators_dir / ctx.discipline / f"{dimension}.json"
+    for i, dimension in enumerate(dimensions):
+        log_divider(f"[{i + 1}/{total}] {dimension}")
+        evaluator_file = ctx.evaluators_dir / ctx.discipline / f"{dimension}.json"
 
         if not evaluator_file.exists():
             log_error(f"Evaluator file not found: {evaluator_file}")
@@ -66,8 +66,6 @@ def run_dimensions(dimensions: list[str], ctx: DimensionRunContext) -> tuple[int
 
         evidence_file = str(ctx.evidence_dir / f"{dimension}_evidence.json")
         eval_file = str(ctx.evaluation_dir / f"{dimension}_eval.md")
-
-        log_info(f"Evaluating: {dimension}...")
 
         ok = run_two_phase_dimension(
             work_dir=ctx.work_dir,
@@ -95,14 +93,10 @@ def run_dimensions(dimensions: list[str], ctx: DimensionRunContext) -> tuple[int
         if ok:
             success += 1
         else:
-            log_error(f"Failed: {dimension}")
+            log_error(f"[{dimension}] Failed")
             failed += 1
 
-    log_info("=" * 42)
-    log_info("Assessment Complete")
-    log_info("=" * 42)
-    log_success(f"Successful: {success}")
-    if failed:
-        log_error(f"Failed: {failed}")
+    status = f"Assessment complete  ·  {success} passed  ·  {failed} failed"
+    log_banner([status])
 
     return success, failed

--- a/src/codecompass/evaluate/lib/dimensions.py
+++ b/src/codecompass/evaluate/lib/dimensions.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
-def resolve_dimension_selection(selection: list[str], available: list[str]) -> list[str]:
+
+def resolve_dimension_selection(
+    selection: list[str], available: list[str]
+) -> tuple[list[str], list[str]]:
+    """Return (selected, skipped).
+
+    Dimensions in *selection* that are not in *available* are skipped with a
+    warning rather than aborting.  Raises ValueError only when nothing is left.
+    """
     if not selection or "all" in selection:
-        return available
-    for dim in selection:
-        if dim not in available:
-            raise ValueError(f"Dimension {dim} is not available")
-    return selection
+        return available, []
+
+    selected = [d for d in selection if d in available]
+    skipped  = [d for d in selection if d not in available]
+
+    if not selected:
+        raise ValueError(
+            f"None of the requested dimensions are available for this discipline. "
+            f"Available: {', '.join(available)}"
+        )
+
+    return selected, skipped
 
 
 def list_available_dimensions(evaluators_repo: object, discipline: str) -> list[str]:

--- a/src/codecompass/evaluate/lib/evaluation.py
+++ b/src/codecompass/evaluate/lib/evaluation.py
@@ -12,7 +12,7 @@ from codecompass.evaluate.lib.analysis import (
     run_analysis_phase,
     run_scoring_phase,
 )
-from codecompass.evaluate.lib.common import log_error, log_info, log_warning
+from codecompass.evaluate.lib.common import log_error, log_info, log_step, log_warning
 from codecompass.evaluate.lib.evidence import build_evidence_file
 from codecompass.evaluate.lib.evaluator_renderer import (
     extract_analysis_context,
@@ -77,7 +77,7 @@ def run_two_phase_dimension(
         prescan_guidance=prescan_guidance,
     )
 
-    log_info(f"{dimension_tag} Analysis: Gathering evidence (JSONL streaming)...")
+    log_step("Gathering evidence")
 
     # --- Phase 1: Analysis ---
     with (
@@ -109,9 +109,9 @@ def run_two_phase_dimension(
 
         if not stream_ok:
             if jsonl_path.exists() and jsonl_path.stat().st_size > 0:
-                log_info(f"{dimension_tag} Analysis budget reached — proceeding with partial evidence")
+                log_warning("Analysis budget reached — proceeding with partial evidence")
             else:
-                log_error(f"{dimension_tag} Analysis failed with no output")
+                log_error(f"{dimension_tag} Analysis produced no output")
                 return False
 
         # --- Assemble + validate evidence ---
@@ -151,7 +151,7 @@ def run_two_phase_dimension(
             with open(scores_file, "w") as f:
                 json.dump(scores_data, f, indent=2, sort_keys=True)
         except Exception as exc:
-            log_warning(f"{dimension_tag} Score computation failed: {exc}")
+            log_warning(f"Score computation failed: {exc}")
 
     # --- Phase 2: Scoring ---
     scoring_prompt = build_scoring_prompt(
@@ -184,6 +184,6 @@ def run_two_phase_dimension(
             scores_file=scores_file if Path(scores_file).exists() else None,
         )
     except Exception as exc:
-        log_warning(f"{dimension_tag} JSON generation failed — dashboard will fall back to .md: {exc}")
+        log_warning(f"JSON report generation failed — dashboard will fall back to .md: {exc}")
 
     return True

--- a/src/codecompass/evaluate/lib/evidence.py
+++ b/src/codecompass/evaluate/lib/evidence.py
@@ -182,10 +182,13 @@ def assemble_evidence_from_jsonl(
     with open(output_file, "w") as fh:
         json.dump(result, fh, indent=2)
 
-    log_info(
-        f"Assembled {accepted} findings across {len(principles)} principles "
-        f"({rejected} lines skipped, {dropped} duplicates removed)"
-    )
+    extras = []
+    if rejected:
+        extras.append(f"{rejected} skipped")
+    if dropped:
+        extras.append(f"{dropped} duplicates removed")
+    suffix = f"  ({', '.join(extras)})" if extras else ""
+    log_success(f"{accepted} findings across {len(principles)} principles{suffix}")
     return True
 
 
@@ -236,7 +239,6 @@ def validate_evidence_json(file: str) -> bool:
         return False
 
     path.write_text(json.dumps(data, indent=2))
-    log_info(f"Valid evidence JSON: {len(data['principles'])} principles found")
     return True
 
 
@@ -262,17 +264,15 @@ def build_evidence_file(
         source_file_count, analysis_hash, scoring_hash, mapping_hash, codecompass_version,
     )
     if not has_evidence:
-        log_warning(f"{dimension_tag} No valid evidence lines found — scoring will note insufficient evidence")
+        log_warning("No valid evidence found — scoring will note insufficient evidence")
 
     if has_evidence:
         if not validate_evidence_json(evidence_file):
-            log_error(f"{dimension_tag} Assembled evidence JSON validation failed")
+            log_error("Evidence validation failed")
             has_evidence = False
-        else:
-            log_success(f"{dimension_tag} Evidence gathered -> {evidence_file}")
 
     if not has_evidence:
-        log_warning(f"{dimension_tag} Creating minimal evidence file for scoring")
+        log_warning("Creating minimal evidence — scores will reflect insufficient data")
         minimal = {
             "repository": project_name,
             "discipline": discipline,

--- a/src/codecompass/evaluate/lib/repo_handler.py
+++ b/src/codecompass/evaluate/lib/repo_handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import tempfile
 from pathlib import Path
 import subprocess
 
@@ -31,12 +32,9 @@ def _strip_gitignored(src_repo: Path, dest: Path) -> None:
 
 
 def prepare_repository(repo_input: str) -> str:
-    repo_root = Path(__file__).resolve().parents[3]
-    tmp_base = repo_root / "tmp"
-    tmp_base.mkdir(parents=True, exist_ok=True)
-
     if is_repo_url(repo_input):
         repo_name = repo_input.split("/")[-1].replace(".git", "")
+        tmp_base = Path(tempfile.mkdtemp())
         dest = tmp_base / repo_name
         subprocess.run(["git", "clone", repo_input, str(dest)], check=True)
         return str(dest.resolve())
@@ -45,9 +43,7 @@ def prepare_repository(repo_input: str) -> str:
     if not local_path.exists():
         raise FileNotFoundError(f"Local path {local_path} does not exist")
 
-    dest = tmp_base / local_path.name
-    if dest.exists():
-        shutil.rmtree(dest)
+    dest = Path(tempfile.mkdtemp()) / local_path.name
     shutil.copytree(str(local_path), str(dest), ignore=shutil.ignore_patterns(".git"))
     _strip_gitignored(local_path, dest)
     return str(dest.resolve())

--- a/src/codecompass/evaluate/runner.py
+++ b/src/codecompass/evaluate/runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from codecompass.config.paths import default_paths
 from codecompass.evaluate.lib.ai_cli import run_ai_cli
-from codecompass.evaluate.lib.common import fail_with_error, log_info
+from codecompass.evaluate.lib.common import fail_with_error, log_banner, log_info, log_step, log_success, log_warning
 from codecompass.evaluate.lib.dimension_runner import DimensionRunContext, run_dimensions
 from codecompass.evaluate.lib.dimensions import list_available_dimensions, resolve_dimension_selection
 from codecompass.evaluate.lib.discipline_detector import (
@@ -17,7 +17,6 @@ from codecompass.evaluate.lib.discipline_detector import (
 from codecompass.evaluate.lib.evaluation import compute_prompt_hash
 from codecompass.evaluate.lib.practices_runner import build_practices_evaluation
 from codecompass.evaluate.lib.prescan import run_prescan_metrics
-from codecompass.evaluate.lib.progress import format_end, format_start
 from codecompass.evaluate.lib.repo_handler import prepare_repository
 from codecompass.adapters.fs.evaluators_repository import FilesystemEvaluatorsRepository
 from codecompass.adapters.fs.practices_repository import FilesystemPracticesRepository
@@ -113,11 +112,19 @@ def run(config: EvaluateConfig) -> int:
     except NotFoundError:
         return fail_with_error("discipline missing or evaluators directory absent")
     try:
-        selected = resolve_dimension_selection(config.dimensions or ["all"], available)
+        selected, skipped = resolve_dimension_selection(config.dimensions or ["all"], available)
     except ValueError as exc:
         return fail_with_error(str(exc))
+    if skipped:
+        log_warning(f"Skipped (not available for {config.discipline}): {', '.join(skipped)}")
     today = date.today().strftime("%Y%m%d")
     project_name = Path(config.repo).name
+
+    dim_label = ", ".join(selected) if len(selected) <= 4 else f"{len(selected)} dimensions"
+    log_banner([
+        "CodeCompass Evaluation",
+        f"Repo: {project_name}  ·  Discipline: {config.discipline}  ·  {dim_label}",
+    ])
 
     evidence_dir = config.reports_dir / project_name / today / "evidence"
     evaluation_dir = config.reports_dir / project_name / today / "evaluation"
@@ -143,11 +150,11 @@ def run(config: EvaluateConfig) -> int:
     prescan_metrics = ""
     source_file_count = 0
     if not config.no_prescan:
-        log_info(format_start("prescan"))
+        log_step("Scanning repository")
         prescan_summary = run_prescan_metrics(config.repo, config.discipline)
-        log_info(format_end("prescan"))
         prescan_metrics = prescan_summary
         source_file_count = _parse_source_file_count(prescan_summary)
+        log_success(f"{source_file_count:,} source files")
 
     ctx = DimensionRunContext(
         work_dir=config.repo,

--- a/ui/server/src/app.js
+++ b/ui/server/src/app.js
@@ -64,20 +64,19 @@ export function createApp(options = {}) {
   app.use(cors());
   app.use(express.json({ limit: '1mb' }));
 
-  // Routes handled by the Node server regardless of whether an action API is present
-  app.get('/api/projects/:project/info', (req, res) => {
-    try {
-      const infoPath = path.join(reportsRoot, req.params.project, 'repository_info.json');
-      const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
-      res.json(info);
-    } catch {
-      res.status(404).json({ error: 'Repository info not found' });
-    }
-  });
-
   if (actionApiBase) {
     app.use('/api', (req, res) => proxyToActionApi(req, res, actionApiBase));
   } else {
+    app.get('/api/projects/:project/info', (req, res) => {
+      try {
+        const infoPath = path.join(reportsRoot, req.params.project, 'repository_info.json');
+        const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+        res.json(info);
+      } catch {
+        res.status(404).json({ error: 'Repository info not found' });
+      }
+    });
+
     app.get('/api/health', (_req, res) => {
       res.json({ ok: true });
     });

--- a/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -16,6 +16,9 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
 
   if (!info) return null;
 
+  const available = new Set(info.availableDimensions ?? []);
+  const hasFilter = available.size > 0;
+
   function toggleDimension(code) {
     setSelectedDimensions((prev) =>
       prev.includes(code) ? prev.filter((d) => d !== code) : [...prev, code]
@@ -51,7 +54,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
               <button
                 type="button"
                 className="dim-action-btn"
-                onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.map((d) => d.code))}
+                onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.filter((d) => !hasFilter || available.has(d.code)).map((d) => d.code))}
               >
                 Select all
               </button>
@@ -65,16 +68,21 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
             </div>
           </div>
           <div className="dimension-grid">
-            {DIMENSION_OPTIONS.map((dim) => (
-              <button
-                key={dim.code}
-                type="button"
-                className={`dimension-chip-btn${selectedDimensions.includes(dim.code) ? ' selected' : ''}`}
-                onClick={() => toggleDimension(dim.code)}
-              >
-                {dim.name}
-              </button>
-            ))}
+            {DIMENSION_OPTIONS.map((dim) => {
+              const enabled = !hasFilter || available.has(dim.code);
+              return (
+                <button
+                  key={dim.code}
+                  type="button"
+                  className={`dimension-chip-btn${selectedDimensions.includes(dim.code) ? ' selected' : ''}`}
+                  disabled={!enabled}
+                  title={!enabled ? 'Not available for this discipline' : undefined}
+                  onClick={() => enabled && toggleDimension(dim.code)}
+                >
+                  {dim.name}
+                </button>
+              );
+            })}
           </div>
         </div>
 

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -420,8 +420,9 @@
 }
 
 .dimension-chip-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.35;
   cursor: not-allowed;
+  text-decoration: line-through;
 }
 
 .form-options {


### PR DESCRIPTION
## Summary

- **Fix infinite recursive copy** when evaluating the repo itself — use `tempfile.mkdtemp()` instead of a path inside the source tree
- **Fix `-d` dimension flag** being parsed but never passed to `EvaluateConfig` in the CLI (all dimensions were always running)
- **Console output redesign** — startup banner, `[1/N]` progress, human-readable heartbeat, cleaner success/warning/error messages across all evaluation modules
- **Re-evaluate panel shows available dimensions per discipline** — unavailable ones are disabled with strikethrough; backend infers discipline from evidence files when `repository_info.json` lacks it
- **Fix Node server intercepting `/api/projects/:project/info`** before the Python proxy, returning raw JSON without `availableDimensions`
- **Fix Ctrl+Z accumulating stale processes** — SIGTSTP now triggers a clean shutdown (like Ctrl+C) instead of suspending; child processes run in their own session so they are isolated from terminal signals

## Test plan

- [x] Run `codecompass evaluate` with `-d resilience` on a `python_fullstack` project — should warn "Skipped: resilience" and continue with the 6 available dimensions instead of aborting
- [x] Run `codecompass evaluate` on the codecompass repo itself — should complete without hanging on infinite copy
- [x] Open Re-evaluate panel for a `python_fullstack` project — 9 unavailable dimensions should appear greyed out with strikethrough; only the 6 available ones are selectable
- [x] Press Ctrl+Z while dashboard is running — should exit cleanly with no orphaned processes on subsequent start