### PR TITLE
feat: Projects tab

### DIFF
--- a/docs/plans/2026-03-02-projects-tab-design.md
+++ b/docs/plans/2026-03-02-projects-tab-design.md
@@ -1,0 +1,111 @@
+# Projects Tab Design
+
+**Date:** 2026-03-02
+**Status:** Approved
+
+## Problem
+
+The project selector is an inline `<select>` dropdown buried in the sidebar. It gives no overview of available projects, no indication of quality, no run dates, and no way to express relationships between projects (e.g. a platform composed of multiple services).
+
+## Goal
+
+Replace the sidebar dropdown with a dedicated **Projects** tab that shows all projects in a tree, supports parent/child relationships, and lets users switch projects from a richer UI.
+
+## Data Model
+
+### Backend change — `list_projects`
+
+`action_provider_fs.py` `list_projects` will peek at each project's `repository_info.json` and include a `parent` field if present. No migration needed — opt-in, existing projects return `parent: null`.
+
+Each project object becomes:
+```json
+{
+  "name": "service-a",
+  "runsCount": 12,
+  "latestRunId": "run-2026-03-01",
+  "latestDate": "2026-03-01T10:00:00Z",
+  "parent": "my-platform"
+}
+```
+
+### Declaring a parent
+
+Add a `parent` key to `repository_info.json` inside the child project's data folder:
+```json
+{
+  "discipline": "backend",
+  "parent": "my-platform"
+}
+```
+
+## Sidebar & Navigation
+
+- New **Projects** nav button between Overview and Evaluate (folder/stack icon)
+- Calls `navTab('projects')` — fits existing pattern
+- `activeTab` expanded to include `'projects'`
+- Current `sidebar-project-section` dropdown **removed**
+- `showProjectHeader` updated to exclude the `projects` page
+
+```
+[CC]
+────
+[⊞] Overview
+[⬡] Projects
+[◎] Evaluate
+────
+[⚙] Settings
+```
+
+## Projects Page Component
+
+New `ProjectsPage.jsx`. Builds a tree client-side from the flat `projects` array.
+
+**Tree structure:**
+- Roots: projects with no `parent`
+- Children: grouped under their parent by the `parent` field
+- Orphaned children (parent not found in list) fall back to root level
+
+**Each row shows:**
+- Project name
+- Latest score badge (grade-colored, e.g. `B  7.4`)
+- Latest run date (muted)
+
+**Interaction:**
+- Root projects with children: `▾/▸` chevron toggles expand/collapse
+- Clicking the project name selects it and navigates to `overview`
+- Children are indented with a subtle connector line
+- Selected project row is highlighted
+- Empty state if no projects: prompt to go to Evaluate
+
+```
+Projects
+─────────────────────────────────────────
+▾ my-platform          B  7.4    Feb 28
+  ├ service-a          C  5.1    Mar 01  ← selected
+  └ service-b          A  8.9    Feb 20
+  standalone-repo      D  3.2    Jan 15
+─────────────────────────────────────────
+```
+
+## Overview Header — Parent › Child
+
+When the selected project has a `parent`, the content header title renders:
+
+```
+my-platform › service-a
+```
+
+- Parent name in muted style
+- `›` separator
+- Child name as primary text
+
+No change when there is no parent.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `src/codecompass/action_provider_fs.py` | Add `parent` to `list_projects` response |
+| `ui/web/src/App.jsx` | Add Projects nav, remove dropdown, add `case 'projects'`, update header |
+| `ui/web/src/features/dashboard/components/ProjectsPage.jsx` | New component |
+| `ui/web/src/styles/dashboard.css` | Styles for projects page |

--- a/docs/plans/2026-03-02-projects-tab.md
+++ b/docs/plans/2026-03-02-projects-tab.md
@@ -1,0 +1,604 @@
+# Projects Tab Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the sidebar project dropdown with a dedicated Projects tab that shows all projects in a collapsible tree with grade/date info and supports parent/child relationships.
+
+**Architecture:** Add `parent` to the backend `list_projects` response by reading `repository_info.json`. Add a new `projects` page to the frontend nav stack, rendered by a new `ProjectsPage.jsx`. Remove the inline sidebar dropdown. Update the content header to show `parent › child` when a child project is selected.
+
+**Tech Stack:** Python (backend), React + CSS custom properties (frontend), no new dependencies.
+
+---
+
+### Task 1: Backend — expose `parent` in list_projects
+
+**Files:**
+- Modify: `src/codecompass/action_provider_fs.py:123-141`
+
+**Step 1: Edit `list_projects` to read `repository_info.json` per project**
+
+In `FilesystemActionProvider.list_projects`, after computing `runs`, peek at the project's `repository_info.json` and extract `parent` if present. Replace the current `projects.append(...)` block with:
+
+```python
+def list_projects(self, reports_dir: str):
+    reports_root = Path(reports_dir)
+    projects = []
+    for entry in _safe_read_dir(reports_root):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        runs = _list_runs(reports_root, entry.name)
+        if not runs:
+            continue
+        parent = None
+        info_path = reports_root / entry.name / "repository_info.json"
+        if info_path.exists():
+            try:
+                info = json.loads(info_path.read_text())
+                parent = info.get("parent") or None
+            except (json.JSONDecodeError, OSError):
+                pass
+        projects.append(
+            {
+                "name": entry.name,
+                "runsCount": len(runs),
+                "latestRunId": runs[0].run_id if runs else None,
+                "latestDate": runs[0].date_iso if runs else None,
+                "parent": parent,
+            }
+        )
+    projects.sort(key=lambda item: item["name"])
+    return {"projects": projects}
+```
+
+**Step 2: Verify manually**
+
+Start the backend and call:
+```
+curl http://localhost:5000/api/projects
+```
+Expected: each project object includes a `"parent"` key (null if not set). Add a `"parent": "some-project"` entry to any `repository_info.json` and re-call to confirm it appears.
+
+**Step 3: Commit**
+
+```bash
+git add src/codecompass/action_provider_fs.py
+git commit -m "feat: include parent field in list_projects response"
+```
+
+---
+
+### Task 2: App.jsx — add Projects nav item, remove dropdown
+
+**Files:**
+- Modify: `ui/web/src/App.jsx`
+
+This task has several small edits. Do them all before committing.
+
+**Step 1: Add the Projects icon constant** (after `ICON_EVALUATE`, before `ICON_SETTINGS`)
+
+```jsx
+const ICON_PROJECTS = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 7h18M3 12h18M3 17h18" />
+    <rect x="3" y="3" width="4" height="4" rx="0.5" />
+    <rect x="3" y="10" width="4" height="4" rx="0.5" />
+    <rect x="3" y="17" width="4" height="4" rx="0.5" />
+  </svg>
+);
+```
+
+**Step 2: Expand `activeTab` to include `'projects'`** (line ~292)
+
+Change:
+```js
+const activeTab = ['overview', 'evaluate', 'settings'].includes(activePage.page)
+  ? activePage.page
+  : 'overview';
+```
+To:
+```js
+const activeTab = ['overview', 'projects', 'evaluate', 'settings'].includes(activePage.page)
+  ? activePage.page
+  : 'overview';
+```
+
+**Step 3: Update `showProjectHeader`** (line ~297)
+
+Change:
+```js
+const showProjectHeader = activeTab === 'overview' && projects.length > 0 && !!selectedProject;
+```
+To:
+```js
+const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
+```
+
+(This excludes the `projects` tab from showing the project header.)
+
+**Step 4: Add the Projects nav button in the sidebar** (after the Evaluate button, before the closing `</nav>`)
+
+```jsx
+<button
+  type="button"
+  className={`sidebar-nav-item${activeTab === 'projects' ? ' active' : ''}`}
+  onClick={() => navTab('projects')}
+  title="Projects"
+>
+  {ICON_PROJECTS}
+  <span className="sidebar-nav-label">Projects</span>
+</button>
+```
+
+**Step 5: Remove the entire `sidebar-project-section` block** (lines ~617-633)
+
+Delete:
+```jsx
+{/* Project selector */}
+{projects.length > 0 && (
+  <div className="sidebar-project-section">
+    <p className="sidebar-project-label">Project</p>
+    <select
+      className="project-select-styled"
+      value={selectedProject}
+      disabled={projects.length === 0}
+      onChange={(e) => handleProjectChange(e.target.value)}
+    >
+      {projects.map((p) => {
+        const name = p.name || p;
+        return <option key={name} value={name}>{name}</option>;
+      })}
+    </select>
+  </div>
+)}
+```
+
+**Step 6: Add `case 'projects'` stub in `renderContent`** (before the `default:` case)
+
+```jsx
+case 'projects':
+  return (
+    <ProjectsPage
+      projects={projects}
+      selectedProject={selectedProject}
+      onSelect={(name) => { handleProjectChange(name); navTab('overview'); }}
+    />
+  );
+```
+
+**Step 7: Add the import for `ProjectsPage`** at the top of the file (after the existing imports)
+
+```jsx
+import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
+```
+
+**Step 8: Verify the app builds**
+
+```bash
+cd ui/web && npm run build
+```
+Expected: no errors. The app should load, show three nav items, and clicking Projects should hit the stub (which will show nothing until Task 3).
+
+**Step 9: Commit**
+
+```bash
+git add ui/web/src/App.jsx
+git commit -m "feat: add Projects nav tab, remove sidebar dropdown"
+```
+
+---
+
+### Task 3: ProjectsPage.jsx — tree component
+
+**Files:**
+- Create: `ui/web/src/features/dashboard/components/ProjectsPage.jsx`
+
+**Step 1: Create the component**
+
+```jsx
+import { useState } from 'react';
+
+function gradeLabel(grade) {
+  if (!grade) return null;
+  const k = grade.trim().toLowerCase();
+  // Map verbose grades to single letter
+  const MAP = { exemplary: 'A', good: 'B', proficient: 'B', adequate: 'C', developing: 'C', poor: 'D', insufficient: 'D', critical: 'F' };
+  const letter = MAP[k] ?? grade.trim().toUpperCase().charAt(0);
+  return letter;
+}
+
+function formatDate(iso) {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return null;
+  }
+}
+
+export default function ProjectsPage({ projects = [], selectedProject, onSelect }) {
+  // Build tree
+  const projectMap = Object.fromEntries(projects.map((p) => [p.name || p, p]));
+  const children = {};
+  const roots = [];
+
+  for (const p of projects) {
+    const name = p.name || p;
+    const parent = p.parent;
+    if (parent && projectMap[parent]) {
+      if (!children[parent]) children[parent] = [];
+      children[parent].push(p);
+    } else {
+      roots.push(p);
+    }
+  }
+
+  // Default: expand the parent of the selected project (if any)
+  const selectedData = projectMap[selectedProject];
+  const initialExpanded = selectedData?.parent ? { [selectedData.parent]: true } : {};
+  // Also expand any root that has children
+  roots.forEach((p) => {
+    const name = p.name || p;
+    if (children[name]?.length) initialExpanded[name] = true;
+  });
+
+  const [expanded, setExpanded] = useState(initialExpanded);
+
+  function toggle(name) {
+    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
+  }
+
+  function renderRow(p, depth = 0) {
+    const name = p.name || p;
+    const hasChildren = !!(children[name]?.length);
+    const isSelected = name === selectedProject;
+    const grade = gradeLabel(p.overallGrade ?? p.latestGrade);
+    const score = p.latestScore != null ? parseFloat(p.latestScore).toFixed(1)
+                : p.numericAverage != null ? parseFloat(p.numericAverage).toFixed(1)
+                : null;
+    const date = formatDate(p.latestDate);
+    const isExpanded = expanded[name];
+
+    return (
+      <div key={name}>
+        <div
+          className={`projects-row${isSelected ? ' projects-row--selected' : ''}${depth > 0 ? ' projects-row--child' : ''}`}
+          style={{ '--depth': depth }}
+        >
+          <span
+            className={`projects-chevron${hasChildren ? '' : ' projects-chevron--hidden'}`}
+            onClick={hasChildren ? () => toggle(name) : undefined}
+          >
+            {hasChildren ? (isExpanded ? '▾' : '▸') : ''}
+          </span>
+          <span className="projects-row-name" onClick={() => onSelect(name)}>
+            {name}
+          </span>
+          <span className="projects-row-meta">
+            {(grade || score) && (
+              <span className={`projects-grade projects-grade--${(grade ?? 'x').toLowerCase()}`}>
+                {grade}{score ? ` ${score}` : ''}
+              </span>
+            )}
+            {date && <span className="projects-date">{date}</span>}
+          </span>
+        </div>
+        {hasChildren && isExpanded && children[name].map((child) => renderRow(child, depth + 1))}
+      </div>
+    );
+  }
+
+  return (
+    <section className="projects-page">
+      <div className="projects-header">
+        <h1 className="projects-title">Projects</h1>
+      </div>
+      {projects.length === 0 ? (
+        <div className="projects-empty">
+          <p>No projects yet. Run an evaluation to get started.</p>
+        </div>
+      ) : (
+        <div className="projects-list panel">
+          {roots.map((p) => renderRow(p, 0))}
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+**Step 2: Verify the build**
+
+```bash
+cd ui/web && npm run build
+```
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add ui/web/src/features/dashboard/components/ProjectsPage.jsx
+git commit -m "feat: add ProjectsPage tree component"
+```
+
+---
+
+### Task 4: CSS — projects page styles
+
+**Files:**
+- Modify: `ui/web/src/styles/dashboard.css` (append at end)
+
+**Step 1: Append styles**
+
+```css
+/* ── Projects page ─────────────────────────────────────── */
+
+.projects-page {
+  padding: var(--space-6);
+  max-width: 720px;
+}
+
+.projects-header {
+  margin-bottom: var(--space-5);
+}
+
+.projects-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.projects-list {
+  padding: var(--space-2) 0;
+}
+
+.projects-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  padding-left: calc(var(--space-4) + var(--depth, 0) * 20px);
+  border-radius: var(--radius-sm);
+  cursor: default;
+  transition: background 120ms ease;
+}
+
+.projects-row:hover {
+  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+}
+
+.projects-row--selected {
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+
+.projects-row--child {
+  font-size: var(--text-sm);
+}
+
+.projects-chevron {
+  width: 14px;
+  font-size: 11px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.projects-chevron--hidden {
+  visibility: hidden;
+  cursor: default;
+  pointer-events: none;
+}
+
+.projects-row-name {
+  flex: 1;
+  color: var(--color-text);
+  cursor: pointer;
+  font-weight: var(--weight-medium);
+}
+
+.projects-row-name:hover {
+  color: var(--color-accent);
+}
+
+.projects-row--selected .projects-row-name {
+  color: var(--color-accent);
+}
+
+.projects-row-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+
+.projects-grade {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  letter-spacing: 0.03em;
+}
+
+.projects-grade--a { color: var(--color-grade-top-text); }
+.projects-grade--b { color: var(--color-grade-high-text); }
+.projects-grade--c { color: var(--color-grade-mid-text); }
+.projects-grade--d { color: var(--color-grade-low-text); }
+.projects-grade--f { color: var(--color-grade-bottom-text); }
+.projects-grade--x { color: var(--color-text-muted); }
+
+.projects-date {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  min-width: 48px;
+  text-align: right;
+}
+
+.projects-empty {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: var(--space-6);
+}
+```
+
+**Step 2: Verify the build**
+
+```bash
+cd ui/web && npm run build
+```
+Expected: no errors.
+
+**Step 3: Commit**
+
+```bash
+git add ui/web/src/styles/dashboard.css
+git commit -m "feat: add projects page styles"
+```
+
+---
+
+### Task 5: App.jsx — parent › child in content header
+
+**Files:**
+- Modify: `ui/web/src/App.jsx`
+
+**Step 1: Add a `selectedProjectParent` derived value** (after the `headerMeta` useMemo, around line ~206)
+
+```js
+const selectedProjectParent = useMemo(() => {
+  if (!selectedProject || !projects.length) return null;
+  const data = projects.find((p) => (p.name || p) === selectedProject);
+  return data?.parent || null;
+}, [selectedProject, projects]);
+```
+
+**Step 2: Update the `<h1>` in the content header** (around line ~642)
+
+Change:
+```jsx
+<h1 className="content-project-name">{selectedProject}</h1>
+```
+To:
+```jsx
+<h1 className="content-project-name">
+  {selectedProjectParent && (
+    <>
+      <span className="content-project-parent">{selectedProjectParent}</span>
+      <span className="content-project-sep">›</span>
+    </>
+  )}
+  {selectedProject}
+</h1>
+```
+
+**Step 3: Add CSS for the parent label** in `ui/web/src/styles/base.css` (append to the content-header section, or add after `.content-project-name` styles)
+
+Find where `.content-project-name` is defined and append:
+```css
+.content-project-parent {
+  color: var(--color-text-muted);
+  font-weight: var(--weight-normal);
+}
+
+.content-project-sep {
+  color: var(--color-text-muted);
+  margin: 0 var(--space-2);
+  font-weight: var(--weight-normal);
+}
+```
+
+**Step 4: Verify the build**
+
+```bash
+cd ui/web && npm run build
+```
+Expected: no errors.
+
+**Step 5: Commit**
+
+```bash
+git add ui/web/src/App.jsx ui/web/src/styles/base.css
+git commit -m "feat: show parent › child in content header"
+```
+
+---
+
+### Task 6: Wire up grade/score data from list_projects
+
+**Context:** `ProjectsPage` references `p.overallGrade`, `p.latestGrade`, `p.latestScore`, `p.numericAverage` — but currently `list_projects` only returns `name`, `runsCount`, `latestRunId`, `latestDate`, `parent`. The grade/score need to come from somewhere.
+
+The `latestDate` already exists. For grade/score: the simplest approach is to read the latest run summary from the reports folder in `list_projects`.
+
+**Files:**
+- Modify: `src/codecompass/action_provider_fs.py:123-141` (the list_projects method from Task 1)
+
+**Step 1: Extend `list_projects` to include latest grade/score**
+
+The summary data is stored per-run. Look at how `get_dashboard` works: it calls `_read_run_data` and `_summarize_dimensions`. We need the overall grade/score from the latest run.
+
+Read the `_summarize_dimensions` helper to understand what it returns (it's in the same file). Then add a helper call to get the summary for the latest run:
+
+```python
+# After computing runs, get latest run summary
+latest_grade = None
+latest_score = None
+if runs:
+    try:
+        dims = _read_run_data(reports_root, entry.name, runs[0].run_id)
+        summary = _summarize_dimensions(dims)
+        latest_grade = summary.get("overallGrade")
+        latest_score = summary.get("numericAverage")
+    except Exception:
+        pass
+
+projects.append(
+    {
+        "name": entry.name,
+        "runsCount": len(runs),
+        "latestRunId": runs[0].run_id if runs else None,
+        "latestDate": runs[0].date_iso if runs else None,
+        "parent": parent,
+        "latestGrade": latest_grade,
+        "latestScore": latest_score,
+    }
+)
+```
+
+**Step 2: Check what `_summarize_dimensions` returns**
+
+Search the file for `def _summarize_dimensions` and read its return value to confirm `overallGrade` and `numericAverage` are the right keys.
+
+**Step 3: Verify manually**
+
+```
+curl http://localhost:5000/api/projects
+```
+Expected: each project includes `latestGrade` (e.g. `"good"`) and `latestScore` (e.g. `7.4`).
+
+**Step 4: Commit**
+
+```bash
+git add src/codecompass/action_provider_fs.py
+git commit -m "feat: include latestGrade and latestScore in list_projects"
+```
+
+---
+
+### Task 7: Final smoke test
+
+**Step 1:** Start the full stack (backend + `npm run dev`)
+
+**Step 2:** Open the app. Confirm:
+- Three nav items visible: Overview, Projects, Evaluate
+- No project dropdown in sidebar
+- Clicking Projects shows the projects list with names, grades, dates
+- Add `"parent": "some-parent"` to a project's `repository_info.json`, restart backend, reload — confirm the child appears indented under the parent
+- Selecting a child project navigates to Overview with `parent › child` in the header
+- Selecting a root (parent) project shows only its name in the header
+
+**Step 3: Commit (if any loose ends)**
+
+```bash
+git push
+```

--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -29,6 +29,19 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
     def list_projects():
         return jsonify(provider.list_projects(_reports_dir()))
 
+    @app.patch("/api/projects/<project>/path")
+    def update_project_path(project: str):
+        data = request.get_json(silent=True) or {}
+        new_path = data.get("path", "").strip()
+        if not new_path:
+            body, status = _error("Path is required", 400, "INVALID_INPUT")
+            return jsonify(body), status
+        ok = provider.update_project_path(_reports_dir(), project, new_path)
+        if not ok:
+            body, status = _error("Project not found", 404, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify({"updated": project, "path": new_path})
+
     @app.delete("/api/projects/<project>")
     def delete_project(project: str):
         ok = provider.delete_project(_reports_dir(), project)

--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -42,6 +42,24 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
             return jsonify(body), status
         return jsonify({"updated": project, "path": new_path})
 
+    @app.get("/api/projects/<project>/export")
+    def export_project(project: str):
+        import io
+        import zipfile
+        from pathlib import Path as _Path
+        from flask import send_file
+        project_path = _Path(_reports_dir()) / project
+        if not project_path.exists() or not project_path.is_dir():
+            body, status = _error("Project not found", 404, "NOT_FOUND")
+            return jsonify(body), status
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in project_path.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(project_path.parent))
+        buf.seek(0)
+        return send_file(buf, mimetype="application/zip", as_attachment=True, download_name=f"{project}.zip")
+
     @app.delete("/api/projects/<project>")
     def delete_project(project: str):
         ok = provider.delete_project(_reports_dir(), project)

--- a/src/codecompass/action_api.py
+++ b/src/codecompass/action_api.py
@@ -29,6 +29,13 @@ def create_app(provider: ActionProvider | None = None) -> Flask:
     def list_projects():
         return jsonify(provider.list_projects(_reports_dir()))
 
+    @app.delete("/api/projects/<project>")
+    def delete_project(project: str):
+        ok = provider.delete_project(_reports_dir(), project)
+        if not ok:
+            return jsonify({"error": "Project not found"}), 404
+        return jsonify({"deleted": project})
+
     @app.get("/api/projects/<project>/info")
     def project_info(project: str):
         info = provider.get_project_info(_reports_dir(), project)

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -133,6 +133,7 @@ class FilesystemActionProvider(ActionProvider):
             discipline = None
             path = None
             location = None
+            display_name = None
             info_path = reports_root / entry.name / "repository_info.json"
             if info_path.exists():
                 try:
@@ -141,6 +142,7 @@ class FilesystemActionProvider(ActionProvider):
                     discipline = info.get("discipline") or None
                     path = info.get("path") or None
                     location = info.get("location") or None
+                    display_name = info.get("displayName") or None
                 except (json.JSONDecodeError, OSError):
                     pass
             latest_grade = None
@@ -155,6 +157,7 @@ class FilesystemActionProvider(ActionProvider):
                 files_count = total if total > 0 else None
             except Exception:
                 pass
+            path_exists = Path(path).exists() if location == "local" and path else None
             projects.append(
                 {
                     "name": entry.name,
@@ -162,9 +165,11 @@ class FilesystemActionProvider(ActionProvider):
                     "latestRunId": runs[0].run_id,
                     "latestDate": runs[0].date_iso,
                     "parent": parent,
+                    "displayName": display_name,
                     "discipline": discipline,
                     "path": path,
                     "location": location,
+                    "pathExists": path_exists,
                     "filesCount": files_count,
                     "latestGrade": latest_grade,
                     "latestScore": latest_score,
@@ -191,6 +196,19 @@ class FilesystemActionProvider(ActionProvider):
             if best_parent:
                 p["parent"] = best_parent
         return {"projects": projects}
+
+    def update_project_path(self, reports_dir: str, project: str, new_path: str) -> bool:
+        info_path = Path(reports_dir) / project / "repository_info.json"
+        if not info_path.exists():
+            return False
+        try:
+            info = json.loads(info_path.read_text())
+            info["path"] = new_path
+            info["location"] = "local"
+            info_path.write_text(json.dumps(info, indent=2))
+            return True
+        except (json.JSONDecodeError, OSError):
+            return False
 
     def delete_project(self, reports_dir: str, project: str) -> bool:
         import shutil

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -129,12 +129,21 @@ class FilesystemActionProvider(ActionProvider):
             runs = _list_runs(reports_root, entry.name)
             if not runs:
                 continue
+            parent = None
+            info_path = reports_root / entry.name / "repository_info.json"
+            if info_path.exists():
+                try:
+                    info = json.loads(info_path.read_text())
+                    parent = info.get("parent") or None
+                except (json.JSONDecodeError, OSError):
+                    pass
             projects.append(
                 {
                     "name": entry.name,
                     "runsCount": len(runs),
-                    "latestRunId": runs[0].run_id if runs else None,
-                    "latestDate": runs[0].date_iso if runs else None,
+                    "latestRunId": runs[0].run_id,
+                    "latestDate": runs[0].date_iso,
+                    "parent": parent,
                 }
             )
         projects.sort(key=lambda item: item["name"])

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -130,20 +130,29 @@ class FilesystemActionProvider(ActionProvider):
             if not runs:
                 continue
             parent = None
+            discipline = None
+            path = None
+            location = None
             info_path = reports_root / entry.name / "repository_info.json"
             if info_path.exists():
                 try:
                     info = json.loads(info_path.read_text())
                     parent = info.get("parent") or None
+                    discipline = info.get("discipline") or None
+                    path = info.get("path") or None
+                    location = info.get("location") or None
                 except (json.JSONDecodeError, OSError):
                     pass
             latest_grade = None
             latest_score = None
+            files_count = None
             try:
                 dims = _read_run_data(reports_root, entry.name, runs[0].run_id)
                 summary = _summarize_dimensions(dims)
                 latest_grade = summary.get("overallGrade")
                 latest_score = summary.get("numericAverage")
+                total = sum(d.get("sourceFileCount") or 0 for d in dims)
+                files_count = total if total > 0 else None
             except Exception:
                 pass
             projects.append(
@@ -153,12 +162,43 @@ class FilesystemActionProvider(ActionProvider):
                     "latestRunId": runs[0].run_id,
                     "latestDate": runs[0].date_iso,
                     "parent": parent,
+                    "discipline": discipline,
+                    "path": path,
+                    "location": location,
+                    "filesCount": files_count,
                     "latestGrade": latest_grade,
                     "latestScore": latest_score,
                 }
             )
         projects.sort(key=lambda item: item["name"])
+        # Auto-detect parent for local projects that have no explicit parent
+        local_with_path = [p for p in projects if p.get("location") == "local" and p.get("path")]
+        for p in projects:
+            if p.get("parent") is not None:
+                continue
+            if p.get("location") != "local" or not p.get("path"):
+                continue
+            p_path = p["path"].rstrip("/")
+            best_parent = None
+            best_len = 0
+            for candidate in local_with_path:
+                if candidate["name"] == p["name"]:
+                    continue
+                c_path = candidate["path"].rstrip("/")
+                if p_path.startswith(c_path + "/") and len(c_path) > best_len:
+                    best_parent = candidate["name"]
+                    best_len = len(c_path)
+            if best_parent:
+                p["parent"] = best_parent
         return {"projects": projects}
+
+    def delete_project(self, reports_dir: str, project: str) -> bool:
+        import shutil
+        project_path = Path(reports_dir) / project
+        if not project_path.exists() or not project_path.is_dir():
+            return False
+        shutil.rmtree(project_path)
+        return True
 
     def get_project_info(self, reports_dir: str, project: str):
         info_path = Path(reports_dir) / project / "repository_info.json"

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -137,6 +137,15 @@ class FilesystemActionProvider(ActionProvider):
                     parent = info.get("parent") or None
                 except (json.JSONDecodeError, OSError):
                     pass
+            latest_grade = None
+            latest_score = None
+            try:
+                dims = _read_run_data(reports_root, entry.name, runs[0].run_id)
+                summary = _summarize_dimensions(dims)
+                latest_grade = summary.get("overallGrade")
+                latest_score = summary.get("numericAverage")
+            except Exception:
+                pass
             projects.append(
                 {
                     "name": entry.name,
@@ -144,6 +153,8 @@ class FilesystemActionProvider(ActionProvider):
                     "latestRunId": runs[0].run_id,
                     "latestDate": runs[0].date_iso,
                     "parent": parent,
+                    "latestGrade": latest_grade,
+                    "latestScore": latest_score,
                 }
             )
         projects.sort(key=lambda item: item["name"])

--- a/ui/server/src/app.js
+++ b/ui/server/src/app.js
@@ -34,10 +34,14 @@ export async function proxyToActionApi(req, res, actionApiBase) {
       fetchOptions.body = JSON.stringify(req.body ?? {});
     }
     const response = await fetch(url, fetchOptions);
-    const body = await response.text();
     const contentType = response.headers.get('content-type') || 'application/json';
+    const isBinary = !contentType.startsWith('text/') && !contentType.includes('json');
+    const body = isBinary ? Buffer.from(await response.arrayBuffer()) : await response.text();
     res.status(response.status);
     res.set('content-type', contentType);
+    if (response.headers.has('content-disposition')) {
+      res.set('content-disposition', response.headers.get('content-disposition'));
+    }
     res.send(body);
   } catch (error) {
     res.status(502).json({ error: error.message || 'Failed to reach action API' });

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -13,6 +13,7 @@ import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
 import PrincipleDetailPage from './features/explorer/components/PrincipleDetailPage.jsx';
 import EvalPrincipleDetailPage from './features/explorer/components/EvalPrincipleDetailPage.jsx';
 import { formatRunId } from './utils/formatters.js';
+import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
 
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,17 @@ const ICON_EVALUATE = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="11" cy="11" r="7" />
     <line x1="16.5" y1="16.5" x2="22" y2="22" />
+  </svg>
+);
+
+const ICON_PROJECTS = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3"  width="4" height="4" rx="0.5" />
+    <rect x="3" y="10" width="4" height="4" rx="0.5" />
+    <rect x="3" y="17" width="4" height="4" rx="0.5" />
+    <line x1="9" y1="5"  x2="21" y2="5"  />
+    <line x1="9" y1="12" x2="21" y2="12" />
+    <line x1="9" y1="19" x2="21" y2="19" />
   </svg>
 );
 
@@ -205,6 +217,12 @@ export default function App() {
     return { discipline, repository, totalFiles: totalFiles || null };
   }, [accumulated]);
 
+  const selectedProjectParent = useMemo(() => {
+    if (!selectedProject || !projects.length) return null;
+    const data = projects.find((p) => (p.name || p) === selectedProject);
+    return data?.parent || null;
+  }, [selectedProject, projects]);
+
   // -------------------------------------------------------------------------
   // Theme
   // -------------------------------------------------------------------------
@@ -289,12 +307,12 @@ export default function App() {
   // -------------------------------------------------------------------------
   // Active tab / header visibility
   // -------------------------------------------------------------------------
-  const activeTab = ['overview', 'evaluate', 'settings'].includes(activePage.page)
+  const activeTab = ['overview', 'projects', 'evaluate', 'settings'].includes(activePage.page)
     ? activePage.page
     : 'overview';
 
   // Show the project header on all data pages; hide it on evaluate and settings.
-  const showProjectHeader = activeTab === 'overview' && projects.length > 0 && !!selectedProject;
+  const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
 
   // Show the run navigator only on top-level data pages (not when drilled into a sub-page).
   const showRunNav = showProjectHeader && availableRuns.length > 0 && navStack.length === 1;
@@ -562,6 +580,15 @@ export default function App() {
           </div>
         );
 
+      case 'projects':
+        return (
+          <ProjectsPage
+            projects={projects}
+            selectedProject={selectedProject}
+            onSelect={handleProjectChange}
+          />
+        );
+
       default:
         return <div className="empty-state"><p>Page not found: {page}</p></div>;
     }
@@ -599,6 +626,16 @@ export default function App() {
             {ICON_EVALUATE}
             <span className="sidebar-nav-label">Evaluate</span>
           </button>
+
+          <button
+            type="button"
+            className={`sidebar-nav-item${activeTab === 'projects' ? ' active' : ''}`}
+            onClick={() => navTab('projects')}
+            title="Projects"
+          >
+            {ICON_PROJECTS}
+            <span className="sidebar-nav-label">Projects</span>
+          </button>
         </nav>
 
         {/* Settings at bottom */}
@@ -614,23 +651,6 @@ export default function App() {
           </button>
         </div>
 
-        {/* Project selector */}
-        {projects.length > 0 && (
-          <div className="sidebar-project-section">
-            <p className="sidebar-project-label">Project</p>
-            <select
-              className="project-select-styled"
-              value={selectedProject}
-              disabled={projects.length === 0}
-              onChange={(e) => handleProjectChange(e.target.value)}
-            >
-              {projects.map((p) => {
-                const name = p.name || p;
-                return <option key={name} value={name}>{name}</option>;
-              })}
-            </select>
-          </div>
-        )}
       </aside>
 
       {/* Main content */}
@@ -639,7 +659,15 @@ export default function App() {
         {showProjectHeader && (
           <header className="content-header">
             <div className="content-header-left">
-              <h1 className="content-project-name">{selectedProject}</h1>
+              <h1 className="content-project-name">
+                {selectedProjectParent && (
+                  <>
+                    <span className="content-project-parent">{selectedProjectParent}</span>
+                    <span className="content-project-sep">›</span>
+                  </>
+                )}
+                {selectedProject}
+              </h1>
               {headerMeta && (
                 <div className="content-meta-row">
                   {headerMeta.repository && (

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -155,12 +155,24 @@ export default function App() {
     navReset();
   }
 
-  async function handleDeleteProject(name) {
+  function _apiQs() {
     const params = new URLSearchParams(window.location.search);
     const dir = params.get('evaluations') || '';
-    const qs = dir ? `?evaluations=${encodeURIComponent(dir)}` : '';
-    await fetch(`/api/projects/${encodeURIComponent(name)}${qs}`, { method: 'DELETE' });
+    return dir ? `?evaluations=${encodeURIComponent(dir)}` : '';
+  }
+
+  async function handleDeleteProject(name) {
+    await fetch(`/api/projects/${encodeURIComponent(name)}${_apiQs()}`, { method: 'DELETE' });
     if (selectedProject === name) handleProjectChange(projects.find((p) => (p.name || p) !== name)?.name ?? '');
+    loadProjects();
+  }
+
+  async function handleRelocateProject(name, newPath) {
+    await fetch(`/api/projects/${encodeURIComponent(name)}/path${_apiQs()}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: newPath }),
+    });
     loadProjects();
   }
 
@@ -230,10 +242,15 @@ export default function App() {
     return { discipline, repository, totalFiles: totalFiles || null };
   }, [accumulated]);
 
-  const selectedProjectParent = useMemo(() => {
-    if (!selectedProject || !projects.length) return null;
+  const { selectedDisplayName, selectedProjectParent } = useMemo(() => {
+    if (!selectedProject || !projects.length) return { selectedDisplayName: selectedProject, selectedProjectParent: null };
     const data = projects.find((p) => (p.name || p) === selectedProject);
-    return data?.parent || null;
+    const parentName = data?.parent || null;
+    const parentData = parentName ? projects.find((p) => (p.name || p) === parentName) : null;
+    return {
+      selectedDisplayName: data?.displayName || selectedProject,
+      selectedProjectParent: parentData?.displayName || parentName,
+    };
   }, [selectedProject, projects]);
 
   // -------------------------------------------------------------------------
@@ -600,6 +617,7 @@ export default function App() {
             selectedProject={selectedProject}
             onSelect={handleProjectChange}
             onDelete={handleDeleteProject}
+            onRelocate={handleRelocateProject}
           />
         );
 
@@ -680,7 +698,7 @@ export default function App() {
                     <span className="content-project-sep">›</span>
                   </>
                 )}
-                {selectedProject}
+                {selectedDisplayName}
               </h1>
               {headerMeta && (
                 <div className="content-meta-row">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -167,6 +167,17 @@ export default function App() {
     loadProjects();
   }
 
+  function handleExportProject(name) {
+    const qs = _apiQs();
+    const url = `/api/projects/${encodeURIComponent(name)}/export${qs}`;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${name}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+
   async function handleRelocateProject(name, newPath) {
     await fetch(`/api/projects/${encodeURIComponent(name)}/path${_apiQs()}`, {
       method: 'PATCH',
@@ -617,6 +628,7 @@ export default function App() {
             selectedProject={selectedProject}
             onSelect={handleProjectChange}
             onDelete={handleDeleteProject}
+            onExport={handleExportProject}
             onRelocate={handleRelocateProject}
           />
         );

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -131,7 +131,7 @@ export default function App() {
   const [selectedProject, setSelectedProject] = useState('');
   const [selectedRun, setSelectedRun] = useState('latest');
 
-  useEffect(() => {
+  function loadProjects() {
     listProjects()
       .then((data) => {
         const list = data.projects || data || [];
@@ -143,12 +143,25 @@ export default function App() {
         }
       })
       .catch(() => {});
+  }
+
+  useEffect(() => {
+    loadProjects();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleProjectChange(name) {
     setSelectedProject(name);
     setSelectedRun('latest');
     navReset();
+  }
+
+  async function handleDeleteProject(name) {
+    const params = new URLSearchParams(window.location.search);
+    const dir = params.get('evaluations') || '';
+    const qs = dir ? `?evaluations=${encodeURIComponent(dir)}` : '';
+    await fetch(`/api/projects/${encodeURIComponent(name)}${qs}`, { method: 'DELETE' });
+    if (selectedProject === name) handleProjectChange(projects.find((p) => (p.name || p) !== name)?.name ?? '');
+    loadProjects();
   }
 
   function handleRunChange(runId) { setSelectedRun(runId); }
@@ -586,6 +599,7 @@ export default function App() {
             projects={projects}
             selectedProject={selectedProject}
             onSelect={handleProjectChange}
+            onDelete={handleDeleteProject}
           />
         );
 

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -1,5 +1,29 @@
 import { useState, useMemo, useEffect } from 'react';
 
+const DISCIPLINE_LABEL = {
+  frontend_nextjs: 'Next.js',
+  frontend_react: 'React',
+  frontend_vue: 'Vue',
+  frontend_angular: 'Angular',
+  frontend: 'Frontend',
+  backend: 'Backend',
+  backend_python: 'Python',
+  backend_java: 'Java',
+  backend_node: 'Node.js',
+  mobile_ios: 'iOS',
+  mobile_android: 'Android',
+  mobile_react_native: 'React Native',
+  mobile: 'Mobile',
+  fullstack: 'Full Stack',
+  devops: 'DevOps',
+  data: 'Data',
+};
+
+function disciplineLabel(d) {
+  if (!d) return null;
+  return DISCIPLINE_LABEL[d.toLowerCase()] ?? d.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function gradeLabel(grade) {
   if (!grade) return null;
   const k = grade.trim().toLowerCase();
@@ -18,8 +42,24 @@ function formatDate(iso) {
   }
 }
 
-export default function ProjectsPage({ projects = [], selectedProject, onSelect }) {
-  // Build tree
+function formatPath(path) {
+  if (!path) return null;
+  const gitMatch = path.match(/[@/](github\.com|gitlab\.com|bitbucket\.org)[:/](.+?)(?:\.git)?$/);
+  if (gitMatch) return `${gitMatch[1]}/${gitMatch[2]}`;
+  return path;
+}
+
+function GradeChip({ grade, score }) {
+  if (!grade && score == null) return null;
+  const cls = grade ? `projects-grade--${grade.toLowerCase()}` : 'projects-grade--x';
+  return (
+    <span className={`projects-grade ${cls}`}>
+      {grade}{score != null ? ` ${score}` : ''}
+    </span>
+  );
+}
+
+export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete }) {
   const { projectMap, children, roots } = useMemo(() => {
     const projectMap = Object.fromEntries(projects.map((p) => [p.name || p, p]));
     const children = {};
@@ -36,6 +76,8 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect 
     }
     return { projectMap, children, roots };
   }, [projects]);
+
+  const [confirming, setConfirming] = useState(null); // holds project name being confirmed
 
   const [expanded, setExpanded] = useState(() => {
     const selectedData = projectMap[selectedProject];
@@ -61,44 +103,6 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect 
     setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
   }
 
-  function renderRow(p, depth = 0) {
-    const name = p.name || p;
-    const hasChildren = !!(children[name]?.length);
-    const isSelected = name === selectedProject;
-    const grade = gradeLabel(p.overallGrade ?? p.latestGrade);
-    const score = p.latestScore != null ? parseFloat(p.latestScore).toFixed(1) : null;
-    const date = formatDate(p.latestDate);
-    const isExpanded = expanded[name];
-
-    return (
-      <div key={name}>
-        <div
-          className={`projects-row${isSelected ? ' projects-row--selected' : ''}${depth > 0 ? ' projects-row--child' : ''}`}
-          style={{ '--depth': depth }}
-        >
-          <span
-            className={`projects-chevron${hasChildren ? '' : ' projects-chevron--hidden'}`}
-            onClick={hasChildren ? () => toggle(name) : undefined}
-          >
-            {hasChildren ? (isExpanded ? '▾' : '▸') : ''}
-          </span>
-          <span className="projects-row-name" onClick={() => onSelect?.(name)}>
-            {name}
-          </span>
-          <span className="projects-row-meta">
-            {(grade || score) && (
-              <span className={`projects-grade projects-grade--${(grade ?? 'x').toLowerCase()}`}>
-                {grade}{score ? ` ${score}` : ''}
-              </span>
-            )}
-            {date && <span className="projects-date">{date}</span>}
-          </span>
-        </div>
-        {hasChildren && isExpanded && children[name].map((child) => renderRow(child, depth + 1))}
-      </div>
-    );
-  }
-
   return (
     <section className="projects-page">
       <div className="projects-header">
@@ -109,8 +113,146 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect 
           <p>No projects yet. Run an evaluation to get started.</p>
         </div>
       ) : (
-        <div className="projects-list panel">
-          {roots.map((p) => renderRow(p, 0))}
+        <div className="projects-cards">
+          {roots.map((p) => {
+            const name = p.name || p;
+            const isSelected = name === selectedProject;
+            const hasChildren = !!(children[name]?.length);
+            const isExpanded = expanded[name];
+            const grade = gradeLabel(p.overallGrade ?? p.latestGrade);
+            const score = p.latestScore != null ? parseFloat(p.latestScore).toFixed(1) : null;
+            const date = formatDate(p.latestDate);
+            const discipline = disciplineLabel(p.discipline);
+            const path = formatPath(p.path);
+            const childSelected = hasChildren && children[name].some((c) => (c.name || c) === selectedProject);
+
+            return (
+              <div
+                key={name}
+                className={`project-card panel${isSelected ? ' project-card--selected' : ''}${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}
+              >
+                <div className="project-card-main" onClick={() => onSelect?.(name)}>
+                  <div className="project-card-top">
+                    <span className="project-card-name">{name}</span>
+                    <GradeChip grade={grade} score={score} />
+                  </div>
+                  <div className="project-card-meta">
+                    {discipline && <span className="project-meta-tag">{discipline}</span>}
+                    {p.filesCount != null && (
+                      <span className="project-meta-item">{p.filesCount.toLocaleString()} files</span>
+                    )}
+                    <span className="project-meta-item">{p.runsCount} {p.runsCount === 1 ? 'run' : 'runs'}</span>
+                    {date && <span className="project-meta-date">{date}</span>}
+                  </div>
+                  {path && <div className="project-card-path">{path}</div>}
+                </div>
+                <div className="project-card-footer">
+                  {confirming === name ? (
+                    <div className="project-card-actions">
+                      <span className="project-delete-confirm-label">Delete?</span>
+                      <button
+                        type="button"
+                        className="project-delete-btn project-delete-btn--confirm"
+                        onClick={(e) => { e.stopPropagation(); onDelete?.(name); setConfirming(null); }}
+                      >Yes</button>
+                      <button
+                        type="button"
+                        className="project-delete-btn project-delete-btn--cancel"
+                        onClick={(e) => { e.stopPropagation(); setConfirming(null); }}
+                      >No</button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="project-delete-btn"
+                      title="Delete project"
+                      onClick={(e) => { e.stopPropagation(); setConfirming(name); }}
+                    >
+                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="3 6 5 6 21 6" />
+                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                        <path d="M10 11v6M14 11v6" />
+                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+
+                {hasChildren && (
+                  <div className="project-children">
+                    <button
+                      type="button"
+                      className="project-children-toggle"
+                      onClick={() => toggle(name)}
+                    >
+                      <span className="project-children-chevron">{isExpanded ? '▾' : '▸'}</span>
+                      <span>{children[name].length} {children[name].length === 1 ? 'Sub project' : 'Sub projects'}</span>
+                    </button>
+                    {isExpanded && children[name].map((child) => {
+                      const childName = child.name || child;
+                      const isChildSelected = childName === selectedProject;
+                      const cGrade = gradeLabel(child.overallGrade ?? child.latestGrade);
+                      const cScore = child.latestScore != null ? parseFloat(child.latestScore).toFixed(1) : null;
+                      const cDate = formatDate(child.latestDate);
+                      const cDiscipline = disciplineLabel(child.discipline);
+
+                      return (
+                        <div
+                          key={childName}
+                          className={`project-child-row${isChildSelected ? ' project-child-row--selected' : ''}`}
+                          onClick={() => onSelect?.(childName)}
+                        >
+                          <div className="project-child-top">
+                            <span className="project-child-name">{childName}</span>
+                            <GradeChip grade={cGrade} score={cScore} />
+                          </div>
+                          <div className="project-card-meta">
+                            {cDiscipline && <span className="project-meta-tag project-meta-tag--sm">{cDiscipline}</span>}
+                            {child.filesCount != null && (
+                              <span className="project-meta-item">{child.filesCount.toLocaleString()} files</span>
+                            )}
+                            <span className="project-meta-item">{child.runsCount} {child.runsCount === 1 ? 'run' : 'runs'}</span>
+                            {cDate && <span className="project-meta-date">{cDate}</span>}
+                          </div>
+                          <div className="project-card-footer" onClick={(e) => e.stopPropagation()}>
+                            {confirming === childName ? (
+                              <div className="project-card-actions">
+                                <span className="project-delete-confirm-label">Delete?</span>
+                                <button
+                                  type="button"
+                                  className="project-delete-btn project-delete-btn--confirm"
+                                  onClick={(e) => { e.stopPropagation(); onDelete?.(childName); setConfirming(null); }}
+                                >Yes</button>
+                                <button
+                                  type="button"
+                                  className="project-delete-btn project-delete-btn--cancel"
+                                  onClick={(e) => { e.stopPropagation(); setConfirming(null); }}
+                                >No</button>
+                              </div>
+                            ) : (
+                              <button
+                                type="button"
+                                className="project-delete-btn"
+                                title="Delete sub project"
+                                onClick={(e) => { e.stopPropagation(); setConfirming(childName); }}
+                              >
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                  <polyline points="3 6 5 6 21 6" />
+                                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                                  <path d="M10 11v6M14 11v6" />
+                                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                                </svg>
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </section>

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -1,0 +1,118 @@
+import { useState, useMemo, useEffect } from 'react';
+
+function gradeLabel(grade) {
+  if (!grade) return null;
+  const k = grade.trim().toLowerCase();
+  const MAP = { exemplary: 'A', good: 'B', proficient: 'B', adequate: 'C', developing: 'C', poor: 'D', insufficient: 'D', critical: 'F' };
+  if (MAP[k]) return MAP[k];
+  const firstChar = grade.trim().toUpperCase().charAt(0);
+  return ['A', 'B', 'C', 'D', 'F'].includes(firstChar) ? firstChar : null;
+}
+
+function formatDate(iso) {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  } catch {
+    return null;
+  }
+}
+
+export default function ProjectsPage({ projects = [], selectedProject, onSelect }) {
+  // Build tree
+  const { projectMap, children, roots } = useMemo(() => {
+    const projectMap = Object.fromEntries(projects.map((p) => [p.name || p, p]));
+    const children = {};
+    const roots = [];
+    for (const p of projects) {
+      const name = p.name || p;
+      const parent = p.parent;
+      if (parent && projectMap[parent]) {
+        if (!children[parent]) children[parent] = [];
+        children[parent].push(p);
+      } else {
+        roots.push(p);
+      }
+    }
+    return { projectMap, children, roots };
+  }, [projects]);
+
+  const [expanded, setExpanded] = useState(() => {
+    const selectedData = projectMap[selectedProject];
+    const init = selectedData?.parent ? { [selectedData.parent]: true } : {};
+    roots.forEach((p) => {
+      const name = p.name || p;
+      if (children[name]?.length) init[name] = true;
+    });
+    return init;
+  });
+
+  useEffect(() => {
+    const selectedData = projectMap[selectedProject];
+    const init = selectedData?.parent ? { [selectedData.parent]: true } : {};
+    roots.forEach((p) => {
+      const name = p.name || p;
+      if (children[name]?.length) init[name] = true;
+    });
+    setExpanded(init);
+  }, [projects]);
+
+  function toggle(name) {
+    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
+  }
+
+  function renderRow(p, depth = 0) {
+    const name = p.name || p;
+    const hasChildren = !!(children[name]?.length);
+    const isSelected = name === selectedProject;
+    const grade = gradeLabel(p.overallGrade ?? p.latestGrade);
+    const score = p.latestScore != null ? parseFloat(p.latestScore).toFixed(1) : null;
+    const date = formatDate(p.latestDate);
+    const isExpanded = expanded[name];
+
+    return (
+      <div key={name}>
+        <div
+          className={`projects-row${isSelected ? ' projects-row--selected' : ''}${depth > 0 ? ' projects-row--child' : ''}`}
+          style={{ '--depth': depth }}
+        >
+          <span
+            className={`projects-chevron${hasChildren ? '' : ' projects-chevron--hidden'}`}
+            onClick={hasChildren ? () => toggle(name) : undefined}
+          >
+            {hasChildren ? (isExpanded ? '▾' : '▸') : ''}
+          </span>
+          <span className="projects-row-name" onClick={() => onSelect?.(name)}>
+            {name}
+          </span>
+          <span className="projects-row-meta">
+            {(grade || score) && (
+              <span className={`projects-grade projects-grade--${(grade ?? 'x').toLowerCase()}`}>
+                {grade}{score ? ` ${score}` : ''}
+              </span>
+            )}
+            {date && <span className="projects-date">{date}</span>}
+          </span>
+        </div>
+        {hasChildren && isExpanded && children[name].map((child) => renderRow(child, depth + 1))}
+      </div>
+    );
+  }
+
+  return (
+    <section className="projects-page">
+      <div className="projects-header">
+        <h1 className="projects-title">Projects</h1>
+      </div>
+      {projects.length === 0 ? (
+        <div className="projects-empty">
+          <p>No projects yet. Run an evaluation to get started.</p>
+        </div>
+      ) : (
+        <div className="projects-list panel">
+          {roots.map((p) => renderRow(p, 0))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
+import CopyButton from '../../../components/CopyButton.jsx';
 
 const DISCIPLINE_LABEL = {
   frontend_nextjs: 'Next.js',
@@ -59,7 +60,7 @@ function GradeChip({ grade, score }) {
   );
 }
 
-export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete }) {
+export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete, onRelocate }) {
   const { projectMap, children, roots } = useMemo(() => {
     const projectMap = Object.fromEntries(projects.map((p) => [p.name || p, p]));
     const children = {};
@@ -77,7 +78,19 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
     return { projectMap, children, roots };
   }, [projects]);
 
-  const [confirming, setConfirming] = useState(null); // holds project name being confirmed
+  const [confirming, setConfirming] = useState(null);
+  const [relocating, setRelocating] = useState(null);   // project name being relocated
+  const [relocatePath, setRelocatePath] = useState('');
+  function startRelocate(name, currentPath) {
+    setRelocating(name);
+    setRelocatePath(currentPath || '');
+  }
+
+  function submitRelocate(name) {
+    if (relocatePath.trim()) onRelocate?.(name, relocatePath.trim());
+    setRelocating(null);
+  }
+
 
   const [expanded, setExpanded] = useState(() => {
     const selectedData = projectMap[selectedProject];
@@ -124,6 +137,7 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
             const date = formatDate(p.latestDate);
             const discipline = disciplineLabel(p.discipline);
             const path = formatPath(p.path);
+            const pathMissing = p.location === 'local' && p.pathExists === false;
             const childSelected = hasChildren && children[name].some((c) => (c.name || c) === selectedProject);
 
             return (
@@ -133,7 +147,7 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
               >
                 <div className="project-card-main" onClick={() => onSelect?.(name)}>
                   <div className="project-card-top">
-                    <span className="project-card-name">{name}</span>
+                    <span className="project-card-name">{p.displayName || name}</span>
                     <GradeChip grade={grade} score={score} />
                   </div>
                   <div className="project-card-meta">
@@ -144,7 +158,37 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
                     <span className="project-meta-item">{p.runsCount} {p.runsCount === 1 ? 'run' : 'runs'}</span>
                     {date && <span className="project-meta-date">{date}</span>}
                   </div>
-                  {path && <div className="project-card-path">{path}</div>}
+                  {relocating === name ? (
+                    <div className="project-relocate-row" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        className="project-relocate-input"
+                        value={relocatePath}
+                        onChange={(e) => setRelocatePath(e.target.value)}
+                        onKeyDown={(e) => { if (e.key === 'Enter') submitRelocate(name); if (e.key === 'Escape') setRelocating(null); }}
+                        placeholder="/new/path/to/repo"
+                        autoFocus
+                      />
+                      <button type="button" className="project-delete-btn project-delete-btn--confirm" onClick={() => submitRelocate(name)}>Save</button>
+                      <button type="button" className="project-delete-btn project-delete-btn--cancel" onClick={() => setRelocating(null)}>Cancel</button>
+                    </div>
+                  ) : (
+                    <div className="project-path-row">
+                      {pathMissing && <span className="project-path-missing">Path not found</span>}
+                      {path && <div className="project-card-path">{path}</div>}
+                      {p.location === 'online' && p.path && (
+                        <span onClick={(e) => e.stopPropagation()}>
+                          <CopyButton label="" onClick={() => navigator.clipboard?.writeText(p.path)} />
+                        </span>
+                      )}
+                      {pathMissing && (
+                        <button
+                          type="button"
+                          className="project-path-action project-path-action--warn"
+                          onClick={(e) => { e.stopPropagation(); startRelocate(name, p.path); }}
+                        >Relocate</button>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="project-card-footer">
                   {confirming === name ? (
@@ -203,7 +247,7 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
                           onClick={() => onSelect?.(childName)}
                         >
                           <div className="project-child-top">
-                            <span className="project-child-name">{childName}</span>
+                            <span className="project-child-name">{child.displayName || childName}</span>
                             <GradeChip grade={cGrade} score={cScore} />
                           </div>
                           <div className="project-card-meta">

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import CopyButton from '../../../components/CopyButton.jsx';
 
 const DISCIPLINE_LABEL = {
@@ -60,7 +60,28 @@ function GradeChip({ grade, score }) {
   );
 }
 
-export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete, onRelocate }) {
+function DownloadIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="3 6 5 6 21 6" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6M14 11v6" />
+      <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+    </svg>
+  );
+}
+
+export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete, onExport, onRelocate }) {
   const { projectMap, children, roots } = useMemo(() => {
     const projectMap = Object.fromEntries(projects.map((p) => [p.name || p, p]));
     const children = {};
@@ -79,8 +100,9 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
   }, [projects]);
 
   const [confirming, setConfirming] = useState(null);
-  const [relocating, setRelocating] = useState(null);   // project name being relocated
+  const [relocating, setRelocating] = useState(null);
   const [relocatePath, setRelocatePath] = useState('');
+
   function startRelocate(name, currentPath) {
     setRelocating(name);
     setRelocatePath(currentPath || '');
@@ -91,29 +113,40 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
     setRelocating(null);
   }
 
-
-  const [expanded, setExpanded] = useState(() => {
-    const selectedData = projectMap[selectedProject];
-    const init = selectedData?.parent ? { [selectedData.parent]: true } : {};
-    roots.forEach((p) => {
-      const name = p.name || p;
-      if (children[name]?.length) init[name] = true;
-    });
-    return init;
-  });
-
-  useEffect(() => {
-    const selectedData = projectMap[selectedProject];
-    const init = selectedData?.parent ? { [selectedData.parent]: true } : {};
-    roots.forEach((p) => {
-      const name = p.name || p;
-      if (children[name]?.length) init[name] = true;
-    });
-    setExpanded(init);
-  }, [projects]);
-
-  function toggle(name) {
-    setExpanded((prev) => ({ ...prev, [name]: !prev[name] }));
+  function renderCardFooter(name) {
+    if (confirming === name) {
+      return (
+        <div className="project-card-actions">
+          <span className="project-delete-confirm-label">Delete?</span>
+          <button
+            type="button"
+            className="project-delete-btn project-delete-btn--confirm"
+            onClick={(e) => { e.stopPropagation(); onDelete?.(name); setConfirming(null); }}
+          >Yes</button>
+          <button
+            type="button"
+            className="project-delete-btn project-delete-btn--cancel"
+            onClick={(e) => { e.stopPropagation(); setConfirming(null); }}
+          >No</button>
+        </div>
+      );
+    }
+    return (
+      <>
+        <button
+          type="button"
+          className="project-delete-btn"
+          title="Download project reports"
+          onClick={(e) => { e.stopPropagation(); onExport?.(name); }}
+        ><DownloadIcon /></button>
+        <button
+          type="button"
+          className="project-delete-btn"
+          title="Delete project"
+          onClick={(e) => { e.stopPropagation(); setConfirming(name); }}
+        ><TrashIcon /></button>
+      </>
+    );
   }
 
   return (
@@ -131,7 +164,6 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
             const name = p.name || p;
             const isSelected = name === selectedProject;
             const hasChildren = !!(children[name]?.length);
-            const isExpanded = expanded[name];
             const grade = gradeLabel(p.overallGrade ?? p.latestGrade);
             const score = p.latestScore != null ? parseFloat(p.latestScore).toFixed(1) : null;
             const date = formatDate(p.latestDate);
@@ -141,98 +173,64 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
             const childSelected = hasChildren && children[name].some((c) => (c.name || c) === selectedProject);
 
             return (
-              <div
-                key={name}
-                className={`project-card panel${isSelected ? ' project-card--selected' : ''}${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}
-              >
-                <div className="project-card-main" onClick={() => onSelect?.(name)}>
-                  <div className="project-card-top">
-                    <span className="project-card-name">{p.displayName || name}</span>
-                    <GradeChip grade={grade} score={score} />
-                  </div>
-                  <div className="project-card-meta">
-                    {discipline && <span className="project-meta-tag">{discipline}</span>}
-                    {p.filesCount != null && (
-                      <span className="project-meta-item">{p.filesCount.toLocaleString()} files</span>
+              <div key={name} className="project-card-group">
+                <div
+                  className={`project-card panel${isSelected ? ' project-card--selected' : ''}${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}
+                >
+                  <div className="project-card-main" onClick={() => onSelect?.(name)}>
+                    <div className="project-card-top">
+                      <span className="project-card-name">{p.displayName || name}</span>
+                      <GradeChip grade={grade} score={score} />
+                    </div>
+                    <div className="project-card-meta">
+                      {discipline && <span className="project-meta-tag">{discipline}</span>}
+                      {p.filesCount != null && (
+                        <span className="project-meta-item">{p.filesCount.toLocaleString()} files</span>
+                      )}
+                      <span className="project-meta-item">{p.runsCount} {p.runsCount === 1 ? 'run' : 'runs'}</span>
+                      {date && <span className="project-meta-date">{date}</span>}
+                    </div>
+                    {relocating === name ? (
+                      <div className="project-relocate-row" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          className="project-relocate-input"
+                          value={relocatePath}
+                          onChange={(e) => setRelocatePath(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') submitRelocate(name); if (e.key === 'Escape') setRelocating(null); }}
+                          placeholder="/new/path/to/repo"
+                          autoFocus
+                        />
+                        <button type="button" className="project-delete-btn project-delete-btn--confirm" onClick={() => submitRelocate(name)}>Save</button>
+                        <button type="button" className="project-delete-btn project-delete-btn--cancel" onClick={() => setRelocating(null)}>Cancel</button>
+                      </div>
+                    ) : (
+                      <div className="project-path-row">
+                        {pathMissing && <span className="project-path-missing">Path not found</span>}
+                        {p.location === 'online' && p.path ? (
+                          <span onClick={(e) => e.stopPropagation()}>
+                            <CopyButton label={path} onClick={() => navigator.clipboard?.writeText(p.path)} />
+                          </span>
+                        ) : (
+                          path && <div className="project-card-path">{path}</div>
+                        )}
+                        {pathMissing && (
+                          <button
+                            type="button"
+                            className="project-path-action project-path-action--warn"
+                            onClick={(e) => { e.stopPropagation(); startRelocate(name, p.path); }}
+                          >Relocate</button>
+                        )}
+                      </div>
                     )}
-                    <span className="project-meta-item">{p.runsCount} {p.runsCount === 1 ? 'run' : 'runs'}</span>
-                    {date && <span className="project-meta-date">{date}</span>}
                   </div>
-                  {relocating === name ? (
-                    <div className="project-relocate-row" onClick={(e) => e.stopPropagation()}>
-                      <input
-                        className="project-relocate-input"
-                        value={relocatePath}
-                        onChange={(e) => setRelocatePath(e.target.value)}
-                        onKeyDown={(e) => { if (e.key === 'Enter') submitRelocate(name); if (e.key === 'Escape') setRelocating(null); }}
-                        placeholder="/new/path/to/repo"
-                        autoFocus
-                      />
-                      <button type="button" className="project-delete-btn project-delete-btn--confirm" onClick={() => submitRelocate(name)}>Save</button>
-                      <button type="button" className="project-delete-btn project-delete-btn--cancel" onClick={() => setRelocating(null)}>Cancel</button>
-                    </div>
-                  ) : (
-                    <div className="project-path-row">
-                      {pathMissing && <span className="project-path-missing">Path not found</span>}
-                      {path && <div className="project-card-path">{path}</div>}
-                      {p.location === 'online' && p.path && (
-                        <span onClick={(e) => e.stopPropagation()}>
-                          <CopyButton label="" onClick={() => navigator.clipboard?.writeText(p.path)} />
-                        </span>
-                      )}
-                      {pathMissing && (
-                        <button
-                          type="button"
-                          className="project-path-action project-path-action--warn"
-                          onClick={(e) => { e.stopPropagation(); startRelocate(name, p.path); }}
-                        >Relocate</button>
-                      )}
-                    </div>
-                  )}
-                </div>
-                <div className="project-card-footer">
-                  {confirming === name ? (
-                    <div className="project-card-actions">
-                      <span className="project-delete-confirm-label">Delete?</span>
-                      <button
-                        type="button"
-                        className="project-delete-btn project-delete-btn--confirm"
-                        onClick={(e) => { e.stopPropagation(); onDelete?.(name); setConfirming(null); }}
-                      >Yes</button>
-                      <button
-                        type="button"
-                        className="project-delete-btn project-delete-btn--cancel"
-                        onClick={(e) => { e.stopPropagation(); setConfirming(null); }}
-                      >No</button>
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      className="project-delete-btn"
-                      title="Delete project"
-                      onClick={(e) => { e.stopPropagation(); setConfirming(name); }}
-                    >
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <polyline points="3 6 5 6 21 6" />
-                        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                        <path d="M10 11v6M14 11v6" />
-                        <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                      </svg>
-                    </button>
-                  )}
+                  <div className="project-card-footer">
+                    {renderCardFooter(name)}
+                  </div>
                 </div>
 
                 {hasChildren && (
-                  <div className="project-children">
-                    <button
-                      type="button"
-                      className="project-children-toggle"
-                      onClick={() => toggle(name)}
-                    >
-                      <span className="project-children-chevron">{isExpanded ? '▾' : '▸'}</span>
-                      <span>{children[name].length} {children[name].length === 1 ? 'Sub project' : 'Sub projects'}</span>
-                    </button>
-                    {isExpanded && children[name].map((child) => {
+                  <div className="project-children-outer">
+                    {children[name].map((child) => {
                       const childName = child.name || child;
                       const isChildSelected = childName === selectedProject;
                       const cGrade = gradeLabel(child.overallGrade ?? child.latestGrade);
@@ -241,53 +239,27 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
                       const cDiscipline = disciplineLabel(child.discipline);
 
                       return (
-                        <div
-                          key={childName}
-                          className={`project-child-row${isChildSelected ? ' project-child-row--selected' : ''}`}
-                          onClick={() => onSelect?.(childName)}
-                        >
-                          <div className="project-child-top">
-                            <span className="project-child-name">{child.displayName || childName}</span>
-                            <GradeChip grade={cGrade} score={cScore} />
-                          </div>
-                          <div className="project-card-meta">
-                            {cDiscipline && <span className="project-meta-tag project-meta-tag--sm">{cDiscipline}</span>}
-                            {child.filesCount != null && (
-                              <span className="project-meta-item">{child.filesCount.toLocaleString()} files</span>
-                            )}
-                            <span className="project-meta-item">{child.runsCount} {child.runsCount === 1 ? 'run' : 'runs'}</span>
-                            {cDate && <span className="project-meta-date">{cDate}</span>}
-                          </div>
-                          <div className="project-card-footer" onClick={(e) => e.stopPropagation()}>
-                            {confirming === childName ? (
-                              <div className="project-card-actions">
-                                <span className="project-delete-confirm-label">Delete?</span>
-                                <button
-                                  type="button"
-                                  className="project-delete-btn project-delete-btn--confirm"
-                                  onClick={(e) => { e.stopPropagation(); onDelete?.(childName); setConfirming(null); }}
-                                >Yes</button>
-                                <button
-                                  type="button"
-                                  className="project-delete-btn project-delete-btn--cancel"
-                                  onClick={(e) => { e.stopPropagation(); setConfirming(null); }}
-                                >No</button>
+                        <div key={childName} className="project-child-entry">
+                          <div
+                            className={`project-card project-card--child panel${isChildSelected ? ' project-card--selected' : ''}`}
+                          >
+                            <div className="project-card-main" onClick={() => onSelect?.(childName)}>
+                              <div className="project-card-top">
+                                <span className="project-card-name">{child.displayName || childName}</span>
+                                <GradeChip grade={cGrade} score={cScore} />
                               </div>
-                            ) : (
-                              <button
-                                type="button"
-                                className="project-delete-btn"
-                                title="Delete sub project"
-                                onClick={(e) => { e.stopPropagation(); setConfirming(childName); }}
-                              >
-                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                                  <polyline points="3 6 5 6 21 6" />
-                                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                                  <path d="M10 11v6M14 11v6" />
-                                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-                                </svg>
-                              </button>
-                            )}
+                              <div className="project-card-meta">
+                                {cDiscipline && <span className="project-meta-tag">{cDiscipline}</span>}
+                                {child.filesCount != null && (
+                                  <span className="project-meta-item">{child.filesCount.toLocaleString()} files</span>
+                                )}
+                                <span className="project-meta-item">{child.runsCount} {child.runsCount === 1 ? 'run' : 'runs'}</span>
+                                {cDate && <span className="project-meta-date">{cDate}</span>}
+                              </div>
+                            </div>
+                            <div className="project-card-footer" onClick={(e) => e.stopPropagation()}>
+                              {renderCardFooter(childName)}
+                            </div>
                           </div>
                         </div>
                       );

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -606,6 +606,17 @@ textarea:focus {
   margin: 0;
 }
 
+.content-project-parent {
+  color: var(--color-text-muted);
+  font-weight: var(--weight-normal);
+}
+
+.content-project-sep {
+  color: var(--color-text-muted);
+  margin: 0 var(--space-2);
+  font-weight: var(--weight-normal);
+}
+
 .content-meta-row {
   display: flex;
   align-items: center;

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2236,3 +2236,118 @@
   flex: 1 1 0;
   min-width: 0;
 }
+
+/* ── Projects page ─────────────────────────────────────── */
+
+.projects-page {
+  padding: var(--space-6);
+  max-width: 720px;
+}
+
+.projects-header {
+  margin-bottom: var(--space-5);
+}
+
+.projects-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.projects-list {
+  padding: var(--space-2) 0;
+}
+
+.projects-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  padding-left: calc(var(--space-4) + var(--depth, 0) * 20px);
+  border-radius: var(--radius-sm);
+  cursor: default;
+  transition: background 120ms ease;
+}
+
+.projects-row:hover {
+  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+}
+
+.projects-row--selected {
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+
+.projects-row--selected:hover {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+}
+
+.projects-row--child {
+  font-size: var(--text-sm);
+}
+
+.projects-chevron {
+  width: 14px;
+  font-size: 11px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.projects-chevron--hidden {
+  visibility: hidden;
+  cursor: default;
+  pointer-events: none;
+}
+
+.projects-row-name {
+  flex: 1;
+  color: var(--color-text);
+  cursor: pointer;
+  font-weight: var(--weight-medium);
+}
+
+.projects-row-name:hover {
+  color: var(--color-accent);
+}
+
+.projects-row--selected .projects-row-name {
+  color: var(--color-accent);
+}
+
+.projects-row-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+
+.projects-grade {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  letter-spacing: 0.03em;
+}
+
+.projects-grade--a { color: var(--color-grade-top-text); }
+.projects-grade--b { color: var(--color-grade-high-text); }
+.projects-grade--c { color: var(--color-grade-mid-text); }
+.projects-grade--d { color: var(--color-grade-low-text); }
+.projects-grade--f { color: var(--color-grade-bottom-text); }
+.projects-grade--x { color: var(--color-text-muted); }
+
+.projects-date {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  min-width: 48px;
+  text-align: right;
+}
+
+.projects-empty {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: var(--space-6);
+}

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2469,6 +2469,57 @@
   flex: 1;
 }
 
+/* ── Path row (warning / copy / relocate) ── */
+
+.project-path-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-5) var(--space-3);
+  flex-wrap: wrap;
+}
+
+.project-path-missing {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-danger, #c0392b);
+  background: color-mix(in srgb, var(--color-danger, #c0392b) 10%, transparent);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+}
+
+.project-path-action--warn {
+  color: var(--color-danger, #c0392b);
+  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 30%, transparent);
+}
+
+.project-path-action--warn:hover {
+  background: color-mix(in srgb, var(--color-danger, #c0392b) 8%, transparent);
+}
+
+.project-relocate-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5) var(--space-3);
+}
+
+.project-relocate-input {
+  flex: 1;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+  outline: none;
+}
+
+.project-relocate-input:focus {
+  border-color: var(--color-accent);
+}
+
 /* ── Empty state ── */
 
 .projects-empty {

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2388,85 +2388,56 @@
 
 /* ── Children section ── */
 
-.project-children {
-  border-top: 1px solid var(--color-border);
-}
-
-.project-children-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-2) var(--space-5);
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  text-align: left;
-  transition: background 120ms ease, color 120ms ease;
-}
-
-.project-children-toggle:hover {
-  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
-  color: var(--color-text);
-}
-
-.project-children-chevron {
-  font-size: 11px;
-}
-
-.project-child-row {
+.project-card-group {
   display: flex;
   flex-direction: column;
-  cursor: pointer;
-  transition: background 120ms ease;
-  border-top: 1px solid var(--color-border);
 }
 
-.project-child-row:hover {
-  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
-}
-
-.project-child-row--selected {
-  background: color-mix(in srgb, var(--color-accent) 9%, transparent);
-}
-
-.project-child-row--selected:hover {
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-}
-
-.project-child-top {
+.project-children-outer {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-4) var(--space-5) var(--space-1);
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 28px;
+  margin-top: 6px;
 }
 
-.project-child-row .project-card-meta {
-  padding: 0 var(--space-5) var(--space-3);
+.project-child-entry {
+  position: relative;
 }
 
-.project-child-row .project-card-footer {
-  padding: var(--space-1) var(--space-4) var(--space-2);
+/* L connector — vertical segment */
+.project-child-entry::before {
+  content: '';
+  position: absolute;
+  left: -18px;
+  top: -6px;
+  height: 34px;
+  width: 1.5px;
+  background: var(--color-border);
 }
 
-.project-child-name {
+/* L connector — horizontal segment */
+.project-child-entry::after {
+  content: '';
+  position: absolute;
+  left: -18px;
+  top: 28px;
+  width: 18px;
+  height: 1.5px;
+  background: var(--color-border);
+}
+
+/* Child card — slightly more compact */
+.project-card--child .project-card-main {
+  padding: var(--space-4);
+}
+
+.project-card--child .project-card-name {
   font-size: var(--text-sm);
-  font-weight: var(--weight-medium);
-  color: var(--color-text);
 }
 
-.project-child-row--selected .project-child-name {
-  color: var(--color-accent);
-}
-
-.project-child-spacer {
-  flex: 1;
+.project-card--child .project-card-meta {
+  padding: 0 var(--space-4) var(--space-3);
 }
 
 /* ── Path row (warning / copy / relocate) ── */
@@ -2475,8 +2446,12 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-1) var(--space-5) var(--space-3);
+  padding: var(--space-1) 0 var(--space-1);
   flex-wrap: wrap;
+}
+
+.project-path-row .detail-copy-btn {
+  padding-left: 0;
 }
 
 .project-path-missing {

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2241,11 +2241,18 @@
 
 .projects-page {
   padding: var(--space-6);
-  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.projects-page > * {
+  width: 100%;
+  max-width: 680px;
 }
 
 .projects-header {
-  margin-bottom: var(--space-5);
+  margin-bottom: var(--space-6);
 }
 
 .projects-title {
@@ -2255,81 +2262,121 @@
   margin: 0;
 }
 
-.projects-list {
-  padding: var(--space-2) 0;
+.projects-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 680px;
+  margin: 0 auto;
 }
 
-.projects-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-4);
-  padding-left: calc(var(--space-4) + var(--depth, 0) * 20px);
-  border-radius: var(--radius-sm);
+/* ── Project card ── */
+
+.project-card {
+  padding: 0;
+  overflow: hidden;
   cursor: default;
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.project-card--selected {
+  border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.project-card--child-selected {
+  border-color: color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+}
+
+.project-card-main {
+  padding: var(--space-5);
+  cursor: pointer;
   transition: background 120ms ease;
 }
 
-.projects-row:hover {
-  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+.project-card-main:hover {
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
 }
 
-.projects-row--selected {
-  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+.project-card--selected .project-card-main {
+  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
 }
 
-.projects-row--selected:hover {
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
-}
-
-.projects-row--child {
-  font-size: var(--text-sm);
-}
-
-.projects-chevron {
-  width: 14px;
-  font-size: 11px;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.projects-chevron--hidden {
-  visibility: hidden;
-  cursor: default;
-  pointer-events: none;
-}
-
-.projects-row-name {
-  flex: 1;
-  color: var(--color-text);
-  cursor: pointer;
-  font-weight: var(--weight-medium);
-}
-
-.projects-row-name:hover {
-  color: var(--color-accent);
-}
-
-.projects-row--selected .projects-row-name {
-  color: var(--color-accent);
-}
-
-.projects-row-meta {
+.project-card-top {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--space-4);
+  margin-bottom: var(--space-2);
+}
+
+.project-card-name {
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+.project-card--selected .project-card-name {
+  color: var(--color-accent);
+}
+
+.project-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.project-meta-tag {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.02em;
   flex-shrink: 0;
 }
+
+.project-meta-tag--sm {
+  font-size: 11px;
+  padding: 1px 5px;
+}
+
+.project-meta-item {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.project-meta-date {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-left: auto;
+}
+
+.project-card-path {
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  opacity: 0.7;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Grade chip ── */
 
 .projects-grade {
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
-  padding: 2px 6px;
+  padding: 2px 7px;
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, currentColor 12%, transparent);
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
 }
 
 .projects-grade--a { color: var(--color-grade-top-text); }
@@ -2339,15 +2386,154 @@
 .projects-grade--f { color: var(--color-grade-bottom-text); }
 .projects-grade--x { color: var(--color-text-muted); }
 
-.projects-date {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  min-width: 48px;
-  text-align: right;
+/* ── Children section ── */
+
+.project-children {
+  border-top: 1px solid var(--color-border);
 }
+
+.project-children-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-5);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-align: left;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.project-children-toggle:hover {
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+  color: var(--color-text);
+}
+
+.project-children-chevron {
+  font-size: 11px;
+}
+
+.project-child-row {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  transition: background 120ms ease;
+  border-top: 1px solid var(--color-border);
+}
+
+.project-child-row:hover {
+  background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+}
+
+.project-child-row--selected {
+  background: color-mix(in srgb, var(--color-accent) 9%, transparent);
+}
+
+.project-child-row--selected:hover {
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+.project-child-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5) var(--space-1);
+}
+
+.project-child-row .project-card-meta {
+  padding: 0 var(--space-5) var(--space-3);
+}
+
+.project-child-row .project-card-footer {
+  padding: var(--space-1) var(--space-4) var(--space-2);
+}
+
+.project-child-name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+}
+
+.project-child-row--selected .project-child-name {
+  color: var(--color-accent);
+}
+
+.project-child-spacer {
+  flex: 1;
+}
+
+/* ── Empty state ── */
 
 .projects-empty {
   color: var(--color-text-muted);
   font-size: var(--text-sm);
   padding: var(--space-6);
+}
+
+/* ── Project card footer / delete ── */
+
+.project-card-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}
+
+.project-card-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.project-delete-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 6px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}
+
+
+.project-delete-btn:hover {
+  color: var(--color-danger, #c0392b);
+  background: color-mix(in srgb, var(--color-danger, #c0392b) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 20%, transparent);
+}
+
+.project-delete-btn--confirm {
+  color: var(--color-danger, #c0392b);
+  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 30%, transparent);
+}
+
+.project-delete-btn--confirm:hover {
+  background: color-mix(in srgb, var(--color-danger, #c0392b) 15%, transparent);
+}
+
+.project-delete-btn--cancel {
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
+}
+
+.project-delete-btn--cancel:hover {
+  background: color-mix(in srgb, var(--color-text-muted) 8%, transparent);
+}
+
+.project-delete-confirm-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }


### PR DESCRIPTION
## Summary

- Add a dedicated Projects tab to the dashboard with a card-based layout showing grade, score, discipline, file count, and run history
- Sub-projects are rendered as indented child cards with an L-shaped connector line (non-collapsible)
- Project management: delete, relocate local paths, copy online repo URLs, displayName support
- Project export: download all evaluation reports as a `.zip` via `GET /api/projects/<project>/export`
- Fix proxy binary corruption: Node.js proxy now uses `arrayBuffer()` for non-text responses so zip downloads are not mangled

## Commits

1. **Planning & backend API** — design doc, impl plan, `parent`/`latestGrade`/`latestScore` fields in `list_projects`
2. **Initial Projects tab UI** — nav tab, tree component, styles, parent › child header
3. **Cards redesign & project management** — card layout, discipline/path/files metadata, delete, auto-detect parent, sub-project rows
4. **Path & display** — path-exists check, relocate for local repos, copy for online repos, `displayName` field
5. **Export & child card layout** — zip export endpoint, child cards as separate indented cards with L connector, binary proxy fix

## Test plan

- [x] Projects tab appears in the nav and lists all projects
- [x] Sub-projects render as indented cards with an L connector below their parent
- [x] Delete confirms and removes the project card
- [x] Relocate saves a new path; missing-path warning shows when path not found
- [x] Download button triggers a valid `.zip` download containing the evaluation reports
- [x] Online repo projects show a copy button instead of a path