### PR TITLE
fix(repo): use original path for local repos, only clone remote URLs

### DIFF
--- a/src/codecompass/evaluate/lib/repo_handler.py
+++ b/src/codecompass/evaluate/lib/repo_handler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 import tempfile
 from pathlib import Path
 import subprocess
@@ -10,40 +9,9 @@ def is_repo_url(repo_input: str) -> bool:
     return repo_input.startswith(("http://", "https://", "git@"))
 
 
-def _strip_gitignored(src_repo: Path, dest: Path) -> None:
-    """Remove files/dirs from dest that are gitignored in src_repo."""
-    result = subprocess.run(
-        ["git", "ls-files", "--others", "--ignored", "--exclude-standard", "--directory"],
-        cwd=str(src_repo),
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return
-    for rel in result.stdout.splitlines():
-        rel = rel.strip().rstrip("/")
-        if not rel:
-            continue
-        target = dest / rel
-        if target.is_dir():
-            shutil.rmtree(target, ignore_errors=True)
-        elif target.is_file():
-            target.unlink(missing_ok=True)
-
-
 def prepare_repository(repo_input: str) -> str:
-    if is_repo_url(repo_input):
-        repo_name = repo_input.split("/")[-1].replace(".git", "")
-        tmp_base = Path(tempfile.mkdtemp())
-        dest = tmp_base / repo_name
-        subprocess.run(["git", "clone", repo_input, str(dest)], check=True)
-        return str(dest.resolve())
-
-    local_path = Path(repo_input).resolve()
-    if not local_path.exists():
-        raise FileNotFoundError(f"Local path {local_path} does not exist")
-
-    dest = Path(tempfile.mkdtemp()) / local_path.name
-    shutil.copytree(str(local_path), str(dest), ignore=shutil.ignore_patterns(".git"))
-    _strip_gitignored(local_path, dest)
+    """Clone a remote repository to a temporary directory and return its path."""
+    repo_name = repo_input.split("/")[-1].replace(".git", "")
+    dest = Path(tempfile.mkdtemp()) / repo_name
+    subprocess.run(["git", "clone", repo_input, str(dest)], check=True)
     return str(dest.resolve())

--- a/src/codecompass/evaluate/runner.py
+++ b/src/codecompass/evaluate/runner.py
@@ -17,7 +17,7 @@ from codecompass.evaluate.lib.discipline_detector import (
 from codecompass.evaluate.lib.evaluation import compute_prompt_hash
 from codecompass.evaluate.lib.practices_runner import build_practices_evaluation
 from codecompass.evaluate.lib.prescan import run_prescan_metrics
-from codecompass.evaluate.lib.repo_handler import prepare_repository
+from codecompass.evaluate.lib.repo_handler import is_repo_url, prepare_repository
 from codecompass.adapters.fs.evaluators_repository import FilesystemEvaluatorsRepository
 from codecompass.adapters.fs.practices_repository import FilesystemPracticesRepository
 from codecompass.bootstrap import DataProvider
@@ -81,10 +81,16 @@ def run(config: EvaluateConfig) -> int:
 
     ensure_reports_dir(config.reports_dir, config.reports_defaulted)
 
-    try:
-        _repo_path = prepare_repository(config.repo)
-    except FileNotFoundError as exc:
-        return fail_with_error(str(exc))
+    if is_repo_url(config.repo):
+        try:
+            repo_path = prepare_repository(config.repo)
+        except Exception as exc:
+            return fail_with_error(str(exc))
+    else:
+        local = Path(config.repo).resolve()
+        if not local.exists():
+            return fail_with_error(f"Local path {local} does not exist")
+        repo_path = str(local)
 
     paths = default_paths(version=config.version)
     if not config.discipline:
@@ -157,7 +163,7 @@ def run(config: EvaluateConfig) -> int:
         log_success(f"{source_file_count:,} source files")
 
     ctx = DimensionRunContext(
-        work_dir=config.repo,
+        work_dir=repo_path,
         discipline=config.discipline,
         project_name=project_name,
         today=today,


### PR DESCRIPTION
## Summary

- Local repositories are now evaluated against their original path — no temp copy is made
- Remote git URLs (http/https/git@) still clone to a temp directory via `prepare_repository`
- Removed dead `_strip_gitignored` logic and `shutil` dependency from `repo_handler.py`
- Fixed `runner.py` to properly route local vs remote repos and use `repo_path` as `work_dir`

## Test plan

- [x] Run evaluation against a local repo — confirm it runs in-place (no temp dir created)
- [x] Run evaluation against a remote git URL — confirm it clones to temp dir and evaluates correctly
- [x] Confirm error message shown when local path does not exist