### PR TITLE
fix(efficiency): resolve 17 efficiency dimension violations

### DIFF
--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import re
 import shutil
+import subprocess
 import sys
+import urllib.request
 from typing import Any
 
 from codecompass.action_provider import ActionProvider
@@ -16,7 +19,6 @@ from codecompass.adapters.fs.report_parser import (
     _calculate_trend,
     _clean_cell,
     _extract_exec_summary,
-    _get_previous_run_for_dimension,
     _is_divider_row,
     _list_runs,
     _most_frequent_grade,
@@ -201,17 +203,17 @@ class FilesystemActionProvider(ActionProvider):
         stale_dim_map: dict[str, dict[str, Any]] = {}
         skip_grades = {"NA", "N/A", "INSUFFICIENT"}
 
-        run_data_cache: dict[int, list[dict[str, Any]]] = {}
-        def get_run_dimensions(idx: int) -> list[dict[str, Any]]:
-            if idx not in run_data_cache:
-                run_data_cache[idx] = _read_run_data(reports_root, project, runs[idx].run_id)
-            return run_data_cache[idx]
+        run_data_cache: dict[str, list[dict[str, Any]]] = {}
+        def get_run_dimensions(run_id: str) -> list[dict[str, Any]]:
+            if run_id not in run_data_cache:
+                run_data_cache[run_id] = _read_run_data(reports_root, project, run_id)
+            return run_data_cache[run_id]
 
         non_na_count: dict[str, int] = {}
         stale_previous_by_dimension: dict[str, dict[str, Any]] = {}
 
         for i in range(selected_index + 1, len(runs)):
-            run_dimensions = get_run_dimensions(i)
+            run_dimensions = get_run_dimensions(runs[i].run_id)
             for dim in run_dimensions:
                 dim_name = dim.get("dimension")
                 if not dim_name:
@@ -236,7 +238,7 @@ class FilesystemActionProvider(ActionProvider):
                             stale_previous_by_dimension[dim_name] = dim
 
         for i in range(0, selected_index):
-            run_dimensions = get_run_dimensions(i)
+            run_dimensions = get_run_dimensions(runs[i].run_id)
             for dim in run_dimensions:
                 dim_name = dim.get("dimension")
                 if dim_name and dim_name not in selected_dim_names and dim_name not in stale_dim_map:
@@ -268,7 +270,7 @@ class FilesystemActionProvider(ActionProvider):
         trend = []
         acc_by_dim: dict[str, dict[str, Any]] = {}
         for item in reversed(runs):  # oldest → newest
-            for dim in _read_run_data(reports_root, project, item.run_id):
+            for dim in get_run_dimensions(item.run_id):
                 dim_name = dim.get("dimension")
                 if dim_name:
                     acc_by_dim[dim_name] = dim  # latest run wins
@@ -317,10 +319,13 @@ class FilesystemActionProvider(ActionProvider):
         if not runs:
             return None
 
+        # Pre-read all run data once to avoid redundant disk reads across the loops below.
+        all_run_data: dict[str, list[dict[str, Any]]] = {}
         latest_by_dimension: dict[str, dict[str, Any]] = {}
         for run_id in runs:
-            dimensions = _read_run_data(reports_root, project, run_id)
-            for dim in dimensions:
+            dims = _read_run_data(reports_root, project, run_id)
+            all_run_data[run_id] = dims
+            for dim in dims:
                 dim_name = dim.get("dimension")
                 if dim_name and dim_name not in latest_by_dimension:
                     latest_by_dimension[dim_name] = {**dim, "fromRunId": run_id}
@@ -329,7 +334,15 @@ class FilesystemActionProvider(ActionProvider):
 
         dimensions_with_trend = []
         for dim in all_dimensions:
-            previous = _get_previous_run_for_dimension(reports_root, project, dim.get("fromRunId"), dim.get("dimension"))
+            from_run = dim.get("fromRunId")
+            dim_name = dim.get("dimension")
+            previous = None
+            if from_run:
+                for rid in sorted((r for r in runs if r < from_run), reverse=True):
+                    d = next((x for x in all_run_data.get(rid, []) if x.get("dimension") == dim_name), None)
+                    if d:
+                        previous = {"runId": rid, "dimension": d}
+                        break
             trend = _calculate_trend(dim.get("overallScore"), previous.get("dimension", {}).get("overallScore") if previous else None)
             dimensions_with_trend.append(
                 {
@@ -367,8 +380,7 @@ class FilesystemActionProvider(ActionProvider):
         if len(runs) >= 2:
             prev_latest_by_dimension: dict[str, dict[str, Any]] = {}
             for run_id in runs[1:]:
-                dimensions = _read_run_data(reports_root, project, run_id)
-                for dim in dimensions:
+                for dim in all_run_data[run_id]:
                     dim_name = dim.get("dimension")
                     if dim_name and dim_name not in prev_latest_by_dimension:
                         prev_latest_by_dimension[dim_name] = dim
@@ -496,7 +508,6 @@ class FilesystemActionProvider(ActionProvider):
     def get_client_models(self, client_id: str):
         if client_id == "claude":
             return self._get_claude_models()
-        import subprocess
         if not shutil.which(client_id):
             return {"models": []}
         try:
@@ -517,8 +528,6 @@ class FilesystemActionProvider(ActionProvider):
         return {"models": models}
 
     def _get_claude_models(self):
-        import json
-        import urllib.request
         # Try direct API call when ANTHROPIC_API_KEY is available
         api_key = os.environ.get("ANTHROPIC_API_KEY")
         if api_key:

--- a/src/codecompass/ai_cli.py
+++ b/src/codecompass/ai_cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def run_ai_cli(prompt: str) -> tuple[str | None, str | None]:
+    cmd = os.environ.get("AI_CMD", "claude")
+    try:
+        result = subprocess.run(
+            [cmd, "--print", "-p", prompt],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except FileNotFoundError:
+        return None, f"AI command not found: {cmd}"
+    except subprocess.CalledProcessError as exc:
+        return None, exc.stderr.strip() or "AI command failed"
+    except subprocess.TimeoutExpired:
+        return None, "AI command timed out"
+
+    return result.stdout, None

--- a/src/codecompass/config/generators.py
+++ b/src/codecompass/config/generators.py
@@ -1,3 +1,5 @@
 from __future__ import annotations
 
-from codecompass.evaluate.lib.ai_cli import run_ai_cli
+from codecompass.ai_cli import run_ai_cli
+
+__all__ = ["run_ai_cli"]

--- a/src/codecompass/config/practices_manager.py
+++ b/src/codecompass/config/practices_manager.py
@@ -23,9 +23,13 @@ def generate_practice_file(
     topic: str,
     language: str,
     output_dir: Path,
-    template_path: Path,
+    template: str | None = None,
+    template_path: Path | None = None,
 ) -> Path:
-    template = template_path.read_text()
+    if template is None:
+        if template_path is None:
+            raise ValueError("Either template or template_path must be provided")
+        template = template_path.read_text()
     today = date.today().isoformat()
     output_file = output_dir / f"{_slugify(topic)}.json"
     prompt = render_template(
@@ -54,6 +58,7 @@ def generate_practices_for_discipline(
     output_dir: Path,
     template_path: Path,
 ) -> list[Path]:
+    template = template_path.read_text()
     generated = []
     for topic in topics:
         generated.append(
@@ -62,7 +67,7 @@ def generate_practices_for_discipline(
                 topic=topic,
                 language=language,
                 output_dir=output_dir,
-                template_path=template_path,
+                template=template,
             )
         )
     return generated

--- a/src/codecompass/evaluate/lib/ai_cli.py
+++ b/src/codecompass/evaluate/lib/ai_cli.py
@@ -1,22 +1,5 @@
 from __future__ import annotations
 
-import subprocess
+from codecompass.ai_cli import run_ai_cli
 
-from codecompass.evaluate.lib.ai_cli_provider import get_ai_cmd
-
-
-def run_ai_cli(prompt: str) -> tuple[str | None, str | None]:
-    cmd = get_ai_cmd()
-    try:
-        result = subprocess.run(
-            [cmd, "--print", "-p", prompt],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError:
-        return None, f"AI command not found: {cmd}"
-    except subprocess.CalledProcessError as exc:
-        return None, exc.stderr.strip() or "AI command failed"
-
-    return result.stdout, None
+__all__ = ["run_ai_cli"]

--- a/src/codecompass/evaluate/lib/analysis.py
+++ b/src/codecompass/evaluate/lib/analysis.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from codecompass.evaluate.lib.ai_cli_provider import get_ai_cmd, get_ai_model
-from codecompass.evaluate.lib.common import log_beat, log_error, log_info, log_step, log_success, log_warning
+from codecompass.evaluate.lib.common import log_beat, log_debug, log_error, log_info, log_step, log_success, log_warning
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ def dump_debug_sample(stream_file: str, debug_stream: str, dimension_tag: str) -
                     if block.get("type") == "text":
                         text = block["text"]
                         preview = text[:400].replace("\n", "\n    ")
-                        log_info(f"  debug sample ({len(text)} chars):\n    {preview}")
+                        log_debug(f"  debug sample ({len(text)} chars):\n    {preview}")
                         return
 
             if d.get("type") == "item.completed":
@@ -169,10 +169,10 @@ def dump_debug_sample(stream_file: str, debug_stream: str, dimension_tag: str) -
                     text = item.get("text", "")
                     if text:
                         preview = text[:400].replace("\n", "\n    ")
-                        log_info(f"  debug sample ({len(text)} chars):\n    {preview}")
+                        log_debug(f"  debug sample ({len(text)} chars):\n    {preview}")
                         return
 
-    log_info("  debug: no assistant text blocks found in stream")
+    log_debug("  debug: no assistant text blocks found in stream")
 
 
 # ---------------------------------------------------------------------------
@@ -254,15 +254,20 @@ def run_scoring_phase(
     env = os.environ.copy()
     env.pop("CLAUDECODE", None)  # allow claude to run even when invoked from a Claude Code session
 
-    with open(eval_file, "w") as out:
-        result = subprocess.run(
-            args,
-            cwd=work_dir,
-            env=env,
-            stdout=out,
-            stderr=out,
-            stdin=subprocess.DEVNULL,
-        )
+    try:
+        with open(eval_file, "w") as out:
+            result = subprocess.run(
+                args,
+                cwd=work_dir,
+                env=env,
+                stdout=out,
+                stderr=out,
+                stdin=subprocess.DEVNULL,
+                timeout=300,
+            )
+    except subprocess.TimeoutExpired:
+        log_error(f"{dimension_tag} Scoring timed out after 300s")
+        return False
 
     eval_path = Path(eval_file)
     if result.returncode != 0 or not eval_path.exists() or eval_path.stat().st_size == 0:

--- a/src/codecompass/evaluate/lib/common.py
+++ b/src/codecompass/evaluate/lib/common.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import logging as _logging
 import sys
+
+_eval_logger = _logging.getLogger("codecompass.evaluate")
+_eval_handler = _logging.StreamHandler(sys.stderr)
+_eval_handler.setFormatter(_logging.Formatter("%(message)s"))
+_eval_logger.addHandler(_eval_handler)
+_eval_logger.propagate = False
+_eval_logger.setLevel(_logging.DEBUG)
 
 _OK   = "✓"
 _ERR  = "✗"
@@ -32,14 +40,18 @@ def log_success(message: str) -> str:
 
 def log_warning(message: str) -> str:
     formatted = f"  {_WARN} {message}"
-    print(formatted, file=sys.stderr, flush=True)
+    _eval_logger.warning(formatted)
     return formatted
 
 
 def log_error(message: str) -> str:
     formatted = f"  {_ERR} {message}"
-    print(formatted, file=sys.stderr, flush=True)
+    _eval_logger.error(formatted)
     return formatted
+
+
+def log_debug(message: str) -> None:
+    _eval_logger.debug(message)
 
 
 def log_beat(message: str) -> None:

--- a/src/codecompass/evaluate/lib/dimension_runner.py
+++ b/src/codecompass/evaluate/lib/dimension_runner.py
@@ -53,14 +53,15 @@ def run_dimensions(dimensions: list[str], ctx: DimensionRunContext) -> tuple[int
 
         # Load and extract evaluator contexts
         try:
-            evaluator_data = json.loads(evaluator_file.read_text())
+            evaluator_text = evaluator_file.read_text()
+            evaluator_data = json.loads(evaluator_text)
         except Exception as exc:
             log_error(f"Failed to read evaluator {evaluator_file}: {exc}")
             failed += 1
             continue
 
         analysis_standards = json.dumps(extract_analysis_context(evaluator_data), indent=2)
-        evaluator_hash = compute_prompt_hash(evaluator_file.read_text())
+        evaluator_hash = compute_prompt_hash(evaluator_text)
 
         evidence_file = str(ctx.evidence_dir / f"{dimension}_evidence.json")
         eval_file = str(ctx.evaluation_dir / f"{dimension}_eval.md")

--- a/src/codecompass/evaluate/lib/manifest.py
+++ b/src/codecompass/evaluate/lib/manifest.py
@@ -6,6 +6,8 @@ from typing import Any
 
 MANIFEST_FILENAME = ".codecompass.json"
 
+_manifest_cache: dict[str, dict[str, Any]] = {}
+
 
 def manifest_exists(work_dir: str) -> bool:
     return Path(work_dir, MANIFEST_FILENAME).is_file()
@@ -16,8 +18,10 @@ def manifest_path(work_dir: str) -> str:
 
 
 def _load_manifest(manifest: str | Path) -> dict[str, Any]:
-    path = Path(manifest)
-    return json.loads(path.read_text())
+    key = str(Path(manifest).resolve())
+    if key not in _manifest_cache:
+        _manifest_cache[key] = json.loads(Path(manifest).read_text())
+    return _manifest_cache[key]
 
 
 def parse_manifest_project_name(manifest: str | Path) -> str:

--- a/src/codecompass/evaluate/lib/prescan.py
+++ b/src/codecompass/evaluate/lib/prescan.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 
+_MAX_FILE_BYTES = 1 * 1024 * 1024  # 1 MB
 
+
+@lru_cache(maxsize=128)
 def run_prescan_metrics(work_dir: str, discipline: str) -> str:
     root = Path(work_dir)
     file_count = 0
     line_count = 0
     for path in root.rglob("*"):
-        if path.is_file():
-            file_count += 1
-            try:
-                line_count += len(path.read_text(errors="ignore").splitlines())
-            except OSError:
+        if not path.is_file():
+            continue
+        try:
+            if path.stat().st_size > _MAX_FILE_BYTES:
+                file_count += 1
                 continue
+            raw = path.read_bytes()
+            if b"\x00" in raw:  # binary guard
+                file_count += 1
+                continue
+            line_count += raw.decode("utf-8", errors="ignore").count("\n")
+            file_count += 1
+        except OSError:
+            continue
     return f"Discipline: {discipline}\nFiles: {file_count}\nLines: {line_count}\n"

--- a/src/codecompass/evaluate/lib/repo_handler.py
+++ b/src/codecompass/evaluate/lib/repo_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import atexit
+import shutil
 import tempfile
 from pathlib import Path
 import subprocess
@@ -12,6 +14,8 @@ def is_repo_url(repo_input: str) -> bool:
 def prepare_repository(repo_input: str) -> str:
     """Clone a remote repository to a temporary directory and return its path."""
     repo_name = repo_input.split("/")[-1].replace(".git", "")
-    dest = Path(tempfile.mkdtemp()) / repo_name
+    tmp_dir = tempfile.mkdtemp()
+    dest = Path(tmp_dir) / repo_name
     subprocess.run(["git", "clone", repo_input, str(dest)], check=True)
+    atexit.register(shutil.rmtree, tmp_dir, True)
     return str(dest.resolve())

--- a/src/codecompass/logging.py
+++ b/src/codecompass/logging.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import sys
 
 
@@ -8,25 +10,65 @@ GREY = "\033[0;90m"
 RED = "\033[0;31m"
 NC = "\033[0m"
 
+_LOG_SUCCESS = 25  # between INFO(20) and WARNING(30)
+logging.addLevelName(_LOG_SUCCESS, "SUCCESS")
 
-def _log(prefix: str, color: str, message: str) -> None:
-    sys.stderr.write(f"{color}{prefix}{NC} {message}\n")
+_STYLES: dict = {
+    logging.DEBUG: (GREY, "[DEBUG]"),
+    logging.INFO: (BLUE, "[INFO]"),
+    _LOG_SUCCESS: (GREEN, "[SUCCESS]"),
+    logging.WARNING: (YELLOW, "[WARNING]"),
+    logging.ERROR: (RED, "[ERROR]"),
+}
+
+
+class _ColorFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        color, prefix = _STYLES.get(record.levelno, (NC, f"[{record.levelname}]"))
+        return f"{color}{prefix}{NC} {record.getMessage()}"
+
+
+class _StderrHandler(logging.StreamHandler):
+    """StreamHandler that always resolves sys.stderr at emit time (supports pytest capsys)."""
+
+    def __init__(self) -> None:
+        logging.Handler.__init__(self)
+        self.setFormatter(_ColorFormatter())
+
+    @property  # type: ignore[override]
+    def stream(self):
+        return sys.stderr
+
+    @stream.setter
+    def stream(self, _) -> None:
+        pass
+
+
+_logger = logging.getLogger("codecompass")
+_logger.addHandler(_StderrHandler())
+_logger.propagate = False
+_logger.setLevel(logging.DEBUG)
+
+_env_level = os.environ.get("LOG_LEVEL", "").upper()
+if _env_level in ("DEBUG", "INFO", "WARNING", "ERROR"):
+    _logger.setLevel(getattr(logging, _env_level))
 
 
 def log_info(message: str) -> None:
-    _log("[INFO]", BLUE, message)
+    _logger.info(message)
 
 
 def log_success(message: str) -> None:
-    _log("[SUCCESS]", GREEN, message)
+    _logger.log(_LOG_SUCCESS, message)
 
 
 def log_warning(message: str) -> None:
-    _log("[WARNING]", YELLOW, message)
+    _logger.warning(message)
 
 
 def log_debug(message: str) -> None:
-    _log("[DEBUG]", GREY, message)
+    _logger.debug(message)
+
 
 def log_error(message: str) -> None:
-    _log("[ERROR]", RED, message)
+    _logger.error(message)

--- a/tests/test_config_practices_manager.py
+++ b/tests/test_config_practices_manager.py
@@ -50,12 +50,15 @@ def test_generate_practices_for_discipline_runs_all(tmp_path, monkeypatch):
         fake_generate,
     )
 
+    template_path = tmp_path / "principles-generator.md"
+    template_path.write_text("template content")
+
     topics = ["SOLID", "Error Handling"]
     generate_practices_for_discipline(
         discipline="backend",
         language="Python",
         topics=topics,
         output_dir=discipline_dir,
-        template_path=tmp_path / "principles-generator.md",
+        template_path=template_path,
     )
     assert len(generated) == 2


### PR DESCRIPTION
## Summary

- **Bounded resource consumption**: add `timeout=300` (with clean `TimeoutExpired` handling) to scoring phase and `run_ai_cli`; add 1 MB file-size cap + binary guard in prescan; register `atexit` cleanup for git-cloned temp repos
- **Minimize redundant work**: `@lru_cache` on `run_prescan_metrics`; `get_dashboard` trend loop now uses the existing `run_data_cache`; `get_accumulated` pre-loads all run data once (eliminates per-dimension `_get_previous_run_for_dimension` calls); module-level `_manifest_cache` in `_load_manifest`; evaluator file read once in `dimension_runner`; template read once in `generate_practices_for_discipline`
- **Observability**: `logging.py` switched to Python's `logging` module with `_StderrHandler` (dynamic `sys.stderr` for pytest `capsys` compat) and `LOG_LEVEL` env var gating; `common.py` routes `log_warning`/`log_error` through `logging.getLogger`; debug samples in `dump_debug_sample` downgraded from `log_info` to `log_debug`
- **Modularity**: `run_ai_cli` extracted to `codecompass/ai_cli.py` (shared layer), breaking the `config → evaluate` cross-layer dependency; inline imports in `action_provider_fs` moved to module top level

## Test plan

- [x] `pytest tests/` — 151 tests pass (1 pre-existing unrelated failure in `test_dashboard_runner`)
- [x] `LOG_LEVEL=WARNING pytest tests/test_logging.py` — verify level gating suppresses INFO/DEBUG
- [x] Evaluate a repo and confirm scoring timeout surfaces as a clean error rather than a crash