### PR TITLE
PR 5: LLM Judgment Layer + Runner

### DIFF
--- a/src/codecompass/v2/engine/context_builder.py
+++ b/src/codecompass/v2/engine/context_builder.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codecompass.v2.engine.finding import Finding
+
+
+def build_judge_context(
+    findings: list[Finding],
+    practices: dict,
+    analysis_md: str,
+    dimensions_config: dict,
+    standards_dir: Path | None = None,
+    src_dir: Path | None = None,
+) -> str:
+    """Assemble the full context string for the LLM judge."""
+    sections: list[str] = []
+
+    # Section 1: Detector findings grouped by dimension
+    sections.append(_format_findings(findings))
+
+    # Section 2: Practices with bad/good examples
+    sections.append(_format_practices(practices))
+
+    # Section 3: Analysis guidance
+    if analysis_md:
+        sections.append(f"## Analysis Guidance\n\n{analysis_md}")
+
+    # Section 4: ISO 25010 dimension requirements
+    sections.append(_format_dimensions(dimensions_config, standards_dir))
+
+    # Section 5: Code snippets around finding locations
+    if src_dir and findings:
+        snippet_section = _format_code_snippets(findings, src_dir)
+        if snippet_section:
+            sections.append(snippet_section)
+
+    return "\n\n---\n\n".join(sections)
+
+
+def _format_findings(findings: list[Finding]) -> str:
+    if not findings:
+        return "## Detector Findings\n\nNo findings from automated detectors."
+
+    by_dimension: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_dimension.setdefault(f.dimension, []).append(f)
+
+    lines = ["## Detector Findings\n"]
+    for dim, dim_findings in sorted(by_dimension.items()):
+        lines.append(f"### {dim.title()}")
+        for f in dim_findings:
+            cwe = f" (CWE-{f.cwe})" if f.cwe else ""
+            snippet = f": `{f.snippet}`" if f.snippet else ""
+            lines.append(f"- **{f.label}**{cwe} — `{f.file}`:{f.line or '?'}{snippet}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_practices(practices: dict) -> str:
+    practice_list = practices.get("practices", [])
+    if not practice_list:
+        return "## Practices\n\nNo practices defined."
+
+    lines = ["## Practices\n"]
+    for p in practice_list:
+        lines.append(f"### {p['id']}: {p['title']}")
+        lines.append(f"- **Dimension:** {p['dimension']} | **Severity:** {p['severity']} | **CWE:** {p.get('cwe', 'N/A')}")
+        lines.append(f"- **Bad:**\n```\n{p['bad']}\n```")
+        lines.append(f"- **Good:**\n```\n{p['good']}\n```")
+        lines.append(f"- **Why:** {p.get('explanation', '')}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_dimensions(dimensions_config: dict, standards_dir: Path | None) -> str:
+    applies = dimensions_config.get("applies", [])
+    if not applies:
+        return "## Dimensions\n\nNo dimensions configured."
+
+    lines = ["## Dimensions\n"]
+    for dim in applies:
+        iso = dim.get("iso_25010", "")
+        source = dim.get("source", "")
+        weight = dim.get("weight", 1.0)
+        lines.append(f"- **{dim['id']}** (weight: {weight}){f' — {iso}' if iso else ''}{f' [{source}]' if source else ''}")
+
+        # Load standards requirements if available
+        if standards_dir:
+            std_file = standards_dir / "iso25010" / f"{dim['id']}.json"
+            if std_file.exists():
+                import json
+                std = json.loads(std_file.read_text())
+                reqs = std.get("requirements", [])[:5]
+                for req in reqs:
+                    lines.append(f"  - {req.get('id', '')}: {req.get('text', '')}")
+
+    return "\n".join(lines)
+
+
+def _format_code_snippets(findings: list[Finding], src_dir: Path) -> str:
+    """Extract code snippets around finding locations."""
+    seen: set[tuple[str, int]] = set()
+    lines = ["## Code Context\n"]
+    count = 0
+
+    for f in findings:
+        if not f.file or not f.line:
+            continue
+        key = (f.file, f.line)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        filepath = Path(f.file) if Path(f.file).is_absolute() else src_dir / f.file
+        if not filepath.exists():
+            continue
+
+        try:
+            source_lines = filepath.read_text().splitlines()
+            start = max(0, f.line - 3)
+            end = min(len(source_lines), f.line + 3)
+            snippet = "\n".join(
+                f"{'>' if i + 1 == f.line else ' '} {i + 1:4d} | {source_lines[i]}"
+                for i in range(start, end)
+            )
+            lines.append(f"### `{f.file}` line {f.line} ({f.label})")
+            lines.append(f"```\n{snippet}\n```\n")
+            count += 1
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        if count >= 20:
+            break
+
+    return "\n".join(lines) if count > 0 else ""

--- a/src/codecompass/v2/engine/evidence.py
+++ b/src/codecompass/v2/engine/evidence.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from codecompass.evaluate.lib.evidence import DEFAULT_WEIGHT
+
+
+@dataclass
+class Judgment:
+    """One LLM judgment per finding."""
+    practice_id: str
+    finding_rule: str = ""
+    file: str = ""
+    line: int = 0
+    snippet: str = ""
+    verdict: str = "violation"  # violation | compliance | dismissed
+    severity: str = "medium"
+    reason: str = ""
+    dimension: str = ""
+    cwe: int | None = None
+    violation_type: str = ""
+
+
+@dataclass
+class PrincipleEvidence:
+    """Aggregated evidence for a single practice/principle."""
+    practice_id: str
+    display_name: str
+    dimension: str
+    severity: str
+    weight: str = DEFAULT_WEIGHT
+    violations: list[dict] = field(default_factory=list)
+    compliance: list[dict] = field(default_factory=list)
+    metrics: dict = field(default_factory=dict)
+
+    def compute_metrics(self, scale_multiplier: int = 1) -> None:
+        high_threshold = 10 * scale_multiplier
+        medium_threshold = 5 * scale_multiplier
+
+        n_violations = len(self.violations)
+        n_compliance = len(self.compliance)
+        total = n_violations + n_compliance
+        pct = round(n_compliance / total * 100, 1) if total > 0 else 0.0
+
+        if total >= high_threshold:
+            confidence = "high"
+        elif total >= medium_threshold:
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+        self.metrics = {
+            "total_instances": total,
+            "compliant": n_compliance,
+            "violating": n_violations,
+            "compliance_percentage": pct,
+            "confidence_level": confidence,
+            "is_balanced": n_violations > 0 and n_compliance > 0,
+        }
+
+
+@dataclass
+class Evidence:
+    """Complete evaluation output for one plugin run."""
+    repository: str
+    plugin_id: str
+    date: str
+    source_file_count: int
+    files_read: int
+    coverage_pct: float
+    principles: dict[str, PrincipleEvidence] = field(default_factory=dict)
+    dismissed_count: int = 0
+    meta: dict = field(default_factory=dict)
+
+    def summary(self) -> dict:
+        total = sum(p.metrics.get("total_instances", 0) for p in self.principles.values())
+        low_conf = [k for k, p in self.principles.items() if p.metrics.get("confidence_level") == "low"]
+        unbalanced = [k for k, p in self.principles.items() if not p.metrics.get("is_balanced", True)]
+        return {
+            "total_findings": total,
+            "principles_count": len(self.principles),
+            "low_confidence_principles": low_conf,
+            "unbalanced_principles": unbalanced,
+            "overall_confidence": (
+                "low" if len(low_conf) > len(self.principles) / 2
+                else "medium" if low_conf
+                else "high"
+            ),
+            "dismissed_count": self.dismissed_count,
+        }
+
+    def to_v1_evidence_dict(self) -> dict:
+        """Convert to the dict shape that v1's run_scoring() expects."""
+        principles = {}
+        for key, pe in self.principles.items():
+            principles[key] = {
+                "display_name": pe.display_name,
+                "weight": pe.weight,
+                "violations": pe.violations,
+                "compliance": pe.compliance,
+                "metrics": pe.metrics,
+            }
+        return {
+            "repository": self.repository,
+            "discipline": self.plugin_id,
+            "date": self.date,
+            "source_file_count": self.source_file_count,
+            "files_read": self.files_read,
+            "coverage_pct": self.coverage_pct,
+            "meta": self.meta,
+            "principles": principles,
+            "evidence_summary": self.summary(),
+        }

--- a/src/codecompass/v2/engine/judge.py
+++ b/src/codecompass/v2/engine/judge.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from codecompass.config.generators import run_ai_cli
+from codecompass.v2.engine.evidence import Evidence, Judgment, PrincipleEvidence
+
+_PROMPT_PATH = Path(__file__).parent / "prompts" / "judge.md"
+
+
+def run_judge(
+    context: str,
+    repository: str,
+    plugin_id: str,
+    date_str: str,
+    practices: dict,
+    source_file_count: int,
+    files_read: int = 0,
+    ai_caller=None,
+) -> Evidence:
+    """Send context to the LLM judge and parse the JSONL response into Evidence."""
+    if ai_caller is None:
+        ai_caller = run_ai_cli
+
+    prompt_template = _PROMPT_PATH.read_text()
+    prompt = prompt_template.replace("{{CONTEXT}}", context)
+
+    stdout, error = ai_caller(prompt)
+    if error:
+        raise RuntimeError(f"Judge AI call failed: {error}")
+
+    judgments, dismissed = _parse_judge_output(stdout)
+
+    coverage_pct = (
+        round(files_read / source_file_count * 100, 1)
+        if source_file_count > 0 and files_read > 0
+        else 0.0
+    )
+
+    return _assemble_evidence(
+        judgments=judgments,
+        dismissed_count=dismissed,
+        repository=repository,
+        plugin_id=plugin_id,
+        date_str=date_str,
+        practices=practices,
+        source_file_count=source_file_count,
+        files_read=files_read,
+        coverage_pct=coverage_pct,
+    )
+
+
+def _parse_judge_output(raw: str) -> tuple[list[Judgment], int]:
+    """Parse JSONL from judge output. Returns (judgments, dismissed_count)."""
+    # Strip markdown code fences
+    raw = re.sub(r"^\s*```[a-z]*\s*$", "", raw, flags=re.MULTILINE)
+
+    judgments: list[Judgment] = []
+    dismissed = 0
+
+    for line in raw.strip().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("//"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        practice_id = obj.get("practice_id")
+        verdict = obj.get("verdict")
+        if not practice_id or not verdict:
+            continue
+
+        if verdict == "dismissed":
+            dismissed += 1
+            continue
+
+        judgments.append(Judgment(
+            practice_id=practice_id,
+            finding_rule=obj.get("finding_rule", ""),
+            file=obj.get("file", ""),
+            line=obj.get("line", 0),
+            snippet=obj.get("snippet", ""),
+            verdict=verdict,
+            severity=obj.get("severity", "medium"),
+            reason=obj.get("reason", ""),
+            dimension=obj.get("dimension", ""),
+            cwe=obj.get("cwe"),
+            violation_type=obj.get("vt", ""),
+        ))
+
+    return judgments, dismissed
+
+
+def _assemble_evidence(
+    judgments: list[Judgment],
+    dismissed_count: int,
+    repository: str,
+    plugin_id: str,
+    date_str: str,
+    practices: dict,
+    source_file_count: int,
+    files_read: int,
+    coverage_pct: float,
+) -> Evidence:
+    """Group judgments by practice_id into PrincipleEvidence."""
+    # Build practice lookup for display names and dimensions
+    practice_lookup: dict[str, dict] = {}
+    for p in practices.get("practices", []):
+        practice_lookup[p["id"]] = p
+
+    principles: dict[str, PrincipleEvidence] = {}
+
+    for j in judgments:
+        if j.practice_id not in principles:
+            p_info = practice_lookup.get(j.practice_id, {})
+            principles[j.practice_id] = PrincipleEvidence(
+                practice_id=j.practice_id,
+                display_name=p_info.get("title", j.practice_id),
+                dimension=j.dimension or p_info.get("dimension", ""),
+                severity=j.severity or p_info.get("severity", "medium"),
+            )
+
+        pe = principles[j.practice_id]
+        record = {
+            "file": j.file,
+            "line": j.line,
+            "snippet": j.snippet,
+            "reason": j.reason,
+        }
+
+        if j.verdict == "violation":
+            record["severity"] = j.severity
+            if j.violation_type:
+                record["vt"] = j.violation_type
+            pe.violations.append(record)
+        elif j.verdict == "compliance":
+            pe.compliance.append(record)
+
+    from codecompass.evaluate.lib.scoring import _scale_multiplier
+    scale_mult = _scale_multiplier(source_file_count)
+
+    for pe in principles.values():
+        pe.compute_metrics(scale_mult)
+
+    return Evidence(
+        repository=repository,
+        plugin_id=plugin_id,
+        date=date_str,
+        source_file_count=source_file_count,
+        files_read=files_read,
+        coverage_pct=coverage_pct,
+        principles=principles,
+        dismissed_count=dismissed_count,
+    )

--- a/src/codecompass/v2/engine/prompts/judge.md
+++ b/src/codecompass/v2/engine/prompts/judge.md
@@ -1,0 +1,43 @@
+# CodeCompass v2 — LLM Judge
+
+You are a code quality judge. You receive structured context about a codebase:
+detector findings, practice definitions, analysis guidance, and quality standards.
+
+## Your task
+
+For each detector finding, decide whether it is a genuine violation, a compliance example, or should be dismissed (false positive).
+
+## Output format
+
+Output one JSON object per line (JSONL). Each line must have these fields:
+
+```json
+{"practice_id": "ts-001", "verdict": "violation", "file": "src/app.ts", "line": 42, "snippet": "eval(input)", "severity": "high", "reason": "eval() with user input enables code injection", "dimension": "security", "cwe": 95, "vt": "code-injection"}
+```
+
+### Required fields
+- `practice_id` — which practice this judgment applies to
+- `verdict` — one of: `violation`, `compliance`, `dismissed`
+
+### Expected fields (include when available)
+- `file` — file path
+- `line` — line number
+- `snippet` — code snippet (first line only)
+- `severity` — `critical`, `high`, `medium`, `low`
+- `reason` — explanation of why this is a violation/compliance/dismissed
+- `dimension` — quality dimension (security, maintainability, reliability, performance)
+- `cwe` — CWE ID (integer)
+- `vt` — violation type tag for deduction grouping
+
+## Guidelines
+
+1. **Review each finding** from the detector output and assess it against the matching practice
+2. **Dismiss false positives** — test files, comments, demo code, function names containing keywords
+3. **Assess severity in context** — a hardcoded secret in a test fixture is lower severity than in production config
+4. **Include compliance examples** — for balanced evidence, also note when a practice is followed well
+5. **Map to practices** — every judgment must reference a practice_id from the practices list
+6. **Be specific** — include file, line, and snippet for each judgment
+
+## Context
+
+{{CONTEXT}}

--- a/src/codecompass/v2/engine/runner.py
+++ b/src/codecompass/v2/engine/runner.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from codecompass.config.generators import run_ai_cli
+from codecompass.v2.engine.context_builder import build_judge_context
+from codecompass.v2.engine.detectors.grep import GrepDetector
+from codecompass.v2.engine.evidence import Evidence
+from codecompass.v2.engine.finding import Finding
+from codecompass.v2.engine.judge import run_judge
+from codecompass.v2.engine.plugin_loader import load_plugin_full
+
+_DETECTOR_REGISTRY = {
+    "grep": GrepDetector(),
+}
+
+
+@dataclass
+class RunConfig:
+    src: Path
+    plugin_id: str
+    evaluators_dir: Path
+    standards_dir: Path | None = None
+    source_file_count: int = 0
+    ai_caller: object = None
+
+
+def run(config: RunConfig) -> Evidence:
+    """Orchestrator: load plugin → detect → build context → judge → Evidence."""
+    plugin_dir = config.evaluators_dir / config.plugin_id
+    if not plugin_dir.exists():
+        raise ValueError(f"Plugin directory not found: {plugin_dir}")
+
+    full = load_plugin_full(plugin_dir)
+
+    findings = _run_detectors(full["detectors"], config.src, plugin_dir)
+
+    # Count files read (files that had at least one finding)
+    files_with_findings = {f.file for f in findings if f.file}
+
+    # Load analysis guidance
+    analysis_file = plugin_dir / "knowledge" / "analysis.md"
+    analysis_md = analysis_file.read_text() if analysis_file.exists() else ""
+
+    context = build_judge_context(
+        findings=findings,
+        practices=full["practices"],
+        analysis_md=analysis_md,
+        dimensions_config=full["dimensions"],
+        standards_dir=config.standards_dir,
+        src_dir=config.src,
+    )
+
+    ai_caller = config.ai_caller or run_ai_cli
+    files_read = len(files_with_findings) or config.source_file_count
+
+    return run_judge(
+        context=context,
+        repository=str(config.src),
+        plugin_id=config.plugin_id,
+        date_str=full["plugin"].get("version", ""),
+        practices=full["practices"],
+        source_file_count=config.source_file_count,
+        files_read=files_read,
+        ai_caller=ai_caller,
+    )
+
+
+def _run_detectors(detectors_config: list, src: Path, plugin_dir: Path) -> list[Finding]:
+    """Run all configured detectors and collect findings."""
+    all_findings: list[Finding] = []
+
+    for det_config in detectors_config:
+        det_type = det_config.get("type")
+        detector = _DETECTOR_REGISTRY.get(det_type)
+        if not detector:
+            continue
+
+        config = {}
+        if det_type == "grep":
+            rules_file = det_config.get("rules", "scan_rules.ini")
+            config["rules_file"] = str(plugin_dir / rules_file)
+
+        findings = detector.run(src, config)
+        all_findings.extend(findings)
+
+    return all_findings

--- a/tests/v2/test_context_builder.py
+++ b/tests/v2/test_context_builder.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codecompass.v2.engine.context_builder import build_judge_context
+from codecompass.v2.engine.finding import Finding
+
+
+def _sample_finding(**overrides) -> Finding:
+    defaults = {
+        "rule": "cwe_95_eval",
+        "label": "CWE-95: eval()",
+        "file": "src/app.ts",
+        "dimension": "security",
+        "detector": "grep",
+        "cwe": 95,
+        "line": 10,
+        "snippet": "eval(userInput)",
+    }
+    defaults.update(overrides)
+    return Finding(**defaults)
+
+
+def _sample_practices() -> dict:
+    return {
+        "runtime": "typescript",
+        "version": "1.0.0",
+        "practices": [
+            {
+                "id": "ts-001",
+                "title": "Avoid eval()",
+                "cwe": 95,
+                "dimension": "security",
+                "severity": "high",
+                "bad": "eval(x)",
+                "good": "JSON.parse(x)",
+                "explanation": "eval is dangerous",
+            }
+        ],
+    }
+
+
+def _sample_dimensions() -> dict:
+    return {
+        "applies": [
+            {"id": "security", "weight": 1.2, "iso_25010": "Security", "source": "OWASP"},
+            {"id": "maintainability", "weight": 1.0},
+        ],
+    }
+
+
+def test_empty_findings():
+    ctx = build_judge_context([], {}, "", {"applies": []})
+    assert "No findings" in ctx
+
+
+def test_findings_grouped_by_dimension():
+    findings = [
+        _sample_finding(dimension="security"),
+        _sample_finding(dimension="maintainability", rule="cwe_1080", label="Large file", cwe=1080),
+    ]
+    ctx = build_judge_context(findings, {}, "", {"applies": []})
+    assert "### Security" in ctx
+    assert "### Maintainability" in ctx
+
+
+def test_practices_formatting():
+    ctx = build_judge_context([], _sample_practices(), "", {"applies": []})
+    assert "ts-001" in ctx
+    assert "Avoid eval()" in ctx
+    assert "eval is dangerous" in ctx
+
+
+def test_full_context_has_all_sections():
+    findings = [_sample_finding()]
+    ctx = build_judge_context(
+        findings,
+        _sample_practices(),
+        "Look for eval() calls",
+        _sample_dimensions(),
+    )
+    assert "## Detector Findings" in ctx
+    assert "## Practices" in ctx
+    assert "## Analysis Guidance" in ctx
+    assert "## Dimensions" in ctx
+
+
+def test_code_snippet_extraction(tmp_path):
+    src_file = tmp_path / "app.ts"
+    src_file.write_text("line1\nline2\nline3\neval(x)\nline5\nline6\n")
+    finding = _sample_finding(file=str(src_file), line=4)
+    ctx = build_judge_context([finding], {}, "", {"applies": []}, src_dir=tmp_path)
+    assert "Code Context" in ctx
+    assert "eval(x)" in ctx

--- a/tests/v2/test_evidence.py
+++ b/tests/v2/test_evidence.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from codecompass.v2.engine.evidence import Evidence, Judgment, PrincipleEvidence
+
+
+def test_judgment_defaults():
+    j = Judgment(practice_id="ts-001")
+    assert j.verdict == "violation"
+    assert j.severity == "medium"
+    assert j.line == 0
+    assert j.file == ""
+
+
+def test_principle_evidence_compute_metrics():
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Avoid eval()",
+        dimension="security",
+        severity="high",
+    )
+    pe.violations = [{"file": "a.ts", "line": 1}]
+    pe.compliance = [{"file": "b.ts", "line": 2}, {"file": "c.ts", "line": 3}]
+    pe.compute_metrics()
+
+    assert pe.metrics["total_instances"] == 3
+    assert pe.metrics["compliant"] == 2
+    assert pe.metrics["violating"] == 1
+    assert pe.metrics["compliance_percentage"] == 66.7
+    assert pe.metrics["is_balanced"] is True
+    assert pe.metrics["confidence_level"] == "low"  # 3 < 5
+
+
+def test_principle_evidence_unbalanced():
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Test",
+        dimension="security",
+        severity="high",
+    )
+    pe.violations = [{"file": "a.ts"} for _ in range(5)]
+    pe.compute_metrics()
+    assert pe.metrics["is_balanced"] is False
+
+
+def test_evidence_summary():
+    pe1 = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Test1",
+        dimension="security",
+        severity="high",
+        metrics={"total_instances": 10, "confidence_level": "high", "is_balanced": True},
+    )
+    pe2 = PrincipleEvidence(
+        practice_id="ts-002",
+        display_name="Test2",
+        dimension="maintainability",
+        severity="medium",
+        metrics={"total_instances": 2, "confidence_level": "low", "is_balanced": False},
+    )
+    ev = Evidence(
+        repository="test-repo",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=100,
+        files_read=50,
+        coverage_pct=50.0,
+        principles={"ts-001": pe1, "ts-002": pe2},
+        dismissed_count=3,
+    )
+    s = ev.summary()
+    assert s["total_findings"] == 12
+    assert s["principles_count"] == 2
+    assert s["dismissed_count"] == 3
+    assert "ts-002" in s["low_confidence_principles"]
+    assert "ts-002" in s["unbalanced_principles"]
+
+
+def test_evidence_to_v1_dict():
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Avoid eval()",
+        dimension="security",
+        severity="high",
+        violations=[{"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "injection", "severity": "high"}],
+        compliance=[{"file": "b.ts", "line": 2, "snippet": "JSON.parse(x)", "reason": "safe parsing"}],
+        metrics={"total_instances": 2, "compliant": 1, "violating": 1,
+                 "compliance_percentage": 50.0, "confidence_level": "low", "is_balanced": True},
+    )
+    ev = Evidence(
+        repository="test-repo",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=100,
+        files_read=50,
+        coverage_pct=50.0,
+        principles={"ts-001": pe},
+    )
+    d = ev.to_v1_evidence_dict()
+    assert d["repository"] == "test-repo"
+    assert d["discipline"] == "typescript"
+    assert "ts-001" in d["principles"]
+    assert d["principles"]["ts-001"]["violations"][0]["severity"] == "high"
+    assert d["source_file_count"] == 100
+    assert d["files_read"] == 50

--- a/tests/v2/test_judge.py
+++ b/tests/v2/test_judge.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codecompass.v2.engine.judge import _parse_judge_output, _assemble_evidence, run_judge
+from codecompass.v2.engine.evidence import Judgment
+
+
+def _sample_practices():
+    return {
+        "runtime": "typescript",
+        "version": "1.0.0",
+        "practices": [
+            {
+                "id": "ts-001",
+                "title": "Avoid eval()",
+                "cwe": 95,
+                "dimension": "security",
+                "severity": "high",
+                "bad": "eval(x)",
+                "good": "JSON.parse(x)",
+                "explanation": "eval is dangerous",
+            }
+        ],
+    }
+
+
+# ── JSONL parsing ────────────────────────────────────────────────────
+
+def test_parse_valid_jsonl():
+    raw = json.dumps({"practice_id": "ts-001", "verdict": "violation", "file": "a.ts", "line": 1, "severity": "high"})
+    judgments, dismissed = _parse_judge_output(raw)
+    assert len(judgments) == 1
+    assert judgments[0].practice_id == "ts-001"
+    assert judgments[0].verdict == "violation"
+    assert dismissed == 0
+
+
+def test_parse_with_markdown_fences():
+    raw = "```json\n" + json.dumps({"practice_id": "ts-001", "verdict": "violation"}) + "\n```"
+    judgments, dismissed = _parse_judge_output(raw)
+    assert len(judgments) == 1
+
+
+def test_parse_invalid_lines_skipped():
+    raw = "not json\n" + json.dumps({"practice_id": "ts-001", "verdict": "violation"}) + "\nalso not json"
+    judgments, _ = _parse_judge_output(raw)
+    assert len(judgments) == 1
+
+
+def test_parse_missing_required_fields():
+    raw = json.dumps({"practice_id": "ts-001"})  # no verdict
+    judgments, _ = _parse_judge_output(raw)
+    assert len(judgments) == 0
+
+
+def test_parse_dismissed_verdict():
+    raw = json.dumps({"practice_id": "ts-001", "verdict": "dismissed"})
+    judgments, dismissed = _parse_judge_output(raw)
+    assert len(judgments) == 0
+    assert dismissed == 1
+
+
+def test_parse_compliance_verdict():
+    raw = json.dumps({"practice_id": "ts-001", "verdict": "compliance", "file": "b.ts"})
+    judgments, _ = _parse_judge_output(raw)
+    assert len(judgments) == 1
+    assert judgments[0].verdict == "compliance"
+
+
+# ── Evidence assembly ────────────────────────────────────────────────
+
+def test_assemble_evidence_groups_by_practice():
+    judgments = [
+        Judgment(practice_id="ts-001", verdict="violation", file="a.ts", line=1, severity="high", dimension="security"),
+        Judgment(practice_id="ts-001", verdict="compliance", file="b.ts", line=2, dimension="security"),
+        Judgment(practice_id="ts-002", verdict="violation", file="c.ts", line=3, severity="medium", dimension="maintainability"),
+    ]
+    practices = {
+        "practices": [
+            {"id": "ts-001", "title": "Avoid eval()", "dimension": "security", "severity": "high"},
+            {"id": "ts-002", "title": "Small functions", "dimension": "maintainability", "severity": "medium"},
+        ]
+    }
+    ev = _assemble_evidence(
+        judgments=judgments,
+        dismissed_count=1,
+        repository="test",
+        plugin_id="typescript",
+        date_str="2026-03-03",
+        practices=practices,
+        source_file_count=10,
+        files_read=5,
+        coverage_pct=50.0,
+    )
+    assert "ts-001" in ev.principles
+    assert "ts-002" in ev.principles
+    assert len(ev.principles["ts-001"].violations) == 1
+    assert len(ev.principles["ts-001"].compliance) == 1
+    assert ev.dismissed_count == 1
+
+
+# ── Mock AI caller ───────────────────────────────────────────────────
+
+def test_run_judge_with_mock_ai():
+    mock_output = "\n".join([
+        json.dumps({"practice_id": "ts-001", "verdict": "violation", "file": "a.ts", "line": 1, "severity": "high", "reason": "eval", "dimension": "security"}),
+        json.dumps({"practice_id": "ts-001", "verdict": "compliance", "file": "b.ts", "line": 5, "reason": "safe parse", "dimension": "security"}),
+    ])
+
+    def mock_ai(prompt):
+        return (mock_output, None)
+
+    ev = run_judge(
+        context="test context",
+        repository="test-repo",
+        plugin_id="typescript",
+        date_str="2026-03-03",
+        practices=_sample_practices(),
+        source_file_count=10,
+        files_read=5,
+        ai_caller=mock_ai,
+    )
+    assert ev.repository == "test-repo"
+    assert "ts-001" in ev.principles
+    assert ev.principles["ts-001"].metrics["is_balanced"] is True
+
+
+def test_run_judge_ai_error():
+    def mock_ai(prompt):
+        return ("", "API error")
+
+    with pytest.raises(RuntimeError, match="Judge AI call failed"):
+        run_judge(
+            context="test",
+            repository="test",
+            plugin_id="ts",
+            date_str="",
+            practices={},
+            source_file_count=0,
+            ai_caller=mock_ai,
+        )

--- a/tests/v2/test_runner.py
+++ b/tests/v2/test_runner.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codecompass.v2.engine.runner import run, RunConfig
+
+
+def _make_plugin_dir(base: Path) -> Path:
+    """Create a minimal valid typescript plugin in a temp dir."""
+    plugin_dir = base / "evaluators" / "typescript"
+    plugin_dir.mkdir(parents=True)
+
+    (plugin_dir / "plugin.json").write_text(json.dumps({
+        "id": "typescript",
+        "name": "TypeScript",
+        "version": "1.0.0",
+        "engine_version": ">=2.0.0",
+        "detects": {"extensions": [".ts"]},
+    }))
+
+    (plugin_dir / "dimensions.json").write_text(json.dumps({
+        "applies": [{"id": "security", "weight": 1.2}],
+    }))
+
+    (plugin_dir / "detectors.json").write_text(json.dumps([
+        {"type": "grep", "rules": "scan_rules.ini"},
+    ]))
+
+    (plugin_dir / "scan_rules.ini").write_text(
+        "[cwe_95_eval]\n"
+        "label=CWE-95: eval()\n"
+        "cwe=95\n"
+        "dimension=security\n"
+        "command=grep -rn \"eval(\" {src} --include=\"*.ts\"\n"
+        "format=file_list\n"
+    )
+
+    knowledge = plugin_dir / "knowledge"
+    knowledge.mkdir()
+    (knowledge / "practices.json").write_text(json.dumps({
+        "runtime": "typescript",
+        "version": "1.0.0",
+        "practices": [{
+            "id": "ts-001",
+            "title": "Avoid eval()",
+            "cwe": 95,
+            "dimension": "security",
+            "severity": "high",
+            "bad": "eval(x)",
+            "good": "JSON.parse(x)",
+            "explanation": "eval is dangerous",
+        }],
+    }))
+
+    (knowledge / "analysis.md").write_text("# Analysis\nLook for eval().\n")
+
+    return base / "evaluators"
+
+
+def test_run_end_to_end_with_mock_ai(tmp_path):
+    evaluators_dir = _make_plugin_dir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.ts").write_text("const x = eval(input);\n")
+
+    mock_output = json.dumps({
+        "practice_id": "ts-001",
+        "verdict": "violation",
+        "file": str(src / "app.ts"),
+        "line": 1,
+        "severity": "high",
+        "reason": "eval with user input",
+        "dimension": "security",
+    })
+
+    def mock_ai(prompt):
+        return (mock_output, None)
+
+    config = RunConfig(
+        src=src,
+        plugin_id="typescript",
+        evaluators_dir=evaluators_dir,
+        source_file_count=1,
+        ai_caller=mock_ai,
+    )
+    evidence = run(config)
+    assert evidence.plugin_id == "typescript"
+    assert "ts-001" in evidence.principles
+    assert len(evidence.principles["ts-001"].violations) == 1
+
+
+def test_detector_finds_eval(tmp_path):
+    evaluators_dir = _make_plugin_dir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "bad.ts").write_text("const result = eval(userInput);\n")
+
+    from codecompass.v2.engine.runner import _run_detectors
+
+    plugin_dir = evaluators_dir / "typescript"
+    detectors_config = json.loads((plugin_dir / "detectors.json").read_text())
+    findings = _run_detectors(detectors_config, src, plugin_dir)
+    assert len(findings) >= 1
+    assert any(f.cwe == 95 for f in findings)
+
+
+def test_empty_project(tmp_path):
+    evaluators_dir = _make_plugin_dir(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+
+    def mock_ai(prompt):
+        return ("", None)
+
+    config = RunConfig(
+        src=src,
+        plugin_id="typescript",
+        evaluators_dir=evaluators_dir,
+        source_file_count=0,
+        ai_caller=mock_ai,
+    )
+    evidence = run(config)
+    assert evidence.principles == {}
+
+
+def test_unknown_plugin_error(tmp_path):
+    evaluators_dir = tmp_path / "evaluators"
+    evaluators_dir.mkdir()
+    src = tmp_path / "src"
+    src.mkdir()
+
+    config = RunConfig(
+        src=src,
+        plugin_id="nonexistent",
+        evaluators_dir=evaluators_dir,
+    )
+    with pytest.raises(ValueError, match="not found"):
+        run(config)


### PR DESCRIPTION
## Summary
- Add `evidence.py` with Judgment, PrincipleEvidence, Evidence dataclasses and `to_v1_evidence_dict()` for scoring compatibility
- Add `context_builder.py` that assembles findings + practices + analysis + standards into structured LLM prompt context
- Add `judge.py` that sends context to LLM, parses JSONL verdicts, assembles Evidence
- Add `runner.py` orchestrator that wires detection → context → judgment
- Add `prompts/judge.md` LLM judge prompt template

## Test plan
- [x] `uv run pytest tests/v2/ -v` — 58 tests pass
- [x] JSONL parsing handles fences, invalid lines, missing fields
- [x] Evidence assembly groups judgments by practice, computes metrics
- [x] Runner end-to-end test with mock AI produces valid Evidence
- [x] Empty project and unknown plugin error cases handled