### PR TITLE
fix(usability): resolve 15 usability violations across 12 files

### DIFF
--- a/src/quodeq/action_api_routes.py
+++ b/src/quodeq/action_api_routes.py
@@ -118,7 +118,8 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
         _logger.info("delete_project: project=%s, remote_addr=%s", project, request.remote_addr)
         ok = provider.delete_project(_reports_dir(), project)
         if not ok:
-            return jsonify({"error": "Project not found"}), HTTPStatus.NOT_FOUND
+            body, status = _error("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
         return jsonify({"deleted": project})
 
     @app.get("/api/projects/<project>/info")

--- a/src/quodeq/config/cli.py
+++ b/src/quodeq/config/cli.py
@@ -19,19 +19,33 @@ from quodeq.config.paths import default_paths
 def build_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser for the configure subcommand."""
     parser = argparse.ArgumentParser(prog="quodeq configure")
-    parser.add_argument("--ai-cli", nargs="?")
-    parser.add_argument("-d", dest="list_dimensions", action="store_true")
-    parser.add_argument("--generate-maps", nargs="?", const="")
-    parser.add_argument("--generate-dimensions", action="store_true")
-    parser.add_argument("--validate-evaluators")
-    parser.add_argument("--patch-evaluator", nargs=3)
-    parser.add_argument("--check-sources", nargs="?")
-    parser.add_argument("--add-discipline", nargs=2)
-    parser.add_argument("--list-gaps", nargs="?")
-    parser.add_argument("--fill-gap", nargs=2)
-    parser.add_argument("--parallel")
-    parser.add_argument("--sequential", action="store_true")
-    parser.add_argument("--data-version", default=None)
+    parser.add_argument("--ai-cli", nargs="?",
+                        help="AI CLI client to use for configuration tasks (e.g. claude, codex)")
+    parser.add_argument("-d", dest="list_dimensions", action="store_true",
+                        help="List all available quality dimensions")
+    parser.add_argument("--generate-maps", nargs="?", const="",
+                        help="Generate evaluator maps for a plugin (omit value to use default)")
+    parser.add_argument("--generate-dimensions", action="store_true",
+                        help="Generate the dimensions index from evaluator definitions")
+    parser.add_argument("--validate-evaluators",
+                        help="Validate evaluator files for the given plugin runtime")
+    parser.add_argument("--patch-evaluator", nargs=3,
+                        metavar=("RUNTIME", "DIMENSION", "PATCH"),
+                        help="Apply a JSON patch to an evaluator for the given runtime and dimension")
+    parser.add_argument("--check-sources", nargs="?",
+                        help="Check data sources for a plugin runtime (omit value to check all)")
+    parser.add_argument("--add-discipline", nargs=2, metavar=("RUNTIME", "DISCIPLINE"),
+                        help="Add a new discipline to a plugin runtime")
+    parser.add_argument("--list-gaps", nargs="?",
+                        help="List coverage gaps for a plugin runtime (omit value to list all)")
+    parser.add_argument("--fill-gap", nargs=2, metavar=("RUNTIME", "PRINCIPLE"),
+                        help="Generate an evaluator to fill a coverage gap for the given principle")
+    parser.add_argument("--parallel",
+                        help="Number of parallel workers to use for generation tasks")
+    parser.add_argument("--sequential", action="store_true",
+                        help="Run generation tasks sequentially instead of in parallel")
+    parser.add_argument("--data-version", default=None,
+                        help="Pin the data version used for generation (default: latest)")
     # Knowledge refresh
     parser.add_argument("--refresh-practices", metavar="RUNTIME",
                         help="Refresh practices.json for a plugin runtime from GitHub cursor-rules")

--- a/src/quodeq/dashboard/cli.py
+++ b/src/quodeq/dashboard/cli.py
@@ -13,15 +13,24 @@ from .runner import BuildConfig, DashboardConfig, ServerConfig, run_dashboard
 def build_parser() -> argparse.ArgumentParser:
     """Create the argument parser for the dashboard command."""
     parser = argparse.ArgumentParser(prog="quodeq dashboard")
-    parser.add_argument("--port", type=int, default=get_dashboard_port())
-    parser.add_argument("--evaluations", default="evaluations")
-    parser.add_argument("--static-dist", default="ui/web/dist")
-    parser.add_argument("--repo-root", default=".")
-    parser.add_argument("--api-host", default=None)
-    parser.add_argument("--api-port", type=int, default=None)
-    parser.add_argument("--no-build", action="store_true")
-    parser.add_argument("--reinstall", action="store_true")
-    parser.add_argument("--open", default="true")
+    parser.add_argument("--port", type=int, default=get_dashboard_port(),
+                        help="Port to run the dashboard server on (default: %(default)s)")
+    parser.add_argument("--evaluations", default="evaluations",
+                        help="Directory containing evaluation reports (default: %(default)s)")
+    parser.add_argument("--static-dist", default="ui/web/dist",
+                        help="Path to the pre-built UI static files (default: %(default)s)")
+    parser.add_argument("--repo-root", default=".",
+                        help="Root directory of the repository being evaluated (default: %(default)s)")
+    parser.add_argument("--api-host", default=None,
+                        help="Hostname of an external API server to proxy to (overrides built-in server)")
+    parser.add_argument("--api-port", type=int, default=None,
+                        help="Port of the external API server (used with --api-host)")
+    parser.add_argument("--no-build", action="store_true",
+                        help="Skip rebuilding the UI before starting the server")
+    parser.add_argument("--reinstall", action="store_true",
+                        help="Force reinstallation of UI dependencies before building")
+    parser.add_argument("--open", default="true",
+                        help="Open the dashboard in a browser after starting (default: %(default)s)")
     return parser
 
 

--- a/src/quodeq/shared/logging.py
+++ b/src/quodeq/shared/logging.py
@@ -7,12 +7,17 @@ import os
 import sys
 
 
-BLUE = "\033[0;34m"
-GREEN = "\033[0;32m"
-YELLOW = "\033[1;33m"
-GREY = "\033[0;90m"
-RED = "\033[0;31m"
-NC = "\033[0m"
+_USE_COLOR = (
+    not os.environ.get("NO_COLOR")
+    and os.environ.get("TERM") != "dumb"
+)
+
+BLUE   = "\033[0;34m" if _USE_COLOR else ""
+GREEN  = "\033[0;32m" if _USE_COLOR else ""
+YELLOW = "\033[1;33m" if _USE_COLOR else ""
+GREY   = "\033[0;90m" if _USE_COLOR else ""
+RED    = "\033[0;31m" if _USE_COLOR else ""
+NC     = "\033[0m"    if _USE_COLOR else ""
 
 _LOG_SUCCESS = 25  # between INFO(20) and WARNING(30)
 logging.addLevelName(_LOG_SUCCESS, "SUCCESS")

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -244,6 +244,9 @@ function AccumulatedOverviewPanel({
                   key={item.dimension}
                   className={`qd-card${isStale ? ' qd-card-stale' : ''}`}
                   onClick={() => onDimensionClick(item)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDimensionClick(item); } }}
                 >
                   <div className="qd-card-header">
                     <span className="qd-card-name">{item.dimension}</span>
@@ -480,6 +483,9 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
                   key={item.dimension}
                   className="qd-card"
                   onClick={() => onDimensionClick(item, selectedRunId)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDimensionClick(item, selectedRunId); } }}
                 >
                   <div className="qd-card-header">
                     <span className="qd-card-name">{item.dimension}</span>
@@ -620,7 +626,7 @@ export default function DashboardPage({
   return (
     <div className="dashboard-page">
       {error && <p className="inline-error">{error}</p>}
-      {loading && <p className="loading">Loading dashboard...</p>}
+      {loading && <p className="loading" role="status" aria-live="polite">Loading dashboard...</p>}
 
       {!loading && dashboard && (
         <>

--- a/ui/web/src/features/dashboard/components/PrincipleAccordion.jsx
+++ b/ui/web/src/features/dashboard/components/PrincipleAccordion.jsx
@@ -7,12 +7,15 @@ import { gradeColorClass } from '../../../utils/formatters.js';
 
 export default function PrincipleAccordion({ principle, onViolationClick }) {
   const [open, setOpen] = useState(false);
+  const contentId = `pa-content-${(principle.name || '').replace(/[^a-zA-Z0-9]/g, '-')}`;
 
   return (
     <div className="principle-accordion">
       <button
         className="principle-accordion-header"
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-controls={contentId}
       >
         <span className={`accordion-chevron ${open ? 'open' : ''}`}>›</span>
         <span className="principle-name">{principle.name}</span>
@@ -20,7 +23,7 @@ export default function PrincipleAccordion({ principle, onViolationClick }) {
       </button>
 
       {open && (
-        <div className="principle-accordion-content">
+        <div id={contentId} className="principle-accordion-content">
           {principle.compliance?.length > 0 && (
             <div className="principle-section">
               <h4>Compliance Evidence</h4>
@@ -39,6 +42,9 @@ export default function PrincipleAccordion({ principle, onViolationClick }) {
                     key={i}
                     className={`violation-row${onViolationClick ? ' clickable' : ''}`}
                     onClick={onViolationClick ? () => onViolationClick(v, principle) : undefined}
+                    role={onViolationClick ? 'button' : undefined}
+                    tabIndex={onViolationClick ? 0 : undefined}
+                    onKeyDown={onViolationClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onViolationClick(v, principle); } } : undefined}
                   >
                     <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
                     <span className="violation-row-file">{v.file || '—'}</span>

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -178,7 +178,13 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
                 <div
                   className={`project-card panel${isSelected ? ' project-card--selected' : ''}${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}
                 >
-                  <div className="project-card-main" onClick={() => onSelect?.(id)}>
+                  <div
+                    className="project-card-main"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => onSelect?.(id)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect?.(id); } }}
+                  >
                     <div className="project-card-top">
                       <span className="project-card-name">{p.displayName || name}</span>
                       <GradeChip grade={grade} score={score} />
@@ -245,7 +251,13 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
                           <div
                             className={`project-card project-card--child panel${isChildSelected ? ' project-card--selected' : ''}`}
                           >
-                            <div className="project-card-main" onClick={() => onSelect?.(childId)}>
+                            <div
+                              className="project-card-main"
+                              role="button"
+                              tabIndex={0}
+                              onClick={() => onSelect?.(childId)}
+                              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect?.(childId); } }}
+                            >
                               <div className="project-card-top">
                                 <span className="project-card-name">{child.displayName || childName}</span>
                                 <GradeChip grade={cGrade} score={cScore} />

--- a/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/ui/web/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -26,6 +26,16 @@ function scoreBarColor(score) {
   return cssVar('--color-grade-bottom-text');            // critical
 }
 
+function scoreTierLabel(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return '';
+  if (n >= 9) return 'A';
+  if (n >= 7) return 'B';
+  if (n >= 5) return 'C';
+  if (n >= 3) return 'D';
+  return 'F';
+}
+
 // Mirrors angleFromDelta in TrendArrow — sqrt curve, max arc 55°
 function angleFromDelta(d) {
   const clamped = Math.max(-4, Math.min(4, d));
@@ -74,28 +84,37 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, sele
     };
   });
 
-  // Custom label above each bar: rotated ↑ arrow + delta value
-  const renderTrendLabel = ({ x, y, width, index }) => {
+  // Custom label above each bar: rotated ↑ arrow + delta value; tier letter inside bar
+  const renderTrendLabel = ({ x, y, width, height, index }) => {
     const entry = data[index];
     const d = entry?.delta;
-    if (d === null || d === undefined) return null;
-    const dir = trendDir(d) ?? 'same';
-    const color = trendColor(dir);
-    const angle = Math.round(angleFromDelta(d));
+    const tier = scoreTierLabel(entry?.numericAverage);
     const cx = x + width / 2;
-    const arrowY = y - 14;
-    const deltaStr = d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1);
+    const hasDelta = d !== null && d !== undefined;
+    const dir = hasDelta ? (trendDir(d) ?? 'same') : null;
+    const color = hasDelta ? trendColor(dir) : null;
     return (
       <g>
-        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={color}>
-          {deltaStr}
-        </text>
-        <text
-          x={cx} y={arrowY}
-          textAnchor="middle" dominantBaseline="central"
-          fontSize={11} fill={color}
-          transform={`rotate(${angle}, ${cx}, ${arrowY})`}
-        >↑</text>
+        {hasDelta && (
+          <>
+            <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={color}>
+              {d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1)}
+            </text>
+            <text
+              x={cx} y={y - 14}
+              textAnchor="middle" dominantBaseline="central"
+              fontSize={11} fill={color}
+              transform={`rotate(${Math.round(angleFromDelta(d))}, ${cx}, ${y - 14})`}
+            >↑</text>
+          </>
+        )}
+        {tier && height > 12 && (
+          <text
+            x={cx} y={y + Math.min(height / 2, 9)}
+            textAnchor="middle" dominantBaseline="central"
+            fontSize={9} fill="white" fillOpacity={0.85}
+          >{tier}</text>
+        )}
       </g>
     );
   };

--- a/ui/web/src/features/dashboard/components/TopOffendingFilesTable.jsx
+++ b/ui/web/src/features/dashboard/components/TopOffendingFilesTable.jsx
@@ -17,6 +17,9 @@ const TopOffendingFilesTable = memo(function TopOffendingFilesTable({ files, onF
             key={idx}
             className={`offending-file-row${onFileClick ? ' offending-file-row--clickable' : ''}`}
             onClick={onFileClick ? () => onFileClick(f) : undefined}
+            role={onFileClick ? 'button' : undefined}
+            tabIndex={onFileClick ? 0 : undefined}
+            onKeyDown={onFileClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onFileClick(f); } } : undefined}
             title={f.file}
           >
             <div className="offending-file-info">

--- a/ui/web/src/features/dashboard/hooks/useDashboard.js
+++ b/ui/web/src/features/dashboard/hooks/useDashboard.js
@@ -64,7 +64,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
         if (active) setAccumulated(data);
       })
       .catch((err) => {
-        console.error('useDashboard: accumulated fetch failed', err);
+        if (active) setError(err.message || 'Failed to load accumulated data');
       });
 
     return () => {

--- a/ui/web/src/features/evaluation/components/FolderBrowser.jsx
+++ b/ui/web/src/features/evaluation/components/FolderBrowser.jsx
@@ -6,10 +6,12 @@ export default function FolderBrowser({ onSelect, onClose }) {
   const [pathInput, setPathInput] = useState('');
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [navError, setNavError] = useState(null);
   const [selectedFolder, setSelectedFolder] = useState(null);
 
   async function navigate(path) {
     setLoading(true);
+    setNavError(null);
     try {
       const result = await browseDirectory(path || '');
       setData(result);
@@ -17,7 +19,7 @@ export default function FolderBrowser({ onSelect, onClose }) {
       setPathInput(result.current);
       setSelectedFolder(result.current);
     } catch (err) {
-      console.error('FolderBrowser: navigation error', err);
+      setNavError(err.message || 'Failed to load folder');
     } finally {
       setLoading(false);
     }
@@ -68,10 +70,11 @@ export default function FolderBrowser({ onSelect, onClose }) {
 
         <div className="folder-browser-list">
           {loading ? (
-            <p className="loading">Loading...</p>
+            <p className="loading" role="status" aria-live="polite">Loading...</p>
           ) : (
             <>
-              {data?.directories?.length === 0 && (
+              {navError && <p className="inline-error" role="alert">{navError}</p>}
+              {!navError && data?.directories?.length === 0 && (
                 <p className="empty-folder">No subfolders in this directory</p>
               )}
               {data?.directories?.length > 0 && (
@@ -81,8 +84,15 @@ export default function FolderBrowser({ onSelect, onClose }) {
                 <div
                   key={dir.path}
                   className={`folder-item ${dir.isGitRepo ? 'is-git-repo' : ''} ${selectedFolder === dir.path ? 'selected' : ''}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-pressed={selectedFolder === dir.path}
                   onClick={() => setSelectedFolder(dir.path)}
                   onDoubleClick={() => navigate(dir.path)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') navigate(dir.path);
+                    if (e.key === ' ') { e.preventDefault(); setSelectedFolder(dir.path); }
+                  }}
                 >
                   <span className="folder-icon">{dir.isGitRepo ? '📦' : '📁'}</span>
                   <span className="folder-name">{dir.name}</span>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -76,7 +76,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
     return map;
   }, [evalData]);
 
-  if (loading) return <div className="loading">Loading…</div>;
+  if (loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
   if (error) return <div className="inline-error">{error}</div>;
   if (!evalData) return <div className="empty-state"><h2>No data found</h2></div>;
 
@@ -169,6 +169,9 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
                 key={pg.principle}
                 className="exec-summary-row exec-summary-row--clickable"
                 onClick={() => onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) })}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) }); } }}
               >
                 <span className="exec-summary-principle">{pg.principle}</span>
                 {pg.score && (


### PR DESCRIPTION
## Summary

- **Accessibility (keyboard & screen reader):** 7 components updated — all interactive non-button elements (`div`, `li`, `article`) now have `role="button"`, `tabIndex={0}`, and `onKeyDown` (Enter/Space) handlers; accordion button gets `aria-expanded`/`aria-controls`; loading indicators get `role="status"` and `aria-live="polite"`
- **Error handling:** `FolderBrowser` surfaces navigation errors in the UI with `role="alert"` instead of console-only; `useDashboard` surfaces accumulated fetch failures via `setError`
- **CLI help strings:** `config/cli.py` (12 flags) and `dashboard/cli.py` (9 flags) now have `help=` strings so `--help` output is informative
- **API consistency:** `delete_project` 404 now uses the `_error()` helper, matching all other error responses
- **UI aesthetics:** `shared/logging.py` respects `NO_COLOR` and `TERM=dumb`; `RunHistoryPanel` renders A–F grade letters inside chart bars as a non-color quality indicator

## Test plan

- [x] All 292 Python tests pass (`pytest tests/`)
- [x] All 40 UI utility tests pass (`node --test src/utils/explorerUtils.test.js`)
- [x] Keyboard navigation: Tab to dimension cards, principle rows, file rows, project cards — Enter/Space activates each
- [x] Screen reader: accordion button announces expanded/collapsed state; loading indicators announced on change
- [x] `NO_COLOR=1 quodeq dashboard` emits no ANSI escape sequences
- [x] `quodeq configure --help` and `quodeq dashboard --help` show descriptions for all flags
- [x] FolderBrowser: navigating to an invalid path shows inline error message (not just console)
- [x] Chart bars display A–F grade letter inside each bar