### PR TITLE
UI design system polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/tmp/
 .idea/
 CLAUDE.md
 .quodeq.env
+.superpowers/

--- a/src/quodeq/action_api.py
+++ b/src/quodeq/action_api.py
@@ -100,7 +100,12 @@ def create_app(provider: ActionProvider | None = None, static_dist: str | None =
     @app.get("/api/health")
     def health() -> Response:
         """Return a simple health-check response."""
-        return jsonify({"ok": True})
+        try:
+            from importlib.metadata import version as _pkg_version
+            v = _pkg_version("quodeq")
+        except Exception:
+            v = None
+        return jsonify({"ok": True, "version": v})
 
     register_project_list_routes(app, provider)
     register_project_data_routes(app, provider)

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -201,7 +201,7 @@ def _wait_for_process(proc: subprocess.Popen) -> None:
         try:
             proc.wait(timeout=_PROCESS_WAIT_TIMEOUT_S)
         except subprocess.TimeoutExpired:
-            log_debug("Process still running, continuing to wait...")
+            pass
 
 
 def _serve_and_wait(action_api_url: str, action_api_process: subprocess.Popen | None, config: DashboardConfig) -> None:

--- a/src/quodeq/engine/runner.py
+++ b/src/quodeq/engine/runner.py
@@ -70,15 +70,13 @@ def _emit_marker(phase: str, **kwargs: _MarkerFields) -> None:
     print(json.dumps({CC_MARKER_KEY: phase, **kwargs}), flush=True)
 
 
-def _make_heartbeat(dim_name: str, idx: int, total: int, src_count: int) -> Callable[[int, dict], None]:
+def _make_heartbeat(dim_name: str, idx: int, total: int) -> Callable[[int, dict], None]:
     """Return a heartbeat callback that prints progress to stdout."""
     def _cb(elapsed: int, progress: dict) -> None:
         secs = elapsed % 60
         mins = elapsed // 60
-        files = progress.get("files_read", 0)
         evidence = progress.get("evidence", 0)
-        pct_str = f" ({min(round(files / src_count * 100), 100)}%)" if src_count > 0 else ""
-        log_info(f"  [{idx}/{total}] {dim_name} | {mins}m{secs:02d}s | {files} files{pct_str} | {evidence} findings")
+        log_info(f"  [{idx}/{total}] {dim_name} | {mins}m{secs:02d}s | {evidence} findings")
     return _cb
 
 
@@ -131,7 +129,7 @@ def _run_dimension_analysis(
     stream_file = evidence_dir / f"{dim_id}_live.stream"
     jsonl_file = evidence_dir / f"{dim_id}_evidence.jsonl"
 
-    heartbeat = config.options.heartbeat_callback or _make_heartbeat(dim_id, idx, ctx.total, config.source_file_count)
+    heartbeat = config.options.heartbeat_callback or _make_heartbeat(dim_id, idx, ctx.total)
 
     ac_kwargs: dict[str, Any] = dict(
         jsonl_file=jsonl_file,

--- a/src/quodeq/provider/jobs.py
+++ b/src/quodeq/provider/jobs.py
@@ -16,6 +16,7 @@ import subprocess
 from quodeq.engine.runner import CC_MARKER_KEY
 
 MAX_LOG_LINES = 600  # rolling buffer size for per-job log lines
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
 _CC_MARKER_PREFIX = '{"' + CC_MARKER_KEY
 REPORT_PATH_RE = re.compile(r"Report path:.*[/\\]([^/\\\s]+)[/\\]([^/\\\s]+)[/\\]evaluation")
 
@@ -145,7 +146,7 @@ class JobManager:
         if line.startswith(_CC_MARKER_PREFIX):
             self._apply_marker(job, line)
             return
-        job.logs.append(line)
+        job.logs.append(_ANSI_RE.sub("", line))
         if len(job.logs) > MAX_LOG_LINES:
             job.logs[:] = job.logs[-MAX_LOG_LINES:]
         match = REPORT_PATH_RE.search(line)

--- a/ui/web/index.html
+++ b/ui/web/index.html
@@ -6,7 +6,7 @@
     <title>Quodeq Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Manrope:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/ui/web/index.html
+++ b/ui/web/index.html
@@ -6,7 +6,7 @@
     <title>Quodeq Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Manrope:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -671,23 +671,19 @@ export default function App() {
                 <div className="panel-header">
                   <h2 className="settings-section-title">About</h2>
                 </div>
-                <div className="settings-row">
-                  <div className="settings-row-label">
-                    <span className="settings-label">Version</span>
+                <div className="settings-about-rows">
+                  <div className="settings-about-row">
+                    <span className="settings-about-key">Version</span>
+                    <span className="settings-about-value">{appVersion ?? '—'}</span>
                   </div>
-                  <span className="settings-about-value">{appVersion ?? '—'}</span>
-                </div>
-                <div className="settings-row">
-                  <div className="settings-row-label">
-                    <span className="settings-label">Website</span>
+                  <div className="settings-about-row">
+                    <span className="settings-about-key">Website</span>
+                    <a className="settings-about-link" href="https://quodeq.ai" target="_blank" rel="noopener noreferrer">quodeq.ai</a>
                   </div>
-                  <a className="settings-about-link" href="https://quodeq.ai" target="_blank" rel="noopener noreferrer">quodeq.ai</a>
-                </div>
-                <div className="settings-row">
-                  <div className="settings-row-label">
-                    <span className="settings-label">Repository</span>
+                  <div className="settings-about-row">
+                    <span className="settings-about-key">Repository</span>
+                    <a className="settings-about-link" href="https://github.com/quodeq/quodeq" target="_blank" rel="noopener noreferrer">github.com/quodeq/quodeq</a>
                   </div>
-                  <a className="settings-about-link" href="https://github.com/quodeq/quodeq" target="_blank" rel="noopener noreferrer">github.com/quodeq/quodeq</a>
                 </div>
                 {settingsPhrase && (
                   <div className="settings-row settings-row--last settings-about-phrase-row">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -20,36 +20,37 @@ import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
 // Icons
 // ---------------------------------------------------------------------------
 const ICON_OVERVIEW = (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <rect x="3" y="3" width="7" height="7" rx="1" />
-    <rect x="14" y="3" width="7" height="7" rx="1" />
-    <rect x="3" y="14" width="7" height="7" rx="1" />
-    <rect x="14" y="14" width="7" height="7" rx="1" />
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="13" width="4" height="8" />
+    <rect x="10" y="8" width="4" height="13" />
+    <rect x="17" y="3" width="4" height="18" />
   </svg>
 );
 
 const ICON_EVALUATE = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="11" cy="11" r="7" />
-    <line x1="16.5" y1="16.5" x2="22" y2="22" />
+    <line x1="16.5" y1="16.5" x2="21" y2="21" />
+    <line x1="8" y1="11" x2="14" y2="11" />
+    <line x1="11" y1="8" x2="11" y2="14" />
   </svg>
 );
 
 const ICON_PROJECTS = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <rect x="3" y="3"  width="4" height="4" rx="0.5" />
-    <rect x="3" y="10" width="4" height="4" rx="0.5" />
-    <rect x="3" y="17" width="4" height="4" rx="0.5" />
-    <line x1="9" y1="5"  x2="21" y2="5"  />
-    <line x1="9" y1="12" x2="21" y2="12" />
-    <line x1="9" y1="19" x2="21" y2="19" />
+    <polyline points="3,4 5.5,6 3,8" />
+    <line x1="9" y1="6" x2="21" y2="6" />
+    <polyline points="3,11 5.5,13 3,15" />
+    <line x1="9" y1="13" x2="21" y2="13" />
+    <polyline points="3,18 5.5,20 3,22" />
+    <line x1="9" y1="20" x2="21" y2="20" />
   </svg>
 );
 
 const ICON_SETTINGS = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <circle cx="12" cy="12" r="3" />
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77" />
   </svg>
 );
 
@@ -444,7 +445,9 @@ export default function App() {
                   <div className="eval-icon-static">
                     <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
                       <circle cx="11" cy="11" r="7" />
-                      <line x1="16.5" y1="16.5" x2="22" y2="22" />
+                      <line x1="16.5" y1="16.5" x2="21" y2="21" />
+                      <line x1="8" y1="11" x2="14" y2="11" />
+                      <line x1="11" y1="8" x2="11" y2="14" />
                     </svg>
                   </div>
                   {/* Animated layer — visible when running */}
@@ -454,7 +457,9 @@ export default function App() {
                     <span className="eval-file-chip" style={{animationDelay: '1.1s'}} />
                     <svg className="eval-glass-sweep" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
                       <circle cx="11" cy="11" r="7" />
-                      <line x1="16.5" y1="16.5" x2="22" y2="22" />
+                      <line x1="16.5" y1="16.5" x2="21" y2="21" />
+                      <line x1="8" y1="11" x2="14" y2="11" />
+                      <line x1="11" y1="8" x2="11" y2="14" />
                     </svg>
                   </div>
                 </div>
@@ -534,9 +539,9 @@ export default function App() {
             <div className="settings-header">
               <div className="settings-header-content">
                 <div className="settings-page-icon">
-                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+                  <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
                     <circle cx="12" cy="12" r="3" />
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+                    <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77" />
                   </svg>
                 </div>
                 <div>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { listProjects, getAiClients } from './api/index.js';
+import { listProjects, getAiClients, getHealth } from './api/index.js';
 import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import RunNavigator from './features/dashboard/components/RunNavigator.jsx';
@@ -301,6 +301,24 @@ export default function App() {
   // -------------------------------------------------------------------------
   const [aiCmd, setAiCmd] = useState(localStorage.getItem('cc-ai-cmd') || '');
   const [availableClients, setAvailableClients] = useState(null);
+  const [appVersion, setAppVersion] = useState(null);
+  const [settingsPhrase, setSettingsPhrase] = useState('');
+
+  const _SETTINGS_PHRASES = [
+    'quode with cuore ♥',
+    'human aligned quode',
+    'quode safe',
+    'navigate your quode to excellence',
+    'code quality compass',
+  ];
+
+  useEffect(() => {
+    if (activePage.page !== 'settings') return;
+    setSettingsPhrase(_SETTINGS_PHRASES[Math.floor(Math.random() * _SETTINGS_PHRASES.length)]);
+    if (appVersion === null) {
+      getHealth().then((d) => setAppVersion(d.version || null)).catch(() => {});
+    }
+  }, [activePage]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (activePage.page !== 'settings' || availableClients !== null) return;
@@ -646,6 +664,34 @@ export default function App() {
                         Uses your client's default model. Run <code>{aiCmd} --help</code> to see how to change it.
                       </span>
                     </div>
+                  </div>
+                )}
+              </section>
+              <section className="panel settings-section">
+                <div className="panel-header">
+                  <h2 className="settings-section-title">About</h2>
+                </div>
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Version</span>
+                  </div>
+                  <span className="settings-about-value">{appVersion ?? '—'}</span>
+                </div>
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Website</span>
+                  </div>
+                  <a className="settings-about-link" href="https://quodeq.ai" target="_blank" rel="noopener noreferrer">quodeq.ai</a>
+                </div>
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Repository</span>
+                  </div>
+                  <a className="settings-about-link" href="https://github.com/quodeq/quodeq" target="_blank" rel="noopener noreferrer">github.com/quodeq/quodeq</a>
+                </div>
+                {settingsPhrase && (
+                  <div className="settings-row settings-row--last settings-about-phrase-row">
+                    <span className="settings-about-phrase">{settingsPhrase}</span>
                   </div>
                 )}
               </section>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -691,7 +691,7 @@ export default function App() {
               </g>
             </svg>
           </div>
-          <span className="sidebar-brand-text">Quodeq</span>
+          <span className="sidebar-brand-text">quodeq</span>
         </div>
 
         <nav className="sidebar-nav">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -561,8 +561,6 @@ export default function App() {
                       { value: 'system',      label: 'System' },
                       { value: 'light',       label: 'Light' },
                       { value: 'dark',        label: 'Dark' },
-                      { value: 'media-light', label: 'Media Lt' },
-                      { value: 'media-dark',  label: 'Media Dk' },
                       { value: 'ember',       label: 'Ember' },
                       { value: 'forest',      label: 'Forest' },
                       { value: 'midnight',    label: 'Midnight' },

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -14,6 +14,7 @@ import PrincipleDetailPage from './features/explorer/components/PrincipleDetailP
 import EvalPrincipleDetailPage from './features/explorer/components/EvalPrincipleDetailPage.jsx';
 import { formatRunId } from './utils/formatters.js';
 import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
+import SettingsAside from './features/settings/components/SettingsAside.jsx';
 
 
 // ---------------------------------------------------------------------------
@@ -551,6 +552,7 @@ export default function App() {
               </div>
             </div>
 
+            <div className="settings-layout">
             <div className="settings-body">
               <section className="panel settings-section">
                 <div className="panel-header">
@@ -647,6 +649,9 @@ export default function App() {
                   </div>
                 )}
               </section>
+            </div>
+
+            <SettingsAside />
             </div>
           </div>
         );

--- a/ui/web/src/api/index.js
+++ b/ui/web/src/api/index.js
@@ -18,6 +18,10 @@ async function request(path, options = {}) {
   return payload;
 }
 
+export function getHealth() {
+  return request('/health');
+}
+
 export function listProjects() {
   return request('/projects');
 }

--- a/ui/web/src/components/TrendArrow.jsx
+++ b/ui/web/src/components/TrendArrow.jsx
@@ -1,8 +1,33 @@
-export default function TrendArrow({ trend }) {
-  if (trend === 'up') return <span className="trend-arrow trend-up" title="Improved">↑</span>;
-  if (trend === 'soft-up') return <span className="trend-arrow trend-soft-up" title="Slightly improving">↗</span>;
-  if (trend === 'soft-down') return <span className="trend-arrow trend-soft-down" title="Slightly declining">↘</span>;
-  if (trend === 'down') return <span className="trend-arrow trend-down" title="Declined">↓</span>;
-  if (trend === 'stable' || trend === 'same') return <span className="trend-arrow trend-same" title="No change">→</span>;
-  return null;
+// Rotation: 0° = straight up (↑), 90° = horizontal (→), 180° = straight down (↓)
+// sqrt curve: non-zero deltas always tilt; max arc 55° keeps small changes subtle
+function angleFromDelta(d) {
+  const clamped = Math.max(-4, Math.min(4, d));
+  return 90 - Math.sign(clamped) * Math.sqrt(Math.abs(clamped) / 4) * 55;
+}
+
+const TREND_ANGLES = { up: 38, 'soft-up': 63, same: 90, stable: 90, 'soft-down': 118, down: 142 };
+
+export default function TrendArrow({ trend, delta }) {
+  const d = delta !== undefined && delta !== null ? parseFloat(delta) : null;
+
+  const angle = (d !== null && !isNaN(d))
+    ? angleFromDelta(d)
+    : (TREND_ANGLES[trend] ?? 90);
+
+  const colorClass =
+    angle <= 70  ? 'trend-up'
+    : angle <= 88  ? 'trend-soft-up'
+    : angle >= 110 ? 'trend-down'
+    : angle >= 92  ? 'trend-soft-down'
+    : 'trend-same';
+
+  const title = d !== null ? `${d > 0 ? '+' : ''}${d.toFixed(2)}` : (trend ?? '');
+
+  return (
+    <span
+      className={`trend-arrow ${colorClass}`}
+      style={{ display: 'inline-block', transform: `rotate(${Math.round(angle)}deg)` }}
+      title={title}
+    >↑</span>
+  );
 }

--- a/ui/web/src/components/TrendBadge.jsx
+++ b/ui/web/src/components/TrendBadge.jsx
@@ -5,7 +5,7 @@ export default function TrendBadge({ delta, trend, showLabel = false }) {
 
   const d = parseFloat(delta);
   const label = d > 1 ? 'Improving' : d < -1 ? 'Declining' : 'Stable';
-  const dir = trend || (d > 1 ? 'up' : d > 0.5 ? 'soft-up' : d < -1 ? 'down' : d < -0.5 ? 'soft-down' : 'same');
+  const dir = trend || (d > 1 ? 'up' : d > 0.1 ? 'soft-up' : d < -1 ? 'down' : d < -0.1 ? 'soft-down' : 'same');
 
   return (
     <span className={`trend-badge trend-badge-${dir}`}>
@@ -13,7 +13,7 @@ export default function TrendBadge({ delta, trend, showLabel = false }) {
         {d > 0 ? '+' : ''}
         {typeof delta === 'string' ? delta : d.toFixed(1)}
       </span>
-      <TrendArrow trend={dir} />
+      <TrendArrow trend={dir} delta={d} />
       {showLabel && <span className="trend-badge-label">{label}</span>}
     </span>
   );

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -6,7 +6,7 @@ import ViolationsByPrincipleTable from './ViolationsByPrincipleTable.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
-import { formatRunId, gradeColorClass, mostFrequentGrade, splitScore } from '../../../utils/formatters.js';
+import { formatRunId, gradeColorClass, scoreColorClass, mostFrequentGrade, splitScore } from '../../../utils/formatters.js';
 import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 
@@ -111,15 +111,19 @@ function AccumulatedOverviewPanel({
     return (curr - prev).toFixed(1);
   }, [accumulated]);
 
-  const accumulatedLastDate = useMemo(() => {
+  const accumulatedLastRun = useMemo(() => {
     // Find the most recent date using fromDateISO (already in API response)
     const withDates = accumulatedDimensions
       .filter((d) => d.fromRunId)
       .map((d) => ({ runId: d.fromRunId, dateISO: d.fromDateISO, dateLabel: d.fromDateLabel }));
-    if (withDates.length === 0) return null;
+    if (withDates.length === 0) return { date: null, runId: null };
     withDates.sort((a, b) => (b.dateISO || '').localeCompare(a.dateISO || ''));
-    return withDates[0].dateLabel || formatRunId(withDates[0].runId);
+    return {
+      date: withDates[0].dateLabel || formatRunId(withDates[0].runId),
+      runId: withDates[0].runId,
+    };
   }, [accumulatedDimensions]);
+  const accumulatedLastDate = accumulatedLastRun.date;
 
   const accumulatedUniquePrinciples = useMemo(
     () => new Set(accumulatedViolationsByPrinciple.map((v) => v.principle).filter(Boolean)).size,
@@ -144,7 +148,7 @@ function AccumulatedOverviewPanel({
 
         <div className="acc-eval-hero">
           <span
-            className={`acc-eval-grade-chip chip ${gradeColorClass(accumulated?.summary?.overallGrade)}`}
+            className={`acc-eval-grade-chip chip ${scoreColorClass(accumulated?.summary?.numericAverage)}`}
           >
             {accumulated?.summary?.overallGrade || '—'}
           </span>
@@ -213,7 +217,12 @@ function AccumulatedOverviewPanel({
           selectedRunScore={accumulated?.summary?.numericAverage}
           onBarClick={onRunClick}
         />
-        <DimensionScorePanel dimensions={accumulatedDimensions} onBarClick={onDimensionClick} />
+        <DimensionScorePanel
+          dimensions={accumulatedDimensions}
+          onBarClick={onDimensionClick}
+          runDate={accumulatedLastDate}
+          runId={accumulatedLastRun.runId}
+        />
       </div>
 
       {/* Quality dimension cards */}
@@ -405,7 +414,7 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
         </div>
 
         <div className="acc-eval-hero">
-          <span className={`acc-eval-grade-chip chip ${gradeColorClass(runSummary.overallGrade)}`}>
+          <span className={`acc-eval-grade-chip chip ${scoreColorClass(runSummary.numericAverage)}`}>
             {runSummary.overallGrade || '—'}
           </span>
           <div className="acc-eval-score-row">

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -9,6 +9,7 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+import { formatShortDate } from '../../../utils/formatters.js';
 
 function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
@@ -115,7 +116,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
         <span className="run-history-title">Dimension Scores</span>
         {(runDate || runId) && (
           <span className="dim-panel-run-meta">
-            {runDate && <span className="dim-panel-run-date">{runDate}</span>}
+            {runDate && <span className="dim-panel-run-date">{formatShortDate(runDate)}</span>}
             {runId && <span className="dim-panel-run-id">{runId}</span>}
           </span>
         )}

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -14,27 +14,14 @@ function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
-const GRADE_VAR = {
-  exemplary:    '--color-grade-top-text',
-  good:         '--color-grade-high-text',
-  proficient:   '--color-grade-high-text',
-  adequate:     '--color-grade-mid-text',
-  developing:   '--color-grade-mid-text',
-  poor:         '--color-grade-low-text',
-  insufficient: '--color-grade-low-text',
-  critical:     '--color-grade-bottom-text',
-  a: '--color-grade-top-text',
-  b: '--color-grade-high-text',
-  c: '--color-grade-mid-text',
-  d: '--color-grade-low-text',
-  f: '--color-grade-bottom-text',
-};
-
-function gradeBarColor(grade) {
-  if (!grade) return cssVar('--color-accent');
-  const key = grade.trim().toLowerCase();
-  const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
-  return varName ? cssVar(varName) : cssVar('--color-accent');
+function scoreBarColor(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return cssVar('--color-accent');
+  if (n >= 9) return cssVar('--color-grade-top-text');   // exemplary
+  if (n >= 7) return cssVar('--color-grade-high-text');  // good
+  if (n >= 5) return cssVar('--color-grade-mid-text');   // adequate
+  if (n >= 3) return cssVar('--color-grade-low-text');   // poor
+  return cssVar('--color-grade-bottom-text');            // critical
 }
 
 const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
@@ -92,7 +79,7 @@ function DimensionTooltip({ active, payload }) {
 }
 
 
-export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
+export default function DimensionScorePanel({ dimensions = [], onBarClick, runDate, runId }) {
   if (!dimensions || dimensions.length === 0) return null;
 
   const data = [...dimensions]
@@ -126,6 +113,12 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
     <section className="run-history-panel panel">
       <div className="run-history-header">
         <span className="run-history-title">Dimension Scores</span>
+        {(runDate || runId) && (
+          <span className="dim-panel-run-meta">
+            {runDate && <span className="dim-panel-run-date">{runDate}</span>}
+            {runId && <span className="dim-panel-run-id">{runId}</span>}
+          </span>
+        )}
       </div>
       <ResponsiveContainer width="100%" height={160}>
         <BarChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
@@ -161,7 +154,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick }) {
             {data.map((entry, i) => (
               <Cell
                 key={entry.dimension ?? i}
-                fill={gradeBarColor(entry.overallGrade)}
+                fill={scoreBarColor(entry.numericScore)}
                 opacity={0.85}
               />
             ))}

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatShortDate } from '../../../utils/formatters.js';
 import {
   ComposedChart,
   Bar,
@@ -109,6 +110,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
           <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
           <XAxis
             dataKey="dateLabel"
+            tickFormatter={formatShortDate}
             tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             axisLine={false}
             tickLine={false}

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -15,59 +15,43 @@ function cssVar(name, fallback) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
-const GRADE_VAR = {
-  exemplary:    '--color-grade-top-text',
-  good:         '--color-grade-high-text',
-  proficient:   '--color-grade-high-text',
-  adequate:     '--color-grade-mid-text',
-  developing:   '--color-grade-mid-text',
-  poor:         '--color-grade-low-text',
-  insufficient: '--color-grade-low-text',
-  critical:     '--color-grade-bottom-text',
-  a: '--color-grade-top-text',
-  b: '--color-grade-high-text',
-  c: '--color-grade-mid-text',
-  d: '--color-grade-low-text',
-  f: '--color-grade-bottom-text',
-};
-
-function gradeBarColor(grade) {
-  if (!grade) return cssVar('--color-accent');
-  const key = grade.trim().toLowerCase();
-  const varName = GRADE_VAR[key] ?? GRADE_VAR[key.charAt(0)];
-  return varName ? cssVar(varName) : cssVar('--color-accent');
+function scoreBarColor(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return cssVar('--color-accent');
+  if (n >= 9) return cssVar('--color-grade-top-text');   // exemplary
+  if (n >= 7) return cssVar('--color-grade-high-text');  // good
+  if (n >= 5) return cssVar('--color-grade-mid-text');   // adequate
+  if (n >= 3) return cssVar('--color-grade-low-text');   // poor
+  return cssVar('--color-grade-bottom-text');            // critical
 }
 
-// Trend direction — mirrors the logic in TrendBadge
-const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
-const TREND_COLOR = {
-  up:         cssVar('--color-trend-up'),
-  'soft-up':  cssVar('--color-trend-soft-up'),
-  same:       cssVar('--color-text-muted'),
-  'soft-down':cssVar('--color-trend-soft-down'),
-  down:       cssVar('--color-trend-down'),
-};
+// Mirrors angleFromDelta in TrendArrow — sqrt curve, max arc 55°
+function angleFromDelta(d) {
+  const clamped = Math.max(-4, Math.min(4, d));
+  return 90 - Math.sign(clamped) * Math.sqrt(Math.abs(clamped) / 4) * 55;
+}
 
+// Trend direction — mirrors TrendBadge thresholds
 function trendDir(delta) {
   if (delta === null || delta === undefined) return null;
-  if (delta > 1)   return 'up';
-  if (delta > 0.5) return 'soft-up';
-  if (delta < -1)  return 'down';
-  if (delta < -0.5) return 'soft-down';
+  if (delta > 1)    return 'up';
+  if (delta > 0.1)  return 'soft-up';
+  if (delta < -1)   return 'down';
+  if (delta < -0.1) return 'soft-down';
   return 'same';
 }
 
-function RunHistoryTooltip({ active, payload }) {
-  if (!active || !payload?.length) return null;
-  const d = payload[0].payload;
-  return (
-    <div className="run-history-tooltip">
-      <span className="rht-date">{d.dateLabel}</span>
-      <span className="rht-score">{d.numericAverage.toFixed(1)} / 10</span>
-      <span className="rht-grade">{d.overallGrade}</span>
-    </div>
-  );
+function trendColor(dir) {
+  const map = {
+    'up':         '--color-trend-up',
+    'soft-up':    '--color-trend-soft-up',
+    'same':       '--color-text-muted',
+    'soft-down':  '--color-trend-soft-down',
+    'down':       '--color-trend-down',
+  };
+  return cssVar(map[dir] ?? '--color-text-muted');
 }
+
 
 export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
@@ -89,21 +73,28 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
     };
   });
 
-  // Custom label above each bar: trend arrow + delta value below it
+  // Custom label above each bar: rotated ↑ arrow + delta value
   const renderTrendLabel = ({ x, y, width, index }) => {
     const entry = data[index];
-    const dir = trendDir(entry?.delta);
-    if (!dir) return null;
+    const d = entry?.delta;
+    if (d === null || d === undefined) return null;
+    const dir = trendDir(d) ?? 'same';
+    const color = trendColor(dir);
+    const angle = Math.round(angleFromDelta(d));
     const cx = x + width / 2;
-    const deltaStr = entry.delta > 0 ? `+${entry.delta.toFixed(1)}` : entry.delta.toFixed(1);
+    const arrowY = y - 14;
+    const deltaStr = d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1);
     return (
       <g>
-        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={TREND_COLOR[dir]}>
+        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={color}>
           {deltaStr}
         </text>
-        <text x={cx} y={y - 14} textAnchor="middle" fontSize={11} fill={TREND_COLOR[dir]}>
-          {TREND_ARROW[dir]}
-        </text>
+        <text
+          x={cx} y={arrowY}
+          textAnchor="middle" dominantBaseline="central"
+          fontSize={11} fill={color}
+          transform={`rotate(${angle}, ${cx}, ${arrowY})`}
+        >↑</text>
       </g>
     );
   };
@@ -129,7 +120,23 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
             axisLine={false}
             tickLine={false}
           />
-          <Tooltip content={RunHistoryTooltip} cursor={false} isAnimationActive={false} offset={20} />
+          <Tooltip
+            cursor={false}
+            isAnimationActive={false}
+            offset={20}
+            content={({ active }) => {
+              if (!active || hoveredIndex === null) return null;
+              const entry = data[hoveredIndex];
+              if (!entry) return null;
+              return (
+                <div className="run-history-tooltip">
+                  <span className="rht-date">{entry.dateLabel}</span>
+                  <span className="rht-score">{entry.numericAverage.toFixed(1)} / 10</span>
+                  <span className="rht-grade">{entry.overallGrade}</span>
+                </div>
+              );
+            }}
+          />
           <ReferenceLine y={2.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
           <ReferenceLine y={5}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.3} />
           <ReferenceLine y={7.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
@@ -147,7 +154,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
             {data.map((entry, i) => (
               <Cell
                 key={entry.runId ?? i}
-                fill={gradeBarColor(entry.overallGrade)}
+                fill={scoreBarColor(entry.numericAverage)}
                 opacity={entry.runId === selectedRunId ? 1 : 0.55}
                 stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
                 strokeWidth={hoveredIndex === i ? 1.5 : 0}

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -36,6 +36,14 @@ export default function EvaluationForm({ onStart, disabled }) {
     });
   }
 
+  function selectAll() {
+    setSelectedDims(new Set(allDimensions.map((d) => d.id)));
+  }
+
+  function clearAll() {
+    setSelectedDims(new Set());
+  }
+
   function handleSubmit(e) {
     e.preventDefault();
     const payload = { repo };
@@ -52,7 +60,7 @@ export default function EvaluationForm({ onStart, disabled }) {
     setFolderBrowserOpen(false);
   }
 
-  const canSubmit = !disabled && !!repo;
+  const canSubmit = !disabled && !!repo && (allDimensions.length === 0 || selectedDims.size > 0);
 
   return (
     <>
@@ -95,7 +103,13 @@ export default function EvaluationForm({ onStart, disabled }) {
 
         {repo && allDimensions.length > 0 && (
           <div className="form-group">
-            <label><a className="iso-link" href="https://www.iso.org/" target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
+            <div className="dimension-label-row">
+              <label><a className="iso-link" href="https://www.iso.org/" target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
+              <div className="dimension-chip-actions">
+                <button type="button" className="dim-action-btn" onClick={selectAll}>All</button>
+                <button type="button" className="dim-action-btn" onClick={clearAll}>Clear</button>
+              </div>
+            </div>
             <div className="dimension-grid">
               {allDimensions.map((dim) => (
                 <button
@@ -111,7 +125,7 @@ export default function EvaluationForm({ onStart, disabled }) {
             </div>
             <p className="form-hint">
               {selectedDims.size === 0
-                ? 'All dimensions will be evaluated.'
+                ? 'Select at least one dimension to evaluate.'
                 : `${selectedDims.size} of ${allDimensions.length} selected.`}
             </p>
           </div>

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -19,19 +19,19 @@ export default function EvaluationForm({ onStart, disabled }) {
             }
           }
         }
-        setAllDimensions([...seen.values()]);
+        const dims = [...seen.values()];
+        setAllDimensions(dims);
+        setSelectedDims(new Set(dims.map((d) => d.id)));
       })
       .catch(() => setAllDimensions([]));
   }, []);
 
   function toggleDim(id) {
     setSelectedDims((prev) => {
+      if (prev.has(id) && prev.size === 1) return prev;
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   }
@@ -125,8 +125,10 @@ export default function EvaluationForm({ onStart, disabled }) {
             </div>
             <p className="form-hint">
               {selectedDims.size === 0
-                ? 'Select at least one dimension to evaluate.'
-                : `${selectedDims.size} of ${allDimensions.length} selected.`}
+                ? 'Select at least one dimension.'
+                : selectedDims.size === allDimensions.length
+                  ? 'All dimensions selected.'
+                  : `${selectedDims.size} of ${allDimensions.length} selected.`}
             </p>
           </div>
         )}

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -19,16 +19,13 @@ export default function EvaluationForm({ onStart, disabled }) {
             }
           }
         }
-        const dims = [...seen.values()];
-        setAllDimensions(dims);
-        setSelectedDims(new Set(dims.map((d) => d.id)));
+        setAllDimensions([...seen.values()]);
       })
       .catch(() => setAllDimensions([]));
   }, []);
 
   function toggleDim(id) {
     setSelectedDims((prev) => {
-      if (prev.has(id) && prev.size === 1) return prev;
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -60,6 +57,12 @@ export default function EvaluationForm({ onStart, disabled }) {
     setFolderBrowserOpen(false);
   }
 
+  // When repo is cleared, also reset dims to all so next repo entry starts fresh
+  function handleRepoClear() {
+    setRepo('');
+    setSelectedDims(new Set());
+  }
+
   const canSubmit = !disabled && !!repo && (allDimensions.length === 0 || selectedDims.size > 0);
 
   return (
@@ -79,7 +82,7 @@ export default function EvaluationForm({ onStart, disabled }) {
               <button
                 type="button"
                 className="input-clear-btn"
-                onClick={() => setRepo('')}
+                onClick={handleRepoClear}
                 title="Clear"
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
@@ -123,13 +126,6 @@ export default function EvaluationForm({ onStart, disabled }) {
                 </button>
               ))}
             </div>
-            <p className="form-hint">
-              {selectedDims.size === 0
-                ? 'Select at least one dimension.'
-                : selectedDims.size === allDimensions.length
-                  ? 'All dimensions selected.'
-                  : `${selectedDims.size} of ${allDimensions.length} selected.`}
-            </p>
           </div>
         )}
 

--- a/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -25,7 +25,9 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
             }
           }
         }
-        setAllDimensions([...seen.values()]);
+        const dims = [...seen.values()];
+        setAllDimensions(dims);
+        setSelectedDims(new Set(dims.map((d) => d.id)));
       })
       .catch(() => setAllDimensions([]));
   }, []);
@@ -34,14 +36,20 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
 
   function toggleDim(id) {
     setSelectedDims((prev) => {
+      if (prev.has(id) && prev.size === 1) return prev;
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
+  }
+
+  function selectAll() {
+    setSelectedDims(new Set(allDimensions.map((d) => d.id)));
+  }
+
+  function clearAll() {
+    setSelectedDims(new Set());
   }
 
   function handleStart() {
@@ -51,6 +59,8 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
     }
     onStart(payload);
   }
+
+  const canStart = !disabled && selectedDims.size > 0;
 
   return (
     <div className="panel evaluate-panel">
@@ -66,7 +76,13 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
 
         {allDimensions.length > 0 && (
           <div className="form-group">
-            <label><a className="iso-link" href="https://www.iso.org/" target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
+            <div className="dimension-label-row">
+              <label><a className="iso-link" href="https://www.iso.org/" target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
+              <div className="dimension-chip-actions">
+                <button type="button" className="dim-action-btn" onClick={selectAll}>All</button>
+                <button type="button" className="dim-action-btn" onClick={clearAll}>Clear</button>
+              </div>
+            </div>
             <div className="dimension-grid">
               {allDimensions.map((dim) => (
                 <button
@@ -82,8 +98,10 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
             </div>
             <p className="form-hint">
               {selectedDims.size === 0
-                ? 'All dimensions will be evaluated.'
-                : `${selectedDims.size} of ${allDimensions.length} selected.`}
+                ? 'Select at least one dimension.'
+                : selectedDims.size === allDimensions.length
+                  ? 'All dimensions selected.'
+                  : `${selectedDims.size} of ${allDimensions.length} selected.`}
             </p>
           </div>
         )}
@@ -91,7 +109,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
         <button
           type="button"
           className="evaluate-submit-btn"
-          disabled={disabled}
+          disabled={!canStart}
           onClick={handleStart}
         >
           {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}

--- a/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/ui/web/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -25,9 +25,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
             }
           }
         }
-        const dims = [...seen.values()];
-        setAllDimensions(dims);
-        setSelectedDims(new Set(dims.map((d) => d.id)));
+        setAllDimensions([...seen.values()]);
       })
       .catch(() => setAllDimensions([]));
   }, []);
@@ -36,7 +34,6 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
 
   function toggleDim(id) {
     setSelectedDims((prev) => {
-      if (prev.has(id) && prev.size === 1) return prev;
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
@@ -96,13 +93,6 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
                 </button>
               ))}
             </div>
-            <p className="form-hint">
-              {selectedDims.size === 0
-                ? 'Select at least one dimension.'
-                : selectedDims.size === allDimensions.length
-                  ? 'All dimensions selected.'
-                  : `${selectedDims.size} of ${allDimensions.length} selected.`}
-            </p>
           </div>
         )}
 

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -289,6 +289,7 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
                   return (
                     <>
                       <div className="vdetail-row-main">
+                        <span className="severity-tag compliance">compliant</span>
                         <span className="vrow-label">[{c.principle || principle}]</span>
                         {filename && (
                           <FileCopyBtn display={display} copyText={ref} />

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -3,7 +3,7 @@ import { getDimensionEval } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
-import { gradeColorClass } from '../../../utils/formatters.js';
+import { gradeColorClass, scoreColorClass } from '../../../utils/formatters.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 
 export default function ExplorerPage({ project, dimension, runId, dateLabel, onNavigate }) {
@@ -112,7 +112,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
         </div>
 
         <div className="acc-eval-hero">
-          <span className={`acc-eval-grade-chip chip ${gradeColorClass(overallGrade?.grade)}`}>
+          <span className={`acc-eval-grade-chip chip ${scoreColorClass(overallGrade?.score)}`}>
             {overallGrade?.grade || '—'}
           </span>
           {overallGrade?.score && (

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -11,7 +11,7 @@ const PHRASES = [
   'quality covers <b>reliability</b>, <b>security</b>, <b>maintainability</b>, <b>performance</b>, and more',
 ];
 
-const AUTO_ADVANCE_MS = 5000;
+const AUTO_ADVANCE_MS = 7000;
 const TRANSITION_MS = 180;
 
 export default function SettingsAside() {

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -4,7 +4,7 @@ const PHRASES = [
   'evaluate <b>local folders</b> or <b>remote git repositories</b>, no cloning needed',
   'target a <b>subfolder</b> to focus analysis on a specific module or service',
   'run evaluations over time and <b>track quality trends</b> across runs',
-  'each finding includes a <b>fix plan</b> — a concrete path to resolve the issue',
+  'each finding includes a <b>fix plan</b>, a concrete path to resolve the issue',
   'violations explain <b>what went wrong</b>, why it matters, and <b>how to fix it</b>',
   'findings are mapped to <b>CWE</b> — the industry standard for software weaknesses',
   'dimensions follow <b>ISO 25010</b>, the international standard for software quality',

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 const PHRASES = [
-  'point to any local folder or remote git repo to start an evaluation',
+  'evaluate local folders or remote git repositories — no cloning needed for remote',
   'target a subfolder to focus analysis on a specific module or service',
   'run evaluations over time and track quality trends across runs',
   'each finding includes a fix plan — a concrete path to resolve the issue',

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 const PHRASES = [
-  'evaluate <b>local folders</b> or <b>remote git repositories</b> — no cloning needed',
+  'evaluate <b>local folders</b> or <b>remote git repositories</b>, no cloning needed',
   'target a <b>subfolder</b> to focus analysis on a specific module or service',
   'run evaluations over time and <b>track quality trends</b> across runs',
   'each finding includes a <b>fix plan</b> — a concrete path to resolve the issue',

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -1,14 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 const PHRASES = [
-  'evaluate local folders or remote git repositories — no cloning needed for remote',
-  'target a subfolder to focus analysis on a specific module or service',
-  'run evaluations over time and track quality trends across runs',
-  'each finding includes a fix plan — a concrete path to resolve the issue',
-  'violations explain what went wrong, why it matters, and how to fix it',
-  'findings are mapped to CWE — the industry standard for software weaknesses',
-  'dimensions follow ISO 25010, the international standard for software quality',
-  'quality covers reliability, security, maintainability, performance, and more',
+  'evaluate <b>local folders</b> or <b>remote git repositories</b> — no cloning needed',
+  'target a <b>subfolder</b> to focus analysis on a specific module or service',
+  'run evaluations over time and <b>track quality trends</b> across runs',
+  'each finding includes a <b>fix plan</b> — a concrete path to resolve the issue',
+  'violations explain <b>what went wrong</b>, why it matters, and <b>how to fix it</b>',
+  'findings are mapped to <b>CWE</b> — the industry standard for software weaknesses',
+  'dimensions follow <b>ISO 25010</b>, the international standard for software quality',
+  'quality covers <b>reliability</b>, <b>security</b>, <b>maintainability</b>, <b>performance</b>, and more',
 ];
 
 const AUTO_ADVANCE_MS = 5000;
@@ -145,9 +145,10 @@ export default function SettingsAside() {
         <span className="sa-wordmark">quodeq</span>
 
         <p className="sa-phrase-wrap">
-          <span className={changing ? 'sa-phrase sa-phrase--changing' : 'sa-phrase'}>
-            {PHRASES[index]}
-          </span>
+          <span
+            className={changing ? 'sa-phrase sa-phrase--changing' : 'sa-phrase'}
+            dangerouslySetInnerHTML={{ __html: PHRASES[index] }}
+          />
         </p>
       </div>
     </div>

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -1,15 +1,17 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
 const PHRASES = [
-  'code quality compass',
-  'quoming soon',
-  'human aligned quode',
-  'less drift, quode safe',
-  'code with quore ♥',
-  'bearing quode with you',
+  'point to any local folder or remote git repo to start an evaluation',
+  'target a subfolder to focus analysis on a specific module or service',
+  'run evaluations over time and track quality trends across runs',
+  'each finding includes a fix plan — a concrete path to resolve the issue',
+  'violations explain what went wrong, why it matters, and how to fix it',
+  'findings are mapped to CWE — the industry standard for software weaknesses',
+  'dimensions follow ISO 25010, the international standard for software quality',
+  'quality covers reliability, security, maintainability, performance, and more',
 ];
 
-const AUTO_ADVANCE_MS = 2500;
+const AUTO_ADVANCE_MS = 5000;
 const TRANSITION_MS = 180;
 
 export default function SettingsAside() {

--- a/ui/web/src/features/settings/components/SettingsAside.jsx
+++ b/ui/web/src/features/settings/components/SettingsAside.jsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const PHRASES = [
+  'code quality compass',
+  'quoming soon',
+  'human aligned quode',
+  'less drift, quode safe',
+  'code with quore ♥',
+  'bearing quode with you',
+];
+
+const AUTO_ADVANCE_MS = 2500;
+const TRANSITION_MS = 180;
+
+export default function SettingsAside() {
+  const [index, setIndex] = useState(0);
+  const [changing, setChanging] = useState(false);
+  const [leftPress, setLeftPress] = useState(false);
+  const [rightPress, setRightPress] = useState(false);
+  const [rightAuto, setRightAuto] = useState(false);
+  const [needleWobble, setNeedleWobble] = useState(false);
+  const autoRef = useRef(null);
+  const autoEnabledRef = useRef(true);
+
+  function triggerWobble() {
+    setNeedleWobble(false);
+    requestAnimationFrame(() => setNeedleWobble(true));
+  }
+
+  const stepPhrase = useCallback((dir) => {
+    triggerWobble();
+    setChanging(true);
+    setTimeout(() => {
+      setIndex((i) => (i + dir + PHRASES.length) % PHRASES.length);
+      setChanging(false);
+    }, TRANSITION_MS);
+  }, []);
+
+  const stopAuto = useCallback(() => {
+    autoEnabledRef.current = false;
+    clearTimeout(autoRef.current);
+    setRightAuto(false);
+    setLeftPress(false);
+    setRightPress(false);
+  }, []);
+
+  const scheduleAuto = useCallback(() => {
+    if (!autoEnabledRef.current) return;
+    clearTimeout(autoRef.current);
+    autoRef.current = setTimeout(() => {
+      if (!autoEnabledRef.current) return;
+      setRightAuto(true);
+      setTimeout(() => {
+        setRightAuto(false);
+        stepPhrase(1);
+        scheduleAuto();
+      }, TRANSITION_MS);
+    }, AUTO_ADVANCE_MS);
+  }, [stepPhrase]);
+
+  useEffect(() => {
+    autoEnabledRef.current = true;
+    scheduleAuto();
+    return () => clearTimeout(autoRef.current);
+  }, [scheduleAuto]);
+
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'ArrowLeft')  { stopAuto(); stepPhrase(-1); }
+      if (e.key === 'ArrowRight') { stopAuto(); stepPhrase(1); }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [stopAuto, stepPhrase]);
+
+  function handleLeft() { stopAuto(); stepPhrase(-1); }
+  function handleRight() { stopAuto(); stepPhrase(1); }
+
+  const leftCls  = leftPress  ? 'sa-chevron sa-chevron--press' : 'sa-chevron';
+  const rightCls = rightAuto  ? 'sa-chevron sa-chevron--auto'
+                 : rightPress ? 'sa-chevron sa-chevron--press'
+                 :              'sa-chevron';
+
+  return (
+    <div className="settings-aside" aria-hidden="true">
+      <div className="sa-brand">
+        <div className="sa-logo-shell">
+          <button
+            type="button"
+            className="sa-hit sa-hit--left"
+            tabIndex={-1}
+            onPointerDown={() => setLeftPress(true)}
+            onPointerUp={() => setLeftPress(false)}
+            onPointerLeave={() => setLeftPress(false)}
+            onClick={handleLeft}
+          />
+          <button
+            type="button"
+            className="sa-hit sa-hit--right"
+            tabIndex={-1}
+            onPointerDown={() => setRightPress(true)}
+            onPointerUp={() => setRightPress(false)}
+            onPointerLeave={() => setRightPress(false)}
+            onClick={handleRight}
+          />
+          <svg className="sa-logo" viewBox="288 209 965 588" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <mask id="sa-needle-mask">
+                <rect width="1536" height="1024" fill="#fff" />
+                <circle cx="768" cy="502" r="31" fill="#000" />
+              </mask>
+            </defs>
+            <path
+              className={leftCls}
+              d="M4542 7154 c-29 -14 -68 -45 -87 -68 -18 -22 -109 -135 -201 -251 -92 -115 -229 -286 -304 -380 -75 -93 -262 -327 -415 -520 -153 -192 -299 -375 -323 -405 -62 -77 -84 -125 -90 -195 -6 -79 17 -158 61 -210 18 -22 161 -202 317 -400 156 -198 324 -412 374 -475 131 -165 195 -245 336 -424 237 -301 295 -370 338 -401 l44 -30 255 -3 c288 -3 303 0 303 61 0 32 -21 62 -405 557 -49 63 -159 205 -245 316 -164 213 -528 680 -620 796 -83 106 -100 137 -99 188 0 58 13 86 76 162 28 35 181 225 340 423 158 199 440 550 626 781 247 310 337 428 337 447 0 53 -19 57 -305 57 l-261 0 -52 -26z"
+              transform="translate(0 1024) scale(0.1 -0.1)"
+              onClick={handleLeft}
+              style={{ cursor: 'pointer' }}
+            />
+            <path
+              className={rightCls}
+              d="M10234 7155 c-19 -19 -23 -31 -18 -48 8 -26 -11 -3 354 -447 155 -190 346 -424 425 -520 137 -170 359 -439 529 -646 92 -110 111 -153 102 -219 -7 -45 -2 -38 -511 -685 -152 -193 -608 -777 -719 -920 -27 -36 -71 -92 -98 -125 -35 -43 -48 -68 -48 -92 0 -60 14 -63 290 -63 244 0 246 0 298 26 28 14 64 40 79 58 31 36 531 667 658 831 44 56 206 261 360 454 154 194 292 371 308 394 34 51 47 97 47 163 0 109 39 55 -653 904 -34 41 -140 172 -236 290 -97 118 -218 267 -269 330 -52 63 -124 152 -160 198 -53 66 -78 89 -126 112 l-59 30 -264 0 -264 0 -25 -25z"
+              transform="translate(0 1024) scale(0.1 -0.1)"
+              onClick={handleRight}
+              style={{ cursor: 'pointer' }}
+            />
+            <path
+              d="M7347 7895 c-421 -51 -848 -208 -1192 -437 -514 -342 -923 -889 -1083 -1449 -82 -285 -107 -484 -99 -789 6 -255 21 -365 77 -586 50 -195 94 -313 190 -509 212 -432 526 -792 922 -1055 713 -474 1602 -586 2428 -305 89 30 100 31 149 5 166 -84 533 -188 821 -231 158 -24 466 -31 613 -16 l79 9 -39 26 c-104 69 -293 257 -411 409 -90 116 -252 354 -252 370 0 6 6 13 14 16 22 9 237 254 320 366 221 297 383 652 456 996 36 170 50 293 56 485 23 701 -228 1336 -732 1860 -442 458 -1035 753 -1677 835 -145 18 -487 18 -640 0z m643 -551 c628 -93 1210 -469 1534 -994 143 -230 235 -481 283 -769 24 -146 24 -443 -1 -601 -83 -527 -331 -972 -731 -1310 -230 -194 -532 -349 -830 -426 -180 -46 -294 -63 -475 -70 -360 -15 -699 57 -1025 215 -426 208 -750 530 -966 957 -254 505 -298 1067 -122 1594 44 132 153 357 230 475 294 447 746 764 1278 894 249 61 561 74 825 35z"
+              transform="translate(0 1024) scale(0.1 -0.1)"
+              fill="var(--logo-q)"
+              fillRule="evenodd"
+            />
+            <g
+              className={needleWobble ? 'sa-needle sa-needle--wobble' : 'sa-needle'}
+              mask="url(#sa-needle-mask)"
+            >
+              <path d="M 640.21436,652.66711 721.35247,466.18696 899.84338,349.64453 c -87.009,100.60868 -173.29796,201.83295 -259.62902,303.02258 z" fill="var(--logo-needle)" />
+              <path d="M 640.21436,652.66711 810.38705,542.33876 899.84338,349.64453 c -87.009,100.60868 -173.29796,201.83295 -259.62902,303.02258 z" fill="var(--logo-needle-dark)" />
+            </g>
+          </svg>
+        </div>
+
+        <span className="sa-wordmark">quodeq</span>
+
+        <p className="sa-phrase-wrap">
+          <span className={changing ? 'sa-phrase sa-phrase--changing' : 'sa-phrase'}>
+            {PHRASES[index]}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/web/src/main.jsx
+++ b/ui/web/src/main.jsx
@@ -5,7 +5,7 @@ import './styles/index.css';
 
 // Apply saved theme before first render (prevents flash)
 const savedTheme = localStorage.getItem('cc-theme');
-const validThemes = ['dark', 'light', 'media-dark', 'media-light', 'ember', 'forest', 'midnight', 'slate', 'horizon'];
+const validThemes = ['dark', 'light', 'ember', 'forest', 'midnight', 'slate', 'horizon'];
 if (validThemes.includes(savedTheme)) {
   document.documentElement.setAttribute('data-theme', savedTheme);
 }

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -938,6 +938,12 @@ textarea:focus {
   position: relative;
   width: min(80%, 280px);
   padding: 0 3rem;
+  opacity: 0.22;
+  transition: opacity 300ms ease;
+}
+
+.sa-logo-shell:hover {
+  opacity: 0.65;
 }
 
 .sa-logo {
@@ -1000,6 +1006,12 @@ textarea:focus {
   letter-spacing: 0.06em;
   color: var(--color-text);
   margin-top: 0.25rem;
+  opacity: 0.22;
+  transition: opacity 300ms ease;
+}
+
+.sa-brand:hover .sa-wordmark {
+  opacity: 0.65;
 }
 
 .sa-phrase-wrap {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1150,6 +1150,37 @@ textarea:focus {
   white-space: nowrap;
 }
 
+.settings-about-value {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.settings-about-link {
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.settings-about-link:hover {
+  text-decoration: underline;
+}
+
+.settings-about-phrase-row {
+  justify-content: center;
+  padding-top: var(--space-6);
+  padding-bottom: var(--space-6);
+}
+
+.settings-about-phrase {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  letter-spacing: 0.12em;
+  text-transform: lowercase;
+  text-align: center;
+  font-style: italic;
+}
+
 /* Shared field base for controls on the right side of a row */
 .settings-select,
 .settings-input {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1004,13 +1004,21 @@ textarea:focus {
 
 .sa-phrase-wrap {
   margin: 0;
-  min-height: 3em;
+  height: 4.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-text-muted);
-  font-size: clamp(0.75rem, 1vw, 0.82rem);
-  letter-spacing: 0.04em;
+  font-size: clamp(0.82rem, 1.1vw, 0.95rem);
+  letter-spacing: 0.02em;
   text-align: center;
-  line-height: 1.55;
-  max-width: 28ch;
+  line-height: 1.6;
+  max-width: 30ch;
+}
+
+.sa-phrase-wrap b {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
 }
 
 .sa-phrase {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -896,12 +896,129 @@ textarea:focus {
   color: var(--color-text-muted);
 }
 
+.settings-layout {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-height: 0;
+}
+
 .settings-body {
   padding: var(--space-8);
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+  width: 100%;
   max-width: 760px;
+  flex-shrink: 0;
+}
+
+.settings-aside {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  border-left: 1px solid var(--color-border);
+}
+
+@media (max-width: 900px) {
+  .settings-aside { display: none; }
+}
+
+/* ── Settings aside brand panel ── */
+.sa-brand {
+  display: grid;
+  justify-items: center;
+  gap: 0.5rem;
+  width: min(100%, 360px);
+}
+
+.sa-logo-shell {
+  position: relative;
+  width: min(80%, 280px);
+  padding: 0 3rem;
+}
+
+.sa-logo {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+  user-select: none;
+}
+
+.sa-hit {
+  position: absolute;
+  top: 18%;
+  z-index: 2;
+  width: 23%;
+  height: 52%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.sa-hit--left  { left: 0; }
+.sa-hit--right { right: 0; }
+
+.sa-chevron {
+  fill: var(--logo-chevron);
+  cursor: pointer;
+  transition: fill 180ms ease, filter 180ms ease;
+}
+.sa-chevron:hover,
+.sa-chevron--auto,
+.sa-chevron--press {
+  fill: var(--logo-chevron-hover);
+  filter: drop-shadow(0 0 5px color-mix(in srgb, var(--logo-chevron-hover) 40%, transparent));
+}
+
+.sa-needle {
+  transform-box: fill-box;
+  transform-origin: center;
+}
+.sa-needle--wobble {
+  animation: sa-needle-wobble 720ms ease-out;
+}
+@keyframes sa-needle-wobble {
+  0%   { transform: rotate(0deg); }
+  8%   { transform: rotate(-0.7deg); }
+  18%  { transform: rotate(2.6deg); }
+  32%  { transform: rotate(-1.9deg); }
+  46%  { transform: rotate(1.25deg); }
+  60%  { transform: rotate(-0.8deg); }
+  74%  { transform: rotate(0.48deg); }
+  88%  { transform: rotate(-0.22deg); }
+  100% { transform: rotate(0deg); }
+}
+
+.sa-wordmark {
+  font-size: clamp(1.5rem, 2.5vw, 2.4rem);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.06em;
+  color: var(--color-text);
+  margin-top: 0.25rem;
+}
+
+.sa-phrase-wrap {
+  margin: 0;
+  min-height: 1.8em;
+  color: var(--color-text-muted);
+  font-size: clamp(0.72rem, 1vw, 0.85rem);
+  letter-spacing: 0.16em;
+  text-transform: lowercase;
+  text-align: center;
+}
+
+.sa-phrase {
+  display: inline-block;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+.sa-phrase--changing {
+  opacity: 0;
+  transform: translateY(6px);
 }
 
 /* Card: zero out .panel's default padding; rows carry their own */

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -763,14 +763,15 @@ textarea:focus {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
   white-space: nowrap;
+  border: 1px solid transparent;
 }
 
-.chip.grade-top    { color: var(--color-grade-top-text);    background: var(--color-grade-top-bg); }
-.chip.grade-high   { color: var(--color-grade-high-text);   background: var(--color-grade-high-bg); }
-.chip.grade-mid    { color: var(--color-grade-mid-text);    background: var(--color-grade-mid-bg); }
-.chip.grade-low    { color: var(--color-grade-low-text);    background: var(--color-grade-low-bg); }
-.chip.grade-bottom { color: var(--color-grade-bottom-text); background: var(--color-grade-bottom-bg); }
-.chip.grade-none   { color: var(--color-text-muted); background: var(--color-surface-alt); }
+.chip.grade-top    { color: color-mix(in srgb, var(--color-grade-top-text) 80%, black);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
+.chip.grade-high   { color: var(--color-grade-high-text);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 28%, transparent); }
+.chip.grade-mid    { color: var(--color-grade-mid-text);    background: var(--color-grade-mid-bg);    border-color: color-mix(in srgb, var(--color-grade-mid-text) 28%, transparent); }
+.chip.grade-low    { color: var(--color-grade-low-text);    background: var(--color-grade-low-bg);    border-color: color-mix(in srgb, var(--color-grade-low-text) 28%, transparent); }
+.chip.grade-bottom { color: var(--color-grade-bottom-text); background: var(--color-grade-bottom-bg); border-color: color-mix(in srgb, var(--color-grade-bottom-text) 28%, transparent); }
+.chip.grade-none   { color: var(--color-text-muted); background: var(--color-surface-alt); border-color: var(--color-border); }
 
 .chip.small {
   font-size: 0.7rem;
@@ -816,30 +817,22 @@ textarea:focus {
 
 /* --- Trend Arrows --- */
 .trend-arrow {
-  font-size: 0.72rem;
-  font-weight: 600;
+  font-size: 0.85rem;
+  font-weight: 700;
   line-height: 1;
-  letter-spacing: -0.08em;
+  margin-left: 4px;
+  vertical-align: middle;
 }
 
-.trend-arrow-up { color: var(--color-trend-up); }
+.trend-arrow-up     { color: var(--color-trend-up); }
 .trend-arrow-up-big { color: var(--color-trend-strong-up); }
-.trend-arrow-same { color: var(--color-text-muted); font-size: 0.8rem; }
-.trend-up { color: var(--color-trend-up); }
-.trend-soft-up { color: var(--color-trend-soft-up); }
-.trend-soft-down { color: var(--color-trend-soft-down); }
-.trend-down { color: var(--color-trend-down); }
+.trend-arrow-same   { color: var(--color-text-muted); }
+.trend-up           { color: var(--color-trend-up); }
+.trend-soft-up      { color: var(--color-trend-soft-up); }
+.trend-soft-down    { color: var(--color-trend-soft-down); }
+.trend-down         { color: var(--color-trend-down); }
 .trend-arrow-down-big { color: var(--color-trend-strong-down); }
-
-.trend-arrow {
-  font-size: 1rem;
-  font-weight: bold;
-  margin-left: 8px;
-}
-
-.trend-same {
-  color: var(--color-text-muted);
-}
+.trend-same         { color: var(--color-text-muted); }
 
 /* ─── Settings page ─── */
 
@@ -926,9 +919,9 @@ textarea:focus {
 
 .settings-row {
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-8);
+  gap: var(--space-3);
   padding: var(--space-5) var(--space-6);
   border-bottom: 1px solid var(--color-border);
 }
@@ -941,9 +934,6 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 3px;
-  flex: 1;
-  min-width: 0;
-  padding-top: 2px;
 }
 
 .settings-label {
@@ -1056,35 +1046,33 @@ textarea:focus {
 .theme-toggle {
   display: flex;
   flex-wrap: wrap;
-  gap: 1px;
-  background: var(--color-border);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  overflow: hidden;
-  flex-shrink: 0;
+  gap: var(--space-2);
 }
 
 .theme-toggle-btn {
-  padding: var(--space-2) var(--space-3);
-  border: none;
+  padding: 4px var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
   background: var(--color-surface);
   color: var(--color-text-muted);
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
   white-space: nowrap;
 }
 
 .theme-toggle-btn:hover {
   background: var(--color-surface-alt);
   color: var(--color-text);
+  border-color: var(--color-text-muted);
 }
 
 .theme-toggle-btn.active {
   background: var(--color-accent-soft);
   color: var(--color-accent);
+  border-color: var(--color-accent);
   font-weight: var(--weight-semibold);
 }
 

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1150,14 +1150,36 @@ textarea:focus {
   white-space: nowrap;
 }
 
-.settings-about-value {
-  font-size: var(--text-sm);
+.settings-about-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: var(--space-4) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.settings-about-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: 5px 0;
+}
+
+.settings-about-key {
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
+  width: 72px;
+  flex-shrink: 0;
+}
+
+.settings-about-value {
+  font-size: var(--text-xs);
+  color: var(--color-text);
   font-family: var(--font-mono);
 }
 
 .settings-about-link {
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   color: var(--color-accent);
   text-decoration: none;
 }

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -34,7 +34,7 @@ body {
   min-height: 100vh;
   display: grid;
   grid-template-columns: var(--sidebar-width) 1fr;
-  transition: grid-template-columns var(--sidebar-transition);
+  transition: grid-template-columns 200ms ease;
 }
 
 /* Expand sidebar on hover */

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1189,7 +1189,7 @@ textarea:focus {
 }
 
 .settings-about-phrase-row {
-  justify-content: flex-end;
+  align-items: flex-end;
   padding-top: var(--space-4);
   padding-bottom: var(--space-4);
 }

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -524,7 +524,7 @@ textarea:focus {
 }
 
 .violation-file {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   background: var(--color-surface-alt);
@@ -676,7 +676,7 @@ textarea:focus {
   background: var(--color-surface);
   color: var(--color-text-muted);
   font-weight: var(--weight-medium);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   white-space: nowrap;
 }
 
@@ -1175,7 +1175,7 @@ textarea:focus {
 .settings-about-value {
   font-size: var(--text-xs);
   color: var(--color-text);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
 }
 
 .settings-about-link {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1189,17 +1189,17 @@ textarea:focus {
 }
 
 .settings-about-phrase-row {
-  justify-content: center;
-  padding-top: var(--space-6);
-  padding-bottom: var(--space-6);
+  justify-content: flex-end;
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
 }
 
 .settings-about-phrase {
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: lowercase;
-  text-align: center;
+  text-align: right;
   font-style: italic;
 }
 

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -138,6 +138,11 @@ body {
   color: var(--color-accent);
 }
 
+.sidebar-nav-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
 .sidebar-nav-item svg {
   flex-shrink: 0;
   width: 18px;
@@ -202,8 +207,9 @@ body {
   border-color: var(--color-border-focus);
 }
 
-.project-select-styled:focus {
-  outline: none;
+.project-select-styled:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
   border-color: var(--color-accent);
 }
 
@@ -362,6 +368,11 @@ button {
   transform: translateY(-1px);
 }
 
+.btn-primary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .btn-primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -386,6 +397,11 @@ button {
 .btn-secondary:hover:not(:disabled) {
   border-color: var(--color-accent);
   background: var(--color-accent-soft);
+}
+
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* ── Form fields ──────────────────────────────────────── */
@@ -766,7 +782,7 @@ textarea:focus {
   border: 1px solid transparent;
 }
 
-.chip.grade-top    { color: color-mix(in srgb, var(--color-grade-top-text) 80%, black);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
+.chip.grade-top    { color: color-mix(in srgb, var(--color-grade-top-text) 65%, black);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
 .chip.grade-high   { color: var(--color-grade-high-text);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 28%, transparent); }
 .chip.grade-mid    { color: var(--color-grade-mid-text);    background: var(--color-grade-mid-bg);    border-color: color-mix(in srgb, var(--color-grade-mid-text) 28%, transparent); }
 .chip.grade-low    { color: var(--color-grade-low-text);    background: var(--color-grade-low-bg);    border-color: color-mix(in srgb, var(--color-grade-low-text) 28%, transparent); }

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1004,12 +1004,13 @@ textarea:focus {
 
 .sa-phrase-wrap {
   margin: 0;
-  min-height: 1.8em;
+  min-height: 3em;
   color: var(--color-text-muted);
-  font-size: clamp(0.72rem, 1vw, 0.85rem);
-  letter-spacing: 0.16em;
-  text-transform: lowercase;
+  font-size: clamp(0.75rem, 1vw, 0.82rem);
+  letter-spacing: 0.04em;
   text-align: center;
+  line-height: 1.55;
+  max-width: 28ch;
 }
 
 .sa-phrase {

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -764,7 +764,7 @@ textarea:focus {
 }
 
 .severity-tag.compliance {
-  color: var(--color-compliance);
+  color: color-mix(in srgb, var(--color-compliance) 65%, black);
   background: var(--color-compliance-bg);
   border-color: var(--color-compliance-border);
 }
@@ -783,7 +783,7 @@ textarea:focus {
 }
 
 .chip.grade-top    { color: color-mix(in srgb, var(--color-grade-top-text) 65%, black);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
-.chip.grade-high   { color: var(--color-grade-high-text);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 28%, transparent); }
+.chip.grade-high   { color: color-mix(in srgb, var(--color-grade-high-text) 75%, black);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 38%, transparent); }
 .chip.grade-mid    { color: var(--color-grade-mid-text);    background: var(--color-grade-mid-bg);    border-color: color-mix(in srgb, var(--color-grade-mid-text) 28%, transparent); }
 .chip.grade-low    { color: var(--color-grade-low-text);    background: var(--color-grade-low-bg);    border-color: color-mix(in srgb, var(--color-grade-low-text) 28%, transparent); }
 .chip.grade-bottom { color: var(--color-grade-bottom-text); background: var(--color-grade-bottom-bg); border-color: color-mix(in srgb, var(--color-grade-bottom-text) 28%, transparent); }

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -627,7 +627,7 @@
 .qd-card-stat-compliance {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: color-mix(in srgb, var(--color-grade-top-text) 80%, black);
+  color: color-mix(in srgb, var(--color-grade-top-text) 65%, black);
   background: var(--color-grade-top-bg);
   border: 1px solid color-mix(in srgb, var(--color-grade-top-text) 48%, transparent);
   border-radius: var(--radius-sm);
@@ -2186,9 +2186,8 @@
 .run-history-panel .recharts-surface,
 .run-history-panel .recharts-tooltip-wrapper,
 .run-history-panel svg,
-.run-history-panel svg *,
-.run-history-panel *:focus {
-  outline: none !important;
+.run-history-panel svg * {
+  outline: none;
   user-select: none;
 }
 

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -616,9 +616,9 @@
 .qd-card-stat-violations {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: var(--color-sev-major-text);
-  background: var(--color-sev-major-bg);
-  border: 1px solid var(--color-sev-major-border);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 38%, transparent);
   border-radius: var(--radius-sm);
   padding: 2px var(--space-2);
   white-space: nowrap;
@@ -627,9 +627,9 @@
 .qd-card-stat-compliance {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: var(--color-text-muted);
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
+  color: color-mix(in srgb, var(--color-grade-top-text) 80%, black);
+  background: var(--color-grade-top-bg);
+  border: 1px solid color-mix(in srgb, var(--color-grade-top-text) 48%, transparent);
   border-radius: var(--radius-sm);
   padding: 2px var(--space-2);
   white-space: nowrap;
@@ -694,14 +694,15 @@
 }
 
 .run-navigator .run-nav-action--danger {
-  color: var(--color-danger);
-  border-color: color-mix(in srgb, var(--color-danger) 35%, transparent);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 38%, transparent);
 }
 
 .run-navigator .run-nav-action--danger:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--color-danger) 55%, transparent);
-  color: var(--color-danger);
-  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 /* Segmented pager: [‹][date][›] as one bordered unit */
@@ -2206,6 +2207,31 @@
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--color-text-muted);
+  flex: 1;
+}
+
+.dim-panel-run-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+
+.dim-panel-run-date {
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  line-height: 1.2;
+}
+
+.dim-panel-run-id {
+  font-size: 0.62rem;
+  color: var(--color-text-subtle);
+  font-family: monospace;
+  line-height: 1.2;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .run-history-tooltip {
@@ -2459,6 +2485,7 @@
   font-weight: var(--weight-medium);
   color: var(--color-danger);
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 30%, transparent);
   padding: 2px 7px;
   border-radius: var(--radius-sm);
 }

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -2404,8 +2404,8 @@
   flex-shrink: 0;
 }
 
-.projects-grade--a { color: var(--color-grade-top-text); }
-.projects-grade--b { color: var(--color-grade-high-text); }
+.projects-grade--a { color: color-mix(in srgb, var(--color-grade-top-text) 65%, black); }
+.projects-grade--b { color: color-mix(in srgb, var(--color-grade-high-text) 75%, black); }
 .projects-grade--c { color: var(--color-grade-mid-text); }
 .projects-grade--d { color: var(--color-grade-low-text); }
 .projects-grade--f { color: var(--color-grade-bottom-text); }

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -282,7 +282,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
 }
 
@@ -746,7 +746,7 @@
   padding: 4px var(--space-3);
   border-left: 1px solid var(--color-border);
   border-right: 1px solid var(--color-border);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
   color: var(--color-text);
@@ -1659,7 +1659,7 @@
 }
 
 .violation-row-file {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   max-width: 200px;
@@ -2380,7 +2380,7 @@
 .project-card-path {
   margin-top: var(--space-2);
   font-size: var(--text-xs);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   color: var(--color-text-muted);
   opacity: 0.7;
   white-space: nowrap;
@@ -2504,7 +2504,7 @@
 .project-relocate-input {
   flex: 1;
   font-size: var(--text-xs);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   padding: 4px 8px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -1456,10 +1456,6 @@
 }
 
 @media (max-width: 1180px) {
-  .app-shell {
-    grid-template-columns: 300px 1fr;
-  }
-
   .metrics-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -896,7 +896,7 @@
 /* Dimension grid */
 .dimension-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  grid-template-columns: repeat(6, 1fr);
   gap: 6px;
   padding: 12px;
   background: var(--color-surface-alt);

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -262,8 +262,9 @@
 /* Console */
 .console-output {
   background: var(--color-console-bg);
-  border: 1px solid var(--color-border);
+  border: 1px solid color-mix(in srgb, var(--color-console-text) 18%, var(--color-console-bg));
   border-radius: var(--radius-lg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-accent) 8%, transparent);
   padding: 16px;
   max-height: 420px;
   overflow-y: auto;
@@ -278,16 +279,16 @@
 }
 
 .console-output::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--color-text) 10%, transparent);
+  background: color-mix(in srgb, var(--color-console-text) 22%, transparent);
   border-radius: 3px;
 }
 
 .console-output pre {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 0.8rem;
+  font-size: 0.82rem;
   line-height: 1.65;
-  color: var(--color-console-success);
+  color: var(--color-console-text);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -527,12 +527,6 @@
   color: var(--color-text-muted);
 }
 
-.dimension-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 10px;
-  margin-top: 10px;
-}
 
 .dimension-chip-btn:disabled {
   opacity: 0.35;
@@ -570,7 +564,7 @@
   }
 
   .dimension-grid {
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 6px;
   }
 
   .vrow-file {
@@ -897,15 +891,19 @@
 /* Dimension grid */
 .dimension-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 6px;
+  padding: 12px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
 }
 
 .dimension-chip-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 10px;
+  padding: 7px 10px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -915,13 +913,17 @@
   color: var(--color-text-muted);
   text-align: center;
   cursor: pointer;
-  transition: border-color 150ms, background 150ms, color 150ms;
+  transition: border-color 150ms, background 150ms, color 150ms, box-shadow 150ms;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .dimension-chip-btn:hover:not(:disabled) {
-  background: var(--color-surface-alt);
-  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  background: var(--color-surface);
+  border-color: color-mix(in srgb, var(--color-accent) 50%, transparent);
   color: var(--color-text);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 .dimension-chip-btn.selected {
@@ -929,6 +931,7 @@
   border-color: var(--color-accent);
   color: var(--color-accent);
   font-weight: var(--weight-semibold);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
 /* Improve submit button */
@@ -1596,7 +1599,7 @@
 .vlive-detail {
   margin: 0 0 4px;
   padding: 12px 14px;
-  background: var(--color-bg);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   display: flex;
@@ -1816,4 +1819,4 @@
 .vdetail-row--major     { border-color: var(--color-sev-major-border); }
 .vdetail-row--minor     { border-color: var(--color-sev-minor-border); }
 .vdetail-row--unknown   { border-color: var(--color-border); }
-.vdetail-row--compliant { border-color: var(--color-success); }
+.vdetail-row--compliant { border-color: color-mix(in srgb, var(--color-grade-top-text) 55%, transparent); }

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -939,6 +939,13 @@
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
+.dimension-chip-btn.selected:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-accent-soft) 85%, var(--color-accent));
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 28%, transparent);
+}
+
 /* Improve submit button */
 .evaluate-submit-btn {
   margin-top: 8px;

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -888,6 +888,11 @@
   background: var(--color-accent-soft);
 }
 
+.dim-action-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
 /* Dimension grid */
 .dimension-grid {
   display: grid;

--- a/ui/web/src/styles/evaluation.css
+++ b/ui/web/src/styles/evaluation.css
@@ -234,7 +234,7 @@
 }
 
 .job-meta-code {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-sm);
   color: var(--color-text);
   white-space: nowrap;
@@ -315,7 +315,7 @@
 
 .eval-status-line {
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   white-space: nowrap;
@@ -842,7 +842,7 @@
 
 .re-eval-repo-path code {
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-sm);
   color: var(--color-text-muted);
   white-space: nowrap;
@@ -1587,7 +1587,7 @@
 
 .vrow-file {
   flex: 1;
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
   color: var(--color-text);
@@ -1700,7 +1700,7 @@
 }
 
 .vlive-detail-meta-dir {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-text-subtle);
   flex-shrink: 1;
@@ -1719,7 +1719,7 @@
   background: transparent;
   border: none;
   border-radius: var(--radius-sm);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   color: var(--color-text-muted);
@@ -1799,7 +1799,7 @@
 
 /* Dimension label inline in the row (file detail page) */
 .vlive-dimension-inline {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   opacity: 0.7;

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -404,7 +404,7 @@
 .file-picker-item {
   padding: 8px 16px;
   font-size: 0.82rem;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--font-data);
   cursor: pointer;
   color: var(--color-text-muted);
   transition: background 100ms ease;
@@ -446,7 +446,7 @@
   padding: 10px;
   border-radius: 10px;
   text-align: left;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--font-data);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -254,7 +254,7 @@
 .file-detail-stat-sep { color: var(--color-text-subtle); }
 
 .file-detail-title {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-base);
   font-weight: var(--weight-semibold);
   color: var(--color-text);
@@ -296,7 +296,7 @@
 .file-violation-dimension {
   font-size: 0.8rem;
   color: var(--color-text-muted);
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
 }
 
 .file-violation-principle {
@@ -569,7 +569,7 @@
 .violation-table-row:last-child { border-bottom: none; }
 
 .violation-file {
-  font-family: var(--font-mono);
+  font-family: var(--font-data);
   font-size: var(--text-xs);
   color: var(--color-accent);
   word-break: break-all;

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -158,6 +158,7 @@
   --primitive-amber-800:   #a16207;
   --primitive-daruma-600:  #d9a010;  /* warm yellow-gold — daruma eye rings */
   --primitive-daruma-400:  #d4d8e0;  /* light gray for dark backgrounds — visibly lighter than grade-high */
+  --primitive-brand-300:   #b8bec8;  /* mid gray for dark grade-high — between brand-400 (text-muted) and brand-200 */
   --primitive-emerald-300: #6ee7a0;
   --primitive-rust-700:    #9f3a28;
   --primitive-brown-500:   #92581a;
@@ -294,9 +295,9 @@
     --color-success: var(--primitive-green-400);
 
     /* Severity — traditional: red=critical, amber=major, green=minor */
-    --color-sev-critical-text:   var(--primitive-crimson-300);
-    --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
-    --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+    --color-sev-critical-text:   var(--primitive-crimson-200);
+    --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+    --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
     --color-sev-major-text:      var(--primitive-ired-300);
     --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
     --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
@@ -306,8 +307,8 @@
 
     --color-grade-top-text:    var(--primitive-daruma-400);
     --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-    --color-grade-high-text:   var(--primitive-brand-400);
-    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-400) 14%, transparent);
+    --color-grade-high-text:   var(--primitive-brand-300);
+    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
     --color-grade-mid-text:    var(--primitive-ired-300);
     --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
     --color-grade-low-text:    var(--primitive-ired-400);
@@ -321,9 +322,9 @@
     --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 12%, transparent);
 
     /* Danger variants */
-    --color-danger-text:   var(--primitive-crimson-300);
-    --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 12%, transparent);
-    --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 25%, transparent);
+    --color-danger-text:   var(--primitive-crimson-200);
+    --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
+    --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
     /* Overlays */
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
@@ -337,12 +338,12 @@
     --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
     /* Trend — gray → crimson on dark backgrounds */
-    --color-trend-strong-up:   var(--primitive-brand-400);
+    --color-trend-strong-up:   var(--primitive-brand-300);
     --color-trend-up:          var(--primitive-ired-200);
     --color-trend-soft-up:     var(--primitive-brand-500);
     --color-trend-soft-down:   var(--primitive-ired-300);
     --color-trend-down:        var(--primitive-ired-400);
-    --color-trend-strong-down: var(--primitive-crimson-300);
+    --color-trend-strong-down: var(--primitive-crimson-200);
 
     /* Logo — monochrome light */
     --logo-q:              var(--primitive-brand-200);
@@ -377,9 +378,9 @@ html[data-theme="dark"]:root {
   --color-success: var(--primitive-green-400);
 
   /* Severity — traditional: red=critical, amber=major, green=minor */
-  --color-sev-critical-text:   var(--primitive-crimson-300);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-critical-text:   var(--primitive-crimson-200);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
   --color-sev-major-text:      var(--primitive-ired-300);
   --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
   --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
@@ -389,14 +390,14 @@ html[data-theme="dark"]:root {
 
   --color-grade-top-text:    var(--primitive-daruma-400);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-  --color-grade-high-text:   var(--primitive-brand-400);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-400) 14%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-300);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 15%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-300);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-200);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-400);
@@ -404,9 +405,9 @@ html[data-theme="dark"]:root {
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 12%, transparent);
 
   /* Danger variants */
-  --color-danger-text:   var(--primitive-crimson-300);
-  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 12%, transparent);
-  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 25%, transparent);
+  --color-danger-text:   var(--primitive-crimson-200);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
@@ -420,12 +421,12 @@ html[data-theme="dark"]:root {
   --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
   /* Trend — gray → crimson on dark backgrounds */
-  --color-trend-strong-up:   var(--primitive-brand-400);
+  --color-trend-strong-up:   var(--primitive-brand-300);
   --color-trend-up:          var(--primitive-ired-200);
   --color-trend-soft-up:     var(--primitive-brand-500);
   --color-trend-soft-down:   var(--primitive-ired-300);
   --color-trend-down:        var(--primitive-ired-400);
-  --color-trend-strong-down: var(--primitive-crimson-300);
+  --color-trend-strong-down: var(--primitive-crimson-200);
 
   /* Console — cool-dark tint */
   --color-console-bg:      #060810;
@@ -538,9 +539,9 @@ html[data-theme="ember"]:root {
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   var(--primitive-crimson-300);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-critical-text:   var(--primitive-crimson-200);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
   --color-sev-major-text:      var(--primitive-ired-300);
   --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
   --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
@@ -550,22 +551,22 @@ html[data-theme="ember"]:root {
 
   --color-grade-top-text:    var(--primitive-emerald-300);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-emerald-300) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-ember-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-500) 10%, transparent);
+  --color-grade-high-text:   #c0b5ae;
+  --color-grade-high-bg:     color-mix(in srgb, #c0b5ae 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-300);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-200);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   var(--primitive-crimson-300);
-  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
-  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 30%, transparent);
+  --color-danger-text:   var(--primitive-crimson-200);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -699,9 +700,9 @@ html[data-theme="midnight"]:root {
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   var(--primitive-crimson-300);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-critical-text:   var(--primitive-crimson-200);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
   --color-sev-major-text:      var(--primitive-ired-300);
   --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
   --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
@@ -711,14 +712,14 @@ html[data-theme="midnight"]:root {
 
   --color-grade-top-text:    #00d4ff;
   --color-grade-top-bg:      color-mix(in srgb, #00d4ff 12%, transparent);
-  --color-grade-high-text:   var(--primitive-midnight-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-midnight-500) 12%, transparent);
+  --color-grade-high-text:   #8aafcc;
+  --color-grade-high-bg:     color-mix(in srgb, #8aafcc 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-300);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-200);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -925,6 +925,7 @@ html[data-theme="horizon"]:root {
 
 :root {
   --font-sans: "Plus Jakarta Sans", "Manrope", system-ui, -apple-system, sans-serif;
+  --font-data: "Manrope", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 
   /* Type scale */

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -228,10 +228,9 @@
   --color-trend-down:        var(--primitive-ired-900);
   --color-trend-strong-down: var(--primitive-crimson-600);
 
-  /* Console — always dark (terminal convention) */
-  --color-console-bg:      #0d1117;
-  --color-console-text:    #cfdaea;
-  --color-console-success: #8bc34a;
+  /* Console — always dark (terminal convention); text auto-adapts to accent */
+  --color-console-bg:   #0d1117;
+  --color-console-text: color-mix(in srgb, var(--color-accent) 35%, #dce8f2);
 
   /* On-accent text (theme-invariant) */
   --color-on-accent: #ffffff;
@@ -429,9 +428,7 @@ html[data-theme="dark"]:root {
   --color-trend-strong-down: var(--primitive-crimson-200);
 
   /* Console — cool-dark tint */
-  --color-console-bg:      #060810;
-  --color-console-text:    #c8d2e0;
-  --color-console-success: var(--primitive-green-200);
+  --color-console-bg: #060810;
 
   /* Logo — monochrome light */
   --logo-q:              var(--primitive-brand-200);
@@ -586,9 +583,7 @@ html[data-theme="ember"]:root {
   --color-trend-strong-down: var(--primitive-crimson-300);
 
   /* Console — warm tint */
-  --color-console-bg:      #100c06;
-  --color-console-text:    #e8dece;
-  --color-console-success: var(--primitive-emerald-300);
+  --color-console-bg: #100c06;
 
   --shadow-sm: none;
   --shadow-md: none;
@@ -747,9 +742,7 @@ html[data-theme="midnight"]:root {
   --color-trend-strong-down: var(--primitive-crimson-300);
 
   /* Console — navy tint */
-  --color-console-bg:      #060c16;
-  --color-console-text:    #c8d8ee;
-  --color-console-success: var(--primitive-cyan-300);
+  --color-console-bg: #060c16;
 
   --shadow-sm: none;
   --shadow-md: none;

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -925,7 +925,7 @@ html[data-theme="horizon"]:root {
 
 :root {
   --font-sans: "Plus Jakarta Sans", "Manrope", system-ui, -apple-system, sans-serif;
-  --font-data: "Manrope", system-ui, -apple-system, sans-serif;
+  --font-data: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 
   /* Type scale */

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -514,6 +514,13 @@ html[data-theme="light"]:root {
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+
+  /* Logo — force light values regardless of system theme */
+  --logo-q:              var(--primitive-crimson-500);
+  --logo-chevron:        var(--primitive-brand-900);
+  --logo-chevron-hover:  var(--primitive-crimson-500);
+  --logo-needle:         var(--primitive-crimson-300);
+  --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
 /* ── Ember — warm dark, logo-derived ────────────────────── */

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -108,6 +108,7 @@
   --primitive-crimson-500: #d80c18;
   --primitive-crimson-400: #e82030;
   --primitive-crimson-300: #f1171e;
+  --primitive-crimson-200: #ff4a4a;
 
   /* Brand extensions */
   --primitive-brand-600: #454b57;
@@ -142,7 +143,7 @@
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
   --primitive-ired-300: #d86060;   /* dark C: rose-red */
-  --primitive-ired-400: #f04040;   /* dark D: bright red */
+  --primitive-ired-400: #f55050;   /* dark D: bright red */
   --primitive-ired-700: #7d606a;   /* light B: warm rose-gray */
   --primitive-ired-800: #9a4040;   /* light C: muted dark red */
   --primitive-ired-900: #c02020;   /* light D: medium red */
@@ -311,8 +312,8 @@
     --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
     --color-grade-low-text:    var(--primitive-ired-400);
     --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 15%, transparent);
-    --color-grade-bottom-text: var(--primitive-crimson-300);
-    --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
+    --color-grade-bottom-text: var(--primitive-crimson-200);
+    --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
 
     /* Warning */
     --color-warning:      var(--primitive-amber-400);

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -45,27 +45,6 @@
   --primitive-dark-500: #9a9490;
   --primitive-dark-200: #f0ece6;
 
-  /* Media brand palette */
-  --primitive-media-red:        #e6463c;
-  --primitive-media-red-dark:   #c93530;
-  --primitive-media-red-light:  #f05855;
-  --primitive-media-pink:       #d23278;
-  --primitive-media-yellow:     #fabb22;
-  --primitive-media-violet:     #783c96;
-  --primitive-media-dark-950:   #161616;
-  --primitive-media-dark-900:   #242424;
-  --primitive-media-dark-800:   #2c2c2c;
-  --primitive-media-dark-700:   #3a3a3a;
-  --primitive-media-dark-500:   #a0a0a0;
-  --primitive-media-dark-200:   #f5f5f5;
-  --primitive-media-light-50:   #f7f7f7;
-  --primitive-media-light-100:  #f0f0f0;
-  --primitive-media-light-200:  #dedede;
-  --primitive-media-light-300:  #c8c8c8;
-  --primitive-media-text-900:   #1c1c1c;
-  --primitive-media-text-500:   #6b6b6b;
-  --primitive-media-text-400:   #9b9b9b;
-
   /* Ember palette (warm dark, logo-derived) */
   --primitive-ember-950: #12100e;
   --primitive-ember-900: #1c1916;
@@ -107,6 +86,87 @@
   --primitive-horizon-700: #4f46e5;
   --primitive-horizon-800: #4338ca;
   --primitive-horizon-900: #111827;
+
+  /* Brand neutrals (cool near-black, logo-derived) */
+  --primitive-brand-950: #0d1014;
+  --primitive-brand-900: #14161b;
+  --primitive-brand-800: #1e2128;
+  --primitive-brand-700: #2a2e38;
+  --primitive-brand-500: #70757f;
+  --primitive-brand-400: #9ba1ab;
+  --primitive-brand-200: #e8ecf2;
+
+  /* Cool neutrals (light-mode cool-white) */
+  --primitive-cool-50:  #f8f9fb;
+  --primitive-cool-100: #f1f4f8;
+  --primitive-cool-200: #dde1e8;
+  --primitive-cool-300: #b8bec9;
+
+  /* Crimson (brand red accent) */
+  --primitive-crimson-700: #aa0000;
+  --primitive-crimson-600: #b00a14;
+  --primitive-crimson-500: #d80c18;
+  --primitive-crimson-400: #e82030;
+  --primitive-crimson-300: #f1171e;
+
+  /* Brand extensions */
+  --primitive-brand-600: #454b57;
+
+  /* Red scale extensions */
+  --primitive-red-800: #991b1b;
+  --primitive-red-700: #b91c1c;
+  --primitive-red-300: #f87171;
+
+  /* Amber scale */
+  --primitive-amber-900: #92400e;
+  --primitive-amber-700: #b45309;
+  --primitive-amber-400: #fbbf24;
+  --primitive-amber-300: #fcd34d;
+
+  /* Orange scale */
+  --primitive-orange-700: #9a3412;
+  --primitive-orange-400: #fb923c;
+
+  /* Green scale extensions */
+  --primitive-green-800: #166534;
+  --primitive-green-200: #4ade80;
+  --primitive-green-electric: #00cc6a;  /* vivid electric green for horizon grade-A / trend-up */
+
+  /* Teal scale */
+  --primitive-teal-700: #0f766e;
+  --primitive-teal-400: #2dd4bf;
+
+  /* Compliance */
+  --primitive-compliance: #5ee6a0;
+
+  /* Issue-intensity heat scale (gray → crimson, default light + dark) */
+  --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
+  --primitive-ired-300: #d86060;   /* dark C: rose-red */
+  --primitive-ired-400: #f04040;   /* dark D: bright red */
+  --primitive-ired-700: #7d606a;   /* light B: warm rose-gray */
+  --primitive-ired-800: #9a4040;   /* light C: muted dark red */
+  --primitive-ired-900: #c02020;   /* light D: medium red */
+
+  /* Extended gamma palette (theme-native grade / severity / trend) */
+  --primitive-forest-500:  #5a7a5a;
+  --primitive-cyan-700:    #0e6d8a;
+  --primitive-cyan-400:    #22d3ee;
+  --primitive-cyan-300:    #67e8f9;
+  --primitive-amber-500:   #f59e0b;
+  --primitive-amber-600:   #d97706;
+  --primitive-amber-800:   #a16207;
+  --primitive-daruma-600:  #d9a010;  /* warm yellow-gold — daruma eye rings */
+  --primitive-daruma-400:  #d4d8e0;  /* light gray for dark backgrounds — visibly lighter than grade-high */
+  --primitive-emerald-300: #6ee7a0;
+  --primitive-rust-700:    #9f3a28;
+  --primitive-brown-500:   #92581a;
+  --primitive-brown-600:   #8b3a2e;
+  --primitive-red-500:     #dc2626;
+  --primitive-red-900:     #7f1d1d;
+  --primitive-green-900:   #1a5c36;
+  --primitive-olive-700:   #7a5a00;
+  --primitive-brown-900:   #7a3030;
+  --primitive-horizon-600: #6366f1;
 }
 
 /* ── 2. Semantic tokens — Light mode (default) ────────────
@@ -115,58 +175,58 @@
 
 :root {
   /* Surface */
-  --color-bg:           var(--primitive-sand-50);
+  --color-bg:           var(--primitive-cool-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-sand-100);
-  --color-border:       var(--primitive-sand-200);
-  --color-border-focus: var(--primitive-coral-600);
+  --color-surface-alt:  var(--primitive-cool-100);
+  --color-border:       var(--primitive-cool-200);
+  --color-border-focus: var(--primitive-crimson-500);
 
   /* Text */
-  --color-text:         var(--primitive-gray-900);
-  --color-text-muted:   var(--primitive-gray-500);
-  --color-text-subtle:  var(--primitive-gray-400);
+  --color-text:         var(--primitive-brand-900);
+  --color-text-muted:   var(--primitive-brand-500);
+  --color-text-subtle:  var(--primitive-brand-400);
 
   /* Accent */
-  --color-accent:       var(--primitive-coral-600);
-  --color-accent-hover: var(--primitive-coral-700);
-  --color-accent-soft:  var(--primitive-coral-50);
+  --color-accent:       var(--primitive-crimson-500);
+  --color-accent-hover: var(--primitive-crimson-600);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
 
   /* Status */
   --color-danger:  var(--primitive-red-600);
   --color-success: var(--primitive-green-700);
 
-  /* Severity bands */
-  --color-sev-critical-text:   #b91c1c;
-  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
-  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
-  --color-sev-major-text:      #b45309;
-  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
-  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
-  --color-sev-minor-text:      var(--primitive-gray-700);
-  --color-sev-minor-bg:        rgba(61, 58, 55, 0.06);
-  --color-sev-minor-border:    var(--primitive-sand-200);
+  /* Severity bands — traditional: red=critical, amber=major, green=minor */
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
   /* Grade tier colors */
-  --color-grade-top-text:    #166534;
-  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
-  --color-grade-high-text:   #0f766e;
-  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
-  --color-grade-mid-text:    #92400e;
-  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
-  --color-grade-low-text:    #9a3412;
-  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
-  --color-grade-bottom-text: #991b1b;
-  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+  --color-grade-top-text:    var(--primitive-daruma-600);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-500) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
-  /* Trend (theme-invariant) */
-  --color-trend-strong-up:   #2ecc71;
-  --color-trend-up:          #5ee6a0;
-  --color-trend-soft-up:     #92c9a8;
-  --color-trend-soft-down:   #c8956c;
-  --color-trend-down:        #f09070;
-  --color-trend-strong-down: #e74c3c;
+  /* Trend — default is light; dark themes override below */
+  --color-trend-strong-up:   var(--primitive-brand-500);
+  --color-trend-up:          var(--primitive-ired-700);
+  --color-trend-soft-up:     var(--primitive-brand-400);
+  --color-trend-soft-down:   var(--primitive-ired-800);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
 
-  /* Console (theme-invariant) */
+  /* Console — always dark (terminal convention) */
   --color-console-bg:      #0d1117;
   --color-console-text:    #cfdaea;
   --color-console-success: #8bc34a;
@@ -175,21 +235,21 @@
   --color-on-accent: #ffffff;
 
   /* Logo (defaults for themes that don't override) */
-  --logo-q:              #d80c18;
-  --logo-chevron:        #14161b;
-  --logo-chevron-hover:  #d80c18;
-  --logo-needle:         #f1171e;
-  --logo-needle-dark:    #aa0000;
+  --logo-q:              var(--primitive-crimson-500);
+  --logo-chevron:        var(--primitive-brand-900);
+  --logo-chevron-hover:  var(--primitive-crimson-500);
+  --logo-needle:         var(--primitive-crimson-300);
+  --logo-needle-dark:    var(--primitive-crimson-700);
 
-  /* Compliance */
-  --color-compliance:        #5ee6a0;
-  --color-compliance-bg:     color-mix(in srgb, #5ee6a0 12%, transparent);
-  --color-compliance-border: color-mix(in srgb, #5ee6a0 35%, transparent);
+  /* Compliance — inherits grade-top hue so it adapts per theme */
+  --color-compliance:        var(--color-grade-top-text);
+  --color-compliance-bg:     color-mix(in srgb, var(--color-grade-top-text) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--color-grade-top-text) 38%, transparent);
 
   /* Warning */
-  --color-warning:      #b45309;
-  --color-warning-text: #b45309;
-  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+  --color-warning:      var(--primitive-amber-700);
+  --color-warning-text: var(--primitive-amber-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
 
   /* Danger variants */
   --color-danger-text:   var(--color-danger);
@@ -202,9 +262,9 @@
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   /* Chart */
-  --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--color-text-muted);
-  --color-chart-line:   var(--color-text);
+  --color-chart-grid:   var(--primitive-cool-200);
+  --color-chart-axis:   var(--primitive-brand-500);
+  --color-chart-line:   var(--primitive-brand-900);
   --color-chart-stroke: transparent;
 }
 
@@ -215,53 +275,54 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg:           var(--primitive-dark-950);
-    --color-surface:      var(--primitive-dark-900);
-    --color-surface-alt:  var(--primitive-dark-800);
-    --color-border:       var(--primitive-dark-700);
-    --color-border-focus: var(--primitive-coral-400);
+    --color-bg:           var(--primitive-brand-950);
+    --color-surface:      var(--primitive-brand-900);
+    --color-surface-alt:  var(--primitive-brand-800);
+    --color-border:       var(--primitive-brand-700);
+    --color-border-focus: var(--primitive-crimson-500);
 
-    --color-text:         var(--primitive-dark-200);
-    --color-text-muted:   var(--primitive-dark-500);
-    --color-text-subtle:  #706a64;
+    --color-text:         var(--primitive-brand-200);
+    --color-text-muted:   var(--primitive-brand-400);
+    --color-text-subtle:  var(--primitive-brand-500);
 
-    --color-accent:       var(--primitive-coral-400);
-    --color-accent-hover: var(--primitive-coral-300);
-    --color-accent-soft:  rgba(232, 121, 90, 0.12);
+    --color-accent:       var(--primitive-crimson-400);
+    --color-accent-hover: var(--primitive-crimson-300);
+    --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-400) 14%, transparent);
 
     --color-danger:  var(--primitive-red-400);
     --color-success: var(--primitive-green-400);
 
-    --color-sev-critical-text:   #f87171;
-    --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
-    --color-sev-critical-border: rgba(248, 113, 113, 0.2);
-    --color-sev-major-text:      #fbbf24;
-    --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
-    --color-sev-major-border:    rgba(251, 191, 36, 0.2);
-    --color-sev-minor-text:      var(--primitive-dark-500);
-    --color-sev-minor-bg:        rgba(154, 148, 144, 0.08);
-    --color-sev-minor-border:    var(--primitive-dark-700);
+    /* Severity — traditional: red=critical, amber=major, green=minor */
+    --color-sev-critical-text:   var(--primitive-crimson-300);
+    --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+    --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+    --color-sev-major-text:      var(--primitive-ired-300);
+    --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
+    --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+    --color-sev-minor-text:      var(--primitive-ired-200);
+    --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
+    --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-    --color-grade-top-text:    #4ade80;
-    --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
-    --color-grade-high-text:   #2dd4bf;
-    --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
-    --color-grade-mid-text:    #fcd34d;
-    --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
-    --color-grade-low-text:    #fb923c;
-    --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
-    --color-grade-bottom-text: #f87171;
-    --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+    --color-grade-top-text:    var(--primitive-daruma-400);
+    --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
+    --color-grade-high-text:   var(--primitive-brand-400);
+    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-400) 14%, transparent);
+    --color-grade-mid-text:    var(--primitive-ired-300);
+    --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
+    --color-grade-low-text:    var(--primitive-ired-400);
+    --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 15%, transparent);
+    --color-grade-bottom-text: var(--primitive-crimson-300);
+    --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
 
     /* Warning */
-    --color-warning:      #fbbf24;
-    --color-warning-text: #fbbf24;
-    --color-warning-bg:   rgba(251, 191, 36, 0.1);
+    --color-warning:      var(--primitive-amber-400);
+    --color-warning-text: var(--primitive-amber-400);
+    --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 12%, transparent);
 
     /* Danger variants */
-    --color-danger-text:   #ff6b6b;
-    --color-danger-bg:     rgba(255, 100, 100, 0.15);
-    --color-danger-border: rgba(255, 100, 100, 0.3);
+    --color-danger-text:   var(--primitive-crimson-300);
+    --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 12%, transparent);
+    --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 25%, transparent);
 
     /* Overlays */
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
@@ -269,9 +330,25 @@
     --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
     /* Chart */
-    --color-chart-grid:   #383532;
-    --color-chart-axis:   #9a9490;
-    --color-chart-stroke: rgba(255, 255, 255, 0.25);
+    --color-chart-grid:   var(--primitive-brand-700);
+    --color-chart-axis:   var(--primitive-brand-500);
+    --color-chart-line:   var(--primitive-brand-200);
+    --color-chart-stroke: rgba(255, 255, 255, 0.2);
+
+    /* Trend — gray → crimson on dark backgrounds */
+    --color-trend-strong-up:   var(--primitive-brand-400);
+    --color-trend-up:          var(--primitive-ired-200);
+    --color-trend-soft-up:     var(--primitive-brand-500);
+    --color-trend-soft-down:   var(--primitive-ired-300);
+    --color-trend-down:        var(--primitive-ired-400);
+    --color-trend-strong-down: var(--primitive-crimson-300);
+
+    /* Logo — monochrome light */
+    --logo-q:              var(--primitive-brand-200);
+    --logo-chevron:        var(--primitive-brand-200);
+    --logo-chevron-hover:  var(--primitive-crimson-300);
+    --logo-needle:         var(--primitive-brand-200);
+    --logo-needle-dark:    var(--primitive-brand-400);
   }
 }
 
@@ -281,53 +358,54 @@
    ──────────────────────────────────────────────────────── */
 
 html[data-theme="dark"]:root {
-  --color-bg:           var(--primitive-dark-950);
-  --color-surface:      var(--primitive-dark-900);
-  --color-surface-alt:  var(--primitive-dark-800);
-  --color-border:       var(--primitive-dark-700);
-  --color-border-focus: var(--primitive-coral-400);
+  --color-bg:           var(--primitive-brand-950);
+  --color-surface:      var(--primitive-brand-900);
+  --color-surface-alt:  var(--primitive-brand-800);
+  --color-border:       var(--primitive-brand-700);
+  --color-border-focus: var(--primitive-crimson-500);
 
-  --color-text:         var(--primitive-dark-200);
-  --color-text-muted:   var(--primitive-dark-500);
-  --color-text-subtle:  #706a64;
+  --color-text:         var(--primitive-brand-200);
+  --color-text-muted:   var(--primitive-brand-400);
+  --color-text-subtle:  var(--primitive-brand-500);
 
-  --color-accent:       var(--primitive-coral-400);
-  --color-accent-hover: var(--primitive-coral-300);
-  --color-accent-soft:  rgba(232, 121, 90, 0.12);
+  --color-accent:       var(--primitive-crimson-400);
+  --color-accent-hover: var(--primitive-crimson-300);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-400) 14%, transparent);
 
   --color-danger:  var(--primitive-red-400);
   --color-success: var(--primitive-green-400);
 
-  --color-sev-critical-text:   #f87171;
-  --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
-  --color-sev-critical-border: rgba(248, 113, 113, 0.2);
-  --color-sev-major-text:      #fbbf24;
-  --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
-  --color-sev-major-border:    rgba(251, 191, 36, 0.2);
-  --color-sev-minor-text:      var(--primitive-dark-500);
-  --color-sev-minor-bg:        rgba(154, 148, 144, 0.08);
-  --color-sev-minor-border:    var(--primitive-dark-700);
+  /* Severity — traditional: red=critical, amber=major, green=minor */
+  --color-sev-critical-text:   var(--primitive-crimson-300);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-300);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-200);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-  --color-grade-top-text:    #4ade80;
-  --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
-  --color-grade-high-text:   #2dd4bf;
-  --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
-  --color-grade-mid-text:    #fcd34d;
-  --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
-  --color-grade-low-text:    #fb923c;
-  --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
-  --color-grade-bottom-text: #f87171;
-  --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+  --color-grade-top-text:    var(--primitive-daruma-400);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-400);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-400) 14%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-300);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-400);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 15%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-300);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
 
   /* Warning */
-  --color-warning:      #fbbf24;
-  --color-warning-text: #fbbf24;
-  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+  --color-warning:      var(--primitive-amber-400);
+  --color-warning-text: var(--primitive-amber-400);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 12%, transparent);
 
   /* Danger variants */
-  --color-danger-text:   #ff6b6b;
-  --color-danger-bg:     rgba(255, 100, 100, 0.15);
-  --color-danger-border: rgba(255, 100, 100, 0.3);
+  --color-danger-text:   var(--primitive-crimson-300);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 12%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 25%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
@@ -335,9 +413,30 @@ html[data-theme="dark"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
   /* Chart */
-  --color-chart-grid:   #383532;
-  --color-chart-axis:   #9a9490;
-  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+  --color-chart-grid:   var(--primitive-brand-700);
+  --color-chart-axis:   var(--primitive-brand-500);
+  --color-chart-line:   var(--primitive-brand-200);
+  --color-chart-stroke: rgba(255, 255, 255, 0.2);
+
+  /* Trend — gray → crimson on dark backgrounds */
+  --color-trend-strong-up:   var(--primitive-brand-400);
+  --color-trend-up:          var(--primitive-ired-200);
+  --color-trend-soft-up:     var(--primitive-brand-500);
+  --color-trend-soft-down:   var(--primitive-ired-300);
+  --color-trend-down:        var(--primitive-ired-400);
+  --color-trend-strong-down: var(--primitive-crimson-300);
+
+  /* Console — cool-dark tint */
+  --color-console-bg:      #060810;
+  --color-console-text:    #c8d2e0;
+  --color-console-success: var(--primitive-green-200);
+
+  /* Logo — monochrome light */
+  --logo-q:              var(--primitive-brand-200);
+  --logo-chevron:        var(--primitive-brand-200);
+  --logo-chevron-hover:  var(--primitive-crimson-300);
+  --logo-needle:         var(--primitive-brand-200);
+  --logo-needle-dark:    var(--primitive-brand-400);
 
   --shadow-sm: none;
   --shadow-md: none;
@@ -345,48 +444,49 @@ html[data-theme="dark"]:root {
 }
 
 html[data-theme="light"]:root {
-  --color-bg:           var(--primitive-sand-50);
+  --color-bg:           var(--primitive-cool-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-sand-100);
-  --color-border:       var(--primitive-sand-200);
-  --color-border-focus: var(--primitive-coral-600);
+  --color-surface-alt:  var(--primitive-cool-100);
+  --color-border:       var(--primitive-cool-200);
+  --color-border-focus: var(--primitive-crimson-500);
 
-  --color-text:         var(--primitive-gray-900);
-  --color-text-muted:   var(--primitive-gray-500);
-  --color-text-subtle:  var(--primitive-gray-400);
+  --color-text:         var(--primitive-brand-900);
+  --color-text-muted:   var(--primitive-brand-500);
+  --color-text-subtle:  var(--primitive-brand-400);
 
-  --color-accent:       var(--primitive-coral-600);
-  --color-accent-hover: var(--primitive-coral-700);
-  --color-accent-soft:  var(--primitive-coral-50);
+  --color-accent:       var(--primitive-crimson-500);
+  --color-accent-hover: var(--primitive-crimson-600);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
 
   --color-danger:  var(--primitive-red-600);
   --color-success: var(--primitive-green-700);
 
-  --color-sev-critical-text:   #b91c1c;
-  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
-  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
-  --color-sev-major-text:      #b45309;
-  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
-  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
-  --color-sev-minor-text:      var(--primitive-gray-700);
-  --color-sev-minor-bg:        rgba(61, 58, 55, 0.06);
-  --color-sev-minor-border:    var(--primitive-sand-200);
+  /* Severity — traditional: red=critical, amber=major, green=minor */
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #166534;
-  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
-  --color-grade-high-text:   #0f766e;
-  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
-  --color-grade-mid-text:    #92400e;
-  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
-  --color-grade-low-text:    #9a3412;
-  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
-  --color-grade-bottom-text: #991b1b;
-  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+  --color-grade-top-text:    var(--primitive-daruma-600);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-500) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
   /* Warning */
-  --color-warning:      #b45309;
-  --color-warning-text: #b45309;
-  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+  --color-warning:      var(--primitive-amber-700);
+  --color-warning-text: var(--primitive-amber-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 10%, transparent);
 
   /* Danger variants */
   --color-danger-text:   var(--color-danger);
@@ -399,150 +499,22 @@ html[data-theme="light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   /* Chart */
-  --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--color-text-muted);
+  --color-chart-grid:   var(--primitive-cool-200);
+  --color-chart-axis:   var(--primitive-brand-500);
+  --color-chart-line:   var(--primitive-brand-900);
   --color-chart-stroke: transparent;
 
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
-}
+  /* Trend — gray → crimson on light backgrounds */
+  --color-trend-strong-up:   var(--primitive-brand-500);
+  --color-trend-up:          var(--primitive-ired-700);
+  --color-trend-soft-up:     var(--primitive-brand-400);
+  --color-trend-soft-down:   var(--primitive-ired-800);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
 
-/* ── Media themes ─────────────────────────────────────────
-   Media Light / Media Dark — corporate brand colors
-   (Cinnabar red accent, Mine Shaft dark neutrals).
-   ──────────────────────────────────────────────────────── */
-
-html[data-theme="media-light"]:root {
-  --color-bg:           var(--primitive-media-light-50);
-  --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-media-light-100);
-  --color-border:       var(--primitive-media-light-200);
-  --color-border-focus: var(--primitive-media-red);
-
-  --color-text:         var(--primitive-media-text-900);
-  --color-text-muted:   var(--primitive-media-text-500);
-  --color-text-subtle:  var(--primitive-media-text-400);
-
-  --color-accent:       var(--primitive-media-red);
-  --color-accent-hover: var(--primitive-media-red-dark);
-  --color-accent-soft:  rgba(230, 70, 60, 0.08);
-
-  --color-danger:  var(--primitive-media-red-dark);
-  --color-success: #2d7a4f;
-
-  /* Severity — brand-tuned red / yellow / neutral */
-  --color-sev-critical-text:   #c93530;
-  --color-sev-critical-bg:     rgba(230, 70, 60, 0.08);
-  --color-sev-critical-border: rgba(230, 70, 60, 0.22);
-  --color-sev-major-text:      #8a6e00;
-  --color-sev-major-bg:        rgba(250, 187, 34, 0.10);
-  --color-sev-major-border:    rgba(250, 187, 34, 0.28);
-  --color-sev-minor-text:      var(--primitive-media-text-500);
-  --color-sev-minor-bg:        rgba(107, 107, 107, 0.06);
-  --color-sev-minor-border:    var(--primitive-media-light-200);
-
-  /* Grades — green stays semantic, reds/yellows brand-tuned */
-  --color-grade-top-text:    #1a7a3c;
-  --color-grade-top-bg:      rgba(26, 122, 60, 0.08);
-  --color-grade-high-text:   #0f7060;
-  --color-grade-high-bg:     rgba(15, 112, 96, 0.08);
-  --color-grade-mid-text:    #8a6e00;
-  --color-grade-mid-bg:      rgba(250, 187, 34, 0.10);
-  --color-grade-low-text:    #b84038;
-  --color-grade-low-bg:      rgba(230, 70, 60, 0.07);
-  --color-grade-bottom-text: #c93530;
-  --color-grade-bottom-bg:   rgba(230, 70, 60, 0.10);
-
-  /* Warning */
-  --color-warning:      #8a6e00;
-  --color-warning-text: #8a6e00;
-  --color-warning-bg:   rgba(250, 187, 34, 0.1);
-
-  /* Danger variants */
-  --color-danger-text:   var(--color-danger);
-  --color-danger-bg:     var(--color-sev-critical-bg);
-  --color-danger-border: var(--color-sev-critical-border);
-
-  /* Overlays */
-  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
-  --color-overlay-medium: rgba(0, 0, 0, 0.5);
-  --color-overlay-light:  rgba(0, 0, 0, 0.3);
-
-  /* Chart */
-  --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--color-text-muted);
-  --color-chart-stroke: transparent;
-
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
-}
-
-html[data-theme="media-dark"]:root {
-  --color-bg:           var(--primitive-media-dark-950);
-  --color-surface:      var(--primitive-media-dark-900);
-  --color-surface-alt:  var(--primitive-media-dark-800);
-  --color-border:       var(--primitive-media-dark-700);
-  --color-border-focus: var(--primitive-media-red);
-
-  --color-text:         var(--primitive-media-dark-200);
-  --color-text-muted:   var(--primitive-media-dark-500);
-  --color-text-subtle:  #6c6c6c;
-
-  --color-accent:       var(--primitive-media-red);
-  --color-accent-hover: var(--primitive-media-red-light);
-  --color-accent-soft:  rgba(230, 70, 60, 0.14);
-
-  --color-danger:  var(--primitive-media-red-light);
-  --color-success: #4caf7d;
-
-  /* Severity — brand-tuned red / yellow / neutral */
-  --color-sev-critical-text:   #f05855;
-  --color-sev-critical-bg:     rgba(230, 70, 60, 0.12);
-  --color-sev-critical-border: rgba(230, 70, 60, 0.28);
-  --color-sev-major-text:      #fabb22;
-  --color-sev-major-bg:        rgba(250, 187, 34, 0.12);
-  --color-sev-major-border:    rgba(250, 187, 34, 0.30);
-  --color-sev-minor-text:      var(--primitive-media-dark-500);
-  --color-sev-minor-bg:        rgba(160, 160, 160, 0.08);
-  --color-sev-minor-border:    var(--primitive-media-dark-700);
-
-  /* Grades — green stays semantic, reds/yellows brand-tuned */
-  --color-grade-top-text:    #5ee096;
-  --color-grade-top-bg:      rgba(94, 224, 150, 0.10);
-  --color-grade-high-text:   #26c4a8;
-  --color-grade-high-bg:     rgba(38, 196, 168, 0.10);
-  --color-grade-mid-text:    #fabb22;
-  --color-grade-mid-bg:      rgba(250, 187, 34, 0.12);
-  --color-grade-low-text:    #f07855;
-  --color-grade-low-bg:      rgba(230, 70, 60, 0.10);
-  --color-grade-bottom-text: #f05855;
-  --color-grade-bottom-bg:   rgba(230, 70, 60, 0.14);
-
-  /* Warning */
-  --color-warning:      #fabb22;
-  --color-warning-text: #fabb22;
-  --color-warning-bg:   rgba(250, 187, 34, 0.12);
-
-  /* Danger variants */
-  --color-danger-text:   #f05855;
-  --color-danger-bg:     rgba(230, 70, 60, 0.12);
-  --color-danger-border: rgba(230, 70, 60, 0.28);
-
-  /* Overlays */
-  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
-  --color-overlay-medium: rgba(0, 0, 0, 0.82);
-  --color-overlay-light:  rgba(0, 0, 0, 0.72);
-
-  /* Chart */
-  --color-chart-grid:   #3a3a3a;
-  --color-chart-axis:   #a0a0a0;
-  --color-chart-stroke: rgba(255, 255, 255, 0.25);
-
-  --shadow-sm: none;
-  --shadow-md: none;
-  --shadow-lg: none;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
 }
 
 /* ── Ember — warm dark, logo-derived ────────────────────── */
@@ -552,66 +524,80 @@ html[data-theme="ember"]:root {
   --color-surface:      var(--primitive-ember-900);
   --color-surface-alt:  var(--primitive-ember-800);
   --color-border:       var(--primitive-ember-700);
-  --color-border-focus: #f1171e;
+  --color-border-focus: var(--primitive-crimson-300);
 
   --color-text:         var(--primitive-ember-200);
   --color-text-muted:   var(--primitive-ember-500);
   --color-text-subtle:  #706050;
 
-  --color-accent:       #d80c18;
-  --color-accent-hover: #f1171e;
-  --color-accent-soft:  rgba(216, 12, 24, 0.14);
+  --color-accent:       var(--primitive-crimson-500);
+  --color-accent-hover: var(--primitive-crimson-300);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 14%, transparent);
 
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   #f87171;
-  --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
-  --color-sev-critical-border: rgba(248, 113, 113, 0.2);
-  --color-sev-major-text:      #fbbf24;
-  --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
-  --color-sev-major-border:    rgba(251, 191, 36, 0.2);
-  --color-sev-minor-text:      var(--primitive-ember-500);
-  --color-sev-minor-bg:        rgba(154, 142, 132, 0.08);
-  --color-sev-minor-border:    var(--primitive-ember-700);
+  --color-sev-critical-text:   var(--primitive-crimson-300);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-300);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-200);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-  --color-grade-top-text:    #4ade80;
-  --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
-  --color-grade-high-text:   #2dd4bf;
-  --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
-  --color-grade-mid-text:    #fcd34d;
-  --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
-  --color-grade-low-text:    #fb923c;
-  --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
-  --color-grade-bottom-text: #f87171;
-  --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+  --color-grade-top-text:    var(--primitive-emerald-300);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-emerald-300) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-ember-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-500) 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-300);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-400);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-300);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
 
-  --color-warning:      #fbbf24;
-  --color-warning-text: #fbbf24;
-  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+  --color-warning:      var(--primitive-amber-400);
+  --color-warning-text: var(--primitive-amber-400);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   #ff6b6b;
-  --color-danger-bg:     rgba(255, 100, 100, 0.15);
-  --color-danger-border: rgba(255, 100, 100, 0.3);
+  --color-danger-text:   var(--primitive-crimson-300);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-300) 15%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-300) 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   #3a3330;
-  --color-chart-axis:   #9a8e84;
+  --color-chart-grid:   var(--primitive-ember-700);
+  --color-chart-axis:   var(--primitive-ember-500);
+  --color-chart-line:   var(--primitive-ember-200);
   --color-chart-stroke: rgba(255, 255, 255, 0.25);
+
+  /* Trend — emerald reward up, ired chain down */
+  --color-trend-strong-up:   var(--primitive-emerald-300);
+  --color-trend-up:          var(--primitive-amber-400);
+  --color-trend-soft-up:     var(--primitive-ember-500);
+  --color-trend-soft-down:   var(--primitive-ired-200);
+  --color-trend-down:        var(--primitive-ired-300);
+  --color-trend-strong-down: var(--primitive-crimson-300);
+
+  /* Console — warm tint */
+  --color-console-bg:      #100c06;
+  --color-console-text:    #e8dece;
+  --color-console-success: var(--primitive-emerald-300);
 
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              #d80c18;
-  --logo-chevron:        #f0e8e0;
-  --logo-chevron-hover:  #d80c18;
-  --logo-needle:         #f1171e;
-  --logo-needle-dark:    #aa0000;
+  --logo-q:              var(--primitive-crimson-500);
+  --logo-chevron:        var(--primitive-ember-200);
+  --logo-chevron-hover:  var(--primitive-crimson-500);
+  --logo-needle:         var(--primitive-crimson-300);
+  --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
 /* ── Forest — nature greens, sage ───────────────────────── */
@@ -629,35 +615,35 @@ html[data-theme="forest"]:root {
 
   --color-accent:       var(--primitive-forest-700);
   --color-accent-hover: var(--primitive-forest-800);
-  --color-accent-soft:  rgba(45, 106, 79, 0.08);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-forest-700) 8%, transparent);
 
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
 
-  --color-sev-critical-text:   #b91c1c;
-  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
-  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
-  --color-sev-major-text:      #b45309;
-  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
-  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
-  --color-sev-minor-text:      #5a7a5a;
-  --color-sev-minor-bg:        rgba(90, 122, 90, 0.06);
-  --color-sev-minor-border:    var(--primitive-forest-200);
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #166534;
-  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
-  --color-grade-high-text:   #0f766e;
-  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
-  --color-grade-mid-text:    #92400e;
-  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
-  --color-grade-low-text:    #9a3412;
-  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
-  --color-grade-bottom-text: #991b1b;
-  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+  --color-grade-top-text:    var(--primitive-forest-800);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-forest-800) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-forest-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-forest-500) 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
-  --color-warning:      #b45309;
-  --color-warning-text: #b45309;
-  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+  --color-warning:      var(--primitive-brown-500);
+  --color-warning-text: var(--primitive-brown-500);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-brown-500) 8%, transparent);
 
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
@@ -669,18 +655,27 @@ html[data-theme="forest"]:root {
 
   --color-chart-grid:   var(--color-border);
   --color-chart-axis:   var(--color-text-muted);
+  --color-chart-line:   var(--primitive-forest-900);
   --color-chart-stroke: transparent;
+
+  /* Trend — forest greens up, ired chain down */
+  --color-trend-strong-up:   var(--primitive-forest-800);
+  --color-trend-up:          var(--primitive-forest-700);
+  --color-trend-soft-up:     var(--primitive-forest-500);
+  --color-trend-soft-down:   var(--primitive-ired-700);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              #d80c18;
-  --logo-chevron:        #1b4332;
-  --logo-chevron-hover:  #2d6a4f;
-  --logo-needle:         #2d6a4f;
-  --logo-needle-dark:    #1b4332;
+  --logo-q:              var(--primitive-forest-700);
+  --logo-chevron:        var(--primitive-forest-800);
+  --logo-chevron-hover:  var(--primitive-forest-700);
+  --logo-needle:         var(--primitive-forest-700);
+  --logo-needle-dark:    var(--primitive-forest-800);
 }
 
 /* ── Midnight — deep navy, cyan accents ─────────────────── */
@@ -698,54 +693,68 @@ html[data-theme="midnight"]:root {
 
   --color-accent:       #00d4ff;
   --color-accent-hover: #33e0ff;
-  --color-accent-soft:  rgba(0, 212, 255, 0.10);
+  --color-accent-soft:  color-mix(in srgb, #00d4ff 10%, transparent);
 
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   #f87171;
-  --color-sev-critical-bg:     rgba(248, 113, 113, 0.1);
-  --color-sev-critical-border: rgba(248, 113, 113, 0.2);
-  --color-sev-major-text:      #fbbf24;
-  --color-sev-major-bg:        rgba(251, 191, 36, 0.1);
-  --color-sev-major-border:    rgba(251, 191, 36, 0.2);
-  --color-sev-minor-text:      var(--primitive-midnight-500);
-  --color-sev-minor-bg:        rgba(106, 138, 170, 0.08);
-  --color-sev-minor-border:    var(--primitive-midnight-700);
+  --color-sev-critical-text:   var(--primitive-crimson-300);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-300) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-300);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-200);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-  --color-grade-top-text:    #4ade80;
-  --color-grade-top-bg:      rgba(74, 222, 128, 0.1);
-  --color-grade-high-text:   #2dd4bf;
-  --color-grade-high-bg:     rgba(45, 212, 191, 0.1);
-  --color-grade-mid-text:    #fcd34d;
-  --color-grade-mid-bg:      rgba(252, 211, 77, 0.1);
-  --color-grade-low-text:    #fb923c;
-  --color-grade-low-bg:      rgba(251, 146, 60, 0.1);
-  --color-grade-bottom-text: #f87171;
-  --color-grade-bottom-bg:   rgba(248, 113, 113, 0.1);
+  --color-grade-top-text:    #00d4ff;
+  --color-grade-top-bg:      color-mix(in srgb, #00d4ff 12%, transparent);
+  --color-grade-high-text:   var(--primitive-midnight-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-midnight-500) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-300);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-400);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-300);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-300) 4%, transparent);
 
-  --color-warning:      #fbbf24;
-  --color-warning-text: #fbbf24;
-  --color-warning-bg:   rgba(251, 191, 36, 0.1);
+  --color-warning:      var(--primitive-amber-400);
+  --color-warning-text: var(--primitive-amber-400);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   #ff6b6b;
-  --color-danger-bg:     rgba(255, 100, 100, 0.15);
-  --color-danger-border: rgba(255, 100, 100, 0.3);
+  --color-danger-text:   var(--primitive-red-300);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-red-300) 15%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   #2a3545;
-  --color-chart-axis:   #6a8aaa;
+  --color-chart-grid:   var(--primitive-midnight-700);
+  --color-chart-axis:   var(--primitive-midnight-500);
+  --color-chart-line:   var(--primitive-midnight-200);
   --color-chart-stroke: rgba(255, 255, 255, 0.25);
+
+  /* Trend — cyan reward up, ired chain down */
+  --color-trend-strong-up:   #00d4ff;
+  --color-trend-up:          var(--primitive-cyan-300);
+  --color-trend-soft-up:     var(--primitive-midnight-500);
+  --color-trend-soft-down:   var(--primitive-ired-200);
+  --color-trend-down:        var(--primitive-ired-300);
+  --color-trend-strong-down: var(--primitive-crimson-300);
+
+  /* Console — navy tint */
+  --color-console-bg:      #060c16;
+  --color-console-text:    #c8d8ee;
+  --color-console-success: var(--primitive-cyan-300);
 
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              #d80c18;
+  --logo-q:              #00d4ff;
   --logo-chevron:        #00d4ff;
   --logo-chevron-hover:  #33e0ff;
   --logo-needle:         #00d4ff;
@@ -759,43 +768,43 @@ html[data-theme="slate"]:root {
   --color-surface:      #ffffff;
   --color-surface-alt:  var(--primitive-slate-100);
   --color-border:       var(--primitive-slate-200);
-  --color-border-focus: #d80c18;
+  --color-border-focus: var(--primitive-crimson-500);
 
   --color-text:         var(--primitive-slate-900);
   --color-text-muted:   #6b6b6b;
   --color-text-subtle:  #9a9a9a;
 
-  --color-accent:       #d80c18;
-  --color-accent-hover: #b00a14;
-  --color-accent-soft:  rgba(216, 12, 24, 0.06);
+  --color-accent:       var(--primitive-crimson-500);
+  --color-accent-hover: var(--primitive-crimson-600);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
 
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
 
-  --color-sev-critical-text:   #b91c1c;
-  --color-sev-critical-bg:     rgba(185, 28, 28, 0.08);
-  --color-sev-critical-border: rgba(185, 28, 28, 0.2);
-  --color-sev-major-text:      #b45309;
-  --color-sev-major-bg:        rgba(180, 83, 9, 0.08);
-  --color-sev-major-border:    rgba(180, 83, 9, 0.2);
-  --color-sev-minor-text:      #6b6b6b;
-  --color-sev-minor-bg:        rgba(107, 107, 107, 0.06);
-  --color-sev-minor-border:    var(--primitive-slate-200);
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #166534;
-  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
-  --color-grade-high-text:   #0f766e;
-  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
-  --color-grade-mid-text:    #92400e;
-  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
-  --color-grade-low-text:    #9a3412;
-  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
-  --color-grade-bottom-text: #991b1b;
-  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+  --color-grade-top-text:    var(--primitive-green-900);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-900) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-slate-700);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-slate-700) 8%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
-  --color-warning:      #b45309;
-  --color-warning-text: #b45309;
-  --color-warning-bg:   rgba(180, 83, 9, 0.08);
+  --color-warning:      var(--primitive-olive-700);
+  --color-warning-text: var(--primitive-olive-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-olive-700) 7%, transparent);
 
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
@@ -807,18 +816,27 @@ html[data-theme="slate"]:root {
 
   --color-chart-grid:   var(--color-border);
   --color-chart-axis:   var(--color-text-muted);
+  --color-chart-line:   var(--primitive-slate-900);
   --color-chart-stroke: transparent;
+
+  /* Trend — green reward up, ired chain down */
+  --color-trend-strong-up:   var(--primitive-green-900);
+  --color-trend-up:          var(--primitive-slate-700);
+  --color-trend-soft-up:     var(--primitive-slate-300);
+  --color-trend-soft-down:   var(--primitive-ired-700);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              #d80c18;
+  --logo-q:              var(--primitive-crimson-500);
   --logo-chevron:        #333333;
-  --logo-chevron-hover:  #d80c18;
-  --logo-needle:         #d80c18;
-  --logo-needle-dark:    #aa0000;
+  --logo-chevron-hover:  var(--primitive-crimson-500);
+  --logo-needle:         var(--primitive-crimson-500);
+  --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
 /* ── Horizon — AI/tech, cool whites, indigo accent ──────── */
@@ -828,43 +846,43 @@ html[data-theme="horizon"]:root {
   --color-surface:      #ffffff;
   --color-surface-alt:  var(--primitive-horizon-100);
   --color-border:       var(--primitive-horizon-200);
-  --color-border-focus: #6366f1;
+  --color-border-focus: var(--primitive-horizon-600);
 
   --color-text:         var(--primitive-horizon-900);
   --color-text-muted:   #6b7280;
   --color-text-subtle:  #9ca3af;
 
-  --color-accent:       #6366f1;
-  --color-accent-hover: #4f46e5;
-  --color-accent-soft:  rgba(99, 102, 241, 0.08);
+  --color-accent:       var(--primitive-horizon-600);
+  --color-accent-hover: var(--primitive-horizon-700);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-horizon-600) 8%, transparent);
 
-  --color-danger:  #dc2626;
+  --color-danger:  var(--primitive-red-500);
   --color-success: #16a34a;
 
-  --color-sev-critical-text:   #dc2626;
-  --color-sev-critical-bg:     rgba(220, 38, 38, 0.08);
-  --color-sev-critical-border: rgba(220, 38, 38, 0.2);
-  --color-sev-major-text:      #d97706;
-  --color-sev-major-bg:        rgba(217, 119, 6, 0.08);
-  --color-sev-major-border:    rgba(217, 119, 6, 0.2);
-  --color-sev-minor-text:      #6b7280;
-  --color-sev-minor-bg:        rgba(107, 114, 128, 0.06);
-  --color-sev-minor-border:    var(--primitive-horizon-200);
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #166534;
-  --color-grade-top-bg:      rgba(22, 101, 52, 0.08);
-  --color-grade-high-text:   #0f766e;
-  --color-grade-high-bg:     rgba(15, 118, 110, 0.08);
-  --color-grade-mid-text:    #92400e;
-  --color-grade-mid-bg:      rgba(146, 64, 14, 0.08);
-  --color-grade-low-text:    #9a3412;
-  --color-grade-low-bg:      rgba(154, 52, 18, 0.08);
-  --color-grade-bottom-text: #991b1b;
-  --color-grade-bottom-bg:   rgba(153, 27, 27, 0.08);
+  --color-grade-top-text:    var(--primitive-green-electric);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-electric) 12%, transparent);
+  --color-grade-high-text:   #6b7280;
+  --color-grade-high-bg:     color-mix(in srgb, #6b7280 8%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
-  --color-warning:      #d97706;
-  --color-warning-text: #d97706;
-  --color-warning-bg:   rgba(217, 119, 6, 0.08);
+  --color-warning:      var(--primitive-amber-600);
+  --color-warning-text: var(--primitive-amber-600);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-600) 8%, transparent);
 
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
@@ -876,18 +894,27 @@ html[data-theme="horizon"]:root {
 
   --color-chart-grid:   var(--color-border);
   --color-chart-axis:   var(--color-text-muted);
+  --color-chart-line:   var(--primitive-horizon-900);
   --color-chart-stroke: transparent;
+
+  /* Trend — electric green up, ired chain down */
+  --color-trend-strong-up:   var(--primitive-green-electric);
+  --color-trend-up:          var(--primitive-horizon-700);
+  --color-trend-soft-up:     #6b7280;
+  --color-trend-soft-down:   var(--primitive-ired-700);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              #6366f1;
-  --logo-chevron:        #4f46e5;
-  --logo-chevron-hover:  #6366f1;
-  --logo-needle:         #6366f1;
-  --logo-needle-dark:    #4338ca;
+  --logo-q:              var(--primitive-horizon-600);
+  --logo-chevron:        var(--primitive-horizon-700);
+  --logo-chevron-hover:  var(--primitive-horizon-600);
+  --logo-needle:         var(--primitive-horizon-600);
+  --logo-needle-dark:    var(--primitive-horizon-800);
 }
 
 /* ── 5. Typography ────────────────────────────────────────

--- a/ui/web/src/styles/tokens.css
+++ b/ui/web/src/styles/tokens.css
@@ -924,7 +924,7 @@ html[data-theme="horizon"]:root {
    ──────────────────────────────────────────────────────── */
 
 :root {
-  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-sans: "Plus Jakarta Sans", "Manrope", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 
   /* Type scale */

--- a/ui/web/src/utils/formatters.js
+++ b/ui/web/src/utils/formatters.js
@@ -64,6 +64,20 @@ export function gradeColorClass(grade) {
 }
 
 /**
+ * Format a date string as "20 Feb" (day + abbreviated month, no year).
+ * Falls back to the original string if it cannot be parsed as a date.
+ *
+ * @param {string|null|undefined} dateStr
+ * @returns {string}
+ */
+export function formatShortDate(dateStr) {
+  if (!dateStr) return dateStr;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return dateStr;
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+}
+
+/**
  * Format a run identifier for display.
  * - If a dateLabel is provided, use it directly.
  * - "latest" (or falsy) becomes "Latest".

--- a/ui/web/src/utils/formatters.js
+++ b/ui/web/src/utils/formatters.js
@@ -33,6 +33,22 @@ export function splitScore(score) {
 }
 
 /**
+ * Map a numeric score (0–10) to a CSS grade class.
+ *
+ * @param {number|string|null|undefined} score
+ * @returns {string}
+ */
+export function scoreColorClass(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return 'grade-none';
+  if (n >= 9) return 'grade-top';    // exemplary
+  if (n >= 7) return 'grade-high';   // good
+  if (n >= 5) return 'grade-mid';    // adequate
+  if (n >= 3) return 'grade-low';    // poor
+  return 'grade-bottom';             // critical
+}
+
+/**
  * Map a grade word or letter to a CSS class.
  * Tries the full lower-cased word first, then the first character.
  *


### PR DESCRIPTION
## Summary

- **Icons**: Redesigned nav icons to echo the logo (bar chart, crosshair-loupe, chevron list, sun-spokes)
- **Fonts**: Switched to Plus Jakarta Sans (UI), IBM Plex Mono (paths/files/data), JetBrains Mono (console/code) — matches quodeq.ai
- **Console output**: Theme-adaptive accent text color, tinted border, inset glow; strip ANSI escape codes from job logs
- **Dimension selection**: Starts empty, freely toggleable, All/Clear buttons on both eval panels
- **Settings page**: Two-column layout with interactive logo aside (tips, phrase cycling, needle wobble); About section with version, links, random slogan
- **Logo tokens**: Fix explicit light/dark theme not overriding system preference
- **Layout**: Fix sidebar/content gap (grid-template-columns transition); remove stale 300px sidebar breakpoint at 1180px
- **Eval progress**: Remove misleading files-read count from heartbeat log
- **Misc**: Lowercase sidebar brand, `.superpowers/` in .gitignore