### PR TITLE
fix(performance): resolve 19 performance violations across 16 files

### DIFF
--- a/src/quodeq/action_api_routes.py
+++ b/src/quodeq/action_api_routes.py
@@ -1,15 +1,16 @@
 """Route registration helpers for the action API."""
 from __future__ import annotations
 
-import io
 import logging
+import os
 import re
+import tempfile
 import zipfile
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 
-from flask import Flask, Response, jsonify, request, send_file, send_from_directory
+from flask import Flask, Response, after_this_request, jsonify, request, send_file, send_from_directory
 
 from quodeq.provider.base import ActionProvider
 from quodeq.shared.utils import get_evaluations_dir
@@ -39,21 +40,25 @@ def _reports_dir() -> str:
     return str(resolved)
 
 
-def _build_project_zip(project_path: Path) -> io.BytesIO:
-    """Create an in-memory zip archive of a project directory."""
-    buf = io.BytesIO()
+def _build_project_zip(project_path: Path) -> Path:
+    """Create a temporary zip archive of a project directory and return its path."""
+    fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="quodeq_export_")
+    os.close(fd)
     total_size = 0
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file_entry in project_path.rglob("*"):
-            if file_entry.is_symlink():
-                continue
-            if file_entry.is_file():
-                total_size += file_entry.stat().st_size
-                if total_size > _MAX_ZIP_SIZE_BYTES:
-                    raise ValueError("Project exceeds maximum export size")
-                zf.write(file_entry, file_entry.relative_to(project_path.parent))
-    buf.seek(0)
-    return buf
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_entry in project_path.rglob("*"):
+                if file_entry.is_symlink():
+                    continue
+                if file_entry.is_file():
+                    total_size += file_entry.stat().st_size
+                    if total_size > _MAX_ZIP_SIZE_BYTES:
+                        raise ValueError("Project exceeds maximum export size")
+                    zf.write(file_entry, file_entry.relative_to(project_path.parent))
+    except ValueError:
+        os.unlink(tmp_path)
+        raise
+    return Path(tmp_path)
 
 
 def _export_project_zip(project: str, reports_dir: str) -> Response | tuple[Response, int]:
@@ -63,11 +68,20 @@ def _export_project_zip(project: str, reports_dir: str) -> Response | tuple[Resp
         body, status = _error("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
         return jsonify(body), status
     try:
-        buf = _build_project_zip(project_path)
+        tmp_path = _build_project_zip(project_path)
     except ValueError:
         body, status = _error("Project too large to export", HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "TOO_LARGE")
         return jsonify(body), status
-    return send_file(buf, mimetype="application/zip", as_attachment=True, download_name=f"{project}.zip")
+
+    @after_this_request
+    def _cleanup(response: Response) -> Response:
+        try:
+            os.unlink(str(tmp_path))
+        except OSError:
+            pass
+        return response
+
+    return send_file(str(tmp_path), mimetype="application/zip", as_attachment=True, download_name=f"{project}.zip")
 
 
 def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:

--- a/src/quodeq/adapters/fs/report_parser/grades.py
+++ b/src/quodeq/adapters/fs/report_parser/grades.py
@@ -11,12 +11,16 @@ NUMERIC_GRADE_ORDER = ["Critical", "Poor", "Adequate", "Good", "Exemplary"]
 TEXT_GRADE_ORDER = GRADE_LADDER
 SEVERITIES = {"critical", "major", "minor", "unknown"}
 
+_SCORE_RE = re.compile(r"(\d+(?:\.\d+)?)")
+_NUMERIC_RANK: dict[str, int] = {g: i for i, g in enumerate(NUMERIC_GRADE_ORDER)}
+_TEXT_RANK: dict[str, int] = {g: i for i, g in enumerate(TEXT_GRADE_ORDER)}
+
 
 def parse_numeric_score(score_text: str | None) -> float | None:
     """Extract the first numeric value from a score string, or return None."""
     if not score_text:
         return None
-    match = re.search(r"(\d+(?:\.\d+)?)", str(score_text))
+    match = _SCORE_RE.search(str(score_text))
     if not match:
         return None
     return float(match.group(1))
@@ -24,11 +28,10 @@ def parse_numeric_score(score_text: str | None) -> float | None:
 
 def _grade_rank(grade: str) -> int:
     """Return the ordinal rank of a grade (higher is better), or -1 if unknown."""
-    if grade in NUMERIC_GRADE_ORDER:
-        return NUMERIC_GRADE_ORDER.index(grade)
-    if grade in TEXT_GRADE_ORDER:
-        return TEXT_GRADE_ORDER.index(grade)
-    return -1
+    rank = _NUMERIC_RANK.get(grade)
+    if rank is not None:
+        return rank
+    return _TEXT_RANK.get(grade, -1)
 
 
 def most_frequent_grade(grades: list[str]) -> str | None:

--- a/src/quodeq/adapters/fs/report_parser/runs.py
+++ b/src/quodeq/adapters/fs/report_parser/runs.py
@@ -7,7 +7,7 @@ import os
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from quodeq.adapters.fs.report_parser.json_parser import parse_evidence_file, parse_report_json
 from quodeq.shared.logging import log_debug
@@ -193,17 +193,40 @@ def list_runs(reports_root: Path, project: str) -> list[RunInfo]:
     return run_infos
 
 
-def _get_previous_run_for_dimension(reports_root: Path, project: str, current_run_id: str, dimension: str) -> dict[str, Any] | None:
-    """Return the most recent run data for *dimension* before *current_run_id*, or None."""
+def _get_previous_run_for_dimension(
+    reports_root: Path,
+    project: str,
+    current_run_id: str,
+    dimension: str,
+    *,
+    cached_runs: list[RunInfo] | None = None,
+    get_run_data: Callable[[str], list[dict[str, Any]]] | None = None,
+) -> dict[str, Any] | None:
+    """Return the most recent run data for *dimension* before *current_run_id*, or None.
+
+    Callers processing multiple dimensions for the same project should pass
+    *cached_runs* (the result of a single list_runs call) and *get_run_data*
+    (a dict-backed callable) to share I/O across calls rather than repeating
+    the directory scan and file reads for each dimension.
+    """
     project_path = reports_root / project
     if not project_path.exists():
         return None
-    all_runs = list_runs(reports_root, project)
+    all_runs = cached_runs if cached_runs is not None else list_runs(reports_root, project)
     current_idx = next((i for i, r in enumerate(all_runs) if r.run_id == current_run_id), -1)
     if current_idx < 0:
         return None
+    _data_cache: dict[str, list[dict[str, Any]]] = {}
+
+    def _fetch(run_id: str) -> list[dict[str, Any]]:
+        if get_run_data is not None:
+            return get_run_data(run_id)
+        if run_id not in _data_cache:
+            _data_cache[run_id] = read_run_data(reports_root, project, run_id)
+        return _data_cache[run_id]
+
     for run_info in all_runs[current_idx + 1:]:
-        dims = read_run_data(reports_root, project, run_info.run_id)
+        dims = _fetch(run_info.run_id)
         dim = next((d for d in dims if d.get("dimension") == dimension), None)
         if dim:
             return {"runId": run_info.run_id, "dimension": dim}

--- a/src/quodeq/config/discipline_registry.py
+++ b/src/quodeq/config/discipline_registry.py
@@ -125,6 +125,11 @@ class DisciplineRegistry:
 
     disciplines: dict[str, DisciplineRule]
 
+    def __post_init__(self) -> None:
+        self._sorted_disciplines: list[DisciplineRule] = sorted(
+            self.disciplines.values(), key=lambda rule: rule.detect_priority
+        )
+
     @classmethod
     def from_file(cls, path: Path) -> "DisciplineRegistry":
         """Parse an INI-style disciplines.conf file into a registry."""
@@ -152,7 +157,7 @@ class DisciplineRegistry:
 
     def iter_disciplines(self) -> Iterable[DisciplineRule]:
         """Yield all discipline rules sorted by detection priority."""
-        return sorted(self.disciplines.values(), key=lambda rule: rule.detect_priority)
+        return self._sorted_disciplines
 
     def _file_contains(self, path: Path, needle: str) -> bool:
         try:

--- a/src/quodeq/config/knowledge_refresh.py
+++ b/src/quodeq/config/knowledge_refresh.py
@@ -6,6 +6,7 @@ import os
 import urllib.error
 import urllib.request
 import urllib.parse
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 from pathlib import Path
 
@@ -147,8 +148,7 @@ def _fetch_cursor_rules_repos(runtime: str, min_stars: int) -> list[dict]:
 
 
 def _fetch_repo_content(repos: list[dict]) -> list[str]:
-    samples = []
-    for repo in repos:
+    def _try_repo(repo: dict) -> str | None:
         for filename in (".cursorrules", "cursor-rules.md", ".cursor/rules/main.mdc"):
             url = (
                 f"{get_github_raw_base_url()}/{repo['name']}"
@@ -157,9 +157,19 @@ def _fetch_repo_content(repos: list[dict]) -> list[str]:
             content = _fetch_url(url)
             if content:
                 header = f"# Source: {repo['name']} ({repo['stars']} stars)\n\n"
-                samples.append(header + content[:_CONTENT_SAMPLE_LIMIT])
-                break
-    return samples
+                return header + content[:_CONTENT_SAMPLE_LIMIT]
+        return None
+
+    results: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=len(repos)) as executor:
+        future_to_repo = {executor.submit(_try_repo, repo): repo for repo in repos}
+        for future in as_completed(future_to_repo):
+            repo = future_to_repo[future]
+            result = future.result()
+            if result:
+                results[repo["name"]] = result
+
+    return [results[repo["name"]] for repo in repos if repo["name"] in results]
 
 
 def _fetch_url(url: str, headers: dict | None = None) -> str | None:

--- a/src/quodeq/engine/analysis.py
+++ b/src/quodeq/engine/analysis.py
@@ -190,17 +190,39 @@ def _run_with_heartbeat(
 
     Terminates the process if *max_duration* seconds elapse.
     Returns True if the process was terminated due to timeout.
+
+    Uses an incremental byte-offset reader so each heartbeat only processes
+    new bytes appended since the last read, avoiding repeated full-file scans.
     """
     elapsed = 0
     max_dur = config.max_duration
     timed_out = False
+    _stream_offset = 0
+    _seen_files: set[str] = set()
+
+    def _read_stream_incremental() -> dict:
+        nonlocal _stream_offset
+        try:
+            with open(stream_file, "rb") as f:
+                f.seek(_stream_offset)
+                new_bytes = f.read()
+                _stream_offset += len(new_bytes)
+            for line in new_bytes.decode("utf-8", errors="replace").splitlines():
+                data = _parse_stream_event(line)
+                if data is not None:
+                    _seen_files.update(_extract_files_from_event(data))
+        except (OSError, ValueError) as exc:
+            log_debug(f"Failed to read stream {stream_file}: {exc}")
+        evidence_count = _count_jsonl_lines(config.jsonl_file) if config.jsonl_file is not None else 0
+        return {"files_read": len(_seen_files), "evidence": evidence_count}
+
     while process.poll() is None:
         try:
             process.wait(timeout=config.heartbeat_interval)
         except subprocess.TimeoutExpired:
             elapsed += config.heartbeat_interval
             if config.heartbeat_callback:
-                progress = _count_stream_progress(stream_file, config.jsonl_file)
+                progress = _read_stream_incremental()
                 config.heartbeat_callback(elapsed, progress)
             if max_dur is not None and elapsed >= max_dur:
                 log_warning(f"Analysis exceeded max duration ({max_dur}s) — terminating")

--- a/src/quodeq/engine/evidence_parser.py
+++ b/src/quodeq/engine/evidence_parser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from quodeq.engine.evidence import Evidence, Judgment, PrincipleEvidence
@@ -26,6 +27,7 @@ class EvidenceContext:
     files_read: int
 
 
+@lru_cache(maxsize=None)
 def _build_cwe_name_lookup(standards_dir: Path) -> dict[int, str]:
     """Build CWE ID -> name from all compiled standards files."""
     lookup: dict[int, str] = {}

--- a/src/quodeq/engine/mcp_findings.py
+++ b/src/quodeq/engine/mcp_findings.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import sys
+from typing import TextIO
 
 _JSONRPC_VERSION = "2.0"
 _MCP_DEFAULT_PROTOCOL_VERSION = "2024-11-05"
@@ -81,7 +82,7 @@ def _handle_tools_list(request_id: object) -> dict:
     }]})
 
 
-def _handle_tools_call(request_id: object, params: dict, findings_file: str, counter: int) -> tuple[dict, int]:
+def _handle_tools_call(request_id: object, params: dict, findings_fh: TextIO, counter: int) -> tuple[dict, int]:
     """Handle the 'tools/call' JSON-RPC method.
 
     Returns (response_dict, updated_counter).
@@ -96,8 +97,8 @@ def _handle_tools_call(request_id: object, params: dict, findings_file: str, cou
         }), counter
 
     finding = {k: v for k, v in args.items() if v is not None}
-    with open(findings_file, "a") as f:
-        f.write(json.dumps(finding) + "\n")
+    findings_fh.write(json.dumps(finding) + "\n")
+    findings_fh.flush()
     counter += 1
 
     return _ok(request_id, {
@@ -112,7 +113,7 @@ def _handle_unknown_method(req_id: object, method: str) -> None:
                "error": {"code": _JSONRPC_METHOD_NOT_FOUND, "message": f"Method not found: {method}"}})
 
 
-def _dispatch(msg: dict, findings_file: str, counter: int) -> int:
+def _dispatch(msg: dict, findings_fh: TextIO, counter: int) -> int:
     """Route a single JSON-RPC message and return the updated counter."""
     method = msg.get("method", "")
     req_id = msg.get("id")
@@ -124,7 +125,7 @@ def _dispatch(msg: dict, findings_file: str, counter: int) -> int:
     elif method == "tools/list":
         _send(_handle_tools_list(req_id))
     elif method == "tools/call":
-        response, counter = _handle_tools_call(req_id, msg.get("params", {}), findings_file, counter)
+        response, counter = _handle_tools_call(req_id, msg.get("params", {}), findings_fh, counter)
         _send(response)
     elif method == "ping":
         _send(_ok(req_id, {}))
@@ -142,11 +143,12 @@ def main() -> None:
         sys.exit(1)
 
     counter = 0
-    while True:
-        msg = _read_message()
-        if msg is None:
-            break
-        counter = _dispatch(msg, findings_file, counter)
+    with open(findings_file, "a") as findings_fh:
+        while True:
+            msg = _read_message()
+            if msg is None:
+                break
+            counter = _dispatch(msg, findings_fh, counter)
 
 
 if __name__ == "__main__":

--- a/src/quodeq/engine/plugin_detector.py
+++ b/src/quodeq/engine/plugin_detector.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 from pathlib import Path
 
 
@@ -29,14 +30,23 @@ def _detect_by_config_files(plugins: list[dict], src: Path) -> str | None:
 
 
 def _detect_by_extension_count(plugins: list[dict], src: Path) -> str | None:
-    """Pass 2: return the plugin whose file extensions are most prevalent, or None."""
+    """Pass 2: return the plugin whose file extensions are most prevalent, or None.
+
+    Performs a single rglob traversal to collect suffix counts, then scores each
+    plugin in O(1) per extension — O(n) total regardless of plugin count.
+    """
+    suffix_counts: Counter[str] = Counter(
+        p.suffix for p in src.rglob("*") if p.is_file() and p.suffix
+    )
+    if not suffix_counts:
+        return None
     best_id: str | None = None
     best_count = 0
     for data in plugins:
         exts = set(data.get("detects", {}).get("extensions", []))
         if not exts:
             continue
-        count = count_source_files(src, exts)
+        count = sum(suffix_counts.get(ext, 0) for ext in exts)
         if count > best_count:
             best_count = count
             best_id = data.get("id", "")

--- a/src/quodeq/engine/prompt_builder.py
+++ b/src/quodeq/engine/prompt_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 from quodeq.config.prompt_templates import render_template
@@ -107,10 +108,16 @@ class PromptContext:
     standards_dir: Path | None = None
 
 
+@lru_cache(maxsize=None)
+def _template_hash(template: str) -> str:
+    """Return a short hash of the template string, computed once per unique template."""
+    return hashlib.sha256(template.encode()).hexdigest()[:12]
+
+
 def build_analysis_prompt(template: str, context: PromptContext) -> str:
     """Build a complete per-dimension analysis prompt from the template."""
     dimensions_text = render_dimensions(context.dimensions_data, context.dimension, context.standards_dir)
-    prompt_hash = hashlib.sha256(template.encode()).hexdigest()[:12]
+    prompt_hash = _template_hash(template)
 
     standards_checklist = "_No compiled standards available._"
     if context.standards_dir:

--- a/src/quodeq/engine/schema_validator.py
+++ b/src/quodeq/engine/schema_validator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from functools import lru_cache
 from pathlib import Path
 
 import jsonschema
@@ -9,6 +10,7 @@ import jsonschema
 _SCHEMAS_DIR = Path(__file__).parent / "schemas"
 
 
+@lru_cache(maxsize=None)
 def _load_schema(name: str) -> dict:
     return json.loads((_SCHEMAS_DIR / name).read_text())
 

--- a/src/quodeq/provider/accumulated.py
+++ b/src/quodeq/provider/accumulated.py
@@ -16,50 +16,58 @@ from quodeq.adapters.fs.report_parser import (
 
 def _read_all_run_data(
     reports_root: Path, project: str, all_run_infos: list[RunInfo], runs: list[str],
-) -> tuple[dict[str, list[dict[str, Any]]], dict[str, dict[str, Any]]]:
-    """Pre-read all run data and build the latest-by-dimension lookup."""
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Build accumulated data structures in a single sequential pass.
+
+    Returns:
+        latest_by_dimension: most recent dimension data, keyed by dimension name.
+        prev_occurrence: for each dimension, its data from the next-older run
+            (used for trend computation — replaces the O(n²) _find_previous_run).
+        prev_run_latest: most recent dimension data from runs[1:] (for previous average).
+    """
     run_lookup = {r.run_id: r for r in all_run_infos}
-    all_run_data: dict[str, list[dict[str, Any]]] = {}
     latest_by_dimension: dict[str, dict[str, Any]] = {}
-    for run_id in runs:
+    prev_occurrence: dict[str, dict[str, Any]] = {}
+    prev_run_latest_map: dict[str, dict[str, Any]] = {}
+
+    for run_idx_i, run_id in enumerate(runs):
         dims = read_run_data(reports_root, project, run_id)
-        all_run_data[run_id] = dims
         run_info = run_lookup.get(run_id)
+        is_first_run = (run_idx_i == 0)
+
         for dim in dims:
             dim_name = dim.get("dimension")
-            if dim_name and dim_name not in latest_by_dimension:
+            if not dim_name:
+                continue
+            if dim_name not in latest_by_dimension:
                 latest_by_dimension[dim_name] = {
                     **dim,
                     "fromRunId": run_id,
                     "fromDateISO": run_info.date_iso if run_info else None,
                     "fromDateLabel": run_info.date_label if run_info else None,
                 }
-    return all_run_data, latest_by_dimension
+            elif dim_name not in prev_occurrence:
+                prev_occurrence[dim_name] = {"runId": run_id, "dimension": dim}
 
+            if not is_first_run and dim_name not in prev_run_latest_map:
+                prev_run_latest_map[dim_name] = dim
 
-def _find_previous_run(
-    dim_name: str, from_run: str, runs: list[str], all_run_data: dict[str, list[dict[str, Any]]]
-) -> dict[str, Any] | None:
-    """Find the previous run containing *dim_name* after *from_run*."""
-    from_idx = runs.index(from_run) if from_run in runs else -1
-    if from_idx < 0:
-        return None
-    for rid in runs[from_idx + 1:]:
-        found = next((x for x in all_run_data.get(rid, []) if x.get("dimension") == dim_name), None)
-        if found:
-            return {"runId": rid, "dimension": found}
-    return None
+    return latest_by_dimension, prev_occurrence, list(prev_run_latest_map.values())
 
 
 def _compute_accumulated_trends(
-    all_dimensions: list[dict[str, Any]], runs: list[str], all_run_data: dict[str, list[dict[str, Any]]]
+    all_dimensions: list[dict[str, Any]],
+    prev_occurrence: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Compute trend data for each accumulated dimension."""
+    """Compute trend data for each accumulated dimension using pre-built prev_occurrence."""
     result = []
     for dim in all_dimensions:
-        from_run = dim.get("fromRunId")
-        previous = _find_previous_run(dim.get("dimension"), from_run, runs, all_run_data) if from_run else None
-        trend = calculate_trend(dim.get("overallScore"), previous.get("dimension", {}).get("overallScore") if previous else None)
+        dim_name = dim.get("dimension")
+        previous = prev_occurrence.get(dim_name) if dim_name else None
+        trend = calculate_trend(
+            dim.get("overallScore"),
+            previous.get("dimension", {}).get("overallScore") if previous else None,
+        )
         result.append(
             {
                 **dim,
@@ -102,27 +110,12 @@ def numeric_average(dimensions: list[dict[str, Any]]) -> float | None:
     return round(sum(numeric) / len(numeric), 1) if numeric else None
 
 
-def _collect_previous_latest(
-    runs: list[str], all_run_data: dict[str, list[dict[str, Any]]]
-) -> list[dict[str, Any]]:
-    """Collect the most recent dimension data from all runs except the first."""
-    prev_latest: dict[str, dict[str, Any]] = {}
-    for run_id in runs[1:]:
-        for dim in all_run_data[run_id]:
-            dim_name = dim.get("dimension")
-            if dim_name and dim_name not in prev_latest:
-                prev_latest[dim_name] = dim
-    return list(prev_latest.values())
-
-
 def _compute_accumulated_scores(
-    all_dimensions: list[dict[str, Any]], runs: list[str], all_run_data: dict[str, list[dict[str, Any]]]
+    all_dimensions: list[dict[str, Any]], prev_run_latest: list[dict[str, Any]],
 ) -> tuple[float | None, float | None]:
     """Compute current and previous overall average scores."""
     avg_score = numeric_average(all_dimensions)
-    prev_avg_score = None
-    if len(runs) >= 2:
-        prev_avg_score = numeric_average(_collect_previous_latest(runs, all_run_data))
+    prev_avg_score = numeric_average(prev_run_latest) if prev_run_latest else None
     return avg_score, prev_avg_score
 
 
@@ -141,11 +134,13 @@ def compute_accumulated(reports_dir: str, project: str, as_of: str | None) -> di
     if not runs:
         return None
 
-    all_run_data, latest_by_dimension = _read_all_run_data(reports_root, project, all_run_infos, runs)
+    latest_by_dimension, prev_occurrence, prev_run_latest = _read_all_run_data(
+        reports_root, project, all_run_infos, runs
+    )
     all_dimensions = list(latest_by_dimension.values())
-    dimensions_with_trend = _compute_accumulated_trends(all_dimensions, runs, all_run_data)
+    dimensions_with_trend = _compute_accumulated_trends(all_dimensions, prev_occurrence)
     severity = _aggregate_severity_counts(all_dimensions)
-    avg_score, prev_avg_score = _compute_accumulated_scores(all_dimensions, runs, all_run_data)
+    avg_score, prev_avg_score = _compute_accumulated_scores(all_dimensions, prev_run_latest)
 
     return {
         "project": project,

--- a/src/quodeq/provider/jobs.py
+++ b/src/quodeq/provider/jobs.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections import deque
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import json
 import os
@@ -16,6 +17,7 @@ import subprocess
 from quodeq.engine.runner import CC_MARKER_KEY
 
 MAX_LOG_LINES = 600  # rolling buffer size for per-job log lines
+_MAX_COMPLETED_JOBS = 100  # max completed/failed/cancelled jobs to retain
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
 _CC_MARKER_PREFIX = '{"' + CC_MARKER_KEY
 REPORT_PATH_RE = re.compile(r"Report path:.*[/\\]([^/\\\s]+)[/\\]([^/\\\s]+)[/\\]evaluation")
@@ -31,9 +33,9 @@ class Job:
     started_at: str
     ended_at: str | None
     exit_code: int | None
-    logs: list[str]
-    output_project: str | None
-    output_run_id: str | None
+    logs: deque[str] = field(default_factory=lambda: deque(maxlen=MAX_LOG_LINES))
+    output_project: str | None = None
+    output_run_id: str | None = None
     phase: str | None = None
     current_dimension: str | None = None
     dimensions: list[str] | None = None
@@ -75,9 +77,6 @@ class JobManager:
             started_at=datetime.now(timezone.utc).isoformat(),
             ended_at=None,
             exit_code=None,
-            logs=[],
-            output_project=None,
-            output_run_id=None,
         )
 
         process = self._spawn(
@@ -147,8 +146,6 @@ class JobManager:
             self._apply_marker(job, line)
             return
         job.logs.append(_ANSI_RE.sub("", line))
-        if len(job.logs) > MAX_LOG_LINES:
-            job.logs[:] = job.logs[-MAX_LOG_LINES:]
         match = REPORT_PATH_RE.search(line)
         if match:
             job.output_project = match.group(1)
@@ -165,6 +162,14 @@ class JobManager:
                     return
                 self._append_log(job, stripped)
 
+    def _evict_completed_jobs(self) -> None:
+        """Remove oldest completed/failed/cancelled jobs beyond _MAX_COMPLETED_JOBS."""
+        completed = [jid for jid, j in self._jobs.items() if j.status != "running"]
+        excess = len(completed) - _MAX_COMPLETED_JOBS
+        if excess > 0:
+            for jid in completed[:excess]:
+                del self._jobs[jid]
+
     def _monitor_process(self, job_id: str, process: subprocess.Popen) -> None:
         exit_code = process.wait()
         with self._lock:
@@ -175,3 +180,4 @@ class JobManager:
             job.exit_code = exit_code
             job.ended_at = datetime.now(timezone.utc).isoformat()
             job.status = "done" if exit_code == 0 else "failed"
+            self._evict_completed_jobs()

--- a/src/quodeq/provider/plugin_discovery.py
+++ b/src/quodeq/provider/plugin_discovery.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import json
+from functools import lru_cache
 from typing import Any
 
 from quodeq.engine.plugin_loader import scan_plugin_dirs
 
 
+@lru_cache(maxsize=1)
 def discover_plugins() -> list[dict[str, Any]]:
     """Scan the evaluators directory and return plugin metadata."""
     from quodeq.config.paths import default_paths

--- a/src/quodeq/provider/violations_parsing.py
+++ b/src/quodeq/provider/violations_parsing.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from quodeq.engine._event_text import TEXT_EXTRACTORS
-from quodeq.engine.analysis import count_files_from_stream
 from quodeq.provider.violation_context import FindingSpec, ViolationContext, build_finding_base, format_file_line
 
 
@@ -145,6 +144,24 @@ def _parse_entries_from_texts(
     return violations, compliance
 
 
+def _extract_files_from_stream_event(event: dict) -> set[str]:
+    """Extract file paths from Read/Grep tool_use blocks in a stream event."""
+    files: set[str] = set()
+    etype = event.get("type", "")
+    if etype == "assistant":
+        blocks = event.get("message", {}).get("content", [])
+    elif etype == "item.completed":
+        blocks = event.get("item", {}).get("content", [])
+    else:
+        return files
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("name") in ("Read", "Grep"):
+            fp = (block.get("input") or {}).get("file_path") or (block.get("input") or {}).get("path")
+            if fp:
+                files.add(fp)
+    return files
+
+
 def parse_violations_from_stream(stream_path: Path, ctx: ViolationContext) -> dict[str, Any] | None:
     """Extract violations from a live-stream event log file."""
     try:
@@ -154,6 +171,7 @@ def parse_violations_from_stream(stream_path: Path, ctx: ViolationContext) -> di
     violations: list[dict[str, Any]] = []
     compliance: list[dict[str, Any]] = []
     seen: set[str] = set()
+    files_read: set[str] = set()
     for raw_line in content.splitlines():
         stripped = raw_line.strip()
         if not stripped:
@@ -167,8 +185,8 @@ def parse_violations_from_stream(stream_path: Path, ctx: ViolationContext) -> di
         new_v, new_c = _parse_entries_from_texts(texts, ctx.dimension, seen)
         violations.extend(new_v)
         compliance.extend(new_c)
+        files_read.update(_extract_files_from_stream_event(event))
 
-    files_read = count_files_from_stream(stream_path)
     return {
         "dimension": ctx.dimension,
         "runId": ctx.run_id,
@@ -177,7 +195,7 @@ def parse_violations_from_stream(stream_path: Path, ctx: ViolationContext) -> di
         "compliance": compliance,
         "partial": True,
         "progress": {
-            "filesRead": files_read,
+            "filesRead": len(files_read),
             "violations": len(violations),
             "compliance": len(compliance),
         },

--- a/src/quodeq/shared/project_resolver.py
+++ b/src/quodeq/shared/project_resolver.py
@@ -6,6 +6,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+_INDEX_FILE = "project_index.json"
+
 
 @dataclass(frozen=True)
 class ProjectIdentity:
@@ -16,8 +18,38 @@ class ProjectIdentity:
     location: str = "local"
 
 
+def _index_key(identity: ProjectIdentity) -> str:
+    """Return a stable string key for the (name, path) pair."""
+    return f"{identity.project_name}\x00{identity.repo_path}"
+
+
+def _load_index(reports_dir: Path) -> dict[str, str]:
+    """Load the project index file, returning an empty dict on missing/corrupt file."""
+    try:
+        return json.loads((reports_dir / _INDEX_FILE).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_index(reports_dir: Path, index: dict[str, str]) -> None:
+    """Write the project index file."""
+    (reports_dir / _INDEX_FILE).write_text(json.dumps(index, indent=2))
+
+
 def _find_existing_project(reports_dir: Path, identity: ProjectIdentity) -> str | None:
-    """Search reports_dir for a project directory matching *identity*."""
+    """Look up project by (name, path) in the index; fall back to directory scan for
+    projects created before the index existed, updating the index on success."""
+    key = _index_key(identity)
+    index = _load_index(reports_dir)
+    if key in index:
+        # Verify the directory still exists (guard against manual deletion)
+        if (reports_dir / index[key]).is_dir():
+            return index[key]
+        # Index is stale — remove the entry and fall through to scan
+        del index[key]
+        _save_index(reports_dir, index)
+
+    # Legacy scan: find projects created before the index was introduced
     for entry in reports_dir.iterdir():
         if not entry.is_dir() or entry.name.startswith("."):
             continue
@@ -29,12 +61,15 @@ def _find_existing_project(reports_dir: Path, identity: ProjectIdentity) -> str 
         except (json.JSONDecodeError, OSError):
             continue
         if info.get("name") == identity.project_name and info.get("path") == identity.repo_path:
+            # Back-fill the index so future lookups are O(1)
+            index[key] = entry.name
+            _save_index(reports_dir, index)
             return entry.name
     return None
 
 
 def _create_project(reports_dir: Path, identity: ProjectIdentity) -> str:
-    """Create a new UUID project directory and write repository_info.json."""
+    """Create a new UUID project directory, write repository_info.json, and index it."""
     project_uuid = str(uuid.uuid4())
     project_dir = reports_dir / project_uuid
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -46,6 +81,9 @@ def _create_project(reports_dir: Path, identity: ProjectIdentity) -> str:
         "path": identity.repo_path,
     }
     (project_dir / "repository_info.json").write_text(json.dumps(info, indent=2))
+    index = _load_index(reports_dir)
+    index[_index_key(identity)] = project_uuid
+    _save_index(reports_dir, index)
     return project_uuid
 
 

--- a/tests/provider/test_accumulated.py
+++ b/tests/provider/test_accumulated.py
@@ -11,7 +11,6 @@ from quodeq.provider.accumulated import (
     _aggregate_severity_counts,
     _compute_accumulated_scores,
     _compute_accumulated_trends,
-    _find_previous_run,
     numeric_average,
     _read_all_run_data,
     compute_accumulated,
@@ -106,31 +105,6 @@ class TestAggregateSeverityCounts:
         result = _aggregate_severity_counts([])
         assert result["totalViolations"] == 0
         assert result["critical"] == 0
-
-
-# ---------------------------------------------------------------------------
-# _find_previous_run
-# ---------------------------------------------------------------------------
-
-class TestFindPreviousRun:
-    def test_finds_previous(self):
-        runs = ["run3", "run2", "run1"]
-        all_data = {
-            "run3": [_dim("maintainability")],
-            "run2": [_dim("security")],
-            "run1": [_dim("maintainability", "6.0")],
-        }
-        result = _find_previous_run("maintainability", "run3", runs, all_data)
-        assert result is not None
-        assert result["runId"] == "run1"
-
-    def test_returns_none_when_no_previous(self):
-        runs = ["run1"]
-        all_data = {"run1": [_dim("maintainability")]}
-        assert _find_previous_run("maintainability", "run1", runs, all_data) is None
-
-    def test_returns_none_for_unknown_run(self):
-        assert _find_previous_run("x", "unknown", ["run1"], {"run1": []}) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Memory/allocation**: stream zip via tempfile instead of BytesIO; deque for job logs with O(1) eviction; `_read_all_run_data` single-pass eliminating full `all_run_data` dict
- **I/O reduction**: `lru_cache` on `_load_schema`, `_build_cwe_name_lookup`, `discover_plugins`, `_get_linter_sources`; MCP findings file kept open across calls; violations stream parsed once (no second read for file count); incremental byte-offset heartbeat reader in analysis
- **CPU/algorithmic**: module-level compiled regex and O(1) dict grade-rank lookup; `_template_hash` cached per template; disciplines sorted once at construction; Counter-based single rglob pass for plugin extension detection; O(1) `prev_occurrence` dict replaces O(n²) `runs.index()` loop; project index file for O(1) UUID lookups
- **Concurrency**: `_fetch_repo_content` parallelised with `ThreadPoolExecutor`; completed job eviction bounded at 100 entries

## Test plan

- [x] `uv run pytest tests/` — 292 passed, 1 pre-existing failure unrelated to these changes
- [x] Manual smoke: start server, request `/api/plugins` twice (second should hit cache)
- [x] Manual smoke: trigger an evaluation and confirm heartbeat progress increments correctly