### PR TITLE
feat(v2): first plugin — typescript evaluator

### DIFF
--- a/evaluators/_cross_cutting/clean_architecture.md
+++ b/evaluators/_cross_cutting/clean_architecture.md
@@ -1,0 +1,57 @@
+# Clean Architecture — Cross-Cutting Knowledge
+
+Applies to all runtimes. Use these as the lens when assessing structural and maintainability findings.
+
+## The Dependency Rule
+Source code dependencies must point inward. Inner layers know nothing about outer layers.
+
+```
+[Frameworks & Drivers] → [Interface Adapters] → [Use Cases] → [Entities]
+```
+
+**Violation signals:**
+- Domain models importing from HTTP controllers or database adapters
+- Use cases importing Express/Fastify types directly
+- Business rules depending on a specific ORM
+
+## Layer definitions
+
+### Entities (innermost)
+Pure business objects and rules. No I/O, no framework dependencies.
+
+```typescript
+// Good — entity has no dependencies
+class Order {
+  constructor(readonly id: string, readonly items: OrderItem[]) {}
+  get total(): number { return this.items.reduce((sum, i) => sum + i.price, 0); }
+}
+```
+
+### Use Cases
+Application-specific business rules. Depends on entities + repository interfaces (not implementations).
+
+```typescript
+// Good — use case depends on interface, not concrete DB
+interface OrderRepository { findById(id: string): Promise<Order | null>; }
+
+class ProcessOrderUseCase {
+  constructor(private repo: OrderRepository) {}
+  async execute(orderId: string): Promise<void> { ... }
+}
+```
+
+### Interface Adapters
+Converts data between use cases and the outside world (controllers, presenters, gateways).
+
+### Frameworks & Drivers (outermost)
+Express, database drivers, external APIs. Should be swappable without touching inner layers.
+
+## Common architectural smells
+
+| Smell | Description | Finding type |
+|---|---|---|
+| Fat controllers | Business logic in HTTP handlers | SRP violation |
+| God services | One service class orchestrating everything | SRP + DIP violation |
+| Import leakage | Domain importing framework types | DIP violation |
+| Anemic domain | Entities with no behavior, all logic in services | SRP violation |
+| Missing anti-corruption layer | Direct use of third-party models in domain | OCP violation |

--- a/evaluators/_cross_cutting/solid.md
+++ b/evaluators/_cross_cutting/solid.md
@@ -1,0 +1,50 @@
+# SOLID Principles — Cross-Cutting Knowledge
+
+Applies to all runtimes. Use these as the lens when assessing maintainability findings.
+
+## Single Responsibility Principle (SRP)
+A class or module should have one reason to change.
+
+**Violation signals:**
+- A service class that handles HTTP parsing, business logic, and database writes
+- A file named `utils.ts` with unrelated helper functions
+- Functions over 50 lines mixing validation, transformation, and I/O
+
+**TypeScript example:**
+```typescript
+// Bad — UserService doing too much
+class UserService {
+  parseRequest(req: Request): UserInput { ... }
+  validate(input: UserInput): boolean { ... }
+  hashPassword(password: string): string { ... }
+  save(user: User): Promise<void> { ... }
+  sendWelcomeEmail(email: string): Promise<void> { ... }
+}
+
+// Good — separated concerns
+class UserParser { parseRequest(req: Request): UserInput { ... } }
+class UserValidator { validate(input: UserInput): boolean { ... } }
+class PasswordService { hash(password: string): string { ... } }
+class UserRepository { save(user: User): Promise<void> { ... } }
+class EmailService { sendWelcome(email: string): Promise<void> { ... } }
+```
+
+## Open/Closed Principle (OCP)
+Open for extension, closed for modification. Add behavior by adding code, not changing existing code.
+
+**Violation signals:** `switch` or `if/else if` chains that must grow every time a new type is added.
+
+## Liskov Substitution Principle (LSP)
+Subclasses must be usable wherever the base class is expected.
+
+**Violation signals:** Overriding a method to throw `NotImplementedError`, narrowing parameter types in subclasses.
+
+## Interface Segregation Principle (ISP)
+Clients should not depend on methods they don't use.
+
+**Violation signals:** Interfaces with 10+ methods where each implementation only uses 3-4.
+
+## Dependency Inversion Principle (DIP)
+Depend on abstractions, not concretions. High-level modules should not import low-level modules directly.
+
+**Violation signals:** Business logic importing specific database drivers or HTTP clients directly; no injection mechanism.

--- a/evaluators/typescript/detectors.json
+++ b/evaluators/typescript/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/typescript/dimensions.json
+++ b/evaluators/typescript/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0 },
+    { "id": "reliability",     "weight": 1.0 },
+    { "id": "security",        "weight": 1.2 },
+    { "id": "performance",     "weight": 0.8 }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/typescript/knowledge/analysis.md
+++ b/evaluators/typescript/knowledge/analysis.md
@@ -1,0 +1,38 @@
+# TypeScript Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **eval() and new Function()** — search `eval(`, `new Function(`. Any occurrence in non-test code is a finding.
+- **Hardcoded secrets** — search for `apiKey`, `secret`, `password`, `token` assigned to string literals ≥8 chars. Flag anything not reading from `process.env`.
+- **SQL/command injection** — template literals passed to database query methods (`db.query(\`SELECT ${input}\``)) or `child_process.exec`.
+
+### Maintainability signals
+- **File size** — TypeScript files over 300 LOC are a smell. Over 500 LOC is a strong signal of violated SRP.
+- **Cyclomatic complexity** — functions with deeply nested if/switch/try blocks (3+ levels) are hard to test.
+- **Cross-feature imports** — `import { X } from '../../other-feature/...'` indicates feature coupling. Should go through a shared module or be co-located.
+- **Barrel export sprawl** — `index.ts` files with 10+ `export *` re-exports hide what the public API actually is.
+
+### Reliability signals
+- **Unhandled Promises** — `.then()` without `.catch()`, or async functions called without `await` and no error handler.
+- **Missing null checks** — non-null assertions (`!`) on values that could genuinely be null/undefined.
+- **Files without tests** — a `.ts` source file with no matching `.test.ts` or `.spec.ts` is untested by convention.
+
+### Performance signals
+- **Sequential awaits** — two or more `await` calls in sequence on independent operations. Should be `Promise.all`.
+- **Missing timeouts** — `fetch()` or HTTP client calls without an `AbortController` timeout.
+- **N+1 patterns** — a database call inside a loop (look for `await` inside `for`, `forEach`, `map`).
+
+## What to ask the LLM
+
+When presenting findings to the LLM judge, ask it to:
+1. Confirm whether each grep hit is a genuine issue or a false positive (test code, commented code, demo)
+2. Assess severity in context — a hardcoded secret in a test fixture is different from one in production config
+3. Identify compound patterns — e.g. both large files AND no tests in the same module suggests a systemic maintainability problem
+4. Map each confirmed finding to the most specific ISO 25010 sub-characteristic and ASVS ID
+
+## Common false positives
+- `eval` inside `*.test.ts` or `*.spec.ts` — testing dynamic behavior
+- `password` in `createPasswordHash()` function name — not a credential
+- Cross-module imports in `__tests__/` — test setup legitimately crosses boundaries
+- Large files that are auto-generated (`.d.ts`, `*.generated.ts`)

--- a/evaluators/typescript/knowledge/practices.json
+++ b/evaluators/typescript/knowledge/practices.json
@@ -1,0 +1,87 @@
+{
+  "runtime": "typescript",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "ts-001",
+      "title": "Avoid eval() and Function constructor",
+      "cwe": 95,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "const result = eval(userInput);",
+      "good": "const result = JSON.parse(userInput);",
+      "explanation": "eval() executes arbitrary code and creates XSS and code injection vulnerabilities. Use JSON.parse() for data, or redesign to avoid dynamic evaluation entirely."
+    },
+    {
+      "id": "ts-002",
+      "title": "Keep functions under 50 lines",
+      "cwe": 1121,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "function processOrder(order: Order) {\n  // 80 lines of mixed validation, business logic, and persistence\n}",
+      "good": "function processOrder(order: Order) {\n  validateOrder(order);\n  const result = applyBusinessRules(order);\n  await persistOrder(result);\n}",
+      "explanation": "Functions over 50 lines are hard to test and understand. Extract logical sub-steps into named functions."
+    },
+    {
+      "id": "ts-003",
+      "title": "Never use 'any' — use unknown or generics",
+      "cwe": 1121,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "function process(data: any): any { return data.value; }",
+      "good": "function process<T extends { value: string }>(data: T): string { return data.value; }",
+      "explanation": "'any' disables type checking entirely. Use 'unknown' when the type is genuinely unknown and narrow it, or use generics to preserve type information."
+    },
+    {
+      "id": "ts-004",
+      "title": "Always handle Promise rejections",
+      "cwe": 755,
+      "dimension": "reliability",
+      "severity": "high",
+      "bad": "fetchData().then(data => process(data));",
+      "good": "fetchData().then(data => process(data)).catch(err => logger.error('fetch failed', err));",
+      "explanation": "Unhandled Promise rejections cause silent failures in Node.js. Always attach .catch() or use try/catch with async/await."
+    },
+    {
+      "id": "ts-005",
+      "title": "Avoid sequential awaits — use Promise.all",
+      "cwe": 1088,
+      "dimension": "performance",
+      "severity": "medium",
+      "bad": "const a = await fetchA();\nconst b = await fetchB();",
+      "good": "const [a, b] = await Promise.all([fetchA(), fetchB()]);",
+      "explanation": "Sequential awaits on independent async operations waste wall-clock time. Use Promise.all() to run them concurrently."
+    },
+    {
+      "id": "ts-006",
+      "title": "Never store secrets in source code",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "const apiKey = 'sk-prod-abc123xyz456';",
+      "good": "const apiKey = process.env.API_KEY;",
+      "explanation": "Hardcoded secrets are committed to version control and exposed in logs, stack traces, and bundle files. Always read from environment variables or a secrets manager."
+    },
+    {
+      "id": "ts-007",
+      "title": "Use barrel exports deliberately — avoid re-exporting everything",
+      "cwe": 1047,
+      "dimension": "maintainability",
+      "severity": "low",
+      "bad": "// index.ts\nexport * from './moduleA';\nexport * from './moduleB';\nexport * from './moduleC';",
+      "good": "// index.ts — only export the public API\nexport { UserService } from './moduleA';\nexport type { User } from './types';",
+      "explanation": "Wildcard barrel exports create hidden coupling between modules and slow down tree-shaking. Export only what other packages genuinely need."
+    },
+    {
+      "id": "ts-008",
+      "title": "Prefer interfaces over type aliases for object shapes",
+      "cwe": 1061,
+      "dimension": "maintainability",
+      "severity": "low",
+      "bad": "type User = { id: string; name: string; };",
+      "good": "interface User { id: string; name: string; }",
+      "explanation": "Interfaces produce better error messages, support declaration merging, and communicate intent more clearly for object shapes. Use type aliases for unions, intersections, and primitives."
+    }
+  ]
+}

--- a/evaluators/typescript/plugin.json
+++ b/evaluators/typescript/plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "typescript",
+  "name": "TypeScript / Node.js",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".ts", ".tsx"],
+    "config_files": ["tsconfig.json", "package.json"]
+  },
+  "cross_cutting": ["solid", "clean_architecture"]
+}

--- a/evaluators/typescript/scan_rules.ini
+++ b/evaluators/typescript/scan_rules.ini
@@ -1,0 +1,36 @@
+; evaluators/typescript/scan_rules.ini
+
+[cwe_95_eval]
+label=CWE-95: Dynamic code evaluation (eval)
+cwe=95
+dimension=security
+command=grep -rn "eval(" {src} --include="*.ts" --include="*.js" | grep -v ".test." | grep -v ".spec."
+format=file_list
+
+[cwe_1080_large_files]
+label=CWE-1080: Source files exceeding 300 LOC
+cwe=1080
+dimension=maintainability
+command=find {src} \( -name "*.ts" -o -name "*.tsx" \) -not -path "*/node_modules/*" -not -name "*.test.*" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
+format=file_list
+
+[cwe_1047_circular]
+label=CWE-1047: Potential circular dependency (cross-feature imports)
+cwe=1047
+dimension=maintainability
+command=grep -rn "from '\.\./\.\." {src} --include="*.ts" | head -20
+format=file_list
+
+[cwe_1059_no_tests]
+label=CWE-1059: Source files without corresponding test files
+cwe=1059
+dimension=reliability
+command=find {src} -name "*.ts" -not -path "*/node_modules/*" -not -name "*.test.*" -not -name "*.spec.*" -not -name "*.d.ts" | while read f; do base=$(basename "$f" .ts); dir=$(dirname "$f"); ls "$dir/$base.test.ts" "$dir/$base.spec.ts" 2>/dev/null | grep -q . || echo "$f"; done | head -20
+format=file_list
+
+[cwe_798_hardcoded_secrets]
+label=CWE-798: Hardcoded credentials or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(apiKey|api_key|secret|password|token)\s*=\s*['\"][^'\"]{8,}" {src} --include="*.ts" | grep -v ".test." | grep -v "process.env"
+format=file_list

--- a/tests/v2/test_plugin_typescript.py
+++ b/tests/v2/test_plugin_typescript.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path("evaluators/typescript")
+
+
+def test_plugin_loads():
+    plugin = load_plugin(PLUGIN_DIR)
+    assert plugin["id"] == "typescript"
+    assert ".ts" in plugin["detects"]["extensions"]
+
+
+def test_plugin_has_knowledge():
+    assert (PLUGIN_DIR / "knowledge" / "practices.json").exists()
+    assert (PLUGIN_DIR / "knowledge" / "analysis.md").exists()
+
+
+def test_plugin_scan_rules_run(tmp_path):
+    (tmp_path / "bad.ts").write_text("const x = eval(input);")
+    detector = GrepDetector()
+    config = {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")}
+    findings = detector.run(tmp_path, config)
+    assert len(findings) >= 1


### PR DESCRIPTION
## Summary

- Adds the complete `evaluators/typescript/` plugin — proves the full plugin model end-to-end
- 5 CWE-tagged grep scan rules covering security (CWE-95, CWE-798) and maintainability (CWE-1080, CWE-1047, CWE-1059)
- Manually curated `knowledge/practices.json` with 8 TypeScript violations (bad/good examples + explanation)
- `knowledge/analysis.md` — where to look and what to ask the LLM judge
- Cross-cutting knowledge: `_cross_cutting/solid.md` and `_cross_cutting/clean_architecture.md`
- Integration test: plugin loads, knowledge files exist, scan rules find eval()

## Test plan

- [x] `uv run pytest tests/v2/ -v` — 16 passed
- [x] `uv run pytest tests/ -v --ignore=tests/v2/` — v1 tests unchanged