### PR TITLE
refactor(testability): move pytest from runtime deps to dev dependency-group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,13 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "pytest>=9.0.2",
     "jsonschema",
     "flask>=3.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -228,6 +228,10 @@ source = { editable = "." }
 dependencies = [
     { name = "flask" },
     { name = "jsonschema" },
+]
+
+[package.dev-dependencies]
+dev = [
     { name = "pytest" },
 ]
 
@@ -235,8 +239,10 @@ dependencies = [
 requires-dist = [
     { name = "flask", specifier = ">=3.0.0" },
     { name = "jsonschema" },
-    { name = "pytest", specifier = ">=9.0.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.2" }]
 
 [[package]]
 name = "referencing"


### PR DESCRIPTION
## Summary

- Moves `pytest>=9.0.2` out of `[project.dependencies]` into `[dependency-groups] dev` so it is not included in production installs.

## Test plan

- [x] 188 tests pass (`uv run pytest tests/ -q --ignore=tests/test_readme.py`)