### PR TITLE
Refine analysis rubric: deduction-only scoring model

### DIFF
--- a/src/quodeq/engine/report.py
+++ b/src/quodeq/engine/report.py
@@ -60,12 +60,17 @@ def _build_principle_rows(
     for raw_key, pdata in evidence.get("principles", {}).items():
         label = pdata.get("display_name", raw_key)
         matched = lookup.get(label, {})
+        grade = matched.get("grade")
         raw_final = matched.get("final_score")
-        formatted_score = f"{round(raw_final, 1)}/10" if raw_final is not None else None
+        # Insufficient principles have no meaningful score — suppress "0.0/10".
+        if grade == "Insufficient":
+            formatted_score = None
+        else:
+            formatted_score = f"{round(raw_final, 1)}/10" if raw_final is not None else None
         row: dict = {
             "name": label,
             "score": formatted_score,
-            "grade": matched.get("grade") or grade_from_score(formatted_score),
+            "grade": grade or grade_from_score(formatted_score),
         }
         if matched.get("confidence_interval") is not None:
             row["confidence_interval"] = matched["confidence_interval"]

--- a/src/quodeq/engine/scoring.py
+++ b/src/quodeq/engine/scoring.py
@@ -8,13 +8,14 @@ from quodeq.engine.scoring_internals import (
     SCALE_TIER_NAMES,
     scale_multiplier,
     build_deductions,
+    compliance_dampening,
     confidence_interval_for,
     count_grade_drops,
     drop_grade,
     evidence_has_taxonomy,
-    grade_for_compliance,
-    score_for_compliance,
     score_to_grade_label,
+    tally_compliance_types_by_reason,
+    tally_compliance_types_by_taxonomy,
     tally_types_by_reason,
     tally_types_by_taxonomy,
     weight_as_multiplier,
@@ -29,11 +30,9 @@ __all__ = [
     "count_grade_drops",
     "drop_grade",
     "evidence_has_taxonomy",
-    "grade_for_compliance",
     "grade_for_score",
     "run_scoring",
     "score_evidence",
-    "score_for_compliance",
     "score_to_grade_label",
     "tally_types_by_reason",
     "tally_types_by_taxonomy",
@@ -62,6 +61,7 @@ class _PrincipleContext:
     pdata: dict
     pct: float
     vt_counts: dict[str, int]
+    dampening: float
     using_taxonomy: bool
     conf_level: str
     ci: dict
@@ -70,11 +70,27 @@ class _PrincipleContext:
 
 def _score_principle_numerical(ctx: _PrincipleContext) -> dict:
     """Score a single principle in numerical mode."""
-    base_pts = score_for_compliance(ctx.pct)
+    if ctx.conf_level == "low":
+        return {
+            "display_name": ctx.pdata.get("display_name", ctx.key),
+            "weight": ctx.pdata.get("weight", DEFAULT_WEIGHT),
+            "compliance_percentage": ctx.pct,
+            "base_score": 0,
+            "deductions": build_deductions({}, scale_multiplier=ctx.scale_mult),
+            "final_score": 0.0,
+            "grade": "Insufficient",
+            "taxonomy_used": ctx.using_taxonomy,
+            "confidence_level": ctx.conf_level,
+            "confidence_interval": ctx.ci["confidence_interval"],
+            "grade_stability": ctx.ci["grade_stability"],
+        }
+
+    base_pts = 10
     deductions = build_deductions(ctx.vt_counts, scale_multiplier=ctx.scale_mult)
 
+    dampened_deduction = round(deductions["total_deduction"] * ctx.dampening, 2)
     effective_cap = min(deductions["critical_cap"], deductions["major_cap"])
-    adjusted = min(effective_cap, round(base_pts - deductions["total_deduction"], 1))
+    adjusted = min(effective_cap, round(base_pts - dampened_deduction, 1))
     final_pts = max(0.0, min(10.0, adjusted))
 
     return {
@@ -83,6 +99,7 @@ def _score_principle_numerical(ctx: _PrincipleContext) -> dict:
         "compliance_percentage": ctx.pct,
         "base_score": base_pts,
         "deductions": deductions,
+        "dampening_multiplier": ctx.dampening,
         "final_score": final_pts,
         "grade": score_to_grade_label(final_pts),
         "taxonomy_used": ctx.using_taxonomy,
@@ -94,9 +111,26 @@ def _score_principle_numerical(ctx: _PrincipleContext) -> dict:
 
 def _score_principle_graded(ctx: _PrincipleContext) -> dict:
     """Score a single principle in non-numerical (graded) mode."""
-    base_label = grade_for_compliance(ctx.pct)
+    if ctx.conf_level == "low":
+        return {
+            "display_name": ctx.pdata.get("display_name", ctx.key),
+            "weight": ctx.pdata.get("weight", DEFAULT_WEIGHT),
+            "compliance_percentage": ctx.pct,
+            "base_grade": "Insufficient",
+            "severity_drops": 0,
+            "grade": "Insufficient",
+            "taxonomy_used": ctx.using_taxonomy,
+            "confidence_level": ctx.conf_level,
+            "confidence_interval": ctx.ci["confidence_interval"],
+            "grade_stability": ctx.ci["grade_stability"],
+        }
+
+    base_label = "Exemplary"
     level_drops = count_grade_drops(ctx.vt_counts, scale_multiplier=ctx.scale_mult)
-    final_label = drop_grade(base_label, level_drops)
+    # Dampening can reduce drops: multiply then round down so partial drops
+    # don't push the grade lower than the compliance evidence warrants.
+    dampened_drops = int(level_drops * ctx.dampening)
+    final_label = drop_grade(base_label, dampened_drops)
 
     return {
         "display_name": ctx.pdata.get("display_name", ctx.key),
@@ -104,6 +138,7 @@ def _score_principle_graded(ctx: _PrincipleContext) -> dict:
         "compliance_percentage": ctx.pct,
         "base_grade": base_label,
         "severity_drops": level_drops,
+        "dampening_multiplier": ctx.dampening,
         "grade": final_label,
         "taxonomy_used": ctx.using_taxonomy,
         "confidence_level": ctx.conf_level,
@@ -125,6 +160,7 @@ def _score_all_principles(
         metrics = pdata.get("metrics", {})
         pct = metrics.get("compliance_percentage", 0.0)
         violations = pdata.get("violations", [])
+        compliance = pdata.get("compliance", [])
         conf_level = metrics.get("confidence_level", "medium")
 
         using_taxonomy = evidence_has_taxonomy(violations)
@@ -133,6 +169,12 @@ def _score_all_principles(
             if using_taxonomy
             else tally_types_by_reason(violations)
         )
+        ct_counts = (
+            tally_compliance_types_by_taxonomy(compliance)
+            if using_taxonomy
+            else tally_compliance_types_by_reason(compliance)
+        )
+        dampen = compliance_dampening(ct_counts, vt_counts)
         ci = confidence_interval_for(
             confidence_level=conf_level,
             is_balanced=metrics.get("is_balanced", True),
@@ -141,8 +183,8 @@ def _score_all_principles(
         )
         ctx = _PrincipleContext(
             key=key, pdata=pdata, pct=pct, vt_counts=vt_counts,
-            using_taxonomy=using_taxonomy, conf_level=conf_level,
-            ci=ci, scale_mult=scale_mult,
+            dampening=dampen, using_taxonomy=using_taxonomy,
+            conf_level=conf_level, ci=ci, scale_mult=scale_mult,
         )
         if mode == "numerical":
             per_principle[key] = _score_principle_numerical(ctx)
@@ -194,11 +236,21 @@ def _weighted_overall(principles_scores: dict, mode: str) -> dict:
     numerical mode the weighted mean of final_score values is returned. In
     non-numerical mode grades are converted to ladder indices, the weighted
     mean is computed, and the result is rounded back to the nearest grade.
+
+    When more than half of the principles are Insufficient, the overall is
+    flagged as low confidence since it only reflects a minority of principles.
     """
+    total_count = len(principles_scores)
+    insufficient_count = sum(
+        1 for p in principles_scores.values() if p.get("grade") == "Insufficient"
+    )
+
     total_weight = 0
     total_value = 0.0
 
     for pdata in principles_scores.values():
+        if pdata.get("grade") == "Insufficient":
+            continue
         multiplier = weight_as_multiplier(pdata.get("weight", DEFAULT_WEIGHT))
         total_weight += multiplier
 
@@ -208,14 +260,18 @@ def _weighted_overall(principles_scores: dict, mode: str) -> dict:
             grade_index = GRADE_LADDER.index(pdata["grade"])
             total_value += grade_index * multiplier
 
+    low_confidence = (
+        total_count > 0 and insufficient_count > total_count / 2
+    )
+
     if total_weight == 0:
         if mode == "numerical":
-            return {"weighted_score": 0.0, "grade": "Critical"}
+            return {"weighted_score": 0.0, "grade": "Insufficient"}
         return {"weighted_grade": "Insufficient"}
 
     if mode == "numerical":
         mean_score = round(total_value / total_weight, 1)
-        return {
+        result = {
             "weighted_score": mean_score,
             "grade": score_to_grade_label(mean_score),
             "total_weight": total_weight,
@@ -223,10 +279,19 @@ def _weighted_overall(principles_scores: dict, mode: str) -> dict:
     else:
         mean_index = total_value / total_weight
         ladder_pos = min(len(GRADE_LADDER) - 1, round(mean_index))
-        return {
+        result = {
             "weighted_grade": GRADE_LADDER[ladder_pos],
             "total_weight": total_weight,
         }
+
+    if low_confidence:
+        scored_count = total_count - insufficient_count
+        result["confidence"] = "low"
+        result["confidence_reason"] = (
+            f"Only {scored_count}/{total_count} principles had sufficient evidence"
+        )
+
+    return result
 
 
 def score_evidence(evidence: Evidence, mode: str = "numerical") -> dict:

--- a/src/quodeq/engine/scoring_internals.py
+++ b/src/quodeq/engine/scoring_internals.py
@@ -5,31 +5,6 @@ from __future__ import annotations
 # Constants and lookup tables
 # ---------------------------------------------------------------------------
 
-# Each entry is (minimum_compliance_pct_exclusive, score).
-# Walk the list top-to-bottom; the first threshold the compliance % exceeds
-# wins. Last row acts as a catch-all for the 0 % case.
-_SCORE_BANDS: list[tuple[float, int]] = [
-    (70.0, 10),
-    (55.0, 9),
-    (45.0, 8),
-    (38.0, 7),
-    (30.0, 6),
-    (25.0, 5),
-    (18.0, 4),
-    (12.0, 3),
-    (5.0, 2),
-    (1.0, 1),
-    (0.0, 0),
-]
-
-# Same idea for non-numerical grades. Compliance must be *strictly above*
-# the threshold to earn that grade.
-_GRADE_BANDS: list[tuple[float, str]] = [
-    (72.0, "Exemplary"),
-    (48.0, "Proficient"),
-    (20.0, "Developing"),
-]
-
 # Canonical ordering from worst to best — used to convert grades to integers
 # for arithmetic and to clamp drop operations.
 GRADE_LADDER: list[str] = [
@@ -45,9 +20,23 @@ _CRITICAL_DROP_TABLE: list[tuple[int, int]] = [(12, 3), (4, 2), (1, 1)]
 _MAJOR_DROP_TABLE: list[tuple[int, int]] = [(36, 3), (12, 2), (4, 1)]
 
 # Per-type deduction constants for numerical mode.
-_CRITICAL_PENALTY = 1.0   # per distinct critical violation type, cap 3 types
-_MAJOR_PENALTY = 0.5      # per distinct major violation type, cap 5 types
-_MINOR_PENALTY = 0.1      # per distinct minor violation type
+_CRITICAL_PENALTY = 2.0   # per distinct critical violation type, cap 3 types
+_MAJOR_PENALTY = 1.0      # per distinct major violation type, cap 5 types
+_MINOR_PENALTY = 0.25     # per distinct minor violation type
+
+# Ratio-based dampening table: (min_compliance_to_violation_ratio, multiplier).
+# Checked top-to-bottom; first matching row wins.
+# Asymmetric: max discount 15%, max penalty 30%.
+# Uses raw distinct type counts (no severity weighting) to avoid bias from
+# compliance findings that lack proper severity fields.
+_RATIO_DAMPENING_TABLE: list[tuple[float, float]] = [
+    (3.0, 0.85),   # strong compliance evidence
+    (2.0, 0.90),   # good compliance
+    (1.0, 0.95),   # balanced
+    (0.5, 1.00),   # neutral
+    (0.0, 1.15),   # weak compliance (ratio > 0 but < 0.5)
+    (-1.0, 1.30),  # no compliance at all (sentinel, always matches)
+]
 
 # ---------------------------------------------------------------------------
 # Project-size scaling
@@ -80,26 +69,6 @@ def scale_multiplier(source_file_count: int) -> int:
         if source_file_count >= threshold:
             return multiplier
     return 1
-
-
-# ---------------------------------------------------------------------------
-# Band lookups
-# ---------------------------------------------------------------------------
-
-def score_for_compliance(compliance_pct: float) -> int:
-    """Map a compliance percentage to a 0–10 base score via threshold bands."""
-    for min_pct, pts in _SCORE_BANDS:
-        if compliance_pct > min_pct:
-            return pts
-    return 0
-
-
-def grade_for_compliance(compliance_pct: float) -> str:
-    """Map a compliance percentage to a grade word via threshold bands."""
-    for min_pct, label in _GRADE_BANDS:
-        if compliance_pct > min_pct:
-            return label
-    return "Insufficient"
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +119,60 @@ def evidence_has_taxonomy(violations: list[dict]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Compliance counting & dampening
+# ---------------------------------------------------------------------------
+
+def tally_compliance_types_by_taxonomy(compliance: list[dict]) -> dict[str, int]:
+    """Count distinct compliance types per severity using the 'vt' field."""
+    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
+    for item in compliance:
+        vt_tag = item.get("vt")
+        if not vt_tag:
+            continue
+        sev = item.get("severity", "minor")
+        buckets.setdefault(sev, set()).add(vt_tag)
+    return {sev: len(seen) for sev, seen in buckets.items()}
+
+
+def tally_compliance_types_by_reason(compliance: list[dict]) -> dict[str, int]:
+    """Count distinct compliance types per severity using (severity, reason) pairs."""
+    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
+    for item in compliance:
+        sev = item.get("severity", "minor")
+        reason = item.get("reason", "unknown")
+        buckets.setdefault(sev, set()).add(reason)
+    return {sev: len(seen) for sev, seen in buckets.items()}
+
+
+def compliance_dampening(
+    compliance_type_counts: dict[str, int],
+    violation_type_counts: dict[str, int],
+) -> float:
+    """Compute the dampening multiplier from the compliance-to-violation ratio.
+
+    Uses raw distinct type counts (sum across all severities, no weighting)
+    to avoid bias from compliance findings that lack severity fields.
+
+    Asymmetric: max discount 15% (0.85×), max penalty 30% (1.30×).
+    No compliance at all gets the full 1.30× penalty.
+    """
+    total_compliance = sum(compliance_type_counts.values())
+    total_violations = sum(violation_type_counts.values())
+
+    if total_violations == 0:
+        return 1.0  # no violations → dampening is irrelevant
+
+    if total_compliance == 0:
+        return 1.30  # no compliance at all → max penalty
+
+    ratio = total_compliance / total_violations
+    for threshold, multiplier in _RATIO_DAMPENING_TABLE:
+        if ratio >= threshold:
+            return multiplier
+    return 1.30
+
+
+# ---------------------------------------------------------------------------
 # Deduction / drop computation
 # ---------------------------------------------------------------------------
 
@@ -157,10 +180,10 @@ def build_deductions(violation_type_counts: dict[str, int], scale_multiplier: in
     """Compute point deductions for numerical mode.
 
     Rules:
-    - Each distinct critical violation type removes 1.0 point; types are capped
+    - Each distinct critical violation type removes 2.0 points; types are capped
       at 3*scale before computing the deduction.
-    - Each distinct major violation type removes 0.5 points; capped at 5*scale.
-    - Each distinct minor violation type removes 0.1 points; capped at 2*scale.
+    - Each distinct major violation type removes 1.0 point; capped at 5*scale.
+    - Minor violation types are NOT capped — every distinct type deducts 0.25.
     - If the raw critical count reaches 3*scale, the score is hard-capped at 3.
     - If the raw major count reaches 5*scale, the score is hard-capped at 5.
     - Both caps may apply simultaneously (take min).
@@ -171,15 +194,13 @@ def build_deductions(violation_type_counts: dict[str, int], scale_multiplier: in
 
     critical_type_cap = 3 * scale_multiplier
     major_type_cap = 5 * scale_multiplier
-    minor_type_cap = 2 * scale_multiplier
 
     effective_critical = min(n_critical, critical_type_cap)
     effective_major = min(n_major, major_type_cap)
-    effective_minor = min(n_minor, minor_type_cap)
 
     critical_deduction = effective_critical * _CRITICAL_PENALTY
     major_deduction = effective_major * _MAJOR_PENALTY
-    minor_deduction = effective_minor * _MINOR_PENALTY
+    minor_deduction = n_minor * _MINOR_PENALTY
 
     cap_from_critical = 3 if n_critical >= critical_type_cap else 10
     cap_from_major = 5 if n_major >= major_type_cap else 10

--- a/tests/engine/test_report.py
+++ b/tests/engine/test_report.py
@@ -25,7 +25,7 @@ def _make_evidence() -> Evidence:
             "compliant": 1,
             "violating": 1,
             "compliance_percentage": 50.0,
-            "confidence_level": "low",
+            "confidence_level": "medium",
             "is_balanced": True,
         },
     )

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -22,7 +22,7 @@ def _make_evidence(violations=None, compliance=None) -> Evidence:
             "compliant": 2,
             "violating": 1,
             "compliance_percentage": 66.7,
-            "confidence_level": "low",
+            "confidence_level": "medium",
             "is_balanced": True,
         },
     )
@@ -81,3 +81,305 @@ def test_scoring_structure():
     assert "scale" in scores
     assert "tier" in scores["scale"]
     assert "multiplier" in scores["scale"]
+
+
+# ---------------------------------------------------------------------------
+# Deduction-only scoring model tests
+# ---------------------------------------------------------------------------
+
+def _make_evidence_with_confidence(
+    confidence_level="high",
+    violations=None,
+    compliance=None,
+    n_violations=1,
+    n_compliance=2,
+):
+    """Build Evidence with explicit confidence level and finding counts."""
+    viol = violations or [
+        {"file": f"v{i}.ts", "line": i, "snippet": "eval(x)", "reason": "injection", "severity": "high", "vt": "code-injection"}
+        for i in range(n_violations)
+    ]
+    comp = compliance or [
+        {"file": f"c{i}.ts", "line": i, "snippet": "JSON.parse(x)", "reason": "safe"}
+        for i in range(n_compliance)
+    ]
+    total = len(viol) + len(comp)
+    pct = round(len(comp) / total * 100, 1) if total > 0 else 0.0
+    pe = PrincipleEvidence(
+        practice_id="ts-001",
+        display_name="Avoid eval()",
+        dimension="security",
+        severity="high",
+        violations=viol,
+        compliance=comp,
+        metrics={
+            "total_instances": total,
+            "compliant": len(comp),
+            "violating": len(viol),
+            "compliance_percentage": pct,
+            "confidence_level": confidence_level,
+            "is_balanced": len(viol) > 0 and len(comp) > 0,
+        },
+    )
+    return Evidence(
+        repository="test-repo",
+        plugin_id="typescript",
+        date="2026-03-03",
+        source_file_count=100,
+        files_read=50,
+        coverage_pct=50.0,
+        principles={"ts-001": pe},
+    )
+
+
+def test_numerical_low_confidence_returns_insufficient():
+    ev = _make_evidence_with_confidence(confidence_level="low")
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["grade"] == "Insufficient"
+    assert ts001["final_score"] == 0.0
+
+
+def test_graded_low_confidence_returns_insufficient():
+    ev = _make_evidence_with_confidence(confidence_level="low")
+    scores = score_evidence(ev, mode="non-numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["grade"] == "Insufficient"
+
+
+def test_numerical_high_confidence_no_violations():
+    ev = _make_evidence_with_confidence(
+        confidence_level="high", violations=[], n_violations=0, n_compliance=10,
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["base_score"] == 10
+    assert ts001["final_score"] == 10.0
+    assert ts001["grade"] == "Exemplary"
+
+
+def test_numerical_high_confidence_with_violations():
+    ev = _make_evidence_with_confidence(
+        confidence_level="high", n_violations=2, n_compliance=8,
+        violations=[
+            {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "r", "severity": "critical", "vt": "code-injection"},
+            {"file": "b.ts", "line": 2, "snippet": "eval(y)", "reason": "r", "severity": "major", "vt": "unsafe-call"},
+        ],
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["base_score"] == 10
+    # 1 critical type (-2.0) + 1 major type (-1.0) = 3.0 raw deduction
+    # compliance has no vt → 0 types via taxonomy → 1.30× penalty
+    # 3.0 × 1.30 = 3.90 → 10 - 3.9 = 6.1
+    assert ts001["dampening_multiplier"] == 1.30
+    assert ts001["final_score"] == 6.1
+
+
+def test_graded_high_confidence_no_violations():
+    ev = _make_evidence_with_confidence(
+        confidence_level="high", violations=[], n_violations=0, n_compliance=10,
+    )
+    scores = score_evidence(ev, mode="non-numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["base_grade"] == "Exemplary"
+    assert ts001["grade"] == "Exemplary"
+
+
+def test_weighted_overall_excludes_insufficient():
+    """A mix of Insufficient and scored principles: overall uses only scored ones."""
+    pe_low = PrincipleEvidence(
+        practice_id="p-low", display_name="Low Conf", dimension="security",
+        severity="high", violations=[], compliance=[],
+        metrics={"total_instances": 1, "compliant": 1, "violating": 0,
+                 "compliance_percentage": 100.0, "confidence_level": "low", "is_balanced": False},
+    )
+    pe_high = PrincipleEvidence(
+        practice_id="p-high", display_name="High Conf", dimension="security",
+        severity="high",
+        violations=[{"file": "a.ts", "line": 1, "snippet": "x", "reason": "r", "severity": "critical", "vt": "vt1"}],
+        compliance=[{"file": "b.ts", "line": 2, "snippet": "y", "reason": "r"}] * 9,
+        metrics={"total_instances": 10, "compliant": 9, "violating": 1,
+                 "compliance_percentage": 90.0, "confidence_level": "high", "is_balanced": True},
+    )
+    ev = Evidence(
+        repository="test", plugin_id="ts", date="2026-03-03",
+        source_file_count=100, files_read=50, coverage_pct=50.0,
+        principles={"p-low": pe_low, "p-high": pe_high},
+    )
+    scores = score_evidence(ev, mode="numerical")
+    assert scores["principles"]["p-low"]["grade"] == "Insufficient"
+    # Overall should reflect only p-high, not be dragged down by p-low
+    assert scores["overall"]["weighted_score"] == scores["principles"]["p-high"]["final_score"]
+
+
+def test_all_insufficient_overall():
+    ev = _make_evidence_with_confidence(confidence_level="low")
+    scores = score_evidence(ev, mode="numerical")
+    assert scores["overall"]["grade"] == "Insufficient"
+    assert scores["overall"]["weighted_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Compliance dampening tests
+# ---------------------------------------------------------------------------
+
+def test_balanced_ratio_dampens_deductions():
+    """Compliance/violation ratio ≥ 1.0 → 0.95 dampening."""
+    # 1 critical violation type (1 total type)
+    violations = [
+        {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "r",
+         "severity": "critical", "vt": "code-injection"},
+    ]
+    # 2 compliance types → ratio 2/1 = 2.0 → 0.90 dampening
+    compliance = [
+        {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
+         "severity": "minor", "vt": f"comp-type-{i}"}
+        for i in range(2)
+    ]
+    ev = _make_evidence_with_confidence(
+        confidence_level="high",
+        violations=violations,
+        compliance=compliance,
+        n_violations=1,
+        n_compliance=2,
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    # ratio = 2 compliance types / 1 violation type = 2.0 → 0.90
+    # raw deduction = 2.0, dampened = 2.0 × 0.90 = 1.80 → 10 - 1.8 = 8.2
+    assert ts001["dampening_multiplier"] == 0.90
+    assert ts001["final_score"] == 8.2
+
+
+def test_strong_compliance_ratio_gives_max_discount():
+    """Compliance/violation ratio ≥ 3.0 → 0.85 dampening (max discount)."""
+    violations = [
+        {"file": "a.ts", "line": 1, "snippet": "x", "reason": "r",
+         "severity": "major", "vt": "bad-pattern"},
+    ]
+    # 4 compliance types vs 1 violation type → ratio 4.0 → 0.85
+    compliance = [
+        {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
+         "severity": "minor", "vt": f"safe-{i}"}
+        for i in range(4)
+    ]
+    ev = _make_evidence_with_confidence(
+        confidence_level="high",
+        violations=violations,
+        compliance=compliance,
+        n_violations=1,
+        n_compliance=4,
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    # raw major deduction = 1.0, dampened = 1.0 × 0.85 = 0.85 → 10 - 0.85 = 9.2
+    assert ts001["dampening_multiplier"] == 0.85
+    assert ts001["final_score"] == 9.2
+
+
+def test_no_compliance_penalises_deductions():
+    """No compliance at all → 1.30× penalty on deductions."""
+    violations = [
+        {"file": "a.ts", "line": 1, "snippet": "x", "reason": "r",
+         "severity": "major", "vt": "bad"},
+    ]
+    ev = _make_evidence_with_confidence(
+        confidence_level="high",
+        violations=violations,
+        compliance=[],
+        n_violations=1,
+        n_compliance=0,
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["dampening_multiplier"] == 1.30
+    # raw major deduction = 1.0, dampened = 1.0 × 1.30 = 1.30 → 10 - 1.3 = 8.7
+    assert ts001["final_score"] == 8.7
+
+
+def test_weak_compliance_ratio_penalises():
+    """Compliance/violation ratio < 0.5 but > 0 → 1.15× penalty."""
+    # 4 violation types, 1 compliance type → ratio 0.25 → 1.15
+    violations = [
+        {"file": f"v{i}.ts", "line": i, "snippet": "x", "reason": f"r{i}",
+         "severity": "minor", "vt": f"vt-{i}"}
+        for i in range(4)
+    ]
+    compliance = [
+        {"file": "c.ts", "line": 1, "snippet": "ok", "reason": "r",
+         "severity": "minor", "vt": "comp-1"},
+    ]
+    ev = _make_evidence_with_confidence(
+        confidence_level="high",
+        violations=violations,
+        compliance=compliance,
+        n_violations=4,
+        n_compliance=1,
+    )
+    scores = score_evidence(ev, mode="numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["dampening_multiplier"] == 1.15
+    # raw deduction = 4 × 0.25 = 1.0, dampened = 1.0 × 1.15 = 1.15 → 10 - 1.15 = 8.8
+    assert ts001["final_score"] == 8.8
+
+
+def test_dampening_in_graded_mode():
+    """Dampening should reduce grade drops in non-numerical mode too."""
+    # 4 critical violation types → normally 2 drops
+    violations = [
+        {"file": f"v{i}.ts", "line": i, "snippet": "x", "reason": f"r{i}",
+         "severity": "critical", "vt": f"vt-{i}"}
+        for i in range(4)
+    ]
+    # 6 compliance types → ratio 6/4 = 1.5 → 0.95 dampening
+    # 2 drops × 0.95 = 1.9 → int(1.9) = 1 drop → Proficient
+    compliance = [
+        {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
+         "severity": "minor", "vt": f"comp-{i}"}
+        for i in range(6)
+    ]
+    ev = _make_evidence_with_confidence(
+        confidence_level="high",
+        violations=violations,
+        compliance=compliance,
+        n_violations=4,
+        n_compliance=6,
+    )
+    scores = score_evidence(ev, mode="non-numerical")
+    ts001 = scores["principles"]["ts-001"]
+    assert ts001["dampening_multiplier"] == 0.95
+    assert ts001["severity_drops"] == 2  # raw drops before dampening
+    assert ts001["grade"] == "Proficient"
+
+
+def test_overall_low_confidence_when_most_insufficient():
+    """Overall should be flagged low confidence when >50% principles are Insufficient."""
+    pe_low1 = PrincipleEvidence(
+        practice_id="p1", display_name="P1", dimension="security",
+        severity="high", violations=[], compliance=[],
+        metrics={"total_instances": 1, "compliant": 1, "violating": 0,
+                 "compliance_percentage": 100.0, "confidence_level": "low", "is_balanced": False},
+    )
+    pe_low2 = PrincipleEvidence(
+        practice_id="p2", display_name="P2", dimension="security",
+        severity="high", violations=[], compliance=[],
+        metrics={"total_instances": 1, "compliant": 1, "violating": 0,
+                 "compliance_percentage": 100.0, "confidence_level": "low", "is_balanced": False},
+    )
+    pe_high = PrincipleEvidence(
+        practice_id="p3", display_name="P3", dimension="security",
+        severity="high", violations=[], compliance=[
+            {"file": "a.ts", "line": 1, "snippet": "ok", "reason": "safe"},
+        ],
+        metrics={"total_instances": 10, "compliant": 10, "violating": 0,
+                 "compliance_percentage": 100.0, "confidence_level": "high", "is_balanced": False},
+    )
+    ev = Evidence(
+        repository="test", plugin_id="ts", date="2026-03-03",
+        source_file_count=100, files_read=50, coverage_pct=50.0,
+        principles={"p1": pe_low1, "p2": pe_low2, "p3": pe_high},
+    )
+    scores = score_evidence(ev, mode="numerical")
+    assert scores["overall"]["confidence"] == "low"
+    assert "1/3" in scores["overall"]["confidence_reason"]

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -173,13 +173,19 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
         <h3 className="file-detail-title">{principle}</h3>
         <div className="file-detail-stats-row">
           <div className="file-detail-stats">
-            {score && (
+            {grade === 'Insufficient' ? (
+              <span className="exec-summary-insufficient">Not enough evidence</span>
+            ) : (
               <>
-                <span className="file-detail-stat"><strong>{score}</strong></span>
-                <span className="file-detail-stat-sep">·</span>
+                {score && (
+                  <>
+                    <span className="file-detail-stat"><strong>{score}</strong></span>
+                    <span className="file-detail-stat-sep">·</span>
+                  </>
+                )}
+                <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
               </>
             )}
-            <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
             {violations.length > 0 && (
               <>
                 <span className="file-detail-stat-sep">·</span>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -174,12 +174,18 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onNavigate && onNavigate('evalprinciple', { evalPrincipal: buildEvalPrincipal(pg.principle) }); } }}
               >
                 <span className="exec-summary-principle">{pg.principle}</span>
-                {pg.score && (
-                  <span className="exec-summary-score">
-                    {pg.score.replace('/10', '')}<span className="exec-summary-score-denom">/10</span>
-                  </span>
+                {pg.grade === 'Insufficient' ? (
+                  <span className="exec-summary-insufficient">Not enough evidence</span>
+                ) : (
+                  <>
+                    {pg.score && (
+                      <span className="exec-summary-score">
+                        {pg.score.replace('/10', '')}<span className="exec-summary-score-denom">/10</span>
+                      </span>
+                    )}
+                    <span className={`chip small ${gradeColorClass(pg.grade)}`}>{pg.grade || '—'}</span>
+                  </>
                 )}
-                <span className={`chip small ${gradeColorClass(pg.grade)}`}>{pg.grade || '—'}</span>
                 <span className="exec-summary-chevron">›</span>
               </li>
             ))}

--- a/ui/web/src/styles/explorer.css
+++ b/ui/web/src/styles/explorer.css
@@ -544,6 +544,13 @@
   color: var(--color-text-subtle);
 }
 
+.exec-summary-insufficient {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-left: auto;
+}
+
 .exec-summary-chevron {
   color: var(--color-text-subtle);
   font-size: 1rem;


### PR DESCRIPTION
## Summary

- Replace ratio-based scoring with deduction-only model (base=10, violations deduct)
- Steeper penalties: critical=2.0, major=1.0, minor=0.25 per distinct violation type
- Ratio-based compliance dampening: compliance/violation type ratio drives multiplier (0.85×–1.30×), asymmetric (max discount 15%, max penalty 30%)
- Low confidence principles gated as "Insufficient" and excluded from overall
- Overall flagged low confidence when >50% principles lack sufficient evidence
- Suppress "0.0/10" for Insufficient principles in reports and UI
- UI shows "Not enough evidence" instead of score/grade for Insufficient principles

## Test plan

- [x] 305 tests pass (17 scoring tests including 6 new dampening/confidence tests)
- [x] Verify Insufficient principles show "Not enough evidence" in dashboard
- [x] Verify scored principles show score/grade as before
- [x] Run a fresh evaluation and confirm scores reflect the new model