### PR TITLE
feat(ui): detail page row redesign with severity borders and compliance data fix

### DIFF
--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -348,12 +348,29 @@ class FilesystemActionProvider(ActionProvider):
         numeric_scores = [score for score in (_parse_numeric_score(s) for s in scores) if score is not None]
         avg_score = round(sum(numeric_scores) / len(numeric_scores), 1) if numeric_scores else None
 
+        # Compute previous overall average by re-accumulating over runs[1:] (i.e., excluding
+        # the latest run). This gives the true prior snapshot rather than mixing each dimension's
+        # individual previousScore which may point to different runs.
+        prev_avg_score = None
+        if len(runs) >= 2:
+            prev_latest_by_dimension: dict[str, dict[str, Any]] = {}
+            for run_id in runs[1:]:
+                dimensions = _read_run_data(reports_root, project, run_id)
+                for dim in dimensions:
+                    dim_name = dim.get("dimension")
+                    if dim_name and dim_name not in prev_latest_by_dimension:
+                        prev_latest_by_dimension[dim_name] = dim
+            prev_scores_raw = [d.get("overallScore") for d in prev_latest_by_dimension.values() if d.get("overallScore")]
+            prev_numeric_scores = [s for s in (_parse_numeric_score(s) for s in prev_scores_raw) if s is not None]
+            prev_avg_score = round(sum(prev_numeric_scores) / len(prev_numeric_scores), 1) if prev_numeric_scores else None
+
         return {
             "project": project,
             "dimensions": dimensions_with_trend,
             "summary": {
                 "overallGrade": _most_frequent_grade(grades),
                 "numericAverage": avg_score,
+                "previousNumericAverage": prev_avg_score,
                 "totalViolations": total_violations,
                 "totalCompliance": total_compliance,
                 "dimensionCount": len(dimensions_with_trend),

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -34,6 +34,87 @@ from codecompass.adapters.fs.report_parser import (
 from codecompass.evaluate.lib.repo_handler import is_repo_url
 
 
+def _parse_violations_from_evidence(evidence_path: Path, project: str, run_id: str, dimension: str) -> dict[str, Any] | None:
+    try:
+        data = json.loads(evidence_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    violations = []
+    for raw_key, pdata in (data.get("principles") or {}).items():
+        label = pdata.get("display_name") or raw_key
+        for v in pdata.get("violations") or []:
+            f = v.get("file")
+            line = v.get("line")
+            violations.append({
+                "principle": label,
+                "file": f"{f}:{line}" if f and line else f,
+                "line": line,
+                "reason": v.get("reason"),
+                "snippet": v.get("snippet"),
+                "severity": v.get("severity") or "minor",
+            })
+    return {"dimension": dimension, "runId": run_id, "project": project, "violations": violations, "partial": True}
+
+
+def _parse_violations_from_stream(stream_path: Path, project: str, run_id: str, dimension: str) -> dict[str, Any] | None:
+    try:
+        content = stream_path.read_text()
+    except OSError:
+        return None
+    violations: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_line in content.splitlines():
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        texts: list[str] = []
+        etype = event.get("type")
+        if etype == "assistant":
+            for block in (event.get("message") or {}).get("content") or []:
+                if block.get("type") == "text" and block.get("text"):
+                    texts.append(block["text"])
+        elif etype == "result":
+            if event.get("result"):
+                texts.append(event["result"])
+        elif etype == "item.completed":
+            item = event.get("item") or {}
+            if item.get("type") == "agent_message":
+                if item.get("text"):
+                    texts.append(item["text"])
+                for block in item.get("content") or []:
+                    if block.get("type") in ("text", "output_text") and block.get("text"):
+                        texts.append(block["text"])
+        for text in texts:
+            for tl in text.splitlines():
+                t = tl.strip()
+                if not t.startswith("{"):
+                    continue
+                try:
+                    obj = json.loads(t)
+                except json.JSONDecodeError:
+                    continue
+                if not obj.get("p") or obj.get("t") != "violation":
+                    continue
+                key = f"{obj['p']}:{obj.get('file', '')}:{obj.get('line', '')}"
+                if key in seen:
+                    continue
+                seen.add(key)
+                snippet = obj.get("snippet")
+                violations.append({
+                    "principle": obj.get("d") or obj["p"],
+                    "file": obj.get("file"),
+                    "line": obj.get("line"),
+                    "reason": obj.get("reason"),
+                    "snippet": str(snippet).splitlines()[0].strip() if snippet else None,
+                    "severity": obj.get("severity") or "minor",
+                })
+    return {"dimension": dimension, "runId": run_id, "project": project, "violations": violations, "partial": True}
+
+
 class FilesystemActionProvider(ActionProvider):
     def __init__(self, job_manager: JobManager | None = None) -> None:
         self._jobs = job_manager or JobManager()
@@ -281,16 +362,23 @@ class FilesystemActionProvider(ActionProvider):
         }
 
     def get_dimension_eval(self, reports_dir: str, project: str, run_id: str, dimension: str):
-        eval_path = Path(reports_dir) / project / run_id / "evaluation" / f"{dimension}.json"
+        base = Path(reports_dir) / project / run_id
+        eval_path = base / "evaluation" / f"{dimension}.json"
         if eval_path.exists():
             return _parse_eval_from_json(eval_path, project, run_id, dimension)
-        markdown_path = Path(reports_dir) / project / run_id / "evaluation" / f"{dimension}_eval.md"
+        markdown_path = base / "evaluation" / f"{dimension}_eval.md"
         if markdown_path.exists():
             try:
                 content = markdown_path.read_text()
             except OSError:
                 return None
             return _parse_eval_markdown(content, project, run_id, dimension)
+        evidence_path = base / "evidence" / f"{dimension}_evidence.json"
+        if evidence_path.exists():
+            return _parse_violations_from_evidence(evidence_path, project, run_id, dimension)
+        stream_path = base / "evidence" / f"{dimension}_live.stream"
+        if stream_path.exists():
+            return _parse_violations_from_stream(stream_path, project, run_id, dimension)
         return None
 
     def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str, ai_cmd: str | None = None, ai_model: str | None = None):

--- a/src/codecompass/dashboard/runner.py
+++ b/src/codecompass/dashboard/runner.py
@@ -93,6 +93,17 @@ def _choose_action_api_port(start: int = 8001, taken: set[int] | None = None) ->
     return port
 
 
+def _kill_stale_action_api(host: str, port: int) -> None:
+    """Kill any lingering action API processes so the dashboard always loads fresh code."""
+    try:
+        subprocess.run(["pkill", "-f", "codecompass.action_api"], capture_output=True)
+    except OSError:
+        pass
+    deadline = time.monotonic() + 3
+    while _is_port_open(host, port) and time.monotonic() < deadline:
+        time.sleep(0.1)
+
+
 def _spawn_action_api(port: int) -> subprocess.Popen:
     env = os.environ.copy()
     env["CODECOMPASS_ACTION_API_PORT"] = str(port)
@@ -240,6 +251,7 @@ def run_dashboard(config: DashboardConfig) -> int:
     if config.api_forced:
         action_api_url, action_api_process = _ensure_action_api_forced(action_api_host, action_api_port)
     else:
+        _kill_stale_action_api(action_api_host, action_api_port)
         action_api_url, action_api_process = _ensure_action_api(action_api_host, action_api_port)
 
     process = _start_ui_server(config, action_api_url)

--- a/src/codecompass/dashboard/runner.py
+++ b/src/codecompass/dashboard/runner.py
@@ -249,8 +249,10 @@ def run_dashboard(config: DashboardConfig) -> int:
     if config.open_browser:
         webbrowser.open(f"http://localhost:{config.port}")
 
+    current_action_api_process = action_api_process
+
     def _stop_children() -> None:
-        for proc in (process, action_api_process):
+        for proc in (process, current_action_api_process):
             if proc and proc.poll() is None:
                 proc.terminate()
                 try:
@@ -266,7 +268,22 @@ def run_dashboard(config: DashboardConfig) -> int:
     signal.signal(signal.SIGTSTP, _handle_tstp)
 
     try:
-        return process.wait()
+        while process.poll() is None:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            # Restart action API if it crashed
+            if current_action_api_process and current_action_api_process.poll() is not None:
+                if not _action_api_healthy(action_api_url):
+                    log_warning("Action API stopped — restarting…")
+                    try:
+                        _, current_action_api_process = _ensure_action_api(
+                            action_api_host, action_api_port
+                        )
+                        log_success("Action API restarted.")
+                    except Exception as exc:
+                        log_warning(f"Could not restart Action API: {exc}")
     except KeyboardInterrupt:
         pass
     finally:

--- a/src/codecompass/evaluate/lib/evaluation.py
+++ b/src/codecompass/evaluate/lib/evaluation.py
@@ -80,11 +80,9 @@ def run_two_phase_dimension(
     log_step("Gathering evidence")
 
     # --- Phase 1: Analysis ---
-    with (
-        tempfile.NamedTemporaryFile(mode="w", suffix=".stream", delete=False) as sf,
-        tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as jf,
-    ):
-        stream_file = sf.name
+    # Use a predictable path so the server can read violations live while the stream grows.
+    stream_file = str(Path(evidence_file).parent / f"{dimension}_live.stream")
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as jf:
         jsonl_file = jf.name
 
     try:

--- a/ui/server/src/parsers/evalParser.js
+++ b/ui/server/src/parsers/evalParser.js
@@ -309,6 +309,101 @@ function parseFromMarkdown(mdPath, project, runId, dimension) {
 }
 
 // ---------------------------------------------------------------------------
+// Live stream reader — extracts violations from the growing stream-json file
+// written during Phase 1 analysis (deleted once Phase 1 finishes)
+// ---------------------------------------------------------------------------
+function parseFromLiveStream(streamPath, project, runId, dimension) {
+  let content;
+  try {
+    content = fs.readFileSync(streamPath, 'utf-8');
+  } catch {
+    return null;
+  }
+
+  const violations = [];
+  const seen = new Set();
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let event;
+    try { event = JSON.parse(trimmed); } catch { continue; }
+
+    const texts = [];
+    const etype = event.type;
+    if (etype === 'assistant') {
+      for (const block of event.message?.content ?? []) {
+        if (block.type === 'text' && block.text) texts.push(block.text);
+      }
+    } else if (etype === 'result') {
+      if (event.result) texts.push(event.result);
+    } else if (etype === 'item.completed') {
+      const item = event.item ?? {};
+      if (item.type === 'agent_message') {
+        if (item.text) texts.push(item.text);
+        for (const block of item.content ?? []) {
+          if ((block.type === 'text' || block.type === 'output_text') && block.text) texts.push(block.text);
+        }
+      }
+    }
+
+    for (const text of texts) {
+      for (const tl of text.split('\n')) {
+        const t = tl.trim();
+        if (!t.startsWith('{')) continue;
+        let obj;
+        try { obj = JSON.parse(t); } catch { continue; }
+        if (!obj.p || obj.t !== 'violation') continue;
+
+        const key = `${obj.p}:${obj.file ?? ''}:${obj.line ?? ''}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        violations.push({
+          principle: obj.d || obj.p,
+          file:      obj.file ?? null,
+          line:      obj.line ?? null,
+          reason:    obj.reason ?? null,
+          snippet:   obj.snippet ? String(obj.snippet).split('\n')[0].trim() : null,
+          severity:  obj.severity ?? 'minor',
+        });
+      }
+    }
+  }
+
+  return { dimension, runId, project, violations, partial: true };
+}
+
+// ---------------------------------------------------------------------------
+// Evidence file fallback — returns partial violations before scoring completes
+// ---------------------------------------------------------------------------
+function parseFromEvidence(evidencePath, project, runId, dimension) {
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(evidencePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  const violations = [];
+  for (const [rawKey, pdata] of Object.entries(data.principles ?? {})) {
+    const label = pdata.display_name || rawKey;
+    for (const v of pdata.violations ?? []) {
+      violations.push({
+        principle: label,
+        file:      v.file ? (v.line ? `${v.file}:${v.line}` : v.file) : null,
+        line:      v.line ?? null,
+        reason:    v.reason ?? null,
+        snippet:   v.snippet ?? null,
+        severity:  v.severity ?? 'minor',
+      });
+    }
+  }
+
+  return { dimension, runId, project, violations, partial: true };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 export function parseEvalFile(reportsRoot, project, runId, dimension) {
@@ -320,7 +415,19 @@ export function parseEvalFile(reportsRoot, project, runId, dimension) {
   }
 
   const mdPath = path.join(base, `${dimension}_eval.md`);
-  if (!fs.existsSync(mdPath)) return null;
+  if (fs.existsSync(mdPath)) {
+    return parseFromMarkdown(mdPath, project, runId, dimension);
+  }
 
-  return parseFromMarkdown(mdPath, project, runId, dimension);
+  const evidencePath = path.join(reportsRoot, project, runId, 'evidence', `${dimension}_evidence.json`);
+  if (fs.existsSync(evidencePath)) {
+    return parseFromEvidence(evidencePath, project, runId, dimension);
+  }
+
+  const streamPath = path.join(reportsRoot, project, runId, 'evidence', `${dimension}_live.stream`);
+  if (fs.existsSync(streamPath)) {
+    return parseFromLiveStream(streamPath, project, runId, dimension);
+  }
+
+  return null;
 }

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -246,7 +246,7 @@ export default function App() {
   // -------------------------------------------------------------------------
   // Evaluation
   // -------------------------------------------------------------------------
-  const { job, jobError, startEvaluation, clearJob, cancelEvaluation } = useEvaluation();
+  const { job, jobError, liveViolations, startEvaluation, clearJob, cancelEvaluation } = useEvaluation();
 
   function handleStartEvaluation(payload) {
     startEvaluation({ ...payload, aiCmd: aiCmd || undefined });
@@ -397,7 +397,7 @@ export default function App() {
               )}
 
               {jobError && <div className="job-error-banner">{jobError}</div>}
-              <EvaluationStatus job={job} onDismiss={handleEvalDismiss} onCancel={cancelEvaluation} />
+              <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={handleEvalDismiss} onCancel={cancelEvaluation} />
 
               <div className="panel evaluate-help-panel">
                 <div className="panel-header">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -352,11 +352,10 @@ export default function App() {
           <section className="evaluate-screen">
             <header className="evaluate-header">
               <div className="evaluate-header-content">
-                <div className="evaluate-icon">
-                  <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M12 2L2 7l10 5 10-5-10-5z" />
-                    <path d="M2 17l10 5 10-5" />
-                    <path d="M2 12l10 5 10-5" />
+                <div className={`evaluate-icon${job?.status === 'running' ? ' running' : ''}`}>
+                  <svg className="eval-icon-glass" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <circle cx="11" cy="11" r="7" />
+                    <line x1="16.5" y1="16.5" x2="22" y2="22" />
                   </svg>
                 </div>
                 <div>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -28,10 +28,9 @@ const ICON_OVERVIEW = (
 );
 
 const ICON_EVALUATE = (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M12 2L2 7l10 5 10-5-10-5z" />
-    <path d="M2 17l10 5 10-5" />
-    <path d="M2 12l10 5 10-5" />
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="11" cy="11" r="7" />
+    <line x1="16.5" y1="16.5" x2="22" y2="22" />
   </svg>
 );
 
@@ -399,7 +398,7 @@ export default function App() {
               {jobError && <div className="job-error-banner">{jobError}</div>}
               <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={handleEvalDismiss} onCancel={cancelEvaluation} />
 
-              <div className="panel evaluate-help-panel">
+              {!job && <div className="panel evaluate-help-panel">
                 <div className="panel-header">
                   <h3>How It Works</h3>
                 </div>
@@ -426,7 +425,7 @@ export default function App() {
                     </div>
                   </div>
                 </div>
-              </div>
+              </div>}
             </div>
           </section>
         );

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -353,10 +353,23 @@ export default function App() {
             <header className="evaluate-header">
               <div className="evaluate-header-content">
                 <div className={`evaluate-icon${job?.status === 'running' ? ' running' : ''}`}>
-                  <svg className="eval-icon-glass" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-                    <circle cx="11" cy="11" r="7" />
-                    <line x1="16.5" y1="16.5" x2="22" y2="22" />
-                  </svg>
+                  {/* Static layer — visible when idle */}
+                  <div className="eval-icon-static">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="11" cy="11" r="7" />
+                      <line x1="16.5" y1="16.5" x2="22" y2="22" />
+                    </svg>
+                  </div>
+                  {/* Animated layer — visible when running */}
+                  <div className="eval-icon-animated">
+                    <span className="eval-file-chip" style={{animationDelay: '0s'}} />
+                    <span className="eval-file-chip" style={{animationDelay: '0.55s'}} />
+                    <span className="eval-file-chip" style={{animationDelay: '1.1s'}} />
+                    <svg className="eval-glass-sweep" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="11" cy="11" r="7" />
+                      <line x1="16.5" y1="16.5" x2="22" y2="22" />
+                    </svg>
+                  </div>
                 </div>
                 <div>
                   <h1>Evaluate Repository</h1>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -389,7 +389,7 @@ export default function App() {
               {!job && (
                 <div className="panel evaluate-panel">
                   <div className="panel-header">
-                    <h3>Evaluate a Repository</h3>
+                    <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
                   </div>
                   <EvaluationForm onStart={handleStartEvaluation} disabled={false} />
                 </div>

--- a/ui/web/src/components/TrendArrow.jsx
+++ b/ui/web/src/components/TrendArrow.jsx
@@ -1,5 +1,7 @@
 export default function TrendArrow({ trend }) {
   if (trend === 'up') return <span className="trend-arrow trend-up" title="Improved">↑</span>;
+  if (trend === 'soft-up') return <span className="trend-arrow trend-soft-up" title="Slightly improving">↗</span>;
+  if (trend === 'soft-down') return <span className="trend-arrow trend-soft-down" title="Slightly declining">↘</span>;
   if (trend === 'down') return <span className="trend-arrow trend-down" title="Declined">↓</span>;
   if (trend === 'stable' || trend === 'same') return <span className="trend-arrow trend-same" title="No change">→</span>;
   return null;

--- a/ui/web/src/components/TrendBadge.jsx
+++ b/ui/web/src/components/TrendBadge.jsx
@@ -4,8 +4,8 @@ export default function TrendBadge({ delta, trend, showLabel = false }) {
   if (delta === null || delta === undefined) return null;
 
   const d = parseFloat(delta);
-  const dir = trend || (d > 0 ? 'up' : d < 0 ? 'down' : 'same');
-  const label = d > 0.3 ? 'Improving' : d < -0.3 ? 'Declining' : 'Stable';
+  const label = d > 1 ? 'Improving' : d < -1 ? 'Declining' : 'Stable';
+  const dir = trend || (d > 1 ? 'up' : d > 0.5 ? 'soft-up' : d < -1 ? 'down' : d < -0.5 ? 'soft-down' : 'same');
 
   return (
     <span className={`trend-badge trend-badge-${dir}`}>

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -100,15 +100,11 @@ function AccumulatedOverviewPanel({
   );
 
   const accumulatedScoreDelta = useMemo(() => {
-    const prevScores = accumulatedDimensions
-      .map((d) => parseFloat(d.previousScore))
-      .filter((v) => !isNaN(v));
-    if (prevScores.length === 0) return null;
-    const prevAvg = prevScores.reduce((a, b) => a + b, 0) / prevScores.length;
-    const currAvg = parseFloat(accumulated?.summary?.numericAverage);
-    if (isNaN(currAvg)) return null;
-    return (currAvg - prevAvg).toFixed(1);
-  }, [accumulatedDimensions, accumulated]);
+    const curr = parseFloat(accumulated?.summary?.numericAverage);
+    const prev = parseFloat(accumulated?.summary?.previousNumericAverage);
+    if (isNaN(curr) || isNaN(prev)) return null;
+    return (curr - prev).toFixed(1);
+  }, [accumulated]);
 
   const accumulatedLastDate = useMemo(() => {
     const ids = accumulatedDimensions.map((d) => d.fromRunId).filter(Boolean);
@@ -149,7 +145,7 @@ function AccumulatedOverviewPanel({
           </div>
           {accumulatedScoreDelta !== null && (
             <div className="acc-eval-trend">
-              <TrendBadge delta={accumulatedScoreDelta} showLabel={true} />
+              <TrendBadge delta={accumulatedScoreDelta} showLabel={false} />
             </div>
           )}
         </div>
@@ -236,7 +232,7 @@ function AccumulatedOverviewPanel({
                         </span>
                       )}
                     </span>
-                    <TrendBadge delta={delta} trend={item.trend} />
+                    <TrendBadge delta={delta} />
                   </div>
                   <div className="qd-card-stats">
                     {(item.totals?.violationCount ?? 0) > 0 && (
@@ -350,15 +346,15 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
   );
 
   const runScoreDelta = useMemo(() => {
-    const prevScores = (dashboard?.dimensions || [])
-      .map((d) => parseFloat(d.previousScore))
-      .filter((v) => !isNaN(v));
-    if (prevScores.length === 0) return null;
-    const prevAvg = prevScores.reduce((a, b) => a + b, 0) / prevScores.length;
-    const currAvg = parseFloat(runSummary.numericAverage);
-    if (isNaN(currAvg)) return null;
-    return (currAvg - prevAvg).toFixed(1);
-  }, [dashboard, runSummary]);
+    const trendSeries = dashboard?.trend || [];
+    const selectedRunId = dashboard?.selectedRun?.runId;
+    const idx = trendSeries.findIndex((t) => t.runId === selectedRunId);
+    if (idx < 0 || idx + 1 >= trendSeries.length) return null;
+    const curr = parseFloat(trendSeries[idx].numericAverage);
+    const prev = parseFloat(trendSeries[idx + 1].numericAverage);
+    if (isNaN(curr) || isNaN(prev)) return null;
+    return (curr - prev).toFixed(1);
+  }, [dashboard]);
 
   const runUniquePrinciples = useMemo(() => {
     const violations = (dashboard?.dimensions || []).flatMap((d) => d.violations || []);
@@ -399,7 +395,7 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
           </div>
           {runScoreDelta !== null && (
             <div className="acc-eval-trend">
-              <TrendBadge delta={runScoreDelta} showLabel={true} />
+              <TrendBadge delta={runScoreDelta} showLabel={false} />
             </div>
           )}
         </div>
@@ -472,7 +468,7 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
                         </span>
                       )}
                     </span>
-                    <TrendBadge delta={delta} trend={item.trend} />
+                    <TrendBadge delta={delta} />
                   </div>
                   <div className="qd-card-stats">
                     {(item.totals?.violationCount ?? 0) > 0 && (

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import LiveViolationsFeed from './LiveViolationsFeed.jsx';
 
 function deriveProjectName(repo) {
   if (!repo) return null;
@@ -12,7 +13,7 @@ function statusTitle(status) {
   return 'Evaluation Cancelled';
 }
 
-export default function EvaluationStatus({ job, onDismiss, onCancel }) {
+export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, onCancel }) {
   const logViewerRef = useRef(null);
   const [consoleOpen, setConsoleOpen] = useState(false);
 
@@ -91,6 +92,8 @@ export default function EvaluationStatus({ job, onDismiss, onCancel }) {
           </pre>
         </div>
       )}
+
+      <LiveViolationsFeed liveViolations={liveViolations} />
 
       <div className="job-actions">
         {isRunning ? (

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
+import CopyButton from '../../../components/CopyButton.jsx';
 
 function deriveProjectName(repo) {
   if (!repo) return null;
@@ -21,7 +22,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
     if (!logs?.length) return null;
     for (let i = logs.length - 1; i >= 0; i--) {
       const line = logs[i].trim();
-      if (line.length >= 15) return line;
+      if (line.startsWith('→') || line.startsWith('✓')) return line;
     }
     return null;
   }
@@ -46,7 +47,6 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
     <div className="panel evaluate-job-panel">
       <div className="job-header">
         <div className="job-header-left">
-          {isRunning && <span className="job-spinner" />}
           <h3>{statusTitle(job.status)}</h3>
         </div>
         <span className={`job-status-badge ${job.status}`}>{job.status}</span>
@@ -61,7 +61,10 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
         )}
         <div className="job-meta-item">
           <span className="job-meta-label">Job ID</span>
-          <code className="job-meta-code job-meta-code--muted">{job.jobId}</code>
+          <div className="job-meta-id-row">
+            <code className="job-meta-code job-meta-code--muted">{job.jobId}</code>
+            <CopyButton onClick={() => navigator.clipboard.writeText(job.jobId)} />
+          </div>
         </div>
         {job.repo && (
           <div className="job-meta-item job-meta-item--full">

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -49,7 +49,14 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
         <div className="job-header-left">
           <h3>{statusTitle(job.status)}</h3>
         </div>
-        <span className={`job-status-badge ${job.status}`}>{job.status}</span>
+        <div className="job-header-right">
+          {isRunning && (
+            <button type="button" className="job-cancel-inline" onClick={onCancel}>
+              Cancel
+            </button>
+          )}
+          <span className={`job-status-badge ${job.status}`}>{job.status}</span>
+        </div>
       </div>
 
       <div className="job-meta">
@@ -99,24 +106,18 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
 
       <LiveViolationsFeed liveViolations={liveViolations} />
 
-      <div className="job-actions">
-        {isRunning ? (
-          <button className="job-cancel-btn" onClick={onCancel}>
-            Cancel
-          </button>
-        ) : (
-          <>
-            {isDone && (
-              <button className="view-results-btn" onClick={() => onDismiss('view')}>
-                View Results
-              </button>
-            )}
-            <button className="job-close-btn" onClick={() => onDismiss('close')}>
-              {isDone ? 'Dismiss' : 'Close'}
+      {!isRunning && (
+        <div className="job-actions">
+          {isDone && (
+            <button className="view-results-btn" onClick={() => onDismiss('view')}>
+              View Results
             </button>
-          </>
-        )}
-      </div>
+          )}
+          <button className="job-close-btn" onClick={() => onDismiss('close')}>
+            {isDone ? 'Dismiss' : 'Close'}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 function deriveProjectName(repo) {
   if (!repo) return null;
@@ -14,6 +14,16 @@ function statusTitle(status) {
 
 export default function EvaluationStatus({ job, onDismiss, onCancel }) {
   const logViewerRef = useRef(null);
+  const [consoleOpen, setConsoleOpen] = useState(false);
+
+  function lastRelevantLog(logs) {
+    if (!logs?.length) return null;
+    for (let i = logs.length - 1; i >= 0; i--) {
+      const line = logs[i].trim();
+      if (line.length >= 15) return line;
+    }
+    return null;
+  }
 
   useEffect(() => {
     if (logViewerRef.current) {
@@ -56,11 +66,27 @@ export default function EvaluationStatus({ job, onDismiss, onCancel }) {
         )}
       </div>
 
-      <div className="console-output">
-        <pre ref={logViewerRef}>
-          {job.logs?.length ? job.logs.join('\n') : 'Waiting for output…'}
-        </pre>
-      </div>
+      {isRunning && (
+        <div className="eval-status-row">
+          <span className="eval-status-line">
+            {lastRelevantLog(job?.logs) ?? 'Starting…'}
+          </span>
+          <button
+            className="eval-console-toggle"
+            onClick={() => setConsoleOpen(o => !o)}
+            title={consoleOpen ? 'Hide console' : 'Show console'}
+          >
+            {consoleOpen ? '▴' : '···'}
+          </button>
+        </div>
+      )}
+      {consoleOpen && (
+        <div className="console-output">
+          <pre ref={logViewerRef}>
+            {job.logs?.length ? job.logs.join('\n') : 'Waiting for output…'}
+          </pre>
+        </div>
+      )}
 
       <div className="job-actions">
         {isRunning ? (

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -77,6 +77,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
             {lastRelevantLog(job?.logs) ?? 'Starting…'}
           </span>
           <button
+            type="button"
             className="eval-console-toggle"
             onClick={() => setConsoleOpen(o => !o)}
             title={consoleOpen ? 'Hide console' : 'Show console'}

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -31,6 +31,10 @@ export default function EvaluationStatus({ job, onDismiss, onCancel }) {
     }
   }, [job?.logs]);
 
+  useEffect(() => {
+    setConsoleOpen(false);
+  }, [job?.jobId]);
+
   if (!job) return null;
 
   const isRunning = job.status === 'running';

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+function severityOrder(s) {
+  return s === 'critical' ? 0 : s === 'major' ? 1 : 2;
+}
+
+function ViolationLiveRow({ violation, index }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      className={`vlive-row vlive-row--${violation.severity}`}
+      style={{ animationDelay: `${Math.min(index * 40, 400)}ms` }}
+    >
+      <div className="vlive-row-main" onClick={() => setOpen(o => !o)}>
+        <span className={`severity-tag ${violation.severity}`}>{violation.severity}</span>
+        <span className="vlive-principle">{violation.principle}</span>
+        <span className="vlive-file">{violation.file?.split('/').pop() ?? violation.file}</span>
+        <svg
+          className={`vlive-chevron${open ? ' open' : ''}`}
+          width="14" height="14" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" strokeWidth="2.5"
+          strokeLinecap="round" strokeLinejoin="round"
+        >
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </div>
+      {open && (
+        <div className="vlive-detail">
+          <div className="vlive-detail-row">
+            <span className="vlive-detail-label">File</span>
+            <code className="vlive-detail-value">{violation.file}</code>
+          </div>
+          {violation.line != null && (
+            <div className="vlive-detail-row">
+              <span className="vlive-detail-label">Line</span>
+              <code className="vlive-detail-value">{violation.line}</code>
+            </div>
+          )}
+          {violation.reason && (
+            <div className="vlive-detail-row">
+              <span className="vlive-detail-label">Reason</span>
+              <span className="vlive-detail-value">{violation.reason}</span>
+            </div>
+          )}
+          {violation.snippet && (
+            <pre className="vlive-snippet">{violation.snippet}</pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function LiveViolationsFeed({ liveViolations }) {
+  const dims = Object.keys(liveViolations);
+  if (!dims.length) return null;
+
+  const totalCount = dims.reduce((sum, d) => sum + (liveViolations[d]?.length ?? 0), 0);
+
+  return (
+    <div className="vlive-feed">
+      <div className="vlive-counter">
+        {totalCount} violation{totalCount !== 1 ? 's' : ''} found across {dims.length} dimension{dims.length !== 1 ? 's' : ''}
+      </div>
+      {dims.map(dim => {
+        const violations = [...(liveViolations[dim] ?? [])].sort((a, b) =>
+          severityOrder(a.severity) - severityOrder(b.severity)
+        );
+        return (
+          <div key={dim} className="vlive-dimension-group">
+            <div className="vlive-dimension-label">{dim}</div>
+            {violations.map((v, i) => (
+              <ViolationLiveRow key={`${dim}-${i}`} violation={v} index={i} />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -9,7 +9,7 @@ function ViolationLiveRow({ violation, index }) {
 
   return (
     <div
-      className={`vlive-row vlive-row--${violation.severity}`}
+      className="vlive-row"
       style={{ animationDelay: `${Math.min(index * 40, 400)}ms` }}
     >
       <div className="vlive-row-main" onClick={() => setOpen(o => !o)}>
@@ -71,7 +71,7 @@ export default function LiveViolationsFeed({ liveViolations }) {
           <div key={dim} className="vlive-dimension-group">
             <div className="vlive-dimension-label">{dim}</div>
             {violations.map((v, i) => (
-              <ViolationLiveRow key={`${dim}-${i}`} violation={v} index={i} />
+              <ViolationLiveRow key={`${dim}-${v.file}-${v.principle}-${String(v.line ?? '')}`} violation={v} index={i} />
             ))}
           </div>
         );

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -40,7 +40,7 @@ function ViolationLiveRow({ violation, index }) {
           {violation.reason && (
             <div className="vlive-detail-row">
               <span className="vlive-detail-label">Reason</span>
-              <span className="vlive-detail-value">{violation.reason}</span>
+              <span className="vlive-detail-value vlive-detail-value--prose">{violation.reason}</span>
             </div>
           )}
           {violation.snippet && (
@@ -53,7 +53,7 @@ function ViolationLiveRow({ violation, index }) {
 }
 
 export default function LiveViolationsFeed({ liveViolations }) {
-  const dims = Object.keys(liveViolations);
+  const dims = Object.keys(liveViolations ?? {});
   if (!dims.length) return null;
 
   const totalCount = dims.reduce((sum, d) => sum + (liveViolations[d]?.length ?? 0), 0);

--- a/ui/web/src/features/evaluation/hooks/useEvaluation.js
+++ b/ui/web/src/features/evaluation/hooks/useEvaluation.js
@@ -1,16 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
-import { startEvaluation, getEvaluation, cancelEvaluation } from '../../../api/index.js';
+import { startEvaluation, getEvaluation, cancelEvaluation, getDimensionEval } from '../../../api/index.js';
 
 export function useEvaluation() {
   const [job, setJob] = useState(null);
   const [jobError, setJobError] = useState('');
+  const [liveViolations, setLiveViolations] = useState({});
+
   const pollRef = useRef(null);
+  const dimPollRef = useRef(null);
+  const requestedDimensionsRef = useRef([]);
+  const liveViolationsRef = useRef({});
 
   useEffect(() => {
     return () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-      }
+      stopPolling();
+      stopDimensionPolling();
     };
   }, []);
 
@@ -21,14 +25,63 @@ export function useEvaluation() {
     }
   }
 
+  function stopDimensionPolling() {
+    if (dimPollRef.current) {
+      clearInterval(dimPollRef.current);
+      dimPollRef.current = null;
+    }
+  }
+
+  function startDimensionPolling(project, runId) {
+    stopDimensionPolling();
+    dimPollRef.current = setInterval(async () => {
+      const dims = requestedDimensionsRef.current;
+      if (!dims.length) {
+        stopDimensionPolling();
+        return;
+      }
+
+      const pending = dims.filter(d => !liveViolationsRef.current[d]);
+      if (!pending.length) {
+        stopDimensionPolling();
+        return;
+      }
+
+      await Promise.allSettled(
+        pending.map(async (dim) => {
+          try {
+            const data = await getDimensionEval(project, runId, dim);
+            if (data?.violations) {
+              setLiveViolations(prev => {
+                const next = { ...prev, [dim]: data.violations };
+                liveViolationsRef.current = next;
+                return next;
+              });
+            }
+          } catch {
+            // dimension not ready yet — silently skip
+          }
+        })
+      );
+    }, 2000);
+  }
+
   function startPolling(jobId) {
     stopPolling();
+    let dimPollingStarted = false;
     pollRef.current = setInterval(async () => {
       try {
         const updated = await getEvaluation(jobId);
         setJob((prev) => ({ ...updated, repo: prev?.repo }));
         if (updated.status !== 'running') {
           stopPolling();
+          // one final dimension sweep after job completes
+          if (updated.outputProject && updated.outputRunId && !dimPollingStarted) {
+            startDimensionPolling(updated.outputProject, updated.outputRunId);
+          }
+        } else if (updated.outputProject && updated.outputRunId && !dimPollingStarted) {
+          dimPollingStarted = true;
+          startDimensionPolling(updated.outputProject, updated.outputRunId);
         }
       } catch (err) {
         setJobError(err.message);
@@ -39,6 +92,9 @@ export function useEvaluation() {
 
   async function startEvaluationJob(payload) {
     setJobError('');
+    requestedDimensionsRef.current = payload.dimensions ?? [];
+    liveViolationsRef.current = {};
+    setLiveViolations({});
     try {
       const created = await startEvaluation(payload);
       setJob({ ...created, repo: payload.repo });
@@ -49,9 +105,13 @@ export function useEvaluation() {
   }
 
   function clearJob() {
+    stopPolling();
+    stopDimensionPolling();
     setJob(null);
     setJobError('');
-    stopPolling();
+    setLiveViolations({});
+    liveViolationsRef.current = {};
+    requestedDimensionsRef.current = [];
   }
 
   async function cancelEvaluationJob() {
@@ -64,5 +124,5 @@ export function useEvaluation() {
     }
   }
 
-  return { job, jobError, startEvaluation: startEvaluationJob, clearJob, cancelEvaluation: cancelEvaluationJob };
+  return { job, jobError, liveViolations, startEvaluation: startEvaluationJob, clearJob, cancelEvaluation: cancelEvaluationJob };
 }

--- a/ui/web/src/features/evaluation/hooks/useEvaluation.js
+++ b/ui/web/src/features/evaluation/hooks/useEvaluation.js
@@ -18,6 +18,10 @@ export function useEvaluation() {
     };
   }, []);
 
+  useEffect(() => {
+    liveViolationsRef.current = liveViolations;
+  }, [liveViolations]);
+
   function stopPolling() {
     if (pollRef.current) {
       clearInterval(pollRef.current);
@@ -52,11 +56,7 @@ export function useEvaluation() {
           try {
             const data = await getDimensionEval(project, runId, dim);
             if (data?.violations) {
-              setLiveViolations(prev => {
-                const next = { ...prev, [dim]: data.violations };
-                liveViolationsRef.current = next;
-                return next;
-              });
+              setLiveViolations(prev => ({ ...prev, [dim]: data.violations }));
             }
           } catch {
             // dimension not ready yet — silently skip
@@ -77,6 +77,7 @@ export function useEvaluation() {
           stopPolling();
           // one final dimension sweep after job completes
           if (updated.outputProject && updated.outputRunId && !dimPollingStarted) {
+            dimPollingStarted = true;
             startDimensionPolling(updated.outputProject, updated.outputRunId);
           }
         } else if (updated.outputProject && updated.outputRunId && !dimPollingStarted) {

--- a/ui/web/src/features/evaluation/hooks/useEvaluation.js
+++ b/ui/web/src/features/evaluation/hooks/useEvaluation.js
@@ -10,6 +10,7 @@ export function useEvaluation() {
   const dimPollRef = useRef(null);
   const requestedDimensionsRef = useRef([]);
   const liveViolationsRef = useRef({});
+  const partialDimensionsRef = useRef(new Set());
 
   useEffect(() => {
     return () => {
@@ -45,7 +46,7 @@ export function useEvaluation() {
         return;
       }
 
-      const pending = dims.filter(d => !liveViolationsRef.current[d]);
+      const pending = dims.filter(d => !liveViolationsRef.current[d] || partialDimensionsRef.current.has(d));
       if (!pending.length) {
         stopDimensionPolling();
         return;
@@ -56,6 +57,11 @@ export function useEvaluation() {
           try {
             const data = await getDimensionEval(project, runId, dim);
             if (data?.violations) {
+              if (data.partial) {
+                partialDimensionsRef.current.add(dim);
+              } else {
+                partialDimensionsRef.current.delete(dim);
+              }
               setLiveViolations(prev => ({ ...prev, [dim]: data.violations }));
             }
           } catch {
@@ -87,14 +93,19 @@ export function useEvaluation() {
       } catch (err) {
         setJobError(err.message);
         stopPolling();
+        stopDimensionPolling();
       }
     }, 1500);
   }
 
   async function startEvaluationJob(payload) {
     setJobError('');
-    requestedDimensionsRef.current = payload.dimensions ?? [];
+    const rawDims = payload.dimensions ?? [];
+    requestedDimensionsRef.current = typeof rawDims === 'string'
+      ? rawDims.split(',').map(d => d.trim()).filter(Boolean)
+      : rawDims;
     liveViolationsRef.current = {};
+    partialDimensionsRef.current = new Set();
     setLiveViolations({});
     try {
       const created = await startEvaluation(payload);
@@ -113,6 +124,7 @@ export function useEvaluation() {
     setLiveViolations({});
     liveViolationsRef.current = {};
     requestedDimensionsRef.current = [];
+    partialDimensionsRef.current = new Set();
   }
 
   async function cancelEvaluationJob() {

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -69,9 +69,7 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
     ? principleData.violations
     : dimViolations;
 
-  const compliance = (principleData?.compliance?.length > 0)
-    ? principleData.compliance
-    : dimCompliance.map((c) => c.snippet || c.reason || '').filter(Boolean);
+  const compliance = dimCompliance.filter((c) => c.file || c.reason || c.snippet);
 
   const violationsBySeverity = EVAL_SEVERITY_ORDER.reduce((acc, sev) => {
     acc[sev] = violations.filter((v) => (v.severity || 'minor').toLowerCase() === sev);
@@ -193,33 +191,44 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
         return (
           <div key={sev}>
             <div className="violation-group-header">
-              <span className={`severity-tag ${sev}`}>{sev}</span>
+              <span className="violation-group-title">{sev.charAt(0).toUpperCase() + sev.slice(1)}</span>
               <span className="violation-group-count">{vs.length}</span>
             </div>
-            <section className="panel file-violations-section">
+            <div className="vlive-violations-group">
               {vs.map((v, idx) => (
-                <div key={idx} className={`file-violation-card severity-border-${v.severity}`}>
-                  <div className="file-violation-card-header">
+                <div key={idx} className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}>
+                  <div className="vdetail-row-main">
                     <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
                     {v.file && (
-                      <code className="violation-file">
-                        {v.file}{v.line ? `:${v.line}` : ''}
-                      </code>
+                      <span className="vlive-file">
+                        {v.file.split('/').pop()}
+                      </span>
                     )}
                     <CopyButton
                       label="Fix plan"
                       onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v))}
                     />
                   </div>
-                  {(v.code || v.snippet) && (
-                    <pre className={`code-snippet violation ${v.severity}`}>{v.code || v.snippet}</pre>
-                  )}
-                  {(v.reason || v.findings) && (
-                    <p className="violation-context-desc">{v.reason || v.findings}</p>
-                  )}
+                  <div className="vlive-detail">
+                    {v.file && (
+                      <div className="vlive-detail-row">
+                        <span className="vlive-detail-label">File</span>
+                        <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
+                      </div>
+                    )}
+                    {(v.reason || v.findings) && (
+                      <div className="vlive-detail-row">
+                        <span className="vlive-detail-label">Reason</span>
+                        <span className="vlive-detail-value vlive-detail-value--prose">{v.reason || v.findings}</span>
+                      </div>
+                    )}
+                    {(v.code || v.snippet) && (
+                      <pre className="vlive-snippet">{v.code || v.snippet}</pre>
+                    )}
+                  </div>
                 </div>
               ))}
-            </section>
+            </div>
           </div>
         );
       })}
@@ -227,14 +236,35 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
       {compliance.length > 0 && (
         <div>
           <div className="violation-group-header">
-            <span className="severity-tag compliance">compliance</span>
+            <span className="violation-group-title">Compliance</span>
             <span className="violation-group-count">{compliance.length}</span>
           </div>
-          <section className="panel file-violations-section">
-            {displayedCompliance.map((code, idx) => (
-              <pre key={idx} className="code-snippet compliance">{code}</pre>
+          <div className="vlive-violations-group">
+            {displayedCompliance.map((c, idx) => (
+              <div key={idx} className="vdetail-row vdetail-row--compliant" style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}>
+                <div className="vdetail-row-main">
+                  {c.file && (
+                    <span className="vlive-file">{c.file.split('/').pop()}</span>
+                  )}
+                </div>
+                <div className="vlive-detail">
+                  {c.file && (
+                    <div className="vlive-detail-row">
+                      <span className="vlive-detail-label">File</span>
+                      <code className="vlive-detail-value">{c.file}{c.line ? `:${c.line}` : ''}</code>
+                    </div>
+                  )}
+                  {c.reason && (
+                    <div className="vlive-detail-row">
+                      <span className="vlive-detail-label">Reason</span>
+                      <span className="vlive-detail-value vlive-detail-value--prose">{c.reason}</span>
+                    </div>
+                  )}
+                  {c.snippet && <pre className="vlive-snippet">{c.snippet}</pre>}
+                </div>
+              </div>
             ))}
-          </section>
+          </div>
           {hasMoreCompliance && (
             <button
               className="offending-show-more"

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -80,7 +80,7 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
       grade: pg?.grade || null,
       principleData,
       dimViolations: principleData?.violations || [],
-      dimCompliance: principleData?.compliance || [],
+      dimCompliance: (evalData.compliance || []).filter((c) => c.principle === principleId),
     };
   }
 

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -88,29 +88,33 @@ function CopyButton({ onClick, label }) {
   );
 }
 
-function ViolationCard({ v }) {
+function ViolationCard({ v, index }) {
   return (
-    <div className={`file-violation-card severity-border-${v.severity}`}>
-      <div className="file-violation-card-header">
+    <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}>
+      <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
-        <span className="file-violation-dimension">[{v.dimension}]</span>
-        <span className="file-violation-principle">{v.principle}</span>
+        {v.dimension && <span className="vlive-dimension-inline">[{v.dimension}]</span>}
+        <span className="vlive-principle">{v.principle}</span>
         <CopyButton
           label="Fix plan"
           onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v))}
         />
       </div>
-      {v.file && (
-        <code className="violation-file">
-          {v.file}{v.line ? `:${v.line}` : ''}
-        </code>
-      )}
-      {v.snippet && (
-        <pre className={`code-snippet violation ${v.severity}`}>{v.snippet}</pre>
-      )}
-      {v.reason && (
-        <p className="violation-context-desc">{v.reason}</p>
-      )}
+      <div className="vlive-detail">
+        {v.file && (
+          <div className="vlive-detail-row">
+            <span className="vlive-detail-label">File</span>
+            <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
+          </div>
+        )}
+        {v.reason && (
+          <div className="vlive-detail-row">
+            <span className="vlive-detail-label">Reason</span>
+            <span className="vlive-detail-value vlive-detail-value--prose">{v.reason}</span>
+          </div>
+        )}
+        {v.snippet && <pre className="vlive-snippet">{v.snippet}</pre>}
+      </div>
     </div>
   );
 }
@@ -164,14 +168,14 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
         return (
           <div key={sev}>
             <div className="violation-group-header">
-              <span className={`severity-tag ${sev}`}>{sev}</span>
+              <span className="violation-group-title">{sev.charAt(0).toUpperCase() + sev.slice(1)}</span>
               <span className="violation-group-count">{violations.length}</span>
             </div>
-            <section className="panel file-violations-section">
+            <div className="vlive-violations-group">
               {violations.map((v, idx) => (
-                <ViolationCard key={idx} v={v} />
+                <ViolationCard key={idx} v={v} index={idx} />
               ))}
-            </section>
+            </div>
           </div>
         );
       })}

--- a/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -87,27 +87,34 @@ function CopyButton({ onClick, label }) {
   );
 }
 
-function ViolationCard({ v, principleName }) {
+function ViolationCard({ v, principleName, index }) {
   return (
-    <div className={`file-violation-card severity-border-${v.severity}`}>
-      <div className="file-violation-card-header">
+    <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}>
+      <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
-        {v.file && (
-          <code className="violation-file">
-            {v.file}{v.line ? `:${v.line}` : ''}
-          </code>
-        )}
+        <span className="vlive-file">
+          {v.file?.split('/').pop() ?? v.file}
+        </span>
         <CopyButton
           label="Fix plan"
           onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v, principleName))}
         />
       </div>
-      {v.snippet && (
-        <pre className={`code-snippet violation ${v.severity}`}>{v.snippet}</pre>
-      )}
-      {v.reason && (
-        <p className="violation-context-desc">{v.reason}</p>
-      )}
+      <div className="vlive-detail">
+        {v.file && (
+          <div className="vlive-detail-row">
+            <span className="vlive-detail-label">File</span>
+            <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
+          </div>
+        )}
+        {v.reason && (
+          <div className="vlive-detail-row">
+            <span className="vlive-detail-label">Reason</span>
+            <span className="vlive-detail-value vlive-detail-value--prose">{v.reason}</span>
+          </div>
+        )}
+        {v.snippet && <pre className="vlive-snippet">{v.snippet}</pre>}
+      </div>
     </div>
   );
 }
@@ -165,14 +172,14 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ principle }) {
         return (
           <div key={sev}>
             <div className="violation-group-header">
-              <span className={`severity-tag ${sev}`}>{sev}</span>
+              <span className="violation-group-title">{sev.charAt(0).toUpperCase() + sev.slice(1)}</span>
               <span className="violation-group-count">{violations.length}</span>
             </div>
-            <section className="panel file-violations-section">
+            <div className="vlive-violations-group">
               {violations.map((v, idx) => (
-                <ViolationCard key={idx} v={v} principleName={principle.principle} />
+                <ViolationCard key={idx} v={v} principleName={principle.principle} index={idx} />
               ))}
-            </section>
+            </div>
           </div>
         );
       })}

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -820,6 +820,7 @@ textarea:focus {
 /* ─── Settings page ─── */
 
 .settings-page {
+  width: 100%;
   display: flex;
   flex-direction: column;
   min-height: 100%;

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -764,11 +764,15 @@ textarea:focus {
 }
 
 .trend-badge-up {
-  border-color: #5ee6a040;
   color: #5ee6a0;
 }
+.trend-badge-soft-up {
+  color: #92c9a8;
+}
+.trend-badge-soft-down {
+  color: #c8956c;
+}
 .trend-badge-down {
-  border-color: #f0907040;
   color: #f09070;
 }
 .trend-badge-same,
@@ -796,7 +800,10 @@ textarea:focus {
 .trend-arrow-up { color: #5ee6a0; }
 .trend-arrow-up-big { color: #2ecc71; }
 .trend-arrow-same { color: var(--color-text-muted); font-size: 0.8rem; }
-.trend-arrow-down { color: #f09070; }
+.trend-up { color: #5ee6a0; }
+.trend-soft-up { color: #92c9a8; }
+.trend-soft-down { color: #c8956c; }
+.trend-down { color: #f09070; }
 .trend-arrow-down-big { color: #e74c3c; }
 
 .trend-arrow {

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1533,7 +1533,7 @@
 
 /* Accordion detail panel */
 .vlive-detail {
-  margin: 0 12px 4px 12px;
+  margin: 0 0 4px;
   padding: 12px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -1578,12 +1578,69 @@
 .vlive-snippet {
   margin: 0;
   padding: 10px 12px;
-  background: #0d1117;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 0.76rem;
-  color: #8bc34a;
+  color: var(--color-text);
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.5;
 }
+
+/* Detail rows (explorer detail pages) */
+.vdetail-row {
+  animation: vlive-enter 200ms ease-out both;
+  margin-bottom: var(--space-3);
+}
+
+.vdetail-row-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-radius: var(--radius-md);
+  cursor: default;
+}
+
+.vdetail-row-main .detail-copy-btn {
+  margin-left: auto;
+}
+
+/* Dimension label inline in the row (file detail page) */
+.vlive-dimension-inline {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+/* Violations group wrapper in detail pages */
+.vlive-violations-group {
+  margin-bottom: var(--space-4);
+}
+
+/* Title label in violation group headers */
+.violation-group-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-primary);
+}
+
+/* Severity + compliant left border accents */
+.vdetail-row--critical,
+.vdetail-row--major,
+.vdetail-row--minor,
+.vdetail-row--unknown,
+.vdetail-row--compliant {
+  border-left: 2px solid;
+  padding-left: var(--space-3);
+}
+
+.vdetail-row--critical  { border-color: var(--color-sev-critical-border); }
+.vdetail-row--major     { border-color: var(--color-sev-major-border); }
+.vdetail-row--minor     { border-color: var(--color-sev-minor-border); }
+.vdetail-row--unknown   { border-color: var(--color-border); }
+.vdetail-row--compliant { border-color: var(--color-success); }

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1422,3 +1422,138 @@
     text-align: center;
   }
 }
+
+/* ---- Live Violations Feed ---- */
+.vlive-feed {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.vlive-counter {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  padding: 0 4px 12px;
+}
+
+.vlive-dimension-group {
+  margin-bottom: 16px;
+}
+
+.vlive-dimension-label {
+  padding: 4px 0 8px;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: 4px;
+}
+
+/* Entrance animation */
+.vlive-row {
+  animation: vlive-enter 200ms ease-out both;
+}
+
+@keyframes vlive-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.vlive-row-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.vlive-row-main:hover {
+  background: var(--color-surface-alt);
+}
+
+.vlive-principle {
+  flex: 1;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vlive-file {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+.vlive-chevron {
+  color: var(--color-text-muted);
+  transition: transform 180ms ease;
+  flex-shrink: 0;
+}
+
+.vlive-chevron.open {
+  transform: rotate(90deg);
+}
+
+/* Accordion detail panel */
+.vlive-detail {
+  margin: 0 12px 4px 12px;
+  padding: 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.vlive-detail-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: var(--text-sm);
+}
+
+.vlive-detail-label {
+  flex-shrink: 0;
+  width: 52px;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-top: 2px;
+}
+
+.vlive-detail-value {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  word-break: break-all;
+}
+
+.vlive-snippet {
+  margin: 0;
+  padding: 10px 12px;
+  background: #0d1117;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: #8bc34a;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -467,6 +467,7 @@
 }
 
 .evaluate-icon {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -475,6 +476,70 @@
   background: linear-gradient(135deg, var(--color-accent-soft), color-mix(in srgb, var(--color-accent) 5%, transparent));
   border-radius: 20px;
   color: var(--color-accent);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+/* --- idle layer --- */
+.eval-icon-static {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 1;
+  transition: opacity 400ms ease;
+}
+
+/* --- animated layer --- */
+.eval-icon-animated {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 400ms ease;
+}
+
+/* swap on running */
+.evaluate-icon.running .eval-icon-static  { opacity: 0; }
+.evaluate-icon.running .eval-icon-animated { opacity: 1; }
+
+/* floating file chips behind the glass */
+.eval-file-chip {
+  position: absolute;
+  width: 18px;
+  height: 10px;
+  background: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  border-radius: 3px;
+  animation: file-drift 1.65s ease-in-out infinite;
+  opacity: 0;
+}
+
+/* stagger vertical positions */
+.eval-file-chip:nth-child(1) { top: 18px; }
+.eval-file-chip:nth-child(2) { top: 32px; }
+.eval-file-chip:nth-child(3) { top: 46px; }
+
+@keyframes file-drift {
+  0%   { transform: translateX(34px); opacity: 0; }
+  15%  { opacity: 0.7; }
+  85%  { opacity: 0.7; }
+  100% { transform: translateX(-34px); opacity: 0; }
+}
+
+/* glass gently sweeps left→right while running */
+.eval-glass-sweep {
+  position: relative;
+  z-index: 1;
+  animation: glass-sweep 2.5s ease-in-out infinite;
+}
+
+@keyframes glass-sweep {
+  0%, 100% { transform: translateX(0) rotate(0deg); }
+  40%       { transform: translateX(4px) rotate(3deg); }
+  60%       { transform: translateX(-4px) rotate(-3deg); }
 }
 
 .evaluate-header h1 {

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1,6 +1,6 @@
 /* --- Evaluate Screen --- */
 .evaluate-screen {
-  padding: 32px;
+  width: 100%;
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -101,6 +101,7 @@
 /* Job Panel */
 .evaluate-job-panel {
   padding: 24px;
+  min-height: 480px;
 }
 
 .job-header {
@@ -121,22 +122,6 @@
   font-size: var(--text-lg);
   font-weight: var(--weight-semibold);
   color: var(--color-text);
-}
-
-/* Spinner shown while running */
-.job-spinner {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
-  border-top-color: var(--color-accent);
-  border-radius: 50%;
-  animation: spin 0.75s linear infinite;
-  flex-shrink: 0;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 /* Status badge */
@@ -233,6 +218,18 @@
 .job-meta-code--muted {
   color: var(--color-text-muted);
   font-size: var(--text-xs);
+}
+
+.job-meta-id-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.job-meta-id-row .job-meta-code {
+  flex: 1;
+  min-width: 0;
 }
 
 /* Console */
@@ -866,7 +863,7 @@
 
 /* --- Evaluate Page (Full Page) --- */
 .evaluate-page {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 40px 20px;
 }
@@ -1493,7 +1490,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 180px;
+  max-width: 280px;
 }
 
 .vlive-chevron {

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -282,7 +282,7 @@
 .eval-status-line {
   flex: 1;
   font-family: var(--font-mono);
-  font-size: 0.78rem;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -124,6 +124,34 @@
   color: var(--color-text);
 }
 
+/* Header right cluster */
+.job-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Inline cancel — identical pill to the running badge, accent colour, no animation */
+.job-cancel-inline {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: inherit;
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+  border: none;
+  color: var(--color-danger);
+  cursor: pointer;
+  transition: background 150ms ease;
+}
+
+.job-cancel-inline:hover {
+  background: color-mix(in srgb, var(--color-danger) 22%, transparent);
+}
+
 /* Status badge */
 .job-status-badge {
   padding: 4px 12px;

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -268,6 +268,46 @@
   word-break: break-word;
 }
 
+/* Slim status row */
+.eval-status-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.eval-status-line {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.eval-console-toggle {
+  flex-shrink: 0;
+  padding: 3px 9px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease;
+  line-height: 1;
+}
+
+.eval-console-toggle:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
 /* Action row */
 .job-actions {
   margin-top: 20px;

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -497,6 +497,10 @@
   .dimension-grid {
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   }
+
+  .vlive-file {
+    max-width: 120px;
+  }
 }
 
 /* --- Evaluate Screen Enhancements --- */
@@ -1543,6 +1547,12 @@
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   word-break: break-all;
+}
+
+.vlive-detail-value--prose {
+  font-family: var(--font-sans);
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .vlive-snippet {

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1196,11 +1196,6 @@
   opacity: 0.5;
 }
 
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
-}
-
 .folder-browser-hint {
   padding: 8px 14px;
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary

- Refactor explorer detail pages (FileDetailPage, PrincipleDetailPage, EvalPrincipleDetailPage) to use new `vdetail-row` / `vdetail-row-main` classes, decoupled from live feed `vlive-row`
- Add `violation-group-header` title text; remove severity badge from header
- Add severity-colored left border accents (`vdetail-row--critical/major/minor/compliant`) to all detail rows
- Fix compliance data loss: `ExplorerPage` now sources compliance from `evalData.compliance` (full objects with file/line/reason/snippet) instead of the per-principle string-flattened array in evalParser
- Restyle compliance rows to match violation rows with a green left border
- `vlive-snippet` now respects light/dark theme via CSS tokens
- Remove `vlive-violations-group` box container styling

## Test plan

- [x] Open a file detail page — violation rows show severity left border (red/amber/gray)
- [x] Open a principle detail page — same border treatment
- [x] Open an eval principle detail page — violations have severity borders, compliance rows show green border
- [x] Compliance items display file, line, reason, and snippet (not just snippet)
- [x] Toggle light/dark theme — snippet block and borders adapt correctly