### PR TITLE
refactor(reusability): eliminate duplicate logic across runner, analysis, and web adapters

### DIFF
--- a/src/quodeq/_fs_violations.py
+++ b/src/quodeq/_fs_violations.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any, Callable
 
+from quodeq.engine.analysis import count_files_from_stream
+
 
 def parse_violations_from_jsonl(jsonl_path: Path, stream_path: Path | None, project: str, run_id: str, dimension: str) -> dict[str, Any] | None:
     """Parse live JSONL findings written by the MCP server."""
@@ -44,7 +46,7 @@ def parse_violations_from_jsonl(jsonl_path: Path, stream_path: Path | None, proj
             violations.append(entry)
         else:
             compliance.append(entry)
-    files_read = _count_files_read(stream_path.read_text()) if stream_path and stream_path.exists() else 0
+    files_read = count_files_from_stream(stream_path) if stream_path and stream_path.exists() else 0
     return {
         "dimension": dimension,
         "runId": run_id,
@@ -118,26 +120,6 @@ _TEXT_EXTRACTORS: dict[str, Callable] = {
 }
 
 
-def _count_files_read(content: str) -> int:
-    """Count unique files read by the AI from tool_use events in the stream."""
-    files: set[str] = set()
-    for raw_line in content.splitlines():
-        stripped = raw_line.strip()
-        if not stripped:
-            continue
-        try:
-            event = json.loads(stripped)
-        except json.JSONDecodeError:
-            continue
-        etype = event.get("type", "")
-        if etype == "assistant":
-            for block in (event.get("message") or {}).get("content") or []:
-                if block.get("type") == "tool_use" and block.get("name") in ("Read", "Grep"):
-                    fp = (block.get("input") or {}).get("file_path") or (block.get("input") or {}).get("path")
-                    if fp:
-                        files.add(fp)
-    return len(files)
-
 
 def _parse_entries_from_texts(
     texts: list[str], dimension: str, seen: set[str]
@@ -201,7 +183,7 @@ def parse_violations_from_stream(stream_path: Path, project: str, run_id: str, d
         violations.extend(new_v)
         compliance.extend(new_c)
 
-    files_read = _count_files_read(content)
+    files_read = count_files_from_stream(stream_path)
     return {
         "dimension": dimension,
         "runId": run_id,

--- a/src/quodeq/adapters/web/dimensions_repository.py
+++ b/src/quodeq/adapters/web/dimensions_repository.py
@@ -1,5 +1,5 @@
-from quodeq.adapters.web.http_client import HttpClient
-from quodeq.ports.data_errors import AuthError, InvalidDataError, NotFoundError, ServerError
+from quodeq.adapters.web.http_client import HttpClient, check_response_status
+from quodeq.ports.data_errors import InvalidDataError
 
 
 class WebDimensionsRepository:
@@ -9,24 +9,14 @@ class WebDimensionsRepository:
 
     def list_dimensions(self) -> list[str]:
         response = self.client.get_json(f"{self.base_url}/dimensions", {})
-        if response.status in {401, 403}:
-            raise AuthError("Authentication error")
-        elif response.status == 404:
-            raise NotFoundError("Not found")
-        elif response.status >= 500:
-            raise ServerError("Server error")
+        check_response_status(response)
         if not isinstance(response.data, dict) or "dimensions" not in response.data or not isinstance(response.data["dimensions"], list):
             raise InvalidDataError("Invalid data format")
         return response.data["dimensions"]
 
     def get_dimension(self, dimension_id: str) -> dict:
         response = self.client.get_json(f"{self.base_url}/dimensions/{dimension_id}", {})
-        if response.status in {401, 403}:
-            raise AuthError("Authentication error")
-        elif response.status == 404:
-            raise NotFoundError("Not found")
-        elif response.status >= 500:
-            raise ServerError("Server error")
+        check_response_status(response)
         if not isinstance(response.data, dict):
             raise InvalidDataError("Invalid data format")
         return response.data

--- a/src/quodeq/adapters/web/evaluations_repository.py
+++ b/src/quodeq/adapters/web/evaluations_repository.py
@@ -1,5 +1,5 @@
-from quodeq.adapters.web.http_client import HttpClient
-from quodeq.ports.data_errors import AuthError, InvalidDataError, NotFoundError, ServerError
+from quodeq.adapters.web.http_client import HttpClient, check_response_status
+from quodeq.ports.data_errors import InvalidDataError
 
 
 class WebEvaluationsRepository:
@@ -9,24 +9,14 @@ class WebEvaluationsRepository:
 
     def list_reports(self) -> list[str]:
         response = self.client.get_json(f"{self.base_url}/reports", {})
-        if response.status in {401, 403}:
-            raise AuthError("Authentication error")
-        elif response.status == 404:
-            raise NotFoundError("Not found")
-        elif response.status >= 500:
-            raise ServerError("Server error")
+        check_response_status(response)
         if not isinstance(response.data, dict) or "reports" not in response.data or not isinstance(response.data["reports"], list):
             raise InvalidDataError("Invalid data format")
         return response.data["reports"]
 
     def get_report(self, report_id: str) -> dict:
         response = self.client.get_json(f"{self.base_url}/reports/{report_id}", {})
-        if response.status in {401, 403}:
-            raise AuthError("Authentication error")
-        elif response.status == 404:
-            raise NotFoundError("Not found")
-        elif response.status >= 500:
-            raise ServerError("Server error")
+        check_response_status(response)
         if not isinstance(response.data, dict):
             raise InvalidDataError("Invalid data format")
         return response.data

--- a/src/quodeq/adapters/web/evaluators_repository.py
+++ b/src/quodeq/adapters/web/evaluators_repository.py
@@ -1,18 +1,5 @@
-from quodeq.adapters.web.http_client import HttpClient
-from quodeq.ports.data_errors import AuthError, InvalidDataError, NotFoundError, ServerError
-
-
-from quodeq.adapters.web.http_client import HttpResponse
-
-
-def _check_response_status(response: HttpResponse) -> None:
-    """Raise the appropriate error for non-success HTTP status codes."""
-    if response.status in {401, 403}:
-        raise AuthError("Authentication error")
-    if response.status == 404:
-        raise NotFoundError("Not found")
-    if response.status >= 500:
-        raise ServerError("Server error")
+from quodeq.adapters.web.http_client import HttpClient, check_response_status
+from quodeq.ports.data_errors import InvalidDataError
 
 
 class WebEvaluatorsRepository:
@@ -22,14 +9,14 @@ class WebEvaluatorsRepository:
 
     def list_evaluators(self, discipline: str) -> list[str]:
         response = self._client.get_json(f"{self._base_url}/evaluators/{discipline}", {})
-        _check_response_status(response)
+        check_response_status(response)
         if not isinstance(response.data, dict) or "dimensions" not in response.data or not isinstance(response.data["dimensions"], list):
             raise InvalidDataError("Invalid data format")
         return response.data["dimensions"]
 
     def get_evaluator(self, discipline: str, dimension_id: str) -> dict:
         response = self._client.get_json(f"{self._base_url}/evaluators/{discipline}/{dimension_id}", {})
-        _check_response_status(response)
+        check_response_status(response)
         if not isinstance(response.data, dict):
             raise InvalidDataError("Invalid data format")
         return response.data

--- a/src/quodeq/adapters/web/http_client.py
+++ b/src/quodeq/adapters/web/http_client.py
@@ -2,11 +2,23 @@ from dataclasses import dataclass
 import json
 from urllib import request
 
+from quodeq.ports.data_errors import AuthError, NotFoundError, ServerError
+
 
 @dataclass(frozen=True)
 class HttpResponse:
     status: int
     data: dict
+
+
+def check_response_status(response: HttpResponse) -> None:
+    """Raise the appropriate error for non-success HTTP status codes."""
+    if response.status in {401, 403}:
+        raise AuthError("Authentication error")
+    if response.status == 404:
+        raise NotFoundError("Not found")
+    if response.status >= 500:
+        raise ServerError("Server error")
 
 
 class HttpClient:

--- a/src/quodeq/engine/analysis.py
+++ b/src/quodeq/engine/analysis.py
@@ -120,6 +120,8 @@ def run_analysis(
     analysis_budget: str | None = None,
     heartbeat_interval: int = 10,
     heartbeat_callback: object | None = None,
+    ai_cmd: str | None = None,
+    ai_model: str | None = None,
 ) -> None:
     """Spawn AI CLI subprocess with tools, capturing stream-json to *stream_file*.
 
@@ -138,8 +140,8 @@ def run_analysis(
         heartbeat_interval: Seconds between heartbeat callbacks.
         heartbeat_callback: Optional callable(elapsed_seconds, progress) for progress.
     """
-    cmd = _get_ai_cmd()
-    model = _get_ai_model()
+    cmd = ai_cmd or _get_ai_cmd()
+    model = ai_model or _get_ai_model()
     tools = "Bash,Glob,Grep,Read"
 
     args = [cmd, "--print", "--output-format", "stream-json", "--verbose", "--tools", tools]

--- a/src/quodeq/engine/runner.py
+++ b/src/quodeq/engine/runner.py
@@ -71,8 +71,8 @@ def _cleanup_stream(stream_file: Path) -> None:
     err_file.unlink(missing_ok=True)
 
 
-def run(config: RunConfig) -> Evidence:
-    """Orchestrate: load plugin → per-dimension AI analysis → merged Evidence."""
+def _run_dimensions(config: RunConfig) -> dict[str, Evidence]:
+    """Run AI analysis for each dimension and return per-dimension Evidence."""
     plugin_dir = config.evaluators_dir / config.plugin_id
     if not plugin_dir.exists():
         raise ValueError(f"Plugin directory not found: {plugin_dir}")
@@ -91,7 +91,7 @@ def run(config: RunConfig) -> Evidence:
         dimensions = all_dims
     work_dir = config.work_dir or config.src
 
-    all_evidence: list[Evidence] = []
+    result: dict[str, Evidence] = {}
     total = len(dimensions)
     _emit_marker("setup", dimensions=dimensions)
 
@@ -158,100 +158,19 @@ def run(config: RunConfig) -> Evidence:
         violations = sum(len(pe.violations) for pe in ev.principles.values())
         compliances = sum(len(pe.compliance) for pe in ev.principles.values())
         print(f"✓ [{idx}/{total}] {dimension} — {files_read} files, {violations}v/{compliances}c", flush=True)
-        all_evidence.append(ev)
+        result[dimension] = ev
 
-    return _merge_evidence(all_evidence, config)
+    return result
+
+
+def run(config: RunConfig) -> Evidence:
+    """Orchestrate: load plugin → per-dimension AI analysis → merged Evidence."""
+    return _merge_evidence(list(_run_dimensions(config).values()), config)
 
 
 def run_per_dimension(config: RunConfig) -> dict[str, Evidence]:
     """Like run(), but returns a dict of {dimension_id: Evidence} without merging."""
-    plugin_dir = config.evaluators_dir / config.plugin_id
-    if not plugin_dir.exists():
-        raise ValueError(f"Plugin directory not found: {plugin_dir}")
-
-    full = load_plugin_full(plugin_dir)
-    template = load_template(config.template_path)
-    date_str = datetime.now().isoformat(timespec="seconds")
-
-    analysis_file = plugin_dir / "knowledge" / "analysis.md"
-    analysis_md = analysis_file.read_text() if analysis_file.exists() else ""
-
-    all_dims = [d["id"] for d in full["dimensions"].get("applies", [])]
-    if config.dimensions:
-        dimensions = [d for d in all_dims if d in config.dimensions]
-    else:
-        dimensions = all_dims
-    work_dir = config.work_dir or config.src
-
-    result: dict[str, Evidence] = {}
-    total = len(dimensions)
-    _emit_marker("setup", dimensions=dimensions)
-
-    for idx, dimension in enumerate(dimensions, 1):
-        _emit_marker("analyzing", dimension=dimension)
-        print(f"→ [{idx}/{total}] Analyzing {dimension}", flush=True)
-        prompt = build_analysis_prompt(
-            template,
-            PromptContext(
-                plugin_id=config.plugin_id,
-                repo_name=str(config.src),
-                date_str=date_str,
-                dimension=dimension,
-                source_file_count=config.source_file_count,
-                dimensions_data=full["dimensions"],
-                analysis_md=analysis_md,
-                standards_dir=config.standards_dir,
-            ),
-        )
-
-        stream_file = work_dir / f"{dimension}_live.stream"
-        jsonl_file = work_dir / f"{dimension}_evidence.jsonl"
-
-        heartbeat = config.heartbeat_callback or _make_heartbeat(dimension, idx, total, config.source_file_count)
-
-        run_analysis(
-            work_dir=config.src,
-            prompt=prompt,
-            stream_file=stream_file,
-            jsonl_file=jsonl_file,
-            analysis_budget=config.analysis_budget,
-            heartbeat_callback=heartbeat,
-        )
-
-        if not is_stream_valid(stream_file):
-            print(f"  [{idx}/{total}] {dimension} — no valid stream, skipping", flush=True)
-            continue
-
-        _emit_marker("scoring", dimension=dimension)
-
-        mcp_produced = jsonl_file.exists() and jsonl_file.stat().st_size > 0
-        mcp_status = get_mcp_status(stream_file)
-        if mcp_status and mcp_status != "connected":
-            print(f"  ⚠ MCP findings server {mcp_status} — falling back to stream extraction", flush=True)
-        if mcp_produced:
-            files_read = count_files_from_stream(stream_file)
-        else:
-            files_read = extract_evidence_from_stream(stream_file, jsonl_file)
-
-        ev = parse_jsonl_to_evidence(
-            jsonl_file,
-            EvidenceContext(
-                plugin_id=config.plugin_id,
-                repository=str(config.src),
-                date_str=date_str,
-                source_file_count=config.source_file_count,
-                files_read=files_read,
-            ),
-            standards_dir=config.standards_dir,
-        )
-        ev.plugin_name = full["plugin"].get("name", config.plugin_id)
-
-        violations = sum(len(pe.violations) for pe in ev.principles.values())
-        compliances = sum(len(pe.compliance) for pe in ev.principles.values())
-        print(f"✓ [{idx}/{total}] {dimension} — {files_read} files, {violations}v/{compliances}c", flush=True)
-        result[dimension] = ev
-
-    return result
+    return _run_dimensions(config)
 
 
 def _merge_evidence(evidence_list: list[Evidence], config: RunConfig) -> Evidence:


### PR DESCRIPTION
## Summary

Auto-heal pass for M-REU Reusability violations:

- **runner.py (major)**: Extracted the identical dimension-loop body shared by `run()` and `run_per_dimension()` into `_run_dimensions()`. Both public functions are now 1-liners delegating to it.
- **analysis.py**: Added `ai_cmd` and `ai_model` keyword params to `run_analysis()` (env fallback kept) so they can be injected in tests without patching `os.environ` (M-REU-4).
- **_fs_violations.py**: Deleted `_count_files_read()` (19 lines of duplicate stream-parsing logic); replaced 2 call sites with `count_files_from_stream()` from `analysis.py`.
- **web adapters**: Moved `check_response_status()` into `http_client.py`; `dimensions_repository.py`, `evaluations_repository.py`, and `evaluators_repository.py` all import it from there — eliminating the inline 3-branch status check repeated in every method (M-REU-1, CWE-1041).

## Test plan

- [x] 188 tests pass (`uv run pytest tests/ -q --ignore=tests/test_readme.py`)