### PR TITLE
feat: reorder stats grid and fix vite build output path

### DIFF
--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -188,18 +188,29 @@ function AccumulatedOverviewPanel({
             </div>
           </div>
           <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Compliance</span>
+            <span className="acc-eval-stat-value">
+              {accumulated?.summary?.totalCompliance || 0}
+            </span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Ratio</span>
+            <span className="acc-eval-stat-value">
+              {(() => {
+                const v = accumulated?.summary?.totalViolations || 0;
+                const c = accumulated?.summary?.totalCompliance || 0;
+                const total = v + c;
+                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+              })()}
+            </span>
+          </div>
+          <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Files Affected</span>
             <span className="acc-eval-stat-value">{accumulatedTopFiles.length}</span>
           </div>
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Principles</span>
             <span className="acc-eval-stat-value">{accumulatedUniquePrinciples}</span>
-          </div>
-          <div className="acc-eval-stat-block">
-            <span className="acc-eval-stat-label">Compliant</span>
-            <span className="acc-eval-stat-value">
-              {accumulated?.summary?.totalCompliance || 0}
-            </span>
           </div>
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Dimensions</span>
@@ -448,16 +459,27 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
             </div>
           </div>
           <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Compliance</span>
+            <span className="acc-eval-stat-value">{runSummary.totalCompliance || 0}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Ratio</span>
+            <span className="acc-eval-stat-value">
+              {(() => {
+                const v = runSummary.totalViolations || 0;
+                const c = runSummary.totalCompliance || 0;
+                const total = v + c;
+                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+              })()}
+            </span>
+          </div>
+          <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Files Affected</span>
             <span className="acc-eval-stat-value">{runTopFiles.length}</span>
           </div>
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Principles</span>
             <span className="acc-eval-stat-value">{runUniquePrinciples}</span>
-          </div>
-          <div className="acc-eval-stat-block">
-            <span className="acc-eval-stat-label">Compliant</span>
-            <span className="acc-eval-stat-value">{runSummary.totalCompliance || 0}</span>
           </div>
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Dimensions</span>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -140,16 +140,27 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
             </div>
           </div>
           <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Compliance</span>
+            <span className="acc-eval-stat-value">{totalCompliant}</span>
+          </div>
+          <div className="acc-eval-stat-block">
+            <span className="acc-eval-stat-label">Ratio</span>
+            <span className="acc-eval-stat-value">
+              {(() => {
+                const v = allViolations.length;
+                const c = totalCompliant;
+                const total = v + c;
+                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+              })()}
+            </span>
+          </div>
+          <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Files Affected</span>
             <span className="acc-eval-stat-value">{topFiles.length}</span>
           </div>
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Principles</span>
             <span className="acc-eval-stat-value">{uniquePrinciples}</span>
-          </div>
-          <div className="acc-eval-stat-block">
-            <span className="acc-eval-stat-label">Compliant</span>
-            <span className="acc-eval-stat-value">{totalCompliant}</span>
           </div>
         </div>
       </section>

--- a/ui/web/src/styles/dashboard.css
+++ b/ui/web/src/styles/dashboard.css
@@ -78,7 +78,7 @@
 
 .acc-eval-stats-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   gap: 12px;
   padding-top: 16px;
   border-top: 1px solid var(--color-border);

--- a/ui/web/vite.config.js
+++ b/ui/web/vite.config.js
@@ -5,6 +5,10 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: '../../src/quodeq/static',
+    emptyOutDir: true,
+  },
   server: {
     port: Number(process.env.VITE_PORT) || 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- Reorder stats grid: Violations, Compliance, Ratio (V/C%), Files Affected, Principles, Dimensions
- Dimension detail (ExplorerPage) omits the Dimensions stat (redundant when viewing a single dimension)
- Add violation/compliance ratio percentage as a new stat
- Fix vite `outDir` to build directly into `src/quodeq/static/` so `quodeq dashboard` always serves the latest UI

## Test plan
- [x] Run `uv run quodeq dashboard` and verify the stats grid order on the accumulated view
- [x] Verify the stats grid on the run-level view
- [x] Open a dimension detail and verify 5 stats (no Dimensions column)
- [x] Verify the ratio shows a percentage