### PR TITLE
feat(v2): standards layer — ISO 25010, OWASP ASVS L1, CISQ CWE lists

### DIFF
--- a/scripts/fetch-asvs.py
+++ b/scripts/fetch-asvs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Fetch OWASP ASVS Level 1 requirements from GitHub and save to standards/asvs/level1.json"""
+import json
+import urllib.request
+from pathlib import Path
+
+ASVS_URL = "https://raw.githubusercontent.com/OWASP/ASVS/v4.0.3/4.0/docs_en/OWASP%20Application%20Security%20Verification%20Standard%204.0.3-en.json"
+
+Path("standards/asvs").mkdir(parents=True, exist_ok=True)
+with urllib.request.urlopen(ASVS_URL) as r:
+    raw = json.loads(r.read())
+
+# Extract L1 requirements only
+requirements = []
+for chapter in raw.get("Requirements", []):
+    for section in chapter.get("Items", []):
+        for req in section.get("Items", []):
+            if req.get("L1", {}).get("Required"):
+                requirements.append({
+                    "id": req["Shortcode"],
+                    "level": 1,
+                    "text": req["Description"],
+                    "cwe": req.get("CWE", []),
+                    "section": chapter["ShortName"],
+                })
+
+output = {
+    "source": "OWASP ASVS 4.0.3",
+    "level": 1,
+    "fetched": "2026-03-03",
+    "requirements": requirements,
+}
+Path("standards/asvs/level1.json").write_text(json.dumps(output, indent=2))
+print(f"Saved {len(requirements)} L1 requirements")

--- a/src/codecompass/v2/engine/standards.py
+++ b/src/codecompass/v2/engine/standards.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+STANDARDS_DIR = Path(__file__).parent.parent.parent.parent.parent / "standards"
+
+
+def load_dimension(dimension_id: str) -> dict:
+    path = STANDARDS_DIR / "iso25010" / f"{dimension_id}.json"
+    return json.loads(path.read_text())
+
+
+def load_asvs_l1() -> dict:
+    return json.loads((STANDARDS_DIR / "asvs" / "level1.json").read_text())
+
+
+def load_cisq(characteristic: str) -> dict:
+    path = STANDARDS_DIR / "cisq" / f"{characteristic}.json"
+    return json.loads(path.read_text())

--- a/standards/asvs/level1.json
+++ b/standards/asvs/level1.json
@@ -1,0 +1,1159 @@
+{
+  "source": "OWASP ASVS 4.0.3",
+  "level": 1,
+  "fetched": "2026-03-03",
+  "requirements": [
+    {
+      "id": "V2.1.1",
+      "level": 1,
+      "text": "Verify that user set passwords are at least 12 characters in length (after multiple spaces are combined). ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.2",
+      "level": 1,
+      "text": "Verify that passwords of at least 64 characters are permitted, and that passwords of more than 128 characters are denied. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.3",
+      "level": 1,
+      "text": "Verify that password truncation is not performed. However, consecutive multiple spaces may be replaced by a single space. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.4",
+      "level": 1,
+      "text": "Verify that any printable Unicode character, including language neutral characters such as spaces and Emojis are permitted in passwords.",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.5",
+      "level": 1,
+      "text": "Verify users can change their password.",
+      "cwe": [
+        620
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.6",
+      "level": 1,
+      "text": "Verify that password change functionality requires the user's current and new password.",
+      "cwe": [
+        620
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.7",
+      "level": 1,
+      "text": "Verify that passwords submitted during account registration, login, and password change are checked against a set of breached passwords either locally (such as the top 1,000 or 10,000 most common passwords which match the system's password policy) or using an external API. If using an API a zero knowledge proof or other mechanism should be used to ensure that the plain text password is not sent or used in verifying the breach status of the password. If the password is breached, the application must require the user to set a new non-breached password. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.8",
+      "level": 1,
+      "text": "Verify that a password strength meter is provided to help users set a stronger password.",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.9",
+      "level": 1,
+      "text": "Verify that there are no password composition rules limiting the type of characters permitted. There should be no requirement for upper or lower case or numbers or special characters. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.10",
+      "level": 1,
+      "text": "Verify that there are no periodic credential rotation or password history requirements.",
+      "cwe": [
+        263
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.11",
+      "level": 1,
+      "text": "Verify that \"paste\" functionality, browser password helpers, and external password managers are permitted.",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.1.12",
+      "level": 1,
+      "text": "Verify that the user can choose to either temporarily view the entire masked password, or temporarily view the last typed character of the password on platforms that do not have this as built-in functionality.",
+      "cwe": [
+        521
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.2.1",
+      "level": 1,
+      "text": "Verify that anti-automation controls are effective at mitigating breached credential testing, brute force, and account lockout attacks. Such controls include blocking the most common breached passwords, soft lockouts, rate limiting, CAPTCHA, ever increasing delays between attempts, IP address restrictions, or risk-based restrictions such as location, first login on a device, recent attempts to unlock the account, or similar. Verify that no more than 100 failed attempts per hour is possible on a single account.",
+      "cwe": [
+        307
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.2.2",
+      "level": 1,
+      "text": "Verify that the use of weak authenticators (such as SMS and email) is limited to secondary verification and transaction approval and not as a replacement for more secure authentication methods. Verify that stronger methods are offered before weak methods, users are aware of the risks, or that proper measures are in place to limit the risks of account compromise.",
+      "cwe": [
+        304
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.2.3",
+      "level": 1,
+      "text": "Verify that secure notifications are sent to users after updates to authentication details, such as credential resets, email or address changes, logging in from unknown or risky locations. The use of push notifications - rather than SMS or email - is preferred, but in the absence of push notifications, SMS or email is acceptable as long as no sensitive information is disclosed in the notification.",
+      "cwe": [
+        620
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.3.1",
+      "level": 1,
+      "text": "Verify system generated initial passwords or activation codes SHOULD be securely randomly generated, SHOULD be at least 6 characters long, and MAY contain letters and numbers, and expire after a short period of time. These initial secrets must not be permitted to become the long term password.",
+      "cwe": [
+        330
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.1",
+      "level": 1,
+      "text": "Verify that a system generated initial activation or recovery secret is not sent in clear text to the user. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        640
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.2",
+      "level": 1,
+      "text": "Verify password hints or knowledge-based authentication (so-called \"secret questions\") are not present.",
+      "cwe": [
+        640
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.3",
+      "level": 1,
+      "text": "Verify password credential recovery does not reveal the current password in any way. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        640
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.4",
+      "level": 1,
+      "text": "Verify shared or default accounts are not present (e.g. \"root\", \"admin\", or \"sa\").",
+      "cwe": [
+        16
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.5",
+      "level": 1,
+      "text": "Verify that if an authentication factor is changed or replaced, that the user is notified of this event.",
+      "cwe": [
+        304
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.5.6",
+      "level": 1,
+      "text": "Verify forgotten password, and other recovery paths use a secure recovery mechanism, such as time-based OTP (TOTP) or other soft token, mobile push, or another offline recovery mechanism. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        640
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.7.1",
+      "level": 1,
+      "text": "Verify that clear text out of band (NIST \"restricted\") authenticators, such as SMS or PSTN, are not offered by default, and stronger alternatives such as push notifications are offered first.",
+      "cwe": [
+        287
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.7.2",
+      "level": 1,
+      "text": "Verify that the out of band verifier expires out of band authentication requests, codes, or tokens after 10 minutes.",
+      "cwe": [
+        287
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.7.3",
+      "level": 1,
+      "text": "Verify that the out of band verifier authentication requests, codes, or tokens are only usable once, and only for the original authentication request.",
+      "cwe": [
+        287
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.7.4",
+      "level": 1,
+      "text": "Verify that the out of band authenticator and verifier communicates over a secure independent channel.",
+      "cwe": [
+        523
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V2.8.1",
+      "level": 1,
+      "text": "Verify that time-based OTPs have a defined lifetime before expiring.",
+      "cwe": [
+        613
+      ],
+      "section": "Authentication"
+    },
+    {
+      "id": "V3.1.1",
+      "level": 1,
+      "text": "Verify the application never reveals session tokens in URL parameters.",
+      "cwe": [
+        598
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.2.1",
+      "level": 1,
+      "text": "Verify the application generates a new session token on user authentication. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        384
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.2.2",
+      "level": 1,
+      "text": "Verify that session tokens possess at least 64 bits of entropy. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        331
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.2.3",
+      "level": 1,
+      "text": "Verify the application only stores session tokens in the browser using secure methods such as appropriately secured cookies (see section 3.4) or HTML 5 session storage.",
+      "cwe": [
+        539
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.3.1",
+      "level": 1,
+      "text": "Verify that logout and expiration invalidate the session token, such that the back button or a downstream relying party does not resume an authenticated session, including across relying parties. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        613
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.3.2",
+      "level": 1,
+      "text": "If authenticators permit users to remain logged in, verify that re-authentication occurs periodically both when actively used or after an idle period. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        613
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.4.1",
+      "level": 1,
+      "text": "Verify that cookie-based session tokens have the 'Secure' attribute set. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        614
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.4.2",
+      "level": 1,
+      "text": "Verify that cookie-based session tokens have the 'HttpOnly' attribute set. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        1004
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.4.3",
+      "level": 1,
+      "text": "Verify that cookie-based session tokens utilize the 'SameSite' attribute to limit exposure to cross-site request forgery attacks. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        1275
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.4.4",
+      "level": 1,
+      "text": "Verify that cookie-based session tokens use the \"__Host-\" prefix so cookies are only sent to the host that initially set the cookie.",
+      "cwe": [
+        16
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.4.5",
+      "level": 1,
+      "text": "Verify that if the application is published under a domain name with other applications that set or use session cookies that might disclose the session cookies, set the path attribute in cookie-based session tokens using the most precise path possible. ([C6](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        16
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V3.7.1",
+      "level": 1,
+      "text": "Verify the application ensures a full, valid login session or requires re-authentication or secondary verification before allowing any sensitive transactions or account modifications.",
+      "cwe": [
+        306
+      ],
+      "section": "Session"
+    },
+    {
+      "id": "V4.1.1",
+      "level": 1,
+      "text": "Verify that the application enforces access control rules on a trusted service layer, especially if client-side access control is present and could be bypassed.",
+      "cwe": [
+        602
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.1.2",
+      "level": 1,
+      "text": "Verify that all user and data attributes and policy information used by access controls cannot be manipulated by end users unless specifically authorized.",
+      "cwe": [
+        639
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.1.3",
+      "level": 1,
+      "text": "Verify that the principle of least privilege exists - users should only be able to access functions, data files, URLs, controllers, services, and other resources, for which they possess specific authorization. This implies protection against spoofing and elevation of privilege. ([C7](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        285
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.1.5",
+      "level": 1,
+      "text": "Verify that access controls fail securely including when an exception occurs. ([C10](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        285
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.2.1",
+      "level": 1,
+      "text": "Verify that sensitive data and APIs are protected against Insecure Direct Object Reference (IDOR) attacks targeting creation, reading, updating and deletion of records, such as creating or updating someone else's record, viewing everyone's records, or deleting all records.",
+      "cwe": [
+        639
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.2.2",
+      "level": 1,
+      "text": "Verify that the application or framework enforces a strong anti-CSRF mechanism to protect authenticated functionality, and effective anti-automation or anti-CSRF protects unauthenticated functionality.",
+      "cwe": [
+        352
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.3.1",
+      "level": 1,
+      "text": "Verify administrative interfaces use appropriate multi-factor authentication to prevent unauthorized use.",
+      "cwe": [
+        419
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V4.3.2",
+      "level": 1,
+      "text": "Verify that directory browsing is disabled unless deliberately desired. Additionally, applications should not allow discovery or disclosure of file or directory metadata, such as Thumbs.db, .DS_Store, .git or .svn folders.",
+      "cwe": [
+        548
+      ],
+      "section": "Access"
+    },
+    {
+      "id": "V5.1.1",
+      "level": 1,
+      "text": "Verify that the application has defenses against HTTP parameter pollution attacks, particularly if the application framework makes no distinction about the source of request parameters (GET, POST, cookies, headers, or environment variables).",
+      "cwe": [
+        235
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.1.2",
+      "level": 1,
+      "text": "Verify that frameworks protect against mass parameter assignment attacks, or that the application has countermeasures to protect against unsafe parameter assignment, such as marking fields private or similar. ([C5](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        915
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.1.3",
+      "level": 1,
+      "text": "Verify that all input (HTML form fields, REST requests, URL parameters, HTTP headers, cookies, batch files, RSS feeds, etc) is validated using positive validation (allow lists). ([C5](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        20
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.1.4",
+      "level": 1,
+      "text": "Verify that structured data is strongly typed and validated against a defined schema including allowed characters, length and pattern (e.g. credit card numbers, e-mail addresses, telephone numbers, or validating that two related fields are reasonable, such as checking that suburb and zip/postcode match). ([C5](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        20
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.1.5",
+      "level": 1,
+      "text": "Verify that URL redirects and forwards only allow destinations which appear on an allow list, or show a warning when redirecting to potentially untrusted content.",
+      "cwe": [
+        601
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.1",
+      "level": 1,
+      "text": "Verify that all untrusted HTML input from WYSIWYG editors or similar is properly sanitized with an HTML sanitizer library or framework feature. ([C5](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        116
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.2",
+      "level": 1,
+      "text": "Verify that unstructured data is sanitized to enforce safety measures such as allowed characters and length.",
+      "cwe": [
+        138
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.3",
+      "level": 1,
+      "text": "Verify that the application sanitizes user input before passing to mail systems to protect against SMTP or IMAP injection.",
+      "cwe": [
+        147
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.4",
+      "level": 1,
+      "text": "Verify that the application avoids the use of eval() or other dynamic code execution features. Where there is no alternative, any user input being included must be sanitized or sandboxed before being executed.",
+      "cwe": [
+        95
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.5",
+      "level": 1,
+      "text": "Verify that the application protects against template injection attacks by ensuring that any user input being included is sanitized or sandboxed.",
+      "cwe": [
+        94
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.6",
+      "level": 1,
+      "text": "Verify that the application protects against SSRF attacks, by validating or sanitizing untrusted data or HTTP file metadata, such as filenames and URL input fields, and uses allow lists of protocols, domains, paths and ports.",
+      "cwe": [
+        918
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.7",
+      "level": 1,
+      "text": "Verify that the application sanitizes, disables, or sandboxes user-supplied Scalable Vector Graphics (SVG) scriptable content, especially as they relate to XSS resulting from inline scripts, and foreignObject.",
+      "cwe": [
+        159
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.2.8",
+      "level": 1,
+      "text": "Verify that the application sanitizes, disables, or sandboxes user-supplied scriptable or expression template language content, such as Markdown, CSS or XSL stylesheets, BBCode, or similar.",
+      "cwe": [
+        94
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.1",
+      "level": 1,
+      "text": "Verify that output encoding is relevant for the interpreter and context required. For example, use encoders specifically for HTML values, HTML attributes, JavaScript, URL parameters, HTTP headers, SMTP, and others as the context requires, especially from untrusted inputs (e.g. names with Unicode or apostrophes, such as \u306d\u3053 or O'Hara). ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        116
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.2",
+      "level": 1,
+      "text": "Verify that output encoding preserves the user's chosen character set and locale, such that any Unicode character point is valid and safely handled. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        176
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.3",
+      "level": 1,
+      "text": "Verify that context-aware, preferably automated - or at worst, manual - output escaping protects against reflected, stored, and DOM based XSS. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        79
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.4",
+      "level": 1,
+      "text": "Verify that data selection or database queries (e.g. SQL, HQL, ORM, NoSQL) use parameterized queries, ORMs, entity frameworks, or are otherwise protected from database injection attacks. ([C3](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        89
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.5",
+      "level": 1,
+      "text": "Verify that where parameterized or safer mechanisms are not present, context-specific output encoding is used to protect against injection attacks, such as the use of SQL escaping to protect against SQL injection. ([C3, C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        89
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.6",
+      "level": 1,
+      "text": "Verify that the application protects against JSON injection attacks, JSON eval attacks, and JavaScript expression evaluation. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        830
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.7",
+      "level": 1,
+      "text": "Verify that the application protects against LDAP injection vulnerabilities, or that specific security controls to prevent LDAP injection have been implemented. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        90
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.8",
+      "level": 1,
+      "text": "Verify that the application protects against OS command injection and that operating system calls use parameterized OS queries or use contextual command line output encoding. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        78
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.9",
+      "level": 1,
+      "text": "Verify that the application protects against Local File Inclusion (LFI) or Remote File Inclusion (RFI) attacks.",
+      "cwe": [
+        829
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.3.10",
+      "level": 1,
+      "text": "Verify that the application protects against XPath injection or XML injection attacks. ([C4](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        643
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.5.1",
+      "level": 1,
+      "text": "Verify that serialized objects use integrity checks or are encrypted to prevent hostile object creation or data tampering. ([C5](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        502
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.5.2",
+      "level": 1,
+      "text": "Verify that the application correctly restricts XML parsers to only use the most restrictive configuration possible and to ensure that unsafe features such as resolving external entities are disabled to prevent XML eXternal Entity (XXE) attacks.",
+      "cwe": [
+        611
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.5.3",
+      "level": 1,
+      "text": "Verify that deserialization of untrusted data is avoided or is protected in both custom code and third-party libraries (such as JSON, XML and YAML parsers).",
+      "cwe": [
+        502
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V5.5.4",
+      "level": 1,
+      "text": "Verify that when parsing JSON in browsers or JavaScript-based backends, JSON.parse is used to parse the JSON document. Do not use eval() to parse JSON.",
+      "cwe": [
+        95
+      ],
+      "section": "Validation"
+    },
+    {
+      "id": "V6.2.1",
+      "level": 1,
+      "text": "Verify that all cryptographic modules fail securely, and errors are handled in a way that does not enable Padding Oracle attacks.",
+      "cwe": [
+        310
+      ],
+      "section": "Cryptography"
+    },
+    {
+      "id": "V7.1.1",
+      "level": 1,
+      "text": "Verify that the application does not log credentials or payment details. Session tokens should only be stored in logs in an irreversible, hashed form. ([C9, C10](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        532
+      ],
+      "section": "Error"
+    },
+    {
+      "id": "V7.1.2",
+      "level": 1,
+      "text": "Verify that the application does not log other sensitive data as defined under local privacy laws or relevant security policy. ([C9](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        532
+      ],
+      "section": "Error"
+    },
+    {
+      "id": "V7.4.1",
+      "level": 1,
+      "text": "Verify that a generic message is shown when an unexpected or security sensitive error occurs, potentially with a unique ID which support personnel can use to investigate. ([C10](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        210
+      ],
+      "section": "Error"
+    },
+    {
+      "id": "V8.2.1",
+      "level": 1,
+      "text": "Verify the application sets sufficient anti-caching headers so that sensitive data is not cached in modern browsers.",
+      "cwe": [
+        525
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.2.2",
+      "level": 1,
+      "text": "Verify that data stored in browser storage (such as localStorage, sessionStorage, IndexedDB, or cookies) does not contain sensitive data.",
+      "cwe": [
+        922
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.2.3",
+      "level": 1,
+      "text": "Verify that authenticated data is cleared from client storage, such as the browser DOM, after the client or session is terminated.",
+      "cwe": [
+        922
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.3.1",
+      "level": 1,
+      "text": "Verify that sensitive data is sent to the server in the HTTP message body or headers, and that query string parameters from any HTTP verb do not contain sensitive data.",
+      "cwe": [
+        319
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.3.2",
+      "level": 1,
+      "text": "Verify that users have a method to remove or export their data on demand.",
+      "cwe": [
+        212
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.3.3",
+      "level": 1,
+      "text": "Verify that users are provided clear language regarding collection and use of supplied personal information and that users have provided opt-in consent for the use of that data before it is used in any way.",
+      "cwe": [
+        285
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V8.3.4",
+      "level": 1,
+      "text": "Verify that all sensitive data created and processed by the application has been identified, and ensure that a policy is in place on how to deal with sensitive data. ([C8](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        200
+      ],
+      "section": "Data"
+    },
+    {
+      "id": "V9.1.1",
+      "level": 1,
+      "text": "Verify that TLS is used for all client connectivity, and does not fall back to insecure or unencrypted communications. ([C8](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        319
+      ],
+      "section": "Communications"
+    },
+    {
+      "id": "V9.1.2",
+      "level": 1,
+      "text": "Verify using up to date TLS testing tools that only strong cipher suites are enabled, with the strongest cipher suites set as preferred.",
+      "cwe": [
+        326
+      ],
+      "section": "Communications"
+    },
+    {
+      "id": "V9.1.3",
+      "level": 1,
+      "text": "Verify that only the latest recommended versions of the TLS protocol are enabled, such as TLS 1.2 and TLS 1.3. The latest version of the TLS protocol should be the preferred option.",
+      "cwe": [
+        326
+      ],
+      "section": "Communications"
+    },
+    {
+      "id": "V10.3.1",
+      "level": 1,
+      "text": "Verify that if the application has a client or server auto-update feature, updates should be obtained over secure channels and digitally signed. The update code must validate the digital signature of the update before installing or executing the update.",
+      "cwe": [
+        16
+      ],
+      "section": "Malicious"
+    },
+    {
+      "id": "V10.3.2",
+      "level": 1,
+      "text": "Verify that the application employs integrity protections, such as code signing or subresource integrity. The application must not load or execute code from untrusted sources, such as loading includes, modules, plugins, code, or libraries from untrusted sources or the Internet.",
+      "cwe": [
+        353
+      ],
+      "section": "Malicious"
+    },
+    {
+      "id": "V10.3.3",
+      "level": 1,
+      "text": "Verify that the application has protection from subdomain takeovers if the application relies upon DNS entries or DNS subdomains, such as expired domain names, out of date DNS pointers or CNAMEs, expired projects at public source code repos, or transient cloud APIs, serverless functions, or storage buckets (*autogen-bucket-id*.cloud.example.com) or similar. Protections can include ensuring that DNS names used by applications are regularly checked for expiry or change.",
+      "cwe": [
+        350
+      ],
+      "section": "Malicious"
+    },
+    {
+      "id": "V11.1.1",
+      "level": 1,
+      "text": "Verify that the application will only process business logic flows for the same user in sequential step order and without skipping steps.",
+      "cwe": [
+        841
+      ],
+      "section": "BusLogic"
+    },
+    {
+      "id": "V11.1.2",
+      "level": 1,
+      "text": "Verify that the application will only process business logic flows with all steps being processed in realistic human time, i.e. transactions are not submitted too quickly.",
+      "cwe": [
+        799
+      ],
+      "section": "BusLogic"
+    },
+    {
+      "id": "V11.1.3",
+      "level": 1,
+      "text": "Verify the application has appropriate limits for specific business actions or transactions which are correctly enforced on a per user basis.",
+      "cwe": [
+        770
+      ],
+      "section": "BusLogic"
+    },
+    {
+      "id": "V11.1.4",
+      "level": 1,
+      "text": "Verify that the application has anti-automation controls to protect against excessive calls such as mass data exfiltration, business logic requests, file uploads or denial of service attacks.",
+      "cwe": [
+        770
+      ],
+      "section": "BusLogic"
+    },
+    {
+      "id": "V11.1.5",
+      "level": 1,
+      "text": "Verify the application has business logic limits or validation to protect against likely business risks or threats, identified using threat modeling or similar methodologies.",
+      "cwe": [
+        841
+      ],
+      "section": "BusLogic"
+    },
+    {
+      "id": "V12.1.1",
+      "level": 1,
+      "text": "Verify that the application will not accept large files that could fill up storage or cause a denial of service.",
+      "cwe": [
+        400
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.3.1",
+      "level": 1,
+      "text": "Verify that user-submitted filename metadata is not used directly by system or framework filesystems and that a URL API is used to protect against path traversal.",
+      "cwe": [
+        22
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.3.2",
+      "level": 1,
+      "text": "Verify that user-submitted filename metadata is validated or ignored to prevent the disclosure, creation, updating or removal of local files (LFI).",
+      "cwe": [
+        73
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.3.3",
+      "level": 1,
+      "text": "Verify that user-submitted filename metadata is validated or ignored to prevent the disclosure or execution of remote files via Remote File Inclusion (RFI) or Server-side Request Forgery (SSRF) attacks.",
+      "cwe": [
+        98
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.3.4",
+      "level": 1,
+      "text": "Verify that the application protects against Reflective File Download (RFD) by validating or ignoring user-submitted filenames in a JSON, JSONP, or URL parameter, the response Content-Type header should be set to text/plain, and the Content-Disposition header should have a fixed filename.",
+      "cwe": [
+        641
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.3.5",
+      "level": 1,
+      "text": "Verify that untrusted file metadata is not used directly with system API or libraries, to protect against OS command injection.",
+      "cwe": [
+        78
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.4.1",
+      "level": 1,
+      "text": "Verify that files obtained from untrusted sources are stored outside the web root, with limited permissions.",
+      "cwe": [
+        552
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.4.2",
+      "level": 1,
+      "text": "Verify that files obtained from untrusted sources are scanned by antivirus scanners to prevent upload and serving of known malicious content.",
+      "cwe": [
+        509
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.5.1",
+      "level": 1,
+      "text": "Verify that the web tier is configured to serve only files with specific file extensions to prevent unintentional information and source code leakage. For example, backup files (e.g. .bak), temporary working files (e.g. .swp), compressed files (.zip, .tar.gz, etc) and other extensions commonly used by editors should be blocked unless required.",
+      "cwe": [
+        552
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.5.2",
+      "level": 1,
+      "text": "Verify that direct requests to uploaded files will never be executed as HTML/JavaScript content.",
+      "cwe": [
+        434
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V12.6.1",
+      "level": 1,
+      "text": "Verify that the web or application server is configured with an allow list of resources or systems to which the server can send requests or load data/files from.",
+      "cwe": [
+        918
+      ],
+      "section": "Files"
+    },
+    {
+      "id": "V13.1.1",
+      "level": 1,
+      "text": "Verify that all application components use the same encodings and parsers to avoid parsing attacks that exploit different URI or file parsing behavior that could be used in SSRF and RFI attacks.",
+      "cwe": [
+        116
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V13.1.3",
+      "level": 1,
+      "text": "Verify API URLs do not expose sensitive information, such as the API key, session tokens etc.",
+      "cwe": [
+        598
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V13.2.1",
+      "level": 1,
+      "text": "Verify that enabled RESTful HTTP methods are a valid choice for the user or action, such as preventing normal users using DELETE or PUT on protected API or resources.",
+      "cwe": [
+        650
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V13.2.2",
+      "level": 1,
+      "text": "Verify that JSON schema validation is in place and verified before accepting input.",
+      "cwe": [
+        20
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V13.2.3",
+      "level": 1,
+      "text": "Verify that RESTful web services that utilize cookies are protected from Cross-Site Request Forgery via the use of at least one or more of the following: double submit cookie pattern, CSRF nonces, or Origin request header checks.",
+      "cwe": [
+        352
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V13.3.1",
+      "level": 1,
+      "text": "Verify that XSD schema validation takes place to ensure a properly formed XML document, followed by validation of each input field before any processing of that data takes place.",
+      "cwe": [
+        20
+      ],
+      "section": "API"
+    },
+    {
+      "id": "V14.2.1",
+      "level": 1,
+      "text": "Verify that all components are up to date, preferably using a dependency checker during build or compile time. ([C2](https://owasp.org/www-project-proactive-controls/#div-numbering))",
+      "cwe": [
+        1026
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.2.2",
+      "level": 1,
+      "text": "Verify that all unneeded features, documentation, sample applications and configurations are removed.",
+      "cwe": [
+        1002
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.2.3",
+      "level": 1,
+      "text": "Verify that if application assets, such as JavaScript libraries, CSS or web fonts, are hosted externally on a Content Delivery Network (CDN) or external provider, Subresource Integrity (SRI) is used to validate the integrity of the asset.",
+      "cwe": [
+        829
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.3.2",
+      "level": 1,
+      "text": "Verify that web or application server and application framework debug modes are disabled in production to eliminate debug features, developer consoles, and unintended security disclosures.",
+      "cwe": [
+        497
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.3.3",
+      "level": 1,
+      "text": "Verify that the HTTP headers or any part of the HTTP response do not expose detailed version information of system components.",
+      "cwe": [
+        200
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.1",
+      "level": 1,
+      "text": "Verify that every HTTP response contains a Content-Type header. Also specify a safe character set (e.g., UTF-8, ISO-8859-1) if the content types are text/*, /+xml and application/xml. Content must match with the provided Content-Type header.",
+      "cwe": [
+        173
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.2",
+      "level": 1,
+      "text": "Verify that all API responses contain a Content-Disposition: attachment; filename=\"api.json\" header (or other appropriate filename for the content type).",
+      "cwe": [
+        116
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.3",
+      "level": 1,
+      "text": "Verify that a Content Security Policy (CSP) response header is in place that helps mitigate impact for XSS attacks like HTML, DOM, JSON, and JavaScript injection vulnerabilities.",
+      "cwe": [
+        1021
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.4",
+      "level": 1,
+      "text": "Verify that all responses contain a X-Content-Type-Options: nosniff header.",
+      "cwe": [
+        116
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.5",
+      "level": 1,
+      "text": "Verify that a Strict-Transport-Security header is included on all responses and for all subdomains, such as Strict-Transport-Security: max-age=15724800; includeSubdomains.",
+      "cwe": [
+        523
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.6",
+      "level": 1,
+      "text": "Verify that a suitable Referrer-Policy header is included to avoid exposing sensitive information in the URL through the Referer header to untrusted parties.",
+      "cwe": [
+        116
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.4.7",
+      "level": 1,
+      "text": "Verify that the content of a web application cannot be embedded in a third-party site by default and that embedding of the exact resources is only allowed where necessary by using suitable Content-Security-Policy: frame-ancestors and X-Frame-Options response headers.",
+      "cwe": [
+        1021
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.5.1",
+      "level": 1,
+      "text": "Verify that the application server only accepts the HTTP methods in use by the application/API, including pre-flight OPTIONS, and logs/alerts on any requests that are not valid for the application context.",
+      "cwe": [
+        749
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.5.2",
+      "level": 1,
+      "text": "Verify that the supplied Origin header is not used for authentication or access control decisions, as the Origin header can easily be changed by an attacker.",
+      "cwe": [
+        346
+      ],
+      "section": "Config"
+    },
+    {
+      "id": "V14.5.3",
+      "level": 1,
+      "text": "Verify that the Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header uses a strict allow list of trusted domains and subdomains to match against and does not support the \"null\" origin.",
+      "cwe": [
+        346
+      ],
+      "section": "Config"
+    }
+  ]
+}

--- a/standards/cisq/maintainability.json
+++ b/standards/cisq/maintainability.json
@@ -1,0 +1,12 @@
+{
+  "characteristic": "Maintainability",
+  "source": "ISO 5055 / CISQ 2021",
+  "cwes": [
+    { "id": 1057, "name": "Data Access Outside Expected Component" },
+    { "id": 1061, "name": "Insufficient Encapsulation" },
+    { "id": 1080, "name": "Source File With Excessive Lines of Code" },
+    { "id": 1121, "name": "Excessive McCabe Cyclomatic Complexity" },
+    { "id": 1047, "name": "Modules with Circular Dependencies" },
+    { "id": 1059, "name": "Insufficient Technical Documentation" }
+  ]
+}

--- a/standards/cisq/performance.json
+++ b/standards/cisq/performance.json
@@ -1,0 +1,9 @@
+{
+  "characteristic": "Performance Efficiency",
+  "source": "ISO 5055 / CISQ 2021",
+  "cwes": [
+    { "id": 400,  "name": "Uncontrolled Resource Consumption" },
+    { "id": 1084, "name": "Invokable Control Element with Excessive File or Data Access Operations" },
+    { "id": 1088, "name": "Synchronous Access of Remote Resource without Timeout" }
+  ]
+}

--- a/standards/cisq/reliability.json
+++ b/standards/cisq/reliability.json
@@ -1,0 +1,11 @@
+{
+  "characteristic": "Reliability",
+  "source": "ISO 5055 / CISQ 2021",
+  "cwes": [
+    { "id": 390, "name": "Detection of Error Condition Without Action" },
+    { "id": 476, "name": "NULL Pointer Dereference" },
+    { "id": 755, "name": "Improper Handling of Exceptional Conditions" },
+    { "id": 772, "name": "Missing Release of Resource after Effective Lifetime" },
+    { "id": 1059, "name": "Insufficient Technical Documentation" }
+  ]
+}

--- a/standards/cisq/security.json
+++ b/standards/cisq/security.json
@@ -1,0 +1,12 @@
+{
+  "characteristic": "Security",
+  "source": "ISO 5055 / CISQ 2021",
+  "cwes": [
+    { "id": 20,  "name": "Improper Input Validation" },
+    { "id": 78,  "name": "OS Command Injection" },
+    { "id": 89,  "name": "SQL Injection" },
+    { "id": 95,  "name": "Improper Neutralization of Directives in Dynamically Evaluated Code" },
+    { "id": 798, "name": "Use of Hard-coded Credentials" },
+    { "id": 306, "name": "Missing Authentication for Critical Function" }
+  ]
+}

--- a/standards/iso25010/flexibility.json
+++ b/standards/iso25010/flexibility.json
@@ -1,0 +1,14 @@
+{
+  "id": "flexibility",
+  "name": "Flexibility",
+  "iso_25010": "Flexibility",
+  "version": "2023",
+  "sub_characteristics": [
+    "Adaptability", "Scalability", "Installability", "Replaceability"
+  ],
+  "requirements": [
+    { "id": "F-1", "text": "Configuration MUST be externalised (env vars or config files); no hardcoded env-specific values", "cwe": [1188] },
+    { "id": "F-2", "text": "Public interfaces MUST be versioned; breaking changes require a major version bump", "cwe": [1059] },
+    { "id": "F-3", "text": "Components MUST be replaceable without modifying callers (dependency inversion)", "cwe": [1061] }
+  ]
+}

--- a/standards/iso25010/maintainability.json
+++ b/standards/iso25010/maintainability.json
@@ -1,0 +1,16 @@
+{
+  "id": "maintainability",
+  "name": "Maintainability",
+  "iso_25010": "Maintainability",
+  "version": "2023",
+  "sub_characteristics": [
+    "Modularity", "Reusability", "Analyzability", "Modifiability", "Testability"
+  ],
+  "requirements": [
+    { "id": "M-1", "text": "Cyclomatic complexity MUST be \u226410 per function", "cwe": [1121] },
+    { "id": "M-2", "text": "Source files MUST NOT exceed 300 lines", "cwe": [1080] },
+    { "id": "M-3", "text": "Package dependency cycles MUST be 0", "cwe": [1047] },
+    { "id": "M-4", "text": "Test coverage MUST be \u226580%", "cwe": [1059] },
+    { "id": "M-5", "text": "Public APIs MUST be documented", "cwe": [1053] }
+  ]
+}

--- a/standards/iso25010/performance.json
+++ b/standards/iso25010/performance.json
@@ -1,0 +1,15 @@
+{
+  "id": "performance",
+  "name": "Performance Efficiency",
+  "iso_25010": "Performance Efficiency",
+  "version": "2023",
+  "sub_characteristics": [
+    "Time Behaviour", "Resource Utilisation", "Capacity"
+  ],
+  "requirements": [
+    { "id": "P-1", "text": "Database queries inside loops are forbidden (N+1 problem)", "cwe": [1084] },
+    { "id": "P-2", "text": "Synchronous blocking I/O MUST NOT be used in async contexts", "cwe": [1088] },
+    { "id": "P-3", "text": "Unbounded result sets MUST be paginated or limited", "cwe": [400] },
+    { "id": "P-4", "text": "Sequential awaits on independent async calls MUST be parallelised", "cwe": [1088] }
+  ]
+}

--- a/standards/iso25010/reliability.json
+++ b/standards/iso25010/reliability.json
@@ -1,0 +1,16 @@
+{
+  "id": "reliability",
+  "name": "Reliability",
+  "iso_25010": "Reliability",
+  "version": "2023",
+  "sub_characteristics": [
+    "Maturity", "Availability", "Fault Tolerance", "Recoverability"
+  ],
+  "requirements": [
+    { "id": "R-1", "text": "Exceptions MUST be caught and handled; empty catch blocks are forbidden", "cwe": [390] },
+    { "id": "R-2", "text": "All public functions MUST have corresponding test files", "cwe": [1059] },
+    { "id": "R-3", "text": "Resource handles (files, connections) MUST be closed in finally blocks or using RAII", "cwe": [772] },
+    { "id": "R-4", "text": "Null/undefined dereferences MUST be guarded before use", "cwe": [476] },
+    { "id": "R-5", "text": "Async operations MUST handle rejection/error paths explicitly", "cwe": [755] }
+  ]
+}

--- a/standards/iso25010/security.json
+++ b/standards/iso25010/security.json
@@ -1,0 +1,17 @@
+{
+  "id": "security",
+  "name": "Security",
+  "iso_25010": "Security",
+  "version": "2023",
+  "note": "Security requirements are sourced from OWASP ASVS L1 (standards/asvs/level1.json). This file contains structural metadata only.",
+  "sub_characteristics": [
+    "Confidentiality", "Integrity", "Non-repudiation", "Accountability", "Authenticity"
+  ],
+  "requirements": [
+    { "id": "S-1", "text": "Dynamic code evaluation (eval) MUST NOT be used with user-controlled input", "cwe": [95] },
+    { "id": "S-2", "text": "Credentials and secrets MUST NOT be hardcoded in source files", "cwe": [798] },
+    { "id": "S-3", "text": "All user input MUST be validated and sanitised before use", "cwe": [20] },
+    { "id": "S-4", "text": "SQL queries MUST use parameterised statements; string concatenation is forbidden", "cwe": [89] },
+    { "id": "S-5", "text": "Shell commands MUST NOT be constructed from user-controlled data", "cwe": [78] }
+  ]
+}

--- a/standards/iso25010/usability.json
+++ b/standards/iso25010/usability.json
@@ -1,0 +1,15 @@
+{
+  "id": "usability",
+  "name": "Usability",
+  "iso_25010": "Usability",
+  "version": "2023",
+  "sub_characteristics": [
+    "Appropriateness Recognisability", "Learnability", "Operability",
+    "User Error Protection", "User Interface Aesthetics", "Accessibility"
+  ],
+  "requirements": [
+    { "id": "U-1", "text": "All user-facing error messages MUST be human-readable (no stack traces exposed)", "cwe": [209] },
+    { "id": "U-2", "text": "API responses MUST include machine-readable error codes alongside messages", "cwe": [1059] },
+    { "id": "U-3", "text": "CLI commands MUST provide --help output describing all flags", "cwe": [1053] }
+  ]
+}

--- a/tests/v2/test_standards.py
+++ b/tests/v2/test_standards.py
@@ -1,0 +1,20 @@
+from codecompass.v2.engine.standards import load_dimension, load_asvs_l1, load_cisq
+
+
+def test_load_maintainability_dimension():
+    dim = load_dimension("maintainability")
+    assert dim["id"] == "maintainability"
+    assert "requirements" in dim
+    assert all("cwe" in r for r in dim["requirements"])
+
+
+def test_load_asvs_l1():
+    asvs = load_asvs_l1()
+    assert asvs["level"] == 1
+    assert len(asvs["requirements"]) > 50
+    assert all("id" in r for r in asvs["requirements"])
+
+
+def test_load_cisq_maintainability():
+    cisq = load_cisq("maintainability")
+    assert len(cisq["cwes"]) > 0


### PR DESCRIPTION
## Summary

- `standards/iso25010/` — 6 dimension files (maintainability, reliability, performance, security, usability, flexibility), each with CWE-anchored requirements
- `standards/asvs/level1.json` — 128 OWASP ASVS 4.0.3 L1 requirements fetched via `scripts/fetch-asvs.py`
- `standards/cisq/` — 4 CISQ/ISO 5055 CWE mapping files (maintainability, reliability, security, performance)
- `src/codecompass/v2/engine/standards.py` — `load_dimension()`, `load_asvs_l1()`, `load_cisq()` loaders
- `scripts/fetch-asvs.py` — re-runnable script to refresh ASVS data from OWASP GitHub

## Test plan

- [x] `pytest tests/v2/ -v` → 13 passed
- [x] v1 tests unchanged