### PR TITLE
feat: refine evaluation — verification pass, weighted scoring, model settings

### DIFF
--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -37,6 +37,7 @@ class AnalysisOptions:
     max_duration: int | None = None
     n_subagents: int = 1
     subagent_model: str | None = None
+    verify_findings: bool = True
 
 
 @dataclass

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -12,7 +12,7 @@ from quodeq.engine.prompt_builder import PromptContext, build_analysis_prompt, l
 from quodeq.shared.logging import log_info, log_success
 from quodeq.shared.utils import open_text
 
-_DEFAULT_VERIFY_AGENTS = 2
+_DEFAULT_VERIFY_AGENTS = 1
 _DEFAULT_VERIFY_BUDGET = 300  # 5 minutes per verifier
 _VERIFY_TEMPLATE = "verify.md"
 

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -1,4 +1,4 @@
-"""Post-analysis verification pass — re-checks findings and hunts for compliance."""
+"""Post-analysis verification pass — re-checks previous run's findings for consistency."""
 from __future__ import annotations
 
 import json
@@ -7,9 +7,10 @@ from typing import Any
 
 from quodeq.analysis.subprocess import AnalysisConfig, run_analysis
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
+from quodeq.data.fs.report_parser.runs import list_runs
 from quodeq.engine.evidence import Evidence
 from quodeq.engine.prompt_builder import PromptContext, build_analysis_prompt, load_template
-from quodeq.shared.logging import log_info, log_success
+from quodeq.shared.logging import log_info, log_success, log_warning
 from quodeq.shared.utils import open_text
 
 _DEFAULT_VERIFY_AGENTS = 1
@@ -17,10 +18,22 @@ _DEFAULT_VERIFY_BUDGET = 300  # 5 minutes per verifier
 _VERIFY_TEMPLATE = "verify.md"
 
 
+def _find_previous_evidence(reports_root: Path, project_uuid: str, current_run_id: str, dim_id: str) -> Path | None:
+    """Find the JSONL evidence file from the most recent previous run."""
+    runs = list_runs(reports_root, project_uuid)
+    for run in runs:
+        if run.run_id == current_run_id:
+            continue
+        prev_jsonl = reports_root / project_uuid / run.run_id / "evidence" / f"{dim_id}_evidence.jsonl"
+        if prev_jsonl.exists() and prev_jsonl.stat().st_size > 0:
+            return prev_jsonl
+    return None
+
+
 def _format_findings_summary(jsonl_path: Path) -> str:
-    """Format first-pass findings into a readable summary for verifiers."""
+    """Format findings from a JSONL file into a readable summary for verifiers."""
     if not jsonl_path.exists():
-        return "_No findings from first pass._"
+        return "_No findings from previous evaluation._"
 
     by_principle: dict[str, list[dict]] = {}
     try:
@@ -36,7 +49,7 @@ def _format_findings_summary(jsonl_path: Path) -> str:
                 principle = entry.get("p", "unknown")
                 by_principle.setdefault(principle, []).append(entry)
     except OSError:
-        return "_Could not read first-pass findings._"
+        return "_Could not read previous findings._"
 
     lines: list[str] = []
     for principle, findings in sorted(by_principle.items()):
@@ -53,7 +66,7 @@ def _format_findings_summary(jsonl_path: Path) -> str:
             lines.append(f"- _...and {len(violations) - 10} more violations_")
         lines.append("")
 
-    return "\n".join(lines) if lines else "_No findings from first pass._"
+    return "\n".join(lines) if lines else "_No findings from previous evaluation._"
 
 
 def _build_verify_prompt(
@@ -91,23 +104,38 @@ def run_verification_pass(
     n_agents: int = _DEFAULT_VERIFY_AGENTS,
     max_duration: int = _DEFAULT_VERIFY_BUDGET,
 ) -> int:
-    """Run verification agents that re-check findings and add compliance evidence.
+    """Re-check the previous run's findings against the current code.
 
-    Appends to the existing JSONL file. Returns the number of new findings added.
+    Reads violations/compliance from the most recent previous evaluation,
+    then launches verification agents that confirm which are still present
+    and hunt for missing compliance evidence. New findings are appended to
+    the current run's JSONL (dedup prevents duplicates).
+
+    Returns the number of new findings added, or 0 if no previous run exists.
     """
-    jsonl_path = evidence_dir / f"{dim_id}_evidence.jsonl"
-    findings_summary = _format_findings_summary(jsonl_path)
+    # Find the previous run's evidence
+    reports_root = Path(config.work_dir or evidence_dir).parent.parent
+    current_run_id = Path(config.work_dir or evidence_dir).parent.name
+    project_uuid = reports_root.name
+    reports_base = reports_root.parent
 
+    prev_jsonl = _find_previous_evidence(reports_base, project_uuid, current_run_id, dim_id)
+    if prev_jsonl is None:
+        log_info(f"  [{dim_id}] No previous evaluation found — skipping verification")
+        return 0
+
+    findings_summary = _format_findings_summary(prev_jsonl)
     if "_No findings" in findings_summary:
         return 0
 
+    jsonl_path = evidence_dir / f"{dim_id}_evidence.jsonl"
     prompt = _build_verify_prompt(config, dim_id, ctx, findings_summary)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
 
     # Count findings before verification
     before_count = _count_findings(jsonl_path)
 
-    log_info(f"  [{dim_id}] Starting verification pass ({n_agents} agents)")
+    log_info(f"  [{dim_id}] Verifying previous run findings ({n_agents} agents)")
 
     for i in range(n_agents):
         stream_file = evidence_dir / f"{dim_id}_verify_{i}.stream"
@@ -133,7 +161,7 @@ def run_verification_pass(
 
     after_count = _count_findings(jsonl_path)
     new_findings = after_count - before_count
-    log_success(f"  [{dim_id}] Verification complete: +{new_findings} new findings")
+    log_success(f"  [{dim_id}] Verification complete: +{new_findings} findings from previous run check")
     return new_findings
 
 

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -53,17 +53,14 @@ def _format_findings_summary(jsonl_path: Path) -> str:
 
     lines: list[str] = []
     for principle, findings in sorted(by_principle.items()):
-        violations = [f for f in findings if f.get("t") == "violation"]
-        compliances = [f for f in findings if f.get("t") == "compliance"]
-        lines.append(f"### {principle} ({len(violations)}v / {len(compliances)}c)")
-        for f in violations[:10]:  # cap to keep prompt manageable
+        lines.append(f"### {principle}")
+        for f in findings:
+            t = f.get("t", "?")
             file = f.get("file", "?")
             line_num = f.get("line", "?")
-            desc = f.get("w", "")
             severity = f.get("severity", "?")
-            lines.append(f"- **{severity}** `{file}:{line_num}` — {desc}")
-        if len(violations) > 10:
-            lines.append(f"- _...and {len(violations) - 10} more violations_")
+            desc = f.get("w", "")
+            lines.append(f"- {t} [{severity}] `{file}:{line_num}` — {desc}")
         lines.append("")
 
     return "\n".join(lines) if lines else "_No findings from previous evaluation._"

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -1,0 +1,148 @@
+"""Post-analysis verification pass — re-checks findings and hunts for compliance."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from quodeq.analysis.subprocess import AnalysisConfig, run_analysis
+from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
+from quodeq.engine.evidence import Evidence
+from quodeq.engine.prompt_builder import PromptContext, build_analysis_prompt, load_template
+from quodeq.shared.logging import log_info, log_success
+from quodeq.shared.utils import open_text
+
+_DEFAULT_VERIFY_AGENTS = 2
+_DEFAULT_VERIFY_BUDGET = 300  # 5 minutes per verifier
+_VERIFY_TEMPLATE = "verify.md"
+
+
+def _format_findings_summary(jsonl_path: Path) -> str:
+    """Format first-pass findings into a readable summary for verifiers."""
+    if not jsonl_path.exists():
+        return "_No findings from first pass._"
+
+    by_principle: dict[str, list[dict]] = {}
+    try:
+        with open_text(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                principle = entry.get("p", "unknown")
+                by_principle.setdefault(principle, []).append(entry)
+    except OSError:
+        return "_Could not read first-pass findings._"
+
+    lines: list[str] = []
+    for principle, findings in sorted(by_principle.items()):
+        violations = [f for f in findings if f.get("t") == "violation"]
+        compliances = [f for f in findings if f.get("t") == "compliance"]
+        lines.append(f"### {principle} ({len(violations)}v / {len(compliances)}c)")
+        for f in violations[:10]:  # cap to keep prompt manageable
+            file = f.get("file", "?")
+            line_num = f.get("line", "?")
+            desc = f.get("w", "")
+            severity = f.get("severity", "?")
+            lines.append(f"- **{severity}** `{file}:{line_num}` — {desc}")
+        if len(violations) > 10:
+            lines.append(f"- _...and {len(violations) - 10} more violations_")
+        lines.append("")
+
+    return "\n".join(lines) if lines else "_No findings from first pass._"
+
+
+def _build_verify_prompt(
+    config: Any,
+    dim_id: str,
+    ctx: Any,
+    findings_summary: str,
+) -> str:
+    """Build a verification prompt from the verify.md template."""
+    template = load_template(template_name=_VERIFY_TEMPLATE)
+    prompt = build_analysis_prompt(
+        template,
+        PromptContext(
+            plugin_id=config.plugin_id,
+            repo_name=str(config.src),
+            date_str=ctx.date_str,
+            dimension=dim_id,
+            source_file_count=config.source_file_count,
+            dimensions_data=ctx.dimensions_data,
+            analysis_md="",  # verifiers don't need analysis guidance
+            standards_dir=config.standards_dir,
+        ),
+    )
+    # Inject the findings summary (not a standard template var)
+    prompt = prompt.replace("{{FINDINGS_SUMMARY}}", findings_summary)
+    return prompt
+
+
+def run_verification_pass(
+    config: Any,
+    dim_id: str,
+    ctx: Any,
+    evidence_dir: Path,
+    *,
+    n_agents: int = _DEFAULT_VERIFY_AGENTS,
+    max_duration: int = _DEFAULT_VERIFY_BUDGET,
+) -> int:
+    """Run verification agents that re-check findings and add compliance evidence.
+
+    Appends to the existing JSONL file. Returns the number of new findings added.
+    """
+    jsonl_path = evidence_dir / f"{dim_id}_evidence.jsonl"
+    findings_summary = _format_findings_summary(jsonl_path)
+
+    if "_No findings" in findings_summary:
+        return 0
+
+    prompt = _build_verify_prompt(config, dim_id, ctx, findings_summary)
+    compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
+
+    # Count findings before verification
+    before_count = _count_findings(jsonl_path)
+
+    log_info(f"  [{dim_id}] Starting verification pass ({n_agents} agents)")
+
+    for i in range(n_agents):
+        stream_file = evidence_dir / f"{dim_id}_verify_{i}.stream"
+        ac = AnalysisConfig(
+            jsonl_file=jsonl_path,
+            compiled_dir=compiled_dir,
+            dimension=dim_id,
+            max_duration=max_duration,
+            agent_id=f"verify-{i}",
+        )
+        try:
+            run_analysis(
+                work_dir=config.src,
+                prompt=prompt,
+                stream_file=stream_file,
+                config=ac,
+            )
+        except Exception as exc:
+            log_info(f"  [{dim_id}] Verifier {i} finished with: {exc}")
+
+    # Deduplicate after all verifiers have appended
+    deduplicate_jsonl(jsonl_path)
+
+    after_count = _count_findings(jsonl_path)
+    new_findings = after_count - before_count
+    log_success(f"  [{dim_id}] Verification complete: +{new_findings} new findings")
+    return new_findings
+
+
+def _count_findings(jsonl_path: Path) -> int:
+    """Count non-empty lines in a JSONL file."""
+    if not jsonl_path.exists():
+        return 0
+    try:
+        with open_text(jsonl_path) as f:
+            return sum(1 for line in f if line.strip())
+    except OSError:
+        return 0

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -201,6 +201,7 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider) -> Non
                     ai_cmd=ai_cmd,
                     ai_model=payload.get("aiModel") or None,
                     subagent_model=payload.get("subagentModel") or None,
+                    verify_findings=bool(payload.get("verifyFindings", True)),
                 ),
             )
         except (FileNotFoundError, ValueError):

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -86,6 +86,10 @@ def _add_evaluate_args(parser: argparse.ArgumentParser) -> None:
         "--n-subagents", type=int, default=_DEFAULT_N_SUBAGENTS,
         help="Number of parallel subagents per dimension (default: %(default)s)",
     )
+    parser.add_argument(
+        "--no-verify", action="store_true",
+        help="Skip post-analysis verification pass",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -224,6 +228,7 @@ def _build_run_config(
             max_duration=args.max_duration if args.max_duration is not None else _env_int(_ENV_MAX_DURATION, None),
             n_subagents=args.n_subagents,
             subagent_model=_subagent_model(),
+            verify_findings=not args.no_verify and os.environ.get("QUODEQ_NO_VERIFY") != "1",
         ),
     )
 

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -22,10 +22,11 @@ GRADE_LADDER: list[str] = [
 # Ratio-based dampening table: (min_compliance_to_violation_ratio, multiplier).
 # Checked top-to-bottom; first matching row wins.
 # Asymmetric: max discount 15%, max penalty 30%.
-# Severity weights for dampening ratio: critical compliance/violations count
-# more than minor ones, preventing cheap minor-compliance from offsetting
-# critical violations.  Findings without a severity field default to minor (1).
-_SEVERITY_WEIGHT = {"critical": 4, "major": 2, "minor": 1}
+# Severity weights for dampening ratio, aligned with deduction penalties
+# (critical=2.0, major=1.0, minor=0.25 → ratio 8:4:1).  This ensures
+# 1 critical compliance perfectly neutralizes the dampening impact of
+# 1 critical violation at the same severity level.
+_SEVERITY_WEIGHT = {"critical": 8, "major": 4, "minor": 1}
 _MAX_PENALTY_MULTIPLIER = 1.30
 
 _RATIO_DAMPENING_TABLE: list[tuple[float, float]] = [

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -22,8 +22,10 @@ GRADE_LADDER: list[str] = [
 # Ratio-based dampening table: (min_compliance_to_violation_ratio, multiplier).
 # Checked top-to-bottom; first matching row wins.
 # Asymmetric: max discount 15%, max penalty 30%.
-# Uses raw distinct type counts (no severity weighting) to avoid bias from
-# compliance findings that lack proper severity fields.
+# Severity weights for dampening ratio: critical compliance/violations count
+# more than minor ones, preventing cheap minor-compliance from offsetting
+# critical violations.  Findings without a severity field default to minor (1).
+_SEVERITY_WEIGHT = {"critical": 4, "major": 2, "minor": 1}
 _MAX_PENALTY_MULTIPLIER = 1.30
 
 _RATIO_DAMPENING_TABLE: list[tuple[float, float]] = [
@@ -128,28 +130,37 @@ def tally_compliance_types_by_reason(compliance: list[dict]) -> dict[str, int]:
     return _tally_types(compliance, "reason")
 
 
+def _weighted_sum(type_counts: dict[str, int]) -> float:
+    """Sum type counts weighted by severity (critical=4, major=2, minor=1)."""
+    return sum(
+        count * _SEVERITY_WEIGHT.get(sev, 1)
+        for sev, count in type_counts.items()
+    )
+
+
 def compliance_dampening(
     compliance_type_counts: dict[str, int],
     violation_type_counts: dict[str, int],
 ) -> float:
     """Compute the dampening multiplier from the compliance-to-violation ratio.
 
-    Uses raw distinct type counts (sum across all severities, no weighting)
-    to avoid bias from compliance findings that lack severity fields.
+    Uses severity-weighted type counts so critical compliance has more
+    impact than minor compliance, and minor compliance can't cheaply
+    offset critical violations.
 
     Asymmetric: max discount 15% (0.85x), max penalty 30% (1.30x).
     No compliance at all gets the full 1.30x penalty.
     """
-    total_compliance = sum(compliance_type_counts.values())
-    total_violations = sum(violation_type_counts.values())
+    weighted_compliance = _weighted_sum(compliance_type_counts)
+    weighted_violations = _weighted_sum(violation_type_counts)
 
-    if total_violations == 0:
+    if weighted_violations == 0:
         return 1.0  # no violations -> dampening is irrelevant
 
-    if total_compliance == 0:
+    if weighted_compliance == 0:
         return _MAX_PENALTY_MULTIPLIER  # no compliance at all -> max penalty
 
-    ratio = total_compliance / total_violations
+    ratio = weighted_compliance / weighted_violations
     for threshold, multiplier in _RATIO_DAMPENING_TABLE:
         if ratio >= threshold:
             return multiplier

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -47,7 +47,7 @@ def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
     _dims, ctx = _load_plugin_context(config)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
 
-    log_info("Starting verification pass (%d dimensions in parallel)...", len(per_dim_evidence))
+    log_info(f"Starting verification pass ({len(per_dim_evidence)} dimensions in parallel)...")
     with ThreadPoolExecutor(max_workers=len(per_dim_evidence)) as pool:
         futures = {
             pool.submit(

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -12,34 +12,53 @@ _NUMERICAL_MODE = "numerical"
 _NA_LABEL = "N/A"
 
 
-def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
-    """Run verification pass on each dimension to re-check findings and add compliance."""
+def _verify_single_dimension(
+    config: RunConfig, dimension: str, files_read: int,
+    ctx: object, compiled_dir: Path | None,
+) -> tuple[str, object]:
+    """Run verification for one dimension and return (dimension, updated_evidence)."""
     from quodeq.analysis.subagents.verify import run_verification_pass
     from quodeq.engine.evidence_parser import EvidenceContext, parse_jsonl_to_evidence
+
+    work_dir = config.work_dir or config.src
+    run_verification_pass(config, dimension, ctx, work_dir)
+    jsonl_path = work_dir / f"{dimension}_evidence.jsonl"
+    ev = parse_jsonl_to_evidence(
+        jsonl_path,
+        EvidenceContext(
+            plugin_id=config.plugin_id,
+            repository=str(config.src),
+            date_str=ctx.date_str,
+            source_file_count=config.source_file_count,
+            files_read=files_read,
+        ),
+        compiled_dir=compiled_dir,
+    )
+    ev.plugin_name = ctx.plugin_name
+    return dimension, ev
+
+
+def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
+    """Run verification pass on all dimensions in parallel."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
     from quodeq.engine.runner import _load_plugin_context
 
     work_dir = config.work_dir or config.src
     _dims, ctx = _load_plugin_context(config)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
 
-    log_info("Starting verification pass...")
-    for dimension in per_dim_evidence:
-        run_verification_pass(config, dimension, ctx, work_dir)
-        # Re-parse evidence after verification added new findings
-        jsonl_path = work_dir / f"{dimension}_evidence.jsonl"
-        ev = parse_jsonl_to_evidence(
-            jsonl_path,
-            EvidenceContext(
-                plugin_id=config.plugin_id,
-                repository=str(config.src),
-                date_str=ctx.date_str,
-                source_file_count=config.source_file_count,
-                files_read=per_dim_evidence[dimension].files_read,
-            ),
-            compiled_dir=compiled_dir,
-        )
-        ev.plugin_name = ctx.plugin_name
-        per_dim_evidence[dimension] = ev
+    log_info("Starting verification pass (%d dimensions in parallel)...", len(per_dim_evidence))
+    with ThreadPoolExecutor(max_workers=len(per_dim_evidence)) as pool:
+        futures = {
+            pool.submit(
+                _verify_single_dimension,
+                config, dim, per_dim_evidence[dim].files_read, ctx, compiled_dir,
+            ): dim
+            for dim in per_dim_evidence
+        }
+        for future in as_completed(futures):
+            dim, ev = future.result()
+            per_dim_evidence[dim] = ev
 
     return per_dim_evidence
 

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -41,7 +41,7 @@ def _verify_single_dimension(
 def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
     """Run verification pass on all dimensions in parallel."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
-    from quodeq.engine.runner import _load_plugin_context
+    from quodeq.analysis.runner import _load_plugin_context
 
     work_dir = config.work_dir or config.src
     _dims, ctx = _load_plugin_context(config)

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -72,7 +72,7 @@ def run_full(config: RunConfig, output_dir: Path, mode: str = _NUMERICAL_MODE) -
     per_dim_evidence = run_per_dimension(config)
 
     # Verification pass: re-check violations + hunt for compliance evidence
-    if config.options.n_subagents > 1:
+    if config.options.verify_findings and config.options.n_subagents > 1:
         per_dim_evidence = _run_verification(config, per_dim_evidence)
 
     results: dict[str, str] = {}

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -6,18 +6,56 @@ from pathlib import Path
 from quodeq.core.scoring.engine import score_evidence
 from quodeq.engine.report import write_dimension_report
 from quodeq.engine.runner import RunConfig, run_per_dimension, cleanup_stream
+from quodeq.shared.logging import log_info
 
 _NUMERICAL_MODE = "numerical"
 _NA_LABEL = "N/A"
 
 
+def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
+    """Run verification pass on each dimension to re-check findings and add compliance."""
+    from quodeq.analysis.subagents.verify import run_verification_pass
+    from quodeq.engine.evidence_parser import EvidenceContext, parse_jsonl_to_evidence
+    from quodeq.engine.runner import _load_plugin_context
+
+    work_dir = config.work_dir or config.src
+    _dims, ctx = _load_plugin_context(config)
+    compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
+
+    log_info("Starting verification pass...")
+    for dimension in per_dim_evidence:
+        run_verification_pass(config, dimension, ctx, work_dir)
+        # Re-parse evidence after verification added new findings
+        jsonl_path = work_dir / f"{dimension}_evidence.jsonl"
+        ev = parse_jsonl_to_evidence(
+            jsonl_path,
+            EvidenceContext(
+                plugin_id=config.plugin_id,
+                repository=str(config.src),
+                date_str=ctx.date_str,
+                source_file_count=config.source_file_count,
+                files_read=per_dim_evidence[dimension].files_read,
+            ),
+            compiled_dir=compiled_dir,
+        )
+        ev.plugin_name = ctx.plugin_name
+        per_dim_evidence[dimension] = ev
+
+    return per_dim_evidence
+
+
 def run_full(config: RunConfig, output_dir: Path, mode: str = _NUMERICAL_MODE) -> dict:
-    """Full pipeline: run per-dimension → score each → write per-dimension reports.
+    """Full pipeline: run per-dimension → verify → score each → write reports.
 
     Returns dict of {dimension: overall_score_str}.
     """
     work_dir = config.work_dir or config.src
     per_dim_evidence = run_per_dimension(config)
+
+    # Verification pass: re-check violations + hunt for compliance evidence
+    if config.options.n_subagents > 1:
+        per_dim_evidence = _run_verification(config, per_dim_evidence)
+
     results: dict[str, str] = {}
 
     for dimension, evidence in per_dim_evidence.items():

--- a/src/quodeq/data/prompts/subagent.md
+++ b/src/quodeq/data/prompts/subagent.md
@@ -26,7 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 - Call `report_finding` immediately after confirming each finding — do not batch
 - If it says "Duplicate", move on — already captured
-- Report BOTH violations AND compliance (scoring needs both)
+- **Report BOTH violations AND compliance** — scoring uses the ratio between them. For every principle where you find violations, actively look for files that DO follow the standard and report compliance with `t: "compliance"`
 - Every finding must have a specific file, line, and snippet
 - Do not fabricate findings — only report what you can see in the code
 - Skip generated/vendored directories: `node_modules/`, `vendor/`, `build/`, `dist/`, `target/`, `__pycache__/`

--- a/src/quodeq/data/prompts/subagent.md
+++ b/src/quodeq/data/prompts/subagent.md
@@ -31,11 +31,17 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 - Do not fabricate findings — only report what you can see in the code
 - Skip generated/vendored directories: `node_modules/`, `vendor/`, `build/`, `dist/`, `target/`, `__pycache__/`
 
-## Severity
+## Severity (applies to BOTH violations AND compliance)
 
+For violations:
 - **critical** — Security vulnerability, data loss risk, or crash in production path
 - **major** — Significant quality issue that should be fixed
 - **minor** — Style issue, minor inefficiency, or improvement opportunity
+
+For compliance — use the same severity to indicate the importance of what's done right:
+- **critical** — Security best practice correctly implemented, safe data handling
+- **major** — Significant quality pattern properly followed
+- **minor** — Good style, naming, or minor best practice followed
 
 ## Standards Checklist
 

--- a/src/quodeq/data/prompts/verify.md
+++ b/src/quodeq/data/prompts/verify.md
@@ -1,0 +1,55 @@
+# {{DIMENSION}} Verification — Quodeq Verifier
+
+You are a code quality verifier reviewing findings from a previous analysis of **{{REPO_NAME}}** for the **{{DIMENSION}}** dimension.
+
+**Date:** {{DATE}}
+
+---
+
+## Your mission
+
+A first-pass analysis already produced the findings listed below. Your job:
+
+1. **Verify violations** — Read each cited file and line. Confirm the violation is real, or report it as compliance if the code is actually correct.
+2. **Find missing compliance** — For every principle that has violations, actively search for files that DO follow the standard and report them as compliance.
+3. **Catch missed violations** — If you spot additional violations not in the first-pass list, report them.
+
+## Workflow
+
+1. Review the findings summary below
+2. For each violation: Read the file, check if the issue is still present
+3. For each principle with violations: Find at least one file that follows the standard and report compliance
+4. Call `report_finding()` for every new finding (violations AND compliance)
+5. When done reviewing all findings, stop immediately
+
+**IMPORTANT:** When you have reviewed all findings and searched for compliance evidence, stop. Do not re-read files you have already checked.
+
+## report_finding parameters
+
+**Required:** `p` (the `###` heading name from the checklist — e.g. `Modularity`, `Analyzability`, `Confidentiality` — NEVER a requirement ID like M-ANA-1), `t` (`violation` or `compliance`), `d` (dimension), `w` (short description)
+
+**Include with every finding:** `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `reason`, `req` (the **bold requirement ID** from the checklist, e.g. `M-MOD-1`, `S-CON-3`), `vt` (violation type)
+
+## Rules
+
+- If a violation from the first pass is still present, you do NOT need to re-report it (it will be deduplicated)
+- If a violation was fixed or is a false positive, report compliance for that file+line
+- **Actively hunt for compliance evidence** — this is the most valuable thing you can do
+- Do not fabricate findings — only report what you can see in the code
+- Skip generated/vendored directories: `node_modules/`, `vendor/`, `build/`, `dist/`, `target/`, `__pycache__/`
+
+## Severity
+
+- **critical** — Security vulnerability, data loss risk, or crash in production path
+- **major** — Significant quality issue that should be fixed
+- **minor** — Style issue, minor inefficiency, or improvement opportunity
+
+## First-Pass Findings to Verify
+
+{{FINDINGS_SUMMARY}}
+
+## Standards Checklist
+
+Use the `###` heading (e.g. `Modularity`) as `p`. Use the **bold ID** (e.g. `M-MOD-1`) as `req`.
+
+{{STANDARDS_CHECKLIST}}

--- a/src/quodeq/data/prompts/verify.md
+++ b/src/quodeq/data/prompts/verify.md
@@ -38,11 +38,17 @@ The previous evaluation produced the findings listed below. The code may have ch
 - Do not fabricate findings — only report what you can see in the code
 - Skip generated/vendored directories: `node_modules/`, `vendor/`, `build/`, `dist/`, `target/`, `__pycache__/`
 
-## Severity
+## Severity (applies to BOTH violations AND compliance)
 
+For violations:
 - **critical** — Security vulnerability, data loss risk, or crash in production path
 - **major** — Significant quality issue that should be fixed
 - **minor** — Style issue, minor inefficiency, or improvement opportunity
+
+For compliance — use the same severity to indicate the importance of what's done right:
+- **critical** — Security best practice correctly implemented, safe data handling
+- **major** — Significant quality pattern properly followed
+- **minor** — Good style, naming, or minor best practice followed
 
 ## Previous Evaluation Findings
 

--- a/src/quodeq/data/prompts/verify.md
+++ b/src/quodeq/data/prompts/verify.md
@@ -1,61 +1,34 @@
 # {{DIMENSION}} Verification — Quodeq Verifier
 
-You are a code quality verifier reviewing findings from the **previous evaluation** of **{{REPO_NAME}}** for the **{{DIMENSION}}** dimension.
+You are verifying findings from the **previous evaluation** of **{{REPO_NAME}}** for the **{{DIMENSION}}** dimension.
 
 **Date:** {{DATE}}
 
 ---
 
-## Your mission
+## Your job
 
-The previous evaluation produced the findings listed below. The code may have changed since then. Your job:
+For each finding below, read the cited file and line. If it is still present in the current code, re-report it with `report_finding()` using the **same** `p`, `t`, `severity`, `vt`, and `req`. If it is no longer present (code was fixed), skip it.
 
-1. **Verify violations** — Read each cited file and line. If the violation is still present, report it. If the code has been fixed, report compliance instead.
-2. **Find missing compliance** — For every principle that has violations, actively search for files that DO follow the standard and report them as compliance.
-3. **Catch missed violations** — If you spot additional violations not in the previous list, report them.
-
-## Workflow
-
-1. Review the previous evaluation findings below
-2. For each violation: Read the file, check if the issue is still present in the current code
-3. For each principle with violations: Find at least one file that follows the standard and report compliance
-4. Call `report_finding()` for every finding (violations AND compliance)
-5. When done reviewing all findings, stop immediately
-
-**IMPORTANT:** When you have reviewed all findings and searched for compliance evidence, stop. Do not re-read files you have already checked.
+After checking all findings, stop immediately.
 
 ## report_finding parameters
 
-**Required:** `p` (the `###` heading name from the checklist — e.g. `Modularity`, `Analyzability`, `Confidentiality` — NEVER a requirement ID like M-ANA-1), `t` (`violation` or `compliance`), `d` (dimension), `w` (short description)
+**Required:** `p`, `t` (`violation` or `compliance`), `d` (dimension), `w` (short description)
 
-**Include with every finding:** `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `reason`, `req` (the **bold requirement ID** from the checklist, e.g. `M-MOD-1`, `S-CON-3`), `vt` (violation type)
+**Include:** `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `reason`, `req`, `vt`
 
 ## Rules
 
-- If a violation from the previous run is still present, report it again — it confirms consistency
-- If a violation was fixed or is a false positive, report compliance for that file+line
-- **Actively hunt for compliance evidence** — this is the most valuable thing you can do
+- **Preserve severity** — use the same severity from the previous finding
+- Re-report findings that are still present — duplicates are handled automatically
+- If a violation was fixed, skip it (do not report compliance for fixes)
 - Do not fabricate findings — only report what you can see in the code
-- Skip generated/vendored directories: `node_modules/`, `vendor/`, `build/`, `dist/`, `target/`, `__pycache__/`
-
-## Severity (applies to BOTH violations AND compliance)
-
-For violations:
-- **critical** — Security vulnerability, data loss risk, or crash in production path
-- **major** — Significant quality issue that should be fixed
-- **minor** — Style issue, minor inefficiency, or improvement opportunity
-
-For compliance — use the same severity to indicate the importance of what's done right:
-- **critical** — Security best practice correctly implemented, safe data handling
-- **major** — Significant quality pattern properly followed
-- **minor** — Good style, naming, or minor best practice followed
 
 ## Previous Evaluation Findings
 
 {{FINDINGS_SUMMARY}}
 
 ## Standards Checklist
-
-Use the `###` heading (e.g. `Modularity`) as `p`. Use the **bold ID** (e.g. `M-MOD-1`) as `req`.
 
 {{STANDARDS_CHECKLIST}}

--- a/src/quodeq/data/prompts/verify.md
+++ b/src/quodeq/data/prompts/verify.md
@@ -1,6 +1,6 @@
 # {{DIMENSION}} Verification — Quodeq Verifier
 
-You are a code quality verifier reviewing findings from a previous analysis of **{{REPO_NAME}}** for the **{{DIMENSION}}** dimension.
+You are a code quality verifier reviewing findings from the **previous evaluation** of **{{REPO_NAME}}** for the **{{DIMENSION}}** dimension.
 
 **Date:** {{DATE}}
 
@@ -8,18 +8,18 @@ You are a code quality verifier reviewing findings from a previous analysis of *
 
 ## Your mission
 
-A first-pass analysis already produced the findings listed below. Your job:
+The previous evaluation produced the findings listed below. The code may have changed since then. Your job:
 
-1. **Verify violations** — Read each cited file and line. Confirm the violation is real, or report it as compliance if the code is actually correct.
+1. **Verify violations** — Read each cited file and line. If the violation is still present, report it. If the code has been fixed, report compliance instead.
 2. **Find missing compliance** — For every principle that has violations, actively search for files that DO follow the standard and report them as compliance.
-3. **Catch missed violations** — If you spot additional violations not in the first-pass list, report them.
+3. **Catch missed violations** — If you spot additional violations not in the previous list, report them.
 
 ## Workflow
 
-1. Review the findings summary below
-2. For each violation: Read the file, check if the issue is still present
+1. Review the previous evaluation findings below
+2. For each violation: Read the file, check if the issue is still present in the current code
 3. For each principle with violations: Find at least one file that follows the standard and report compliance
-4. Call `report_finding()` for every new finding (violations AND compliance)
+4. Call `report_finding()` for every finding (violations AND compliance)
 5. When done reviewing all findings, stop immediately
 
 **IMPORTANT:** When you have reviewed all findings and searched for compliance evidence, stop. Do not re-read files you have already checked.
@@ -32,7 +32,7 @@ A first-pass analysis already produced the findings listed below. Your job:
 
 ## Rules
 
-- If a violation from the first pass is still present, you do NOT need to re-report it (it will be deduplicated)
+- If a violation from the previous run is still present, report it again — it confirms consistency
 - If a violation was fixed or is a false positive, report compliance for that file+line
 - **Actively hunt for compliance evidence** — this is the most valuable thing you can do
 - Do not fabricate findings — only report what you can see in the code
@@ -44,7 +44,7 @@ A first-pass analysis already produced the findings listed below. Your job:
 - **major** — Significant quality issue that should be fixed
 - **minor** — Style issue, minor inefficiency, or improvement opportunity
 
-## First-Pass Findings to Verify
+## Previous Evaluation Findings
 
 {{FINDINGS_SUMMARY}}
 

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -17,6 +17,7 @@ class EvaluationOptions:
     ai_cmd: str | None = None
     ai_model: str | None = None
     subagent_model: str | None = None
+    verify_findings: bool = True
 
 
 class ProjectActions(Protocol):

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -111,6 +111,8 @@ class FsEvaluationMixin:
             env["AI_MODEL"] = ai_model
         if options.subagent_model:
             env["SUBAGENT_MODEL"] = options.subagent_model
+        if not options.verify_findings:
+            env["QUODEQ_NO_VERIFY"] = "1"
         return env
 
     def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> JobSnapshot:

--- a/tests/engine/test_scoring_graded.py
+++ b/tests/engine/test_scoring_graded.py
@@ -14,8 +14,8 @@ from tests.engine.conftest import make_evidence_with_confidence
 def test_balanced_ratio_dampens_deductions():
     """Severity-weighted compliance/violation ratio >= 1.0 -> 0.95 dampening.
 
-    1 critical violation (weight 4) needs >= 4 weighted compliance to reach 1.0.
-    1 critical compliance (weight 4) provides exactly that.
+    1 critical violation (weight 8) needs >= 8 weighted compliance to reach 1.0.
+    1 critical compliance (weight 8) provides exactly that.
     """
     violations = [
         {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "r",
@@ -41,8 +41,8 @@ def test_balanced_ratio_dampens_deductions():
 def test_strong_compliance_ratio_gives_max_discount():
     """Severity-weighted ratio >= 3.0 -> 0.85 dampening (max discount).
 
-    1 major violation (weight 2) needs >= 6 weighted compliance for 3.0 ratio.
-    3 major compliance types (weight 3×2=6) provide exactly that.
+    1 major violation (weight 4) needs >= 12 weighted compliance for 3.0 ratio.
+    3 major compliance types (weight 3×4=12) provide exactly that.
     """
     violations = [
         {"file": "a.ts", "line": 1, "snippet": "x", "reason": "r",
@@ -112,8 +112,8 @@ def test_weak_compliance_ratio_penalises():
 def test_dampening_in_graded_mode():
     """Dampening should reduce grade drops in non-numerical mode too.
 
-    4 critical violations (weight 4×4=16) need >= 16 weighted compliance
-    for ratio 1.0 → 0.95x. 4 critical compliance types provide exactly that.
+    4 critical violations (weight 4×8=32) need >= 32 weighted compliance
+    for ratio 1.0 → 0.95x. 4 critical compliance types (4×8=32) provide exactly that.
     """
     violations = [
         {"file": f"v{i}.ts", "line": i, "snippet": "x", "reason": f"r{i}",

--- a/tests/engine/test_scoring_graded.py
+++ b/tests/engine/test_scoring_graded.py
@@ -12,46 +12,53 @@ from tests.engine.conftest import make_evidence_with_confidence
 # ---------------------------------------------------------------------------
 
 def test_balanced_ratio_dampens_deductions():
-    """Compliance/violation ratio >= 1.0 -> 0.95 dampening."""
+    """Severity-weighted compliance/violation ratio >= 1.0 -> 0.95 dampening.
+
+    1 critical violation (weight 4) needs >= 4 weighted compliance to reach 1.0.
+    1 critical compliance (weight 4) provides exactly that.
+    """
     violations = [
         {"file": "a.ts", "line": 1, "snippet": "eval(x)", "reason": "r",
          "severity": "critical", "vt": "code-injection"},
     ]
     compliance = [
-        {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
-         "severity": "minor", "vt": f"comp-type-{i}"}
-        for i in range(2)
+        {"file": "c0.ts", "line": 1, "snippet": "ok", "reason": "r0",
+         "severity": "critical", "vt": "safe-eval"},
     ]
     ev = make_evidence_with_confidence(
         confidence_level="high",
         violations=violations,
         compliance=compliance,
         n_violations=1,
-        n_compliance=2,
+        n_compliance=1,
     )
     scores = score_evidence(ev, mode="numerical")
     ts001 = scores.principles["ts-001"]
-    assert ts001.dampening_multiplier == 0.90
-    assert ts001.final_score == 8.2
+    assert ts001.dampening_multiplier == 0.95
+    assert ts001.final_score == 8.1
 
 
 def test_strong_compliance_ratio_gives_max_discount():
-    """Compliance/violation ratio >= 3.0 -> 0.85 dampening (max discount)."""
+    """Severity-weighted ratio >= 3.0 -> 0.85 dampening (max discount).
+
+    1 major violation (weight 2) needs >= 6 weighted compliance for 3.0 ratio.
+    3 major compliance types (weight 3×2=6) provide exactly that.
+    """
     violations = [
         {"file": "a.ts", "line": 1, "snippet": "x", "reason": "r",
          "severity": "major", "vt": "bad-pattern"},
     ]
     compliance = [
         {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
-         "severity": "minor", "vt": f"safe-{i}"}
-        for i in range(4)
+         "severity": "major", "vt": f"safe-{i}"}
+        for i in range(3)
     ]
     ev = make_evidence_with_confidence(
         confidence_level="high",
         violations=violations,
         compliance=compliance,
         n_violations=1,
-        n_compliance=4,
+        n_compliance=3,
     )
     scores = score_evidence(ev, mode="numerical")
     ts001 = scores.principles["ts-001"]
@@ -103,7 +110,11 @@ def test_weak_compliance_ratio_penalises():
 
 
 def test_dampening_in_graded_mode():
-    """Dampening should reduce grade drops in non-numerical mode too."""
+    """Dampening should reduce grade drops in non-numerical mode too.
+
+    4 critical violations (weight 4×4=16) need >= 16 weighted compliance
+    for ratio 1.0 → 0.95x. 4 critical compliance types provide exactly that.
+    """
     violations = [
         {"file": f"v{i}.ts", "line": i, "snippet": "x", "reason": f"r{i}",
          "severity": "critical", "vt": f"vt-{i}"}
@@ -111,15 +122,15 @@ def test_dampening_in_graded_mode():
     ]
     compliance = [
         {"file": f"c{i}.ts", "line": i, "snippet": "ok", "reason": f"r{i}",
-         "severity": "minor", "vt": f"comp-{i}"}
-        for i in range(6)
+         "severity": "critical", "vt": f"comp-{i}"}
+        for i in range(4)
     ]
     ev = make_evidence_with_confidence(
         confidence_level="high",
         violations=violations,
         compliance=compliance,
         n_violations=4,
-        n_compliance=6,
+        n_compliance=4,
     )
     scores = score_evidence(ev, mode="non-numerical")
     ts001 = scores.principles["ts-001"]

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -688,6 +688,15 @@ export default function App() {
                     </div>
                   </div>
                 )}
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Analysis power</span>
+                    <span className="settings-description">
+                      Controls the AI model used for analysis. Higher power gives more thorough results but takes longer.
+                    </span>
+                  </div>
+                  <PowerSelector value={analysisPower} onChange={setAnalysisPower} />
+                </div>
                 <div className="settings-row settings-row--last">
                   <div className="settings-row-label">
                     <span className="settings-label">Verify findings</span>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -309,6 +309,9 @@ export default function App() {
   // AI settings
   // -------------------------------------------------------------------------
   const [aiCmd, setAiCmd] = useState(localStorage.getItem('cc-ai-cmd') || '');
+  const [verifyFindings, setVerifyFindings] = useState(() => {
+    try { return localStorage.getItem('cc-verify-findings') !== 'false'; } catch { return true; }
+  });
   const [availableClients, setAvailableClients] = useState(null);
   const [appVersion, setAppVersion] = useState(null);
   const [settingsPhrase, setSettingsPhrase] = useState('');
@@ -365,9 +368,14 @@ export default function App() {
     prevJobRef.current = job;
   }, [job]);
 
+  function applyVerifyFindings(value) {
+    setVerifyFindings(value);
+    localStorage.setItem('cc-verify-findings', value ? 'true' : 'false');
+  }
+
   function handleStartEvaluation(payload) {
     const subagentModel = LEVELS.find(l => l.level === analysisPower)?.model;
-    startEvaluation({ ...payload, aiCmd: aiCmd || undefined, subagentModel });
+    startEvaluation({ ...payload, aiCmd: aiCmd || undefined, subagentModel, verifyFindings });
   }
 
   function handleEvalDismiss(action) {
@@ -671,7 +679,7 @@ export default function App() {
                   </div>
                 )}
                 {aiCmd && (
-                  <div className="settings-row settings-row--last">
+                  <div className="settings-row">
                     <div className="settings-row-label">
                       <span className="settings-label">Model</span>
                       <span className="settings-description">
@@ -680,6 +688,26 @@ export default function App() {
                     </div>
                   </div>
                 )}
+                <div className="settings-row settings-row--last">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Verify findings</span>
+                    <span className="settings-description">
+                      After analysis, run a verification pass that re-checks violations and hunts for compliance evidence. Improves grade accuracy at a small extra cost.
+                    </span>
+                  </div>
+                  <div className="theme-toggle">
+                    <button
+                      type="button"
+                      className={`theme-toggle-btn${verifyFindings ? ' active' : ''}`}
+                      onClick={() => applyVerifyFindings(true)}
+                    >On</button>
+                    <button
+                      type="button"
+                      className={`theme-toggle-btn${!verifyFindings ? ' active' : ''}`}
+                      onClick={() => applyVerifyFindings(false)}
+                    >Off</button>
+                  </div>
+                </div>
               </section>
               <section className="panel settings-section">
                 <div className="panel-header">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -8,7 +8,7 @@ import EvaluationForm from './features/evaluation/components/EvaluationForm.jsx'
 import EvaluationStatus from './features/evaluation/components/EvaluationStatus.jsx';
 import ReEvaluateCard from './features/evaluation/components/ReEvaluateCard.jsx';
 import PowerSelector from './features/evaluation/components/PowerSelector.jsx';
-import { LEVELS, STORAGE_KEY as POWER_KEY } from './features/evaluation/components/powerLevels.js';
+import { getLevels, DEFAULT_MODELS, MODEL_STORAGE_PREFIX, STORAGE_KEY as POWER_KEY } from './features/evaluation/components/powerLevels.js';
 import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
 import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
@@ -309,6 +309,9 @@ export default function App() {
   // AI settings
   // -------------------------------------------------------------------------
   const [aiCmd, setAiCmd] = useState(localStorage.getItem('cc-ai-cmd') || '');
+  const [modelFast, setModelFast] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}1`) || '');
+  const [modelBalanced, setModelBalanced] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}2`) || '');
+  const [modelThorough, setModelThorough] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}3`) || '');
   const [verifyFindings, setVerifyFindings] = useState(() => {
     try { return localStorage.getItem('cc-verify-findings') !== 'false'; } catch { return true; }
   });
@@ -377,7 +380,8 @@ export default function App() {
   }
 
   function handleStartEvaluation(payload) {
-    const subagentModel = LEVELS.find(l => l.level === analysisPower)?.model;
+    const levels = getLevels();
+    const subagentModel = levels.find(l => l.level === analysisPower)?.model;
     startEvaluation({ ...payload, aiCmd: aiCmd || undefined, subagentModel, verifyFindings });
   }
 
@@ -686,9 +690,37 @@ export default function App() {
                     <div className="settings-row-label">
                       <span className="settings-label">Model</span>
                       <span className="settings-description">
-                        Uses your client's default model. Run <code>{aiCmd} --help</code> to see how to change it.
+                        Override the AI model for each analysis power level. Leave blank to use the default.
                       </span>
                     </div>
+                  </div>
+                )}
+                {aiCmd && (
+                  <div className="settings-row settings-model-overrides">
+                    {[
+                      { label: 'Fast', value: modelFast, setter: setModelFast, level: 1, placeholder: DEFAULT_MODELS[1] },
+                      { label: 'Balanced', value: modelBalanced, setter: setModelBalanced, level: 2, placeholder: DEFAULT_MODELS[2] },
+                      { label: 'Thorough', value: modelThorough, setter: setModelThorough, level: 3, placeholder: DEFAULT_MODELS[3] },
+                    ].map(({ label, value, setter, level, placeholder }) => (
+                      <div key={level} className="settings-model-field">
+                        <label className="settings-model-label">{label}</label>
+                        <input
+                          type="text"
+                          className="settings-model-input"
+                          value={value}
+                          placeholder={placeholder}
+                          onChange={(e) => {
+                            const v = e.target.value;
+                            setter(v);
+                            if (v) {
+                              localStorage.setItem(`${MODEL_STORAGE_PREFIX}${level}`, v);
+                            } else {
+                              localStorage.removeItem(`${MODEL_STORAGE_PREFIX}${level}`);
+                            }
+                          }}
+                        />
+                      </div>
+                    ))}
                   </div>
                 )}
                 <div className="settings-row">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -695,6 +695,15 @@ export default function App() {
                     </div>
                   </div>
                 )}
+                <div className="settings-row">
+                  <div className="settings-row-label">
+                    <span className="settings-label">Analysis power</span>
+                    <span className="settings-description">
+                      Controls the AI model used for analysis. Higher power gives more thorough results but takes longer.
+                    </span>
+                  </div>
+                  <PowerSelector value={analysisPower} onChange={setAnalysisPower} />
+                </div>
                 {aiCmd && (
                   <div className="settings-row">
                     <div className="settings-row-label">
@@ -731,15 +740,6 @@ export default function App() {
                     </div>
                   </div>
                 )}
-                <div className="settings-row">
-                  <div className="settings-row-label">
-                    <span className="settings-label">Analysis power</span>
-                    <span className="settings-description">
-                      Controls the AI model used for analysis. Higher power gives more thorough results but takes longer.
-                    </span>
-                  </div>
-                  <PowerSelector value={analysisPower} onChange={setAnalysisPower} />
-                </div>
                 <div className="settings-row settings-row--last">
                   <div className="settings-row-label">
                     <span className="settings-label">Verify findings</span>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -736,7 +736,7 @@ export default function App() {
                   <div className="settings-row-label">
                     <span className="settings-label">Verify findings</span>
                     <span className="settings-description">
-                      After analysis, run a verification pass that re-checks violations and hunts for compliance evidence. Improves grade accuracy at a small extra cost.
+                      After the analysis phase, run a verification agent that re-checks the findings from this run and actively looks for compliance evidence. Improves grade accuracy at a small extra cost.
                     </span>
                   </div>
                   <div className="theme-toggle">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -309,6 +309,7 @@ export default function App() {
   // AI settings
   // -------------------------------------------------------------------------
   const [aiCmd, setAiCmd] = useState(localStorage.getItem('cc-ai-cmd') || '');
+  const [aiModel, setAiModel] = useState(localStorage.getItem('cc-ai-model') || '');
   const [modelFast, setModelFast] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}1`) || '');
   const [modelBalanced, setModelBalanced] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}2`) || '');
   const [modelThorough, setModelThorough] = useState(localStorage.getItem(`${MODEL_STORAGE_PREFIX}3`) || '');
@@ -382,7 +383,7 @@ export default function App() {
   function handleStartEvaluation(payload) {
     const levels = getLevels();
     const subagentModel = levels.find(l => l.level === analysisPower)?.model;
-    startEvaluation({ ...payload, aiCmd: aiCmd || undefined, subagentModel, verifyFindings });
+    startEvaluation({ ...payload, aiCmd: aiCmd || undefined, aiModel: aiModel || undefined, subagentModel, verifyFindings });
   }
 
   function handleEvalDismiss(action) {
@@ -682,9 +683,24 @@ export default function App() {
                     <div className="settings-row-label">
                       <span className="settings-label">Model</span>
                       <span className="settings-description">
-                        Uses your client's default model. Run <code>{aiCmd} --help</code> to see how to change it.
+                        Override the default model for all operations. Leave blank to use your client's default.
                       </span>
                     </div>
+                    <input
+                      type="text"
+                      className="settings-model-input"
+                      value={aiModel}
+                      placeholder="default"
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setAiModel(v);
+                        if (v) {
+                          localStorage.setItem('cc-ai-model', v);
+                        } else {
+                          localStorage.removeItem('cc-ai-model');
+                        }
+                      }}
+                    />
                   </div>
                 )}
                 <div className="settings-row">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -736,7 +736,7 @@ export default function App() {
                   <div className="settings-row-label">
                     <span className="settings-label">Verify findings</span>
                     <span className="settings-description">
-                      After the analysis phase, run a verification agent that re-checks the findings from this run and actively looks for compliance evidence. Improves grade accuracy at a small extra cost.
+                      After analysis, verify findings from the previous evaluation against the current code. Confirms which violations persist, detects fixes, and hunts for missing compliance evidence. Improves grade consistency across runs.
                     </span>
                   </div>
                   <div className="theme-toggle">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -690,13 +690,20 @@ export default function App() {
                     <div className="settings-row-label">
                       <span className="settings-label">Model</span>
                       <span className="settings-description">
-                        Override the AI model for each analysis power level. Leave blank to use the default.
+                        Uses your client's default model. Run <code>{aiCmd} --help</code> to see how to change it.
                       </span>
                     </div>
                   </div>
                 )}
                 {aiCmd && (
-                  <div className="settings-row settings-model-overrides">
+                  <div className="settings-row">
+                    <div className="settings-row-label">
+                      <span className="settings-label">Analysis models</span>
+                      <span className="settings-description">
+                        Override the AI model used by subagents during code evaluation. Leave blank to use the defaults.
+                      </span>
+                    </div>
+                    <div className="settings-model-overrides">
                     {[
                       { label: 'Fast', value: modelFast, setter: setModelFast, level: 1, placeholder: DEFAULT_MODELS[1] },
                       { label: 'Balanced', value: modelBalanced, setter: setModelBalanced, level: 2, placeholder: DEFAULT_MODELS[2] },
@@ -721,6 +728,7 @@ export default function App() {
                         />
                       </div>
                     ))}
+                    </div>
                   </div>
                 )}
                 <div className="settings-row">

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -646,9 +646,9 @@ export default function App() {
                   </div>
                   {availableClients === null ? (
                     <span className="settings-description">Detecting…</span>
-                  ) : availableClients.length > 0 ? (
+                  ) : availableClients.filter((c) => c.id === 'claude').length > 0 ? (
                     <div className="theme-toggle">
-                      {availableClients.map(({ id, label }) => (
+                      {availableClients.filter((c) => c.id === 'claude').map(({ id, label }) => (
                         <button
                           key={id}
                           type="button"
@@ -661,26 +661,18 @@ export default function App() {
                     </div>
                   ) : null}
                 </div>
-                {availableClients !== null && availableClients.length === 0 && (
+                {availableClients !== null && !availableClients.some((c) => c.id === 'claude') && (
                   <div className="settings-row settings-row--last settings-install-guide">
                     <div className="settings-row-label">
-                      <span className="settings-label">No AI client detected</span>
+                      <span className="settings-label">Claude not detected</span>
                       <span className="settings-description">
-                        Install one of the supported CLI tools and restart Quodeq.
+                        Install Claude Code and restart Quodeq.
                       </span>
                     </div>
                     <div className="settings-install-options">
                       <div className="settings-install-item">
                         <span className="settings-install-name">Claude</span>
                         <code className="settings-install-cmd">npm i -g @anthropic-ai/claude-code</code>
-                      </div>
-                      <div className="settings-install-item">
-                        <span className="settings-install-name">Codex</span>
-                        <code className="settings-install-cmd">npm i -g @openai/codex</code>
-                      </div>
-                      <div className="settings-install-item">
-                        <span className="settings-install-name">Copilot</span>
-                        <code className="settings-install-cmd">gh extension install github/gh-copilot</code>
                       </div>
                     </div>
                   </div>

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -342,6 +342,9 @@ export default function App() {
           setAiCmd('');
           localStorage.removeItem('cc-ai-cmd');
         }
+        if (!aiCmd && clients.length > 0) {
+          applyAiCmd(clients[0].id);
+        }
       })
       .catch(() => setAvailableClients([]));
   }, [activePage]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/ui/web/src/features/evaluation/components/powerLevels.js
+++ b/ui/web/src/features/evaluation/components/powerLevels.js
@@ -1,7 +1,27 @@
-export const LEVELS = [
-  { level: 1, model: 'claude-haiku-4-5', label: 'Fast' },
-  { level: 2, model: 'claude-sonnet-4-6', label: 'Balanced' },
-  { level: 3, model: 'claude-opus-4-6', label: 'Thorough' },
-];
+export const DEFAULT_MODELS = {
+  1: 'claude-haiku-4-5',
+  2: 'claude-sonnet-4-6',
+  3: 'claude-opus-4-6',
+};
+
+export const MODEL_STORAGE_PREFIX = 'cc-model-level-';
+
+export function getLevels() {
+  const overrides = {};
+  try {
+    for (const lvl of [1, 2, 3]) {
+      const stored = localStorage.getItem(`${MODEL_STORAGE_PREFIX}${lvl}`);
+      if (stored) overrides[lvl] = stored;
+    }
+  } catch {}
+  return [
+    { level: 1, model: overrides[1] || DEFAULT_MODELS[1], label: 'Fast' },
+    { level: 2, model: overrides[2] || DEFAULT_MODELS[2], label: 'Balanced' },
+    { level: 3, model: overrides[3] || DEFAULT_MODELS[3], label: 'Thorough' },
+  ];
+}
+
+// Static reference for components that don't need live overrides
+export const LEVELS = getLevels();
 
 export const STORAGE_KEY = 'quodeq-analysis-power';

--- a/ui/web/src/features/evaluation/components/powerLevels.js
+++ b/ui/web/src/features/evaluation/components/powerLevels.js
@@ -1,7 +1,7 @@
 export const DEFAULT_MODELS = {
-  1: 'claude-haiku-4-5',
-  2: 'claude-sonnet-4-6',
-  3: 'claude-opus-4-6',
+  1: 'haiku',
+  2: 'sonnet',
+  3: 'opus',
 };
 
 export const MODEL_STORAGE_PREFIX = 'cc-model-level-';

--- a/ui/web/src/styles/base.css
+++ b/ui/web/src/styles/base.css
@@ -1084,6 +1084,49 @@ textarea:focus {
   border-bottom: none;
 }
 
+.settings-model-overrides {
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.settings-model-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-width: 160px;
+}
+
+.settings-model-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.settings-model-input {
+  padding: 6px 10px;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+}
+
+.settings-model-input::placeholder {
+  color: var(--color-text-muted);
+  opacity: 0.6;
+}
+
+.settings-model-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
 .settings-row-label {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Improves evaluation grade consistency and adds model configuration to the dashboard.

### Scoring: severity-weighted compliance dampening
- Dampening ratio now weights findings by severity (critical=8, major=4, minor=1), aligned with deduction penalties
- Prevents minor compliance from cheaply offsetting critical violations
- Same-severity compliance/violation pairs cancel out 1:1 in the ratio

### Verification pass
- After analysis, 1 verification agent re-checks the **previous evaluation's** findings against the current code
- Confirms which violations/compliance are still present and re-adds them (dedup handles overlaps)
- Runs in parallel across dimensions (~5 min added, not sequential)
- Gracefully skips on first run (no previous evaluation)
- Controlled via Settings toggle (default: on) and CLI `--no-verify` / `QUODEQ_NO_VERIFY=1`

### Prompt improvements
- Subagent prompt now emphasizes compliance reporting and the v/c ratio impact
- Severity definitions added for compliance findings (critical/major/minor)
- Stronger stop signal when queue is drained

### Settings UI — Analysis section
- **Client**: Claude only (Codex/Copilot not yet supported)
- **Model**: text input to override the default model for all operations
- **Analysis power**: bar selector (Fast/Balanced/Thorough) — now in Settings too
- **Analysis models**: per-level model override inputs (placeholders: haiku/sonnet/opus)
- **Verify findings**: On/Off toggle with description
- Auto-selects Claude when detected and no client was previously set
- All settings persist in localStorage

## Test plan

- [x] All 457 tests pass
- [x] Scoring weights verified: weighted dampening math correct
- [x] Pipeline wiring verified: verify_findings + n_subagents gate
- [x] Path resolution verified: finds previous run's evidence with real data
- [x] Dedup verified: identical findings merge, different ones kept
- [x] Model flow verified: aliases (haiku/sonnet/opus) → `--model` flag
- [x] UI built and dashboard tested
- [x] Run full evaluation with verification enabled