### PR TITLE
PR 5a: Schema Fix + Validation

### DIFF
--- a/evaluators/typescript/dimensions.json
+++ b/evaluators/typescript/dimensions.json
@@ -1,9 +1,9 @@
 {
   "applies": [
-    { "id": "maintainability", "weight": 1.0 },
-    { "id": "reliability",     "weight": 1.0 },
-    { "id": "security",        "weight": 1.2 },
-    { "id": "performance",     "weight": 0.8 }
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
   ],
   "excludes": ["usability", "flexibility"]
 }

--- a/src/codecompass/v2/engine/plugin_loader.py
+++ b/src/codecompass/v2/engine/plugin_loader.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from codecompass.v2.engine.schema_validator import (
+    validate_plugin,
+    validate_dimensions,
+    validate_detectors,
+    validate_practices,
+)
+
 
 def discover_plugins(evaluators_dir: Path) -> list[dict]:
     """Discover all valid plugins in evaluators_dir.
@@ -23,12 +30,56 @@ def load_plugin(plugin_dir: Path) -> dict:
     return json.loads(plugin_file.read_text())
 
 
+def load_plugin_full(plugin_dir: Path) -> dict:
+    """Load and validate all plugin JSON files into one dict.
+
+    Returns {"plugin": dict, "dimensions": dict, "detectors": list, "practices": dict}.
+    Raises ValueError on validation failure.
+    """
+    plugin_file = plugin_dir / "plugin.json"
+    dims_file = plugin_dir / "dimensions.json"
+    dets_file = plugin_dir / "detectors.json"
+    practices_file = plugin_dir / "knowledge" / "practices.json"
+
+    plugin_data = json.loads(plugin_file.read_text())
+    errors = validate_plugin(plugin_data)
+    if errors:
+        raise ValueError(f"plugin.json: {'; '.join(errors)}")
+
+    dims_data = json.loads(dims_file.read_text())
+    errors = validate_dimensions(dims_data)
+    if errors:
+        raise ValueError(f"dimensions.json: {'; '.join(errors)}")
+
+    dets_data = json.loads(dets_file.read_text())
+    errors = validate_detectors(dets_data)
+    if errors:
+        raise ValueError(f"detectors.json: {'; '.join(errors)}")
+
+    practices_data = {}
+    if practices_file.exists():
+        practices_data = json.loads(practices_file.read_text())
+        errors = validate_practices(practices_data)
+        if errors:
+            raise ValueError(f"knowledge/practices.json: {'; '.join(errors)}")
+
+    return {
+        "plugin": plugin_data,
+        "dimensions": dims_data,
+        "detectors": dets_data,
+        "practices": practices_data,
+    }
+
+
 def _try_load(plugin_dir: Path) -> dict | None:
     plugin_file = plugin_dir / "plugin.json"
     if not plugin_file.exists():
         return None
     try:
         data = json.loads(plugin_file.read_text())
+        errors = validate_plugin(data)
+        if errors:
+            return None
         data["_path"] = str(plugin_dir)
         return data
     except (json.JSONDecodeError, KeyError):

--- a/src/codecompass/v2/engine/schema_validator.py
+++ b/src/codecompass/v2/engine/schema_validator.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+_SCHEMAS_DIR = Path(__file__).parent / "schemas"
+
+
+def _load_schema(name: str) -> dict:
+    return json.loads((_SCHEMAS_DIR / name).read_text())
+
+
+def validate_plugin(data: dict) -> list[str]:
+    """Validate plugin.json data. Returns list of error messages (empty = valid)."""
+    return _validate(data, "plugin_schema.json")
+
+
+def validate_dimensions(data: dict) -> list[str]:
+    """Validate dimensions.json data."""
+    return _validate(data, "dimensions_schema.json")
+
+
+def validate_practices(data: dict) -> list[str]:
+    """Validate practices.json data."""
+    return _validate(data, "practices_schema.json")
+
+
+def validate_detectors(data: list) -> list[str]:
+    """Validate detectors.json data."""
+    return _validate(data, "detectors_schema.json")
+
+
+def validate_plugin_dir(plugin_dir: Path) -> dict[str, list[str]]:
+    """Validate all JSON files in a plugin directory.
+
+    Returns a dict mapping filename to list of errors.
+    Only files with errors appear in the result.
+    """
+    errors: dict[str, list[str]] = {}
+
+    validators = {
+        "plugin.json": validate_plugin,
+        "dimensions.json": validate_dimensions,
+        "detectors.json": validate_detectors,
+    }
+
+    for filename, validator_fn in validators.items():
+        filepath = plugin_dir / filename
+        if not filepath.exists():
+            errors[filename] = [f"{filename} not found"]
+            continue
+        data = json.loads(filepath.read_text())
+        file_errors = validator_fn(data)
+        if file_errors:
+            errors[filename] = file_errors
+
+    practices_file = plugin_dir / "knowledge" / "practices.json"
+    if practices_file.exists():
+        data = json.loads(practices_file.read_text())
+        file_errors = validate_practices(data)
+        if file_errors:
+            errors["knowledge/practices.json"] = file_errors
+
+    return errors
+
+
+def _validate(data, schema_file: str) -> list[str]:
+    schema = _load_schema(schema_file)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(data)]

--- a/src/codecompass/v2/engine/schemas/detectors_schema.json
+++ b/src/codecompass/v2/engine/schemas/detectors_schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Plugin detector configuration",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["type", "rules"],
+    "properties": {
+      "type": { "type": "string", "enum": ["grep"] },
+      "rules": { "type": "string", "minLength": 1 }
+    },
+    "additionalProperties": false
+  }
+}

--- a/src/codecompass/v2/engine/schemas/dimensions_schema.json
+++ b/src/codecompass/v2/engine/schemas/dimensions_schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Plugin dimensions configuration",
+  "type": "object",
+  "required": ["applies"],
+  "properties": {
+    "applies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "weight"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "weight": { "type": "number", "minimum": 0 },
+          "iso_25010": { "type": "string" },
+          "source": { "type": "string" }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    },
+    "excludes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/codecompass/v2/engine/schemas/plugin_schema.json
+++ b/src/codecompass/v2/engine/schemas/plugin_schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Plugin manifest",
+  "type": "object",
+  "required": ["id", "name", "version", "engine_version", "detects"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "version": { "type": "string" },
+    "engine_version": { "type": "string" },
+    "detects": {
+      "type": "object",
+      "required": ["extensions"],
+      "properties": {
+        "extensions": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^\\." },
+          "minItems": 1
+        },
+        "config_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "cross_cutting": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/codecompass/v2/engine/schemas/practices_schema.json
+++ b/src/codecompass/v2/engine/schemas/practices_schema.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Plugin practices knowledge",
+  "type": "object",
+  "required": ["runtime", "version", "practices"],
+  "properties": {
+    "runtime": { "type": "string", "minLength": 1 },
+    "version": { "type": "string" },
+    "source": { "type": "string" },
+    "source_stars": { "type": "integer" },
+    "extracted": { "type": "string" },
+    "practices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "cwe", "dimension", "severity", "bad", "good", "explanation"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "cwe": { "type": "integer" },
+          "dimension": { "type": "string", "minLength": 1 },
+          "severity": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+          "bad": { "type": "string" },
+          "good": { "type": "string" },
+          "explanation": { "type": "string" },
+          "source": { "type": "string" },
+          "source_stars": { "type": "integer" },
+          "extracted": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/v2/test_schema_validator.py
+++ b/tests/v2/test_schema_validator.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codecompass.v2.engine.schema_validator import (
+    validate_plugin,
+    validate_dimensions,
+    validate_practices,
+    validate_detectors,
+    validate_plugin_dir,
+)
+
+
+# ── plugin.json ───────────────────────────────────────────────────────
+
+def _valid_plugin():
+    return {
+        "id": "typescript",
+        "name": "TypeScript / Node.js",
+        "version": "1.0.0",
+        "engine_version": ">=2.0.0",
+        "detects": {
+            "extensions": [".ts", ".tsx"],
+            "config_files": ["tsconfig.json"],
+        },
+    }
+
+
+def test_valid_plugin():
+    assert validate_plugin(_valid_plugin()) == []
+
+
+def test_plugin_missing_id():
+    data = _valid_plugin()
+    del data["id"]
+    errors = validate_plugin(data)
+    assert any("id" in e for e in errors)
+
+
+def test_plugin_bad_id_pattern():
+    data = _valid_plugin()
+    data["id"] = "TypeScript"  # uppercase not allowed
+    errors = validate_plugin(data)
+    assert errors
+
+
+def test_plugin_missing_extensions():
+    data = _valid_plugin()
+    data["detects"] = {"config_files": ["x"]}
+    errors = validate_plugin(data)
+    assert any("extensions" in e for e in errors)
+
+
+def test_plugin_empty_extensions():
+    data = _valid_plugin()
+    data["detects"]["extensions"] = []
+    assert validate_plugin(data) != []
+
+
+# ── dimensions.json ───────────────────────────────────────────────────
+
+def _valid_dimensions():
+    return {
+        "applies": [
+            {"id": "security", "weight": 1.2, "iso_25010": "Security", "source": "OWASP"},
+        ],
+        "excludes": ["usability"],
+    }
+
+
+def test_valid_dimensions():
+    assert validate_dimensions(_valid_dimensions()) == []
+
+
+def test_dimensions_without_optional_fields():
+    data = {"applies": [{"id": "maintainability", "weight": 1.0}]}
+    assert validate_dimensions(data) == []
+
+
+def test_dimensions_missing_applies():
+    assert validate_dimensions({}) != []
+
+
+def test_dimensions_missing_weight():
+    data = {"applies": [{"id": "security"}]}
+    assert validate_dimensions(data) != []
+
+
+# ── practices.json ────────────────────────────────────────────────────
+
+def _valid_practices():
+    return {
+        "runtime": "typescript",
+        "version": "1.0.0",
+        "practices": [
+            {
+                "id": "ts-001",
+                "title": "Avoid eval()",
+                "cwe": 95,
+                "dimension": "security",
+                "severity": "high",
+                "bad": "eval(x)",
+                "good": "JSON.parse(x)",
+                "explanation": "eval is dangerous",
+            }
+        ],
+    }
+
+
+def test_valid_practices():
+    assert validate_practices(_valid_practices()) == []
+
+
+def test_practices_with_provenance():
+    data = _valid_practices()
+    data["source"] = "github/cursor-rules"
+    data["source_stars"] = 1500
+    data["extracted"] = "2026-03-01"
+    assert validate_practices(data) == []
+
+
+def test_practices_bad_severity():
+    data = _valid_practices()
+    data["practices"][0]["severity"] = "extreme"
+    assert validate_practices(data) != []
+
+
+def test_practices_missing_required_field():
+    data = _valid_practices()
+    del data["practices"][0]["cwe"]
+    assert validate_practices(data) != []
+
+
+# ── detectors.json ────────────────────────────────────────────────────
+
+def test_valid_detectors():
+    assert validate_detectors([{"type": "grep", "rules": "scan_rules.ini"}]) == []
+
+
+def test_detectors_invalid_type():
+    assert validate_detectors([{"type": "unknown", "rules": "x.ini"}]) != []
+
+
+def test_detectors_missing_rules():
+    assert validate_detectors([{"type": "grep"}]) != []
+
+
+# ── validate_plugin_dir ───────────────────────────────────────────────
+
+def test_validate_real_typescript_plugin():
+    ts_dir = Path(__file__).parent.parent.parent / "evaluators" / "typescript"
+    if not ts_dir.exists():
+        pytest.skip("TypeScript plugin not available")
+    errors = validate_plugin_dir(ts_dir)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_validate_plugin_dir_missing_files(tmp_path):
+    errors = validate_plugin_dir(tmp_path)
+    assert "plugin.json" in errors
+    assert "dimensions.json" in errors
+    assert "detectors.json" in errors
+
+
+def test_validate_plugin_dir_with_invalid_plugin(tmp_path):
+    (tmp_path / "plugin.json").write_text(json.dumps({"id": "BAD"}))
+    (tmp_path / "dimensions.json").write_text(json.dumps({"applies": [{"id": "x", "weight": 1}]}))
+    (tmp_path / "detectors.json").write_text(json.dumps([{"type": "grep", "rules": "r.ini"}]))
+    errors = validate_plugin_dir(tmp_path)
+    assert "plugin.json" in errors


### PR DESCRIPTION
## Summary
- Add JSON Schema validation for all plugin config files (plugin.json, dimensions.json, practices.json, detectors.json)
- Fix TypeScript plugin's dimensions.json to include `iso_25010` and `source` fields per design doc
- Add `load_plugin_full()` to plugin_loader for validated loading of all plugin JSON into one dict
- Add `validate_plugin_dir()` for directory-level validation

## Test plan
- [x] `uv run pytest tests/v2/ -v` — 35 tests pass
- [x] Schema validation catches missing required fields, bad patterns, invalid enum values
- [x] TypeScript plugin passes validation with new iso_25010/source fields
- [x] `validate_plugin_dir()` reports per-file errors for invalid plugins