### PR TITLE
feat: polish violation detail UI and explorer layout

### DIFF
--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -296,8 +296,8 @@ export default function App() {
   // Show the project header on all data pages; hide it on evaluate and settings.
   const showProjectHeader = activeTab === 'overview' && projects.length > 0 && !!selectedProject;
 
-  // Show the run navigator only on data pages with runs available.
-  const showRunNav = showProjectHeader && availableRuns.length > 0;
+  // Show the run navigator only on top-level data pages (not when drilled into a sub-page).
+  const showRunNav = showProjectHeader && availableRuns.length > 0 && navStack.length === 1;
 
   // "View run" button only on the top-level overview (not when already in run mode or inner pages).
   const onViewRun = activePage.page === 'overview' ? handleRunView : undefined;

--- a/ui/web/src/components/CopyButton.jsx
+++ b/ui/web/src/components/CopyButton.jsx
@@ -20,8 +20,8 @@ export default function CopyButton({ onClick, label }) {
 
   return (
     <button className="detail-copy-btn" onClick={handleClick}>
-      <CopyIcon />
       {copied ? 'Copied!' : label}
+      <CopyIcon />
     </button>
   );
 }

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -564,22 +564,7 @@ export default function DashboardPage({
   availableRuns = [],
   overviewRunIndex = 0,
 }) {
-  const [themePreference, setThemePreference] = useState(
-    () => localStorage.getItem('cc-theme') ?? 'system'
-  );
-  const [showSettingsPanel, setShowSettingsPanel] = useState(false);
-  const [compareMode, setCompareMode] = useState(false);
   const [focusedDimension, setFocusedDimension] = useState(null);
-
-  const applyTheme = (pref) => {
-    setThemePreference(pref);
-    localStorage.setItem('cc-theme', pref);
-    if (pref === 'system') {
-      document.documentElement.removeAttribute('data-theme');
-    } else {
-      document.documentElement.setAttribute('data-theme', pref);
-    }
-  };
 
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
   const accumulatedDimensions = accumulated?.dimensions || [];
@@ -673,50 +658,6 @@ export default function DashboardPage({
         </>
       )}
 
-      {/* Settings toggle */}
-      <button
-        type="button"
-        className="settings-panel-toggle"
-        onClick={() => setShowSettingsPanel((v) => !v)}
-        title="Settings"
-        aria-label="Toggle settings panel"
-      >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="3" />
-          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-        </svg>
-      </button>
-
-      {showSettingsPanel && (
-        <aside className="settings-panel panel">
-          <h4 className="settings-panel-title">Settings</h4>
-          <div className="settings-section">
-            <p className="settings-label">Theme</p>
-            <div className="theme-toggle-group">
-              {['light', 'system', 'dark'].map((pref) => (
-                <button
-                  key={pref}
-                  type="button"
-                  className={`theme-toggle-btn${themePreference === pref ? ' active' : ''}`}
-                  onClick={() => applyTheme(pref)}
-                >
-                  {pref.charAt(0).toUpperCase() + pref.slice(1)}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="settings-section">
-            <label className="settings-toggle-row">
-              <span className="settings-label">Compare mode</span>
-              <input
-                type="checkbox"
-                checked={compareMode}
-                onChange={(e) => setCompareMode(e.target.checked)}
-              />
-            </label>
-          </div>
-        </aside>
-      )}
     </div>
   );
 }

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -14,6 +14,29 @@ function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
+const GRADE_VAR = {
+  exemplary:    '--color-grade-top-text',
+  good:         '--color-grade-high-text',
+  proficient:   '--color-grade-high-text',
+  adequate:     '--color-grade-mid-text',
+  developing:   '--color-grade-mid-text',
+  poor:         '--color-grade-low-text',
+  insufficient: '--color-grade-low-text',
+  critical:     '--color-grade-bottom-text',
+  a: '--color-grade-top-text',
+  b: '--color-grade-high-text',
+  c: '--color-grade-mid-text',
+  d: '--color-grade-low-text',
+  f: '--color-grade-bottom-text',
+};
+
+function gradeBarColor(grade) {
+  if (!grade) return cssVar('--color-accent', '#e8795a');
+  const key = grade.trim().toLowerCase();
+  const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
+  return varName ? cssVar(varName, '#e8795a') : cssVar('--color-accent', '#e8795a');
+}
+
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
 const TREND_COLOR = {
   up:         '#5ee6a0',
@@ -136,7 +159,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
             {data.map((entry, i) => (
               <Cell
                 key={entry.dimension ?? i}
-                fill={cssVar('--color-accent', '#e8795a')}
+                fill={gradeBarColor(entry.overallGrade)}
                 opacity={0.85}
               />
             ))}

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -15,6 +15,29 @@ function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
+const GRADE_VAR = {
+  exemplary:    '--color-grade-top-text',
+  good:         '--color-grade-high-text',
+  proficient:   '--color-grade-high-text',
+  adequate:     '--color-grade-mid-text',
+  developing:   '--color-grade-mid-text',
+  poor:         '--color-grade-low-text',
+  insufficient: '--color-grade-low-text',
+  critical:     '--color-grade-bottom-text',
+  a: '--color-grade-top-text',
+  b: '--color-grade-high-text',
+  c: '--color-grade-mid-text',
+  d: '--color-grade-low-text',
+  f: '--color-grade-bottom-text',
+};
+
+function gradeBarColor(grade) {
+  if (!grade) return cssVar('--color-accent', '#e8795a');
+  const key = grade.trim().toLowerCase();
+  const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
+  return varName ? cssVar(varName, '#e8795a') : cssVar('--color-accent', '#e8795a');
+}
+
 // Trend direction — mirrors the logic in TrendBadge
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
 const TREND_COLOR = {
@@ -122,7 +145,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
             {data.map((entry, i) => (
               <Cell
                 key={entry.runId ?? i}
-                fill={cssVar('--color-accent', '#e8795a')}
+                fill={gradeBarColor(entry.overallGrade)}
                 opacity={entry.runId === selectedRunId ? 1 : 0.45}
                 stroke={hoveredIndex === i ? 'rgba(255,255,255,0.25)' : 'none'}
                 strokeWidth={hoveredIndex === i ? 1.5 : 0}

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -4,6 +4,43 @@ function severityOrder(s) {
   return s === 'critical' ? 0 : s === 'major' ? 1 : 2;
 }
 
+function CopyIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function FileCopyBtn({ display, copyText }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="vlive-detail-file-btn"
+      onClick={() => {
+        navigator.clipboard.writeText(copyText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? 'Copied!' : display}
+      <CopyIcon />
+    </button>
+  );
+}
+
+// Parse a raw file string that may or may not carry a trailing :line.
+// Returns { filePath, line } where filePath has no line suffix.
+function parseFileRef(rawFile, rawLine) {
+  if (!rawFile) return { filePath: null, line: rawLine ?? null };
+  const m = rawFile.match(/^(.*?)(?::(\d+))?$/);
+  const filePath = m[1] || rawFile;
+  const line = rawLine ?? (m[2] ? parseInt(m[2], 10) : null);
+  return { filePath, line };
+}
+
 function ViolationLiveRow({ violation, index }) {
   const [open, setOpen] = useState(false);
 
@@ -15,7 +52,7 @@ function ViolationLiveRow({ violation, index }) {
       <div className="vlive-row-main" onClick={() => setOpen(o => !o)}>
         <span className={`severity-tag ${violation.severity}`}>{violation.severity}</span>
         <span className="vlive-principle">{violation.principle}</span>
-        <span className="vlive-file">{violation.file?.split('/').pop() ?? violation.file}</span>
+        <span className="vlive-file">{(() => { const { filePath, line } = parseFileRef(violation.file, violation.line); const name = filePath?.split('/').pop() ?? filePath; return line != null ? `${name}:${line}` : name; })()}</span>
         <svg
           className={`vlive-chevron${open ? ' open' : ''}`}
           width="14" height="14" viewBox="0 0 24 24"
@@ -25,29 +62,30 @@ function ViolationLiveRow({ violation, index }) {
           <polyline points="9 18 15 12 9 6" />
         </svg>
       </div>
-      {open && (
-        <div className="vlive-detail">
-          <div className="vlive-detail-row">
-            <span className="vlive-detail-label">File</span>
-            <code className="vlive-detail-value">{violation.file}</code>
+      {open && (() => {
+        const { filePath, line } = parseFileRef(violation.file, violation.line);
+        const filename = filePath ? filePath.split('/').pop() : null;
+        const dir = filePath?.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/') + 1) : null;
+        const ref = line != null ? `${filePath}:${line}` : filePath;
+        const display = line != null ? `${filename}:${line}` : filename;
+        return (
+          <div className="vlive-detail">
+            {violation.reason && (
+              <div className="vlive-detail-section">
+                <span className="vlive-detail-section-label">Reason</span>
+                <p className="vlive-detail-reason">{violation.reason}</p>
+              </div>
+            )}
+            {filename && (
+              <div className="vlive-detail-meta">
+                {dir && <span className="vlive-detail-meta-dir">{dir}</span>}
+                <FileCopyBtn display={display} copyText={ref} />
+              </div>
+            )}
+            {violation.snippet && <pre className="vlive-snippet">{violation.snippet}</pre>}
           </div>
-          {violation.line != null && (
-            <div className="vlive-detail-row">
-              <span className="vlive-detail-label">Line</span>
-              <code className="vlive-detail-value">{violation.line}</code>
-            </div>
-          )}
-          {violation.reason && (
-            <div className="vlive-detail-row">
-              <span className="vlive-detail-label">Reason</span>
-              <span className="vlive-detail-value vlive-detail-value--prose">{violation.reason}</span>
-            </div>
-          )}
-          {violation.snippet && (
-            <pre className="vlive-snippet">{violation.snippet}</pre>
-          )}
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -45,10 +45,36 @@ function CopyButton({ onClick, label }) {
   };
   return (
     <button className="detail-copy-btn" onClick={handleClick}>
-      <CopyIcon />
       {copied ? 'Copied!' : label}
+      <CopyIcon />
     </button>
   );
+}
+
+function FileCopyBtn({ display, copyText }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="vlive-detail-file-btn"
+      onClick={() => {
+        navigator.clipboard.writeText(copyText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? 'Copied!' : display}
+      <CopyIcon />
+    </button>
+  );
+}
+
+function parseFileRef(rawFile, rawLine) {
+  if (!rawFile) return { filePath: null, line: rawLine ?? null };
+  const m = rawFile.match(/^(.*?)(?::(\d+))?$/);
+  const filePath = m[1] || rawFile;
+  const line = rawLine ?? (m[2] ? parseInt(m[2], 10) : null);
+  return { filePath, line };
 }
 
 const PAGE_SIZE = 20;
@@ -197,35 +223,42 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
             <div className="vlive-violations-group">
               {vs.map((v, idx) => (
                 <div key={idx} className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}>
-                  <div className="vdetail-row-main">
-                    <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
-                    {v.file && (
-                      <span className="vlive-file">
-                        {v.file.split('/').pop()}
-                      </span>
-                    )}
-                    <CopyButton
-                      label="Fix plan"
-                      onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v))}
-                    />
-                  </div>
-                  <div className="vlive-detail">
-                    {v.file && (
-                      <div className="vlive-detail-row">
-                        <span className="vlive-detail-label">File</span>
-                        <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
-                      </div>
-                    )}
-                    {(v.reason || v.findings) && (
-                      <div className="vlive-detail-row">
-                        <span className="vlive-detail-label">Reason</span>
-                        <span className="vlive-detail-value vlive-detail-value--prose">{v.reason || v.findings}</span>
-                      </div>
-                    )}
-                    {(v.code || v.snippet) && (
-                      <pre className="vlive-snippet">{v.code || v.snippet}</pre>
-                    )}
-                  </div>
+                  {(() => {
+                    const { filePath, line } = parseFileRef(v.file, v.line);
+                    const filename = filePath ? filePath.split('/').pop() : null;
+                    const dir = filePath?.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/') + 1) : null;
+                    const ref = line != null ? `${filePath}:${line}` : filePath;
+                    const display = line != null ? `${filename}:${line}` : filename;
+                    return (
+                      <>
+                        <div className="vdetail-row-main">
+                          <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
+                          {filename && <span className="vlive-file">{display}</span>}
+                          <CopyButton
+                            label="Fix plan"
+                            onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v))}
+                          />
+                        </div>
+                        <div className="vlive-detail">
+                          {(v.reason || v.findings) && (
+                            <div className="vlive-detail-section">
+                              <span className="vlive-detail-section-label">Reason</span>
+                              <p className="vlive-detail-reason">{v.reason || v.findings}</p>
+                            </div>
+                          )}
+                          {filename && (
+                            <div className="vlive-detail-meta">
+                              {dir && <span className="vlive-detail-meta-dir">{dir}</span>}
+                              <FileCopyBtn display={display} copyText={ref} />
+                            </div>
+                          )}
+                          {(v.code || v.snippet) && (
+                            <pre className="vlive-snippet">{v.code || v.snippet}</pre>
+                          )}
+                        </div>
+                      </>
+                    );
+                  })()}
                 </div>
               ))}
             </div>
@@ -242,26 +275,38 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
           <div className="vlive-violations-group">
             {displayedCompliance.map((c, idx) => (
               <div key={idx} className="vdetail-row vdetail-row--compliant" style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}>
-                <div className="vdetail-row-main">
-                  {c.file && (
-                    <span className="vlive-file">{c.file.split('/').pop()}</span>
-                  )}
-                </div>
-                <div className="vlive-detail">
-                  {c.file && (
-                    <div className="vlive-detail-row">
-                      <span className="vlive-detail-label">File</span>
-                      <code className="vlive-detail-value">{c.file}{c.line ? `:${c.line}` : ''}</code>
-                    </div>
-                  )}
-                  {c.reason && (
-                    <div className="vlive-detail-row">
-                      <span className="vlive-detail-label">Reason</span>
-                      <span className="vlive-detail-value vlive-detail-value--prose">{c.reason}</span>
-                    </div>
-                  )}
-                  {c.snippet && <pre className="vlive-snippet">{c.snippet}</pre>}
-                </div>
+                {(() => {
+                  const { filePath, line } = parseFileRef(c.file, c.line);
+                  const filename = filePath ? filePath.split('/').pop() : null;
+                  const dir = filePath?.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/') + 1) : null;
+                  const ref = line != null ? `${filePath}:${line}` : filePath;
+                  const display = line != null ? `${filename}:${line}` : filename;
+                  return (
+                    <>
+                      <div className="vdetail-row-main">
+                        {filename && <span className="vlive-file">{display}</span>}
+                      </div>
+                      <div className="vlive-detail">
+                        {c.reason && (
+                          <div className="vlive-detail-section">
+                            <span className="vlive-detail-section-label">Reason</span>
+                            <p className="vlive-detail-reason">{c.reason}</p>
+                          </div>
+                        )}
+                        {filename && (
+                          <div className="vlive-detail-section">
+                            <span className="vlive-detail-section-label">File</span>
+                            <div className="vlive-detail-meta">
+                              {dir && <span className="vlive-detail-meta-dir">{dir}</span>}
+                              <FileCopyBtn display={display} copyText={ref} />
+                            </div>
+                          </div>
+                        )}
+                        {c.snippet && <pre className="vlive-snippet">{c.snippet}</pre>}
+                      </div>
+                    </>
+                  );
+                })()}
               </div>
             ))}
           </div>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -3,7 +3,7 @@ import { getDimensionEval } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
-import { gradeColorClass } from '../../../utils/formatters.js';
+import { gradeColorClass, formatRunId } from '../../../utils/formatters.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 
 export default function ExplorerPage({ project, dimension, runId, onNavigate }) {
@@ -86,9 +86,12 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
 
   return (
     <>
-      <section className="acc-eval-panel panel">
+      <section className="acc-eval-panel acc-eval-panel--compact panel">
         <div className="acc-eval-top">
-          <span className="acc-eval-label">{evalData.dimension}</span>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <span className="explorer-dimension-title">{evalData.dimension}</span>
+            {runId && <span className="acc-eval-date">{formatRunId(runId)}</span>}
+          </div>
           {allViolations.length > 0 && (
             <CopyButton
               label="Fix plan"
@@ -143,6 +146,12 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
 
       {/* Principles list */}
       {principleGrades.length > 0 && (
+        <>
+        <div className="section-header">
+          <h3 className="section-title">
+            {evalData.dimension.charAt(0).toUpperCase() + evalData.dimension.slice(1).toLowerCase()} Principles
+          </h3>
+        </div>
         <section className="panel eval-summary-panel">
           <ul className="exec-summary-list">
             {principleGrades.map((pg) => (
@@ -159,6 +168,7 @@ export default function ExplorerPage({ project, dimension, runId, onNavigate }) 
             ))}
           </ul>
         </section>
+        </>
       )}
 
       {/* Violations by principle */}

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -3,6 +3,14 @@ import { PLAN_TEST_INSTRUCTION_GROUP, PLAN_TEST_INSTRUCTION_SINGLE } from '../..
 
 const SEVERITY_ORDER = ['critical', 'major', 'minor', 'unknown'];
 
+function parseFileRef(rawFile, rawLine) {
+  if (!rawFile) return { filePath: null, line: rawLine ?? null };
+  const m = rawFile.match(/^(.*?)(?::(\d+))?$/);
+  const filePath = m[1] || rawFile;
+  const line = rawLine ?? (m[2] ? parseInt(m[2], 10) : null);
+  return { filePath, line };
+}
+
 function CopyIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -82,13 +90,36 @@ function CopyButton({ onClick, label }) {
   };
   return (
     <button className="detail-copy-btn" onClick={handleClick}>
-      <CopyIcon />
       {copied ? 'Copied!' : label}
+      <CopyIcon />
+    </button>
+  );
+}
+
+function FileCopyBtn({ display, copyText }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="vlive-detail-file-btn"
+      onClick={() => {
+        navigator.clipboard.writeText(copyText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? 'Copied!' : display}
+      <CopyIcon />
     </button>
   );
 }
 
 function ViolationCard({ v, index }) {
+  const { filePath, line } = parseFileRef(v.file, v.line);
+  const filename = filePath ? filePath.split('/').pop() : null;
+  const dir = filePath?.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/') + 1) : null;
+  const ref = line != null ? `${filePath}:${line}` : filePath;
+  const display = line != null ? `${filename}:${line}` : filename;
   return (
     <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}>
       <div className="vdetail-row-main">
@@ -101,16 +132,16 @@ function ViolationCard({ v, index }) {
         />
       </div>
       <div className="vlive-detail">
-        {v.file && (
-          <div className="vlive-detail-row">
-            <span className="vlive-detail-label">File</span>
-            <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
+        {v.reason && (
+          <div className="vlive-detail-section">
+            <span className="vlive-detail-section-label">Reason</span>
+            <p className="vlive-detail-reason">{v.reason}</p>
           </div>
         )}
-        {v.reason && (
-          <div className="vlive-detail-row">
-            <span className="vlive-detail-label">Reason</span>
-            <span className="vlive-detail-value vlive-detail-value--prose">{v.reason}</span>
+        {filename && (
+          <div className="vlive-detail-meta">
+            {dir && <span className="vlive-detail-meta-dir">{dir}</span>}
+            <FileCopyBtn display={display} copyText={ref} />
           </div>
         )}
         {v.snippet && <pre className="vlive-snippet">{v.snippet}</pre>}

--- a/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -3,6 +3,14 @@ import { PLAN_TEST_INSTRUCTION_GROUP, PLAN_TEST_INSTRUCTION_SINGLE } from '../..
 
 const SEVERITY_ORDER = ['critical', 'major', 'minor', 'unknown'];
 
+function parseFileRef(rawFile, rawLine) {
+  if (!rawFile) return { filePath: null, line: rawLine ?? null };
+  const m = rawFile.match(/^(.*?)(?::(\d+))?$/);
+  const filePath = m[1] || rawFile;
+  const line = rawLine ?? (m[2] ? parseInt(m[2], 10) : null);
+  return { filePath, line };
+}
+
 function CopyIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -81,36 +89,57 @@ function CopyButton({ onClick, label }) {
   };
   return (
     <button className="detail-copy-btn" onClick={handleClick}>
-      <CopyIcon />
       {copied ? 'Copied!' : label}
+      <CopyIcon />
+    </button>
+  );
+}
+
+function FileCopyBtn({ display, copyText }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="vlive-detail-file-btn"
+      onClick={() => {
+        navigator.clipboard.writeText(copyText);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? 'Copied!' : display}
+      <CopyIcon />
     </button>
   );
 }
 
 function ViolationCard({ v, principleName, index }) {
+  const { filePath, line } = parseFileRef(v.file, v.line);
+  const filename = filePath ? filePath.split('/').pop() : null;
+  const dir = filePath?.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/') + 1) : null;
+  const ref = line != null ? `${filePath}:${line}` : filePath;
+  const display = line != null ? `${filename}:${line}` : filename;
   return (
     <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * 30, 300)}ms` }}>
       <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
-        <span className="vlive-file">
-          {v.file?.split('/').pop() ?? v.file}
-        </span>
+        {filename && <span className="vlive-file">{display}</span>}
         <CopyButton
           label="Fix plan"
           onClick={() => navigator.clipboard.writeText(buildViolationPlanText(v, principleName))}
         />
       </div>
       <div className="vlive-detail">
-        {v.file && (
-          <div className="vlive-detail-row">
-            <span className="vlive-detail-label">File</span>
-            <code className="vlive-detail-value">{v.file}{v.line ? `:${v.line}` : ''}</code>
+        {v.reason && (
+          <div className="vlive-detail-section">
+            <span className="vlive-detail-section-label">Reason</span>
+            <p className="vlive-detail-reason">{v.reason}</p>
           </div>
         )}
-        {v.reason && (
-          <div className="vlive-detail-row">
-            <span className="vlive-detail-label">Reason</span>
-            <span className="vlive-detail-value vlive-detail-value--prose">{v.reason}</span>
+        {filename && (
+          <div className="vlive-detail-meta">
+            {dir && <span className="vlive-detail-meta-dir">{dir}</span>}
+            <FileCopyBtn display={display} copyText={ref} />
           </div>
         )}
         {v.snippet && <pre className="vlive-snippet">{v.snippet}</pre>}

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -21,6 +21,14 @@
   letter-spacing: 0.06em;
 }
 
+.explorer-dimension-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  letter-spacing: -0.01em;
+  text-transform: capitalize;
+}
+
 .acc-eval-date {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
@@ -62,6 +70,11 @@
 
 .acc-eval-trend .trend-badge-delta { font-size: 0.82rem; }
 .acc-eval-trend .trend-badge-label { font-size: 0.75rem; }
+
+.acc-eval-panel--compact .acc-eval-hero { gap: 10px; }
+.acc-eval-panel--compact .acc-eval-grade-chip { font-size: 1rem !important; padding: 4px 10px !important; }
+.acc-eval-panel--compact .acc-eval-score { font-size: 1.6rem; }
+.acc-eval-panel--compact .acc-eval-score-denom { font-size: 0.85rem; }
 
 .acc-eval-stats-grid {
   display: grid;
@@ -841,28 +854,6 @@
   background: rgba(255, 111, 111, 0.1);
   transform: none;
   filter: none;
-}
-
-.settings-panel {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 250ms ease, opacity 200ms ease;
-  opacity: 0;
-}
-
-.settings-panel > .settings-panel-inner {
-  overflow: hidden;
-}
-
-.settings-panel.visible {
-  grid-template-rows: 1fr;
-  opacity: 1;
-}
-
-.settings-panel-inner {
-  display: grid;
-  gap: 14px;
-  padding-top: 12px;
 }
 
 .filter-section {
@@ -2070,55 +2061,6 @@
   flex-wrap: wrap;
   gap: var(--space-1);
   margin-top: var(--space-1);
-}
-
-/* ── Settings panel toggle (floating button) ──────────── */
-
-.settings-panel-toggle {
-  position: fixed;
-  bottom: var(--space-5);
-  right: var(--space-5);
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--shadow-md);
-  transition: background 120ms ease, color 120ms ease, box-shadow 120ms ease;
-  z-index: 100;
-}
-
-.settings-panel-toggle:hover {
-  background: var(--color-surface-alt);
-  color: var(--color-text);
-  box-shadow: var(--shadow-lg);
-}
-
-.settings-panel-title {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
-  color: var(--color-text);
-  margin: 0 0 var(--space-4) 0;
-}
-
-.settings-toggle-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-2) 0;
-}
-
-.theme-toggle-group {
-  display: flex;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
 }
 
 /* ── DimensionCard missing classes ────────────────────── */

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -1531,52 +1531,95 @@
   transform: rotate(90deg);
 }
 
-/* Accordion detail panel */
+/* Accordion / expanded detail panel */
 .vlive-detail {
   margin: 0 0 4px;
-  padding: 12px;
+  padding: 12px 14px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.vlive-detail-row {
-  display: flex;
   gap: 10px;
-  align-items: flex-start;
-  font-size: var(--text-sm);
 }
 
-.vlive-detail-label {
-  flex-shrink: 0;
-  width: 52px;
+/* Section label (Reason / File) */
+.vlive-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.vlive-detail-section-label {
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   color: var(--color-text-subtle);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding-top: 2px;
+  letter-spacing: 0.06em;
 }
 
-.vlive-detail-value {
-  flex: 1;
+/* Reason: prose text */
+.vlive-detail-reason {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  line-height: var(--leading-normal);
+}
+
+
+/* File meta row: [dir/][filename.py:12 📋] */
+.vlive-detail-meta {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.vlive-detail-meta-dir {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  word-break: break-all;
+  color: var(--color-text-subtle);
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.vlive-detail-value--prose {
-  font-family: var(--font-sans);
-  word-break: normal;
-  overflow-wrap: break-word;
+/* filename:line copy button — styled like detail-copy-btn but mono */
+.vlive-detail-file-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 5px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+  transition: color 120ms ease;
+}
+
+.vlive-detail-file-btn:hover {
+  color: var(--color-accent);
+}
+
+.vlive-detail-file-btn svg {
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.vlive-detail-file-btn:hover svg {
+  opacity: 1;
 }
 
 .vlive-snippet {
-  margin: 0;
+  margin: 10px 0 0;
   padding: 10px 12px;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary

- **Settings panel removed** — floating gear button and settings aside eliminated
- **Grade-colored bars** — dimension and run-history bars now use the grade tier color scale (green → red)
- **Run navigator hidden on sub-pages** — only shown at top-level (navStack depth check)
- **Explorer dimension page improvements** — larger capitalized title, run date below it, compact eval hero panel, principles section header
- **Violation detail redesign** (LiveViolationsFeed, FileDetailPage, PrincipleDetailPage, EvalPrincipleDetailPage):
  - `REASON` label above prose text
  - File row: muted directory path + `filename:line 📋` copy button with "Copied!" feedback
  - Extra top margin between file location and snippet
- **Copy buttons** — icon moved to the right on all fix-plan buttons

## Test plan

- [x] Dashboard: dimension bars and run history bars colored by grade
- [x] Dashboard: no floating settings gear button
- [x] Dimension detail page: run navigator not visible, title styled correctly
- [x] Violation detail expanded: Reason label + prose, file path + copy button, snippet spaced correctly
- [x] All fix-plan copy buttons show icon on right and "Copied!" feedback