### PR TITLE
fix: usability — parent lookup, project model, grade from score

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,83 @@ quodeq configure
 | `bash` | Bash, Shell |
 | `mobile_ios` | Swift (iOS) |
 
+## Environment Variables
+
+All environment variables are optional. They override built-in defaults and, where noted, the corresponding CLI flags take precedence over env vars.
+
+### API & Dashboard
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_API_KEY` | *(none)* | API key for authenticating dashboard API requests. When unset, endpoints are unauthenticated |
+| `QUODEQ_ACTION_API_PORT` | `8001` | Port for the Action API server |
+| `QUODEQ_ACTION_API_HOST` | `127.0.0.1` | Host/IP the Action API binds to |
+| `QUODEQ_DASHBOARD_PORT` | `4173` | Port for the dashboard preview server |
+| `QUODEQ_STATIC_DIST` | *(bundled)* | Path to pre-built web UI assets (overrides the bundled `static/` directory) |
+| `QUODEQ_EVALUATIONS_DIR` | `~/.quodeq/evaluations` | Directory where evaluation results are stored |
+| `QUODEQ_RUN_DIR` | `~/.quodeq/run` | Directory for runtime files (PID file, etc.) |
+| `QUODEQ_ALLOW_PLAINTEXT_HTTP` | *(off)* | Set to `1` to allow plaintext HTTP to non-localhost API hosts |
+| `QUODEQ_MAX_PROJECTS_LISTED` | `200` | Maximum number of projects returned by the browse endpoint |
+| `QUODEQ_MAX_ZIP_SIZE_MB` | `100` | Maximum zip export size in megabytes |
+
+### AI Analysis
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_AI_CLIENTS` | *(auto-detect)* | Comma-separated list of allowed AI CLI client IDs (e.g. `claude,codex`) |
+| `QUODEQ_AI_TOOLS` | `Glob,Grep,Read` | Comma-separated list of tools enabled for the AI subprocess |
+| `QUODEQ_AI_BASE_ARGS` | `--print --output-format stream-json --verbose` | Base CLI arguments passed to the AI subprocess |
+| `QUODEQ_AI_CLI_TIMEOUT` | `300` | Timeout in seconds for AI CLI subprocess calls |
+| `QUODEQ_SUBAGENT_MODEL` | *(client default)* | Model override for subagent analysis (omits `--model` when unset) |
+| `QUODEQ_MAX_TURNS` | `200` | Maximum AI conversation turns per dimension (CLI flag `--max-turns` takes precedence) |
+| `QUODEQ_MAX_DURATION` | `1800` | Maximum seconds per dimension (CLI flag `--max-duration` takes precedence) |
+
+### Scoring & Evaluation
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_CRITICAL_PENALTY` | `2.0` | Points deducted per critical violation type |
+| `QUODEQ_MAJOR_PENALTY` | `1.0` | Points deducted per major violation type |
+| `QUODEQ_MINOR_PENALTY` | `0.25` | Points deducted per minor violation type |
+| `QUODEQ_DEFAULT_DIM_WEIGHT` | `1.0` | Default weight for quality dimensions during plugin scaffolding |
+| `QUODEQ_SECURITY_DIM_WEIGHT` | `1.2` | Weight for the Security dimension |
+| `QUODEQ_PERFORMANCE_DIM_WEIGHT` | `0.8` | Weight for the Performance dimension |
+| `QUODEQ_MAX_VIOLATION_FILES` | `20` | Maximum number of violation files included in results |
+| `QUODEQ_CWE_URL_TEMPLATE` | `https://cwe.mitre.org/data/definitions/{cwe_id}.html` | URL template for CWE references (`{cwe_id}` is replaced) |
+
+### Caching
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_RUN_DIM_CACHE_MAX` | `256` | Maximum entries in the run-dimension cache |
+| `QUODEQ_ACC_CACHE_MAX` | `256` | Maximum entries in the accumulated-view cache |
+
+### Knowledge Refresh & HTTP
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_FETCH_TIMEOUT` | `15` | Timeout in seconds for knowledge-refresh HTTP fetches |
+| `QUODEQ_CONTENT_SAMPLE_LIMIT` | `4000` | Character limit for content samples during knowledge refresh |
+| `QUODEQ_MAX_FETCH_WORKERS` | `8` | Maximum concurrent worker threads for knowledge refresh |
+| `QUODEQ_HTTP_TIMEOUT` | `10` | Default HTTP client timeout in seconds |
+| `QUODEQ_HTTP_MAX_RETRIES` | `3` | Maximum HTTP retry attempts |
+| `QUODEQ_HTTP_RETRY_DELAY` | `0.5` | Base delay in seconds between HTTP retries (exponential backoff) |
+| `QUODEQ_HTTP_RETRY_JITTER` | `0.3` | Random jitter in seconds added to retry delays |
+| `QUODEQ_CB_THRESHOLD` | `5` | Circuit breaker failure threshold (opens after N consecutive failures) |
+| `QUODEQ_CB_RESET` | `60` | Circuit breaker reset time in seconds |
+| `QUODEQ_ALLOW_PRIVATE_URLS` | *(off)* | Set to `1` to allow HTTP requests to private/internal addresses |
+| `QUODEQ_GIT_CLONE_TIMEOUT` | `300` | Timeout in seconds for `git clone` operations |
+
+### OWASP ASVS
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QUODEQ_ASVS_URL` | *(GitHub raw URL)* | URL to the OWASP ASVS JSON file |
+| `QUODEQ_ASVS_VERSION` | `4.0.3` | ASVS version string used for fetching standards |
+| `QUODEQ_ASVS_SHA256` | *(none)* | Expected SHA-256 hash for ASVS integrity verification |
+| `QUODEQ_GITHUB_SEARCH_URL` | `https://api.github.com/search/repositories` | GitHub API search endpoint |
+| `QUODEQ_GITHUB_RAW_BASE_URL` | `https://raw.githubusercontent.com` | GitHub raw content base URL |
+
 ## How it works
 
 1. **Plugin detection** — identifies the language and loads the matching evaluator

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -245,9 +245,6 @@ def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
     def browse() -> Response | tuple[Response, int]:
         """List directories at a given path for repository browsing."""
         path = request.args.get("path")
-        if path is None:
-            body, status = error_response("Missing required 'path' query parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
         payload = provider.browse_repo(path)
         if "error" in payload:
             browse_status = HTTPStatus.BAD_REQUEST if _BROWSE_NOT_A_DIR_KEYWORD in payload["error"].lower() else HTTPStatus.NOT_FOUND

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -152,7 +152,7 @@ def _resolve_plugin(args: argparse.Namespace, src: Path, evaluators_dir: Path) -
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return None
-    print(f"Plugin: {plugin_id}")
+    print(f"Plugin: {plugin_id}", file=sys.stderr)
     plugin_dir = evaluators_dir / plugin_id
     if not plugin_dir.exists():
         print(f"Plugin directory not found: {plugin_dir}", file=sys.stderr)
@@ -188,8 +188,6 @@ def _execute_pipeline(args: argparse.Namespace, config: RunConfig, evidence_dir:
             print(f"Evidence written to {out_file}")
         else:
             print("Starting evaluation...", file=sys.stderr)
-            print("Scoring evidence...", file=sys.stderr)
-            print("Generating report...", file=sys.stderr)
             scores = run_full(config, evaluation_dir, mode=args.mode)
             print(f"Reports written to {evaluation_dir}/")
             for dim, score in scores.items():

--- a/src/quodeq/dashboard/_api_health.py
+++ b/src/quodeq/dashboard/_api_health.py
@@ -14,7 +14,7 @@ import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
-from quodeq.shared.logging import log_warning
+from quodeq.shared.logging import log_info, log_warning
 from quodeq.shared.utils import ACTION_API_MODULE, IS_WIN32 as _IS_WIN32
 
 _HEALTH_CHECK_TIMEOUT_S = 0.5
@@ -58,6 +58,7 @@ def action_api_healthy(base_url: str) -> bool:
 
 def wait_for_action_api(base_url: str, timeout_s: float = _DEFAULT_WAIT_TIMEOUT_S) -> None:
     """Block until the action API becomes healthy, or raise TimeoutError."""
+    log_info(f"Waiting for Action API at {base_url}...")
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if action_api_healthy(base_url):

--- a/src/quodeq/data/fs/report_parser/grades.py
+++ b/src/quodeq/data/fs/report_parser/grades.py
@@ -7,7 +7,7 @@ import re
 from typing import Any
 
 from quodeq.core.types import DimensionResult, DimensionSummary, Finding, GradeBreakdown, SeverityTally, Totals
-from quodeq.engine.scoring_internals import GRADE_LADDER
+from quodeq.engine.scoring_internals import GRADE_LADDER, score_to_grade_label
 
 _logger = logging.getLogger(__name__)
 
@@ -124,9 +124,16 @@ def summarize_dimensions(dimensions: list[DimensionResult]) -> DimensionSummary:
     for grade in overall_grades:
         grade_counts[grade] = grade_counts.get(grade, 0) + 1
 
+    # Derive overall grade from the numeric average when available,
+    # falling back to most-frequent vote when scores are absent.
+    if numeric_average is not None:
+        overall_grade = score_to_grade_label(numeric_average)
+    else:
+        overall_grade = most_frequent_grade(overall_grades)
+
     return DimensionSummary(
         dimensions_count=len(dimensions),
-        overall_grade=most_frequent_grade(overall_grades),
+        overall_grade=overall_grade,
         numeric_average=numeric_average,
         grade_breakdown=[
             GradeBreakdown(grade=grade, count=count)

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -17,6 +17,7 @@ from quodeq.adapters.fs.report_parser import (
     read_run_data,
 )
 from quodeq.core.types import DimensionResult, to_camel_dict
+from quodeq.engine.scoring_internals import score_to_grade_label
 from quodeq.services._cache import make_lru_dimension_fetcher
 
 # Module-level LRU cache for accumulated-view disk reads (bounded, cross-request).
@@ -193,8 +194,9 @@ def _build_accumulated_response(
         "project": project,
         "dimensions": [to_camel_dict(d) for d in result.dimensions_with_trend],
         "summary": {
-            "overallGrade": most_frequent_grade(
-                [d.overall_grade for d in result.all_dimensions if d.overall_grade]
+            "overallGrade": (
+                score_to_grade_label(result.avg_score) if result.avg_score is not None
+                else most_frequent_grade([d.overall_grade for d in result.all_dimensions if d.overall_grade])
             ),
             "numericAverage": result.avg_score,
             "previousNumericAverage": result.prev_avg_score,

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -23,6 +23,7 @@ from quodeq.services._dashboard_stale import collect_stale_dimensions
 
 # Re-export for backward compatibility (tests import this name)
 _collect_stale_dimensions = collect_stale_dimensions
+from quodeq.engine.scoring_internals import score_to_grade_label
 from quodeq.services.accumulated import numeric_average
 
 
@@ -121,8 +122,11 @@ def _build_accumulated_trend(
                 "dateISO": item.date_iso,
                 "dateLabel": item.date_label,
                 "dimensionsCount": len(acc_by_dim),
-                "overallGrade": most_frequent_grade(acc_grades) if acc_grades else None,
                 "numericAverage": numeric_average(acc_dims),
+                "overallGrade": (
+                    score_to_grade_label(numeric_average(acc_dims)) if numeric_average(acc_dims) is not None
+                    else (most_frequent_grade(acc_grades) if acc_grades else None)
+                ),
             }
         )
     trend.reverse()

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -277,12 +277,12 @@ export default function App() {
   const { selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => {
     if (!selectedProject || !projects.length) return { selectedDisplayName: selectedProject, selectedProjectParent: null, selectedProjectParentId: null };
     const data = projects.find((p) => (p.id || p.name || p) === selectedProject);
-    const parentName = data?.parent || null;
-    const parentData = parentName ? projects.find((p) => (p.name || p) === parentName) : null;
-    const parentId = parentData ? (parentData.id || parentData.name || parentName) : null;
+    const parentRef = data?.parent || null;
+    const parentData = parentRef ? projects.find((p) => (p.id || p.name || p) === parentRef) : null;
+    const parentId = parentData ? (parentData.id || parentData.name || parentRef) : null;
     return {
       selectedDisplayName: data?.displayName || data?.name || selectedProject,
-      selectedProjectParent: parentData?.displayName || parentData?.name || parentName,
+      selectedProjectParent: parentData?.displayName || parentData?.name || parentRef,
       selectedProjectParentId: parentId,
     };
   }, [selectedProject, projects]);

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -174,7 +174,14 @@ export default function App() {
   }
 
   async function handleDeleteProject(projectId) {
-    await fetch(`/api/projects/${encodeURIComponent(projectId)}${_apiQs()}`, { method: 'DELETE' });
+    const qs = _apiQs();
+    const separator = qs ? '&' : '?';
+    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}${qs}${separator}confirm=true`, { method: 'DELETE' });
+    if (!res.ok) {
+      const msg = await res.text().catch(() => res.statusText);
+      alert(`Failed to delete project: ${msg}`);
+      return;
+    }
     if (selectedProject === projectId) handleProjectChange(projects.find((p) => (p.id || p.name || p) !== projectId)?.id ?? '');
     loadProjects();
   }

--- a/ui/web/src/components/CopyButton.jsx
+++ b/ui/web/src/components/CopyButton.jsx
@@ -9,7 +9,7 @@ function CopyIcon() {
   );
 }
 
-export default function CopyButton({ onClick, label }) {
+export default function CopyButton({ onClick, label, 'aria-label': ariaLabel }) {
   const [copied, setCopied] = useState(false);
 
   const handleClick = () => {
@@ -19,7 +19,7 @@ export default function CopyButton({ onClick, label }) {
   };
 
   return (
-    <button className="detail-copy-btn" onClick={handleClick}>
+    <button className="detail-copy-btn" onClick={handleClick} aria-label={ariaLabel}>
       {copied ? 'Copied!' : label}
       <CopyIcon />
     </button>

--- a/ui/web/src/components/TrendArrow.jsx
+++ b/ui/web/src/components/TrendArrow.jsx
@@ -27,6 +27,8 @@ export default function TrendArrow({ trend, delta }) {
     <span
       className={`trend-arrow ${colorClass}`}
       style={{ display: 'inline-block', transform: `rotate(${Math.round(angle)}deg)` }}
+      role="img"
+      aria-label={title}
       title={title}
     >↑</span>
   );

--- a/ui/web/src/features/dashboard/components/DimensionCard.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionCard.jsx
@@ -131,6 +131,7 @@ export default function DimensionCard({ title, dimension, isSingleFocus }) {
                   key={sev}
                   type="button"
                   className={`pill-btn severity-pill ${sev} ${selectedSeverities.includes(sev) ? 'active' : ''}`}
+                  aria-pressed={selectedSeverities.includes(sev)}
                   onClick={() => setSelectedSeverities((prev) => toggleInList(prev, sev))}
                 >
                   {sev}
@@ -143,6 +144,7 @@ export default function DimensionCard({ title, dimension, isSingleFocus }) {
                 className="file-filter-input"
                 type="text"
                 placeholder="Filter by file..."
+                aria-label="Filter by file"
                 value={fileFilter}
                 onChange={(e) => setFileFilter(e.target.value)}
               />

--- a/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/ui/web/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -125,7 +125,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
   };
 
   return (
-    <section className="run-history-panel panel">
+    <section className="run-history-panel panel" aria-label="Dimension scores bar chart">
       <div className="run-history-header">
         <span className="run-history-title">Dimension Scores</span>
         {(runDate || runId) && (

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -83,13 +83,19 @@ function TrashIcon() {
 
 export default function ProjectsPage({ projects = [], selectedProject, onSelect, onDelete, onExport, onRelocate }) {
   const { children, roots } = useMemo(() => {
-    const nameToProject = Object.fromEntries(projects.map((p) => [p.name || p, p]));
+    const lookup = {};
+    for (const p of projects) {
+      const id = p.id || p.name || p;
+      const name = p.name || p;
+      lookup[id] = p;
+      lookup[name] = p;
+    }
     const children = {};
     const roots = [];
     for (const p of projects) {
       const parent = p.parent;
-      if (parent && nameToProject[parent]) {
-        const parentId = nameToProject[parent].id || nameToProject[parent].name || parent;
+      if (parent && lookup[parent]) {
+        const parentId = lookup[parent].id || lookup[parent].name || parent;
         if (!children[parentId]) children[parentId] = [];
         children[parentId].push(p);
       } else {

--- a/ui/web/src/features/dashboard/components/ProjectsPage.jsx
+++ b/ui/web/src/features/dashboard/components/ProjectsPage.jsx
@@ -62,7 +62,7 @@ function GradeChip({ grade, score }) {
 
 function DownloadIcon() {
   return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
       <polyline points="7 10 12 15 17 10" />
       <line x1="12" y1="15" x2="12" y2="3" />
@@ -72,7 +72,7 @@ function DownloadIcon() {
 
 function TrashIcon() {
   return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <polyline points="3 6 5 6 21 6" />
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
       <path d="M10 11v6M14 11v6" />
@@ -137,12 +137,14 @@ export default function ProjectsPage({ projects = [], selectedProject, onSelect,
           type="button"
           className="project-delete-btn"
           title="Download project reports"
+          aria-label="Download project reports"
           onClick={(e) => { e.stopPropagation(); onExport?.(name); }}
         ><DownloadIcon /></button>
         <button
           type="button"
           className="project-delete-btn"
           title="Delete project"
+          aria-label="Delete project"
           onClick={(e) => { e.stopPropagation(); setConfirming(name); }}
         ><TrashIcon /></button>
       </>

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -85,7 +85,7 @@ export default function EvaluationForm({ onStart, disabled }) {
                 onClick={handleRepoClear}
                 title="Clear"
               >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
                   <path d="M18 6L6 18M6 6l12 12" />
                 </svg>
               </button>
@@ -96,7 +96,7 @@ export default function EvaluationForm({ onStart, disabled }) {
               onClick={() => setFolderBrowserOpen(true)}
               title="Browse local filesystem"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                 <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
               </svg>
               Local
@@ -120,6 +120,7 @@ export default function EvaluationForm({ onStart, disabled }) {
                   type="button"
                   className={`dimension-chip-btn ${selectedDims.has(dim.id) ? 'selected' : ''}`}
                   title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : undefined}
+                  aria-pressed={selectedDims.has(dim.id)}
                   onClick={() => toggleDim(dim.id)}
                 >
                   {dim.id}

--- a/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationStatus.jsx
@@ -91,7 +91,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
           <span className="job-meta-label">Job ID</span>
           <div className="job-meta-id-row">
             <code className="job-meta-code job-meta-code--muted">{job.jobId}</code>
-            <CopyButton onClick={() => navigator.clipboard.writeText(job.jobId)} />
+            <CopyButton aria-label="Copy job ID" onClick={() => navigator.clipboard.writeText(job.jobId)} />
           </div>
         </div>
         {job.repo && (

--- a/ui/web/src/features/evaluation/components/FolderBrowser.jsx
+++ b/ui/web/src/features/evaluation/components/FolderBrowser.jsx
@@ -43,10 +43,10 @@ export default function FolderBrowser({ onSelect, onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal folder-browser-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal folder-browser-modal" role="dialog" aria-modal="true" aria-labelledby="folder-browser-title" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
-          <h2>Select Repository Folder</h2>
-          <button className="modal-close" onClick={onClose}>&times;</button>
+          <h2 id="folder-browser-title">Select Repository Folder</h2>
+          <button className="modal-close" onClick={onClose} aria-label="Close">&times;</button>
         </div>
 
         <div className="folder-browser-path">
@@ -65,6 +65,7 @@ export default function FolderBrowser({ onSelect, onClose }) {
             onChange={(e) => setPathInput(e.target.value)}
             onKeyDown={handlePathKeyDown}
             placeholder="Enter path and press Enter"
+            aria-label="Enter folder path"
           />
         </div>
 

--- a/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/ui/web/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -55,7 +55,13 @@ function ViolationLiveRow({ violation, index }) {
       className={`vdetail-row vdetail-row--${v.severity}`}
       style={{ animationDelay: `${Math.min(index * 40, 400)}ms` }}
     >
-      <div className="vdetail-row-main vlive-collapsible" onClick={() => setOpen(o => !o)}>
+      <div
+        className="vdetail-row-main vlive-collapsible"
+        role="button"
+        tabIndex={0}
+        onClick={() => setOpen(o => !o)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(o => !o); } }}
+      >
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
         {v.dimension && <span className="vrow-label">[{v.dimension}]</span>}
         {v.principle && <span className="vrow-label">[{v.principle}]</span>}

--- a/ui/web/src/features/explorer/components/FilePickerDialog.jsx
+++ b/ui/web/src/features/explorer/components/FilePickerDialog.jsx
@@ -9,22 +9,27 @@ export default function FilePickerDialog({ files, selectedFile, onSelect, onClos
 
   return (
     <div className="dialog-backdrop" onClick={onClose}>
-      <div className="dialog-panel" onClick={(e) => e.stopPropagation()}>
+      <div className="dialog-panel" role="dialog" aria-modal="true" aria-labelledby="file-picker-title" onClick={(e) => e.stopPropagation()}>
         <div className="dialog-header">
-          <h3>Select file</h3>
-          <button type="button" className="dialog-close" onClick={onClose}>&times;</button>
+          <h3 id="file-picker-title">Select file</h3>
+          <button type="button" className="dialog-close" onClick={onClose} aria-label="Close">&times;</button>
         </div>
         <input
           className="dialog-search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search files..."
+          aria-label="Search files"
           autoFocus
         />
-        <ul className="file-picker-list">
+        <ul className="file-picker-list" role="listbox">
           <li
             className={`file-picker-item ${!selectedFile ? 'active' : ''}`}
+            role="option"
+            aria-selected={!selectedFile}
+            tabIndex={0}
             onClick={() => { onSelect(''); onClose(); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(''); onClose(); } }}
           >
             All files (no filter)
           </li>
@@ -32,7 +37,11 @@ export default function FilePickerDialog({ files, selectedFile, onSelect, onClos
             <li
               key={file}
               className={`file-picker-item ${selectedFile === file ? 'active' : ''}`}
+              role="option"
+              aria-selected={selectedFile === file}
+              tabIndex={0}
               onClick={() => { onSelect(file); onClose(); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(file); onClose(); } }}
             >
               {file}
             </li>

--- a/ui/web/src/models/project.js
+++ b/ui/web/src/models/project.js
@@ -5,11 +5,17 @@
  * @property {string}       name
  * @property {string|null}  id
  * @property {string|null}  parent
+ * @property {string|null}  displayName
  * @property {string|null}  discipline
  * @property {string|null}  path
  * @property {string|null}  location    - 'local' | 'online'
  * @property {boolean|null} pathExists
  * @property {string|null}  latestDate
+ * @property {string|null}  latestRunId
+ * @property {string|null}  latestGrade
+ * @property {number|null}  latestScore
+ * @property {number}       runsCount
+ * @property {number|null}  filesCount
  */
 
 /**
@@ -21,13 +27,19 @@
 export function createProject(raw) {
   if (!raw || typeof raw !== 'object') return raw;
   return {
-    name:       raw.name ?? '',
-    id:         raw.id ?? null,
-    parent:     raw.parent ?? null,
-    discipline: raw.discipline ?? null,
-    path:       raw.path ?? null,
-    location:   raw.location ?? null,
-    pathExists: raw.pathExists ?? null,
-    latestDate: raw.latestDate ?? null,
+    name:         raw.name ?? '',
+    id:           raw.id ?? null,
+    parent:       raw.parent ?? null,
+    displayName:  raw.displayName ?? null,
+    discipline:   raw.discipline ?? null,
+    path:         raw.path ?? null,
+    location:     raw.location ?? null,
+    pathExists:   raw.pathExists ?? null,
+    latestDate:   raw.latestDate ?? null,
+    latestRunId:  raw.latestRunId ?? null,
+    latestGrade:  raw.latestGrade ?? null,
+    latestScore:  raw.latestScore ?? null,
+    runsCount:    raw.runsCount ?? 0,
+    filesCount:   raw.filesCount ?? null,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up fixes discovered during usability testing after PR #75.

- **Subproject parent lookup**: Parent field contains UUID but frontend looked up by name — fixed in both ProjectsPage and App.jsx header breadcrumb
- **Project model missing fields**: `createProject()` only mapped 8 of 14 API fields, dropping `runsCount`, `latestGrade`, `latestScore`, `displayName`, `filesCount`
- **Overall grade from score**: Grade was computed via most-frequent-vote across dimensions (could show "Exemplary" for 8.8/10). Now derived from `score_to_grade_label(numericAverage)` in all 3 places (summarize_dimensions, accumulated response, dashboard trend)
- **Browse API**: Allow missing `path` param (defaults to home directory)

## Test plan
- [x] All 457 tests pass
- [x] Verify subproject appears nested under parent in Projects page
- [x] Verify header shows "parent › child" with clickable parent
- [x] Verify project card shows run count, grade chip, and score
- [x] Verify 8.8/10 shows "Good" not "Exemplary"