### PR TITLE
feat: v1/v2 dashboard split, dimension filtering, file sampler and reviewer

### DIFF
--- a/evaluators/python/scan_rules.ini
+++ b/evaluators/python/scan_rules.ini
@@ -4,54 +4,82 @@
 label=CWE-95: Dynamic code evaluation (eval/exec)
 cwe=95
 dimension=security
-command=grep -rn -E "\b(eval|exec)\s*\(" {src} --include="*.py"
+command=grep -rn -E "\b(eval|exec)\s*\(" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests
 format=file_list
 
 [cwe_798_secrets]
 label=CWE-798: Hardcoded credentials or secrets
 cwe=798
 dimension=security
-command=grep -rn -E "(api_key|apikey|secret|password|token)\s*=\s*['\"][^'\"]{8,}" {src} --include="*.py"
+command=grep -rn -E "(api_key|apikey|secret|password|token)\s*=\s*['\"][^'\"]{8,}" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests
+format=file_list
+
+[cwe_78_shell_true]
+label=CWE-78: Subprocess with shell=True (command injection risk)
+cwe=78
+dimension=security
+command=grep -rn "shell\s*=\s*True" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
 format=file_list
 
 [cwe_78_os_system]
-label=CWE-78: OS command injection via os.system/subprocess shell=True
+label=CWE-78: OS command injection via os.system()
 cwe=78
 dimension=security
-command=grep -rn -E "(os\.system\(|subprocess\.(call|run|Popen)\(.*shell\s*=\s*True)" {src} --include="*.py" | head -20
+command=grep -rn -E "os\.system\(" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
 format=file_list
 
 [cwe_89_sql_fstring]
 label=CWE-89: SQL injection via f-string
 cwe=89
 dimension=security
-command=grep -rn -E 'f".*[Ss][Ee][Ll][Ee][Cc][Tt].*\{|f".*[Ii][Nn][Ss][Ee][Rr][Tt].*\{' {src} --include="*.py" | head -20
+command=grep -rn -E 'f".*[Ss][Ee][Ll][Ee][Cc][Tt].*\{|f".*[Ii][Nn][Ss][Ee][Rr][Tt].*\{' {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
+format=file_list
+
+[cwe_295_no_verify]
+label=CWE-295: TLS certificate verification disabled
+cwe=295
+dimension=security
+command=grep -rn -E "verify\s*=\s*False" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
+format=file_list
+
+[cwe_502_pickle]
+label=CWE-502: Unsafe deserialization (pickle/yaml.load)
+cwe=502
+dimension=security
+command=grep -rn -E "(pickle\.load|yaml\.load\()" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
+format=file_list
+
+[cwe_377_tempfile]
+label=CWE-377: Insecure temporary file creation
+cwe=377
+dimension=security
+command=grep -rn -E "(tempfile\.mktemp\(|open\s*\(\s*['\"]\/tmp\/)" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
 format=file_list
 
 [cwe_390_bare_except]
 label=CWE-390: Bare except clause (catches all exceptions including SystemExit)
 cwe=390
 dimension=reliability
-command=grep -rn -E "^\s*except\s*:" {src} --include="*.py" | head -20
+command=grep -rn -E "^\s*except\s*:" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
 format=file_list
 
 [cwe_1061_star_import]
 label=CWE-1061: Wildcard import (from x import *)
 cwe=1061
 dimension=maintainability
-command=grep -rn -E "from\s+\S+\s+import\s+\*" {src} --include="*.py" | head -20
+command=grep -rn -E "from\s+\S+\s+import\s+\*" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | head -20
 format=file_list
 
 [cwe_1080_large_files]
 label=CWE-1080: Source files exceeding 300 LOC
 cwe=1080
 dimension=maintainability
-command=find {src} -name "*.py" -not -path "*/test*" -not -name "__init__.py" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
+command=find {src} -name "*.py" -not -path "*/.venv/*" -not -path "*/node_modules/*" -not -path "*/.worktrees/*" -not -path "*/.git/*" -not -path "*/test*" -not -name "__init__.py" | xargs wc -l 2>/dev/null | awk '$1 > 300 && !/total/' | sort -rn | head -20
 format=file_list
 
 [cwe_1059_missing_type_hints]
 label=CWE-1059: Public functions without type hints
 cwe=1059
 dimension=maintainability
-command=grep -rn -E "^\s*def [a-z_]+\([^)]*\)\s*:" {src} --include="*.py" | grep -v "->.*:" | grep -v "test_\|_test\|__" | head -20
+command=grep -rn -E "^\s*def [a-z_]+\([^)]*\)\s*:" {src} --include="*.py" --exclude-dir=.venv --exclude-dir=node_modules --exclude-dir=.worktrees --exclude-dir=.git --exclude-dir=tests | grep -v "->.*:" | grep -v "test_\|_test\|__" | head -20
 format=file_list

--- a/src/codecompass/action_provider_fs.py
+++ b/src/codecompass/action_provider_fs.py
@@ -505,20 +505,29 @@ class FilesystemActionProvider(ActionProvider):
             raise FileNotFoundError(f"Repository not found: {repo}")
 
         reports_abs = str(Path(reports_dir).resolve())
-        cmd = [sys.executable, "-m", "codecompass.cli", "evaluate"]
-        cmd += ["--evaluations", reports_abs]
-        if dimensions:
-            cmd += ["-d", dimensions]
-        if numerical:
-            cmd.append("-n")
-        if discipline:
-            cmd.append(discipline)
-        if is_repo_url(repo):
-            cmd.append(repo)
-        else:
-            cmd.append(str(repo_path.resolve()))
-
+        version = os.environ.get("CODECOMPASS_VERSION", "v1")
         info = _build_repository_info(repo, discipline)
+
+        if version == "v2":
+            cmd = [sys.executable, "-m", "codecompass.cli", "evaluate"]
+            if dimensions:
+                cmd += ["-d", dimensions]
+            cmd += ["-o", reports_abs]
+            repo_arg = repo if is_repo_url(repo) else str(repo_path.resolve())
+            cmd.append(repo_arg)
+        else:
+            cmd = [sys.executable, "-m", "codecompass.cli", "evaluate-v1"]
+            cmd += ["--evaluations", reports_abs]
+            if dimensions:
+                cmd += ["-d", dimensions]
+            if numerical:
+                cmd.append("-n")
+            if discipline:
+                cmd.append(discipline)
+            if is_repo_url(repo):
+                cmd.append(repo)
+            else:
+                cmd.append(str(repo_path.resolve()))
         info_dir = Path(reports_dir) / str(info["name"])
         info_dir.mkdir(parents=True, exist_ok=True)
         (info_dir / "repository_info.json").write_text(json.dumps(info))

--- a/src/codecompass/cli.py
+++ b/src/codecompass/cli.py
@@ -19,8 +19,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="codecompass")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    dashboard_parser = subparsers.add_parser("dashboard", help="Run the dashboard")
+    dashboard_parser = subparsers.add_parser("dashboard", help="Run the v2 dashboard")
     dashboard_parser.set_defaults(_command="dashboard")
+
+    dashboard_v1_parser = subparsers.add_parser("dashboard-v1", help="Run the legacy v1 dashboard")
+    dashboard_v1_parser.set_defaults(_command="dashboard-v1")
 
     # v2 evaluate (default)
     evaluate_parser = subparsers.add_parser(
@@ -48,6 +51,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Produce evidence JSON only (skip scoring)",
     )
+    evaluate_parser.add_argument(
+        "-d",
+        "--dimensions",
+        default=None,
+        help="Comma-separated list of dimension IDs to evaluate (e.g. maintainability,security)",
+    )
     evaluate_parser.set_defaults(_command="evaluate")
 
     # v1 evaluate (legacy, explicit discipline)
@@ -74,6 +83,8 @@ def build_parser() -> argparse.ArgumentParser:
 
 def run_evaluate_v2(args: argparse.Namespace) -> int:
     """Run the v2 evaluation pipeline."""
+    import uuid
+
     from codecompass.v2.engine.runner import (
         RunConfig,
         count_source_files,
@@ -122,27 +133,54 @@ def run_evaluate_v2(args: argparse.Namespace) -> int:
             source_file_count = count_source_files(src, extensions)
             print(f"Source files: {source_file_count}")
 
-    # 5. Build config and run
+    # 5. Parse dimension filter
+    dimensions = None
+    if args.dimensions:
+        dimensions = [d.strip() for d in args.dimensions.split(",") if d.strip()]
+
+    # 6. Build config and run
     config = RunConfig(
         src=src,
         plugin_id=plugin_id,
         evaluators_dir=evaluators_dir,
         source_file_count=source_file_count,
+        dimensions=dimensions,
     )
 
-    output_dir = Path(args.output)
+    # 7. Build output directory: <reports>/<project>/<run_id>/
+    import json as _json
+
+    reports_root = Path(args.output)
+    project_name = src.name
+    run_id = uuid.uuid4().hex[:12]
+    run_dir = reports_root / project_name / run_id
+
+    # Write repository_info.json so the dashboard can discover this project
+    project_dir = reports_root / project_name
+    project_dir.mkdir(parents=True, exist_ok=True)
+    info_file = project_dir / "repository_info.json"
+    if not info_file.exists():
+        info = {
+            "name": project_name,
+            "discipline": plugin_id,
+            "location": "online" if is_repo_url(args.repo) else "local",
+            "path": str(src),
+        }
+        info_file.write_text(_json.dumps(info))
 
     if args.evidence_only:
         import json
 
         evidence = run(config)
-        out_file = output_dir / f"{plugin_id}_evidence.json"
-        out_file.parent.mkdir(parents=True, exist_ok=True)
-        out_file.write_text(json.dumps(evidence.to_v1_evidence_dict(), indent=2))
-        print(f"Evidence written to {out_file}")
+        evidence_dir = run_dir / "evidence"
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        for dim_name in (dimensions or [plugin_id]):
+            out_file = evidence_dir / f"{dim_name}_evidence.json"
+            out_file.write_text(json.dumps(evidence.to_v1_evidence_dict(), indent=2))
+        print(f"Report path: {run_dir / 'evaluation'}")
     else:
-        scores = run_full(config, output_dir, mode=args.mode)
-        print(f"Reports written to {output_dir}/")
+        scores = run_full(config, run_dir, mode=args.mode)
+        print(f"Report path: {run_dir / 'evaluation'}")
         for dim, score in scores.items():
             print(f"  {dim}: {score}")
 
@@ -154,6 +192,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args._command == "dashboard":
+        sub_argv = argv[1:] if argv is not None else sys.argv[2:]
+        return dashboard_main(["--version", "v2"] + sub_argv)
+    if args._command == "dashboard-v1":
         sub_argv = argv[1:] if argv is not None else sys.argv[2:]
         return dashboard_main(sub_argv)
     if args._command == "evaluate":

--- a/src/codecompass/dashboard/cli.py
+++ b/src/codecompass/dashboard/cli.py
@@ -16,6 +16,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-build", action="store_true")
     parser.add_argument("--reinstall", action="store_true")
     parser.add_argument("--open", default="true")
+    parser.add_argument("--version", default="v1", choices=["v1", "v2"])
     return parser
 
 
@@ -37,6 +38,7 @@ def parse_args(argv: list[str] | None = None) -> DashboardConfig:
         api_host=args.api_host,
         api_port=args.api_port,
         api_forced=api_forced,
+        version=args.version,
     )
 
 

--- a/src/codecompass/dashboard/runner.py
+++ b/src/codecompass/dashboard/runner.py
@@ -30,6 +30,7 @@ class DashboardConfig:
     api_host: str | None = None
     api_port: int | None = None
     api_forced: bool = False
+    version: str = "v1"
 
 
 def validate_paths(config: DashboardConfig) -> None:
@@ -184,6 +185,7 @@ def _ensure_action_api_forced(host: str, port: int) -> tuple[str, subprocess.Pop
 def _start_ui_server(config: DashboardConfig, action_api_url: str) -> subprocess.Popen:
     env = os.environ.copy()
     env["CODECOMPASS_ACTION_API"] = action_api_url
+    env["CODECOMPASS_VERSION"] = config.version
     return subprocess.Popen(
         [
             "node",
@@ -237,9 +239,13 @@ def run_dashboard(config: DashboardConfig) -> int:
         api_host=config.api_host,
         api_port=config.api_port,
         api_forced=config.api_forced,
+        version=config.version,
     )
 
     validate_paths(config)
+
+    # Propagate version to child processes (action API + Node server)
+    os.environ["CODECOMPASS_VERSION"] = config.version
 
     log_info("Starting dashboard...")
     log_info(f"Reports: {config.reports_dir}")
@@ -300,3 +306,5 @@ def run_dashboard(config: DashboardConfig) -> int:
         pass
     finally:
         _stop_children()
+
+    return process.poll() or 0

--- a/src/codecompass/v2/engine/evidence.py
+++ b/src/codecompass/v2/engine/evidence.py
@@ -40,7 +40,21 @@ class PrincipleEvidence:
         n_violations = len(self.violations)
         n_compliance = len(self.compliance)
         total = n_violations + n_compliance
-        pct = round(n_compliance / total * 100, 1) if total > 0 else 0.0
+
+        # No findings at all → treat as "no evidence" (100 % compliance, low confidence)
+        if total == 0:
+            self.metrics = {
+                "total_instances": 0,
+                "compliant": 0,
+                "violating": 0,
+                "compliance_percentage": 100.0,
+                "confidence_level": "low",
+                "is_balanced": False,
+                "no_evidence": True,
+            }
+            return
+
+        pct = round(n_compliance / total * 100, 1)
 
         if total >= high_threshold:
             confidence = "high"

--- a/src/codecompass/v2/engine/file_sampler.py
+++ b/src/codecompass/v2/engine/file_sampler.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+from codecompass.v2.engine.finding import Finding
+
+_SKIP_DIRS = {".venv", "node_modules", "tests", ".git", ".worktrees", "__pycache__", ".tox", "dist", "build"}
+
+_HIGH_RISK_NAMES = {
+    "config", "auth", "main", "app", "server", "api", "db",
+    "handler", "middleware", "route", "settings", "database",
+    "login", "password", "secret", "admin", "security",
+}
+
+_ENTRY_POINT_MARKERS = [
+    'if __name__',
+    'app = Flask',
+    'app = FastAPI',
+    'urlpatterns',
+    'createApp',
+    'express()',
+    'http.createServer',
+    'public static void main',
+]
+
+
+@dataclass
+class SampledFile:
+    path: str
+    content: str
+    lines: int
+    reason: str  # "detector_finding" | "high_risk_name" | "entry_point" | "large_file" | "random"
+    truncated: bool
+
+
+def sample_files(
+    src: Path,
+    findings: list[Finding],
+    extensions: set[str],
+    max_files: int = 20,
+    max_lines: int = 500,
+) -> list[SampledFile]:
+    """Select files for LLM code review using a priority system."""
+    candidates = _collect_candidates(src, extensions)
+    if not candidates:
+        return []
+
+    finding_files = {f.file for f in findings if f.file}
+    # Normalize finding paths to be relative to src
+    finding_rel = set()
+    for fp in finding_files:
+        p = Path(fp)
+        try:
+            finding_rel.add(str(p.relative_to(src)))
+        except ValueError:
+            finding_rel.add(fp)
+
+    selected_paths: list[str] = []
+    selected_set: set[str] = set()
+
+    def _add(path: str) -> bool:
+        if path not in selected_set and len(selected_paths) < max_files:
+            selected_set.add(path)
+            selected_paths.append(path)
+            return True
+        return False
+
+    # Categorize candidates
+    detector_files: list[str] = []
+    high_risk_files: list[str] = []
+    entry_point_files: list[str] = []
+    large_files: list[tuple[int, str]] = []  # (line_count, path)
+    rest: list[str] = []
+
+    for rel_path, line_count in candidates:
+        if rel_path in finding_rel:
+            detector_files.append(rel_path)
+        else:
+            stem = Path(rel_path).stem.lower()
+            if stem in _HIGH_RISK_NAMES:
+                high_risk_files.append(rel_path)
+            else:
+                rest.append(rel_path)
+            large_files.append((line_count, rel_path))
+
+    # Sort large files by line count descending
+    large_files.sort(reverse=True)
+
+    # Check entry points from rest + high_risk (lazily, reading content)
+    for rel_path in rest + high_risk_files:
+        if rel_path in selected_set:
+            continue
+        try:
+            text = (src / rel_path).read_text(errors="replace")
+            if any(marker in text for marker in _ENTRY_POINT_MARKERS):
+                entry_point_files.append(rel_path)
+        except OSError:
+            continue
+
+    # Priority 1: files with detector findings
+    for p in detector_files:
+        _add(p)
+
+    # Priority 2: high-risk names
+    for p in high_risk_files:
+        _add(p)
+
+    # Priority 3: entry points
+    for p in entry_point_files:
+        _add(p)
+
+    # Priority 4: large files
+    for _, p in large_files:
+        _add(p)
+
+    # Priority 5: random sample to fill remaining
+    remaining = [p for p in rest if p not in selected_set]
+    random.shuffle(remaining)
+    for p in remaining:
+        _add(p)
+
+    # Now read content and build SampledFile objects
+    result: list[SampledFile] = []
+    for rel_path in selected_paths:
+        reason = _classify(rel_path, finding_rel, entry_point_files)
+        sf = _read_file(src, rel_path, reason, max_lines)
+        if sf:
+            result.append(sf)
+
+    return result
+
+
+def _collect_candidates(src: Path, extensions: set[str]) -> list[tuple[str, int]]:
+    """Walk src and return (relative_path, line_count) for matching files."""
+    candidates: list[tuple[str, int]] = []
+    for p in src.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix not in extensions:
+            continue
+        # Skip excluded directories
+        parts = p.relative_to(src).parts
+        if any(part in _SKIP_DIRS for part in parts):
+            continue
+        try:
+            line_count = p.read_text(errors="replace").count("\n")
+        except OSError:
+            continue
+        candidates.append((str(p.relative_to(src)), line_count))
+    return candidates
+
+
+def _classify(rel_path: str, finding_rel: set[str], entry_points: list[str]) -> str:
+    if rel_path in finding_rel:
+        return "detector_finding"
+    stem = Path(rel_path).stem.lower()
+    if stem in _HIGH_RISK_NAMES:
+        return "high_risk_name"
+    if rel_path in entry_points:
+        return "entry_point"
+    return "random"
+
+
+def _read_file(src: Path, rel_path: str, reason: str, max_lines: int) -> SampledFile | None:
+    try:
+        full = (src / rel_path).read_text(errors="replace")
+    except OSError:
+        return None
+    all_lines = full.splitlines()
+    total = len(all_lines)
+    truncated = total > max_lines
+    if truncated:
+        content = "\n".join(all_lines[:max_lines]) + f"\n\n... (truncated, {total - max_lines} more lines)"
+    else:
+        content = full
+    return SampledFile(
+        path=rel_path,
+        content=content,
+        lines=total,
+        reason=reason,
+        truncated=truncated,
+    )

--- a/src/codecompass/v2/engine/judge.py
+++ b/src/codecompass/v2/engine/judge.py
@@ -114,6 +114,16 @@ def _assemble_evidence(
 
     principles: dict[str, PrincipleEvidence] = {}
 
+    # Seed all known practices so they appear even with 0 findings
+    for p_info in practices.get("practices", []):
+        pid = p_info["id"]
+        principles[pid] = PrincipleEvidence(
+            practice_id=pid,
+            display_name=p_info.get("title", pid),
+            dimension=p_info.get("dimension", ""),
+            severity=p_info.get("severity", "medium"),
+        )
+
     for j in judgments:
         if j.practice_id not in principles:
             p_info = practice_lookup.get(j.practice_id, {})

--- a/src/codecompass/v2/engine/prompts/reviewer.md
+++ b/src/codecompass/v2/engine/prompts/reviewer.md
@@ -1,0 +1,52 @@
+# CodeCompass v2 — LLM Code Reviewer
+
+You are a code quality reviewer. You are reading **actual source code** to find issues that static analysis (grep) missed — logic problems, missing validation, insecure patterns, architectural concerns, and poor practices.
+
+## Your task
+
+Review each source file against the practices listed below. Find:
+1. **Violations** — code that breaks a practice (logic bugs, missing validation, insecure patterns, bad architecture)
+2. **Compliance** — code that follows a practice well (good patterns worth noting)
+
+Focus on issues that grep-based detectors CANNOT catch:
+- Logic errors and incorrect control flow
+- Missing input validation or error handling
+- Insecure patterns that aren't simple keyword matches
+- Architectural problems (tight coupling, god objects, missing abstractions)
+- Hardcoded values that should be configurable
+- Race conditions, resource leaks, or concurrency issues
+
+## Output format
+
+Output one JSON object per line (JSONL). Each line must have these fields:
+
+```json
+{"practice_id": "py-003", "verdict": "violation", "file": "src/app.py", "line": 42, "snippet": "os.system(f'rm {path}')", "severity": "high", "reason": "Shell command with string interpolation enables command injection", "dimension": "security", "cwe": 78, "vt": "command-injection", "source": "code_review"}
+```
+
+### Required fields
+- `practice_id` — which practice this judgment applies to
+- `verdict` — one of: `violation`, `compliance`, `dismissed`
+
+### Expected fields (include when available)
+- `file` — file path (as provided in the source files section)
+- `line` — line number
+- `snippet` — code snippet (first line only)
+- `severity` — `critical`, `high`, `medium`, `low`
+- `reason` — explanation of why this is a violation/compliance
+- `dimension` — quality dimension (security, maintainability, reliability, performance)
+- `cwe` — CWE ID (integer)
+- `vt` — violation type tag for deduction grouping
+- `source` — always set to `"code_review"`
+
+## Guidelines
+
+1. **Read the full source code** — don't just scan for keywords, understand the logic
+2. **Focus on real issues** — not style nitpicks or formatting
+3. **Assess severity in context** — a missing check in a CLI tool differs from one in a web server
+4. **Include compliance examples** — note where practices are followed well for balanced evidence
+5. **Map to practices** — every judgment must reference a practice_id from the list
+6. **Be specific** — include file, line, and snippet for each judgment
+7. **Don't duplicate** — if a violation is obvious from a keyword match, it's likely already caught by static analysis; focus on deeper issues
+
+{{CONTEXT}}

--- a/src/codecompass/v2/engine/report.py
+++ b/src/codecompass/v2/engine/report.py
@@ -7,6 +7,21 @@ from pathlib import Path
 from codecompass.v2.engine.evidence import Evidence
 
 
+_SEVERITY_MAP = {
+    "critical": "critical",
+    "high": "critical",
+    "major": "major",
+    "medium": "major",
+    "minor": "minor",
+    "low": "minor",
+}
+
+
+def _normalize_severity(raw: str | None) -> str:
+    """Map AI judge severities (high/medium/low) to dashboard severities (critical/major/minor)."""
+    return _SEVERITY_MAP.get((raw or "").lower(), "minor")
+
+
 def grade_from_score(score: str | None) -> str | None:
     # Nothing to map if the input is falsy
     if not score:
@@ -85,15 +100,16 @@ def build_report_json(dimension: str, evidence: dict, scores: dict | None) -> di
 
         # Flatten violations, stamping each with the principle name
         for viol in pdata.get("violations", []):
+            normalized_sev = _normalize_severity(viol.get("severity"))
             flat_entry: dict = {"principle": label}
             flat_entry.update(
-                {field: viol.get(field) for field in ("file", "line", "reason", "snippet", "severity")}
+                {field: viol.get(field) for field in ("file", "line", "reason", "snippet")}
             )
+            flat_entry["severity"] = normalized_sev
             flat_violations.append(flat_entry)
 
-            bucket = viol.get("severity", "minor")
-            if bucket in sev_tally:
-                sev_tally[bucket] += 1
+            if normalized_sev in sev_tally:
+                sev_tally[normalized_sev] += 1
 
         # Flatten compliance examples the same way
         for comp in pdata.get("compliance", []):
@@ -144,29 +160,76 @@ def build_report_json(dimension: str, evidence: dict, scores: dict | None) -> di
     }
 
 
-def build_v2_report(evidence: Evidence, scores: dict) -> dict:
-    """Build v2 report: v1 report + v2-specific fields."""
+def build_report(evidence: Evidence, scores: dict, dimension: str | None = None) -> dict:
+    """Build the scored evaluation report for the dashboard."""
     v1_evidence = evidence.to_v1_evidence_dict()
-    base = build_report_json(evidence.plugin_id, v1_evidence, scores)
-    base["engine_version"] = "2.0.0"
-    base["dismissed_count"] = evidence.dismissed_count
-    base["evidence_summary"] = evidence.summary()
-    return base
+    dim_label = dimension or evidence.plugin_id
+    return build_report_json(dim_label, v1_evidence, scores)
 
 
-def build_v1_compatible_report(evidence: Evidence, scores: dict) -> dict:
-    """Build exact v1 web dashboard format, no v2 fields."""
-    v1_evidence = evidence.to_v1_evidence_dict()
-    return build_report_json(evidence.plugin_id, v1_evidence, scores)
+def _split_evidence_by_dimension(evidence: Evidence) -> dict[str, Evidence]:
+    """Split a single Evidence into per-dimension Evidence objects."""
+    from codecompass.v2.engine.evidence import Evidence as Ev, PrincipleEvidence
+
+    dim_principles: dict[str, dict[str, PrincipleEvidence]] = {}
+    for key, pe in evidence.principles.items():
+        dim = pe.dimension or evidence.plugin_id
+        dim_principles.setdefault(dim, {})[key] = pe
+
+    result: dict[str, Ev] = {}
+    for dim, principles in dim_principles.items():
+        result[dim] = Ev(
+            repository=evidence.repository,
+            plugin_id=evidence.plugin_id,
+            date=evidence.date,
+            source_file_count=evidence.source_file_count,
+            files_read=evidence.files_read,
+            coverage_pct=evidence.coverage_pct,
+            principles=principles,
+            dismissed_count=evidence.dismissed_count,
+            meta=evidence.meta,
+        )
+    return result
 
 
-def write_reports(evidence: Evidence, scores: dict, output_dir: Path) -> None:
-    """Write both v2 and v1-compatible report files."""
-    output_dir.mkdir(parents=True, exist_ok=True)
+def write_reports(
+    evidence: Evidence,
+    scores: dict,
+    run_dir: Path,
+    dimensions: list[str] | None = None,
+) -> None:
+    """Write per-dimension evaluation and evidence files.
 
-    v2_report = build_v2_report(evidence, scores)
-    v1_report = build_v1_compatible_report(evidence, scores)
+    Output structure under *run_dir*::
 
-    dim = evidence.plugin_id
-    (output_dir / f"{dim}_v2.json").write_text(json.dumps(v2_report, indent=2))
-    (output_dir / f"{dim}.json").write_text(json.dumps(v1_report, indent=2))
+        evaluation/<dimension>.json        — scored report
+        evidence/<dimension>_evidence.json  — raw findings
+
+    *dimensions* is the list requested via ``-d``; when the judge produces
+    no principles we still write one file per requested dimension.
+    """
+    from codecompass.v2.engine.scoring import score_evidence
+
+    eval_dir = run_dir / "evaluation"
+    evidence_dir = run_dir / "evidence"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+
+    per_dim = _split_evidence_by_dimension(evidence)
+
+    if not per_dim:
+        # No principles — write one file per requested dimension (or plugin_id)
+        dim_names = dimensions if dimensions else [evidence.plugin_id]
+        for dim in dim_names:
+            report = build_report(evidence, scores, dimension=dim)
+            (eval_dir / f"{dim}.json").write_text(json.dumps(report, indent=2))
+            ev_dict = evidence.to_v1_evidence_dict()
+            (evidence_dir / f"{dim}_evidence.json").write_text(json.dumps(ev_dict, indent=2))
+        return
+
+    for dim, dim_evidence in per_dim.items():
+        dim_scores = score_evidence(dim_evidence, mode=scores.get("mode", "numerical"))
+        report = build_report(dim_evidence, dim_scores, dimension=dim)
+        (eval_dir / f"{dim}.json").write_text(json.dumps(report, indent=2))
+        ev_dict = dim_evidence.to_v1_evidence_dict()
+        (evidence_dir / f"{dim}_evidence.json").write_text(json.dumps(ev_dict, indent=2))

--- a/src/codecompass/v2/engine/reviewer.py
+++ b/src/codecompass/v2/engine/reviewer.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codecompass.config.generators import run_ai_cli
+from codecompass.v2.engine.evidence import Judgment
+from codecompass.v2.engine.file_sampler import SampledFile
+from codecompass.v2.engine.judge import _parse_judge_output
+
+_PROMPT_PATH = Path(__file__).parent / "prompts" / "reviewer.md"
+
+
+def run_code_review(
+    sampled_files: list[SampledFile],
+    practices: dict,
+    analysis_md: str,
+    dimensions_config: dict,
+    ai_caller=None,
+    batch_size: int = 5,
+) -> tuple[list[Judgment], int]:
+    """Run LLM code review on batched source files.
+
+    Returns (judgments, dismissed_count).
+    """
+    if ai_caller is None:
+        ai_caller = run_ai_cli
+
+    if not sampled_files:
+        return [], 0
+
+    prompt_template = _PROMPT_PATH.read_text()
+    batches = _make_batches(sampled_files, batch_size)
+    total_batches = len(batches)
+
+    all_judgments: list[Judgment] = []
+    total_dismissed = 0
+
+    for i, batch in enumerate(batches, 1):
+        context = _build_batch_context(batch, practices, analysis_md, dimensions_config, i, total_batches)
+        prompt = prompt_template.replace("{{CONTEXT}}", context)
+
+        try:
+            stdout, error = ai_caller(prompt)
+        except Exception:
+            continue
+
+        if error:
+            continue
+
+        judgments, dismissed = _parse_judge_output(stdout)
+
+        # Tag all judgments with source = "code_review"
+        for j in judgments:
+            if not j.finding_rule:
+                j.finding_rule = "code_review"
+
+        all_judgments.extend(judgments)
+        total_dismissed += dismissed
+
+    return all_judgments, total_dismissed
+
+
+def _make_batches(files: list[SampledFile], batch_size: int) -> list[list[SampledFile]]:
+    return [files[i:i + batch_size] for i in range(0, len(files), batch_size)]
+
+
+def _build_batch_context(
+    batch: list[SampledFile],
+    practices: dict,
+    analysis_md: str,
+    dimensions_config: dict,
+    batch_num: int,
+    total_batches: int,
+) -> str:
+    sections: list[str] = []
+
+    sections.append(f"## Code Review — Batch {batch_num} of {total_batches}")
+
+    # Practices section
+    practice_list = practices.get("practices", [])
+    if practice_list:
+        lines = ["## Practices\n"]
+        for p in practice_list:
+            lines.append(f"### {p['id']}: {p['title']}")
+            lines.append(f"- **Dimension:** {p['dimension']} | **Severity:** {p['severity']} | **CWE:** {p.get('cwe', 'N/A')}")
+            lines.append(f"- **Bad:**\n```\n{p['bad']}\n```")
+            lines.append(f"- **Good:**\n```\n{p['good']}\n```")
+            lines.append(f"- **Why:** {p.get('explanation', '')}")
+            lines.append("")
+        sections.append("\n".join(lines))
+
+    # Analysis guidance
+    if analysis_md:
+        sections.append(f"## Analysis Guidance\n\n{analysis_md}")
+
+    # Source files section
+    file_lines = ["## Source Files\n"]
+    for sf in batch:
+        trunc_note = " (TRUNCATED)" if sf.truncated else ""
+        file_lines.append(f"### {sf.path} ({sf.lines} lines, selected: {sf.reason}){trunc_note}")
+        file_lines.append(f"```\n{sf.content}\n```\n")
+    sections.append("\n".join(file_lines))
+
+    return "\n\n---\n\n".join(sections)

--- a/src/codecompass/v2/engine/runner.py
+++ b/src/codecompass/v2/engine/runner.py
@@ -8,10 +8,18 @@ from codecompass.v2.engine.context_builder import build_judge_context
 from codecompass.v2.engine.detectors.grep import GrepDetector
 from codecompass.v2.engine.detectors.tool import ToolDetector, register_parser
 from codecompass.v2.engine.detectors.parsers.eslint import parse_eslint_output
-from codecompass.v2.engine.evidence import Evidence
+from codecompass.v2.engine.evidence import Evidence, Judgment
+from codecompass.v2.engine.file_sampler import sample_files
 from codecompass.v2.engine.finding import Finding
-from codecompass.v2.engine.judge import run_judge
+from codecompass.v2.engine.judge import run_judge, _parse_judge_output, _assemble_evidence
 from codecompass.v2.engine.plugin_loader import load_plugin_full
+from codecompass.v2.engine.reviewer import run_code_review
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
 
 _DETECTOR_REGISTRY = {
     "grep": GrepDetector(),
@@ -30,17 +38,36 @@ class RunConfig:
     standards_dir: Path | None = None
     source_file_count: int = 0
     ai_caller: object = None
+    dimensions: list[str] | None = None
 
 
 def run(config: RunConfig) -> Evidence:
-    """Orchestrator: load plugin → detect → build context → judge → Evidence."""
+    """Orchestrator: load plugin → detect → judge (Pass 1) → review (Pass 2) → Evidence."""
     plugin_dir = config.evaluators_dir / config.plugin_id
     if not plugin_dir.exists():
         raise ValueError(f"Plugin directory not found: {plugin_dir}")
 
     full = load_plugin_full(plugin_dir)
 
+    # Filter dimensions and practices if -d was specified
+    if config.dimensions:
+        dim_set = set(config.dimensions)
+        full["dimensions"]["applies"] = [
+            d for d in full["dimensions"]["applies"]
+            if d["id"] in dim_set
+        ]
+        if "practices" in full["practices"]:
+            full["practices"]["practices"] = [
+                p for p in full["practices"]["practices"]
+                if p.get("dimension") in dim_set
+            ]
+
     findings = _run_detectors(full["detectors"], config.src, plugin_dir)
+
+    # Filter findings to requested dimensions so the judge only sees relevant ones
+    if config.dimensions:
+        dim_set_lower = {d.lower() for d in config.dimensions}
+        findings = [f for f in findings if f.dimension.lower() in dim_set_lower]
 
     # Count files read (files that had at least one finding)
     files_with_findings = {f.file for f in findings if f.file}
@@ -49,6 +76,9 @@ def run(config: RunConfig) -> Evidence:
     analysis_file = plugin_dir / "knowledge" / "analysis.md"
     analysis_md = analysis_file.read_text() if analysis_file.exists() else ""
 
+    ai_caller = config.ai_caller or run_ai_cli
+
+    # ── Pass 1: Judge triages detector findings ──────────────────────
     context = build_judge_context(
         findings=findings,
         practices=full["practices"],
@@ -58,19 +88,74 @@ def run(config: RunConfig) -> Evidence:
         src_dir=config.src,
     )
 
-    ai_caller = config.ai_caller or run_ai_cli
-    files_read = len(files_with_findings) or config.source_file_count
+    judge_judgments, judge_dismissed = _run_judge_pass(context, ai_caller)
 
-    return run_judge(
-        context=context,
+    # ── Pass 2: LLM reads actual source files ────────────────────────
+    extensions = set(full["plugin"].get("detects", {}).get("extensions", []))
+    sampled = sample_files(config.src, findings, extensions)
+
+    review_judgments, review_dismissed = run_code_review(
+        sampled_files=sampled,
+        practices=full["practices"],
+        analysis_md=analysis_md,
+        dimensions_config=full["dimensions"],
+        ai_caller=ai_caller,
+    )
+
+    # ── Merge and deduplicate ────────────────────────────────────────
+    all_judgments = _deduplicate(judge_judgments + review_judgments)
+    total_dismissed = judge_dismissed + review_dismissed
+
+    # Count files read: union of detector-hit files and sampled files
+    sampled_files_set = {sf.path for sf in sampled}
+    all_files_read = files_with_findings | sampled_files_set
+    files_read = len(all_files_read) or config.source_file_count
+
+    coverage_pct = (
+        round(files_read / config.source_file_count * 100, 1)
+        if config.source_file_count > 0 and files_read > 0
+        else 0.0
+    )
+
+    return _assemble_evidence(
+        judgments=all_judgments,
+        dismissed_count=total_dismissed,
         repository=str(config.src),
         plugin_id=config.plugin_id,
-        date_str=full["plugin"].get("version", ""),
+        date_str=_now_iso(),
         practices=full["practices"],
         source_file_count=config.source_file_count,
         files_read=files_read,
-        ai_caller=ai_caller,
+        coverage_pct=coverage_pct,
     )
+
+
+def _run_judge_pass(context: str, ai_caller) -> tuple[list[Judgment], int]:
+    """Run Pass 1: send context to judge LLM and parse JSONL."""
+    from codecompass.v2.engine.judge import _PROMPT_PATH
+
+    prompt_template = _PROMPT_PATH.read_text()
+    prompt = prompt_template.replace("{{CONTEXT}}", context)
+
+    stdout, error = ai_caller(prompt)
+    if error:
+        raise RuntimeError(f"Judge AI call failed: {error}")
+
+    return _parse_judge_output(stdout)
+
+
+def _deduplicate(judgments: list[Judgment]) -> list[Judgment]:
+    """Deduplicate judgments by (file, line, practice_id). Keep longer reason."""
+    seen: dict[tuple[str, int, str], Judgment] = {}
+    for j in judgments:
+        key = (j.file, j.line, j.practice_id)
+        if key in seen:
+            existing = seen[key]
+            if len(j.reason) > len(existing.reason):
+                seen[key] = j
+        else:
+            seen[key] = j
+    return list(seen.values())
 
 
 def _run_detectors(detectors_config: list, src: Path, plugin_dir: Path) -> list[Finding]:
@@ -152,5 +237,5 @@ def run_full(config: RunConfig, output_dir: Path, mode: str = "numerical") -> di
 
     evidence = run(config)
     scores = score_evidence(evidence, mode=mode)
-    write_reports(evidence, scores, output_dir)
+    write_reports(evidence, scores, output_dir, dimensions=config.dimensions)
     return scores

--- a/tests/test_action_provider_fs_evaluations.py
+++ b/tests/test_action_provider_fs_evaluations.py
@@ -103,7 +103,7 @@ def test_start_evaluation_uses_cli_module(tmp_path: Path) -> None:
         sys.executable,
         "-m",
         "codecompass.cli",
-        "evaluate",
+        "evaluate-v1",
         "--evaluations",
     ]
     assert captured["cmd"][5] == str(reports_dir)

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -35,7 +35,7 @@ def test_cli_dashboard_passes_subcommand_args(monkeypatch):
     result = __import__("codecompass.cli", fromlist=["main"]).main(["dashboard"])
 
     assert result == 0
-    assert captured["argv"] == []
+    assert captured["argv"] == ["--version", "v2"]
 
 
 def test_cli_evaluate_v1_single_repo_defaults_discipline(monkeypatch):

--- a/tests/test_dashboard_runner.py
+++ b/tests/test_dashboard_runner.py
@@ -54,6 +54,10 @@ def test_run_dashboard_invokes_node(tmp_path: Path, monkeypatch):
         "codecompass.dashboard.runner._ensure_action_api",
         lambda *_args, **_kwargs: ("http://127.0.0.1:8001", None),
     )
+    monkeypatch.setattr(
+        "codecompass.dashboard.runner._kill_stale_action_api",
+        lambda *_args, **_kwargs: None,
+    )
 
     config = DashboardConfig(
         port=4173,
@@ -87,6 +91,10 @@ def test_run_dashboard_creates_default_reports(tmp_path: Path, monkeypatch):
         "codecompass.dashboard.runner._ensure_action_api",
         lambda *_args, **_kwargs: ("http://127.0.0.1:8001", None),
     )
+    monkeypatch.setattr(
+        "codecompass.dashboard.runner._kill_stale_action_api",
+        lambda *_args, **_kwargs: None,
+    )
 
     reports_dir = tmp_path / "reports"
     config = DashboardConfig(
@@ -119,6 +127,7 @@ def test_run_dashboard_auto_picks_ui_port(monkeypatch, tmp_path):
     (tmp_path / "ui/server/node_modules").mkdir(parents=True)
 
     monkeypatch.setattr(runner, "_ensure_action_api", lambda *_args, **_kwargs: ("http://127.0.0.1:8001", None))
+    monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(runner, "_is_port_open", lambda host, port: port == 4173)
     monkeypatch.setattr(
         runner,

--- a/tests/v2/test_file_sampler.py
+++ b/tests/v2/test_file_sampler.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codecompass.v2.engine.file_sampler import sample_files, SampledFile
+from codecompass.v2.engine.finding import Finding
+
+
+def _make_source_tree(tmp_path: Path) -> Path:
+    """Create a source tree with various files."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("from flask import Flask\napp = Flask(__name__)\n\n@app.route('/')\ndef index():\n    return 'hello'\n")
+    (src / "config.py").write_text("SECRET_KEY = 'changeme'\nDEBUG = True\n")
+    (src / "utils.py").write_text("def helper():\n    pass\n")
+    (src / "main.py").write_text("if __name__ == '__main__':\n    print('hi')\n")
+
+    sub = src / "handlers"
+    sub.mkdir()
+    (sub / "auth.py").write_text("def login(user, password):\n    return True\n")
+    (sub / "api.py").write_text("def get_users():\n    return []\n")
+    (sub / "data.py").write_text("x = 1\n")
+
+    return src
+
+
+def test_sample_files_basic(tmp_path):
+    src = _make_source_tree(tmp_path)
+    findings = []
+    sampled = sample_files(src, findings, {".py"}, max_files=20)
+    assert len(sampled) > 0
+    assert all(isinstance(sf, SampledFile) for sf in sampled)
+
+
+def test_detector_finding_files_prioritized(tmp_path):
+    src = _make_source_tree(tmp_path)
+    findings = [
+        Finding(rule="r1", label="test", file=str(src / "utils.py"), dimension="security", detector="grep"),
+    ]
+    sampled = sample_files(src, findings, {".py"}, max_files=20)
+    paths = [sf.path for sf in sampled]
+    # utils.py should come first because it has a detector finding
+    assert paths[0] == "utils.py"
+    assert sampled[0].reason == "detector_finding"
+
+
+def test_high_risk_names_selected(tmp_path):
+    src = _make_source_tree(tmp_path)
+    sampled = sample_files(src, [], {".py"}, max_files=20)
+    reasons = {sf.path: sf.reason for sf in sampled}
+    assert reasons.get("config.py") == "high_risk_name"
+    assert reasons.get("handlers/auth.py") == "high_risk_name"
+    assert reasons.get("handlers/api.py") == "high_risk_name"
+
+
+def test_entry_points_detected(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    # Use names that are NOT in _HIGH_RISK_NAMES so they get classified as entry_point
+    (src / "cli.py").write_text("if __name__ == '__main__':\n    print('hi')\n")
+    (src / "web.py").write_text("from flask import Flask\napp = Flask(__name__)\n")
+    (src / "utils.py").write_text("def helper():\n    pass\n")
+
+    sampled = sample_files(src, [], {".py"}, max_files=20)
+    entry_files = [sf.path for sf in sampled if sf.reason == "entry_point"]
+    assert "cli.py" in entry_files or "web.py" in entry_files
+
+
+def test_max_files_limit(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    for i in range(30):
+        (src / f"mod_{i}.py").write_text(f"x = {i}\n")
+    sampled = sample_files(src, [], {".py"}, max_files=5)
+    assert len(sampled) == 5
+
+
+def test_truncation(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    long_content = "\n".join(f"line {i}" for i in range(600))
+    (src / "big.py").write_text(long_content)
+    sampled = sample_files(src, [], {".py"}, max_files=5, max_lines=100)
+    assert len(sampled) == 1
+    assert sampled[0].truncated is True
+    assert sampled[0].lines == 600
+    assert "truncated" in sampled[0].content
+
+
+def test_skip_dirs(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "good.py").write_text("x = 1\n")
+    venv = src / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "bad.py").write_text("y = 2\n")
+    node = src / "node_modules" / "pkg"
+    node.mkdir(parents=True)
+    (node / "index.py").write_text("z = 3\n")
+
+    sampled = sample_files(src, [], {".py"}, max_files=20)
+    paths = [sf.path for sf in sampled]
+    assert "good.py" in paths
+    assert not any(".venv" in p for p in paths)
+    assert not any("node_modules" in p for p in paths)
+
+
+def test_extension_filter(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "app.py").write_text("x = 1\n")
+    (src / "app.js").write_text("x = 1;\n")
+    (src / "readme.md").write_text("# hi\n")
+
+    sampled = sample_files(src, [], {".py"}, max_files=20)
+    paths = [sf.path for sf in sampled]
+    assert "app.py" in paths
+    assert "app.js" not in paths
+    assert "readme.md" not in paths
+
+
+def test_empty_src(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    sampled = sample_files(src, [], {".py"}, max_files=20)
+    assert sampled == []
+
+
+def test_finding_with_relative_path(tmp_path):
+    src = _make_source_tree(tmp_path)
+    # Finding with absolute path that should be resolved relative to src
+    findings = [
+        Finding(rule="r1", label="test", file=str(src / "utils.py"), dimension="security", detector="grep"),
+    ]
+    sampled = sample_files(src, findings, {".py"}, max_files=20)
+    detector_files = [sf for sf in sampled if sf.reason == "detector_finding"]
+    assert len(detector_files) == 1
+    assert detector_files[0].path == "utils.py"

--- a/tests/v2/test_reviewer.py
+++ b/tests/v2/test_reviewer.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codecompass.v2.engine.reviewer import run_code_review, _build_batch_context, _make_batches
+from codecompass.v2.engine.file_sampler import SampledFile
+from codecompass.v2.engine.evidence import Judgment
+
+
+def _sample_practices():
+    return {
+        "runtime": "python",
+        "version": "1.0.0",
+        "practices": [
+            {
+                "id": "py-003",
+                "title": "Avoid os.system and shell=True",
+                "cwe": 78,
+                "dimension": "security",
+                "severity": "high",
+                "bad": "os.system(f'rm {path}')",
+                "good": "subprocess.run(['rm', path])",
+                "explanation": "Shell injection risk",
+            },
+            {
+                "id": "py-010",
+                "title": "Use parameterized queries",
+                "cwe": 89,
+                "dimension": "security",
+                "severity": "critical",
+                "bad": "cursor.execute(f'SELECT * FROM users WHERE id={uid}')",
+                "good": "cursor.execute('SELECT * FROM users WHERE id=?', (uid,))",
+                "explanation": "SQL injection risk",
+            },
+        ],
+    }
+
+
+def _sample_files():
+    return [
+        SampledFile(
+            path="src/app.py",
+            content="import os\n\ndef run(cmd):\n    os.system(cmd)\n",
+            lines=4,
+            reason="high_risk_name",
+            truncated=False,
+        ),
+        SampledFile(
+            path="src/db.py",
+            content="import sqlite3\n\ndef get_user(uid):\n    c.execute(f'SELECT * FROM users WHERE id={uid}')\n",
+            lines=4,
+            reason="high_risk_name",
+            truncated=False,
+        ),
+    ]
+
+
+# ── Batching ────────────────────────────────────────────────────────
+
+def test_make_batches():
+    files = _sample_files()
+    batches = _make_batches(files, batch_size=1)
+    assert len(batches) == 2
+    assert len(batches[0]) == 1
+    assert len(batches[1]) == 1
+
+
+def test_make_batches_single():
+    files = _sample_files()
+    batches = _make_batches(files, batch_size=5)
+    assert len(batches) == 1
+    assert len(batches[0]) == 2
+
+
+# ── Context building ────────────────────────────────────────────────
+
+def test_build_batch_context():
+    ctx = _build_batch_context(
+        batch=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="Look for injection.",
+        dimensions_config={"applies": [{"id": "security", "weight": 1.2}]},
+        batch_num=1,
+        total_batches=2,
+    )
+    assert "Batch 1 of 2" in ctx
+    assert "py-003" in ctx
+    assert "src/app.py" in ctx
+    assert "src/db.py" in ctx
+    assert "Look for injection" in ctx
+
+
+# ── Code review with mock AI ────────────────────────────────────────
+
+def test_run_code_review_basic():
+    mock_output = "\n".join([
+        json.dumps({
+            "practice_id": "py-003",
+            "verdict": "violation",
+            "file": "src/app.py",
+            "line": 4,
+            "snippet": "os.system(cmd)",
+            "severity": "high",
+            "reason": "Direct shell execution",
+            "dimension": "security",
+            "source": "code_review",
+        }),
+        json.dumps({
+            "practice_id": "py-010",
+            "verdict": "violation",
+            "file": "src/db.py",
+            "line": 4,
+            "snippet": "c.execute(f'SELECT...')",
+            "severity": "critical",
+            "reason": "SQL injection via f-string",
+            "dimension": "security",
+            "source": "code_review",
+        }),
+    ])
+
+    def mock_ai(prompt):
+        return (mock_output, None)
+
+    judgments, dismissed = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+    )
+    assert len(judgments) == 2
+    assert judgments[0].practice_id == "py-003"
+    assert judgments[1].practice_id == "py-010"
+    assert dismissed == 0
+
+
+def test_run_code_review_with_dismissed():
+    mock_output = json.dumps({
+        "practice_id": "py-003",
+        "verdict": "dismissed",
+    })
+
+    def mock_ai(prompt):
+        return (mock_output, None)
+
+    judgments, dismissed = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+    )
+    assert len(judgments) == 0
+    assert dismissed == 1
+
+
+def test_run_code_review_empty_files():
+    judgments, dismissed = run_code_review(
+        sampled_files=[],
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+    )
+    assert judgments == []
+    assert dismissed == 0
+
+
+def test_run_code_review_ai_error_graceful():
+    """AI errors on a batch should be skipped gracefully."""
+    def mock_ai(prompt):
+        return ("", "API error")
+
+    judgments, dismissed = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+    )
+    assert judgments == []
+    assert dismissed == 0
+
+
+def test_run_code_review_ai_exception_graceful():
+    """AI exceptions should be caught per batch."""
+    def mock_ai(prompt):
+        raise ConnectionError("network down")
+
+    judgments, dismissed = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+    )
+    assert judgments == []
+    assert dismissed == 0
+
+
+def test_run_code_review_multiple_batches():
+    """Each batch gets its own AI call."""
+    call_count = 0
+    mock_output = json.dumps({
+        "practice_id": "py-003",
+        "verdict": "compliance",
+        "file": "src/app.py",
+        "line": 1,
+        "reason": "Good pattern",
+        "source": "code_review",
+    })
+
+    def mock_ai(prompt):
+        nonlocal call_count
+        call_count += 1
+        return (mock_output, None)
+
+    judgments, _ = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+        batch_size=1,
+    )
+    assert call_count == 2
+    assert len(judgments) == 2
+
+
+def test_finding_rule_tagged():
+    """Judgments from reviewer should have finding_rule = 'code_review'."""
+    mock_output = json.dumps({
+        "practice_id": "py-003",
+        "verdict": "violation",
+        "file": "src/app.py",
+        "line": 4,
+        "reason": "bad",
+    })
+
+    def mock_ai(prompt):
+        return (mock_output, None)
+
+    judgments, _ = run_code_review(
+        sampled_files=_sample_files(),
+        practices=_sample_practices(),
+        analysis_md="",
+        dimensions_config={"applies": []},
+        ai_caller=mock_ai,
+    )
+    assert judgments[0].finding_rule == "code_review"

--- a/tests/v2/test_runner.py
+++ b/tests/v2/test_runner.py
@@ -123,7 +123,11 @@ def test_empty_project(tmp_path):
         ai_caller=mock_ai,
     )
     evidence = run(config)
-    assert evidence.principles == {}
+    # Practices are seeded even when the judge returns nothing
+    for pe in evidence.principles.values():
+        assert pe.violations == []
+        assert pe.compliance == []
+        assert pe.metrics.get("no_evidence") is True
 
 
 def test_unknown_plugin_error(tmp_path):

--- a/tests/v2/test_v2_report.py
+++ b/tests/v2/test_v2_report.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from codecompass.v2.engine.evidence import Evidence, PrincipleEvidence
-from codecompass.v2.engine.report import build_v2_report, build_v1_compatible_report, write_reports
+from codecompass.v2.engine.report import build_report, write_reports
 from codecompass.v2.engine.scoring import score_evidence
 
 
@@ -41,22 +41,10 @@ def _make_evidence() -> Evidence:
     )
 
 
-def test_v2_report_extra_fields():
+def test_report_shape():
     ev = _make_evidence()
     scores = score_evidence(ev)
-    report = build_v2_report(ev, scores)
-    assert report["engine_version"] == "2.0.0"
-    assert report["dismissed_count"] == 2
-    assert "evidence_summary" in report
-    assert report["evidence_summary"]["dismissed_count"] == 2
-
-
-def test_v1_shape_match():
-    ev = _make_evidence()
-    scores = score_evidence(ev)
-    report = build_v1_compatible_report(ev, scores)
-    assert "engine_version" not in report
-    assert "dismissed_count" not in report
+    report = build_report(ev, scores)
     assert "dimension" in report
     assert "principles" in report
     assert "violations" in report
@@ -67,22 +55,24 @@ def test_file_writing(tmp_path):
     scores = score_evidence(ev)
     write_reports(ev, scores, tmp_path)
 
-    v2_file = tmp_path / "typescript_v2.json"
-    v1_file = tmp_path / "typescript.json"
-    assert v2_file.exists()
-    assert v1_file.exists()
+    eval_file = tmp_path / "evaluation" / "security.json"
+    evidence_file = tmp_path / "evidence" / "security_evidence.json"
+    assert eval_file.exists()
+    assert evidence_file.exists()
 
-    v2_data = json.loads(v2_file.read_text())
-    v1_data = json.loads(v1_file.read_text())
+    eval_data = json.loads(eval_file.read_text())
+    assert eval_data["dimension"] == "security"
+    assert len(eval_data["principles"]) == 1
 
-    assert v2_data["engine_version"] == "2.0.0"
-    assert "engine_version" not in v1_data
+    ev_data = json.loads(evidence_file.read_text())
+    assert "principles" in ev_data
+    assert "ts-001" in ev_data["principles"]
 
 
 def test_violations_structure():
     ev = _make_evidence()
     scores = score_evidence(ev)
-    report = build_v2_report(ev, scores)
+    report = build_report(ev, scores)
     assert len(report["violations"]) == 1
     assert report["violations"][0]["principle"] == "Avoid eval()"
     assert report["violations"][0]["file"] == "a.ts"

--- a/ui/server/src/app.js
+++ b/ui/server/src/app.js
@@ -12,12 +12,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const defaultRepoRoot = path.resolve(__dirname, '../../..');
 const defaultReportsRoot = path.resolve(defaultRepoRoot, 'evaluations');
 
-function resolveEvaluateCommand(repoRoot) {
+function resolveEvaluateCommand(repoRoot, version = 'v1') {
+  const subcommand = version === 'v2' ? 'evaluate' : 'evaluate-v1';
   const venvCommand = path.resolve(repoRoot, '.venv', 'bin', 'codecompass');
   if (fs.existsSync(venvCommand)) {
-    return [venvCommand, 'evaluate'];
+    return [venvCommand, subcommand];
   }
-  return ['uv', 'run', 'codecompass', 'evaluate'];
+  return ['uv', 'run', 'codecompass', subcommand];
 }
 
 function parseCommand(value) {
@@ -48,6 +49,31 @@ export async function proxyToActionApi(req, res, actionApiBase) {
   }
 }
 
+const V1_DIMENSIONS = [
+  { name: 'Affordability',   code: 'affordability' },
+  { name: 'Availability',    code: 'availability' },
+  { name: 'Configurability', code: 'configurability' },
+  { name: 'Efficiency',      code: 'efficiency' },
+  { name: 'Evolvability',    code: 'evolvability' },
+  { name: 'Extensibility',   code: 'extensibility' },
+  { name: 'Flexibility',     code: 'flexibility' },
+  { name: 'Maintainability', code: 'maintainability' },
+  { name: 'Performance',     code: 'performance' },
+  { name: 'Recoverability',  code: 'recoverability' },
+  { name: 'Resilience',      code: 'resilience' },
+  { name: 'Robustness',      code: 'robustness' },
+  { name: 'Scalability',     code: 'scalability' },
+  { name: 'Simplicity',      code: 'simplicity' },
+  { name: 'Usability',       code: 'usability' },
+];
+
+const V2_DIMENSIONS = [
+  { name: 'Maintainability', code: 'maintainability' },
+  { name: 'Reliability',     code: 'reliability' },
+  { name: 'Security',        code: 'security' },
+  { name: 'Performance',     code: 'performance' },
+];
+
 export function createApp(options = {}) {
   const app = express();
 
@@ -55,39 +81,50 @@ export function createApp(options = {}) {
   const repoRoot = options.repoRoot ?? defaultRepoRoot;
   const staticDistPath = options.staticDistPath ?? options.staticDist ?? null;
   const actionApiBase = options.actionApiBase ?? process.env.CODECOMPASS_ACTION_API ?? null;
+  const version = options.version ?? process.env.CODECOMPASS_VERSION ?? 'v1';
 
   const evaluateCommand =
     options.evaluateCommand ??
     parseCommand(process.env.CODECOMPASS_EVALUATE_CMD) ??
-    resolveEvaluateCommand(repoRoot);
+    resolveEvaluateCommand(repoRoot, version);
 
   const jobManager =
     options.jobManager ??
-    createJobManager({ repoRoot, reportsRoot, evaluateCommand });
+    createJobManager({ repoRoot, reportsRoot, evaluateCommand, version });
 
   app.use(cors());
   app.use(express.json({ limit: '1mb' }));
 
+  // Config endpoint — always served locally
+  app.get('/api/config', (_req, res) => {
+    res.json({
+      version,
+      dimensions: version === 'v2' ? V2_DIMENSIONS : V1_DIMENSIONS,
+    });
+  });
+
+  // Node-handled routes — always registered (data lives on local filesystem)
+  app.get('/api/projects/:project/info', (req, res) => {
+    try {
+      const infoPath = path.join(reportsRoot, req.params.project, 'repository_info.json');
+      const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+      res.json(info);
+    } catch {
+      res.status(404).json({ error: 'Repository info not found' });
+    }
+  });
+
+  app.get('/api/health', (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/api', createProjectsRouter({ reportsRoot }));
+  app.use('/api', createEvaluationsRouter({ jobManager }));
+  app.use('/api', createBrowseRouter());
+
+  // Proxy remaining /api/* to Python action API when available
   if (actionApiBase) {
     app.use('/api', (req, res) => proxyToActionApi(req, res, actionApiBase));
-  } else {
-    app.get('/api/projects/:project/info', (req, res) => {
-      try {
-        const infoPath = path.join(reportsRoot, req.params.project, 'repository_info.json');
-        const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
-        res.json(info);
-      } catch {
-        res.status(404).json({ error: 'Repository info not found' });
-      }
-    });
-
-    app.get('/api/health', (_req, res) => {
-      res.json({ ok: true });
-    });
-
-    app.use('/api', createProjectsRouter({ reportsRoot }));
-    app.use('/api', createEvaluationsRouter({ jobManager }));
-    app.use('/api', createBrowseRouter());
   }
 
   if (staticDistPath) {

--- a/ui/server/src/jobs/evaluationJobs.js
+++ b/ui/server/src/jobs/evaluationJobs.js
@@ -14,7 +14,7 @@ function parseDimensions(raw) {
   return String(raw).split(',').map((d) => d.trim()).filter(Boolean);
 }
 
-function buildArgs(payload, reportsRoot) {
+function buildArgsV1(payload, reportsRoot) {
   const result = [];
   const dims = parseDimensions(payload.dimensions);
 
@@ -29,6 +29,22 @@ function buildArgs(payload, reportsRoot) {
   }
   if (payload.discipline && String(payload.discipline).trim()) {
     result.push(String(payload.discipline).trim());
+  }
+  result.push(String(payload.repo).trim());
+  return result;
+}
+
+function buildArgsV2(payload, reportsRoot) {
+  const result = [];
+  if (payload.discipline && String(payload.discipline).trim()) {
+    result.push('-p', String(payload.discipline).trim());
+  }
+  const dims = parseDimensions(payload.dimensions);
+  if (dims.length > 0) {
+    result.push('-d', dims.join(','));
+  }
+  if (reportsRoot) {
+    result.push('-o', String(reportsRoot));
   }
   result.push(String(payload.repo).trim());
   return result;
@@ -53,10 +69,11 @@ function tryExtractReportPath(record, raw) {
 }
 
 function snapshot(record) {
-  return { ...record, logs: record.logs.slice() };
+  const { _proc, ...rest } = record;
+  return { ...rest, logs: record.logs.slice() };
 }
 
-export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, spawnImpl = spawn } = {}) {
+export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, version = 'v1', spawnImpl = spawn } = {}) {
   const registry = new Map();
   let activeId = null;
 
@@ -86,6 +103,7 @@ export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, spawn
     }
 
     const jobId = randomUUID();
+    const buildArgs = version === 'v2' ? buildArgsV2 : buildArgsV1;
     const extraArgs = buildArgs(payload, reportsRoot);
     const fullCmd = [...cmdBase, ...extraArgs];
 
@@ -99,16 +117,24 @@ export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, spawn
       exitCode: null,
       outputProject: null,
       outputRunId: null,
-      logs: []
+      logs: [],
+      _proc: null
     };
 
     registry.set(jobId, record);
     activeId = jobId;
 
+    // Remove CLAUDECODE to allow nested claude --print calls in the AI judge
+    const childEnv = { ...process.env };
+    delete childEnv.CLAUDECODE;
+    childEnv.PYTHONUNBUFFERED = '1';
+
     const proc = spawnImpl(fullCmd[0], fullCmd.slice(1), {
       cwd: repoRoot,
-      env: process.env
+      env: childEnv
     });
+
+    record._proc = proc;
 
     proc.stdout?.on('data', (chunk) => {
       ingestChunk(record, chunk);
@@ -125,6 +151,7 @@ export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, spawn
       record.status = 'failed';
       record.exitCode = -1;
       record.endedAt = new Date().toISOString();
+      record._proc = null;
       if (activeId === jobId) activeId = null;
     });
 
@@ -132,11 +159,25 @@ export function createJobManager({ repoRoot, reportsRoot, evaluateCommand, spawn
       record.exitCode = code;
       record.status = code === 0 ? 'completed' : 'failed';
       record.endedAt = new Date().toISOString();
+      record._proc = null;
       if (activeId === jobId) activeId = null;
     });
 
     return getJob(jobId);
   }
 
-  return { startJob, getJob };
+  function cancelJob(jobId) {
+    const rec = registry.get(jobId);
+    if (!rec || rec.status !== 'running') return false;
+    if (rec._proc) {
+      rec._proc.kill('SIGTERM');
+    }
+    rec.status = 'cancelled';
+    rec.endedAt = new Date().toISOString();
+    rec._proc = null;
+    if (activeId === jobId) activeId = null;
+    return true;
+  }
+
+  return { startJob, getJob, cancelJob };
 }

--- a/ui/server/src/parsers/reportParser.js
+++ b/ui/server/src/parsers/reportParser.js
@@ -10,6 +10,13 @@ import nodePath from 'node:path';
 const NUMERIC_SCALE = ['Critical', 'Poor', 'Adequate', 'Good', 'Exemplary'];
 const TEXT_SCALE = ['Insufficient', 'Developing', 'Proficient', 'Exemplary'];
 const KNOWN_SEVERITIES = ['critical', 'major', 'minor'];
+const SEVERITY_ALIASES = { high: 'critical', medium: 'major', low: 'minor' };
+
+function normalizeSeverity(raw) {
+  const s = (raw || '').toLowerCase();
+  if (KNOWN_SEVERITIES.includes(s)) return s;
+  return SEVERITY_ALIASES[s] || 'unknown';
+}
 
 // ---------------------------------------------------------------------------
 // Low-level filesystem helpers
@@ -368,7 +375,7 @@ function dimensionNameFromEvidencePath(evidencePath) {
 function buildTotals(vios, compls) {
   const sev = { critical: 0, major: 0, minor: 0, unknown: 0 };
   for (const v of vios) {
-    const k = KNOWN_SEVERITIES.includes(v.severity) ? v.severity : 'unknown';
+    const k = normalizeSeverity(v.severity);
     sev[k] += 1;
   }
   return {
@@ -407,6 +414,7 @@ function readReportJson(jsonPath) {
 
   return {
     dimension: data.dimension ?? null,
+    date: data.date ?? null,
     overallScore: data.overallScore ?? null,
     overallGrade: data.overallGrade ?? null,
     principles: (data.principles ?? []).map((p) => ({
@@ -420,7 +428,7 @@ function readReportJson(jsonPath) {
       file: v.file ?? null,
       line: v.line ?? null,
       reason: v.reason ?? null,
-      severity: v.severity ?? 'minor',
+      severity: normalizeSeverity(v.severity),
       snippet: v.snippet ?? null
     })),
     compliance: (data.compliance ?? []).map((c) => ({
@@ -472,12 +480,17 @@ function loadRunDimensions(reportsRoot, project, runId) {
   const evalDir = nodePath.join(runDir, 'evaluation');
   const evidenceDir = nodePath.join(runDir, 'evidence');
 
-  const evalEntries = readdirSafe(evalDir, { withFileTypes: true })
-    .filter((e) => e.isFile() && e.name.endsWith('_eval.md'));
+  const allFiles = readdirSafe(evalDir, { withFileTypes: true })
+    .filter((e) => e.isFile());
 
-  const dimData = evalEntries
+  const mdEntries = allFiles.filter((e) => e.name.endsWith('_eval.md'));
+  const seenDims = new Set();
+
+  // v1: discover from _eval.md files, preferring .json when both exist
+  const dimData = mdEntries
     .map((entry) => {
       const dimName = entry.name.slice(0, -8); // strip _eval.md
+      seenDims.add(dimName);
       const jsonFile = nodePath.join(evalDir, `${dimName}.json`);
       if (fsSync.existsSync(jsonFile)) {
         return readReportJson(jsonFile);
@@ -485,6 +498,15 @@ function loadRunDimensions(reportsRoot, project, runId) {
       return readEvalFile(nodePath.join(evalDir, entry.name));
     })
     .filter(Boolean);
+
+  // v2: discover standalone .json files not already covered by _eval.md
+  for (const entry of allFiles) {
+    if (!entry.name.endsWith('.json') || entry.name.endsWith('_v2.json')) continue;
+    const dimName = entry.name.slice(0, -5); // strip .json
+    if (seenDims.has(dimName)) continue;
+    const parsed = readReportJson(nodePath.join(evalDir, entry.name));
+    if (parsed) dimData.push(parsed);
+  }
 
   // Build evidence map keyed by dimension name
   const evidenceMap = new Map(
@@ -564,9 +586,9 @@ function precedingDimension(reportsRoot, project, beforeRunId, dimensionName) {
   const projectDir = nodePath.join(reportsRoot, project);
   if (!fsSync.existsSync(projectDir)) return null;
 
-  const olderRuns = fsSync.readdirSync(projectDir)
-    .filter((name) => /^\d{8}$/.test(name) && name < beforeRunId)
-    .sort((a, b) => b.localeCompare(a));
+  const allRuns = listRuns(reportsRoot, project);
+  const idx = allRuns.findIndex((r) => r.runId === beforeRunId);
+  const olderRuns = idx >= 0 ? allRuns.slice(idx + 1).map((r) => r.runId) : [];
 
   for (const runId of olderRuns) {
     const dims = loadRunDimensions(reportsRoot, project, runId);
@@ -589,11 +611,17 @@ export function listRuns(reportsRoot, project) {
   const entries = readdirSafe(projectDir, { withFileTypes: true })
     .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
     .map((e) => {
+      // Try YYYYMMDD directory name first (v1 convention)
       const parsed = runIdToDate(e.name);
+      if (parsed) {
+        return { runId: e.name, dateISO: parsed.iso, dateLabel: parsed.label };
+      }
+      // Fall back to reading date from the first evaluation JSON (v2 convention)
+      const dateFromFile = readRunDate(projectDir, e.name);
       return {
         runId: e.name,
-        dateISO: parsed?.iso ?? null,
-        dateLabel: parsed?.label ?? e.name
+        dateISO: dateFromFile?.iso ?? null,
+        dateLabel: dateFromFile?.label ?? e.name
       };
     });
 
@@ -607,6 +635,32 @@ export function listRuns(reportsRoot, project) {
   });
 
   return entries;
+}
+
+/**
+ * Read the date from the first evaluation JSON in a run directory.
+ * Returns { iso, label } or null.
+ */
+function readRunDate(projectDir, runId) {
+  const evalDir = nodePath.join(projectDir, runId, 'evaluation');
+  const files = readdirSafe(evalDir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.json'));
+  for (const f of files) {
+    try {
+      const data = JSON.parse(fsSync.readFileSync(nodePath.join(evalDir, f.name), 'utf-8'));
+      if (data.date) {
+        const dt = new Date(data.date);
+        if (!Number.isNaN(dt.getTime())) {
+          const iso = dt.toISOString().slice(0, 10);
+          const label = dt.toLocaleDateString('en-US', {
+            year: 'numeric', month: 'short', day: '2-digit', timeZone: 'UTC'
+          });
+          return { iso, label };
+        }
+      }
+    } catch { /* skip unreadable files */ }
+  }
+  return null;
 }
 
 /**
@@ -768,7 +822,7 @@ export function buildAccumulatedData(reportsRoot, project, asOfRun = null) {
   if (!fsSync.existsSync(projectDir)) return null;
 
   let runIds = fsSync.readdirSync(projectDir)
-    .filter((name) => /^\d{8}$/.test(name))
+    .filter((name) => !name.startsWith('.') && fsSync.statSync(nodePath.join(projectDir, name)).isDirectory())
     .sort((a, b) => b.localeCompare(a)); // newest first
 
   if (asOfRun) {

--- a/ui/server/src/routes/evaluations.js
+++ b/ui/server/src/routes/evaluations.js
@@ -31,5 +31,14 @@ export function createEvaluationsRouter({ jobManager }) {
     res.json(job);
   });
 
+  router.delete('/evaluations/:jobId', (req, res) => {
+    const cancelled = jobManager.cancelJob(req.params.jobId);
+    if (!cancelled) {
+      res.status(404).json({ error: 'Job not found or not running' });
+      return;
+    }
+    res.json({ ok: true });
+  });
+
   return router;
 }

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { listProjects, getAiClients } from './api/index.js';
+import { listProjects, getAiClients, getConfig } from './api/index.js';
 import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import RunNavigator from './features/dashboard/components/RunNavigator.jsx';
@@ -130,6 +130,13 @@ export default function App() {
   const [projects, setProjects] = useState([]);
   const [selectedProject, setSelectedProject] = useState('');
   const [selectedRun, setSelectedRun] = useState('latest');
+  const [appConfig, setAppConfig] = useState(null);
+
+  useEffect(() => {
+    getConfig()
+      .then(setAppConfig)
+      .catch(() => {});
+  }, []);
 
   function loadProjects() {
     listProjects()
@@ -449,6 +456,7 @@ export default function App() {
                   project={selectedProject}
                   onStart={handleStartEvaluation}
                   disabled={false}
+                  dimensionOptions={appConfig?.dimensions}
                 />
               )}
 
@@ -457,7 +465,7 @@ export default function App() {
                   <div className="panel-header">
                     <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
                   </div>
-                  <EvaluationForm onStart={handleStartEvaluation} disabled={false} />
+                  <EvaluationForm onStart={handleStartEvaluation} disabled={false} dimensionOptions={appConfig?.dimensions} />
                 </div>
               )}
 
@@ -648,6 +656,9 @@ export default function App() {
         <div className="sidebar-header">
           <div className="sidebar-brand-icon">CC</div>
           <span className="sidebar-brand-text">CodeCompass</span>
+          {appConfig?.version && (
+            <span className="sidebar-version-badge">{appConfig.version}</span>
+          )}
         </div>
 
         <nav className="sidebar-nav">

--- a/ui/web/src/api/index.js
+++ b/ui/web/src/api/index.js
@@ -18,6 +18,10 @@ async function request(path, options = {}) {
   return payload;
 }
 
+export function getConfig() {
+  return request('/config');
+}
+
 export function listProjects() {
   return request('/projects');
 }

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import FolderBrowser from './FolderBrowser.jsx';
 import { DIMENSION_OPTIONS } from '../constants.js';
 
-export default function EvaluationForm({ onStart, disabled }) {
+export default function EvaluationForm({ onStart, disabled, dimensionOptions }) {
+  const dims = dimensionOptions || DIMENSION_OPTIONS;
   const [repo, setRepo] = useState('');
   const [selectedDimensions, setSelectedDimensions] = useState([]);
   const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
@@ -77,7 +78,7 @@ export default function EvaluationForm({ onStart, disabled }) {
                 <button
                   type="button"
                   className="dim-action-btn"
-                  onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.map((d) => d.code))}
+                  onClick={() => setSelectedDimensions(dims.map((d) => d.code))}
                 >
                   Select all
                 </button>
@@ -91,7 +92,7 @@ export default function EvaluationForm({ onStart, disabled }) {
               </div>
             </div>
             <div className="dimension-grid">
-              {DIMENSION_OPTIONS.map((dim) => (
+              {dims.map((dim) => (
                 <button
                   key={dim.code}
                   type="button"

--- a/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { getProjectInfo } from '../../../api/index.js';
 import { DIMENSION_OPTIONS } from '../constants.js';
 
-export default function ReEvaluateCard({ project, onStart, disabled }) {
+export default function ReEvaluateCard({ project, onStart, disabled, dimensionOptions }) {
+  const dims = dimensionOptions || DIMENSION_OPTIONS;
   const [info, setInfo] = useState(null);
   const [selectedDimensions, setSelectedDimensions] = useState([]);
 
@@ -28,6 +29,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
   function handleStart() {
     onStart({
       repo: info.path,
+      discipline: info.discipline || '',
       dimensions: selectedDimensions.join(','),
       numerical: true,
     });
@@ -54,7 +56,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
               <button
                 type="button"
                 className="dim-action-btn"
-                onClick={() => setSelectedDimensions(DIMENSION_OPTIONS.filter((d) => !hasFilter || available.has(d.code)).map((d) => d.code))}
+                onClick={() => setSelectedDimensions(dims.filter((d) => !hasFilter || available.has(d.code)).map((d) => d.code))}
               >
                 Select all
               </button>
@@ -68,7 +70,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
             </div>
           </div>
           <div className="dimension-grid">
-            {DIMENSION_OPTIONS.map((dim) => {
+            {dims.map((dim) => {
               const enabled = !hasFilter || available.has(dim.code);
               return (
                 <button

--- a/ui/web/src/features/evaluation/constants.js
+++ b/ui/web/src/features/evaluation/constants.js
@@ -15,3 +15,10 @@ export const DIMENSION_OPTIONS = [
   { name: 'Simplicity',      code: 'simplicity' },
   { name: 'Usability',       code: 'usability' },
 ];
+
+export const V2_DIMENSION_OPTIONS = [
+  { name: 'Maintainability', code: 'maintainability' },
+  { name: 'Reliability',     code: 'reliability' },
+  { name: 'Security',        code: 'security' },
+  { name: 'Performance',     code: 'performance' },
+];

--- a/ui/web/src/features/evaluation/hooks/useEvaluation.js
+++ b/ui/web/src/features/evaluation/hooks/useEvaluation.js
@@ -92,6 +92,7 @@ export function useEvaluation() {
         }
       } catch (err) {
         setJobError(err.message);
+        setJob((prev) => prev ? { ...prev, status: 'failed' } : prev);
         stopPolling();
         stopDimensionPolling();
       }


### PR DESCRIPTION
## Summary
- Split dashboard into v2 (default) and v1 (legacy) modes with version-aware CLI routing and environment propagation
- Add dimension filtering (`-d`) to v2 evaluate command, run-ID based output directories, and auto-generated `repository_info.json`
- Introduce file sampler and LLM-based reviewer modules for the v2 engine
- Normalize severity levels in reports, handle no-evidence cases in scoring, seed all known practices in judge
- Update scan_rules.ini with directory exclusions and new CWE rules
- Wire v2 evaluation support through UI server, jobs, parser, and frontend components

## Test plan
- [ ] Verify `codecompass dashboard` launches v2 mode by default
- [ ] Verify `codecompass dashboard-v1` launches legacy mode
- [ ] Test `codecompass evaluate -d maintainability,security <repo>` filters dimensions correctly
- [ ] Confirm run output lands in `<reports>/<project>/<run_id>/` structure
- [ ] Run existing test suite (`pytest tests/`)
- [ ] Verify UI evaluation form and re-evaluate card work with v2 backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)