### PR TITLE
feat: context rotation + mechanical verification

### DIFF
--- a/src/quodeq/analysis/subagents/file_queue.py
+++ b/src/quodeq/analysis/subagents/file_queue.py
@@ -102,13 +102,20 @@ class FileQueue:
       so files can be accounted for even after a crash.
     """
 
-    def __init__(self, queue_path: Path, files: list[str] | None = None):
+    def __init__(
+        self, queue_path: Path, files: list[str] | None = None,
+        max_files_per_agent: int = 0,
+    ):
         """Create or open a file queue.
 
         Args:
             queue_path: Path to the queue JSON file.
             files: If provided, initialise the queue with this file list.
                    If *None*, the queue must already exist on disk.
+            max_files_per_agent: When > 0, each agent (by agent_id) can take
+                at most this many files before ``take()`` returns empty.
+                The agent finishes, and the pool spawns a fresh one with
+                clean context. 0 means unlimited.
 
         Raises:
             FileQueueError: If *files* is None and the queue file doesn't exist.
@@ -117,7 +124,10 @@ class FileQueue:
         self._lock_path = self._path.with_suffix(".lock")
 
         if files is not None:
-            self._write_state({"version": _QUEUE_VERSION, "pending": list(files), "taken": []})
+            state: dict = {"version": _QUEUE_VERSION, "pending": list(files), "taken": []}
+            if max_files_per_agent > 0:
+                state["max_files_per_agent"] = max_files_per_agent
+            self._write_state(state)
         elif not self._path.exists():
             raise FileQueueError(f"Queue file not found: {self._path}")
 
@@ -128,12 +138,25 @@ class FileQueue:
     def take(self, count: int = 5, agent_id: str = "") -> list[str]:
         """Atomically remove and return the next *count* files.
 
-        Returns an empty list when the queue is drained.
+        Returns an empty list when the queue is drained or the agent has
+        reached its ``max_files_per_agent`` limit.
         """
         if count < 1:
             return []
         with self._locked():
             state = self._read_state()
+
+            # Enforce per-agent file limit for context rotation
+            max_per_agent = state.get("max_files_per_agent", 0)
+            if max_per_agent > 0 and agent_id:
+                agent_total = sum(
+                    len(e["files"]) for e in state["taken"] if e.get("agent") == agent_id
+                )
+                remaining_budget = max_per_agent - agent_total
+                if remaining_budget <= 0:
+                    return []
+                count = min(count, remaining_budget)
+
             pending = state["pending"]
             batch = pending[:count]
             if not batch:

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -20,6 +20,8 @@ from quodeq.shared.logging import log_info, log_warning
 if TYPE_CHECKING:
     from quodeq.analysis.runner import RunConfig
 
+_MAX_FILES_PER_AGENT = 30
+
 
 @dataclass
 class DimensionCallbacks:
@@ -141,14 +143,18 @@ def process_dimension_with_subagents(
         stream_file, jsonl_file = callbacks.run_analysis(config, dim_id, prompt, idx, ctx)
         return callbacks.parse_evidence(config, dim_id, stream_file, jsonl_file, ctx)
 
-    # 2. Create queue
+    # 2. Run mechanical verification (fast, no AI — copies confirmed previous findings)
+    from quodeq.analysis.subagents.verify import run_verify_for_dimension
+    run_verify_for_dimension(config, dim_id, evidence_dir)
+
+    # 3. Create queue with per-agent file limit for context rotation
     queue_path = evidence_dir / f"{dim_id}_queue.json"
-    FileQueue(queue_path, files)
+    FileQueue(queue_path, files, max_files_per_agent=_MAX_FILES_PER_AGENT)
     log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {len(files)} files queued for {config.options.n_subagents} subagents")
 
-    # 3. Build prompt and launch pool
+    # 4. Build prompt and launch pool
     prompt = _build_subagent_prompt(config, dim_id, ctx)
     pool, results = _launch_pool(config, dim_id, evidence_dir, queue_path, prompt)
 
-    # 4. Collect and return evidence
+    # 5. Collect and return evidence
     return _collect_evidence(config, dim_id, evidence_dir, results, ctx)

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -1,20 +1,25 @@
-"""Post-analysis verification pass — re-checks previous run's findings for consistency."""
+"""Mechanical verification — re-checks previous findings against current code.
+
+Instead of one big AI agent re-exploring the codebase, iterate over each
+previous finding mechanically:
+
+1. Read the finding (file, line, snippet, principle)
+2. Check if the file still exists and the code is still there
+3. If confirmed, copy the finding to the current run's JSONL
+
+Fast, zero AI tokens, runs in <1 second.
+"""
 from __future__ import annotations
 
 import json
 from pathlib import Path
 from typing import Any
 
-from quodeq.analysis.subprocess import AnalysisConfig, run_analysis
-from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
 from quodeq.data.fs.report_parser.runs import list_runs
-from quodeq.core.evidence.model import Evidence
 from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt, load_template
-from quodeq.shared.logging import log_info, log_success, log_warning
+from quodeq.shared.logging import log_info, log_success
 from quodeq.shared.utils import open_text
 
-_DEFAULT_VERIFY_AGENTS = 1
-_DEFAULT_VERIFY_BUDGET = 300  # 5 minutes per verifier
 _VERIFY_TEMPLATE = "verify.md"
 
 
@@ -28,6 +33,79 @@ def _find_previous_evidence(reports_root: Path, project_uuid: str, current_run_i
         if prev_jsonl.exists() and prev_jsonl.stat().st_size > 0:
             return prev_jsonl
     return None
+
+
+def _load_previous_findings(jsonl_path: Path) -> list[dict]:
+    """Load all findings from a JSONL file."""
+    findings: list[dict] = []
+    if not jsonl_path.exists():
+        return findings
+    try:
+        with open_text(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    if entry.get("p") and entry.get("t") in ("violation", "compliance"):
+                        findings.append(entry)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        pass
+    return findings
+
+
+def _mechanical_check(finding: dict, src: Path) -> str:
+    """Check if a finding's code location still exists.
+
+    Returns:
+        "confirmed" — file and snippet still match
+        "gone" — file deleted or line changed completely
+        "ambiguous" — file exists but code changed, needs AI judgment
+    """
+    rel_path = finding.get("file", "")
+    if not rel_path:
+        return "gone"
+
+    file_path = src / rel_path
+    if not file_path.exists():
+        return "gone"
+
+    try:
+        lines = file_path.read_text(errors="ignore").splitlines()
+    except OSError:
+        return "gone"
+
+    target_line = finding.get("line", 0)
+    snippet = finding.get("snippet", "").strip()
+
+    if not snippet:
+        # No snippet to match — file exists, assume ambiguous
+        return "ambiguous"
+
+    # Check exact line match first
+    if 0 < target_line <= len(lines):
+        line_content = lines[target_line - 1]
+        if snippet in line_content or line_content.strip() in snippet:
+            return "confirmed"
+
+    # Check nearby lines (code may have shifted by a few lines)
+    search_start = max(0, target_line - 10)
+    search_end = min(len(lines), target_line + 10)
+    for i in range(search_start, search_end):
+        if snippet in lines[i] or lines[i].strip() in snippet:
+            return "confirmed"
+
+    # File exists but snippet not found nearby — code changed
+    return "ambiguous"
+
+
+def _write_finding(finding: dict, output_fh: Any) -> None:
+    """Append a finding to the JSONL output file."""
+    output_fh.write(json.dumps(finding) + "\n")
+    output_fh.flush()
 
 
 def _format_findings_summary(jsonl_path: Path) -> str:
@@ -90,91 +168,85 @@ def _build_verify_prompt(
     )
 
 
-def run_verification_pass(
-    config: Any,
-    dim_id: str,
-    ctx: Any,
-    evidence_dir: Path,
-    *,
-    n_agents: int = _DEFAULT_VERIFY_AGENTS,
-    max_duration: int = _DEFAULT_VERIFY_BUDGET,
-) -> int:
-    """Re-check the previous run's findings against the current code.
-
-    Reads violations/compliance from the most recent previous evaluation,
-    then launches verification agents that confirm which are still present
-    and hunt for missing compliance evidence. New findings are appended to
-    the current run's JSONL (dedup prevents duplicates).
-
-    Returns the number of new findings added, or 0 if no previous run exists.
-    """
-    # Find the previous run's evidence.
-    # Layout: reports_base / project_uuid / run_id / evidence[/target_name]
-    # Walk up from evidence_dir until we find the "evidence" directory name
-    # to locate the run directory reliably for both flat and multi-target.
+def _resolve_evidence_paths(evidence_dir: Path) -> tuple[str, str, Path] | None:
+    """Walk up from evidence_dir to find run_id, project_uuid, reports_base."""
     edir = Path(evidence_dir)
     while edir.name != "evidence" and edir != edir.parent:
         edir = edir.parent
     if edir.name != "evidence":
+        return None
+    run_dir = edir.parent
+    return run_dir.name, run_dir.parent.name, run_dir.parent.parent
+
+
+def run_mechanical_verify(
+    src: Path,
+    prev_findings: list[dict],
+    output_jsonl: Path,
+) -> tuple[int, int, list[dict]]:
+    """Mechanically verify findings against current code.
+
+    Returns (confirmed_count, gone_count, ambiguous_findings).
+    """
+    confirmed = 0
+    gone = 0
+    ambiguous: list[dict] = []
+
+    with open(output_jsonl, "a") as fh:
+        for finding in prev_findings:
+            status = _mechanical_check(finding, src)
+            if status == "confirmed":
+                _write_finding(finding, fh)
+                confirmed += 1
+            elif status == "gone":
+                gone += 1
+            else:
+                ambiguous.append(finding)
+
+    return confirmed, gone, ambiguous
+
+
+def run_verify_for_dimension(
+    config: Any,
+    dim_id: str,
+    evidence_dir: Path,
+) -> int:
+    """Run mechanical verification for a dimension.
+
+    1. Find previous run's JSONL
+    2. For each finding: check if file/snippet still exists
+    3. Confirmed findings → copy to current JSONL
+    4. Gone findings → drop
+    5. Ambiguous findings → drop (conservative; analysis agents will re-discover if real)
+
+    Returns number of findings carried forward.
+    """
+    if not getattr(config, 'options', None) or not config.options.verify_findings:
+        return 0
+
+    paths = _resolve_evidence_paths(evidence_dir)
+    if paths is None:
         log_info(f"  [{dim_id}] Cannot locate evidence root — skipping verification")
         return 0
-    run_dir = edir.parent           # .../project_uuid/run_id
-    current_run_id = run_dir.name
-    project_uuid = run_dir.parent.name
-    reports_base = run_dir.parent.parent
+
+    current_run_id, project_uuid, reports_base = paths
 
     prev_jsonl = _find_previous_evidence(reports_base, project_uuid, current_run_id, dim_id)
     if prev_jsonl is None:
-        log_info(f"  [{dim_id}] No previous evaluation found — skipping verification")
+        log_info(f"  [{dim_id}] No previous evaluation — skipping verification")
         return 0
 
-    findings_summary = _format_findings_summary(prev_jsonl)
-    if "_No findings" in findings_summary:
+    prev_findings = _load_previous_findings(prev_jsonl)
+    if not prev_findings:
         return 0
 
-    jsonl_path = evidence_dir / f"{dim_id}_evidence.jsonl"
-    prompt = _build_verify_prompt(config, dim_id, ctx, findings_summary)
-    compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
+    log_info(f"  [{dim_id}] Verifying {len(prev_findings)} previous findings mechanically")
 
-    # Count findings before verification
-    before_count = _count_findings(jsonl_path)
+    output_jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
+    confirmed, gone, ambiguous = run_mechanical_verify(config.src, prev_findings, output_jsonl)
 
-    log_info(f"  [{dim_id}] Verifying previous run findings ({n_agents} agents)")
-
-    for i in range(n_agents):
-        stream_file = evidence_dir / f"{dim_id}_verify_{i}.stream"
-        ac = AnalysisConfig(
-            jsonl_file=jsonl_path,
-            compiled_dir=compiled_dir,
-            dimension=dim_id,
-            max_duration=max_duration,
-            agent_id=f"verify-{i}",
-        )
-        try:
-            run_analysis(
-                work_dir=config.src,
-                prompt=prompt,
-                stream_file=stream_file,
-                config=ac,
-            )
-        except Exception as exc:
-            log_info(f"  [{dim_id}] Verifier {i} finished with: {exc}")
-
-    # Deduplicate after all verifiers have appended
-    deduplicate_jsonl(jsonl_path)
-
-    after_count = _count_findings(jsonl_path)
-    new_findings = after_count - before_count
-    log_success(f"  [{dim_id}] Verification complete: +{new_findings} findings from previous run check")
-    return new_findings
-
-
-def _count_findings(jsonl_path: Path) -> int:
-    """Count non-empty lines in a JSONL file."""
-    if not jsonl_path.exists():
-        return 0
-    try:
-        with open_text(jsonl_path) as f:
-            return sum(1 for line in f if line.strip())
-    except OSError:
-        return 0
+    log_success(
+        f"  [{dim_id}] Verification: {confirmed} confirmed, "
+        f"{gone} gone, {len(ambiguous)} ambiguous (dropped)"
+    )
+    return confirmed

--- a/src/quodeq/core/scoring/report.py
+++ b/src/quodeq/core/scoring/report.py
@@ -7,74 +7,21 @@ from quodeq.core.scoring.engine import score_evidence
 from quodeq.analysis.report import write_dimension_report
 from quodeq.analysis.runner import RunConfig, run_per_dimension
 from quodeq.engine._runner_markers import cleanup_stream
-from quodeq.shared.logging import log_info
 
 _NUMERICAL_MODE = "numerical"
 _NA_LABEL = "N/A"
 
 
-def _verify_single_dimension(
-    config: RunConfig, dimension: str, files_read: int,
-    ctx: object, compiled_dir: Path | None,
-) -> tuple[str, object]:
-    """Run verification for one dimension and return (dimension, updated_evidence)."""
-    from quodeq.analysis.subagents.verify import run_verification_pass
-    from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
-
-    work_dir = config.work_dir or config.src
-    run_verification_pass(config, dimension, ctx, work_dir)
-    jsonl_path = work_dir / f"{dimension}_evidence.jsonl"
-    ev = parse_jsonl_to_evidence(
-        jsonl_path,
-        EvidenceContext(
-            language=config.language,
-            repository=str(config.src),
-            date_str=ctx.date_str,
-            source_file_count=config.source_file_count,
-            files_read=files_read,
-            module=config.target.name if config.target else "",
-        ),
-        compiled_dir=compiled_dir,
-    )
-    return dimension, ev
-
-
-def _run_verification(config: RunConfig, per_dim_evidence: dict) -> dict:
-    """Run verification pass on all dimensions in parallel."""
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-    from quodeq.analysis.runner import load_analysis_context
-
-    work_dir = config.work_dir or config.src
-    _dims, ctx = load_analysis_context(config)
-    compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
-
-    log_info(f"Starting verification pass ({len(per_dim_evidence)} dimensions in parallel)...")
-    with ThreadPoolExecutor(max_workers=len(per_dim_evidence)) as pool:
-        futures = {
-            pool.submit(
-                _verify_single_dimension,
-                config, dim, per_dim_evidence[dim].files_read, ctx, compiled_dir,
-            ): dim
-            for dim in per_dim_evidence
-        }
-        for future in as_completed(futures):
-            dim, ev = future.result()
-            per_dim_evidence[dim] = ev
-
-    return per_dim_evidence
-
-
 def run_full(config: RunConfig, output_dir: Path, mode: str = _NUMERICAL_MODE) -> dict:
-    """Full pipeline: run per-dimension → verify → score each → write reports.
+    """Full pipeline: run per-dimension → score each → write reports.
+
+    Verification runs mechanically before each dimension's subagent pool
+    (inside process_dimension_with_subagents), not as a separate phase.
 
     Returns dict of {dimension: overall_score_str}.
     """
     work_dir = config.work_dir or config.src
     per_dim_evidence = run_per_dimension(config)
-
-    # Verification pass: re-check violations + hunt for compliance evidence
-    if config.options.verify_findings and config.options.n_subagents > 1:
-        per_dim_evidence = _run_verification(config, per_dim_evidence)
 
     results: dict[str, str] = {}
 


### PR DESCRIPTION
## Summary

- **Context rotation**: Each analysis agent processes at most 30 files before the queue returns empty. Pool spawns a fresh agent with clean context. 300 files / 30 per agent = 10 agent lifecycles across 5 parallel slots. ~7% extra token cost for consistent quality.
- **Mechanical verification**: Replace the 5-minute AI verify agent with pure file I/O. For each previous finding: check if the file exists and the snippet is still at the expected line. Confirmed → copy to current JSONL. Gone/ambiguous → drop. Runs in <1 second.
- **Remove separate verify phase**: No more sequential post-analysis verification. The `_run_verification` / `_verify_single_dimension` code is deleted from `scoring/report.py`.
- **Simplified pool**: SubagentPool is back to a clean single-responsibility design — no verify agent threading, no mixed prompt types.

## What changed

| File | Change |
|------|--------|
| `file_queue.py` | `max_files_per_agent` persisted in queue JSON; `take()` enforces per-agent limit |
| `pool.py` | Removed verify agent logic; simplified back to analysis-only pool with respawn |
| `runner.py` | Calls `run_verify_for_dimension()` before pool; queue created with `max_files_per_agent=30` |
| `verify.py` | Rewritten: mechanical snippet matching instead of AI agent |
| `scoring/report.py` | Removed `_run_verification` / `_verify_single_dimension` |

## Test plan

- [x] `uv run pytest tests/ -x` — 381 tests pass
- [x] First run (no previous evidence) → verify skipped, pool runs normally
- [x] Second run → mechanical verify confirms/drops previous findings in <1s
- [x] Agents respawn after 30 files with fresh context
- [x] `--no-verify` flag still skips verification