### PR TITLE
Migrate hardcoded colors to design token system

### DIFF
--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -31,19 +31,19 @@ const GRADE_VAR = {
 };
 
 function gradeBarColor(grade) {
-  if (!grade) return cssVar('--color-accent', '#e8795a');
+  if (!grade) return cssVar('--color-accent');
   const key = grade.trim().toLowerCase();
   const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
-  return varName ? cssVar(varName, '#e8795a') : cssVar('--color-accent', '#e8795a');
+  return varName ? cssVar(varName) : cssVar('--color-accent');
 }
 
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
 const TREND_COLOR = {
-  up:         '#5ee6a0',
-  'soft-up':  '#92c9a8',
-  same:       '#94a3b8',
-  'soft-down':'#c8956c',
-  down:       '#f09070',
+  up:         cssVar('--color-trend-up'),
+  'soft-up':  cssVar('--color-trend-soft-up'),
+  same:       cssVar('--color-text-muted'),
+  'soft-down':cssVar('--color-trend-soft-down'),
+  down:       cssVar('--color-trend-down'),
 };
 
 // Shortcodes mirror src/codecompass/config/dimensions.py
@@ -129,11 +129,11 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
       </div>
       <ResponsiveContainer width="100%" height={160}>
         <BarChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
-          <CartesianGrid vertical={false} stroke={cssVar('--color-border', '#383532')} />
+          <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
           <XAxis
             dataKey="dimension"
             tickFormatter={dimCode}
-            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             interval={0}
             axisLine={false}
             tickLine={false}
@@ -141,14 +141,14 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
           <YAxis
             domain={[0, 10]}
             ticks={[0, 2.5, 5, 7.5, 10]}
-            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             axisLine={false}
             tickLine={false}
           />
           <Tooltip content={DimensionTooltip} cursor={false} isAnimationActive={false} />
-          <ReferenceLine y={2.5} stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.15} />
-          <ReferenceLine y={5}   stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.3} />
-          <ReferenceLine y={7.5} stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <ReferenceLine y={2.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <ReferenceLine y={5}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.3} />
+          <ReferenceLine y={7.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
           <Bar
             dataKey="numericScore"
             radius={[3, 3, 0, 0]}

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -32,20 +32,20 @@ const GRADE_VAR = {
 };
 
 function gradeBarColor(grade) {
-  if (!grade) return cssVar('--color-accent', '#e8795a');
+  if (!grade) return cssVar('--color-accent');
   const key = grade.trim().toLowerCase();
   const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
-  return varName ? cssVar(varName, '#e8795a') : cssVar('--color-accent', '#e8795a');
+  return varName ? cssVar(varName) : cssVar('--color-accent');
 }
 
 // Trend direction — mirrors the logic in TrendBadge
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
 const TREND_COLOR = {
-  up:         '#5ee6a0',
-  'soft-up':  '#92c9a8',
-  same:       '#94a3b8',
-  'soft-down':'#c8956c',
-  down:       '#f09070',
+  up:         cssVar('--color-trend-up'),
+  'soft-up':  cssVar('--color-trend-soft-up'),
+  same:       cssVar('--color-text-muted'),
+  'soft-down':cssVar('--color-trend-soft-down'),
+  down:       cssVar('--color-trend-down'),
 };
 
 function trendDir(delta) {
@@ -115,24 +115,24 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
       </div>
       <ResponsiveContainer width="100%" height={160}>
         <ComposedChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
-          <CartesianGrid vertical={false} stroke={cssVar('--color-border', '#383532')} />
+          <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
           <XAxis
             dataKey="dateLabel"
-            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             axisLine={false}
             tickLine={false}
           />
           <YAxis
             domain={[0, 10]}
             ticks={[0, 2.5, 5, 7.5, 10]}
-            tick={{ fontSize: 11, fill: cssVar('--color-text-muted', '#9a9490') }}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             axisLine={false}
             tickLine={false}
           />
           <Tooltip content={RunHistoryTooltip} cursor={false} isAnimationActive={false} offset={20} />
-          <ReferenceLine y={2.5} stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.15} />
-          <ReferenceLine y={5}   stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.3} />
-          <ReferenceLine y={7.5} stroke={cssVar('--color-text-muted', '#9a9490')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <ReferenceLine y={2.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <ReferenceLine y={5}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.3} />
+          <ReferenceLine y={7.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
           <Bar
             dataKey="numericAverage"
             radius={[3, 3, 0, 0]}
@@ -149,7 +149,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
                 key={entry.runId ?? i}
                 fill={gradeBarColor(entry.overallGrade)}
                 opacity={entry.runId === selectedRunId ? 1 : 0.55}
-                stroke={hoveredIndex === i ? 'rgba(255,255,255,0.25)' : 'none'}
+                stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
                 strokeWidth={hoveredIndex === i ? 1.5 : 0}
               />
             ))}
@@ -158,7 +158,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
             isAnimationActive={false}
             dataKey="numericAverage"
             type="monotone"
-            stroke={cssVar('--color-text', '#1a1a1a')}
+            stroke={cssVar('--color-chart-line')}
             strokeOpacity={0.55}
             strokeWidth={2.5}
             dot={false}

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -341,7 +341,7 @@ button {
   gap: var(--space-2);
   padding: var(--space-2) var(--space-5);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-family: var(--font-sans);
@@ -466,7 +466,7 @@ textarea:focus {
   background: var(--color-accent);
   border: none;
   border-radius: var(--radius-md);
-  color: #fff;
+  color: var(--color-on-accent);
   font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
   cursor: pointer;
@@ -498,7 +498,7 @@ textarea:focus {
 .code-snippet.violation.minor    { border-left: 3px solid var(--color-sev-minor-text); }
 
 .code-snippet.compliance {
-  border-left: 3px solid #5ee6a0;
+  border-left: 3px solid var(--color-compliance);
 }
 
 .violation-file {
@@ -742,9 +742,9 @@ textarea:focus {
 }
 
 .severity-tag.compliance {
-  color: #5ee6a0;
-  background: color-mix(in srgb, #5ee6a0 12%, transparent);
-  border-color: color-mix(in srgb, #5ee6a0 35%, transparent);
+  color: var(--color-compliance);
+  background: var(--color-compliance-bg);
+  border-color: var(--color-compliance-border);
 }
 
 /* ── Grade chips ──────────────────────────────────────── */
@@ -783,16 +783,16 @@ textarea:focus {
 }
 
 .trend-badge-up {
-  color: #5ee6a0;
+  color: var(--color-trend-up);
 }
 .trend-badge-soft-up {
-  color: #92c9a8;
+  color: var(--color-trend-soft-up);
 }
 .trend-badge-soft-down {
-  color: #c8956c;
+  color: var(--color-trend-soft-down);
 }
 .trend-badge-down {
-  color: #f09070;
+  color: var(--color-trend-down);
 }
 .trend-badge-same,
 .trend-badge-none {
@@ -816,27 +816,19 @@ textarea:focus {
   letter-spacing: -0.08em;
 }
 
-.trend-arrow-up { color: #5ee6a0; }
-.trend-arrow-up-big { color: #2ecc71; }
+.trend-arrow-up { color: var(--color-trend-up); }
+.trend-arrow-up-big { color: var(--color-trend-strong-up); }
 .trend-arrow-same { color: var(--color-text-muted); font-size: 0.8rem; }
-.trend-up { color: #5ee6a0; }
-.trend-soft-up { color: #92c9a8; }
-.trend-soft-down { color: #c8956c; }
-.trend-down { color: #f09070; }
-.trend-arrow-down-big { color: #e74c3c; }
+.trend-up { color: var(--color-trend-up); }
+.trend-soft-up { color: var(--color-trend-soft-up); }
+.trend-soft-down { color: var(--color-trend-soft-down); }
+.trend-down { color: var(--color-trend-down); }
+.trend-arrow-down-big { color: var(--color-trend-strong-down); }
 
 .trend-arrow {
   font-size: 1rem;
   font-weight: bold;
   margin-left: 8px;
-}
-
-.trend-up {
-  color: var(--success, #22c55e);
-}
-
-.trend-down {
-  color: var(--danger, #ef4444);
 }
 
 .trend-same {

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -311,7 +311,7 @@
 }
 
 .detail-row-expanded td {
-  background: rgba(19, 26, 37, 0.72);
+  background: var(--color-overlay-light);
 }
 
 .detail-row-expanded .snippet-box {
@@ -833,7 +833,7 @@
   align-items: center;
   justify-content: center;
   background: var(--color-accent);
-  color: #08231f;
+  color: color-mix(in srgb, var(--color-compliance) 15%, var(--color-console-bg));
   font-size: 0.65rem;
   font-weight: 600;
   border-radius: 999px;
@@ -844,7 +844,7 @@
 
 .clear-filters-btn {
   background: transparent;
-  border: 1px solid rgba(255, 111, 111, 0.3);
+  border: 1px solid var(--color-danger-border);
   color: var(--color-danger);
   font-size: 0.75rem;
   font-weight: 600;
@@ -854,7 +854,7 @@
 }
 
 .clear-filters-btn:hover {
-  background: rgba(255, 111, 111, 0.1);
+  background: var(--color-danger-bg);
   transform: none;
   filter: none;
 }
@@ -939,7 +939,7 @@
   border-radius: 999px;
   border: 1px solid var(--color-border);
   padding: 5px 10px;
-  background: rgba(20, 28, 39, 0.88);
+  background: var(--color-overlay-heavy);
   color: var(--color-text-muted);
   font-size: 0.76rem;
   text-transform: lowercase;
@@ -1119,7 +1119,7 @@
   border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 10px;
-  background: rgba(18, 25, 36, 0.82);
+  background: var(--color-overlay-medium);
 }
 
 .mini-kpi p {
@@ -1246,9 +1246,9 @@
   margin: 10px 0 0;
   border: 1px solid var(--color-border);
   border-radius: 10px;
-  background: #0f1621;
+  background: var(--color-console-bg);
   padding: 10px;
-  color: #cfdaea;
+  color: var(--color-console-text);
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.74rem;
   line-height: 1.35;
@@ -1686,14 +1686,14 @@
 }
 
 .violation-block.clickable:hover {
-  border-color: var(--accent, #6366f1);
-  background: var(--surface-hover, rgba(99, 102, 241, 0.06));
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .violation-explore-hint {
   margin-left: auto;
   font-size: 0.75rem;
-  color: var(--accent, #6366f1);
+  color: var(--color-accent);
   opacity: 0.7;
 }
 
@@ -1846,21 +1846,21 @@
 }
 
 .severity-item.critical {
-  background: rgba(255, 80, 80, 0.14);
-  color: #ff8a8a;
-  border-color: rgba(255, 80, 80, 0.35);
+  background: var(--color-danger-bg);
+  color: var(--color-danger-text);
+  border-color: var(--color-danger-border);
 }
 
 .severity-item.major {
-  background: rgba(245, 158, 11, 0.14);
-  color: #ffc46a;
-  border-color: rgba(245, 158, 11, 0.35);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  border-color: color-mix(in srgb, var(--color-warning) 35%, transparent);
 }
 
 .severity-item.minor {
-  background: rgba(148, 163, 184, 0.12);
-  color: #94a3b8;
-  border-color: rgba(148, 163, 184, 0.28);
+  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
+  color: var(--color-text-muted);
+  border-color: color-mix(in srgb, var(--color-text-muted) 28%, transparent);
 }
 
 /* --- Priority Remediation Section --- */
@@ -1882,7 +1882,7 @@
 }
 
 .remediation-severity.major {
-  color: var(--warning, #f59e0b);
+  color: var(--color-warning);
 }
 
 .remediation-severity.minor {
@@ -2211,7 +2211,7 @@
 .run-history-tooltip {
   background: color-mix(in srgb, var(--color-surface-alt) 70%, transparent);
   backdrop-filter: blur(8px);
-  border: 1px solid var(--color-border, rgba(255,255,255,0.1));
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   padding: 6px 10px;
   display: flex;
@@ -2220,9 +2220,9 @@
   font-size: 0.8rem;
 }
 
-.rht-date  { color: var(--color-text-muted, #94a3b8); }
-.rht-score { font-weight: 600; color: var(--color-text, #f1f5f9); }
-.rht-grade { color: var(--color-text-muted, #94a3b8); font-size: 0.75rem; }
+.rht-date  { color: var(--color-text-muted); }
+.rht-score { font-weight: 600; color: var(--color-text); }
+.rht-grade { color: var(--color-text-muted); font-size: 0.75rem; }
 
 /* ── History panels row (Score History + Dimension Scores side-by-side) ── */
 
@@ -2457,19 +2457,19 @@
 .project-path-missing {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: var(--color-danger, #c0392b);
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 10%, transparent);
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
   padding: 2px 7px;
   border-radius: var(--radius-sm);
 }
 
 .project-path-action--warn {
-  color: var(--color-danger, #c0392b);
-  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 30%, transparent);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 30%, transparent);
 }
 
 .project-path-action--warn:hover {
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 8%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 8%, transparent);
 }
 
 .project-relocate-row {
@@ -2536,18 +2536,18 @@
 
 
 .project-delete-btn:hover {
-  color: var(--color-danger, #c0392b);
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 8%, transparent);
-  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 20%, transparent);
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-danger) 20%, transparent);
 }
 
 .project-delete-btn--confirm {
-  color: var(--color-danger, #c0392b);
-  border-color: color-mix(in srgb, var(--color-danger, #c0392b) 30%, transparent);
+  color: var(--color-danger);
+  border-color: color-mix(in srgb, var(--color-danger) 30%, transparent);
 }
 
 .project-delete-btn--confirm:hover {
-  background: color-mix(in srgb, var(--color-danger, #c0392b) 15%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
 }
 
 .project-delete-btn--cancel {

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -91,7 +91,7 @@
 .job-error {
   margin-top: 16px;
   padding: 12px 16px;
-  background: rgba(255, 111, 111, 0.1);
+  background: var(--color-danger-bg);
   border: 1px solid var(--color-danger);
   border-radius: var(--radius-lg);
   color: var(--color-danger);
@@ -162,8 +162,8 @@
 }
 
 .job-status-badge.pending {
-  background: rgba(255, 193, 7, 0.12);
-  color: #d4a400;
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
 }
 
 .job-status-badge.running {
@@ -261,7 +261,7 @@
 
 /* Console */
 .console-output {
-  background: #0d1117;
+  background: var(--color-console-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 16px;
@@ -278,7 +278,7 @@
 }
 
 .console-output::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: color-mix(in srgb, var(--color-text) 10%, transparent);
   border-radius: 3px;
 }
 
@@ -287,7 +287,7 @@
   font-family: var(--font-mono);
   font-size: 0.8rem;
   line-height: 1.65;
-  color: #8bc34a;
+  color: var(--color-console-success);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -352,9 +352,9 @@
 }
 
 .eval-dim-tag.active {
-  background: var(--color-accent-bg, rgba(59, 130, 246, 0.1));
-  color: var(--color-accent, #3b82f6);
-  border-color: var(--color-accent, #3b82f6);
+  background: var(--color-accent-bg);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
 }
 
 .eval-console-indicator {
@@ -737,7 +737,7 @@
   width: 24px;
   height: 24px;
   padding: 0;
-  background: rgba(255, 255, 255, 0.08);
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
   border: none;
   border-radius: 50%;
   color: var(--color-text-muted);
@@ -747,8 +747,8 @@
 }
 
 .input-clear-btn:hover {
-  background: rgba(255, 100, 100, 0.15);
-  color: #ff6b6b;
+  background: var(--color-danger-bg);
+  color: var(--color-danger-text);
   opacity: 1;
   transform: translateY(-50%) scale(1.1);
 }
@@ -1055,7 +1055,7 @@
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--color-overlay-heavy);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1125,9 +1125,9 @@
 }
 
 .modal-close:hover {
-  background: rgba(255, 100, 100, 0.1);
-  border-color: rgba(255, 100, 100, 0.3);
-  color: #ff6b6b;
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border);
+  color: var(--color-danger-text);
 }
 
 .folder-browser-path {
@@ -1135,7 +1135,7 @@
   align-items: center;
   gap: 10px;
   padding: 14px 20px;
-  background: rgba(0, 0, 0, 0.2);
+  background: color-mix(in srgb, var(--color-text) 20%, transparent);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -1227,7 +1227,7 @@
   overflow-y: auto;
   padding: 12px;
   max-height: 380px;
-  background: linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.1) 100%);
+  background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--color-text) 10%, transparent) 100%);
 }
 
 .folder-browser-list::-webkit-scrollbar {
@@ -1295,8 +1295,8 @@
 }
 
 .folder-item:hover {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.06);
+  background: color-mix(in srgb, var(--color-text) 4%, transparent);
+  border-color: color-mix(in srgb, var(--color-text) 6%, transparent);
 }
 
 .folder-item.is-git-repo {
@@ -1314,7 +1314,7 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in srgb, var(--color-text) 5%, transparent);
   border-radius: 8px;
   font-size: 1rem;
   transition: all 180ms ease;
@@ -1440,7 +1440,7 @@
 
 .btn-cancel {
   padding: 12px 22px;
-  background: rgba(255, 255, 255, 0.03);
+  background: color-mix(in srgb, var(--color-text) 3%, transparent);
   border: 1px solid var(--color-border);
   border-radius: 10px;
   color: var(--color-text-muted);
@@ -1451,8 +1451,8 @@
 }
 
 .btn-cancel:hover {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-text) 20%, transparent);
   color: var(--color-text);
   transform: translateY(-1px);
 }

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -144,7 +144,7 @@
 .fix-it-btn {
   padding: var(--space-2) var(--space-5);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-on-accent);
   border: none;
   border-radius: var(--radius-md);
   font-family: var(--font-sans);
@@ -338,7 +338,7 @@
 .dialog-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(5, 8, 12, 0.7);
+  background: var(--color-overlay-heavy);
   z-index: 1000;
   display: flex;
   align-items: center;
@@ -350,7 +350,7 @@
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 24px 64px var(--color-overlay-medium);
   width: 90%;
   max-width: 520px;
   max-height: 70vh;

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -115,6 +115,48 @@
   --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
   --color-grade-bottom-text: #991b1b;
   --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+
+  /* Trend (theme-invariant) */
+  --color-trend-strong-up:   #2ecc71;
+  --color-trend-up:          #5ee6a0;
+  --color-trend-soft-up:     #92c9a8;
+  --color-trend-soft-down:   #c8956c;
+  --color-trend-down:        #f09070;
+  --color-trend-strong-down: #e74c3c;
+
+  /* Console (theme-invariant) */
+  --color-console-bg:      #0d1117;
+  --color-console-text:    #cfdaea;
+  --color-console-success: #8bc34a;
+
+  /* On-accent text (theme-invariant) */
+  --color-on-accent: #ffffff;
+
+  /* Compliance */
+  --color-compliance:        #5ee6a0;
+  --color-compliance-bg:     color-mix(in srgb, #5ee6a0 12%, transparent);
+  --color-compliance-border: color-mix(in srgb, #5ee6a0 35%, transparent);
+
+  /* Warning */
+  --color-warning:      #b45309;
+  --color-warning-text: #b45309;
+  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+
+  /* Danger variants */
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  /* Overlays */
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  /* Chart */
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-line:   var(--color-text);
+  --color-chart-stroke: transparent;
 }
 
 /* ── 3. Semantic tokens — Dark mode override ──────────────
@@ -161,6 +203,26 @@
     --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
     --color-grade-bottom-text: #f87171;
     --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+
+    /* Warning */
+    --color-warning:      #fbbf24;
+    --color-warning-text: #fbbf24;
+    --color-warning-bg:   rgba(251, 191, 36, 0.1);
+
+    /* Danger variants */
+    --color-danger-text:   #ff6b6b;
+    --color-danger-bg:     rgba(255, 100, 100, 0.15);
+    --color-danger-border: rgba(255, 100, 100, 0.3);
+
+    /* Overlays */
+    --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+    --color-overlay-medium: rgba(0, 0, 0, 0.82);
+    --color-overlay-light:  rgba(0, 0, 0, 0.72);
+
+    /* Chart */
+    --color-chart-grid:   #383532;
+    --color-chart-axis:   #9a9490;
+    --color-chart-stroke: rgba(255, 255, 255, 0.25);
   }
 }
 
@@ -208,6 +270,26 @@ html[data-theme="dark"]:root {
   --color-grade-bottom-text: #f87171;
   --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
 
+  /* Warning */
+  --color-warning:      #fbbf24;
+  --color-warning-text: #fbbf24;
+  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+
+  /* Danger variants */
+  --color-danger-text:   #ff6b6b;
+  --color-danger-bg:     rgba(255, 100, 100, 0.15);
+  --color-danger-border: rgba(255, 100, 100, 0.3);
+
+  /* Overlays */
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+  --color-overlay-medium: rgba(0, 0, 0, 0.82);
+  --color-overlay-light:  rgba(0, 0, 0, 0.72);
+
+  /* Chart */
+  --color-chart-grid:   #383532;
+  --color-chart-axis:   #9a9490;
+  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
@@ -251,6 +333,26 @@ html[data-theme="light"]:root {
   --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
   --color-grade-bottom-text: #991b1b;
   --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+
+  /* Warning */
+  --color-warning:      #b45309;
+  --color-warning-text: #b45309;
+  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+
+  /* Danger variants */
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  /* Overlays */
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  /* Chart */
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-stroke: transparent;
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
@@ -303,6 +405,26 @@ html[data-theme="media-light"]:root {
   --color-grade-bottom-text: #c93530;
   --color-grade-bottom-bg:   rgba(230, 70, 60, 0.10);
 
+  /* Warning */
+  --color-warning:      #8a6e00;
+  --color-warning-text: #8a6e00;
+  --color-warning-bg:   rgba(250, 187, 34, 0.1);
+
+  /* Danger variants */
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  /* Overlays */
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  /* Chart */
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-stroke: transparent;
+
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
@@ -348,6 +470,26 @@ html[data-theme="media-dark"]:root {
   --color-grade-low-bg:      rgba(230, 70, 60, 0.10);
   --color-grade-bottom-text: #f05855;
   --color-grade-bottom-bg:   rgba(230, 70, 60, 0.14);
+
+  /* Warning */
+  --color-warning:      #fabb22;
+  --color-warning-text: #fabb22;
+  --color-warning-bg:   rgba(250, 187, 34, 0.12);
+
+  /* Danger variants */
+  --color-danger-text:   #f05855;
+  --color-danger-bg:     rgba(230, 70, 60, 0.12);
+  --color-danger-border: rgba(230, 70, 60, 0.28);
+
+  /* Overlays */
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+  --color-overlay-medium: rgba(0, 0, 0, 0.82);
+  --color-overlay-light:  rgba(0, 0, 0, 0.72);
+
+  /* Chart */
+  --color-chart-grid:   #3a3a3a;
+  --color-chart-axis:   #a0a0a0;
+  --color-chart-stroke: rgba(255, 255, 255, 0.25);
 
   --shadow-sm: none;
   --shadow-md: none;


### PR DESCRIPTION
## Summary
- Add 26 new semantic design tokens (trend, console, overlay, warning, compliance, danger, chart) to `tokens.css` with proper light/dark theme variants
- Replace all hardcoded hex and rgba color values in `base.css`, `evaluation.css`, `dashboard.css`, `explorer.css` with token references
- Migrate JSX chart components (`DimensionScorePanel`, `RunHistoryPanel`) from hardcoded `TREND_COLOR` objects and `cssVar()` fallbacks to token-driven reads

## Test plan
- [x] Build passes (`npm run build`)
- [x] Light theme renders correctly
- [x] Dark theme renders correctly
- [x] Trend badges show correct green→red gradient
- [x] Chart bars and grid lines render correctly
- [x] Modal overlays are visible and properly occlude content
- [x] Console/code blocks have dark background with green text