### PR TITLE
PR 6: Scoring + Report

### DIFF
--- a/src/codecompass/v2/engine/report.py
+++ b/src/codecompass/v2/engine/report.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.evaluate.lib.report_json import build_report_json
+from codecompass.v2.engine.evidence import Evidence
+
+
+def build_v2_report(evidence: Evidence, scores: dict) -> dict:
+    """Build v2 report: v1 report + v2-specific fields."""
+    v1_evidence = evidence.to_v1_evidence_dict()
+    base = build_report_json(evidence.plugin_id, v1_evidence, scores)
+    base["engine_version"] = "2.0.0"
+    base["dismissed_count"] = evidence.dismissed_count
+    base["evidence_summary"] = evidence.summary()
+    return base
+
+
+def build_v1_compatible_report(evidence: Evidence, scores: dict) -> dict:
+    """Build exact v1 web dashboard format, no v2 fields."""
+    v1_evidence = evidence.to_v1_evidence_dict()
+    return build_report_json(evidence.plugin_id, v1_evidence, scores)
+
+
+def write_reports(evidence: Evidence, scores: dict, output_dir: Path) -> None:
+    """Write both v2 and v1-compatible report files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    v2_report = build_v2_report(evidence, scores)
+    v1_report = build_v1_compatible_report(evidence, scores)
+
+    dim = evidence.plugin_id
+    (output_dir / f"{dim}_v2.json").write_text(json.dumps(v2_report, indent=2))
+    (output_dir / f"{dim}.json").write_text(json.dumps(v1_report, indent=2))

--- a/src/codecompass/v2/engine/runner.py
+++ b/src/codecompass/v2/engine/runner.py
@@ -86,3 +86,14 @@ def _run_detectors(detectors_config: list, src: Path, plugin_dir: Path) -> list[
         all_findings.extend(findings)
 
     return all_findings
+
+
+def run_full(config: RunConfig, output_dir: Path, mode: str = "numerical") -> dict:
+    """Full pipeline: run → score → write reports. Returns scores dict."""
+    from codecompass.v2.engine.scoring import score_evidence
+    from codecompass.v2.engine.report import write_reports
+
+    evidence = run(config)
+    scores = score_evidence(evidence, mode=mode)
+    write_reports(evidence, scores, output_dir)
+    return scores

--- a/src/codecompass/v2/engine/scoring.py
+++ b/src/codecompass/v2/engine/scoring.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from codecompass.evaluate.lib.scoring import run_scoring as v1_run_scoring
+from codecompass.v2.engine.evidence import Evidence
+
+
+def score_evidence(evidence: Evidence, mode: str = "numerical") -> dict:
+    """Score v2 Evidence using v1's proven scoring engine.
+
+    Converts Evidence to the v1 dict shape and delegates to run_scoring().
+    """
+    v1_dict = evidence.to_v1_evidence_dict()
+    return v1_run_scoring(v1_dict, mapping={}, mode=mode)

--- a/tests/v2/test_v2_report.py
+++ b/tests/v2/test_v2_report.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.evidence import Evidence, PrincipleEvidence
+from codecompass.v2.engine.report import build_v2_report, build_v1_compatible_report, write_reports
+from codecompass.v2.engine.scoring import score_evidence
+
+
+def _make_evidence() -> Evidence:
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Avoid eval()",
+        dimension="security",
+        severity="high",
+        violations=[
+            {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "injection", "severity": "high"},
+        ],
+        compliance=[
+            {"file": "b.ts", "line": 2, "snippet": "JSON.parse(x)", "reason": "safe"},
+        ],
+        metrics={
+            "total_instances": 2,
+            "compliant": 1,
+            "violating": 1,
+            "compliance_percentage": 50.0,
+            "confidence_level": "low",
+            "is_balanced": True,
+        },
+    )
+    return Evidence(
+        repository="test-repo",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=100,
+        files_read=50,
+        coverage_pct=50.0,
+        principles={"ts-001": pe},
+        dismissed_count=2,
+    )
+
+
+def test_v2_report_extra_fields():
+    ev = _make_evidence()
+    scores = score_evidence(ev)
+    report = build_v2_report(ev, scores)
+    assert report["engine_version"] == "2.0.0"
+    assert report["dismissed_count"] == 2
+    assert "evidence_summary" in report
+    assert report["evidence_summary"]["dismissed_count"] == 2
+
+
+def test_v1_shape_match():
+    ev = _make_evidence()
+    scores = score_evidence(ev)
+    report = build_v1_compatible_report(ev, scores)
+    assert "engine_version" not in report
+    assert "dismissed_count" not in report
+    assert "dimension" in report
+    assert "principles" in report
+    assert "violations" in report
+
+
+def test_file_writing(tmp_path):
+    ev = _make_evidence()
+    scores = score_evidence(ev)
+    write_reports(ev, scores, tmp_path)
+
+    v2_file = tmp_path / "typescript_v2.json"
+    v1_file = tmp_path / "typescript.json"
+    assert v2_file.exists()
+    assert v1_file.exists()
+
+    v2_data = json.loads(v2_file.read_text())
+    v1_data = json.loads(v1_file.read_text())
+
+    assert v2_data["engine_version"] == "2.0.0"
+    assert "engine_version" not in v1_data
+
+
+def test_violations_structure():
+    ev = _make_evidence()
+    scores = score_evidence(ev)
+    report = build_v2_report(ev, scores)
+    assert len(report["violations"]) == 1
+    assert report["violations"][0]["principle"] == "Avoid eval()"
+    assert report["violations"][0]["file"] == "a.ts"

--- a/tests/v2/test_v2_scoring.py
+++ b/tests/v2/test_v2_scoring.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from codecompass.v2.engine.evidence import Evidence, PrincipleEvidence
+from codecompass.v2.engine.scoring import score_evidence
+
+
+def _make_evidence(violations=None, compliance=None) -> Evidence:
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Avoid eval()",
+        dimension="security",
+        severity="high",
+        violations=violations or [
+            {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "injection", "severity": "high", "vt": "code-injection"},
+        ],
+        compliance=compliance or [
+            {"file": "b.ts", "line": 2, "snippet": "JSON.parse(x)", "reason": "safe"},
+            {"file": "c.ts", "line": 3, "snippet": "JSON.parse(y)", "reason": "safe"},
+        ],
+        metrics={
+            "total_instances": 3,
+            "compliant": 2,
+            "violating": 1,
+            "compliance_percentage": 66.7,
+            "confidence_level": "low",
+            "is_balanced": True,
+        },
+    )
+    return Evidence(
+        repository="test-repo",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=100,
+        files_read=50,
+        coverage_pct=50.0,
+        principles={"ts-001": pe},
+    )
+
+
+def test_numerical_scoring():
+    ev = _make_evidence()
+    scores = score_evidence(ev, mode="numerical")
+    assert "principles" in scores
+    assert "overall" in scores
+    assert scores["mode"] == "numerical"
+    ts001 = scores["principles"].get("ts-001")
+    assert ts001 is not None
+    assert "final_score" in ts001
+    assert isinstance(ts001["final_score"], (int, float))
+
+
+def test_non_numerical_grading():
+    ev = _make_evidence()
+    scores = score_evidence(ev, mode="non-numerical")
+    assert scores["mode"] == "non-numerical"
+    ts001 = scores["principles"].get("ts-001")
+    assert ts001 is not None
+    assert "grade" in ts001
+
+
+def test_empty_evidence():
+    ev = Evidence(
+        repository="test",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=0,
+        files_read=0,
+        coverage_pct=0.0,
+    )
+    scores = score_evidence(ev)
+    assert scores["principles"] == {}
+    assert scores["overall"]["weighted_score"] == 0.0
+
+
+def test_v1_parity():
+    """Ensure v2 scoring produces same structure as v1."""
+    ev = _make_evidence()
+    scores = score_evidence(ev)
+    assert "repository" in scores
+    assert "discipline" in scores
+    assert "scale" in scores
+    assert "tier" in scores["scale"]
+    assert "multiplier" in scores["scale"]


### PR DESCRIPTION
## Summary
- Add thin v2 scoring wrapper (`scoring.py`) that converts Evidence to v1 dict shape and delegates to v1's proven `run_scoring()`
- Add dual-format report writer (`report.py`) producing v2 reports (with engine_version, dismissed_count, evidence_summary) and v1-compatible dashboard JSON
- Add `run_full()` to runner for complete pipeline: run → score → write reports

## Test plan
- [x] `uv run pytest tests/v2/ -v` — 66 tests pass
- [x] Numerical and non-numerical scoring modes both work
- [x] Empty evidence produces valid zero scores
- [x] V2 report has extra fields, V1 report matches dashboard shape exactly
- [x] Both report files written to output directory