### PR TITLE
fix: resolve 28 additional reliability violations

### DIFF
--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -203,11 +203,12 @@ class QuodeqApp(rumps.App):
                     if pip_result.returncode != 0:
                         self._prereq_items["quodeq"].title = "  Quodeq \u2717 pip install failed"
                         return
-                    site_bin = subprocess.run(
+                    site_result = subprocess.run(
                         ["python3", "-m", "site", "--user-base"],
                         capture_output=True, text=True, timeout=5,
-                    ).stdout.strip()
-                    os.environ["PATH"] += f":{site_bin}/bin"
+                    )
+                    if site_result.returncode == 0 and site_result.stdout.strip():
+                        os.environ["PATH"] += f":{site_result.stdout.strip()}/bin"
                     self._prereq_items["quodeq"].title = "  Quodeq \u2713"
                 except (subprocess.TimeoutExpired, OSError):
                     self._prereq_items["quodeq"].title = "  Quodeq \u2717 install failed"

--- a/src/quodeq/data/ports/evaluations.py
+++ b/src/quodeq/data/ports/evaluations.py
@@ -1,7 +1,7 @@
 """Port interface for stored evaluation reports."""
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Any, Protocol
 
 
 class EvaluationsRepository(Protocol):
@@ -11,6 +11,6 @@ class EvaluationsRepository(Protocol):
         """Return identifiers for all available evaluation reports."""
         ...
 
-    def get_report(self, report_id: str) -> dict:
+    def get_report(self, report_id: str) -> dict[str, Any]:
         """Return the full report data for a given report identifier."""
         ...

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -36,7 +36,10 @@ def _acc_dim_cache_max(override: int | None = None, env: dict[str, str] | None =
     """Return the accumulated-view cache size limit. *override* bypasses env for testing."""
     if override is not None:
         return override
-    return int((env or os.environ).get("QUODEQ_ACC_CACHE_MAX", str(_DEFAULT_ACC_CACHE_MAX)))
+    try:
+        return int((env or os.environ).get("QUODEQ_ACC_CACHE_MAX", str(_DEFAULT_ACC_CACHE_MAX)))
+    except (ValueError, TypeError):
+        return _DEFAULT_ACC_CACHE_MAX
 
 
 def _read_all_run_data(

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -47,7 +47,10 @@ def _run_dim_cache_max(override: int | None = None, env: dict[str, str] | None =
     """Return the run-dimension cache size limit. *override* bypasses env for testing."""
     if override is not None:
         return override
-    return int((env or os.environ).get("QUODEQ_RUN_DIM_CACHE_MAX", str(_DEFAULT_RUN_DIM_CACHE_MAX)))
+    try:
+        return int((env or os.environ).get("QUODEQ_RUN_DIM_CACHE_MAX", str(_DEFAULT_RUN_DIM_CACHE_MAX)))
+    except (ValueError, TypeError):
+        return _DEFAULT_RUN_DIM_CACHE_MAX
 
 
 def create_dimension_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]], threading.Lock]:

--- a/src/quodeq/shared/ssrf.py
+++ b/src/quodeq/shared/ssrf.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 import socket
 from functools import lru_cache
+
+_logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=256)
@@ -15,12 +18,12 @@ def is_private_address(hostname: str) -> bool:
         addr = ipaddress.ip_address(hostname)
         return addr.is_private or addr.is_loopback or addr.is_link_local
     except ValueError:
-        pass
+        _logger.debug("Cannot parse %r as IP literal, falling through to DNS", hostname)
     try:
         for _fam, _typ, _pro, _can, sockaddr in socket.getaddrinfo(hostname, None):
             addr = ipaddress.ip_address(sockaddr[0])
             if addr.is_private or addr.is_loopback or addr.is_link_local:
                 return True
-    except (socket.gaierror, OSError):
-        pass
+    except (socket.gaierror, OSError) as exc:
+        _logger.warning("DNS resolution failed for %r — treating as non-private: %s", hostname, exc)
     return False

--- a/tests/provider/test_accumulated.py
+++ b/tests/provider/test_accumulated.py
@@ -81,6 +81,14 @@ class TestNumericAverage:
         result = numeric_average(dims)
         assert result == 9.0
 
+    def test_all_non_numeric_returns_none(self):
+        dims = [_dim("a", "A"), _dim("b", "B+")]
+        assert numeric_average(dims) is None
+
+    def test_single_dimension(self):
+        dims = [_dim("a", "10.0")]
+        assert numeric_average(dims) == 10.0
+
 
 # ---------------------------------------------------------------------------
 # _aggregate_severity_counts

--- a/tests/provider/test_dashboard.py
+++ b/tests/provider/test_dashboard.py
@@ -61,6 +61,18 @@ class TestCollectStaleDimensions:
         stale, _ = _collect_stale_dimensions(runs, 0, {"security"}, fetcher)
         assert stale == []
 
+    def test_empty_runs_returns_empty(self):
+        stale, _ = _collect_stale_dimensions([], 0, {"security"}, lambda rid: [])
+        assert stale == []
+
+
+class TestCollectPreviousScoresEdgeCases:
+    def test_single_run_returns_empty(self):
+        runs = [_make_run("r1")]
+        fetcher = lambda rid: [_dim("security", "A", "9.0")]
+        result = _collect_previous_scores(runs, 0, {"security"}, fetcher)
+        assert result == {}
+
 
 class TestEnrichDimensionsWithTrend:
     def test_adds_trend_fields(self):

--- a/tests/test_web_evaluations_repository.py
+++ b/tests/test_web_evaluations_repository.py
@@ -1,3 +1,5 @@
+import pytest
+
 from quodeq.adapters.web.http_client import HttpResponse
 from quodeq.adapters.web.evaluations_repository import WebEvaluationsRepository
 
@@ -16,3 +18,9 @@ def test_web_evaluations_repository_reads_report():
     assert repo.list_reports() == ["run-1"]
     payload = repo.get_report("run-1")
     assert payload["id"] == "run-1"
+
+
+def test_web_evaluations_repository_404_raises():
+    repo = WebEvaluationsRepository(base_url="https://api.example.com", client=FakeClient())
+    with pytest.raises(Exception):
+        repo.get_report("nonexistent")

--- a/tools/migrate_reason_title.py
+++ b/tools/migrate_reason_title.py
@@ -73,7 +73,7 @@ def migrate_entry(entry: dict) -> bool:
 def migrate_file(path: Path, apply: bool) -> tuple[int, int]:
     """Migrate a single evaluation JSON. Returns (violations_updated, compliance_updated)."""
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         print(f"  SKIP  cannot read {path}: {exc}")
         return 0, 0
@@ -82,7 +82,7 @@ def migrate_file(path: Path, apply: bool) -> tuple[int, int]:
 
     if apply and (v_count or c_count):
         try:
-            path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+            path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         except OSError as exc:
             print(f"  ERROR writing {path}: {exc}")
 

--- a/ui/web/src/App.jsx
+++ b/ui/web/src/App.jsx
@@ -43,7 +43,10 @@ export default function App() {
   async function handleDeleteProject(projectId) {
     const qs = _apiQs();
     const separator = qs ? '&' : '?';
-    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}${qs}${separator}confirm=true`, { method: 'DELETE' });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+    const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}${qs}${separator}confirm=true`, { method: 'DELETE', signal: controller.signal });
+    clearTimeout(timeoutId);
     if (!res.ok) {
       const msg = await res.text().catch(() => res.statusText);
       alert(`Failed to delete project: ${msg}`);
@@ -72,9 +75,15 @@ export default function App() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ path: newPath }),
       });
-      if (!res.ok) console.error('Relocate failed:', res.status);
+      if (!res.ok) {
+        console.error('Relocate failed:', res.status);
+        alert('Failed to relocate project. Please try again.');
+        return;
+      }
     } catch (err) {
       console.error('Relocate failed:', err);
+      alert('Failed to relocate project. Please try again.');
+      return;
     }
     loadProjects();
   }

--- a/ui/web/src/components/FileCopyBtn.jsx
+++ b/ui/web/src/components/FileCopyBtn.jsx
@@ -9,9 +9,10 @@ export default function FileCopyBtn({ display, copyText }) {
       type="button"
       className="vlive-detail-file-btn"
       onClick={() => {
-        copyToClipboard(copyText);
-        setCopied(true);
-        setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+        copyToClipboard(copyText).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+        });
       }}
     >
       {copied ? 'Copied!' : display}

--- a/ui/web/src/features/dashboard/hooks/useDashboard.js
+++ b/ui/web/src/features/dashboard/hooks/useDashboard.js
@@ -35,7 +35,8 @@ export function useDashboard({ selectedProject, selectedRun }) {
       .then((payload) => {
         if (active) setDashboard(payload);
       })
-      .catch(() => {
+      .catch((err) => {
+        console.warn('Dashboard load failed:', err);
         if (active) setError('Failed to load dashboard data. Please try again.');
       })
       .finally(() => {

--- a/ui/web/src/features/evaluation/components/EvaluationForm.jsx
+++ b/ui/web/src/features/evaluation/components/EvaluationForm.jsx
@@ -76,6 +76,7 @@ function useEvaluationForm(onStart) {
   const [allDimensions, setAllDimensions] = useState([]);
   const [selectedDims, setSelectedDims] = useState(new Set());
   const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
+  const [dimLoadError, setDimLoadError] = useState(null);
 
   useEffect(() => {
     listPlugins()
@@ -87,8 +88,9 @@ function useEvaluationForm(onStart) {
           }
         }
         setAllDimensions([...seen.values()]);
+        setDimLoadError(null);
       })
-      .catch((err) => { console.warn('Failed to load dimensions:', err); setAllDimensions([]); });
+      .catch((err) => { console.warn('Failed to load dimensions:', err); setAllDimensions([]); setDimLoadError('Failed to load dimensions. Using defaults.'); });
   }, []);
 
   const toggleDim = (id) => setSelectedDims((prev) => {
@@ -109,13 +111,13 @@ function useEvaluationForm(onStart) {
   const handleFolderSelect = (path) => { setRepo(path); setFolderBrowserOpen(false); };
   const handleRepoClear = () => { setRepo(''); setSelectedDims(new Set()); };
 
-  return { repo, setRepo, allDimensions, selectedDims, folderBrowserOpen, setFolderBrowserOpen, toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear };
+  return { repo, setRepo, allDimensions, selectedDims, folderBrowserOpen, setFolderBrowserOpen, toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear, dimLoadError };
 }
 
 export default function EvaluationForm({ onStart, disabled }) {
   const {
     repo, setRepo, allDimensions, selectedDims, folderBrowserOpen, setFolderBrowserOpen,
-    toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear,
+    toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear, dimLoadError,
   } = useEvaluationForm(onStart);
 
   const canSubmit = !disabled && !!repo && (allDimensions.length === 0 || selectedDims.size > 0);
@@ -130,6 +132,7 @@ export default function EvaluationForm({ onStart, disabled }) {
           onBrowse={() => setFolderBrowserOpen(true)}
         />
 
+        {dimLoadError && <p className="inline-error" style={{ marginBottom: 8 }}>{dimLoadError}</p>}
         {repo && allDimensions.length > 0 && (
           <DimensionGrid
             allDimensions={allDimensions}

--- a/ui/web/src/utils/clipboard.js
+++ b/ui/web/src/utils/clipboard.js
@@ -5,7 +5,7 @@
  * @param {string} text
  */
 export function copyToClipboard(text) {
-  navigator.clipboard.writeText(text).catch((err) =>
+  return navigator.clipboard.writeText(text).catch((err) =>
     console.warn('Clipboard write failed:', err)
   );
 }


### PR DESCRIPTION
## Summary
Follows up on merged PR #98 with remaining reliability violations.

**Backend:**
- Log DNS resolution failures in SSRF guard instead of silent pass
- Safe int parsing for cache env vars (ValueError protection)
- Type `dict[str, Any]` on EvaluationsRepository.get_report port
- Check site --user-base returncode in menubar installer
- Explicit UTF-8 encoding in migrate_reason_title tool

**Frontend:**
- AbortController timeout on DELETE project fetch
- User-visible alert on relocate project failure
- User-visible error on dimension load failure in EvaluationForm
- FileCopyBtn chains setCopied on clipboard promise resolution
- Log error param in useDashboard catch block

**Tests:**
- 404 error path test for WebEvaluationsRepository
- Edge case tests for numeric_average and _collect_previous_scores
- Empty runs test for _collect_stale_dimensions

## Test plan
- [x] All 425 tests pass (5 new)
- [x] Frontend builds clean