### PR TITLE
fix(refs): only show ref badges that have a URL

### DIFF
--- a/src/quodeq/engine/evidence_parser.py
+++ b/src/quodeq/engine/evidence_parser.py
@@ -58,7 +58,12 @@ class EvidenceContext:
 
 
 def _resolve_llm_refs(llm_refs: list[str] | None, all_req_refs: list[dict] | None) -> list[dict] | None:
-    """Filter req_refs to only those the LLM selected, building URLs for unknown labels."""
+    """Filter req_refs to only those the LLM selected, building URLs for unknown labels.
+
+    Only refs that carry a ``url`` are kept.  If nothing with a URL remains
+    after filtering, *all_req_refs* is returned so the caller always gets
+    the compiled CWE/CISQ references.
+    """
     if not llm_refs:
         return all_req_refs
     by_label = {r["label"]: r for r in (all_req_refs or [])}
@@ -74,9 +79,9 @@ def _resolve_llm_refs(llm_refs: list[str] | None, all_req_refs: list[dict] | Non
             matched = next((r for k, r in by_label.items() if label.upper().startswith(k.upper())), None)
             if matched:
                 result.append(matched)
-            else:
-                result.append({"label": label})
-    return result or None
+    # Only keep refs that have a URL — drop bare labels without links
+    result = [r for r in result if r.get("url")]
+    return result if result else all_req_refs
 
 
 def _parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -75,11 +75,10 @@ function ViolationLiveRow({ violation, index }) {
             <div className="vlive-detail-section">
               <div className="vlive-detail-section-header">
                 <span className="vlive-detail-section-label">Reason</span>
-                {v.req_refs?.length > 0
-                  ? <span className="cwe-link-group">{v.req_refs.map((ref, i) => (
-                      <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                    ))}</span>
-                  : v.req && <span className="cwe-link">{v.req}</span>
+                {v.req_refs?.filter(r => r.url)?.length > 0 &&
+                  <span className="cwe-link-group">{v.req_refs.filter(r => r.url).map((ref, i) => (
+                    <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
+                  ))}</span>
                 }
               </div>
               {v.title && <p className="vlive-detail-title">{v.title}</p>}

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -128,8 +128,8 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
         lines.push(`### ${i + 1}.${loc ? ` \`${loc}\`` : ''}`);
         const reason = v.reason || v.findings;
         if (reason) lines.push('', `**Why it's a violation:** ${reason}`);
-        if (v.req_refs?.length > 0) lines.push('', `**References:** ${v.req_refs.map(r => `${r.label} (${r.url})`).join(', ')}`);
-        else if (v.req) lines.push('', `**Requirement:** ${v.req}`);
+        const linkedRefs = (v.req_refs || []).filter(r => r.url);
+        if (linkedRefs.length > 0) lines.push('', `**References:** ${linkedRefs.map(r => `${r.label} (${r.url})`).join(', ')}`);
         const code = v.code || v.snippet;
         if (code) {
           lines.push('', '**Affected code:**');
@@ -257,11 +257,10 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
                             <div className="vlive-detail-section">
                               <div className="vlive-detail-section-header">
                                 {v.title && <span className="vlive-detail-section-label">Reason</span>}
-                                {v.req_refs?.length > 0
-                                  ? <span className="cwe-link-group">{v.req_refs.map((ref, i) => (
-                                      <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                                    ))}</span>
-                                  : v.req && <span className="cwe-link">{v.req}</span>
+                                {v.req_refs?.filter(r => r.url)?.length > 0 &&
+                                  <span className="cwe-link-group">{v.req_refs.filter(r => r.url).map((ref, i) => (
+                                    <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
+                                  ))}</span>
                                 }
                               </div>
                               {v.title && <p className="vlive-detail-title">{v.title}</p>}
@@ -313,11 +312,10 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
                           <div className="vlive-detail-section">
                             <div className="vlive-detail-section-header">
                               {c.title && <span className="vlive-detail-section-label">Reason</span>}
-                              {c.req_refs?.length > 0
-                                ? <span className="cwe-link-group">{c.req_refs.map((ref, i) => (
-                                    <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                                  ))}</span>
-                                : c.req && <span className="cwe-link">{c.req}</span>
+                              {c.req_refs?.filter(r => r.url)?.length > 0 &&
+                                <span className="cwe-link-group">{c.req_refs.filter(r => r.url).map((ref, i) => (
+                                  <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
+                                ))}</span>
                               }
                             </div>
                             {c.title && <p className="vlive-detail-title">{c.title}</p>}

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -138,11 +138,10 @@ function ViolationCard({ v, index }) {
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               <span className="vlive-detail-section-label">Reason</span>
-              {v.req_refs?.length > 0
-                ? <span className="cwe-link-group">{v.req_refs.map((ref, i) => (
-                    <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                  ))}</span>
-                : v.req && <span className="cwe-link">{v.req}</span>
+              {v.req_refs?.filter(r => r.url)?.length > 0 &&
+                <span className="cwe-link-group">{v.req_refs.filter(r => r.url).map((ref, i) => (
+                  <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
+                ))}</span>
               }
             </div>
             {v.title && <p className="vlive-detail-title">{v.title}</p>}

--- a/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -136,11 +136,10 @@ function ViolationCard({ v, principleName, index }) {
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {v.title && <span className="vlive-detail-section-label">Reason</span>}
-              {v.req_refs?.length > 0
-                ? <span className="cwe-link-group">{v.req_refs.map((ref, i) => (
-                    <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                  ))}</span>
-                : v.req && <span className="cwe-link">{v.req}</span>
+              {v.req_refs?.filter(r => r.url)?.length > 0 &&
+                <span className="cwe-link-group">{v.req_refs.filter(r => r.url).map((ref, i) => (
+                  <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
+                ))}</span>
               }
             </div>
             {v.title && <p className="vlive-detail-title">{v.title}</p>}


### PR DESCRIPTION
## Summary
- **Backend**: `_resolve_llm_refs` now filters out refs without a `url` and falls back to all compiled refs when nothing valid remains — prevents internal IDs (e.g. `M-ANA-1`, `ISO-25010:…`) from leaking to the UI
- **UI**: All ref badge renderers across 4 components only display refs that carry a URL — removed `v.req` / `c.req` fallback that showed raw internal IDs

## Test plan
- [x] All 313 tests pass
- [x] Verify existing evaluations show CWE/CISQ links instead of internal IDs
- [x] Verify compliance badges still render correctly
- [x] Verify copy-to-clipboard (fix plan) only includes refs with URLs