### PR TITLE
refactor(modularity): reduce param counts and centralize path resolution

### DIFF
--- a/src/quodeq/_fs_evaluation_mixin.py
+++ b/src/quodeq/_fs_evaluation_mixin.py
@@ -4,6 +4,7 @@ import os
 import sys
 from pathlib import Path
 
+from quodeq.action_provider import EvaluationOptions
 from quodeq.utils import is_repo_url
 
 from typing import Any
@@ -41,19 +42,19 @@ def _register_project(repo: str, discipline: str | None, reports_dir: str) -> No
 class FsEvaluationMixin:
     """Mixin for evaluation start/status/cancel methods."""
 
-    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str, ai_cmd: str | None = None, ai_model: str | None = None) -> dict[str, Any]:
+    def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> dict[str, Any]:
         repo_path = Path(repo)
         if not is_repo_url(repo) and not repo_path.exists():
             raise FileNotFoundError(f"Repository not found: {repo}")
 
-        cmd = _build_evaluate_cmd(repo, discipline, dimensions, numerical, reports_dir)
-        _register_project(repo, discipline, reports_dir)
+        cmd = _build_evaluate_cmd(repo, options.discipline, options.dimensions, options.numerical, reports_dir)
+        _register_project(repo, options.discipline, reports_dir)
 
         env = {**os.environ, "PYTHONUNBUFFERED": "1"}
-        if ai_cmd:
-            env["AI_CMD"] = ai_cmd
-        if ai_model:
-            env["AI_MODEL"] = ai_model
+        if options.ai_cmd:
+            env["AI_CMD"] = options.ai_cmd
+        if options.ai_model:
+            env["AI_MODEL"] = options.ai_model
 
         cwd = str(Path.cwd()) if is_repo_url(repo) else str(repo_path.resolve())
         return self._jobs.start_job(cmd, cwd=cwd, env=env)

--- a/src/quodeq/action_api.py
+++ b/src/quodeq/action_api.py
@@ -137,14 +137,17 @@ def create_app(provider: ActionProvider | None = None, static_dist: str | None =
             body, status = _error("Repository is required", 400, "INVALID_INPUT")
             return jsonify(body), status
         try:
+            from quodeq.action_provider import EvaluationOptions
             job = provider.start_evaluation(
                 repo=repo,
-                discipline=payload.get("discipline"),
-                dimensions=payload.get("dimensions") or "",
-                numerical=bool(payload.get("numerical")),
                 reports_dir=_reports_dir(),
-                ai_cmd=payload.get("aiCmd") or None,
-                ai_model=payload.get("aiModel") or None,
+                options=EvaluationOptions(
+                    discipline=payload.get("discipline"),
+                    dimensions=payload.get("dimensions") or "",
+                    numerical=bool(payload.get("numerical")),
+                    ai_cmd=payload.get("aiCmd") or None,
+                    ai_model=payload.get("aiModel") or None,
+                ),
             )
         except FileNotFoundError as exc:
             body, status = _error(str(exc), 400, "INVALID_INPUT")
@@ -178,7 +181,8 @@ def create_app(provider: ActionProvider | None = None, static_dist: str | None =
     @app.get("/api/plugins")
     def plugins() -> Response:
         import json as _json
-        evaluators_root = Path(__file__).resolve().parent.parent.parent / "evaluators"
+        from quodeq.config.paths import default_paths
+        evaluators_root = default_paths().evaluators_dir
         result: list[dict[str, Any]] = []
         if evaluators_root.is_dir():
             for child in sorted(evaluators_root.iterdir()):

--- a/src/quodeq/action_provider.py
+++ b/src/quodeq/action_provider.py
@@ -1,6 +1,16 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class EvaluationOptions:
+    discipline: str | None = None
+    dimensions: str = ""
+    numerical: bool = False
+    ai_cmd: str | None = None
+    ai_model: str | None = None
 
 
 class ProjectActions(Protocol):
@@ -42,7 +52,7 @@ class ReportActions(Protocol):
 class EvaluationActions(Protocol):
     """Methods for running and managing evaluations."""
 
-    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str, ai_cmd: str | None = None, ai_model: str | None = None) -> dict:
+    def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> dict:
         """Start an asynchronous evaluation job and return job metadata."""
         ...
 

--- a/src/quodeq/action_provider_fs.py
+++ b/src/quodeq/action_provider_fs.py
@@ -331,7 +331,8 @@ def _infer_discipline(reports_root: Path, project: str) -> str | None:
 def _list_available_dimensions_for_discipline(discipline: str) -> list[str]:
     """Resolve available dimensions for a plugin via its dimensions.json."""
     try:
-        plugin_dir = Path(__file__).resolve().parent.parent.parent / "evaluators" / discipline
+        from quodeq.config.paths import default_paths
+        plugin_dir = default_paths().evaluators_dir / discipline
         dims_file = plugin_dir / "dimensions.json"
         if dims_file.exists():
             data = json.loads(dims_file.read_text())

--- a/src/quodeq/adapters/fs/report_parser/__init__.py
+++ b/src/quodeq/adapters/fs/report_parser/__init__.py
@@ -23,9 +23,6 @@ from quodeq.adapters.fs.report_parser.markdown import (
 )
 from quodeq.adapters.fs.report_parser.runs import (
     RunInfo,
-    _get_previous_run_for_dimension,
-    _normalize_date,
-    _parse_run_date,
     build_repository_info,
     list_runs,
     read_run_data,

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -83,7 +83,8 @@ def run_evaluate(args: argparse.Namespace) -> int:
         return 1
 
     # 2. Locate evaluators directory
-    evaluators_dir = Path(__file__).resolve().parents[2] / "evaluators"
+    from quodeq.config.paths import default_paths
+    evaluators_dir = default_paths().evaluators_dir
     if not evaluators_dir.exists():
         print(f"Evaluators directory not found: {evaluators_dir}", file=sys.stderr)
         return 1
@@ -128,7 +129,7 @@ def run_evaluate(args: argparse.Namespace) -> int:
     print(f"Report path: {evaluation_dir}")
 
     # 6. Build config and run
-    standards_dir = Path(__file__).resolve().parents[2] / "standards"
+    standards_dir = default_paths().standards_dir
     dimensions_filter = None
     if args.dimensions:
         dimensions_filter = [d.strip() for d in args.dimensions.split(",") if d.strip()]

--- a/src/quodeq/config/knowledge_refresh.py
+++ b/src/quodeq/config/knowledge_refresh.py
@@ -9,27 +9,8 @@ from pathlib import Path
 from quodeq.config import generators
 
 # Per-runtime linter documentation sources
-_LINTER_SOURCES: dict[str, str] = {
-    "typescript": (
-        "https://raw.githubusercontent.com/typescript-eslint/typescript-eslint"
-        "/main/packages/eslint-plugin/README.md"
-    ),
-    "kotlin": (
-        "https://raw.githubusercontent.com/detekt/detekt/main/website/docs/rules/complexity.md"
-    ),
-    "python": (
-        "https://raw.githubusercontent.com/astral-sh/ruff/main/docs/rules.md"
-    ),
-    "bash": (
-        "https://raw.githubusercontent.com/koalaman/shellcheck/master/README.md"
-    ),
-    "java": (
-        "https://raw.githubusercontent.com/pmd/pmd/main/docs/pages/pmd/rules/java/bestpractices.md"
-    ),
-    "mobile_ios": (
-        "https://raw.githubusercontent.com/realm/SwiftLint/main/README.md"
-    ),
-}
+_LINTER_SOURCES_PATH = Path(__file__).parent / "linter_sources.json"
+_LINTER_SOURCES: dict[str, str] = json.loads(_LINTER_SOURCES_PATH.read_text())
 
 _GITHUB_SEARCH_URL = "https://api.github.com/search/repositories"
 

--- a/src/quodeq/config/linter_sources.json
+++ b/src/quodeq/config/linter_sources.json
@@ -1,0 +1,8 @@
+{
+  "typescript": "https://raw.githubusercontent.com/typescript-eslint/typescript-eslint/main/packages/eslint-plugin/README.md",
+  "kotlin": "https://raw.githubusercontent.com/detekt/detekt/main/website/docs/rules/complexity.md",
+  "python": "https://raw.githubusercontent.com/astral-sh/ruff/main/docs/rules.md",
+  "bash": "https://raw.githubusercontent.com/koalaman/shellcheck/master/README.md",
+  "java": "https://raw.githubusercontent.com/pmd/pmd/main/docs/pages/pmd/rules/java/bestpractices.md",
+  "mobile_ios": "https://raw.githubusercontent.com/realm/SwiftLint/main/README.md"
+}

--- a/src/quodeq/config/paths.py
+++ b/src/quodeq/config/paths.py
@@ -9,6 +9,7 @@ class ConfigPaths:
     practices_dir: Path
     dimensions_dir: Path
     prompts_dir: Path
+    standards_dir: Path
     env_file: Path
     gitignore_file: Path
 
@@ -24,6 +25,7 @@ class ConfigPaths:
             practices_dir=root / "practices",
             dimensions_dir=root / "dimensions",
             prompts_dir=root / "prompts",
+            standards_dir=root / "standards",
             env_file=root / ".quodeq.env",
             gitignore_file=root / ".gitignore",
         )

--- a/src/quodeq/engine/evidence_parser.py
+++ b/src/quodeq/engine/evidence_parser.py
@@ -2,9 +2,19 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.engine.evidence import Evidence, Judgment, PrincipleEvidence
+
+
+@dataclass
+class EvidenceContext:
+    plugin_id: str
+    repository: str
+    date_str: str
+    source_file_count: int
+    files_read: int
 
 
 def _build_cwe_name_lookup(standards_dir: Path) -> dict[int, str]:
@@ -80,12 +90,8 @@ def _judgment_to_dict(j: Judgment, cwe_name: str = "", cwe_id: int | None = None
 
 def parse_jsonl_to_evidence(
     jsonl_file: Path,
+    context: EvidenceContext,
     *,
-    plugin_id: str,
-    repository: str,
-    date_str: str,
-    source_file_count: int,
-    files_read: int,
     standards_dir: Path | None = None,
 ) -> Evidence:
     """Parse extracted JSONL file into a complete Evidence object.
@@ -93,6 +99,11 @@ def parse_jsonl_to_evidence(
     Findings are grouped by principle name (the p field the AI reports).
     CWE names are resolved from compiled standards when available.
     """
+    plugin_id = context.plugin_id
+    repository = context.repository
+    date_str = context.date_str
+    source_file_count = context.source_file_count
+    files_read = context.files_read
     cwe_name_lookup = _build_cwe_name_lookup(standards_dir) if standards_dir else {}
 
     judgments: list[Judgment] = []

--- a/src/quodeq/engine/prompt_builder.py
+++ b/src/quodeq/engine/prompt_builder.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
-_PROMPTS_DIR = Path(__file__).parent.parent.parent.parent / "prompts"
+
+def _prompts_dir() -> Path:
+    from quodeq.config.paths import default_paths
+    return default_paths().prompts_dir
 
 
 def _sub(template: str, **kwargs: str) -> str:
@@ -77,56 +81,42 @@ def render_dimensions(dimensions_data: dict, dimension: str, standards_dir: Path
 
 def load_template(template_path: Path | None = None) -> str:
     """Load the compass.md prompt template."""
-    path = template_path or (_PROMPTS_DIR / "compass.md")
+    path = template_path or (_prompts_dir() / "compass.md")
     return path.read_text()
 
 
-def build_analysis_prompt(
-    template: str,
-    *,
-    plugin_id: str,
-    repo_name: str,
-    date_str: str,
-    dimension: str,
-    source_file_count: int,
-    dimensions_data: dict,
-    analysis_md: str = "",
-    standards_dir: Path | None = None,
-) -> str:
-    """Build a complete per-dimension analysis prompt from the template.
+@dataclass
+class PromptContext:
+    plugin_id: str
+    repo_name: str
+    date_str: str
+    dimension: str
+    source_file_count: int
+    dimensions_data: dict
+    analysis_md: str = ""
+    standards_dir: Path | None = None
 
-    Args:
-        template: Raw compass.md template text.
-        plugin_id: Plugin identifier (e.g. "typescript").
-        repo_name: Repository name.
-        date_str: Evaluation date string.
-        dimension: The dimension being evaluated (e.g. "security").
-        source_file_count: Total source files in the repo.
-        dimensions_data: Parsed dimensions.json dict.
-        analysis_md: Plugin-specific analysis guidance text.
-        standards_dir: Path to standards/ directory.
 
-    Returns:
-        Fully rendered prompt string.
-    """
-    dimensions_text = render_dimensions(dimensions_data, dimension, standards_dir)
+def build_analysis_prompt(template: str, context: PromptContext) -> str:
+    """Build a complete per-dimension analysis prompt from the template."""
+    dimensions_text = render_dimensions(context.dimensions_data, context.dimension, context.standards_dir)
     prompt_hash = hashlib.sha256(template.encode()).hexdigest()[:12]
 
     standards_checklist = "_No compiled standards available._"
-    if standards_dir:
-        compiled_dir = standards_dir / "compiled"
+    if context.standards_dir:
+        compiled_dir = context.standards_dir / "compiled"
         if compiled_dir.exists():
-            standards_checklist = render_compiled_standards(compiled_dir, dimension)
+            standards_checklist = render_compiled_standards(compiled_dir, context.dimension)
 
     return _sub(
         template,
-        DISCIPLINE=plugin_id,
-        REPO_NAME=repo_name,
-        DATE=date_str,
-        DIMENSION=dimension,
-        SOURCE_FILE_COUNT=str(source_file_count),
+        DISCIPLINE=context.plugin_id,
+        REPO_NAME=context.repo_name,
+        DATE=context.date_str,
+        DIMENSION=context.dimension,
+        SOURCE_FILE_COUNT=str(context.source_file_count),
         STANDARDS_CHECKLIST=standards_checklist,
-        ANALYSIS_GUIDANCE=analysis_md or "_No additional guidance._",
+        ANALYSIS_GUIDANCE=context.analysis_md or "_No additional guidance._",
         DIMENSIONS=dimensions_text,
         PROMPT_HASH=prompt_hash,
     )

--- a/src/quodeq/engine/runner.py
+++ b/src/quodeq/engine/runner.py
@@ -23,9 +23,9 @@ from quodeq.engine.analysis import (
     run_analysis,
 )
 from quodeq.engine.evidence import Evidence, PrincipleEvidence
-from quodeq.engine.evidence_parser import parse_jsonl_to_evidence
+from quodeq.engine.evidence_parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.engine.plugin_loader import load_plugin_full
-from quodeq.engine.prompt_builder import build_analysis_prompt, load_template
+from quodeq.engine.prompt_builder import PromptContext, build_analysis_prompt, load_template
 
 
 @dataclass
@@ -100,14 +100,16 @@ def run(config: RunConfig) -> Evidence:
         print(f"→ [{idx}/{total}] Analyzing {dimension}", flush=True)
         prompt = build_analysis_prompt(
             template,
-            plugin_id=config.plugin_id,
-            repo_name=str(config.src),
-            date_str=date_str,
-            dimension=dimension,
-            source_file_count=config.source_file_count,
-            dimensions_data=full["dimensions"],
-            analysis_md=analysis_md,
-            standards_dir=config.standards_dir,
+            PromptContext(
+                plugin_id=config.plugin_id,
+                repo_name=str(config.src),
+                date_str=date_str,
+                dimension=dimension,
+                source_file_count=config.source_file_count,
+                dimensions_data=full["dimensions"],
+                analysis_md=analysis_md,
+                standards_dir=config.standards_dir,
+            ),
         )
 
         stream_file = work_dir / f"{dimension}_live.stream"
@@ -143,11 +145,13 @@ def run(config: RunConfig) -> Evidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl_file,
-            plugin_id=config.plugin_id,
-            repository=str(config.src),
-            date_str=date_str,
-            source_file_count=config.source_file_count,
-            files_read=files_read,
+            EvidenceContext(
+                plugin_id=config.plugin_id,
+                repository=str(config.src),
+                date_str=date_str,
+                source_file_count=config.source_file_count,
+                files_read=files_read,
+            ),
             standards_dir=config.standards_dir,
         )
         ev.plugin_name = full["plugin"].get("name", config.plugin_id)
@@ -188,14 +192,16 @@ def run_per_dimension(config: RunConfig) -> dict[str, Evidence]:
         print(f"→ [{idx}/{total}] Analyzing {dimension}", flush=True)
         prompt = build_analysis_prompt(
             template,
-            plugin_id=config.plugin_id,
-            repo_name=str(config.src),
-            date_str=date_str,
-            dimension=dimension,
-            source_file_count=config.source_file_count,
-            dimensions_data=full["dimensions"],
-            analysis_md=analysis_md,
-            standards_dir=config.standards_dir,
+            PromptContext(
+                plugin_id=config.plugin_id,
+                repo_name=str(config.src),
+                date_str=date_str,
+                dimension=dimension,
+                source_file_count=config.source_file_count,
+                dimensions_data=full["dimensions"],
+                analysis_md=analysis_md,
+                standards_dir=config.standards_dir,
+            ),
         )
 
         stream_file = work_dir / f"{dimension}_live.stream"
@@ -229,11 +235,13 @@ def run_per_dimension(config: RunConfig) -> dict[str, Evidence]:
 
         ev = parse_jsonl_to_evidence(
             jsonl_file,
-            plugin_id=config.plugin_id,
-            repository=str(config.src),
-            date_str=date_str,
-            source_file_count=config.source_file_count,
-            files_read=files_read,
+            EvidenceContext(
+                plugin_id=config.plugin_id,
+                repository=str(config.src),
+                date_str=date_str,
+                source_file_count=config.source_file_count,
+                files_read=files_read,
+            ),
             standards_dir=config.standards_dir,
         )
         ev.plugin_name = full["plugin"].get("name", config.plugin_id)

--- a/src/quodeq/engine/standards.py
+++ b/src/quodeq/engine/standards.py
@@ -2,18 +2,21 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-STANDARDS_DIR = Path(__file__).parent.parent.parent.parent / "standards"
+
+def _standards_dir() -> Path:
+    from quodeq.config.paths import default_paths
+    return default_paths().standards_dir
 
 
 def load_dimension(dimension_id: str) -> dict:
-    path = STANDARDS_DIR / "iso25010" / f"{dimension_id}.json"
+    path = _standards_dir() / "iso25010" / f"{dimension_id}.json"
     return json.loads(path.read_text())
 
 
 def load_asvs_l1() -> dict:
-    return json.loads((STANDARDS_DIR / "asvs" / "level1.json").read_text())
+    return json.loads((_standards_dir() / "asvs" / "level1.json").read_text())
 
 
 def load_cisq(characteristic: str) -> dict:
-    path = STANDARDS_DIR / "cisq" / f"{characteristic}.json"
+    path = _standards_dir() / "cisq" / f"{characteristic}.json"
     return json.loads(path.read_text())

--- a/tests/engine/test_evidence_parser.py
+++ b/tests/engine/test_evidence_parser.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from quodeq.engine.evidence_parser import (
+    EvidenceContext,
     parse_jsonl_to_evidence,
     _parse_jsonl_line,
 )
@@ -94,11 +95,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test-repo",
-            date_str="2026-03-06",
-            source_file_count=50,
-            files_read=10,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test-repo",
+                date_str="2026-03-06",
+                source_file_count=50,
+                files_read=10,
+            ),
         )
 
         assert ev.repository == "test-repo"
@@ -119,11 +122,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         pe = ev.principles["ts-001"]
@@ -141,11 +146,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=0,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=0,
+            ),
         )
 
         assert len(ev.principles) == 0
@@ -156,11 +163,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=0,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=0,
+            ),
         )
 
         assert len(ev.principles) == 0
@@ -171,11 +180,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         assert "unknown-001" in ev.principles
@@ -187,11 +198,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         v = ev.principles["ts-001"].violations[0]
@@ -221,11 +234,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="python",
-            repository="test",
-            date_str="2026-03-09",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="python",
+                repository="test",
+                date_str="2026-03-09",
+                source_file_count=10,
+                files_read=5,
+            ),
             standards_dir=tmp_path / "standards",
         )
 
@@ -245,11 +260,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="python",
-            repository="test",
-            date_str="2026-03-09",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="python",
+                repository="test",
+                date_str="2026-03-09",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         v = ev.principles["Confidentiality"].violations[0]
@@ -262,11 +279,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         assert len(ev.principles) == 1
@@ -277,11 +296,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=0,
-            files_read=0,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=0,
+                files_read=0,
+            ),
         )
 
         assert ev.coverage_pct == 0.0
@@ -296,11 +317,13 @@ class TestParseJsonlToEvidence:
 
         ev = parse_jsonl_to_evidence(
             jsonl,
-            plugin_id="typescript",
-            repository="test",
-            date_str="2026-03-06",
-            source_file_count=10,
-            files_read=5,
+            EvidenceContext(
+                plugin_id="typescript",
+                repository="test",
+                date_str="2026-03-06",
+                source_file_count=10,
+                files_read=5,
+            ),
         )
 
         d = ev.to_evidence_dict()

--- a/tests/engine/test_prompt_builder.py
+++ b/tests/engine/test_prompt_builder.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from quodeq.engine.prompt_builder import (
+    PromptContext,
     build_analysis_prompt,
     load_template,
     render_compiled_standards,
@@ -139,13 +140,15 @@ class TestBuildAnalysisPrompt:
         template = load_template()
         prompt = build_analysis_prompt(
             template,
-            plugin_id="typescript",
-            repo_name="my-app",
-            date_str="2026-03-06",
-            dimension="security",
-            source_file_count=42,
-            dimensions_data=_sample_dimensions(),
-            standards_dir=tmp_path,
+            PromptContext(
+                plugin_id="typescript",
+                repo_name="my-app",
+                date_str="2026-03-06",
+                dimension="security",
+                source_file_count=42,
+                dimensions_data=_sample_dimensions(),
+                standards_dir=tmp_path,
+            ),
         )
         assert "{{" not in prompt  # all placeholders resolved
         assert "my-app" in prompt
@@ -159,13 +162,15 @@ class TestBuildAnalysisPrompt:
         template = load_template()
         prompt = build_analysis_prompt(
             template,
-            plugin_id="typescript",
-            repo_name="test",
-            date_str="2026-03-06",
-            dimension="security",
-            source_file_count=10,
-            dimensions_data=_sample_dimensions(),
-            analysis_md="Look for eval() calls in route handlers",
+            PromptContext(
+                plugin_id="typescript",
+                repo_name="test",
+                date_str="2026-03-06",
+                dimension="security",
+                source_file_count=10,
+                dimensions_data=_sample_dimensions(),
+                analysis_md="Look for eval() calls in route handlers",
+            ),
         )
         assert "Look for eval() calls in route handlers" in prompt
 
@@ -173,12 +178,14 @@ class TestBuildAnalysisPrompt:
         template = load_template()
         prompt = build_analysis_prompt(
             template,
-            plugin_id="typescript",
-            repo_name="test",
-            date_str="2026-03-06",
-            dimension="security",
-            source_file_count=10,
-            dimensions_data=_sample_dimensions(),
+            PromptContext(
+                plugin_id="typescript",
+                repo_name="test",
+                date_str="2026-03-06",
+                dimension="security",
+                source_file_count=10,
+                dimensions_data=_sample_dimensions(),
+            ),
         )
         assert "No additional guidance" in prompt
 
@@ -186,11 +193,13 @@ class TestBuildAnalysisPrompt:
         template = load_template()
         prompt = build_analysis_prompt(
             template,
-            plugin_id="typescript",
-            repo_name="test",
-            date_str="2026-03-06",
-            dimension="security",
-            source_file_count=10,
-            dimensions_data=_sample_dimensions(),
+            PromptContext(
+                plugin_id="typescript",
+                repo_name="test",
+                date_str="2026-03-06",
+                dimension="security",
+                source_file_count=10,
+                dimensions_data=_sample_dimensions(),
+            ),
         )
         assert "PROMPT_HASH" not in prompt

--- a/tests/test_action_api.py
+++ b/tests/test_action_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from quodeq.action_api import create_app
-from quodeq.action_provider import ActionProvider
+from quodeq.action_provider import ActionProvider, EvaluationOptions
 
 
 class StubProvider(ActionProvider):
@@ -23,7 +23,7 @@ class StubProvider(ActionProvider):
     def get_violations(self, reports_dir: str, project: str, run_id: str):
         return {"total": 0, "critical": 0, "major": 0, "minor": 0, "files": []}
 
-    def start_evaluation(self, repo: str, discipline: str | None, dimensions: str, numerical: bool, reports_dir: str):
+    def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> dict:
         return {"jobId": "job-1", "status": "running", "logs": []}
 
     def get_evaluation_status(self, job_id: str):

--- a/tests/test_action_provider_fs_evaluations.py
+++ b/tests/test_action_provider_fs_evaluations.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 import sys
 
+from quodeq.action_provider import EvaluationOptions
 from quodeq.action_provider_fs import FilesystemActionProvider
 
 
@@ -93,10 +94,8 @@ def test_start_evaluation_uses_cli_module(tmp_path: Path) -> None:
 
     provider.start_evaluation(
         repo=str(repo_path),
-        discipline=None,
-        dimensions="",
-        numerical=False,
         reports_dir=str(reports_dir),
+        options=EvaluationOptions(),
     )
 
     assert captured["cmd"][:5] == [
@@ -126,10 +125,8 @@ def test_start_evaluation_always_passes_absolute_reports_path(tmp_path: Path) ->
 
     provider.start_evaluation(
         repo=str(repo_path),
-        discipline=None,
-        dimensions="",
-        numerical=False,
         reports_dir="reports",
+        options=EvaluationOptions(),
     )
 
     assert "-o" in captured["cmd"]
@@ -150,10 +147,8 @@ def test_start_evaluation_writes_repository_info(tmp_path: Path) -> None:
 
     provider.start_evaluation(
         repo=str(repo_path),
-        discipline="cli_bash",
-        dimensions="",
-        numerical=False,
         reports_dir=str(reports_dir),
+        options=EvaluationOptions(discipline="cli_bash"),
     )
 
     # UUID-based project directory — find the created project dir
@@ -180,10 +175,8 @@ def test_start_evaluation_writes_repository_info_for_online_repo(tmp_path: Path)
 
     provider.start_evaluation(
         repo=repo_url,
-        discipline="backend_springboot_java",
-        dimensions="",
-        numerical=False,
         reports_dir=str(reports_dir),
+        options=EvaluationOptions(discipline="backend_springboot_java"),
     )
 
     # UUID-based project directory

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -558,11 +558,16 @@ export default function App() {
                   </div>
                   <div className="theme-toggle">
                     {[
-                      { value: 'system',    label: 'System' },
-                      { value: 'light',     label: 'Light' },
-                      { value: 'dark',      label: 'Dark' },
-                      { value: 'media-light', label: 'Media Light' },
-                      { value: 'media-dark',  label: 'Media Dark' },
+                      { value: 'system',      label: 'System' },
+                      { value: 'light',       label: 'Light' },
+                      { value: 'dark',        label: 'Dark' },
+                      { value: 'media-light', label: 'Media Lt' },
+                      { value: 'media-dark',  label: 'Media Dk' },
+                      { value: 'ember',       label: 'Ember' },
+                      { value: 'forest',      label: 'Forest' },
+                      { value: 'midnight',    label: 'Midnight' },
+                      { value: 'slate',       label: 'Slate' },
+                      { value: 'horizon',     label: 'Horizon' },
                     ].map(({ value, label }) => (
                       <button
                         key={value}

--- a/ui/web/src/main.jsx
+++ b/ui/web/src/main.jsx
@@ -5,7 +5,7 @@ import './styles/index.css';
 
 // Apply saved theme before first render (prevents flash)
 const savedTheme = localStorage.getItem('cc-theme');
-const validThemes = ['dark', 'light', 'media-dark', 'media-light'];
+const validThemes = ['dark', 'light', 'media-dark', 'media-light', 'ember', 'forest', 'midnight', 'slate', 'horizon'];
 if (validThemes.includes(savedTheme)) {
   document.documentElement.setAttribute('data-theme', savedTheme);
 }

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1049,6 +1049,9 @@ textarea:focus {
 
 .theme-toggle {
   display: flex;
+  flex-wrap: wrap;
+  gap: 1px;
+  background: var(--color-border);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
@@ -1056,9 +1059,9 @@ textarea:focus {
 }
 
 .theme-toggle-btn {
-  padding: var(--space-2) var(--space-4);
+  padding: var(--space-2) var(--space-3);
   border: none;
-  background: transparent;
+  background: var(--color-surface);
   color: var(--color-text-muted);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
@@ -1066,10 +1069,6 @@ textarea:focus {
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
   white-space: nowrap;
-}
-
-.theme-toggle-btn:not(:last-child) {
-  border-right: 1px solid var(--color-border);
 }
 
 .theme-toggle-btn:hover {

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -65,6 +65,48 @@
   --primitive-media-text-900:   #1c1c1c;
   --primitive-media-text-500:   #6b6b6b;
   --primitive-media-text-400:   #9b9b9b;
+
+  /* Ember palette (warm dark, logo-derived) */
+  --primitive-ember-950: #12100e;
+  --primitive-ember-900: #1c1916;
+  --primitive-ember-800: #262220;
+  --primitive-ember-700: #3a3330;
+  --primitive-ember-500: #9a8e84;
+  --primitive-ember-200: #f0e8e0;
+
+  /* Forest palette (nature greens, sage) */
+  --primitive-forest-50:  #f4f7f4;
+  --primitive-forest-100: #e8ede8;
+  --primitive-forest-200: #c8d4c8;
+  --primitive-forest-300: #a8bca8;
+  --primitive-forest-700: #2d6a4f;
+  --primitive-forest-800: #1b4332;
+  --primitive-forest-900: #1a2e1a;
+
+  /* Midnight palette (deep navy, cyan accents) */
+  --primitive-midnight-950: #0a0e14;
+  --primitive-midnight-900: #111822;
+  --primitive-midnight-800: #1a2230;
+  --primitive-midnight-700: #2a3545;
+  --primitive-midnight-500: #6a8aaa;
+  --primitive-midnight-200: #d4e0f0;
+
+  /* Slate palette (neutral monochrome) */
+  --primitive-slate-50:  #f5f5f5;
+  --primitive-slate-100: #eaeaea;
+  --primitive-slate-200: #d4d4d4;
+  --primitive-slate-300: #b0b0b0;
+  --primitive-slate-700: #4a4a4a;
+  --primitive-slate-900: #1a1a1a;
+
+  /* Horizon palette (cool whites, indigo accent) */
+  --primitive-horizon-50:  #f8f9fc;
+  --primitive-horizon-100: #eef1f8;
+  --primitive-horizon-200: #d8dce8;
+  --primitive-horizon-300: #b0b8d0;
+  --primitive-horizon-700: #4f46e5;
+  --primitive-horizon-800: #4338ca;
+  --primitive-horizon-900: #111827;
 }
 
 /* ── 2. Semantic tokens — Light mode (default) ────────────
@@ -494,6 +536,346 @@ html[data-theme="media-dark"]:root {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
+}
+
+/* ── Ember — warm dark, logo-derived ────────────────────── */
+
+html[data-theme="ember"]:root {
+  --color-bg:           var(--primitive-ember-950);
+  --color-surface:      var(--primitive-ember-900);
+  --color-surface-alt:  var(--primitive-ember-800);
+  --color-border:       var(--primitive-ember-700);
+  --color-border-focus: #f1171e;
+
+  --color-text:         var(--primitive-ember-200);
+  --color-text-muted:   var(--primitive-ember-500);
+  --color-text-subtle:  #706050;
+
+  --color-accent:       #d80c18;
+  --color-accent-hover: #f1171e;
+  --color-accent-soft:  rgba(216, 12, 24, 0.14);
+
+  --color-danger:  #e05c4b;
+  --color-success: #4caf7d;
+
+  --color-sev-critical-text:   #f87171;
+  --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
+  --color-sev-critical-border: rgba(248, 113, 113, 0.2);
+  --color-sev-major-text:      #fbbf24;
+  --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
+  --color-sev-major-border:    rgba(251, 191, 36, 0.2);
+  --color-sev-minor-text:      var(--primitive-ember-500);
+  --color-sev-minor-bg:        rgba(154, 142, 132, 0.08);
+  --color-sev-minor-border:    var(--primitive-ember-700);
+
+  --color-grade-top-text:    #4ade80;
+  --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
+  --color-grade-high-text:   #2dd4bf;
+  --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
+  --color-grade-mid-text:    #fcd34d;
+  --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
+  --color-grade-low-text:    #fb923c;
+  --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
+  --color-grade-bottom-text: #f87171;
+  --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+
+  --color-warning:      #fbbf24;
+  --color-warning-text: #fbbf24;
+  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+
+  --color-danger-text:   #ff6b6b;
+  --color-danger-bg:     rgba(255, 100, 100, 0.15);
+  --color-danger-border: rgba(255, 100, 100, 0.3);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+  --color-overlay-medium: rgba(0, 0, 0, 0.82);
+  --color-overlay-light:  rgba(0, 0, 0, 0.72);
+
+  --color-chart-grid:   #3a3330;
+  --color-chart-axis:   #9a8e84;
+  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+
+  /* Logo */
+  --logo-q:           #d80c18;
+  --logo-chevron:     #f0e8e0;
+  --logo-needle:      #f1171e;
+  --logo-needle-dark: #aa0000;
+}
+
+/* ── Forest — nature greens, sage ───────────────────────── */
+
+html[data-theme="forest"]:root {
+  --color-bg:           var(--primitive-forest-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-forest-100);
+  --color-border:       var(--primitive-forest-200);
+  --color-border-focus: var(--primitive-forest-700);
+
+  --color-text:         var(--primitive-forest-900);
+  --color-text-muted:   #5a7a5a;
+  --color-text-subtle:  #7a9a7a;
+
+  --color-accent:       var(--primitive-forest-700);
+  --color-accent-hover: var(--primitive-forest-800);
+  --color-accent-soft:  rgba(45, 106, 79, 0.08);
+
+  --color-danger:  #c0392b;
+  --color-success: #2d7a4f;
+
+  --color-sev-critical-text:   #b91c1c;
+  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
+  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
+  --color-sev-major-text:      #b45309;
+  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
+  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
+  --color-sev-minor-text:      #5a7a5a;
+  --color-sev-minor-bg:        rgba(90, 122, 90, 0.06);
+  --color-sev-minor-border:    var(--primitive-forest-200);
+
+  --color-grade-top-text:    #166534;
+  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
+  --color-grade-high-text:   #0f766e;
+  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
+  --color-grade-mid-text:    #92400e;
+  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
+  --color-grade-low-text:    #9a3412;
+  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
+  --color-grade-bottom-text: #991b1b;
+  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+
+  --color-warning:      #b45309;
+  --color-warning-text: #b45309;
+  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-stroke: transparent;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+
+  /* Logo */
+  --logo-q:           #d80c18;
+  --logo-chevron:     #1b4332;
+  --logo-needle:      #2d6a4f;
+  --logo-needle-dark: #1b4332;
+}
+
+/* ── Midnight — deep navy, cyan accents ─────────────────── */
+
+html[data-theme="midnight"]:root {
+  --color-bg:           var(--primitive-midnight-950);
+  --color-surface:      var(--primitive-midnight-900);
+  --color-surface-alt:  var(--primitive-midnight-800);
+  --color-border:       var(--primitive-midnight-700);
+  --color-border-focus: #00d4ff;
+
+  --color-text:         var(--primitive-midnight-200);
+  --color-text-muted:   var(--primitive-midnight-500);
+  --color-text-subtle:  #4a6a88;
+
+  --color-accent:       #00d4ff;
+  --color-accent-hover: #33e0ff;
+  --color-accent-soft:  rgba(0, 212, 255, 0.10);
+
+  --color-danger:  #e05c4b;
+  --color-success: #4caf7d;
+
+  --color-sev-critical-text:   #f87171;
+  --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
+  --color-sev-critical-border: rgba(248, 113, 113, 0.2);
+  --color-sev-major-text:      #fbbf24;
+  --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
+  --color-sev-major-border:    rgba(251, 191, 36, 0.2);
+  --color-sev-minor-text:      var(--primitive-midnight-500);
+  --color-sev-minor-bg:        rgba(106, 138, 170, 0.08);
+  --color-sev-minor-border:    var(--primitive-midnight-700);
+
+  --color-grade-top-text:    #4ade80;
+  --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
+  --color-grade-high-text:   #2dd4bf;
+  --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
+  --color-grade-mid-text:    #fcd34d;
+  --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
+  --color-grade-low-text:    #fb923c;
+  --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
+  --color-grade-bottom-text: #f87171;
+  --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+
+  --color-warning:      #fbbf24;
+  --color-warning-text: #fbbf24;
+  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+
+  --color-danger-text:   #ff6b6b;
+  --color-danger-bg:     rgba(255, 100, 100, 0.15);
+  --color-danger-border: rgba(255, 100, 100, 0.3);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+  --color-overlay-medium: rgba(0, 0, 0, 0.82);
+  --color-overlay-light:  rgba(0, 0, 0, 0.72);
+
+  --color-chart-grid:   #2a3545;
+  --color-chart-axis:   #6a8aaa;
+  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+
+  /* Logo */
+  --logo-q:           #d80c18;
+  --logo-chevron:     #00d4ff;
+  --logo-needle:      #00d4ff;
+  --logo-needle-dark: #0090b0;
+}
+
+/* ── Slate — minimal monochrome, logo red accent ────────── */
+
+html[data-theme="slate"]:root {
+  --color-bg:           var(--primitive-slate-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-slate-100);
+  --color-border:       var(--primitive-slate-200);
+  --color-border-focus: #d80c18;
+
+  --color-text:         var(--primitive-slate-900);
+  --color-text-muted:   #6b6b6b;
+  --color-text-subtle:  #9a9a9a;
+
+  --color-accent:       #d80c18;
+  --color-accent-hover: #b00a14;
+  --color-accent-soft:  rgba(216, 12, 24, 0.06);
+
+  --color-danger:  #c0392b;
+  --color-success: #2d7a4f;
+
+  --color-sev-critical-text:   #b91c1c;
+  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
+  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
+  --color-sev-major-text:      #b45309;
+  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
+  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
+  --color-sev-minor-text:      #6b6b6b;
+  --color-sev-minor-bg:        rgba(107, 107, 107, 0.06);
+  --color-sev-minor-border:    var(--primitive-slate-200);
+
+  --color-grade-top-text:    #166534;
+  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
+  --color-grade-high-text:   #0f766e;
+  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
+  --color-grade-mid-text:    #92400e;
+  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
+  --color-grade-low-text:    #9a3412;
+  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
+  --color-grade-bottom-text: #991b1b;
+  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+
+  --color-warning:      #b45309;
+  --color-warning-text: #b45309;
+  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-stroke: transparent;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+
+  /* Logo */
+  --logo-q:           #d80c18;
+  --logo-chevron:     #333333;
+  --logo-needle:      #d80c18;
+  --logo-needle-dark: #aa0000;
+}
+
+/* ── Horizon — AI/tech, cool whites, indigo accent ──────── */
+
+html[data-theme="horizon"]:root {
+  --color-bg:           var(--primitive-horizon-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-horizon-100);
+  --color-border:       var(--primitive-horizon-200);
+  --color-border-focus: #6366f1;
+
+  --color-text:         var(--primitive-horizon-900);
+  --color-text-muted:   #6b7280;
+  --color-text-subtle:  #9ca3af;
+
+  --color-accent:       #6366f1;
+  --color-accent-hover: #4f46e5;
+  --color-accent-soft:  rgba(99, 102, 241, 0.08);
+
+  --color-danger:  #dc2626;
+  --color-success: #16a34a;
+
+  --color-sev-critical-text:   #dc2626;
+  --color-sev-critical-bg:     rgba(220, 38, 38, 0.08);
+  --color-sev-critical-border: rgba(220, 38, 38, 0.2);
+  --color-sev-major-text:      #d97706;
+  --color-sev-major-bg:        rgba(217, 119, 6, 0.08);
+  --color-sev-major-border:    rgba(217, 119, 6, 0.2);
+  --color-sev-minor-text:      #6b7280;
+  --color-sev-minor-bg:        rgba(107, 114, 128, 0.06);
+  --color-sev-minor-border:    var(--primitive-horizon-200);
+
+  --color-grade-top-text:    #166534;
+  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
+  --color-grade-high-text:   #0f766e;
+  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
+  --color-grade-mid-text:    #92400e;
+  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
+  --color-grade-low-text:    #9a3412;
+  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
+  --color-grade-bottom-text: #991b1b;
+  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+
+  --color-warning:      #d97706;
+  --color-warning-text: #d97706;
+  --color-warning-bg:   rgba(217, 119, 6, 0.08);
+
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-stroke: transparent;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+
+  /* Logo */
+  --logo-q:           #6366f1;
+  --logo-chevron:     #4f46e5;
+  --logo-needle:      #6366f1;
+  --logo-needle-dark: #4338ca;
 }
 
 /* ── 5. Typography ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Auto-heal pass for M-MOD Modularity violations:

- **M-MOD-5 (>5 params)**: Introduced `EvaluationOptions`, `PromptContext`, and `EvidenceContext` dataclasses to group parameters for `start_evaluation`, `build_analysis_prompt`, and `parse_jsonl_to_evidence`
- **M-MOD-14 (hard-coded paths)**: Added `standards_dir` to `ConfigPaths`; replaced all `Path(__file__).parents[N] / "..."` traversals in `engine/standards.py`, `engine/prompt_builder.py`, `action_api.py`, `action_provider_fs.py`, and `cli.py` with `default_paths()` calls
- **CWE-1051 (hard-coded URLs)**: Externalized `_LINTER_SOURCES` dict (6 URLs) from `knowledge_refresh.py` to `config/linter_sources.json`
- **CWE-1076 (private re-exports)**: Removed `_get_previous_run_for_dimension`, `_normalize_date`, `_parse_run_date` from `adapters/fs/report_parser/__init__.py`

## Test plan

- [x] 188 tests pass (`uv run pytest tests/ -q --ignore=tests/test_readme.py`)
- [x] All affected call sites updated (runner.py, action_api.py, 4 test files)