### PR TITLE
fix: resolve 25 maintainability code-quality violations

### DIFF
--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -171,7 +171,7 @@ def _process_dimension_with_subagents(
     )
 
 
-def _load_plugin_context(config: RunConfig) -> tuple[list[str], _PluginContext]:
+def load_plugin_context(config: RunConfig) -> tuple[list[str], _PluginContext]:
     """Load plugin data and resolve which dimensions to analyze."""
     validate_path_segment(config.plugin_id)
     plugin_dir = config.evaluators_dir / config.plugin_id
@@ -233,7 +233,7 @@ def _process_single_dimension(
 
 def _run_dimensions(config: RunConfig) -> dict[str, Evidence]:
     """Run AI analysis for each dimension and return per-dimension Evidence."""
-    dimensions, ctx = _load_plugin_context(config)
+    dimensions, ctx = load_plugin_context(config)
     result: dict[str, Evidence] = {}
     emit_marker("setup", dimensions=dimensions)
     skipped_count = 0

--- a/src/quodeq/analysis/subagents/file_queue.py
+++ b/src/quodeq/analysis/subagents/file_queue.py
@@ -202,6 +202,9 @@ class FileQueue:
             state = json.loads(raw)
         except json.JSONDecodeError as exc:
             raise FileQueueError(f"Queue file is corrupted: {exc}") from exc
+        version = state.get("version")
+        if version != _QUEUE_VERSION:
+            raise FileQueueError(f"Unsupported queue version: {version} (expected {_QUEUE_VERSION})")
         if not isinstance(state.get("pending"), list):
             raise FileQueueError("Queue file missing 'pending' list")
         if not isinstance(state.get("taken"), list):

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -54,12 +54,12 @@ def _format_findings_summary(jsonl_path: Path) -> str:
     lines: list[str] = []
     for principle, findings in sorted(by_principle.items()):
         lines.append(f"### {principle}")
-        for f in findings:
-            t = f.get("t", "?")
-            file = f.get("file", "?")
-            line_num = f.get("line", "?")
-            severity = f.get("severity", "?")
-            desc = f.get("w", "")
+        for finding in findings:
+            t = finding.get("t", "?")
+            file = finding.get("file", "?")
+            line_num = finding.get("line", "?")
+            severity = finding.get("severity", "?")
+            desc = finding.get("w", "")
             lines.append(f"- {t} [{severity}] `{file}:{line_num}` — {desc}")
         lines.append("")
 

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -97,19 +97,12 @@ _DEFAULT_BASE_AI_ARGS = "--print --output-format stream-json --verbose"
 
 
 def _get_ai_tools(env: dict[str, str] | None = None) -> str:
-    """Return the comma-separated list of AI tools to enable.
-
-    Reads QUODEQ_AI_TOOLS from the environment (default: "Glob,Grep,Read").
-    """
+    """Return AI tools from QUODEQ_AI_TOOLS env var (default: "Glob,Grep,Read")."""
     return (env or os.environ).get("QUODEQ_AI_TOOLS", _DEFAULT_AI_TOOLS)
 
 
 def _get_base_ai_args(env: dict[str, str] | None = None) -> tuple[str, ...]:
-    """Return base CLI arguments for the AI subprocess.
-
-    Reads QUODEQ_AI_BASE_ARGS from the environment
-    (default: "--print --output-format stream-json --verbose").
-    """
+    """Return base AI CLI args from QUODEQ_AI_BASE_ARGS env var."""
     return tuple((env or os.environ).get("QUODEQ_AI_BASE_ARGS", _DEFAULT_BASE_AI_ARGS).split())
 
 _AI_PROVIDERS_PATH = Path(__file__).resolve().parent.parent / "data" / "config" / "ai_providers.json"
@@ -130,25 +123,29 @@ _PROVIDER_CONFIGS_FALLBACK: dict[str, dict] = {
 }
 
 
-def _load_provider_configs() -> dict[str, dict]:
-    """Load AI provider configs from external JSON, falling back to built-in defaults."""
-    try:
-        return json.loads(_AI_PROVIDERS_PATH.read_text())
-    except (OSError, json.JSONDecodeError):
-        return _PROVIDER_CONFIGS_FALLBACK
+class _ProviderConfigCache:
+    """Thread-safe lazy cache for provider configurations."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._configs: dict[str, dict] | None = None
+
+    def get(self) -> dict[str, dict]:
+        if self._configs is None:
+            with self._lock:
+                if self._configs is None:
+                    try:
+                        self._configs = json.loads(_AI_PROVIDERS_PATH.read_text())
+                    except (OSError, json.JSONDecodeError):
+                        self._configs = _PROVIDER_CONFIGS_FALLBACK
+        return self._configs
 
 
-_PROVIDER_CONFIGS: dict[str, dict] | None = None
-_PROVIDER_CONFIGS_LOCK = threading.Lock()
+_provider_config_cache = _ProviderConfigCache()
 
 
 def _get_provider_configs() -> dict[str, dict]:
-    global _PROVIDER_CONFIGS
-    if _PROVIDER_CONFIGS is None:
-        with _PROVIDER_CONFIGS_LOCK:
-            if _PROVIDER_CONFIGS is None:
-                _PROVIDER_CONFIGS = _load_provider_configs()
-    return _PROVIDER_CONFIGS
+    return _provider_config_cache.get()
 
 
 class AnalysisError(RuntimeError):

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -1,6 +1,5 @@
 """Route registration helpers for the action API."""
 from __future__ import annotations
-
 import logging
 import re
 from http import HTTPStatus

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -206,6 +206,11 @@ def _execute_pipeline(args: argparse.Namespace, config: RunConfig, evidence_dir:
     return 0
 
 
+def _no_verify(args: argparse.Namespace, env: dict[str, str] | None = None) -> bool:
+    """Return True if verification should be skipped (CLI flag or env var)."""
+    return args.no_verify or (env or os.environ).get("QUODEQ_NO_VERIFY") == "1"
+
+
 def _build_run_config(
     args: argparse.Namespace, src: Path, plugin_id: str,
     evaluators_dir: Path, evidence_dir: Path,
@@ -228,7 +233,7 @@ def _build_run_config(
             max_duration=args.max_duration if args.max_duration is not None else _env_int(_ENV_MAX_DURATION, None),
             n_subagents=args.n_subagents,
             subagent_model=_subagent_model(),
-            verify_findings=not args.no_verify and os.environ.get("QUODEQ_NO_VERIFY") != "1",
+            verify_findings=not _no_verify(args),
         ),
     )
 

--- a/src/quodeq/config/_fetch_client.py
+++ b/src/quodeq/config/_fetch_client.py
@@ -37,11 +37,15 @@ class FetchClient:
 
     _CIRCUIT_THRESHOLD = 5
 
-    def __init__(self, timeout_s: int = 15, allow_private: bool | None = None) -> None:
+    def __init__(self, timeout_s: int = 15, allow_private: bool | None = None, env: dict[str, str] | None = None) -> None:
         self._lock = threading.Lock()
         self._failures = 0
         self._timeout = timeout_s
-        self._allow_private = allow_private
+        self._env = env
+        if allow_private is not None:
+            self._allow_private: bool = allow_private
+        else:
+            self._allow_private = (self._env or os.environ).get("QUODEQ_ALLOW_PRIVATE_URLS") == "1"
 
     def fetch(self, url: str, headers: dict | None = None) -> str | None:
         """Fetch *url* and return body text, or None on failure.
@@ -54,8 +58,7 @@ class FetchClient:
             _logger.warning("Blocked fetch with disallowed scheme: %s", parsed.scheme)
             return None
         hostname = parsed.hostname or ""
-        allow_private = self._allow_private if self._allow_private is not None else (os.environ.get("QUODEQ_ALLOW_PRIVATE_URLS") == "1")
-        if hostname and _is_private_hostname(hostname) and not allow_private:
+        if hostname and _is_private_hostname(hostname) and not self._allow_private:
             _logger.warning("Blocked fetch to private/internal address: %s", hostname)
             return None
 

--- a/src/quodeq/config/paths.py
+++ b/src/quodeq/config/paths.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
+# Number of parent directory levels from this module to the project root
+# (config -> quodeq -> src).
+_FALLBACK_PARENT_DEPTH = 3
 
 # Bundled data directory shipped inside the package.
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
@@ -110,7 +113,6 @@ def default_paths() -> ConfigPaths:
             return ConfigPaths.from_root(root)
 
     # Walk up from src/quodeq/config/paths.py to project root (3 levels: config -> quodeq -> src)
-    _FALLBACK_PARENT_DEPTH = 3
     if len(module_path.parents) > _FALLBACK_PARENT_DEPTH:
         root = module_path.parents[_FALLBACK_PARENT_DEPTH]
     else:

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
-from pathlib import Path
-
 import os
+from pathlib import Path
 
 from quodeq.core.evidence.model import Evidence, Judgment, PrincipleEvidence, compute_coverage_pct
 from quodeq.shared.utils import open_text

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -41,10 +41,10 @@ def _verify_single_dimension(
 def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
     """Run verification pass on all dimensions in parallel."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
-    from quodeq.analysis.runner import _load_plugin_context
+    from quodeq.analysis.runner import load_plugin_context
 
     work_dir = config.work_dir or config.src
-    _dims, ctx = _load_plugin_context(config)
+    _dims, ctx = load_plugin_context(config)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
 
     log_info(f"Starting verification pass ({len(per_dim_evidence)} dimensions in parallel)...")

--- a/src/quodeq/core/types/_serialization.py
+++ b/src/quodeq/core/types/_serialization.py
@@ -1,3 +1,4 @@
+"""Dataclass-to-camelCase-dict serialization utilities."""
 from __future__ import annotations
 
 import dataclasses

--- a/src/quodeq/core/types/mappers.py
+++ b/src/quodeq/core/types/mappers.py
@@ -45,6 +45,16 @@ from ._mapper_entities import (
 # ---------------------------------------------------------------------------
 
 
+def _extract_totals(raw: dict[str, object]) -> Totals | None:
+    """Parse a 'totals' field that may be a Totals instance, a raw dict, or absent."""
+    totals_raw = raw.get("totals")
+    if isinstance(totals_raw, Totals):
+        return totals_raw
+    if isinstance(totals_raw, dict):
+        return parse_totals(totals_raw)
+    return None
+
+
 def parse_principle_grade(raw: dict[str, object]) -> PrincipleGrade:
     return PrincipleGrade(
         name=_opt_str(raw.get("name")),
@@ -67,13 +77,7 @@ def parse_parsed_report(raw: dict[str, object]) -> ParsedReport:
     if isinstance(detail_raw, list):
         detail_principles = list(detail_raw)
 
-    totals_raw = raw.get("totals")
-    if isinstance(totals_raw, Totals):
-        totals = totals_raw
-    elif isinstance(totals_raw, dict):
-        totals = parse_totals(totals_raw)
-    else:
-        totals = None
+    totals = _extract_totals(raw)
 
     return ParsedReport(
         dimension=_opt_str(raw.get("dimension")),
@@ -114,13 +118,7 @@ def parse_dimension_result(raw: dict[str, object]) -> DimensionResult:
     violations = _parse_finding_list(raw.get("violations"))
     compliance = _parse_finding_list(raw.get("compliance"))
 
-    totals_raw = raw.get("totals")
-    if isinstance(totals_raw, Totals):
-        totals = totals_raw
-    elif isinstance(totals_raw, dict):
-        totals = parse_totals(totals_raw)
-    else:
-        totals = None
+    totals = _extract_totals(raw)
 
     return DimensionResult(
         dimension=dim,

--- a/src/quodeq/dashboard/_api_health.py
+++ b/src/quodeq/dashboard/_api_health.py
@@ -59,14 +59,14 @@ def action_api_healthy(base_url: str) -> bool:
 def wait_for_action_api(base_url: str, timeout_s: float = _DEFAULT_WAIT_TIMEOUT_S) -> None:
     """Block until the action API becomes healthy, or raise TimeoutError."""
     log_info(f"Waiting for Action API at {base_url}...")
-    deadline = time.monotonic() + timeout_s
+    start = time.monotonic()
     attempts = 0
-    while time.monotonic() < deadline:
+    while time.monotonic() - start < timeout_s:
         if action_api_healthy(base_url):
             return None
         attempts += 1
         if attempts % 10 == 0:
-            elapsed = round(time.monotonic() + timeout_s - deadline, 1)
+            elapsed = round(time.monotonic() - start, 1)
             log_info(f"Still waiting for Action API ({elapsed:.0f}s elapsed)...")
         time.sleep(_HEALTH_POLL_INTERVAL_S)
     raise TimeoutError(f"Action API did not become ready within {timeout_s} seconds.")

--- a/src/quodeq/data/fs/project_resolver.py
+++ b/src/quodeq/data/fs/project_resolver.py
@@ -15,17 +15,36 @@ from typing import Protocol
 _INDEX_FILE = "project_index.json"
 _MAX_LEGACY_SCAN = 500
 
-# mtime-based cache for _load_index to avoid re-reading on every call.
-# Intentionally module-level for cross-request caching; use clear_index_cache()
-# for testing isolation.
-_index_lock = threading.Lock()
-_index_cache: dict[Path, tuple[float, dict[str, str]]] = {}
+class _IndexCache:
+    """Thread-safe mtime-based cache for the project index file."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._data: dict[Path, tuple[float, dict[str, str]]] = {}
+
+    def get(self, key: Path) -> tuple[float, dict[str, str]] | None:
+        with self._lock:
+            return self._data.get(key)
+
+    def set(self, key: Path, value: tuple[float, dict[str, str]]) -> None:
+        with self._lock:
+            self._data[key] = value
+
+    def pop(self, key: Path) -> None:
+        with self._lock:
+            self._data.pop(key, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+_index_cache = _IndexCache()
 
 
 def clear_index_cache() -> None:
     """Clear the mtime-based index cache (useful for testing and isolation)."""
-    with _index_lock:
-        _index_cache.clear()
+    _index_cache.clear()
 
 
 class ProjectRepository(Protocol):
@@ -69,24 +88,21 @@ def _load_index(reports_dir: Path) -> dict[str, str]:
         mtime = index_path.stat().st_mtime
     except OSError:
         return {}
-    with _index_lock:
-        cached = _index_cache.get(index_path)
-        if cached is not None and cached[0] == mtime:
-            return dict(cached[1])  # return a copy so callers can mutate safely
+    cached = _index_cache.get(index_path)
+    if cached is not None and cached[0] == mtime:
+        return dict(cached[1])  # return a copy so callers can mutate safely
     try:
         data = json.loads(index_path.read_text())
     except (OSError, json.JSONDecodeError):
         return {}
-    with _index_lock:
-        _index_cache[index_path] = (mtime, dict(data))
+    _index_cache.set(index_path, (mtime, dict(data)))
     return data
 
 
 def _save_index(reports_dir: Path, index: dict[str, str]) -> None:
     """Write the project index file atomically."""
     index_path = reports_dir / _INDEX_FILE
-    with _index_lock:
-        _index_cache.pop(index_path, None)  # invalidate cache
+    _index_cache.pop(index_path)  # invalidate cache
     try:
         fd, tmp = tempfile.mkstemp(dir=reports_dir, suffix=".tmp")
         try:

--- a/src/quodeq/engine/_runner_markers.py
+++ b/src/quodeq/engine/_runner_markers.py
@@ -9,6 +9,7 @@ from typing import Any, Callable
 from quodeq.shared.logging import log_info
 
 CC_MARKER_KEY = "_cc"  # shared constant for structured job-tracking markers
+_SECONDS_PER_MINUTE = 60
 
 
 def emit_marker(phase: str, **kwargs: Any) -> None:
@@ -28,8 +29,8 @@ def cleanup_stream(stream_file: Path) -> None:
 def make_heartbeat(dim_name: str, idx: int, total: int) -> Callable[[int, dict], None]:
     """Return a heartbeat callback that prints progress to stdout."""
     def _cb(elapsed: int, progress: dict) -> None:
-        secs = elapsed % 60
-        mins = elapsed // 60
+        secs = elapsed % _SECONDS_PER_MINUTE
+        mins = elapsed // _SECONDS_PER_MINUTE
         evidence = progress.get("evidence", 0)
         log_info(f"  [{idx}/{total}] {dim_name} | {mins}m{secs:02d}s | {evidence} findings")
     return _cb

--- a/src/quodeq/engine/mcp_findings.py
+++ b/src/quodeq/engine/mcp_findings.py
@@ -1,9 +1,9 @@
-"""Re-export for backward compatibility — moved to quodeq.analysis.mcp.findings_server."""
+"""Re-export for backward compatibility — moved to quodeq.analysis.mcp.findings_server.
+
+Reference utilities (ref_label, load_compiled_refs) should be imported
+directly from ``quodeq.engine._ref_utils``.
+"""
 from quodeq.analysis.mcp.findings_server import (  # noqa: F401
     FindingsRouter,
     main,
-)
-from quodeq.engine._ref_utils import (  # noqa: F401
-    ref_label,
-    load_compiled_refs,
 )

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -29,9 +29,6 @@ def create_accumulated_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]
     return OrderedDict(), threading.Lock()
 
 
-_ACC_DIM_CACHE, _ACC_DIM_LOCK = create_accumulated_cache()
-
-
 _DEFAULT_ACC_CACHE_MAX = 256
 
 
@@ -40,15 +37,6 @@ def _acc_dim_cache_max(override: int | None = None) -> int:
     if override is not None:
         return override
     return int(os.environ.get("QUODEQ_ACC_CACHE_MAX", str(_DEFAULT_ACC_CACHE_MAX)))
-
-
-def _make_acc_dimension_fetcher(
-    reports_root: Path, project: str,
-) -> Callable[[str], list[DimensionResult]]:
-    """Return a cached fetcher for run dimension data (LRU, bounded)."""
-    return make_lru_dimension_fetcher(
-        reports_root, project, _ACC_DIM_CACHE, _ACC_DIM_LOCK, _acc_dim_cache_max(),
-    )
 
 
 def _read_all_run_data(

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -64,9 +64,6 @@ def create_dimension_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]],
     return OrderedDict(), threading.Lock()
 
 
-_RUN_DIM_CACHE, _RUN_DIM_LOCK = create_dimension_cache()
-
-
 def _collect_previous_scores(
     runs: list[RunInfo], selected_index: int, selected_dim_names: set[str],
     get_run_dimensions: Callable[[str], list[DimensionResult]],

--- a/src/quodeq/services/plugin_discovery.py
+++ b/src/quodeq/services/plugin_discovery.py
@@ -42,15 +42,18 @@ class _PluginCache:
 _plugin_cache = _PluginCache()
 
 
-def discover_plugins(evaluators_dir: Path | None = None) -> list[PluginInfo]:
+def discover_plugins(evaluators_dir: Path | None = None, *, cache: _PluginCache | None = None) -> list[PluginInfo]:
     """Scan the evaluators directory and return plugin metadata.
 
     Results are cached for _PLUGIN_CACHE_TTL seconds so that plugins installed
     at runtime (without a process restart) are picked up on the next request
     after the TTL expires.
+
+    Pass *cache* to override the module-level cache (useful for testing).
     """
+    _cache = cache if cache is not None else _plugin_cache
     if evaluators_dir is None:
-        cached = _plugin_cache.get()
+        cached = _cache.get()
         if cached is not None:
             return cached
     evaluators_root = evaluators_dir or default_paths().evaluators_dir
@@ -72,5 +75,5 @@ def discover_plugins(evaluators_dir: Path | None = None) -> list[PluginInfo]:
         except (KeyError, ValueError, OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             _logger.warning("Skipping plugin %s: %s", child.name, exc)
             continue
-    _plugin_cache.set(result)
+    _cache.set(result)
     return result

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -109,14 +109,6 @@ def _parse_jsonl_findings(
     return violations, compliance
 
 
-def _count_files_in_stream(stream_path: Path) -> int:
-    """Count unique file paths read by the AI in a stream file.
-
-    Delegates to :func:`quodeq.engine.analysis_stream.count_files_in_stream`.
-    """
-    return len(count_files_in_stream(stream_path))
-
-
 def parse_violations_from_jsonl(
     jsonl_path: Path, stream_path: Path | None, ctx: ViolationContext,
     compiled_dir: Path | None = None,
@@ -129,7 +121,7 @@ def parse_violations_from_jsonl(
     except OSError as exc:
         _logger.warning("Failed to read findings file: %s", exc)
         return None
-    files_read = _count_files_in_stream(stream_path) if stream_path and stream_path.exists() else 0
+    files_read = len(count_files_in_stream(stream_path)) if stream_path and stream_path.exists() else 0
     return _build_violation_response(
         ctx, violations, compliance,
         _ResponseOptions(

--- a/src/quodeq/shared/utils.py
+++ b/src/quodeq/shared/utils.py
@@ -68,18 +68,27 @@ class Config:
 ACTION_API_MODULE = "quodeq.action_api"
 
 
-_config_lock = threading.Lock()
-_config_instance: Config | None = None
+class _ConfigHolder:
+    """Thread-safe lazy holder for the singleton Config instance."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._instance: Config | None = None
+
+    def get(self) -> Config:
+        if self._instance is None:
+            with self._lock:
+                if self._instance is None:
+                    self._instance = Config.from_file(_DEFAULTS_PATH)
+        return self._instance
+
+
+_config_holder = _ConfigHolder()
 
 
 def _get_config() -> Config:
     """Return the lazily-loaded singleton Config instance (thread-safe)."""
-    global _config_instance
-    if _config_instance is None:
-        with _config_lock:
-            if _config_instance is None:
-                _config_instance = Config.from_file(_DEFAULTS_PATH)
-    return _config_instance
+    return _config_holder.get()
 
 
 IS_WIN32: bool = sys.platform == "win32"
@@ -135,9 +144,9 @@ def get_ai_model(env: dict[str, str] | None = None) -> str | None:
     return (env or os.environ).get("AI_MODEL") or None
 
 
-def _env_int(var: str, default: int) -> int:
+def _env_int(var: str, default: int, env: dict[str, str] | None = None) -> int:
     """Read an environment variable as an int, warn and return *default* on failure."""
-    raw = os.environ.get(var)
+    raw = (env or os.environ).get(var)
     if raw is not None:
         try:
             return int(raw)

--- a/tests/engine/test_mcp_findings.py
+++ b/tests/engine/test_mcp_findings.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from quodeq.engine import mcp_findings
+from quodeq.engine._ref_utils import load_compiled_refs
 
 from tests.engine.conftest import _make_request, _run_server
 
@@ -179,7 +180,7 @@ class TestLoadCompiledRefs:
             ]},
         ]}]}
         (compiled_dir / "reliability.json").write_text(json.dumps(data))
-        result = mcp_findings.load_compiled_refs(str(compiled_dir), "reliability")
+        result = load_compiled_refs(str(compiled_dir), "reliability")
         assert "R-FT-1" in result
         assert result["R-FT-1"][0]["label"] == "CWE-391"
         assert "R-FT-2" in result
@@ -195,16 +196,16 @@ class TestLoadCompiledRefs:
             ]},
         ]}]}
         (compiled_dir / "maintainability.json").write_text(json.dumps(data))
-        result = mcp_findings.load_compiled_refs(str(compiled_dir), "maintainability")
+        result = load_compiled_refs(str(compiled_dir), "maintainability")
         assert len(result["R-1"]) == 1
         assert result["R-1"][0]["label"] == "CWE-123"
 
     def test_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
-        result = mcp_findings.load_compiled_refs(str(tmp_path / "missing"), "security")
+        result = load_compiled_refs(str(tmp_path / "missing"), "security")
         assert result == {}
 
     def test_returns_empty_without_args(self) -> None:
-        assert mcp_findings.load_compiled_refs(None, None) == {}
+        assert load_compiled_refs(None, None) == {}
 
 
 class TestMainEntryPoint:

--- a/tools/audit_cwe_abstraction.py
+++ b/tools/audit_cwe_abstraction.py
@@ -147,8 +147,15 @@ def _print_category(label: str, entries: list[dict], *, show_rationale: bool = F
             print(f"           Rationale: {r['mapping_rationale'][:_MAX_RATIONALE_DISPLAY]}")
 
 
+def _write_results_json(results: list[dict]) -> Path:
+    """Write the full audit results to a JSON file and return the output path."""
+    output_path = Path(__file__).resolve().parent.parent / "standards" / "cwe" / "audit.json"
+    output_path.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n")
+    return output_path
+
+
 def _print_results(results: list[dict], *, problems_only: bool) -> None:
-    """Print categorized audit results to stdout and write JSON output."""
+    """Print categorized audit results to stdout."""
     categorized = _categorize_results(results)
     prohibited = categorized["prohibited"]
     discouraged = categorized["discouraged"]
@@ -174,10 +181,6 @@ def _print_results(results: list[dict], *, problems_only: bool) -> None:
         print(f"{'=' * _TERMINAL_WIDTH}")
         for r in unknown:
             print(f"  CWE-{r['id']:4d} [{r['abstraction']:10s}] Usage={r['mapping_usage']} — {r['name']}")
-
-    output_path = Path(__file__).resolve().parent.parent / "standards" / "cwe" / "audit.json"
-    output_path.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n")
-    print(f"\nFull results written to {output_path}")
 
 
 def main() -> None:
@@ -213,6 +216,8 @@ def main() -> None:
         time.sleep(_RATE_LIMIT_SLEEP_S)
 
     _print_results(results, problems_only=args.problems)
+    output_path = _write_results_json(results)
+    print(f"\nFull results written to {output_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Resolve 25 maintainability and code-quality violations across 23 files
- Encapsulate global mutable state in holder classes, remove dead globals and unused re-exports
- Fix private cross-layer imports, variable shadowing, magic numbers, and import ordering
- Extract helpers to deduplicate logic and reduce file length below 300-line limits
- Make env-var reads injectable for testability

## Changed files
`runner.py`, `file_queue.py`, `verify.py`, `subprocess.py`, `routes.py`, `cli.py`, `_fetch_client.py`, `paths.py`, `parser.py`, `report.py`, `_serialization.py`, `mappers.py`, `_api_health.py`, `project_resolver.py`, `_runner_markers.py`, `mcp_findings.py`, `accumulated.py`, `dashboard.py`, `plugin_discovery.py`, `violations_parsing.py`, `utils.py`, `test_mcp_findings.py`, `audit_cwe_abstraction.py`

## Test plan
- [x] Run full test suite (`uv run pytest`)
- [x] Verify no regressions in analysis pipeline
- [x] Confirm dashboard API health endpoint works correctly