### PR TITLE
feat: score history and dimension scores panels

### DIFF
--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -262,20 +262,32 @@ class FilesystemActionProvider(ActionProvider):
                 }
             )
 
+        # Build trend using accumulated scores (same logic as get_accumulated):
+        # for each run, compute the score using the best/latest dimension data
+        # available up to and including that run, not just that run's data alone.
         trend = []
-        for item in runs:
-            dimensions = _read_run_data(reports_root, project, item.run_id)
-            summary = _summarize_dimensions(dimensions)
+        acc_by_dim: dict[str, dict[str, Any]] = {}
+        for item in reversed(runs):  # oldest → newest
+            for dim in _read_run_data(reports_root, project, item.run_id):
+                dim_name = dim.get("dimension")
+                if dim_name:
+                    acc_by_dim[dim_name] = dim  # latest run wins
+            acc_scores = [
+                s for s in (_parse_numeric_score(d.get("overallScore")) for d in acc_by_dim.values())
+                if s is not None
+            ]
+            acc_grades = [d.get("overallGrade") for d in acc_by_dim.values() if d.get("overallGrade")]
             trend.append(
                 {
                     "runId": item.run_id,
                     "dateISO": item.date_iso,
                     "dateLabel": item.date_label,
-                    "dimensionsCount": summary.get("dimensionsCount"),
-                    "overallGrade": summary.get("overallGrade"),
-                    "numericAverage": summary.get("numericAverage"),
+                    "dimensionsCount": len(acc_by_dim),
+                    "overallGrade": _most_frequent_grade(acc_grades) if acc_grades else None,
+                    "numericAverage": round(sum(acc_scores) / len(acc_scores), 1) if acc_scores else None,
                 }
             )
+        trend.reverse()  # back to newest-first
 
         return {
             "project": project,

--- a/ui/web/package-lock.json
+++ b/ui/web/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "recharts": "^3.7.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -739,6 +740,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1096,6 +1133,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1141,11 +1190,80 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1237,12 +1355,142 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1262,12 +1510,28 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1318,6 +1582,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1341,6 +1611,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1491,6 +1780,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1500,6 +1819,57 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.58.0",
@@ -1575,6 +1945,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -1604,6 +1980,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -187,6 +187,12 @@ export default function App() {
     handleNavigate('run', { runId: currentOverviewRun });
   }
 
+  function handleRunSelect(runId) {
+    const idx = availableRuns.findIndex((r) => r.runId === runId);
+    if (idx >= 0) setOverviewRunIndex(idx);
+    handleRunChange(runId);
+  }
+
   // -------------------------------------------------------------------------
   // Header meta (discipline, repository, source files)
   // -------------------------------------------------------------------------
@@ -310,6 +316,7 @@ export default function App() {
             selectedRun={selectedRun}
             projects={projects}
             onNavigate={handleNavigate}
+            onRunSelect={handleRunSelect}
             dashboard={dashboard}
             accumulated={accumulated}
             loading={loading}

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -8,6 +8,7 @@ import CopyButton from '../../../components/CopyButton.jsx';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { formatRunId, gradeColorClass, mostFrequentGrade, splitScore } from '../../../utils/formatters.js';
 import RunHistoryPanel from './RunHistoryPanel.jsx';
+import DimensionScorePanel from './DimensionScorePanel.jsx';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -201,12 +202,15 @@ function AccumulatedOverviewPanel({
         </div>
       </section>
 
-      <RunHistoryPanel
-        trend={trend}
-        selectedRunId={selectedRunId}
-        selectedRunScore={accumulated?.summary?.numericAverage}
-        onBarClick={onRunClick}
-      />
+      <div className="history-panels-row">
+        <RunHistoryPanel
+          trend={trend}
+          selectedRunId={selectedRunId}
+          selectedRunScore={accumulated?.summary?.numericAverage}
+          onBarClick={onRunClick}
+        />
+        <DimensionScorePanel dimensions={accumulatedDimensions} onBarClick={onDimensionClick} />
+      </div>
 
       {/* Quality dimension cards */}
       <div className="dimensions-header">

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -7,6 +7,7 @@ import TrendBadge from '../../../components/TrendBadge.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { formatRunId, gradeColorClass, mostFrequentGrade, splitScore } from '../../../utils/formatters.js';
+import RunHistoryPanel from './RunHistoryPanel.jsx';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,6 +80,9 @@ function AccumulatedOverviewPanel({
   accumulatedDimensions,
   availableRuns,
   overviewRunIndex,
+  trend,
+  selectedRunId,
+  onRunClick,
   onDimensionClick,
   onFileClick,
   onPrincipleClick,
@@ -196,6 +200,13 @@ function AccumulatedOverviewPanel({
           </div>
         </div>
       </section>
+
+      <RunHistoryPanel
+        trend={trend}
+        selectedRunId={selectedRunId}
+        selectedRunScore={accumulated?.summary?.numericAverage}
+        onBarClick={onRunClick}
+      />
 
       {/* Quality dimension cards */}
       <div className="dimensions-header">
@@ -539,6 +550,7 @@ export default function DashboardPage({
   selectedRun,
   projects = [],
   onNavigate,
+  onRunSelect,
   runMode = false,
   // Data from App-level useDashboard
   dashboard,
@@ -642,6 +654,9 @@ export default function DashboardPage({
                   accumulatedDimensions={accumulatedDimensions}
                   availableRuns={availableRuns}
                   overviewRunIndex={overviewRunIndex}
+                  trend={dashboard?.trend || []}
+                  selectedRunId={selectedRunId}
+                  onRunClick={onRunSelect}
                   onDimensionClick={handleAccumulatedDimensionClick}
                   onFileClick={handleFileClick}
                   onPrincipleClick={handlePrincipleClick}

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -1,8 +1,6 @@
-import { useState } from 'react';
 import {
-  ComposedChart,
+  BarChart,
   Bar,
-  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -11,11 +9,11 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+
 function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
-// Trend direction — mirrors the logic in TrendBadge
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
 const TREND_COLOR = {
   up:         '#5ee6a0',
@@ -25,48 +23,64 @@ const TREND_COLOR = {
   down:       '#f09070',
 };
 
+// Shortcodes mirror src/codecompass/config/dimensions.py
+const DIM_CODE = {
+  affordability:  'aff',
+  availability:   'avl',
+  configurability:'cfg',
+  efficiency:     'eff',
+  evolvability:   'evo',
+  extensibility:  'ext',
+  flexibility:    'flx',
+  maintainability:'mnt',
+  performance:    'perf',
+  recoverability: 'rcv',
+  resilience:     'res',
+  robustness:     'rob',
+  scalability:    'scl',
+  simplicity:     'sim',
+  usability:      'usx',
+};
+
+function dimCode(name) {
+  if (!name) return '';
+  return (DIM_CODE[name.toLowerCase()] ?? name.slice(0, 4)).toUpperCase();
+}
+
 function trendDir(delta) {
   if (delta === null || delta === undefined) return null;
-  if (delta > 1)   return 'up';
-  if (delta > 0.5) return 'soft-up';
-  if (delta < -1)  return 'down';
+  if (delta > 1)    return 'up';
+  if (delta > 0.5)  return 'soft-up';
+  if (delta < -1)   return 'down';
   if (delta < -0.5) return 'soft-down';
   return 'same';
 }
 
-function RunHistoryTooltip({ active, payload }) {
+function DimensionTooltip({ active, payload }) {
   if (!active || !payload?.length) return null;
   const d = payload[0].payload;
   return (
     <div className="run-history-tooltip">
-      <span className="rht-date">{d.dateLabel}</span>
-      <span className="rht-score">{d.numericAverage.toFixed(1)} / 10</span>
+      <span className="rht-date">{d.dimension}</span>
+      <span className="rht-score">{parseFloat(d.overallScore).toFixed(1)} / 10</span>
       <span className="rht-grade">{d.overallGrade}</span>
     </div>
   );
 }
 
-export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
-  const [hoveredIndex, setHoveredIndex] = useState(null);
 
-  // Need at least 2 data points to render a meaningful trend line
-  if (!trend || trend.length < 2) return null;
+export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
+  if (!dimensions || dimensions.length === 0) return null;
 
-  // Take the 20 most recent runs (trend is newest-first), then display oldest→newest.
-  // For the selected run, use the accumulated score so the bar matches the acc-eval-hero.
-  const data = [...trend].slice(0, 20).reverse().map((row, i, arr) => {
-    const isSelected = row.runId === selectedRunId;
-    const numericAverage = isSelected && selectedRunScore != null
-      ? parseFloat(selectedRunScore)
-      : parseFloat(row.numericAverage);
-    return {
-      ...row,
-      numericAverage,
-      delta: i > 0 ? numericAverage - parseFloat(arr[i - 1].numericAverage) : null,
-    };
-  });
+  const data = [...dimensions]
+    .sort((a, b) => a.dimension.localeCompare(b.dimension))
+    .map((d) => {
+      const curr = parseFloat(d.overallScore);
+      const prev = parseFloat(d.previousScore);
+      const delta = !isNaN(curr) && !isNaN(prev) ? curr - prev : null;
+      return { ...d, numericScore: isNaN(curr) ? 0 : curr, delta };
+    });
 
-  // Custom label above each bar: trend arrow + delta value below it
   const renderTrendLabel = ({ x, y, width, index }) => {
     const entry = data[index];
     const dir = trendDir(entry?.delta);
@@ -88,14 +102,16 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
   return (
     <section className="run-history-panel panel">
       <div className="run-history-header">
-        <span className="run-history-title">Score History</span>
+        <span className="run-history-title">Dimension Scores</span>
       </div>
       <ResponsiveContainer width="100%" height={160}>
-        <ComposedChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
+        <BarChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
           <CartesianGrid vertical={false} stroke={cssVar('--color-border', '#383532')} />
           <XAxis
-            dataKey="dateLabel"
+            dataKey="dimension"
+            tickFormatter={dimCode}
             tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            interval={0}
             axisLine={false}
             tickLine={false}
           />
@@ -106,39 +122,26 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
             axisLine={false}
             tickLine={false}
           />
-          <Tooltip content={RunHistoryTooltip} cursor={false} />
+          <Tooltip content={DimensionTooltip} cursor={false} />
           <ReferenceLine y={5} stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.5} />
           <Bar
-            dataKey="numericAverage"
+            dataKey="numericScore"
             radius={[3, 3, 0, 0]}
             maxBarSize={40}
             label={renderTrendLabel}
             isAnimationActive={false}
             cursor={onBarClick ? 'pointer' : 'default'}
-            onMouseEnter={(_, index) => setHoveredIndex(index)}
-            onMouseLeave={() => setHoveredIndex(null)}
-            onClick={(entry) => onBarClick?.(entry.runId)}
+            onClick={(entry) => onBarClick?.(entry)}
           >
             {data.map((entry, i) => (
               <Cell
-                key={entry.runId ?? i}
+                key={entry.dimension ?? i}
                 fill={cssVar('--color-accent', '#e8795a')}
-                opacity={entry.runId === selectedRunId ? 1 : 0.45}
-                stroke={hoveredIndex === i ? 'rgba(255,255,255,0.25)' : 'none'}
-                strokeWidth={hoveredIndex === i ? 1.5 : 0}
+                opacity={0.85}
               />
             ))}
           </Bar>
-          <Line
-            isAnimationActive={false}
-            dataKey="numericAverage"
-            type="monotone"
-            stroke={cssVar('--color-text-muted', '#9a9490')}
-            strokeWidth={2.5}
-            dot={{ r: 3, fill: cssVar('--color-text-muted', '#9a9490'), strokeWidth: 0 }}
-            activeDot={false}
-          />
-        </ComposedChart>
+        </BarChart>
       </ResponsiveContainer>
     </section>
   );

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+function cssVar(name, fallback) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+// Trend direction — mirrors the logic in TrendBadge
+const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
+const TREND_COLOR = {
+  up:         '#5ee6a0',
+  'soft-up':  '#92c9a8',
+  same:       '#94a3b8',
+  'soft-down':'#c8956c',
+  down:       '#f09070',
+};
+
+function trendDir(delta) {
+  if (delta === null || delta === undefined) return null;
+  if (delta > 1)   return 'up';
+  if (delta > 0.5) return 'soft-up';
+  if (delta < -1)  return 'down';
+  if (delta < -0.5) return 'soft-down';
+  return 'same';
+}
+
+function RunHistoryTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div className="run-history-tooltip">
+      <span className="rht-date">{d.dateLabel}</span>
+      <span className="rht-score">{d.numericAverage.toFixed(1)} / 10</span>
+      <span className="rht-grade">{d.overallGrade}</span>
+    </div>
+  );
+}
+
+export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+
+  // Need at least 2 data points to render a meaningful trend line
+  if (!trend || trend.length < 2) return null;
+
+  // Take the 20 most recent runs (trend is newest-first), then display oldest→newest.
+  // For the selected run, use the accumulated score so the bar matches the acc-eval-hero.
+  const data = [...trend].slice(0, 20).reverse().map((row, i, arr) => {
+    const isSelected = row.runId === selectedRunId;
+    const numericAverage = isSelected && selectedRunScore != null
+      ? parseFloat(selectedRunScore)
+      : parseFloat(row.numericAverage);
+    return {
+      ...row,
+      numericAverage,
+      delta: i > 0 ? numericAverage - parseFloat(arr[i - 1].numericAverage) : null,
+    };
+  });
+
+  // Custom label above each bar: trend arrow + delta value below it
+  const renderTrendLabel = ({ x, y, width, index }) => {
+    const entry = data[index];
+    const dir = trendDir(entry?.delta);
+    if (!dir) return null;
+    const cx = x + width / 2;
+    const deltaStr = entry.delta > 0 ? `+${entry.delta.toFixed(1)}` : entry.delta.toFixed(1);
+    return (
+      <g>
+        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={TREND_COLOR[dir]}>
+          {deltaStr}
+        </text>
+        <text x={cx} y={y - 14} textAnchor="middle" fontSize={11} fill={TREND_COLOR[dir]}>
+          {TREND_ARROW[dir]}
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <section className="run-history-panel panel">
+      <div className="run-history-header">
+        <span className="run-history-title">Score History</span>
+      </div>
+      <ResponsiveContainer width="100%" height={160}>
+        <ComposedChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
+          <CartesianGrid vertical={false} stroke={cssVar('--color-border', '#383532')} />
+          <XAxis
+            dataKey="dateLabel"
+            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 10]}
+            ticks={[0, 2.5, 5, 7.5, 10]}
+            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip content={RunHistoryTooltip} cursor={false} />
+          <Bar
+            dataKey="numericAverage"
+            radius={[3, 3, 0, 0]}
+            maxBarSize={40}
+            label={renderTrendLabel}
+            isAnimationActive={false}
+            cursor={onBarClick ? 'pointer' : 'default'}
+            onMouseEnter={(_, index) => setHoveredIndex(index)}
+            onMouseLeave={() => setHoveredIndex(null)}
+            onClick={(entry) => onBarClick?.(entry.runId)}
+          >
+            {data.map((entry, i) => (
+              <Cell
+                key={entry.runId ?? i}
+                fill={cssVar('--color-accent', '#e8795a')}
+                opacity={entry.runId === selectedRunId ? 1 : 0.45}
+                stroke={hoveredIndex === i ? 'rgba(255,255,255,0.25)' : 'none'}
+                strokeWidth={hoveredIndex === i ? 1.5 : 0}
+              />
+            ))}
+          </Bar>
+          <Line
+            isAnimationActive={false}
+            dataKey="numericAverage"
+            type="monotone"
+            stroke={cssVar('--color-text-muted', '#9a9490')}
+            strokeWidth={2.5}
+            dot={{ r: 3, fill: cssVar('--color-text-muted', '#9a9490'), strokeWidth: 0 }}
+            activeDot={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}

--- a/ui/web/src/features/dashboard/components/RunNavigator.jsx
+++ b/ui/web/src/features/dashboard/components/RunNavigator.jsx
@@ -7,7 +7,7 @@ export default function RunNavigator({ currentRun, isLatest, isOldest, onPrev, o
     <div className="run-navigator">
       <button
         type="button"
-        className="run-nav-action"
+        className="run-nav-action run-nav-action--danger"
         onClick={onLatest}
         disabled={isLatest}
         title="Go to latest run"

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -677,6 +677,17 @@
   pointer-events: none;
 }
 
+.run-navigator .run-nav-action--danger {
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+}
+
+.run-navigator .run-nav-action--danger:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--color-danger) 55%, transparent);
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+}
+
 /* Segmented pager: [‹][date][›] as one bordered unit */
 .run-nav-pager {
   display: inline-flex;
@@ -2217,3 +2228,47 @@
   border-color: var(--color-sev-minor-text);
   color: var(--color-sev-minor-text);
 }
+
+/* ── Run History Panel ────────────────────────────────── */
+
+.run-history-panel .recharts-wrapper,
+.run-history-panel .recharts-surface,
+.run-history-panel .recharts-tooltip-wrapper,
+.run-history-panel svg,
+.run-history-panel svg *,
+.run-history-panel *:focus {
+  outline: none !important;
+  user-select: none;
+}
+
+.run-history-panel {
+}
+
+.run-history-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.run-history-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.run-history-tooltip {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border, rgba(255,255,255,0.1));
+  border-radius: 6px;
+  padding: 6px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.8rem;
+}
+
+.rht-date  { color: var(--color-text-muted, #94a3b8); }
+.rht-score { font-weight: 600; color: var(--color-text, #f1f5f9); }
+.rht-grade { color: var(--color-text-muted, #94a3b8); font-size: 0.75rem; }

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2272,3 +2272,16 @@
 .rht-date  { color: var(--color-text-muted, #94a3b8); }
 .rht-score { font-weight: 600; color: var(--color-text, #f1f5f9); }
 .rht-grade { color: var(--color-text-muted, #94a3b8); font-size: 0.75rem; }
+
+/* ── History panels row (Score History + Dimension Scores side-by-side) ── */
+
+.history-panels-row {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.history-panels-row > .run-history-panel {
+  flex: 1 1 0;
+  min-width: 0;
+}


### PR DESCRIPTION
## Summary

- New **RunHistoryPanel** — composed chart (bars + line) showing per-run overall scores; click a bar to select that run
- New **DimensionScorePanel** — bar chart showing current accumulated scores per dimension; click a bar to navigate to that dimension in the explorer
- Both panels rendered side-by-side in the accumulated overview
- Trend arrows + delta values above each bar; dashed reference line at y=5
- Dimension X-axis uses uppercase shortcodes (MNT, PERF, SCL…)
- Backend fix: trend scores now use accumulated logic (best dimension per name across runs) to match the hero score

## Test plan

- [x] Score History panel shows bars for each run, line overlay, trend arrows
- [x] Clicking a bar selects that run and updates the navigator label
- [x] Dimension Scores panel shows one bar per dimension with correct shortcode labels
- [x] Clicking a dimension bar opens the explorer for that dimension
- [x] Both panels sit side-by-side in the same row
- [x] Dashed y=5 reference line visible in both charts
- [x] No Recharts focus outline on click, no rebuild animation