### PR TITLE
feat: reduce token usage — file-based standards, MCP auto-fill, leaner prompts

### DIFF
--- a/src/quodeq/analysis/mcp/dispatch.py
+++ b/src/quodeq/analysis/mcp/dispatch.py
@@ -27,19 +27,18 @@ REPORT_FINDING_DESC = (
 REPORT_FINDING_SCHEMA = {
     "type": "object",
     "properties": {
-        "p": {"type": "string", "description": "Sub-characteristic name (the ### heading from the checklist, e.g. 'Modularity', 'Analyzability'). NEVER a requirement ID."},
+        "req": {"type": "string", "description": "Requirement ID from the standards checklist (e.g. 'M-MOD-1', 'S-CON-3'). Server auto-fills principle name and dimension from this."},
         "t": {"type": "string", "enum": ["violation", "compliance"], "description": "Finding type"},
-        "d": {"type": "string", "description": "Dimension being evaluated"},
-        "w": {"type": "string", "description": "Short description of the finding"},
         "file": {"type": "string", "description": "File path relative to repo root"},
         "line": {"type": "integer", "description": "Line number"},
         "snippet": {"type": "string", "description": "Relevant code snippet (under 200 chars)"},
         "severity": {"type": "string", "enum": ["critical", "major", "minor"], "description": "Severity level"},
-        "vt": {"type": "string", "description": "Violation type identifier"},
+        "w": {"type": "string", "description": "Short description of the finding"},
         "reason": {"type": "string", "description": "Why this is a violation or compliance"},
-        "req": {"type": "string", "description": "Requirement ID from the standards checklist (e.g. 'R-FT-1', 'S-CON-3')"},
+        "p": {"type": "string", "description": "Sub-characteristic name — auto-filled from req if omitted"},
+        "d": {"type": "string", "description": "Dimension — auto-filled from server config if omitted"},
     },
-    "required": ["p", "t", "d", "w"],
+    "required": ["req", "t", "file", "line", "snippet", "severity", "w"],
 }
 
 _DEFAULT_FILE_BATCH_SIZE = 5

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -18,6 +18,7 @@ from quodeq.analysis.mcp.dispatch import (
     dispatch as _dispatch,
 )
 from quodeq.engine._ref_utils import ref_label as _ref_label, load_compiled_refs as _load_compiled_refs
+from quodeq.core.standards.refs import load_compiled_requirements as _load_compiled_requirements
 
 _FINDING_SCHEMA_VERSION = 1
 
@@ -39,6 +40,7 @@ class FindingsRouter:
     """Deduplicates and enriches findings before writing to JSONL.
 
     - Dedup by (principle, file, line, type) -- skips duplicate findings
+    - Auto-fills principle name (p) and dimension (d) from req ID
     - Enriches req_refs from compiled standards -- LLM doesn't need to pick refs
     - Returns feedback to the LLM so it can move on from duplicates
     """
@@ -48,29 +50,48 @@ class FindingsRouter:
         output_fh: TextIO,
         compiled_refs: dict[str, list[dict]] | None = None,
         seen_store: DeduplicationStore | None = None,
+        compiled_reqs: dict[str, dict] | None = None,
+        dimension: str | None = None,
     ):
         self._fh = output_fh
         self._refs = compiled_refs or {}
+        self._reqs = compiled_reqs or {}
+        self._dimension = dimension
         self._seen: DeduplicationStore = seen_store if seen_store is not None else set()
         self.counter = 0
 
+    def _enrich(self, args: dict, finding: dict) -> None:
+        """Auto-fill principle, dimension, and refs from compiled standards."""
+        req = args.get("req")
+        if not req:
+            return
+        # Auto-fill principle name from req ID
+        if not args.get("p") and req in self._reqs:
+            finding["p"] = self._reqs[req]["principle"]
+        # Auto-fill dimension from server config
+        if not args.get("d") and self._dimension:
+            finding["d"] = self._dimension
+        # Enrich with compiled standard refs
+        if req in self._refs:
+            finding["req_refs"] = _select_best_refs(
+                self._refs[req], args.get("w", ""), args.get("reason", ""),
+            )
+
     def receive(self, args: dict) -> tuple[str, bool]:
         """Process a finding. Returns (message, is_duplicate)."""
-        key = (args.get("p"), args.get("file"), args.get("line"), args.get("t"))
+        # Resolve principle name for dedup key (prefer explicit, fall back to lookup)
+        p = args.get("p")
+        req = args.get("req")
+        if not p and req and req in self._reqs:
+            p = self._reqs[req]["principle"]
+        key = (p, args.get("file"), args.get("line"), args.get("t"))
         if key in self._seen:
             return "Duplicate finding, already captured. Move on.", True
         self._seen.add(key)
 
         finding: dict = {"schema_version": _FINDING_SCHEMA_VERSION}
         finding.update({k: v for k, v in args.items() if v is not None})
-
-        # Enrich with compiled standard refs -- server-side, zero LLM tokens
-        # Pick one ref per source type (e.g. one CWE, one CISQ) using best text match
-        req = args.get("req")
-        if req and req in self._refs:
-            finding["req_refs"] = _select_best_refs(
-                self._refs[req], args.get("w", ""), args.get("reason", ""),
-            )
+        self._enrich(args, finding)
 
         self._fh.write(json.dumps(finding) + "\n")
         self._fh.flush()
@@ -130,13 +151,17 @@ def main() -> None:
         sys.exit(1)
 
     compiled_refs = _load_compiled_refs(sa.compiled_dir, sa.dimension)
+    compiled_reqs = _load_compiled_requirements(sa.compiled_dir, sa.dimension)
     queue: FileQueue | None = None
     if sa.queue_path:
         queue = FileQueue(Path(sa.queue_path))
 
     try:
         with open(sa.findings_file, "a") as findings_fh:
-            router = FindingsRouter(findings_fh, compiled_refs)
+            router = FindingsRouter(
+                findings_fh, compiled_refs,
+                compiled_reqs=compiled_reqs, dimension=sa.dimension,
+            )
             while True:
                 msg = read_message()
                 if msg is None:

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -23,17 +23,23 @@ _NO_STANDARDS_FOR_DIM = "_No compiled standards for this dimension._"
 _STANDARDS_READ_ERROR = "_Could not read compiled standards._"
 
 
-def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
-    """Render compiled standards as a requirements checklist organized by principle."""
+def _load_dimension_data(compiled_dir: Path, dimension: str) -> dict | None:
+    """Load compiled standards JSON for a dimension, or None on error."""
     compiled_file = compiled_dir / f"{dimension}.json"
     if not compiled_file.exists():
-        return _NO_STANDARDS_FOR_DIM
-
+        return None
     try:
-        data = read_json(compiled_file)
+        return read_json(compiled_file)
     except (OSError, ValueError) as exc:
         _logger.warning("Could not read compiled standards %s: %s", compiled_file, exc)
-        return _STANDARDS_READ_ERROR
+        return None
+
+
+def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
+    """Render compiled standards as a requirements checklist organized by principle."""
+    data = _load_dimension_data(compiled_dir, dimension)
+    if data is None:
+        return _NO_STANDARDS_FOR_DIM
     lines = []
     for principle in data.get("principles", []):
         reqs = principle.get("requirements", [])
@@ -43,6 +49,23 @@ def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
         for req in reqs:
             lines.append(f"- **{req['id']}**: {req['text']}")
         lines.append("")
+    return "\n".join(lines)
+
+
+def render_compact_standards(compiled_dir: Path, dimension: str) -> str:
+    """Render a compact standards checklist for the AI analyzer.
+
+    One line per requirement: ``REQ-ID: text``.
+    No principle headings (server derives principle from req ID),
+    no markdown formatting, no CWE refs (server enriches at report time).
+    """
+    data = _load_dimension_data(compiled_dir, dimension)
+    if data is None:
+        return _NO_STANDARDS_FOR_DIM
+    lines = []
+    for principle in data.get("principles", []):
+        for req in principle.get("requirements", []):
+            lines.append(f"{req['id']}: {req['text']}")
     return "\n".join(lines)
 
 
@@ -111,6 +134,7 @@ class PromptContext:
     manifest: "SourceManifest | None" = None
     target: "AnalysisTarget | None" = None
     extra_vars: dict[str, str] = field(default_factory=dict)
+    work_dir: Path | None = None
 
 
 _TEMPLATE_HASH_CACHE_SIZE = 128
@@ -151,6 +175,28 @@ def _render_manifest_context(context: PromptContext) -> str:
     return _NO_GUIDANCE
 
 
+_STANDARDS_FILE_PREFIX = ".quodeq_standards_"
+
+
+def _write_standards_file(work_dir: Path, dimension: str, content: str) -> Path:
+    """Write standards checklist to a file in the work directory.
+
+    Returns the absolute path to the written file.
+    """
+    standards_path = work_dir / f"{_STANDARDS_FILE_PREFIX}{dimension}.md"
+    standards_path.write_text(content)
+    return standards_path
+
+
+def _standards_read_instruction(standards_path: Path) -> str:
+    """Return prompt text instructing the AI to read the standards file."""
+    return (
+        f"**FIRST ACTION:** Read the standards checklist from `{standards_path}`\n"
+        f"This file contains all requirements you must evaluate against. "
+        f"Read it before analyzing any source files."
+    )
+
+
 def build_analysis_prompt(template: str, context: PromptContext) -> str:
     """Build a complete per-dimension analysis prompt from the template."""
     dimensions_text = render_dimensions(context.dimensions_data, context.dimension)
@@ -160,7 +206,17 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
     if context.standards_dir:
         compiled_dir = context.standards_dir / "compiled"
         if compiled_dir.exists():
-            standards_checklist = render_compiled_standards(compiled_dir, context.dimension)
+            if context.work_dir:
+                compact = render_compact_standards(compiled_dir, context.dimension)
+                if compact not in (_NO_STANDARDS_FOR_DIM,):
+                    standards_path = _write_standards_file(
+                        context.work_dir, context.dimension, compact,
+                    )
+                    standards_checklist = _standards_read_instruction(standards_path)
+                else:
+                    standards_checklist = compact
+            else:
+                standards_checklist = render_compiled_standards(compiled_dir, context.dimension)
 
     manifest_context = _render_manifest_context(context)
 

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -90,6 +90,7 @@ def _build_dimension_prompt(
             standards_dir=config.standards_dir,
             manifest=config.manifest,
             target=config.target,
+            work_dir=config.work_dir or config.src,
         ),
     )
 

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -67,6 +67,7 @@ def _build_subagent_prompt(config: RunConfig, dim_id: str, ctx: Any) -> str:
             standards_dir=config.standards_dir,
             manifest=config.manifest,
             target=config.target,
+            work_dir=config.work_dir or config.src,
         ),
     )
 

--- a/src/quodeq/core/standards/refs.py
+++ b/src/quodeq/core/standards/refs.py
@@ -36,17 +36,24 @@ def ref_label(ref: dict) -> str:
     return source.upper() if source else "REF"
 
 
+def _load_compiled_data(compiled_dir: str | Path | None, dimension: str | None) -> dict | None:
+    """Load raw compiled standards JSON. Returns None on error."""
+    if not compiled_dir or not dimension:
+        return None
+    try:
+        return read_json(Path(compiled_dir) / f"{dimension}.json")
+    except (OSError, ValueError, UnicodeDecodeError) as exc:
+        _logger.warning("Failed to load compiled standards for %s: %s", dimension, exc)
+        return None
+
+
 def load_compiled_refs(compiled_dir: str | Path | None, dimension: str | None) -> dict[str, list[dict]]:
     """Load {req_id: [{label, url, ...}, ...]} from compiled standards.
 
     Returns an empty dict on any I/O or parse error (logged as a warning).
     """
-    if not compiled_dir or not dimension:
-        return {}
-    try:
-        data = read_json(Path(compiled_dir) / f"{dimension}.json")
-    except (OSError, ValueError, UnicodeDecodeError) as exc:
-        _logger.warning("Failed to load compiled standards for %s: %s", dimension, exc)
+    data = _load_compiled_data(compiled_dir, dimension)
+    if not data:
         return {}
     lookup: dict[str, list[dict]] = {}
     for principle in data.get("principles", []):
@@ -60,4 +67,27 @@ def load_compiled_refs(compiled_dir: str | Path | None, dimension: str | None) -
             ]
             if refs:
                 lookup[req_id] = refs
+    return lookup
+
+
+def load_compiled_requirements(compiled_dir: str | Path | None, dimension: str | None) -> dict[str, dict]:
+    """Load {req_id: {principle, text}} from compiled standards.
+
+    Used by the MCP server to auto-fill principle name and requirement text
+    from the requirement ID, so the AI doesn't need to send them.
+    """
+    data = _load_compiled_data(compiled_dir, dimension)
+    if not data:
+        return {}
+    lookup: dict[str, dict] = {}
+    for principle in data.get("principles", []):
+        principle_name = principle.get("name", "")
+        for req in principle.get("requirements", []):
+            req_id = req.get("id")
+            if not req_id:
+                continue
+            lookup[req_id] = {
+                "principle": principle_name,
+                "text": req.get("text", ""),
+            }
     return lookup

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -15,22 +15,17 @@ Analyse the codebase for the **{{DIMENSION}}** quality dimension. Use the tools 
 
 ## Reporting Findings
 
-For EVERY finding (violation or compliance), call the `report_finding` tool with these parameters:
+For EVERY finding (violation or compliance), call `report_finding` with:
 
-**Required:**
-- `p` — the **section header** (### heading) from the standards checklist, i.e. the ISO 25010 sub-characteristic name. Examples: `Modularity`, `Analyzability`, `Confidentiality`, `Fault Tolerance`. **NEVER** put a requirement ID (like M-ANA-1) here.
+- `req` — the **bold requirement ID** from the checklist (e.g. `M-MOD-1`, `S-CON-3`). The server auto-fills principle name and dimension from this.
 - `t` — `violation` or `compliance`
-- `d` — dimension being evaluated
-- `w` — short description of what you found
-
-**Include with every finding:**
 - `file` — file path relative to repo root
 - `line` — line number
-- `snippet` — the relevant code (keep under 200 chars)
+- `snippet` — the relevant code (under 200 chars)
 - `severity` — `critical`, `major`, or `minor`
-- `reason` — brief explanation of why this is a violation or compliance
-- `req` — the **bold requirement ID** from the checklist (e.g. `M-ANA-1`, `S-CON-3`, `R-FT-1`). Always include this.
-- `vt` — violation type (e.g. "hardcoded-secret", "missing-error-handler")
+- `w` — short description of what you found
+
+**Optional:** `reason` — why this is a violation or compliance
 
 ## Severity Definitions
 
@@ -85,10 +80,7 @@ Focus on the project's **own source code** — skip generated, vendored, compile
 
 ## Standards Checklist
 
-This checklist is organized by ISO 25010 sub-characteristic (the `###` headings). Each heading contains numbered requirements (the **bold IDs**).
-
-- `p` field = the **### heading name** (e.g. `Modularity`, `Analyzability`) — NEVER a requirement ID
-- `req` field = the **bold requirement ID** (e.g. `M-MOD-1`, `M-ANA-2`)
+The checklist is organized by ISO 25010 sub-characteristic (`###` headings) with numbered requirements (**bold IDs**). Use the **bold ID** as the `req` field (e.g. `M-MOD-1`, `S-CON-3`).
 
 {{STANDARDS_CHECKLIST}}
 

--- a/src/quodeq/data/prompts/subagent.md
+++ b/src/quodeq/data/prompts/subagent.md
@@ -20,9 +20,9 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 ## report_finding parameters
 
-**Required:** `p` (the `###` heading name from the checklist — e.g. `Modularity`, `Analyzability`, `Confidentiality` — NEVER a requirement ID like M-ANA-1), `t` (`violation` or `compliance`), `d` (dimension), `w` (short description)
+**Required:** `req` (the **bold requirement ID**, e.g. `M-MOD-1`, `S-CON-3` — server auto-fills principle name and dimension), `t` (`violation` or `compliance`), `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `w` (short description)
 
-**Include with every finding:** `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `reason`, `req` (the **bold requirement ID** from the checklist, e.g. `M-MOD-1`, `S-CON-3`), `vt` (violation type)
+**Optional:** `reason` (why this is a violation or compliance)
 
 ## Rules
 
@@ -47,6 +47,6 @@ For compliance — use the same severity to indicate the importance of what's do
 
 ## Standards Checklist
 
-Use the `###` heading (e.g. `Modularity`) as `p`. Use the **bold ID** (e.g. `M-MOD-1`) as `req`.
+Use the **bold ID** (e.g. `M-MOD-1`) as `req`. The server resolves the principle name automatically.
 
 {{STANDARDS_CHECKLIST}}

--- a/tests/engine/test_prompt_builder.py
+++ b/tests/engine/test_prompt_builder.py
@@ -182,6 +182,59 @@ class TestBuildAnalysisPrompt:
         )
         assert "No additional guidance" in prompt
 
+    def test_standards_written_to_file_when_work_dir_set(self, tmp_path):
+        """When work_dir is provided, standards are written to a file and the
+        prompt contains a read instruction instead of inline content."""
+        from quodeq.analysis.manifest import AnalysisTarget, SourceManifest
+
+        compiled_dir = tmp_path / "standards" / "compiled"
+        compiled_dir.mkdir(parents=True)
+        compiled = {
+            "id": "security",
+            "principles": [
+                {
+                    "name": "Confidentiality",
+                    "source": "iso25010",
+                    "requirements": [
+                        {"id": "S-CON-1", "source": "iso25010",
+                         "text": "Secrets MUST NOT be hardcoded in source", "refs": []}
+                    ],
+                },
+            ],
+        }
+        (compiled_dir / "security.json").write_text(json.dumps(compiled))
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        target = AnalysisTarget(name="typescript", language="typescript", total_files=42)
+        manifest = SourceManifest(targets=[target], total_files=42)
+        template = load_template()
+        prompt = build_analysis_prompt(
+            template,
+            PromptContext(
+                language="typescript",
+                repo_name="my-app",
+                date_str="2026-03-06",
+                dimension="security",
+                source_file_count=42,
+                dimensions_data=_sample_dimensions(),
+                standards_dir=tmp_path / "standards",
+                manifest=manifest,
+                work_dir=work_dir,
+            ),
+        )
+        # Standards NOT inline — replaced by read instruction
+        assert "Secrets MUST NOT be hardcoded" not in prompt
+        assert "FIRST ACTION" in prompt
+        assert ".quodeq_standards_security.md" in prompt
+
+        # Standards file was written (compact format: no headings, just ID: text)
+        standards_file = work_dir / ".quodeq_standards_security.md"
+        assert standards_file.exists()
+        content = standards_file.read_text()
+        assert "### Confidentiality" not in content  # no principle headings
+        assert "S-CON-1: Secrets MUST NOT be hardcoded" in content
+
     def test_prompt_hash_present(self):
         template = load_template()
         prompt = build_analysis_prompt(


### PR DESCRIPTION
## Summary
- **File-based standards injection**: Standards refs are now written to a temp file and referenced via `--file` in prompts instead of inlining full standard text, reducing prompt token count significantly
- **MCP auto-fill for findings**: The MCP findings server now auto-populates `file`, `line`, and `reqRefs` fields from the standard, so AI agents don't need to repeat them in every tool call
- **Leaner prompt templates**: Trimmed compass and subagent prompts to remove redundant instructions

## Test plan
- [x] New tests in `test_prompt_builder.py` verify standards file generation
- [x] All 408 Python tests pass
- [x] All 59 JS tests pass
