### PR TITLE
feat: progressive coverage — backfill unevaluated files across incremental runs

### DIFF
--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -39,7 +39,7 @@ def _hash_standards(standards_dir: Path, dimension: str) -> str | None:
         return None
 
 
-def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir: Path | None) -> dict:
+def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir: Path | None, *, analyzed_files: set[str] | None = None) -> dict:
     """Build a fingerprint for the current evaluation state."""
     file_hashes = {}
     for f in files:
@@ -51,6 +51,7 @@ def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir
         "git_commit": _get_git_commit(src),
         "file_hashes": file_hashes,
         "standards_checksum": _hash_standards(standards_dir, dimension) if standards_dir else None,
+        "analyzed_files": sorted(analyzed_files) if analyzed_files else [],
         "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
     }
 

--- a/src/quodeq/analysis/incremental.py
+++ b/src/quodeq/analysis/incremental.py
@@ -158,3 +158,16 @@ def classify_files(src: Path, files: list[str], prev_fingerprint: dict | None,
     to_analyze = detection.changed | dependents
     unchanged = set(files) - to_analyze
     return FileClassification(to_analyze=sorted(to_analyze), unchanged=unchanged)
+
+
+def identify_backfill_files(
+    all_files: list[str],
+    prev_analyzed: list[str],
+    already_queued: set[str],
+) -> list[str]:
+    """Identify files never analyzed that aren't already queued for this run.
+
+    Returns files in the same order as all_files (preserving priority ordering).
+    """
+    covered = set(prev_analyzed) | already_queued
+    return [f for f in all_files if f not in covered]

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -455,6 +455,9 @@ def _run_dimension_incremental(
     new_fp = build_fingerprint(config.src, files, dimension, config.standards_dir, analyzed_files=all_analyzed or None)
     save_fingerprint(new_fp, evidence_dir)
 
+    coverage_pct = len(all_analyzed) * 100 // len(files) if files else 100
+    log_info(f"  [{dimension}] Coverage: {len(all_analyzed)}/{len(files)} files ({coverage_pct}%)")
+
     return ev
 
 

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -6,6 +6,7 @@ Merge per-dimension Evidence into a single Evidence object.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -297,6 +298,7 @@ def _run_dimension_incremental(
     from quodeq.analysis.incremental import classify_files, carry_forward_findings
     from quodeq.analysis.subagents.verify import _resolve_evidence_paths
 
+    phase_start = time.monotonic()
     evidence_dir = config.work_dir or config.src
 
     # Find previous fingerprint
@@ -388,8 +390,67 @@ def _run_dimension_incremental(
                 compiled_dir=compiled_dir,
             )
 
-    # Save new fingerprint
-    new_fp = build_fingerprint(config.src, files, dimension, config.standards_dir)
+    # --- Phase 3: Backfill — analyze previously-unevaluated files with remaining budget ---
+    from quodeq.analysis.incremental import identify_backfill_files
+
+    prev_analyzed = set(prev_fp.get("analyzed_files", [])) if prev_fp else set()
+    phase1_files = set(classification.to_analyze) if classification.to_analyze else set()
+    backfill_candidates = identify_backfill_files(files, list(prev_analyzed), phase1_files)
+
+    output_jsonl = evidence_dir / f"{dimension}_evidence.jsonl"
+    backfill_taken: set[str] = set()
+    if backfill_candidates:
+        elapsed = time.monotonic() - phase_start
+        total_budget = config.options.pool_budget or 600
+        remaining_budget = max(0, total_budget - int(elapsed))
+
+        if remaining_budget >= 60:  # at least 1 minute remaining
+            log_info(
+                f"  [{dimension}] Backfill: {len(backfill_candidates)} unevaluated files, "
+                f"{remaining_budget}s budget remaining"
+            )
+            config.options.incremental_file_filter = set(backfill_candidates)
+            saved_budget = config.options.pool_budget
+            config.options.pool_budget = remaining_budget
+            try:
+                _process_single_dimension(config, dimension, idx, ctx, emit_log=False)
+            finally:
+                config.options.incremental_file_filter = None
+                config.options.pool_budget = saved_budget
+
+            # Read which backfill files were actually taken from queue
+            backfill_queue = evidence_dir / f"{dimension}_queue.json"
+            if backfill_queue.exists():
+                from quodeq.analysis.subagents.file_queue import FileQueue
+                try:
+                    backfill_taken = set(FileQueue(backfill_queue).all_taken_files())
+                except Exception:
+                    pass
+
+            # Dedup carried + phase1 + backfill findings
+            from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl as _dedup_jsonl
+            if output_jsonl.exists():
+                _dedup_jsonl(output_jsonl)
+        else:
+            log_info(f"  [{dimension}] Backfill: {len(backfill_candidates)} unevaluated files, but no budget remaining")
+
+    # Re-parse after all phases to get accurate Evidence
+    if output_jsonl.exists() and output_jsonl.stat().st_size > 0:
+        compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
+        ev = parse_jsonl_to_evidence(
+            output_jsonl,
+            EvidenceContext(
+                language=config.language, repository=str(config.src),
+                date_str=ctx.date_str, source_file_count=config.source_file_count,
+                files_read=len(phase1_files) + len(backfill_taken) + len(classification.unchanged),
+                module=config.target.name if config.target else "",
+            ),
+            compiled_dir=compiled_dir,
+        )
+
+    # Save new fingerprint (include backfill files in analyzed set)
+    all_analyzed = phase1_files | backfill_taken
+    new_fp = build_fingerprint(config.src, files, dimension, config.standards_dir, analyzed_files=all_analyzed or None)
     save_fingerprint(new_fp, evidence_dir)
 
     return ev

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -448,8 +448,10 @@ def _run_dimension_incremental(
             compiled_dir=compiled_dir,
         )
 
-    # Save new fingerprint (include backfill files in analyzed set)
-    all_analyzed = phase1_files | backfill_taken
+    # Save new fingerprint — accumulate analyzed files across runs
+    all_analyzed = prev_analyzed | phase1_files | backfill_taken
+    # Remove files that no longer exist in the project
+    all_analyzed &= set(files)
     new_fp = build_fingerprint(config.src, files, dimension, config.standards_dir, analyzed_files=all_analyzed or None)
     save_fingerprint(new_fp, evidence_dir)
 

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -225,7 +225,10 @@ class EvaluationError(RuntimeError):
     """Raised when an evaluation completes but produces no usable findings."""
 
 
-def _save_dimension_fingerprint(config: RunConfig, dimension: str, files: list[str] | None = None) -> None:
+def _save_dimension_fingerprint(
+    config: RunConfig, dimension: str, files: list[str] | None = None,
+    analyzed_files: set[str] | None = None,
+) -> None:
     """Save a fingerprint after any successful dimension analysis."""
     try:
         from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint
@@ -236,7 +239,17 @@ def _save_dimension_fingerprint(config: RunConfig, dimension: str, files: list[s
             config.options.incremental_file_filter = None
             files, _ = _list_source_files(config, dimension)
             config.options.incremental_file_filter = saved_filter
-        fp = build_fingerprint(config.src, files, dimension, config.standards_dir)
+        # Try to read analyzed files from the queue if not provided
+        if analyzed_files is None:
+            queue_path = evidence_dir / f"{dimension}_queue.json"
+            if queue_path.exists():
+                from quodeq.analysis.subagents.file_queue import FileQueue
+                try:
+                    queue = FileQueue(queue_path)
+                    analyzed_files = set(queue.all_taken_files())
+                except Exception:
+                    pass
+        fp = build_fingerprint(config.src, files, dimension, config.standards_dir, analyzed_files=analyzed_files)
         save_fingerprint(fp, evidence_dir)
     except Exception as exc:
         log_debug(f"  [{dimension}] Fingerprint save failed: {exc}")

--- a/tests/engine/test_fingerprint.py
+++ b/tests/engine/test_fingerprint.py
@@ -39,6 +39,22 @@ class TestBuildFingerprint:
         assert "git_commit" in fp  # may be None if not a git repo
 
 
+def test_fingerprint_includes_analyzed_files(tmp_path):
+    (tmp_path / "a.py").write_text("print('a')")
+    (tmp_path / "b.py").write_text("print('b')")
+    fp = build_fingerprint(
+        tmp_path, ["a.py", "b.py"], "security", None,
+        analyzed_files={"a.py"},
+    )
+    assert fp["analyzed_files"] == ["a.py"]
+
+
+def test_fingerprint_without_analyzed_files_defaults_empty(tmp_path):
+    (tmp_path / "a.py").write_text("print('a')")
+    fp = build_fingerprint(tmp_path, ["a.py"], "security", None)
+    assert fp["analyzed_files"] == []
+
+
 class TestSaveLoadFingerprint:
     def test_round_trip(self, tmp_path):
         fp = {"dimension": "security", "git_commit": "abc", "file_hashes": {"a.py": "hash1"}, "standards_checksum": None, "timestamp": "2026-01-01"}

--- a/tests/engine/test_incremental.py
+++ b/tests/engine/test_incremental.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from quodeq.analysis.incremental import detect_changed_files, ChangeDetectionResult, find_dependents, carry_forward_findings, classify_files, FileClassification
+from quodeq.analysis.incremental import detect_changed_files, ChangeDetectionResult, find_dependents, carry_forward_findings, classify_files, FileClassification, identify_backfill_files
 
 
 class TestDetectChangedFiles:
@@ -136,6 +136,27 @@ class TestClassifyFiles:
         assert set(result.to_analyze) == {"a.py", "b.py"}
         assert len(result.unchanged) == 0
         assert result.full_reanalysis is True
+
+
+class TestIdentifyBackfillFiles:
+    def test_backfill_excludes_previously_analyzed(self):
+        all_files = ["a.py", "b.py", "c.py", "d.py"]
+        prev_analyzed = ["a.py", "b.py"]
+        already_queued = {"c.py"}
+        result = identify_backfill_files(all_files, prev_analyzed, already_queued)
+        assert result == ["d.py"]
+
+    def test_backfill_returns_empty_when_all_covered(self):
+        all_files = ["a.py", "b.py"]
+        prev_analyzed = ["a.py", "b.py"]
+        result = identify_backfill_files(all_files, prev_analyzed, set())
+        assert result == []
+
+    def test_backfill_preserves_input_order(self):
+        all_files = ["z.py", "a.py", "m.py"]
+        prev_analyzed = []
+        result = identify_backfill_files(all_files, prev_analyzed, set())
+        assert result == ["z.py", "a.py", "m.py"]
 
 
 class TestIncrementalRunnerIntegration:

--- a/tests/engine/test_progressive_coverage.py
+++ b/tests/engine/test_progressive_coverage.py
@@ -28,3 +28,34 @@ class TestIdentifyBackfillFiles:
         all_files = ["a.py", "b.py"]
         result = identify_backfill_files(all_files, ["a.py", "b.py"], set())
         assert result == []
+
+
+class TestAnalyzedFilesAccumulation:
+    def test_accumulate_across_three_runs(self):
+        """Simulate 3 runs: each covers more files."""
+        all_files = [f"f{i}.py" for i in range(10)]
+
+        # Run 1: covers f0-f3
+        run1_analyzed = {"f0.py", "f1.py", "f2.py", "f3.py"}
+        backfill = identify_backfill_files(all_files, list(run1_analyzed), set())
+        assert len(backfill) == 6  # f4-f9
+
+        # Run 2: covers f4-f6 (3 more)
+        run2_new = {"f4.py", "f5.py", "f6.py"}
+        run2_analyzed = run1_analyzed | run2_new
+        backfill = identify_backfill_files(all_files, list(run2_analyzed), set())
+        assert len(backfill) == 3  # f7-f9
+
+        # Run 3: covers f7-f9 (last 3)
+        run3_new = {"f7.py", "f8.py", "f9.py"}
+        run3_analyzed = run2_analyzed | run3_new
+        backfill = identify_backfill_files(all_files, list(run3_analyzed), set())
+        assert len(backfill) == 0  # fully covered
+
+    def test_deleted_files_excluded_from_accumulation(self):
+        """Files removed from project should not persist in analyzed set."""
+        all_files = ["a.py", "b.py"]  # c.py was deleted
+        prev_analyzed = ["a.py", "b.py", "c.py"]
+        # Intersection with current files removes c.py
+        accumulated = set(prev_analyzed) & set(all_files)
+        assert accumulated == {"a.py", "b.py"}

--- a/tests/engine/test_progressive_coverage.py
+++ b/tests/engine/test_progressive_coverage.py
@@ -1,0 +1,30 @@
+"""Integration tests for progressive coverage (backfill) in incremental mode."""
+from __future__ import annotations
+
+from quodeq.analysis.incremental import identify_backfill_files
+
+
+class TestIdentifyBackfillFiles:
+    def test_new_project_all_files_are_backfill(self):
+        all_files = [f"file{i}.py" for i in range(100)]
+        result = identify_backfill_files(all_files, [], set())
+        assert len(result) == 100
+
+    def test_partially_covered_project(self):
+        all_files = [f"file{i}.py" for i in range(100)]
+        prev = [f"file{i}.py" for i in range(50)]
+        result = identify_backfill_files(all_files, prev, set())
+        assert len(result) == 50
+        assert all(f not in prev for f in result)
+
+    def test_changed_files_excluded_from_backfill(self):
+        all_files = ["a.py", "b.py", "c.py"]
+        prev = ["a.py"]
+        changed = {"b.py"}
+        result = identify_backfill_files(all_files, prev, changed)
+        assert result == ["c.py"]
+
+    def test_fully_covered_returns_empty(self):
+        all_files = ["a.py", "b.py"]
+        result = identify_backfill_files(all_files, ["a.py", "b.py"], set())
+        assert result == []


### PR DESCRIPTION
## Summary
Enables incremental evaluation to progressively cover more files across runs. After processing changes, the system continues analyzing previously-unevaluated files until the budget is exhausted.

## How it works
Each re-scan now has three phases:
1. **Changes** — Analyze changed files + dependents (existing)
2. **Carry forward** — Carry forward findings for unchanged files (existing)
3. **Backfill** — With remaining budget, analyze files never evaluated in any previous run, ordered by priority score (NEW)

The fingerprint now tracks `analyzed_files` — which files were actually processed by the AI. This set accumulates across runs, so each re-scan increases coverage toward 100%.

## Example output
```
→ [1/1] Analyzing security (incremental)
  [security] Carried forward 122 findings for 200 unchanged files
  [security] Analyzing 3 changed files (200 cached)
  [security] Backfill: 150 unevaluated files, 480s budget remaining
  [security] Coverage: 253/353 files (71%)
```

## Key changes
- `fingerprint.py`: Add `analyzed_files` field
- `incremental.py`: Add `identify_backfill_files()` helper
- `runner.py`: Phase 3 backfill logic, accumulation, coverage logging
- `runner.py`: `_save_dimension_fingerprint()` reads analyzed files from queue

## Test plan
- [x] 548 tests pass (9 new tests added)
- [x] Unit tests for `identify_backfill_files` (order preservation, exclusion, empty cases)
- [x] Accumulation test simulating 3 progressive runs
- [x] Backward compatible — `analyzed_files` defaults to empty list
