### PR TITLE
fix: incremental flow fixes and dashboard --dev flag

### DIFF
--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -26,7 +26,7 @@ from quodeq.engine._runner_markers import CC_MARKER_KEY, cleanup_stream, emit_ma
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt, load_template
 from quodeq.analysis.subagents.runner import DimensionCallbacks, process_dimension_with_subagents
-from quodeq.shared.logging import log_info, log_success, log_warning
+from quodeq.shared.logging import log_debug, log_info, log_success, log_warning
 from quodeq.shared.validation import validate_path_segment
 
 
@@ -238,8 +238,8 @@ def _save_dimension_fingerprint(config: RunConfig, dimension: str, files: list[s
             config.options.incremental_file_filter = saved_filter
         fp = build_fingerprint(config.src, files, dimension, config.standards_dir)
         save_fingerprint(fp, evidence_dir)
-    except Exception:
-        pass  # fingerprint is best-effort, never block evaluation
+    except Exception as exc:
+        log_debug(f"  [{dimension}] Fingerprint save failed: {exc}")
 
 
 def _log_dimension_result(ev: Evidence, dimension: str, idx: int, total: int) -> None:
@@ -252,10 +252,12 @@ def _log_dimension_result(ev: Evidence, dimension: str, idx: int, total: int) ->
 
 def _process_single_dimension(
     config: RunConfig, dimension: str, idx: int, ctx: _AnalysisContext,
+    *, emit_log: bool = True,
 ) -> Evidence | None:
     """Analyze a single dimension: build prompt, run AI, parse evidence."""
-    emit_marker("analyzing", dimension=dimension)
-    log_info(f"→ [{idx}/{ctx.total}] Analyzing {dimension}")
+    if emit_log:
+        emit_marker("analyzing", dimension=dimension)
+        log_info(f"→ [{idx}/{ctx.total}] Analyzing {dimension}")
 
     if config.options.max_subagents > 1:
         ev = _process_dimension_with_subagents(config, dimension, idx, ctx)
@@ -269,7 +271,8 @@ def _process_single_dimension(
         return None
 
     _save_dimension_fingerprint(config, dimension)
-    _log_dimension_result(ev, dimension, idx, ctx.total)
+    if emit_log:
+        _log_dimension_result(ev, dimension, idx, ctx.total)
     return ev
 
 
@@ -339,7 +342,7 @@ def _run_dimension_incremental(
                 EvidenceContext(
                     language=config.language, repository=str(config.src),
                     date_str=ctx.date_str, source_file_count=config.source_file_count,
-                    files_read=0, module=config.target.name if config.target else "",
+                    files_read=len(classification.unchanged), module=config.target.name if config.target else "",
                 ),
                 compiled_dir=compiled_dir,
             )
@@ -350,7 +353,7 @@ def _run_dimension_incremental(
         # Set file filter so _list_source_files returns only changed+dependent files
         config.options.incremental_file_filter = set(classification.to_analyze)
         try:
-            ev = _process_single_dimension(config, dimension, idx, ctx)
+            ev = _process_single_dimension(config, dimension, idx, ctx, emit_log=False)
         finally:
             config.options.incremental_file_filter = None
 
@@ -394,6 +397,7 @@ def _run_dimensions(config: RunConfig) -> dict[str, Evidence]:
                 ev = _run_dimension_incremental(config, dimension, idx, ctx)
             except Exception as exc:
                 log_warning(f"[{idx}/{ctx.total}] {dimension} — incremental failed: {exc}, falling back to full")
+                config.options.incremental_file_filter = None
                 ev = _process_single_dimension(config, dimension, idx, ctx)
             if ev:
                 _log_dimension_result(ev, dimension, idx, ctx.total)

--- a/src/quodeq/analysis/subagents/priority.py
+++ b/src/quodeq/analysis/subagents/priority.py
@@ -201,7 +201,7 @@ def compute_previous_violations(
 
     for dim in dims:
         try:
-            findings = load_previous_findings_for_dimension(config, dim, evidence_dir)
+            findings = load_previous_findings_for_dimension(config, dim, evidence_dir, quiet=True)
         except Exception:
             continue
         for finding in findings:

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -321,12 +321,17 @@ def process_dimension_with_subagents(
         return callbacks.parse_evidence(config, dim_id, stream_file, jsonl_file, ctx)
 
     # 2. Load and pre-filter previous findings for AI verification
-    #    Skip verification in incremental mode — unchanged files have cached findings,
-    #    changed files get full re-analysis. Verification would be redundant.
+    #    Only skip verification in incremental mode when ALL source files are in the
+    #    file filter (meaning the caller already carried forward cached findings for
+    #    unchanged files — verification would be redundant for the changed subset).
     from quodeq.analysis.subagents.verify import (
         load_previous_findings_for_dimension, _group_by_file, _write_verify_manifest,
     )
-    skip_verify = config.options.incremental and config.options.incremental_file_filter is not None
+    skip_verify = (
+        config.options.incremental
+        and config.options.incremental_file_filter is not None
+        and len(config.options.incremental_file_filter) < len(files)
+    )
     prev_findings = [] if skip_verify else load_previous_findings_for_dimension(config, dim_id, evidence_dir)
 
     # 3. Run AI verification pool (fast model) if there are findings to verify

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -136,42 +136,68 @@ def _resolve_evidence_paths(evidence_dir: Path) -> tuple[str, str, Path] | None:
     return run_dir.name, run_dir.parent.name, run_dir.parent.parent
 
 
+_findings_cache: dict[tuple[str, str], tuple[list[dict], int, int]] = {}
+
+
+def _clear_findings_cache() -> None:
+    """Clear the per-run findings cache (call between runs)."""
+    _findings_cache.clear()
+
+
 def load_previous_findings_for_dimension(
     config: Any,
     dim_id: str,
     evidence_dir: Path,
+    *,
+    quiet: bool = False,
 ) -> list[dict]:
     """Load and pre-filter previous findings for a dimension.
 
-    1. Find previous run's JSONL
-    2. Pre-filter: drop findings whose files no longer exist
-    3. Return surviving findings for AI verification
+    Results are cached per (evidence_dir, dim_id) so multiple callers
+    (priority scoring, verification) don't repeat file I/O.
 
     Returns list of findings to verify (may be empty).
     """
     if not getattr(config, 'options', None) or not config.options.verify_findings:
         return []
 
+    cache_key = (str(evidence_dir), dim_id)
+    cached = _findings_cache.get(cache_key)
+    if cached is not None:
+        surviving, total, gone = cached
+        if not quiet and total > 0:
+            log_info(
+                f"  [{dim_id}] {total} previous findings: "
+                f"{gone} files gone, {len(surviving)} to verify"
+            )
+        return surviving
+
     paths = _resolve_evidence_paths(evidence_dir)
     if paths is None:
+        _findings_cache[cache_key] = ([], 0, 0)
         return []
 
     current_run_id, project_uuid, reports_base = paths
 
     prev_jsonl = _find_previous_evidence(reports_base, project_uuid, current_run_id, dim_id)
     if prev_jsonl is None:
-        log_info(f"  [{dim_id}] No previous evaluation — skipping verification")
+        if not quiet:
+            log_info(f"  [{dim_id}] No previous evaluation — skipping verification")
+        _findings_cache[cache_key] = ([], 0, 0)
         return []
 
     prev_findings = _load_previous_findings(prev_jsonl)
     if not prev_findings:
+        _findings_cache[cache_key] = ([], 0, 0)
         return []
 
     surviving, gone = _pre_filter_gone(prev_findings, config.src)
-    log_info(
-        f"  [{dim_id}] {len(prev_findings)} previous findings: "
-        f"{gone} files gone, {len(surviving)} to verify"
-    )
+    if not quiet:
+        log_info(
+            f"  [{dim_id}] {len(prev_findings)} previous findings: "
+            f"{gone} files gone, {len(surviving)} to verify"
+        )
+    _findings_cache[cache_key] = (surviving, len(prev_findings), gone)
     return surviving
 
 

--- a/src/quodeq/dashboard/_build.py
+++ b/src/quodeq/dashboard/_build.py
@@ -104,13 +104,40 @@ def _run_npm_build(workdir: Path, static_dir: Path) -> None:
     subprocess.run([npm, "run", "build"], cwd=str(workdir), check=True, timeout=600, env=env)
 
 
-def maybe_build_ui(no_build: bool, reinstall: bool) -> Path:
+def _resolve_dev_source() -> Path:
+    """Find the UI source directory for --dev mode (repo working copy)."""
+    # Look for ui/web/ relative to cwd, then walk up to find repo root
+    cwd = Path.cwd()
+    for candidate in (cwd / "ui" / "web", cwd / "src" / "quodeq" / "ui"):
+        if (candidate / "package.json").exists():
+            return candidate
+    # Walk up looking for ui/web/
+    for parent in cwd.parents:
+        candidate = parent / "ui" / "web"
+        if (candidate / "package.json").exists():
+            return candidate
+    raise FileNotFoundError(
+        "Cannot find UI source directory. "
+        "Run --dev from the quodeq repo root or a subdirectory."
+    )
+
+
+_DEV_STATIC_DIR = _QUODEQ_DIR / "static-dev"
+_DEV_BUILD_WORKDIR = _QUODEQ_DIR / "ui_build_dev"
+
+
+def maybe_build_ui(no_build: bool, reinstall: bool, dev: bool = False) -> Path:
     """Build the UI if needed and return the path to the static dist directory.
 
     Raises FileNotFoundError if --no-build is set and no cached build exists.
     """
-    static_dir = _STATIC_DIR
-    source_dir = _get_ui_source_dir()
+    if dev:
+        source_dir = _resolve_dev_source()
+        static_dir = _DEV_STATIC_DIR
+        log_info(f"Dev mode: building from {source_dir}")
+    else:
+        source_dir = _get_ui_source_dir()
+        static_dir = _STATIC_DIR
 
     if no_build:
         if not (static_dir / "index.html").exists():
@@ -120,13 +147,17 @@ def maybe_build_ui(no_build: bool, reinstall: bool) -> Path:
             )
         return static_dir
 
-    if not needs_rebuild(source_dir, static_dir, reinstall):
+    if not dev and not needs_rebuild(source_dir, static_dir, reinstall):
         log_info("Web UI is up to date, skipping build.")
         return static_dir
 
     log_info("Building web UI (source changed)...")
-    workdir = _BUILD_WORKDIR
-    sync_source_to_workdir(source_dir, workdir)
+    if dev:
+        # Build directly from repo source — no copy needed
+        workdir = source_dir
+    else:
+        workdir = _BUILD_WORKDIR
+        sync_source_to_workdir(source_dir, workdir)
     static_dir.mkdir(parents=True, exist_ok=True)
     _run_npm_build(workdir, static_dir)
 

--- a/src/quodeq/dashboard/_config.py
+++ b/src/quodeq/dashboard/_config.py
@@ -20,6 +20,7 @@ class BuildConfig:
     open_browser: bool
     no_build: bool
     reinstall: bool
+    dev: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/quodeq/dashboard/cli.py
+++ b/src/quodeq/dashboard/cli.py
@@ -39,6 +39,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Skip rebuilding the UI; use cached build (error if none exists)")
     parser.add_argument("--reinstall", action="store_true",
                         help="Force reinstallation of UI dependencies and full rebuild")
+    parser.add_argument("--dev", action="store_true", default=False,
+                        help=argparse.SUPPRESS)
     parser.add_argument("--open", action=argparse.BooleanOptionalAction, default=True,
                         help="Open the dashboard in a browser after starting (default: %(default)s)")
     return parser
@@ -62,6 +64,7 @@ def parse_args(argv: list[str] | None = None) -> DashboardConfig:
             open_browser=bool(args.open),
             no_build=args.no_build,
             reinstall=args.reinstall,
+            dev=args.dev,
         ),
         reports_dir=Path(args.evaluations),
         static_dist=Path(args.static_dist),

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -170,17 +170,18 @@ def _resolve_paths_and_build(config: DashboardConfig) -> DashboardConfig:
     if chosen_port != config.server.port:
         log_warning(f"Port {config.server.port} is in use. Using {chosen_port} instead.")
 
-    # If user provided --static-dist explicitly, use it as-is (skip build).
-    # Otherwise, run the on-demand build flow.
-    user_provided_dist = resolve_path(str(config.static_dist))
-    if (user_provided_dist / "index.html").exists():
-        # User pointed to an existing build — use it directly
-        static_dist = user_provided_dist
+    # --dev always builds from repo source; otherwise check for existing build.
+    if config.build.dev:
+        check_dashboard_prereqs()
+        static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall, dev=True)
     else:
-        # On-demand build flow
-        if not config.build.no_build:
-            check_dashboard_prereqs()
-        static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall)
+        user_provided_dist = resolve_path(str(config.static_dist))
+        if (user_provided_dist / "index.html").exists():
+            static_dist = user_provided_dist
+        else:
+            if not config.build.no_build:
+                check_dashboard_prereqs()
+            static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall)
 
     return DashboardConfig(
         server=ServerConfig(

--- a/src/quodeq/ui/src/models/project.js
+++ b/src/quodeq/ui/src/models/project.js
@@ -41,5 +41,6 @@ export function createProject(raw) {
     latestScore:  raw.latestScore ?? null,
     runsCount:    raw.runsCount ?? 0,
     filesCount:   raw.filesCount ?? null,
+    hasFingerprints: raw.hasFingerprints ?? false,
   };
 }

--- a/tests/engine/test_file_priority.py
+++ b/tests/engine/test_file_priority.py
@@ -154,7 +154,7 @@ class TestComputePreviousViolations:
         assert counts == {}
 
     def test_consolidated_merges_dimensions(self, tmp_path):
-        def mock_load(config, dim, evidence_dir):
+        def mock_load(config, dim, evidence_dir, **kwargs):
             if dim == "security":
                 return [{"t": "violation", "file": "auth.py", "line": 1}]
             elif dim == "maintainability":


### PR DESCRIPTION
## Summary
- **Critical fix**: `incremental_file_filter` not cleared on fallback — could leak state between dimensions
- **Duplicate logs**: "Analyzing" message and marker emitted multiple times per dimension in incremental mode
- **Verification cache**: `load_previous_findings_for_dimension` called 3x per dimension (priority + verification) — now cached with proper log behavior
- **files_read=0**: no-changes incremental path reported 0 files read instead of unchanged file count
- **Dashboard --dev**: hidden `--dev` flag builds UI from repo source for development testing
- **Re-scan button**: `hasFingerprints` field was dropped by `createProject` model, hiding the button

## Test plan
- [x] All 49 existing tests pass (incremental, fingerprint, subagent pool, prioritization)
- [x] Manual: `uv run quodeq dashboard --dev` builds from repo source
- [x] Manual: Re-scan button visible when fingerprints exist
- [x] Manual: Incremental re-scan with no changes shows clean log output
