### PR TITLE
fix: dimension score arrows, stats layout, and compliance ratio

### DIFF
--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -200,7 +200,7 @@ function AccumulatedOverviewPanel({
                 const v = accumulated?.summary?.totalViolations || 0;
                 const c = accumulated?.summary?.totalCompliance || 0;
                 if (v === 0) return '—';
-                return `1:${(c / v).toFixed(1)}`;
+                return `1:${((r) => r % 1 === 0 ? r.toFixed(0) : r.toFixed(1))(c / v)}`;
               })()}
             </span>
           </div>
@@ -469,7 +469,7 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
                 const v = runSummary.totalViolations || 0;
                 const c = runSummary.totalCompliance || 0;
                 if (v === 0) return '—';
-                return `1:${(c / v).toFixed(1)}`;
+                return `1:${((r) => r % 1 === 0 ? r.toFixed(0) : r.toFixed(1))(c / v)}`;
               })()}
             </span>
           </div>

--- a/ui/web/src/features/dashboard/components/DashboardPage.jsx
+++ b/ui/web/src/features/dashboard/components/DashboardPage.jsx
@@ -199,8 +199,8 @@ function AccumulatedOverviewPanel({
               {(() => {
                 const v = accumulated?.summary?.totalViolations || 0;
                 const c = accumulated?.summary?.totalCompliance || 0;
-                const total = v + c;
-                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+                if (v === 0) return '—';
+                return `1:${(c / v).toFixed(1)}`;
               })()}
             </span>
           </div>
@@ -468,8 +468,8 @@ function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileCl
               {(() => {
                 const v = runSummary.totalViolations || 0;
                 const c = runSummary.totalCompliance || 0;
-                const total = v + c;
-                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+                if (v === 0) return '—';
+                return `1:${(c / v).toFixed(1)}`;
               })()}
             </span>
           </div>

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -25,14 +25,20 @@ function scoreBarColor(score) {
   return cssVar('--color-grade-bottom-text');            // critical
 }
 
-const TREND_ARROW = { up: '↑', 'soft-up': '↗', same: '→', 'soft-down': '↘', down: '↓' };
-const TREND_COLOR = {
-  up:         cssVar('--color-trend-up'),
-  'soft-up':  cssVar('--color-trend-soft-up'),
-  same:       cssVar('--color-text-muted'),
-  'soft-down':cssVar('--color-trend-soft-down'),
-  down:       cssVar('--color-trend-down'),
-};
+// Rotation: 0° = straight up (↑), 90° = horizontal (→), 180° = straight down (↓)
+// sqrt curve: non-zero deltas always tilt; max arc 55° keeps small changes subtle
+function angleFromDelta(d) {
+  const clamped = Math.max(-4, Math.min(4, d));
+  return 90 - Math.sign(clamped) * Math.sqrt(Math.abs(clamped) / 4) * 55;
+}
+
+function trendColorClass(angle) {
+  if (angle <= 70)  return 'trend-up';
+  if (angle <= 88)  return 'trend-soft-up';
+  if (angle >= 110) return 'trend-down';
+  if (angle >= 92)  return 'trend-soft-down';
+  return 'trend-same';
+}
 
 // Shortcodes mirror src/quodeq/config/dimensions.py
 const DIM_CODE = {
@@ -58,13 +64,15 @@ function dimCode(name) {
   return (DIM_CODE[name.toLowerCase()] ?? name.slice(0, 4)).toUpperCase();
 }
 
-function trendDir(delta) {
-  if (delta === null || delta === undefined) return null;
-  if (delta > 1)    return 'up';
-  if (delta > 0.5)  return 'soft-up';
-  if (delta < -1)   return 'down';
-  if (delta < -0.5) return 'soft-down';
-  return 'same';
+function trendColorVar(colorClass) {
+  const map = {
+    'trend-up':        '--color-trend-up',
+    'trend-soft-up':   '--color-trend-soft-up',
+    'trend-same':      '--color-text-muted',
+    'trend-soft-down': '--color-trend-soft-down',
+    'trend-down':      '--color-trend-down',
+  };
+  return cssVar(map[colorClass] || '--color-text-muted');
 }
 
 function DimensionTooltip({ active, payload }) {
@@ -94,17 +102,23 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
 
   const renderTrendLabel = ({ x, y, width, index }) => {
     const entry = data[index];
-    const dir = trendDir(entry?.delta);
-    if (!dir) return null;
+    if (entry?.delta === null || entry?.delta === undefined) return null;
     const cx = x + width / 2;
+    const angle = angleFromDelta(entry.delta);
+    const colorCls = trendColorClass(angle);
+    const fill = trendColorVar(colorCls);
     const deltaStr = entry.delta > 0 ? `+${entry.delta.toFixed(1)}` : entry.delta.toFixed(1);
     return (
       <g>
-        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={TREND_COLOR[dir]}>
+        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={fill}>
           {deltaStr}
         </text>
-        <text x={cx} y={y - 14} textAnchor="middle" fontSize={11} fill={TREND_COLOR[dir]}>
-          {TREND_ARROW[dir]}
+        <text
+          x={cx} y={y - 14}
+          textAnchor="middle" fontSize={11} fill={fill}
+          transform={`rotate(${Math.round(angle)}, ${cx}, ${y - 14})`}
+        >
+          ↑
         </text>
       </g>
     );

--- a/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -168,32 +168,21 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
   return (
     <>
       <section className="panel file-detail-summary-panel">
-        <h3 className="file-detail-title">{principle}</h3>
         <div className="file-detail-stats-row">
           <div className="file-detail-stats">
+            <h3 className="file-detail-title" style={{ margin: 0 }}>{principle}</h3>
             {grade === 'Insufficient' ? (
               <span className="exec-summary-insufficient">Not enough evidence</span>
             ) : (
               <>
                 {score && (
                   <>
-                    <span className="file-detail-stat"><strong>{score}</strong></span>
                     <span className="file-detail-stat-sep">·</span>
+                    <span className="file-detail-stat" style={{ fontSize: '1.1rem' }}><strong>{score.replace('/10', '')}</strong></span>
                   </>
                 )}
+                <span className="file-detail-stat-sep">·</span>
                 <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
-              </>
-            )}
-            {violations.length > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat"><strong>{violations.length}</strong> violations</span>
-              </>
-            )}
-            {compliance.length > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat"><strong>{compliance.length}</strong> compliant</span>
               </>
             )}
           </div>
@@ -202,6 +191,39 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
               label="Principle fix plan"
               onClick={() => navigator.clipboard.writeText(buildPrinciplePlanText())}
             />
+          )}
+        </div>
+        <div className="file-detail-stats" style={{ marginTop: 6 }}>
+          {(() => {
+            const sevCounts = { critical: 0, major: 0, minor: 0 };
+            violations.forEach(v => { const s = (v.severity || 'minor').toLowerCase(); if (sevCounts[s] !== undefined) sevCounts[s]++; });
+            return (
+              <>
+                {sevCounts.critical > 0 && (
+                  <span className="file-detail-stat severity-tag critical">{sevCounts.critical} critical</span>
+                )}
+                {sevCounts.major > 0 && (
+                  <span className="file-detail-stat severity-tag major">{sevCounts.major} major</span>
+                )}
+                {sevCounts.minor > 0 && (
+                  <span className="file-detail-stat severity-tag minor">{sevCounts.minor} minor</span>
+                )}
+                {(sevCounts.critical > 0 || sevCounts.major > 0 || sevCounts.minor > 0) && <span className="file-detail-stat-sep">·</span>}
+              </>
+            );
+          })()}
+          <span className="file-detail-stat"><strong>{violations.length}</strong> violations</span>
+          {compliance.length > 0 && (
+            <>
+              <span className="file-detail-stat-sep">·</span>
+              <span className="file-detail-stat"><strong>{compliance.length}</strong> compliance</span>
+              {violations.length > 0 && (
+                <>
+                  <span className="file-detail-stat-sep">·</span>
+                  <span className="file-detail-stat"><strong>1:{((r) => r % 1 === 0 ? r.toFixed(0) : r.toFixed(1))(compliance.length / violations.length)}</strong> ratio</span>
+                </>
+              )}
+            </>
           )}
         </div>
       </section>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -150,7 +150,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
                 const v = allViolations.length;
                 const c = totalCompliant;
                 if (v === 0) return '—';
-                return `1:${(c / v).toFixed(1)}`;
+                return `1:${((r) => r % 1 === 0 ? r.toFixed(0) : r.toFixed(1))(c / v)}`;
               })()}
             </span>
           </div>

--- a/ui/web/src/features/explorer/components/ExplorerPage.jsx
+++ b/ui/web/src/features/explorer/components/ExplorerPage.jsx
@@ -149,8 +149,8 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
               {(() => {
                 const v = allViolations.length;
                 const c = totalCompliant;
-                const total = v + c;
-                return total > 0 ? `${Math.round((v / total) * 100)}%` : '—';
+                if (v === 0) return '—';
+                return `1:${(c / v).toFixed(1)}`;
               })()}
             </span>
           </div>

--- a/ui/web/src/features/explorer/components/FileDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/FileDetailPage.jsx
@@ -167,6 +167,16 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
         <h3 className="file-detail-title">{file.file}</h3>
         <div className="file-detail-stats-row">
           <div className="file-detail-stats">
+            {file.critical > 0 && (
+              <span className="file-detail-stat severity-tag critical">{file.critical} critical</span>
+            )}
+            {file.major > 0 && (
+              <span className="file-detail-stat severity-tag major">{file.major} major</span>
+            )}
+            {file.minor > 0 && (
+              <span className="file-detail-stat severity-tag minor">{file.minor} minor</span>
+            )}
+            {(file.critical > 0 || file.major > 0 || file.minor > 0) && <span className="file-detail-stat-sep">·</span>}
             <span className="file-detail-stat">
               <strong>{totalViolations}</strong> violations
             </span>
@@ -174,24 +184,6 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
             <span className="file-detail-stat">
               <strong>{dimensionsCount}</strong> {dimensionsCount === 1 ? 'dimension' : 'dimensions'}
             </span>
-            {file.critical > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag critical">{file.critical} critical</span>
-              </>
-            )}
-            {file.major > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag major">{file.major} major</span>
-              </>
-            )}
-            {file.minor > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag minor">{file.minor} minor</span>
-              </>
-            )}
           </div>
           <CopyButton
             label="File fix plan"

--- a/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/ui/web/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -157,6 +157,7 @@ function ViolationCard({ v, principleName, index }) {
 
 const PrincipleDetailPage = memo(function PrincipleDetailPage({ principle }) {
   const totalViolations = principle.total || 0;
+  const totalCompliance = principle.compliance?.length || 0;
 
   const violationsBySeverity = SEVERITY_ORDER.reduce((acc, sev) => {
     acc[sev] = (principle.violations || []).filter(
@@ -173,25 +174,33 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ principle }) {
       <section className="panel file-detail-summary-panel">
         <div className="file-detail-stats-row">
           <div className="file-detail-stats">
+            {principle.critical > 0 && (
+              <span className="file-detail-stat severity-tag critical">{principle.critical} critical</span>
+            )}
+            {principle.major > 0 && (
+              <span className="file-detail-stat severity-tag major">{principle.major} major</span>
+            )}
+            {principle.minor > 0 && (
+              <span className="file-detail-stat severity-tag minor">{principle.minor} minor</span>
+            )}
+            {(principle.critical > 0 || principle.major > 0 || principle.minor > 0) && <span className="file-detail-stat-sep">·</span>}
             <span className="file-detail-stat">
               <strong>{totalViolations}</strong> violations
             </span>
-            {principle.critical > 0 && (
+            {totalCompliance > 0 && (
               <>
                 <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag critical">{principle.critical} critical</span>
-              </>
-            )}
-            {principle.major > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag major">{principle.major} major</span>
-              </>
-            )}
-            {principle.minor > 0 && (
-              <>
-                <span className="file-detail-stat-sep">·</span>
-                <span className="file-detail-stat severity-tag minor">{principle.minor} minor</span>
+                <span className="file-detail-stat">
+                  <strong>{totalCompliance}</strong> compliance
+                </span>
+                {totalViolations > 0 && (
+                  <>
+                    <span className="file-detail-stat-sep">·</span>
+                    <span className="file-detail-stat">
+                      <strong>1:{((r) => r % 1 === 0 ? r.toFixed(0) : r.toFixed(1))(totalCompliance / totalViolations)}</strong> ratio
+                    </span>
+                  </>
+                )}
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Fix dimension score panel arrows to use shared TrendArrow rotation logic (smooth angles + correct colors)
- Reorder stats: Violations, Compliance, Ratio (1:N normalized), Files, Principles, Dimensions
- Add compliance count and ratio to principle detail pages
- Reorder file detail: severity tags first (left), then violations and dimensions
- Split eval principle detail header into two lines: name/score/grade on line 1, stats on line 2
- Hide compliance and ratio when compliance is 0
- Show ratio as integer when whole number (1:4 not 1:4.0)

## Test plan
- [x] Verify dimension score panel arrows match Score History arrows (color + rotation)
- [x] Check stats grid order on accumulated, run, and dimension views
- [x] Open a principle detail with compliance — verify ratio shows
- [x] Open a principle detail without compliance — verify only tags + violations show
- [x] Check file detail has tags on the left