### PR TITLE
PR 8: Tool Adapter Interface

### DIFF
--- a/evaluators/typescript/detectors.json
+++ b/evaluators/typescript/detectors.json
@@ -1,3 +1,4 @@
 [
-  { "type": "grep", "rules": "scan_rules.ini" }
+  { "type": "grep", "rules": "scan_rules.ini" },
+  { "type": "tool", "tool": "eslint", "command": "npx eslint {src} --format=json", "optional": true }
 ]

--- a/src/codecompass/v2/engine/detectors/parsers/eslint.py
+++ b/src/codecompass/v2/engine/detectors/parsers/eslint.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from codecompass.v2.engine.finding import Finding
+
+# ESLint rule → CWE mapping
+_CWE_MAP: dict[str, int] = {
+    "no-eval": 95,
+    "no-implied-eval": 95,
+    "no-new-func": 95,
+    "no-explicit-any": 1121,
+    "no-unused-vars": 1164,
+    "@typescript-eslint/no-unused-vars": 1164,
+    "no-var": 1078,
+    "no-console": 1164,
+    "no-debugger": 1164,
+    "eqeqeq": 697,
+    "no-undef": 457,
+    "no-unreachable": 561,
+    "no-empty-function": 1071,
+    "no-shadow": 710,
+    "prefer-const": 1078,
+}
+
+# ESLint severity: 2 = error, 1 = warning
+_SEVERITY_MAP: dict[int, str] = {
+    2: "high",
+    1: "medium",
+}
+
+
+def parse_eslint_output(stdout: str, config: dict | None = None) -> list[Finding]:
+    """Parse ESLint JSON output into Findings."""
+    if not stdout or not stdout.strip():
+        return []
+
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        return []
+
+    findings: list[Finding] = []
+
+    for file_result in data:
+        filepath = file_result.get("filePath", "")
+        for msg in file_result.get("messages", []):
+            rule_id = msg.get("ruleId") or "unknown"
+            cwe = _CWE_MAP.get(rule_id)
+            severity_code = msg.get("severity", 1)
+            severity = _SEVERITY_MAP.get(severity_code, "medium")
+
+            # Map to dimension based on rule
+            dimension = "maintainability"
+            if rule_id in ("no-eval", "no-implied-eval", "no-new-func", "eqeqeq"):
+                dimension = "security"
+            elif rule_id in ("no-unreachable", "no-undef"):
+                dimension = "reliability"
+
+            findings.append(Finding(
+                rule=f"eslint:{rule_id}",
+                label=f"ESLint: {msg.get('message', rule_id)}",
+                file=filepath,
+                dimension=dimension,
+                detector="tool:eslint",
+                cwe=cwe,
+                line=msg.get("line"),
+                snippet=msg.get("source", ""),
+                severity_hint=severity,
+            ))
+
+    return findings

--- a/src/codecompass/v2/engine/detectors/tool.py
+++ b/src/codecompass/v2/engine/detectors/tool.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from codecompass.v2.engine.detectors.base import DetectorBase
+from codecompass.v2.engine.finding import Finding
+
+# Parser registry: tool_name → callable(stdout, config) -> list[Finding]
+_PARSER_REGISTRY: dict[str, Callable] = {}
+
+
+def register_parser(tool_name: str, parser: Callable) -> None:
+    """Register a parser function for a tool name."""
+    _PARSER_REGISTRY[tool_name] = parser
+
+
+class ToolDetector(DetectorBase):
+    """Runs an external tool command and passes output to a registered parser."""
+
+    def run(self, src: Path, config: dict) -> list[Finding]:
+        tool_name = config.get("tool", "")
+        command_template = config.get("command", "")
+        optional = config.get("optional", False)
+        timeout = config.get("timeout", 60)
+
+        parser = _PARSER_REGISTRY.get(tool_name)
+        if not parser:
+            if optional:
+                return []
+            raise ValueError(f"No parser registered for tool: {tool_name}")
+
+        command = command_template.replace("{src}", str(src))
+
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            # Many tools use non-zero exit for "found issues" — still parse stdout
+            return parser(result.stdout, config)
+        except subprocess.TimeoutExpired:
+            return []
+        except OSError:
+            if optional:
+                return []
+            raise

--- a/src/codecompass/v2/engine/runner.py
+++ b/src/codecompass/v2/engine/runner.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from codecompass.config.generators import run_ai_cli
 from codecompass.v2.engine.context_builder import build_judge_context
 from codecompass.v2.engine.detectors.grep import GrepDetector
+from codecompass.v2.engine.detectors.tool import ToolDetector, register_parser
+from codecompass.v2.engine.detectors.parsers.eslint import parse_eslint_output
 from codecompass.v2.engine.evidence import Evidence
 from codecompass.v2.engine.finding import Finding
 from codecompass.v2.engine.judge import run_judge
@@ -13,7 +15,11 @@ from codecompass.v2.engine.plugin_loader import load_plugin_full
 
 _DETECTOR_REGISTRY = {
     "grep": GrepDetector(),
+    "tool": ToolDetector(),
 }
+
+# Register built-in parsers
+register_parser("eslint", parse_eslint_output)
 
 
 @dataclass
@@ -81,6 +87,11 @@ def _run_detectors(detectors_config: list, src: Path, plugin_dir: Path) -> list[
         if det_type == "grep":
             rules_file = det_config.get("rules", "scan_rules.ini")
             config["rules_file"] = str(plugin_dir / rules_file)
+        elif det_type == "tool":
+            config["tool"] = det_config.get("tool", "")
+            config["command"] = det_config.get("command", "")
+            config["optional"] = det_config.get("optional", False)
+            config["timeout"] = det_config.get("timeout", 60)
 
         findings = detector.run(src, config)
         all_findings.extend(findings)

--- a/src/codecompass/v2/engine/schemas/detectors_schema.json
+++ b/src/codecompass/v2/engine/schemas/detectors_schema.json
@@ -4,11 +4,26 @@
   "type": "array",
   "items": {
     "type": "object",
-    "required": ["type", "rules"],
-    "properties": {
-      "type": { "type": "string", "enum": ["grep"] },
-      "rules": { "type": "string", "minLength": 1 }
-    },
-    "additionalProperties": false
+    "oneOf": [
+      {
+        "required": ["type", "rules"],
+        "properties": {
+          "type": { "type": "string", "const": "grep" },
+          "rules": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      },
+      {
+        "required": ["type", "tool", "command"],
+        "properties": {
+          "type": { "type": "string", "const": "tool" },
+          "tool": { "type": "string", "minLength": 1 },
+          "command": { "type": "string", "minLength": 1 },
+          "optional": { "type": "boolean" },
+          "timeout": { "type": "integer", "minimum": 1 }
+        },
+        "additionalProperties": false
+      }
+    ]
   }
 }

--- a/tests/v2/test_eslint_parser.py
+++ b/tests/v2/test_eslint_parser.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+
+from codecompass.v2.engine.detectors.parsers.eslint import parse_eslint_output
+
+
+def test_empty_output():
+    assert parse_eslint_output("") == []
+    assert parse_eslint_output("   ") == []
+
+
+def test_invalid_json():
+    assert parse_eslint_output("not json") == []
+
+
+def test_single_file_parsing():
+    data = [{
+        "filePath": "/src/app.ts",
+        "messages": [
+            {"ruleId": "no-eval", "severity": 2, "message": "eval is evil", "line": 10, "source": "eval(x)"},
+            {"ruleId": "no-unused-vars", "severity": 1, "message": "unused var", "line": 5, "source": "let x;"},
+        ],
+        "errorCount": 1,
+        "warningCount": 1,
+    }]
+    findings = parse_eslint_output(json.dumps(data))
+    assert len(findings) == 2
+    assert findings[0].rule == "eslint:no-eval"
+    assert findings[0].dimension == "security"
+    assert findings[0].line == 10
+    assert findings[1].rule == "eslint:no-unused-vars"
+
+
+def test_cwe_mapping():
+    data = [{
+        "filePath": "/src/app.ts",
+        "messages": [
+            {"ruleId": "no-eval", "severity": 2, "message": "eval"},
+        ],
+    }]
+    findings = parse_eslint_output(json.dumps(data))
+    assert findings[0].cwe == 95
+
+
+def test_severity_mapping():
+    data = [{
+        "filePath": "/src/app.ts",
+        "messages": [
+            {"ruleId": "no-eval", "severity": 2, "message": "error"},
+            {"ruleId": "no-var", "severity": 1, "message": "warning"},
+        ],
+    }]
+    findings = parse_eslint_output(json.dumps(data))
+    assert findings[0].severity_hint == "high"
+    assert findings[1].severity_hint == "medium"
+
+
+def test_unknown_rule():
+    data = [{
+        "filePath": "/src/app.ts",
+        "messages": [
+            {"ruleId": "custom/my-rule", "severity": 1, "message": "custom"},
+        ],
+    }]
+    findings = parse_eslint_output(json.dumps(data))
+    assert len(findings) == 1
+    assert findings[0].cwe is None
+    assert findings[0].dimension == "maintainability"

--- a/tests/v2/test_tool_detector.py
+++ b/tests/v2/test_tool_detector.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from codecompass.v2.engine.detectors.tool import ToolDetector, register_parser, _PARSER_REGISTRY
+from codecompass.v2.engine.finding import Finding
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Ensure tests don't leak parser registrations."""
+    original = _PARSER_REGISTRY.copy()
+    yield
+    _PARSER_REGISTRY.clear()
+    _PARSER_REGISTRY.update(original)
+
+
+def _dummy_parser(stdout: str, config: dict) -> list[Finding]:
+    return [Finding(
+        rule="test:dummy",
+        label="Dummy finding",
+        file="test.ts",
+        dimension="security",
+        detector="tool:test",
+    )]
+
+
+def test_parser_registration():
+    register_parser("test_tool", _dummy_parser)
+    assert "test_tool" in _PARSER_REGISTRY
+
+
+def test_missing_parser_raises():
+    detector = ToolDetector()
+    config = {"tool": "nonexistent", "command": "echo hi", "optional": False}
+    with pytest.raises(ValueError, match="No parser registered"):
+        detector.run(Path("."), config)
+
+
+def test_missing_parser_optional_returns_empty():
+    detector = ToolDetector()
+    config = {"tool": "nonexistent", "command": "echo hi", "optional": True}
+    findings = detector.run(Path("."), config)
+    assert findings == []
+
+
+def test_tool_runs_command_and_parses(tmp_path):
+    register_parser("echo_tool", _dummy_parser)
+    detector = ToolDetector()
+    config = {"tool": "echo_tool", "command": "echo test", "optional": False}
+    findings = detector.run(tmp_path, config)
+    assert len(findings) == 1
+    assert findings[0].rule == "test:dummy"
+
+
+def test_timeout_returns_empty(tmp_path):
+    register_parser("slow_tool", _dummy_parser)
+    detector = ToolDetector()
+    config = {"tool": "slow_tool", "command": "sleep 10", "optional": False, "timeout": 1}
+    findings = detector.run(tmp_path, config)
+    assert findings == []
+
+
+def test_nonzero_exit_still_parses(tmp_path):
+    """Tools like ESLint return non-zero when they find issues."""
+    register_parser("failing_tool", _dummy_parser)
+    detector = ToolDetector()
+    config = {"tool": "failing_tool", "command": "exit 1", "optional": False}
+    # The subprocess returns exit code 1 but stdout is empty, parser still runs
+    findings = detector.run(tmp_path, config)
+    assert len(findings) == 1


### PR DESCRIPTION
## Summary
- Add `ToolDetector` that runs external tool commands and routes stdout through registered parsers
- Add ESLint parser with CWE mapping (no-eval→95, no-explicit-any→1121, etc.) and severity mapping
- Update detectors schema to support `oneOf` for grep and tool detector types
- Register ESLint as optional tool detector in TypeScript plugin's detectors.json

## Test plan
- [x] `uv run pytest tests/v2/ -v` — 76 tests pass
- [x] Parser registration and missing parser error handling
- [x] Optional tools return empty on missing parser
- [x] Timeout handling returns empty findings
- [x] Non-zero exit code still parses output (ESLint behavior)
- [x] ESLint parser: CWE mapping, severity mapping, empty/invalid JSON handling