### PR TITLE
ci: add test workflow for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest tests/ -q --tb=short


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that runs `pytest` on every PR to `develop` or `main`, and on pushes to `develop`.

- Tests Python 3.12 and 3.13
- Uses `uv` for fast dependency installation
- Runs `uv run pytest tests/ -q --tb=short`