### PR TITLE
fix(runs): parse timezone-aware ISO dates in _normalize_date

### DIFF
--- a/src/quodeq/adapters/fs/report_parser/runs.py
+++ b/src/quodeq/adapters/fs/report_parser/runs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -39,9 +39,11 @@ def _normalize_date(raw: str) -> tuple[str, str] | None:
     or compact date (20260301).  The first element is the full string
     (including time when available) so that same-day runs sort correctly.
     """
-    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d", "%Y%m%d"):
+    for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d", "%Y%m%d"):
         try:
             parsed = datetime.strptime(raw, fmt)
+            if parsed.tzinfo is not None:
+                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
             sortable = parsed.isoformat(timespec='seconds') if "T" in fmt else parsed.date().isoformat()
             label = f"{parsed.year}-{parsed.month:02d}-{parsed.day:02d}"
             return sortable, label


### PR DESCRIPTION
## Summary

- `runner.py` was changed to use `datetime.now(timezone.utc)` which produces dates like `2026-03-10T20:54:44+00:00`
- `_normalize_date` only tried `"%Y-%m-%dT%H:%M:%S"` which fails on the `+00:00` suffix, so those runs got `date_iso=None` and fell behind all older runs in the sort order — making recent runs unreachable in the UI
- Adds `"%Y-%m-%dT%H:%M:%S%z"` as the first format and normalizes to UTC-naive datetime so the sortable key is consistent with legacy timezone-naive dates

## Test plan

- [x] 292 tests pass (`pytest tests/ -q --ignore=tests/test_action_api_health.py`)
- [x] Recent runs with `+00:00` dates now appear correctly sorted in the run picker