### PR TITLE
refactor(modifiability): externalize _PREFIX_MAP hard-coded literal to JSON (CWE-1052)

### DIFF
--- a/tools/enrich_standards.py
+++ b/tools/enrich_standards.py
@@ -28,35 +28,8 @@ _MAPPING_PATH = Path(__file__).resolve().parent / "enrich_standards_mapping.json
 MAPPING: dict = json.loads(_MAPPING_PATH.read_text())
 
 # Prefix map: dimension → principle → id prefix
-_PREFIX_MAP = {
-    "security": {
-        "Confidentiality": "S-CON",
-        "Integrity": "S-INT",
-        "Non-repudiation": "S-NRP",
-        "Accountability": "S-ACC",
-        "Authenticity": "S-AUT",
-    },
-    "reliability": {
-        "Maturity": "R-MAT",
-        "Availability": "R-AVA",
-        "Fault Tolerance": "R-FT",
-        "Recoverability": "R-REC",
-    },
-    "maintainability": {
-        "Modularity": "M-MOD",
-        "Reusability": "M-REU",
-        "Analyzability": "M-ANA",
-        "Modifiability": "M-MDF",
-        "Testability": "M-TST",
-    },
-    "performance": {
-        "Time Behaviour": "P-TIM",
-        "Resource Utilisation": "P-RES",
-        "Capacity": "P-CAP",
-    },
-    "usability": {},
-    "flexibility": {},
-}
+_PREFIX_MAP_PATH = Path(__file__).resolve().parent / "enrich_standards_prefix_map.json"
+_PREFIX_MAP: dict = json.loads(_PREFIX_MAP_PATH.read_text())
 
 
 def _get_existing_cwes(data: dict) -> set[int]:

--- a/tools/enrich_standards_prefix_map.json
+++ b/tools/enrich_standards_prefix_map.json
@@ -1,0 +1,29 @@
+{
+  "security": {
+    "Confidentiality": "S-CON",
+    "Integrity": "S-INT",
+    "Non-repudiation": "S-NRP",
+    "Accountability": "S-ACC",
+    "Authenticity": "S-AUT"
+  },
+  "reliability": {
+    "Maturity": "R-MAT",
+    "Availability": "R-AVA",
+    "Fault Tolerance": "R-FT",
+    "Recoverability": "R-REC"
+  },
+  "maintainability": {
+    "Modularity": "M-MOD",
+    "Reusability": "M-REU",
+    "Analyzability": "M-ANA",
+    "Modifiability": "M-MDF",
+    "Testability": "M-TST"
+  },
+  "performance": {
+    "Time Behaviour": "P-TIM",
+    "Resource Utilisation": "P-RES",
+    "Capacity": "P-CAP"
+  },
+  "usability": {},
+  "flexibility": {}
+}


### PR DESCRIPTION
## Summary

- Moves `_PREFIX_MAP` (29-line hard-coded dict in `tools/enrich_standards.py`) to `tools/enrich_standards_prefix_map.json`, loaded at import time — same pattern already used for `MAPPING` / `enrich_standards_mapping.json`.

## Test plan

- [x] 188 tests pass (`uv run pytest tests/ -q --ignore=tests/test_readme.py`)