### PR TITLE
PR 7: Scaffold + Remaining Plugins

### DIFF
--- a/evaluators/bash/detectors.json
+++ b/evaluators/bash/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/bash/dimensions.json
+++ b/evaluators/bash/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/bash/knowledge/analysis.md
+++ b/evaluators/bash/knowledge/analysis.md
@@ -1,0 +1,22 @@
+# Bash / Shell Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **Unquoted variables** — `$VAR` without quotes enables word splitting and injection.
+- **Hardcoded secrets** — `API_KEY='...'` in scripts.
+- **eval usage** — `eval "$cmd"` with user-controlled input.
+
+### Maintainability signals
+- **Script length** — scripts over 200 LOC should be split into functions or separate scripts.
+- **Missing functions** — long procedural scripts without function decomposition.
+- **No shellcheck compliance** — common pitfalls detectable by shellcheck.
+
+### Reliability signals
+- **Missing `set -euo pipefail`** — scripts without error flags silently continue on failure.
+- **Unchecked return codes** — commands without `|| exit 1` or `set -e`.
+- **Missing cleanup traps** — no `trap cleanup EXIT` for temp file cleanup.
+
+### Performance signals
+- **Subshell overuse** — `$(cat file)` instead of `< file` redirection.
+- **Unnecessary external commands** — using `grep | awk | sed` chains when one tool suffices.

--- a/evaluators/bash/knowledge/practices.json
+++ b/evaluators/bash/knowledge/practices.json
@@ -1,0 +1,47 @@
+{
+  "runtime": "bash",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "sh-001",
+      "title": "Always quote variable expansions",
+      "cwe": 78,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "rm -rf $DIRECTORY",
+      "good": "rm -rf \"${DIRECTORY}\"",
+      "explanation": "Unquoted variables undergo word splitting and glob expansion, enabling injection when variables contain spaces or special characters."
+    },
+    {
+      "id": "sh-002",
+      "title": "Never hardcode secrets in shell scripts",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "API_KEY='sk-prod-abc123xyz456'",
+      "good": "API_KEY=\"${API_KEY:?API_KEY not set}\"",
+      "explanation": "Hardcoded secrets in shell scripts are visible in process listings and version control."
+    },
+    {
+      "id": "sh-003",
+      "title": "Keep scripts under 200 lines — extract functions",
+      "cwe": 1080,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "# 300-line monolithic script",
+      "good": "main() { validate_args; process_data; cleanup; }\nmain \"$@\"",
+      "explanation": "Long scripts are hard to debug and test. Extract reusable logic into functions."
+    },
+    {
+      "id": "sh-004",
+      "title": "Check return codes — use set -euo pipefail",
+      "cwe": 252,
+      "dimension": "reliability",
+      "severity": "medium",
+      "bad": "cd /some/dir\nrm -rf *",
+      "good": "set -euo pipefail\ncd /some/dir || exit 1\nrm -rf *",
+      "explanation": "Without error checking, commands silently fail and subsequent commands run in wrong state."
+    }
+  ]
+}

--- a/evaluators/bash/plugin.json
+++ b/evaluators/bash/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "bash",
+  "name": "Bash / Shell",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".sh", ".bash"],
+    "config_files": [".bashrc", "Makefile"]
+  }
+}

--- a/evaluators/bash/scan_rules.ini
+++ b/evaluators/bash/scan_rules.ini
@@ -1,0 +1,29 @@
+; evaluators/bash/scan_rules.ini
+
+[cwe_78_unquoted_vars]
+label=CWE-78: Unquoted variable expansion (command injection risk)
+cwe=78
+dimension=security
+command=grep -rn -E '\$[A-Za-z_]+[^"'\''{}]' {src} --include="*.sh" | grep -v '#' | head -20
+format=file_list
+
+[cwe_798_secrets]
+label=CWE-798: Hardcoded credentials or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(API_KEY|SECRET|PASSWORD|TOKEN)=['\"][^'\"]{8,}" {src} --include="*.sh" | head -20
+format=file_list
+
+[cwe_1080_long_scripts]
+label=CWE-1080: Shell scripts exceeding 200 LOC
+cwe=1080
+dimension=maintainability
+command=find {src} -name "*.sh" | xargs wc -l 2>/dev/null | awk '$1 > 200 && !/total/' | sort -rn | head -20
+format=file_list
+
+[cwe_252_unchecked_return]
+label=CWE-252: Commands without error checking
+cwe=252
+dimension=reliability
+command=grep -rn -E "^[a-z].*[^&|]$" {src} --include="*.sh" | grep -v "echo\|printf\|#\|then\|else\|fi\|done\|esac" | grep -v "set -e" | head -20
+format=file_list

--- a/evaluators/java/detectors.json
+++ b/evaluators/java/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/java/dimensions.json
+++ b/evaluators/java/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/java/knowledge/analysis.md
+++ b/evaluators/java/knowledge/analysis.md
@@ -1,0 +1,23 @@
+# Java Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **Hardcoded secrets** — string literals assigned to `apiKey`, `secret`, `password` fields.
+- **SQL injection** — string concatenation in SQL queries instead of PreparedStatement.
+- **Insecure deserialization** — ObjectInputStream without type validation.
+
+### Maintainability signals
+- **File size** — Java files over 300 LOC are a code smell.
+- **God classes** — classes with 10+ public methods or excessive constructor parameters.
+- **Deep inheritance** — more than 3 levels of class hierarchy.
+
+### Reliability signals
+- **Catch generic Exception** — swallowing all exceptions hides bugs.
+- **Missing resource cleanup** — streams/connections without try-with-resources.
+- **Unchecked null returns** — methods returning null without @Nullable annotation.
+
+### Performance signals
+- **String concatenation in loops** — `+=` with String instead of StringBuilder.
+- **Synchronous blocking** — Thread.sleep() or blocking I/O on event loop threads.
+- **N+1 queries** — JPA lazy loading triggering queries inside loops.

--- a/evaluators/java/knowledge/practices.json
+++ b/evaluators/java/knowledge/practices.json
@@ -1,0 +1,47 @@
+{
+  "runtime": "java",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "jv-001",
+      "title": "Never hardcode secrets in source code",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "String apiKey = \"sk-prod-abc123xyz456\";",
+      "good": "String apiKey = System.getenv(\"API_KEY\");",
+      "explanation": "Hardcoded secrets are committed to version control and exposed in class files. Use environment variables or a vault."
+    },
+    {
+      "id": "jv-002",
+      "title": "Use PreparedStatement — never concatenate SQL strings",
+      "cwe": 89,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "stmt.execute(\"SELECT * FROM users WHERE id = \" + userId);",
+      "good": "PreparedStatement ps = conn.prepareStatement(\"SELECT * FROM users WHERE id = ?\");\nps.setString(1, userId);",
+      "explanation": "String concatenation in SQL enables injection attacks. PreparedStatement escapes inputs automatically."
+    },
+    {
+      "id": "jv-003",
+      "title": "Catch specific exceptions — never catch generic Exception",
+      "cwe": 396,
+      "dimension": "reliability",
+      "severity": "medium",
+      "bad": "try { op(); } catch (Exception e) { log(e); }",
+      "good": "try { op(); } catch (IOException e) { handleIO(e); } catch (ParseException e) { handleParse(e); }",
+      "explanation": "Catching Exception hides programming errors (NPE, IllegalArgument) that should propagate. Catch only expected checked exceptions."
+    },
+    {
+      "id": "jv-004",
+      "title": "Keep classes under 300 lines",
+      "cwe": 1080,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "// 500-line class mixing data access, business logic, and validation",
+      "good": "// Separate into UserRepository.java, UserService.java, UserValidator.java",
+      "explanation": "Large classes violate Single Responsibility Principle and are hard to test."
+    }
+  ]
+}

--- a/evaluators/java/plugin.json
+++ b/evaluators/java/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "java",
+  "name": "Java / JVM",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".java"],
+    "config_files": ["pom.xml", "build.gradle"]
+  }
+}

--- a/evaluators/java/scan_rules.ini
+++ b/evaluators/java/scan_rules.ini
@@ -1,0 +1,29 @@
+; evaluators/java/scan_rules.ini
+
+[cwe_798_secrets]
+label=CWE-798: Hardcoded credentials or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(apiKey|api_key|secret|password|token)\s*=\s*\"[^\"]{8,}" {src} --include="*.java"
+format=file_list
+
+[cwe_89_string_concat_sql]
+label=CWE-89: SQL injection via string concatenation
+cwe=89
+dimension=security
+command=grep -rn -E '"\s*\+\s*.*[Ss][Ee][Ll][Ee][Cc][Tt]|[Ss][Ee][Ll][Ee][Cc][Tt].*"\s*\+' {src} --include="*.java" | head -20
+format=file_list
+
+[cwe_1080_large_files]
+label=CWE-1080: Source files exceeding 300 LOC
+cwe=1080
+dimension=maintainability
+command=find {src} -name "*.java" -not -path "*/test/*" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
+format=file_list
+
+[cwe_396_catch_exception]
+label=CWE-396: Catching overly broad Exception class
+cwe=396
+dimension=reliability
+command=grep -rn "catch\s*(Exception\b" {src} --include="*.java" | head -20
+format=file_list

--- a/evaluators/kotlin/detectors.json
+++ b/evaluators/kotlin/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/kotlin/dimensions.json
+++ b/evaluators/kotlin/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/kotlin/knowledge/analysis.md
+++ b/evaluators/kotlin/knowledge/analysis.md
@@ -1,0 +1,23 @@
+# Kotlin Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **Hardcoded secrets** — search for `apiKey`, `secret`, `password`, `token` assigned to string literals.
+- **SQL injection** — string templates in SQL queries (`"SELECT * FROM users WHERE id = ${id}"`).
+- **Insecure deserialization** — Gson/Jackson without type validation.
+
+### Maintainability signals
+- **File size** — Kotlin files over 300 LOC suggest SRP violations.
+- **God classes** — classes with 10+ public methods or 5+ injected dependencies.
+- **Deeply nested when/if** — 3+ levels of nesting reduce readability.
+
+### Reliability signals
+- **Empty catch blocks** — swallowed exceptions hide failures.
+- **Missing null safety** — `!!` operator overuse bypasses Kotlin's null safety.
+- **Unclosed resources** — missing `.use {}` on AutoCloseable instances.
+
+### Performance signals
+- **Blocking calls in coroutines** — `Thread.sleep()` or blocking I/O inside `suspend` functions.
+- **N+1 queries** — database calls inside loops.
+- **Missing lazy initialization** — expensive objects created eagerly when not always needed.

--- a/evaluators/kotlin/knowledge/practices.json
+++ b/evaluators/kotlin/knowledge/practices.json
@@ -1,0 +1,47 @@
+{
+  "runtime": "kotlin",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "kt-001",
+      "title": "Never hardcode secrets in source code",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "val apiKey = \"sk-prod-abc123xyz456\"",
+      "good": "val apiKey = System.getenv(\"API_KEY\")",
+      "explanation": "Hardcoded secrets are committed to version control and exposed in logs. Always read from environment variables or a secrets manager."
+    },
+    {
+      "id": "kt-002",
+      "title": "Use parameterized queries — never string-template SQL",
+      "cwe": 89,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "db.query(\"SELECT * FROM users WHERE id = ${userId}\")",
+      "good": "db.query(\"SELECT * FROM users WHERE id = ?\", listOf(userId))",
+      "explanation": "String-templated SQL enables injection attacks. Use parameterized queries or an ORM's safe query builder."
+    },
+    {
+      "id": "kt-003",
+      "title": "Never swallow exceptions with empty catch blocks",
+      "cwe": 755,
+      "dimension": "reliability",
+      "severity": "medium",
+      "bad": "try { riskyOp() } catch (e: Exception) { }",
+      "good": "try { riskyOp() } catch (e: Exception) { logger.error(\"Failed\", e) }",
+      "explanation": "Empty catch blocks hide errors and make debugging impossible. At minimum log the exception."
+    },
+    {
+      "id": "kt-004",
+      "title": "Keep files under 300 lines",
+      "cwe": 1080,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "// 500-line file mixing data classes, business logic, and API calls",
+      "good": "// Separate into UserModel.kt, UserService.kt, UserController.kt",
+      "explanation": "Large files violate Single Responsibility Principle and are hard to navigate and test."
+    }
+  ]
+}

--- a/evaluators/kotlin/plugin.json
+++ b/evaluators/kotlin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "kotlin",
+  "name": "Kotlin / JVM",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".kt", ".kts"],
+    "config_files": ["build.gradle.kts", "build.gradle"]
+  }
+}

--- a/evaluators/kotlin/scan_rules.ini
+++ b/evaluators/kotlin/scan_rules.ini
@@ -1,0 +1,29 @@
+; evaluators/kotlin/scan_rules.ini
+
+[cwe_798_secrets]
+label=CWE-798: Hardcoded credentials or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(apiKey|api_key|secret|password|token)\s*=\s*\"[^\"]{8,}" {src} --include="*.kt"
+format=file_list
+
+[cwe_1080_large_files]
+label=CWE-1080: Source files exceeding 300 LOC
+cwe=1080
+dimension=maintainability
+command=find {src} -name "*.kt" -not -path "*/test/*" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
+format=file_list
+
+[cwe_89_sql_templates]
+label=CWE-89: SQL injection via string templates
+cwe=89
+dimension=security
+command=grep -rn -E '\$\{.*\}.*[Ss][Ee][Ll][Ee][Cc][Tt]|[Ss][Ee][Ll][Ee][Cc][Tt].*\$\{' {src} --include="*.kt" | head -20
+format=file_list
+
+[cwe_755_empty_catch]
+label=CWE-755: Empty catch blocks
+cwe=755
+dimension=reliability
+command=grep -rn -A1 "catch\s*(" {src} --include="*.kt" | grep -B1 "^\s*}" | grep "catch" | head -20
+format=file_list

--- a/evaluators/mobile_ios/detectors.json
+++ b/evaluators/mobile_ios/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/mobile_ios/dimensions.json
+++ b/evaluators/mobile_ios/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/mobile_ios/knowledge/analysis.md
+++ b/evaluators/mobile_ios/knowledge/analysis.md
@@ -1,0 +1,23 @@
+# iOS / Swift Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **Hardcoded secrets** — API keys, tokens, or passwords in Swift string literals.
+- **UserDefaults for secrets** — tokens or passwords stored unencrypted.
+- **Insecure network** — HTTP instead of HTTPS, disabled ATS.
+
+### Maintainability signals
+- **Massive view controllers** — files over 300 LOC, especially UIViewControllers.
+- **Missing MVVM/Coordinator** — business logic mixed into view layer.
+- **Storyboard sprawl** — single storyboard with 10+ scenes.
+
+### Reliability signals
+- **Force unwrap (!)** — crashes on nil values at runtime.
+- **Missing error handling** — `try!` or unhandled throws.
+- **Retain cycles** — missing `[weak self]` in closures.
+
+### Performance signals
+- **Main thread blocking** — network calls or heavy computation on main queue.
+- **Missing image caching** — reloading images without cache.
+- **Large view hierarchies** — deeply nested views without lazy loading.

--- a/evaluators/mobile_ios/knowledge/practices.json
+++ b/evaluators/mobile_ios/knowledge/practices.json
@@ -1,0 +1,47 @@
+{
+  "runtime": "mobile_ios",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "ios-001",
+      "title": "Never hardcode API keys or secrets",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "let apiKey = \"sk-prod-abc123xyz456\"",
+      "good": "let apiKey = Bundle.main.infoDictionary?[\"API_KEY\"] as? String ?? \"\"",
+      "explanation": "Hardcoded secrets in Swift files are visible in the IPA binary. Use Info.plist with build-time substitution or a keychain."
+    },
+    {
+      "id": "ios-002",
+      "title": "Avoid force unwrap (!) — use guard let or if let",
+      "cwe": 476,
+      "dimension": "reliability",
+      "severity": "medium",
+      "bad": "let name = user.name!",
+      "good": "guard let name = user.name else { return }",
+      "explanation": "Force unwrap crashes at runtime if the value is nil. Use optional binding for safe access."
+    },
+    {
+      "id": "ios-003",
+      "title": "Never store sensitive data in UserDefaults",
+      "cwe": 311,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "UserDefaults.standard.set(token, forKey: \"authToken\")",
+      "good": "try Keychain.save(token, forKey: \"authToken\")",
+      "explanation": "UserDefaults is stored unencrypted in a plist file. Use Keychain Services for tokens, passwords, and keys."
+    },
+    {
+      "id": "ios-004",
+      "title": "Keep view controllers under 300 lines",
+      "cwe": 1080,
+      "dimension": "maintainability",
+      "severity": "medium",
+      "bad": "// 500-line ViewController with networking, UI, and data logic",
+      "good": "// Split into ViewModel, Coordinator, and lean ViewController",
+      "explanation": "Massive view controllers are the most common iOS anti-pattern. Use MVVM or similar to separate concerns."
+    }
+  ]
+}

--- a/evaluators/mobile_ios/plugin.json
+++ b/evaluators/mobile_ios/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "mobile_ios",
+  "name": "iOS / Swift",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".swift"],
+    "config_files": ["Package.swift", "Podfile"]
+  }
+}

--- a/evaluators/mobile_ios/scan_rules.ini
+++ b/evaluators/mobile_ios/scan_rules.ini
@@ -1,0 +1,29 @@
+; evaluators/mobile_ios/scan_rules.ini
+
+[cwe_798_hardcoded_keys]
+label=CWE-798: Hardcoded API keys or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(apiKey|apiSecret|password|token)\s*=\s*\"[^\"]{8,}" {src} --include="*.swift"
+format=file_list
+
+[cwe_1080_large_files]
+label=CWE-1080: Source files exceeding 300 LOC
+cwe=1080
+dimension=maintainability
+command=find {src} -name "*.swift" -not -path "*/Tests/*" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
+format=file_list
+
+[cwe_476_force_unwrap]
+label=CWE-476: Force unwrap (!) on optional values
+cwe=476
+dimension=reliability
+command=grep -rn -E "\w+!" {src} --include="*.swift" | grep -v "IBOutlet\|IBAction\|@objc\|//" | head -20
+format=file_list
+
+[cwe_311_userdefaults_unencrypted]
+label=CWE-311: Sensitive data stored in unencrypted UserDefaults
+cwe=311
+dimension=security
+command=grep -rn -E "UserDefaults.*(password|token|secret|apiKey)" {src} --include="*.swift" | head -20
+format=file_list

--- a/evaluators/python/detectors.json
+++ b/evaluators/python/detectors.json
@@ -1,0 +1,3 @@
+[
+  { "type": "grep", "rules": "scan_rules.ini" }
+]

--- a/evaluators/python/dimensions.json
+++ b/evaluators/python/dimensions.json
@@ -1,0 +1,9 @@
+{
+  "applies": [
+    { "id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023" },
+    { "id": "reliability",     "weight": 1.0, "iso_25010": "Reliability",     "source": "ISO/IEC 25010:2023" },
+    { "id": "security",        "weight": 1.2, "iso_25010": "Security",        "source": "OWASP ASVS L1" },
+    { "id": "performance",     "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023" }
+  ],
+  "excludes": ["usability", "flexibility"]
+}

--- a/evaluators/python/knowledge/analysis.md
+++ b/evaluators/python/knowledge/analysis.md
@@ -1,0 +1,24 @@
+# Python Codebase Analysis Guidance
+
+## Where to look first
+
+### Security hotspots
+- **eval()/exec()** — any occurrence in non-test code is a finding.
+- **Hardcoded secrets** — `api_key`, `secret`, `password`, `token` assigned to string literals.
+- **Command injection** — `os.system()`, `subprocess` with `shell=True`.
+- **SQL injection** — f-strings or string formatting in SQL queries.
+
+### Maintainability signals
+- **File size** — Python files over 300 LOC suggest SRP violations.
+- **Cyclomatic complexity** — deeply nested if/for/try blocks.
+- **Missing type hints** — function signatures without type annotations.
+
+### Reliability signals
+- **Bare except clauses** — `except:` or `except Exception:` without specific handling.
+- **Missing context managers** — file handles without `with` statement.
+- **Unchecked return values** — ignoring return values from functions that can fail.
+
+### Performance signals
+- **N+1 queries** — database calls inside loops.
+- **Missing generators** — loading entire datasets into memory when streaming would work.
+- **Synchronous I/O in async code** — blocking calls in async functions.

--- a/evaluators/python/knowledge/practices.json
+++ b/evaluators/python/knowledge/practices.json
@@ -1,0 +1,47 @@
+{
+  "runtime": "python",
+  "version": "1.0.0",
+  "source": "manually curated",
+  "practices": [
+    {
+      "id": "py-001",
+      "title": "Never use eval() or exec() with untrusted input",
+      "cwe": 95,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "result = eval(user_input)",
+      "good": "result = json.loads(user_input)",
+      "explanation": "eval() and exec() execute arbitrary code. Use json.loads(), ast.literal_eval(), or structured parsers instead."
+    },
+    {
+      "id": "py-002",
+      "title": "Never hardcode secrets in source code",
+      "cwe": 798,
+      "dimension": "security",
+      "severity": "critical",
+      "bad": "API_KEY = 'sk-prod-abc123xyz456'",
+      "good": "API_KEY = os.environ['API_KEY']",
+      "explanation": "Hardcoded secrets leak through version control. Use environment variables or a secrets manager."
+    },
+    {
+      "id": "py-003",
+      "title": "Avoid os.system and shell=True — use subprocess with lists",
+      "cwe": 78,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "os.system(f'rm -rf {path}')",
+      "good": "subprocess.run(['rm', '-rf', path], check=True)",
+      "explanation": "os.system and shell=True enable command injection. Use subprocess with argument lists."
+    },
+    {
+      "id": "py-004",
+      "title": "Use parameterized queries — never f-string SQL",
+      "cwe": 89,
+      "dimension": "security",
+      "severity": "high",
+      "bad": "cursor.execute(f\"SELECT * FROM users WHERE id = {user_id}\")",
+      "good": "cursor.execute(\"SELECT * FROM users WHERE id = %s\", (user_id,))",
+      "explanation": "F-string SQL enables injection. Use parameterized queries with the DB-API 2.0 placeholder style."
+    }
+  ]
+}

--- a/evaluators/python/plugin.json
+++ b/evaluators/python/plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "python",
+  "name": "Python",
+  "version": "1.0.0",
+  "engine_version": ">=2.0.0",
+  "detects": {
+    "extensions": [".py"],
+    "config_files": ["pyproject.toml", "setup.py", "requirements.txt"]
+  }
+}

--- a/evaluators/python/scan_rules.ini
+++ b/evaluators/python/scan_rules.ini
@@ -1,0 +1,29 @@
+; evaluators/python/scan_rules.ini
+
+[cwe_95_eval_exec]
+label=CWE-95: Dynamic code evaluation (eval/exec)
+cwe=95
+dimension=security
+command=grep -rn -E "\b(eval|exec)\s*\(" {src} --include="*.py"
+format=file_list
+
+[cwe_798_secrets]
+label=CWE-798: Hardcoded credentials or secrets
+cwe=798
+dimension=security
+command=grep -rn -E "(api_key|apikey|secret|password|token)\s*=\s*['\"][^'\"]{8,}" {src} --include="*.py"
+format=file_list
+
+[cwe_78_os_system]
+label=CWE-78: OS command injection via os.system/subprocess shell=True
+cwe=78
+dimension=security
+command=grep -rn -E "(os\.system\(|subprocess\.(call|run|Popen)\(.*shell\s*=\s*True)" {src} --include="*.py" | head -20
+format=file_list
+
+[cwe_89_sql_fstring]
+label=CWE-89: SQL injection via f-string
+cwe=89
+dimension=security
+command=grep -rn -E 'f".*[Ss][Ee][Ll][Ee][Cc][Tt].*\{|f".*[Ii][Nn][Ss][Ee][Rr][Tt].*\{' {src} --include="*.py" | head -20
+format=file_list

--- a/src/codecompass/config/actions.py
+++ b/src/codecompass/config/actions.py
@@ -145,6 +145,18 @@ def run_refresh_standards(paths: ConfigPaths, *, dry_run: bool = False) -> int:
     return 0
 
 
+def run_scaffold_plugin(runtime: str, paths: ConfigPaths) -> int:
+    from codecompass.config.scaffold import scaffold_plugin
+    evaluators_dir = paths.root / "evaluators"
+    try:
+        plugin_dir = scaffold_plugin(runtime, evaluators_dir)
+        print(f"Created plugin skeleton at {plugin_dir}")
+        return 0
+    except ValueError as e:
+        log_error(str(e))
+        return 1
+
+
 def check_sources(discipline: str, paths: ConfigPaths) -> int:
     practices_dir = paths.practices_dir / discipline
     if not practices_dir.exists():

--- a/src/codecompass/config/cli.py
+++ b/src/codecompass/config/cli.py
@@ -9,6 +9,7 @@ from codecompass.config.actions import run_generate_evaluators
 from codecompass.config.actions import run_refresh_analysis
 from codecompass.config.actions import run_refresh_practices
 from codecompass.config.actions import run_refresh_standards
+from codecompass.config.actions import run_scaffold_plugin
 from codecompass.config.dimensions import render_dimension_table
 from codecompass.config.paths import default_paths
 
@@ -40,6 +41,9 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Minimum stars for cursor-rules repos (default: 500)")
     parser.add_argument("--dry-run", action="store_true",
                         help="Show what would change without writing files")
+    # Plugin scaffolding
+    parser.add_argument("--scaffold-plugin", metavar="RUNTIME",
+                        help="Generate a new v2 plugin skeleton for the given runtime")
     return parser
 
 
@@ -67,4 +71,6 @@ def main(argv: list[str] | None = None) -> int:
         return run_refresh_analysis(args.refresh_analysis, paths, dry_run=args.dry_run)
     if args.refresh_standards:
         return run_refresh_standards(paths, dry_run=args.dry_run)
+    if args.scaffold_plugin is not None:
+        return run_scaffold_plugin(args.scaffold_plugin, paths)
     return 0

--- a/src/codecompass/config/scaffold.py
+++ b/src/codecompass/config/scaffold.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+RUNTIME_PRESETS: dict[str, dict] = {
+    "typescript": {
+        "display_name": "TypeScript / Node.js",
+        "extensions": [".ts", ".tsx"],
+        "config_files": ["tsconfig.json", "package.json"],
+    },
+    "kotlin": {
+        "display_name": "Kotlin / JVM",
+        "extensions": [".kt", ".kts"],
+        "config_files": ["build.gradle.kts", "build.gradle"],
+    },
+    "python": {
+        "display_name": "Python",
+        "extensions": [".py"],
+        "config_files": ["pyproject.toml", "setup.py", "requirements.txt"],
+    },
+    "bash": {
+        "display_name": "Bash / Shell",
+        "extensions": [".sh", ".bash"],
+        "config_files": [".bashrc", "Makefile"],
+    },
+    "java": {
+        "display_name": "Java / JVM",
+        "extensions": [".java"],
+        "config_files": ["pom.xml", "build.gradle"],
+    },
+    "mobile_ios": {
+        "display_name": "iOS / Swift",
+        "extensions": [".swift"],
+        "config_files": ["Package.swift", "Podfile"],
+    },
+}
+
+
+def scaffold_plugin(runtime: str, evaluators_dir: Path) -> Path:
+    """Generate a full plugin directory with schema-valid boilerplate.
+
+    Returns the path to the created plugin directory.
+    Raises ValueError if runtime is unknown or directory already exists.
+    """
+    if runtime not in RUNTIME_PRESETS:
+        raise ValueError(f"Unknown runtime: {runtime}. Available: {', '.join(sorted(RUNTIME_PRESETS))}")
+
+    plugin_dir = evaluators_dir / runtime
+    if plugin_dir.exists():
+        raise ValueError(f"Plugin directory already exists: {plugin_dir}")
+
+    preset = RUNTIME_PRESETS[runtime]
+    plugin_dir.mkdir(parents=True)
+
+    # plugin.json
+    (plugin_dir / "plugin.json").write_text(json.dumps({
+        "id": runtime,
+        "name": preset["display_name"],
+        "version": "1.0.0",
+        "engine_version": ">=2.0.0",
+        "detects": {
+            "extensions": preset["extensions"],
+            "config_files": preset["config_files"],
+        },
+    }, indent=2) + "\n")
+
+    # dimensions.json
+    (plugin_dir / "dimensions.json").write_text(json.dumps({
+        "applies": [
+            {"id": "maintainability", "weight": 1.0, "iso_25010": "Maintainability", "source": "ISO/IEC 25010:2023"},
+            {"id": "reliability", "weight": 1.0, "iso_25010": "Reliability", "source": "ISO/IEC 25010:2023"},
+            {"id": "security", "weight": 1.2, "iso_25010": "Security", "source": "OWASP ASVS L1"},
+            {"id": "performance", "weight": 0.8, "iso_25010": "Performance Efficiency", "source": "ISO/IEC 25010:2023"},
+        ],
+        "excludes": ["usability", "flexibility"],
+    }, indent=2) + "\n")
+
+    # detectors.json
+    (plugin_dir / "detectors.json").write_text(json.dumps([
+        {"type": "grep", "rules": "scan_rules.ini"},
+    ], indent=2) + "\n")
+
+    # scan_rules.ini placeholder
+    ext = preset["extensions"][0]
+    (plugin_dir / "scan_rules.ini").write_text(
+        f"; evaluators/{runtime}/scan_rules.ini\n"
+        f"; Add CWE-tagged grep rules for {preset['display_name']}\n\n"
+        f"[cwe_798_secrets]\n"
+        f"label=CWE-798: Hardcoded credentials or secrets\n"
+        f"cwe=798\n"
+        f"dimension=security\n"
+        f'command=grep -rn -E "(apiKey|api_key|secret|password|token)\\s*=\\s*[\'\\"][^\'\\"]{"{8,}"}" {{src}} --include="*{ext}"\n'
+        f"format=file_list\n"
+    )
+
+    # knowledge directory
+    knowledge_dir = plugin_dir / "knowledge"
+    knowledge_dir.mkdir()
+
+    (knowledge_dir / "practices.json").write_text(json.dumps({
+        "runtime": runtime,
+        "version": "1.0.0",
+        "source": "manually curated",
+        "practices": [],
+    }, indent=2) + "\n")
+
+    (knowledge_dir / "analysis.md").write_text(
+        f"# {preset['display_name']} Codebase Analysis Guidance\n\n"
+        f"## Where to look first\n\n"
+        f"### Security hotspots\n"
+        f"- Hardcoded secrets and credentials\n\n"
+        f"### Maintainability signals\n"
+        f"- File size and complexity\n\n"
+        f"### Reliability signals\n"
+        f"- Error handling patterns\n\n"
+        f"### Performance signals\n"
+        f"- Resource management\n"
+    )
+
+    return plugin_dir

--- a/tests/v2/test_plugin_bash.py
+++ b/tests/v2/test_plugin_bash.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path(__file__).parent.parent.parent / "evaluators" / "bash"
+
+
+def test_plugin_loads():
+    data = load_plugin(PLUGIN_DIR)
+    assert data["id"] == "bash"
+
+
+def test_plugin_has_knowledge():
+    practices = json.loads((PLUGIN_DIR / "knowledge" / "practices.json").read_text())
+    assert len(practices["practices"]) >= 3
+
+
+def test_plugin_passes_validation():
+    errors = validate_plugin_dir(PLUGIN_DIR)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_scan_rules_detect_secrets(tmp_path):
+    bad_file = tmp_path / "deploy.sh"
+    bad_file.write_text("API_KEY='sk-prod-abc123xyz456789'\n")
+    detector = GrepDetector()
+    findings = detector.run(tmp_path, {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")})
+    assert any(f.cwe == 798 for f in findings)

--- a/tests/v2/test_plugin_java.py
+++ b/tests/v2/test_plugin_java.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path(__file__).parent.parent.parent / "evaluators" / "java"
+
+
+def test_plugin_loads():
+    data = load_plugin(PLUGIN_DIR)
+    assert data["id"] == "java"
+
+
+def test_plugin_has_knowledge():
+    practices = json.loads((PLUGIN_DIR / "knowledge" / "practices.json").read_text())
+    assert len(practices["practices"]) >= 3
+
+
+def test_plugin_passes_validation():
+    errors = validate_plugin_dir(PLUGIN_DIR)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_scan_rules_detect_secrets(tmp_path):
+    bad_file = tmp_path / "Config.java"
+    bad_file.write_text('String apiKey = "sk-prod-abc123xyz456789";\n')
+    detector = GrepDetector()
+    findings = detector.run(tmp_path, {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")})
+    assert any(f.cwe == 798 for f in findings)

--- a/tests/v2/test_plugin_kotlin.py
+++ b/tests/v2/test_plugin_kotlin.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path(__file__).parent.parent.parent / "evaluators" / "kotlin"
+
+
+def test_plugin_loads():
+    data = load_plugin(PLUGIN_DIR)
+    assert data["id"] == "kotlin"
+
+
+def test_plugin_has_knowledge():
+    practices = json.loads((PLUGIN_DIR / "knowledge" / "practices.json").read_text())
+    assert len(practices["practices"]) >= 3
+
+
+def test_plugin_passes_validation():
+    errors = validate_plugin_dir(PLUGIN_DIR)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_scan_rules_detect_secrets(tmp_path):
+    bad_file = tmp_path / "App.kt"
+    bad_file.write_text('val apiKey = "sk-prod-abc123xyz456789"\n')
+    detector = GrepDetector()
+    findings = detector.run(tmp_path, {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")})
+    assert any(f.cwe == 798 for f in findings)

--- a/tests/v2/test_plugin_mobile_ios.py
+++ b/tests/v2/test_plugin_mobile_ios.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path(__file__).parent.parent.parent / "evaluators" / "mobile_ios"
+
+
+def test_plugin_loads():
+    data = load_plugin(PLUGIN_DIR)
+    assert data["id"] == "mobile_ios"
+
+
+def test_plugin_has_knowledge():
+    practices = json.loads((PLUGIN_DIR / "knowledge" / "practices.json").read_text())
+    assert len(practices["practices"]) >= 3
+
+
+def test_plugin_passes_validation():
+    errors = validate_plugin_dir(PLUGIN_DIR)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_scan_rules_detect_secrets(tmp_path):
+    bad_file = tmp_path / "Config.swift"
+    bad_file.write_text('let apiKey = "sk-prod-abc123xyz456789"\n')
+    detector = GrepDetector()
+    findings = detector.run(tmp_path, {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")})
+    assert any(f.cwe == 798 for f in findings)

--- a/tests/v2/test_plugin_python.py
+++ b/tests/v2/test_plugin_python.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codecompass.v2.engine.plugin_loader import load_plugin
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+from codecompass.v2.engine.detectors.grep import GrepDetector
+
+PLUGIN_DIR = Path(__file__).parent.parent.parent / "evaluators" / "python"
+
+
+def test_plugin_loads():
+    data = load_plugin(PLUGIN_DIR)
+    assert data["id"] == "python"
+
+
+def test_plugin_has_knowledge():
+    practices = json.loads((PLUGIN_DIR / "knowledge" / "practices.json").read_text())
+    assert len(practices["practices"]) >= 3
+
+
+def test_plugin_passes_validation():
+    errors = validate_plugin_dir(PLUGIN_DIR)
+    assert errors == {}, f"Validation errors: {errors}"
+
+
+def test_scan_rules_detect_eval(tmp_path):
+    bad_file = tmp_path / "app.py"
+    bad_file.write_text("result = eval(user_input)\n")
+    detector = GrepDetector()
+    findings = detector.run(tmp_path, {"rules_file": str(PLUGIN_DIR / "scan_rules.ini")})
+    assert any(f.cwe == 95 for f in findings)

--- a/tests/v2/test_scaffold.py
+++ b/tests/v2/test_scaffold.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codecompass.config.scaffold import scaffold_plugin, RUNTIME_PRESETS
+from codecompass.v2.engine.schema_validator import validate_plugin_dir
+
+
+@pytest.mark.parametrize("runtime", list(RUNTIME_PRESETS.keys()))
+def test_scaffold_creates_all_files(tmp_path, runtime):
+    plugin_dir = scaffold_plugin(runtime, tmp_path)
+    assert (plugin_dir / "plugin.json").exists()
+    assert (plugin_dir / "dimensions.json").exists()
+    assert (plugin_dir / "detectors.json").exists()
+    assert (plugin_dir / "scan_rules.ini").exists()
+    assert (plugin_dir / "knowledge" / "practices.json").exists()
+    assert (plugin_dir / "knowledge" / "analysis.md").exists()
+
+
+@pytest.mark.parametrize("runtime", list(RUNTIME_PRESETS.keys()))
+def test_scaffold_passes_schema_validation(tmp_path, runtime):
+    plugin_dir = scaffold_plugin(runtime, tmp_path)
+    errors = validate_plugin_dir(plugin_dir)
+    assert errors == {}, f"Schema errors for {runtime}: {errors}"
+
+
+def test_scaffold_raises_on_existing_dir(tmp_path):
+    scaffold_plugin("kotlin", tmp_path)
+    with pytest.raises(ValueError, match="already exists"):
+        scaffold_plugin("kotlin", tmp_path)
+
+
+def test_scaffold_raises_on_unknown_runtime(tmp_path):
+    with pytest.raises(ValueError, match="Unknown runtime"):
+        scaffold_plugin("fortran", tmp_path)
+
+
+def test_scaffold_plugin_json_has_correct_id(tmp_path):
+    plugin_dir = scaffold_plugin("python", tmp_path)
+    data = json.loads((plugin_dir / "plugin.json").read_text())
+    assert data["id"] == "python"
+    assert data["detects"]["extensions"] == [".py"]


### PR DESCRIPTION
## Summary
- Add `codecompass configure --scaffold-plugin <runtime>` command that generates schema-valid plugin boilerplate
- Create 5 complete runtime plugins with CWE-tagged scan rules, curated practices, and analysis guidance:
  - **kotlin**: secrets, SQL templates, empty catch, large files
  - **python**: eval/exec, secrets, os.system/shell=True, f-string SQL
  - **bash**: unquoted vars, secrets, long scripts, unchecked return codes
  - **java**: secrets, string concat SQL, large files, catch generic Exception
  - **mobile_ios**: hardcoded keys, large files, force unwrap, UserDefaults secrets

## Test plan
- [x] `uv run pytest tests/v2/ -v` — 70 tests pass
- [x] Scaffold creates all required files for each runtime preset
- [x] All scaffolded plugins pass schema validation
- [x] Scaffold raises on existing directory or unknown runtime
- [x] Each plugin's scan rules detect known bad patterns (secrets, eval, etc.)