### PR TITLE
feat(parser): JS accumulated previousNumericAverage, explorer perf, css fixes

### DIFF
--- a/ui/server/src/parsers/reportParser.js
+++ b/ui/server/src/parsers/reportParser.js
@@ -777,13 +777,20 @@ export function buildAccumulatedData(reportsRoot, project, asOfRun = null) {
 
   if (runIds.length === 0) return null;
 
-  // Collect the latest evaluation per dimension (newest run wins)
+  // Collect the latest evaluation per dimension (newest run wins).
+  // Also collect the previous accumulated state (same logic, skipping the first run)
+  // for a like-for-like overall delta in the trend badge.
   const latestPerDim = new Map();
+  const prevLatestPerDim = new Map();
+  const newestRunId = runIds[0];
   for (const runId of runIds) {
     const dims = loadRunDimensions(reportsRoot, project, runId);
     for (const dim of dims) {
       if (!latestPerDim.has(dim.dimension)) {
         latestPerDim.set(dim.dimension, { ...dim, fromRunId: runId });
+      }
+      if (runId !== newestRunId && !prevLatestPerDim.has(dim.dimension)) {
+        prevLatestPerDim.set(dim.dimension, dim);
       }
     }
   }
@@ -824,12 +831,20 @@ export function buildAccumulatedData(reportsRoot, project, asOfRun = null) {
     ? (numScores.reduce((a, b) => a + b, 0) / numScores.length).toFixed(1)
     : null;
 
+  const prevScores = Array.from(prevLatestPerDim.values())
+    .map((d) => numericScore(d.overallScore))
+    .filter((v) => v !== null);
+  const prevAvgScore = prevScores.length > 0
+    ? (prevScores.reduce((a, b) => a + b, 0) / prevScores.length).toFixed(1)
+    : null;
+
   return {
     project,
     dimensions: dimensionsWithTrend,
     summary: {
       overallGrade: mostCommonGrade(grades),
       numericAverage: avgScore,
+      previousNumericAverage: prevAvgScore,
       totalViolations,
       totalCompliance,
       dimensionCount: dimensionsWithTrend.length,

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -67,6 +67,15 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
     [evalData]
   );
 
+  const complianceByPrinciple = useMemo(() => {
+    const map = new Map();
+    for (const c of (evalData?.compliance || [])) {
+      if (!map.has(c.principle)) map.set(c.principle, []);
+      map.get(c.principle).push(c);
+    }
+    return map;
+  }, [evalData]);
+
   if (loading) return <div className="loading">Loading…</div>;
   if (error) return <div className="inline-error">{error}</div>;
   if (!evalData) return <div className="empty-state"><h2>No data found</h2></div>;
@@ -80,7 +89,7 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
       grade: pg?.grade || null,
       principleData,
       dimViolations: principleData?.violations || [],
-      dimCompliance: (evalData.compliance || []).filter((c) => c.principle === principleId),
+      dimCompliance: complianceByPrinciple.get(principleId) || [],
     };
   }
 

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1600,7 +1600,6 @@
   align-items: center;
   gap: 10px;
   padding: 10px 0;
-  border-radius: var(--radius-md);
   cursor: default;
 }
 
@@ -1626,7 +1625,7 @@
 .violation-group-title {
   font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-text);
 }
 
 /* Severity + compliant left border accents */


### PR DESCRIPTION
## Summary

- **reportParser.js**: mirrors the Python backend fix — computes `previousNumericAverage` by re-accumulating dimensions over `runs[1:]` so the hero trend badge shows a correct apples-to-apples delta
- **ExplorerPage.jsx**: memoize compliance items grouped by principle, replacing a per-render `.filter()` loop with a single `useMemo` Map lookup
- **evaluation.css**: remove stray `border-radius` on violation row, fix color token from `--color-text-primary` to `--color-text`

## Test plan
- [x] Hero badge overall delta matches expected value when JS server is used
- [x] Explorer page renders correctly with compliance items per principle
- [x] Violation row styling unchanged visually