### PR TITLE
fix: resolve 10 reusability violations

### DIFF
--- a/src/quodeq/analysis/report.py
+++ b/src/quodeq/analysis/report.py
@@ -204,8 +204,7 @@ def write_reports(evidence: Evidence, scores: ScoringResult | dict, output_dir: 
     dashboard_report = build_dashboard_report(evidence, scores)
 
     dim = evidence.language
-    if ".." in dim or "/" in dim or "\\" in dim:
-        raise ValueError(f"Invalid language for report output: {dim!r}")
+    validate_path_segment(dim)
     try:
         (output_dir / f"{dim}_full.json").write_text(json.dumps(full_report, indent=2))
         (output_dir / f"{dim}.json").write_text(json.dumps(dashboard_report, indent=2))

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -147,25 +147,19 @@ def _resolve_evidence_paths(evidence_dir: Path) -> tuple[str, str, Path] | None:
     return run_dir.name, run_dir.parent.name, run_dir.parent.parent
 
 
-_findings_cache: dict[tuple[str, str], tuple[list[dict], int, int]] = {}
-
-
-def _clear_findings_cache() -> None:
-    """Clear the per-run findings cache (call between runs)."""
-    _findings_cache.clear()
-
-
 def load_previous_findings_for_dimension(
     config: Any,
     dim_id: str,
     evidence_dir: Path,
     *,
     quiet: bool = False,
+    cache: dict[tuple[str, str], tuple[list[dict], int, int]] | None = None,
 ) -> list[dict]:
     """Load and pre-filter previous findings for a dimension.
 
-    Results are cached per (evidence_dir, dim_id) so multiple callers
-    (priority scoring, verification) don't repeat file I/O.
+    When *cache* is provided, results are stored per (evidence_dir, dim_id)
+    so multiple callers (priority scoring, verification) don't repeat file
+    I/O within the same run.  Pass ``None`` to disable caching.
 
     Returns list of findings to verify (may be empty).
     """
@@ -173,19 +167,21 @@ def load_previous_findings_for_dimension(
         return []
 
     cache_key = (str(evidence_dir), dim_id)
-    cached = _findings_cache.get(cache_key)
-    if cached is not None:
-        surviving, total, gone = cached
-        if not quiet and total > 0:
-            log_info(
-                f"  [{dim_id}] {total} previous findings: "
-                f"{gone} files gone, {len(surviving)} to verify"
-            )
-        return surviving
+    if cache is not None:
+        cached = cache.get(cache_key)
+        if cached is not None:
+            surviving, total, gone = cached
+            if not quiet and total > 0:
+                log_info(
+                    f"  [{dim_id}] {total} previous findings: "
+                    f"{gone} files gone, {len(surviving)} to verify"
+                )
+            return surviving
 
     paths = _resolve_evidence_paths(evidence_dir)
     if paths is None:
-        _findings_cache[cache_key] = ([], 0, 0)
+        if cache is not None:
+            cache[cache_key] = ([], 0, 0)
         return []
 
     current_run_id, project_uuid, reports_base = paths
@@ -194,12 +190,14 @@ def load_previous_findings_for_dimension(
     if prev_jsonl is None:
         if not quiet:
             log_info(f"  [{dim_id}] No previous evaluation — skipping verification")
-        _findings_cache[cache_key] = ([], 0, 0)
+        if cache is not None:
+            cache[cache_key] = ([], 0, 0)
         return []
 
     prev_findings = _load_previous_findings(prev_jsonl)
     if not prev_findings:
-        _findings_cache[cache_key] = ([], 0, 0)
+        if cache is not None:
+            cache[cache_key] = ([], 0, 0)
         return []
 
     surviving, gone = _pre_filter_gone(prev_findings, config.src)
@@ -208,5 +206,6 @@ def load_previous_findings_for_dimension(
             f"  [{dim_id}] {len(prev_findings)} previous findings: "
             f"{gone} files gone, {len(surviving)} to verify"
         )
-    _findings_cache[cache_key] = (surviving, len(prev_findings), gone)
+    if cache is not None:
+        cache[cache_key] = (surviving, len(prev_findings), gone)
     return surviving

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -165,13 +165,17 @@ def _no_verify(args: argparse.Namespace, env: dict[str, str] | None = None) -> b
     return args.no_verify or (env or os.environ).get("QUODEQ_NO_VERIFY") == "1"
 
 
-def _build_run_config(args: argparse.Namespace, *, src: Path, language: str, manifest, dims_data: dict, evidence_dir: Path) -> RunConfig:
+def _build_run_config(args: argparse.Namespace, *, src: Path, language: str, manifest, dims_data: dict, evidence_dir: Path, env: dict[str, str] | None = None) -> RunConfig:
     """Assemble a RunConfig from CLI args and resolved paths.
 
     All keyword parameters are required config inputs with no natural grouping
     (source location, language, pre-scan manifest, dimension definitions, and
     output path) — kept flat intentionally for call-site clarity.
+
+    *env* overrides ``os.environ`` for environment variable reads (useful for
+    testing).
     """
+    _env = env or os.environ
     standards_dir = default_paths().standards_dir
     dimensions_filter = [d.strip() for d in args.dimensions.split(",") if d.strip()] if args.dimensions else None
     print(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all", file=sys.stderr)
@@ -185,13 +189,13 @@ def _build_run_config(args: argparse.Namespace, *, src: Path, language: str, man
         dimensions_data=dims_data,
         options=AnalysisOptions(
             dimensions=dimensions_filter,
-            max_turns=args.max_turns if args.max_turns is not None else _env_int(_ENV_MAX_TURNS, None),
-            max_duration=args.max_duration if args.max_duration is not None else _env_int(_ENV_MAX_DURATION, None),
+            max_turns=args.max_turns if args.max_turns is not None else _env_int(_ENV_MAX_TURNS, None, env=env),
+            max_duration=args.max_duration if args.max_duration is not None else _env_int(_ENV_MAX_DURATION, None, env=env),
             max_subagents=args.n_subagents,
-            subagent_model=_subagent_model(),
-            verify_findings=not _no_verify(args),
-            consolidated=not getattr(args, 'no_consolidated', False) and not bool(os.environ.get("QUODEQ_NO_CONSOLIDATE")),
-            pool_budget=args.pool_budget if args.pool_budget is not None else _env_int(_ENV_POOL_BUDGET, None),
+            subagent_model=_subagent_model(env=env),
+            verify_findings=not _no_verify(args, env=env),
+            consolidated=not getattr(args, 'no_consolidated', False) and not bool(_env.get("QUODEQ_NO_CONSOLIDATE")),
+            pool_budget=args.pool_budget if args.pool_budget is not None else _env_int(_ENV_POOL_BUDGET, None, env=env),
             incremental=args.incremental,
         ),
     )

--- a/src/quodeq/shared/config_loader.py
+++ b/src/quodeq/shared/config_loader.py
@@ -73,6 +73,17 @@ def _get_config() -> Config:
     return _config_instance
 
 
+def _reset_config_for_testing() -> None:
+    """Clear the singleton so the next ``_get_config()`` call reloads from disk.
+
+    Intended **only** for test teardown — never call in production code.
+    """
+    global _config_instance
+    with _config_lock:
+        _config_instance = None
+        _lazy_cache.clear()
+
+
 # ---------------------------------------------------------------------------
 # Lazy accessors for constants derived from defaults.json
 # ---------------------------------------------------------------------------

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -35,13 +35,13 @@ def _parse_major(version_str: str) -> int:
     return int(cleaned.split(".")[0])
 
 
-def check_node(min_major: int = 18) -> None:
-    """Raise RuntimeError if Node.js is missing or below minimum version."""
+def _check_tool_version(cmd: list[str], tool_name: str, min_major: int, install_hint: str) -> None:
+    """Raise RuntimeError if *tool_name* is missing or below *min_major*."""
     try:
-        version_str = _run_version_cmd(["node", "--version"])
+        version_str = _run_version_cmd(cmd)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         raise RuntimeError(
-            f"Node.js {min_major}+ is required but not found.\n{_INSTALL_HINT_NODE}"
+            f"{tool_name} {min_major}+ is required but not found.\n{install_hint}"
         ) from exc
     try:
         major = _parse_major(version_str)
@@ -49,28 +49,19 @@ def check_node(min_major: int = 18) -> None:
         return
     if major < min_major:
         raise RuntimeError(
-            f"Node.js {version_str} is below the minimum required version {min_major}.x.\n"
-            f"{_INSTALL_HINT_NODE}"
+            f"{tool_name} {version_str} is below the minimum required version {min_major}.x.\n"
+            f"{install_hint}"
         )
+
+
+def check_node(min_major: int = 18) -> None:
+    """Raise RuntimeError if Node.js is missing or below minimum version."""
+    _check_tool_version(["node", "--version"], "Node.js", min_major, _INSTALL_HINT_NODE)
 
 
 def check_npm(min_major: int = 9) -> None:
     """Raise RuntimeError if npm is missing or below minimum version."""
-    try:
-        version_str = _run_version_cmd(["npm", "--version"])
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
-        raise RuntimeError(
-            f"npm {min_major}+ is required but not found.\n{_INSTALL_HINT_NODE}"
-        ) from exc
-    try:
-        major = _parse_major(version_str)
-    except (ValueError, IndexError):
-        return
-    if major < min_major:
-        raise RuntimeError(
-            f"npm {version_str} is below the minimum required version {min_major}.x.\n"
-            f"{_INSTALL_HINT_NODE}"
-        )
+    _check_tool_version(["npm", "--version"], "npm", min_major, _INSTALL_HINT_NODE)
 
 
 def check_claude_code() -> None:

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -6,37 +6,9 @@ import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { formatRunId, scoreColorClass, complianceRatio } from '../../../utils/formatters.js';
+import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function withDimensionsStr(files) {
-  return files.map((f) => ({
-    ...f,
-    dimensionsStr: f.dimensions?.length > 0 ? f.dimensions.join(', ') : '',
-  }));
-}
-
-function sortDimensionsByViolationSeverity(dimensions) {
-  return [...dimensions]
-    .filter((d) => (d.violations || []).length > 0)
-    .map((d) => {
-      const counts = { critical: 0, major: 0, minor: 0 };
-      (d.violations || []).forEach((v) => {
-        const s = (v.severity || 'minor').toLowerCase();
-        if (counts[s] !== undefined) counts[s]++;
-      });
-      return { ...d, _c: counts };
-    })
-    .sort((a, b) => {
-      if (b._c.critical !== a._c.critical) return b._c.critical - a._c.critical;
-      if (b._c.major !== a._c.major) return b._c.major - a._c.major;
-      return b._c.minor - a._c.minor;
-    });
-}
 
 // ---------------------------------------------------------------------------
 // Accumulated overview panel

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -5,37 +5,9 @@ import TrendBadge from '../../../components/TrendBadge.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
-import { formatRunId, gradeColorClass, scoreColorClass, splitScore } from '../../../utils/formatters.js';
+import { formatRunId, gradeColorClass, scoreColorClass, splitScore, complianceRatio } from '../../../utils/formatters.js';
+import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import buildRunSummary from '../buildRunSummary.js';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function withDimensionsStr(files) {
-  return files.map((f) => ({
-    ...f,
-    dimensionsStr: f.dimensions?.length > 0 ? f.dimensions.join(', ') : '',
-  }));
-}
-
-function sortDimensionsByViolationSeverity(dimensions) {
-  return [...dimensions]
-    .filter((d) => (d.violations || []).length > 0)
-    .map((d) => {
-      const counts = { critical: 0, major: 0, minor: 0 };
-      (d.violations || []).forEach((v) => {
-        const s = (v.severity || 'minor').toLowerCase();
-        if (counts[s] !== undefined) counts[s]++;
-      });
-      return { ...d, _c: counts };
-    })
-    .sort((a, b) => {
-      if (b._c.critical !== a._c.critical) return b._c.critical - a._c.critical;
-      if (b._c.major !== a._c.major) return b._c.major - a._c.major;
-      return b._c.minor - a._c.minor;
-    });
-}
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -66,12 +38,7 @@ function StatsGrid({ runSummary }) {
       <div className="acc-eval-stat-block">
         <span className="acc-eval-stat-label">Ratio</span>
         <span className="acc-eval-stat-value">
-          {(() => {
-            const v = runSummary.totalViolations || 0;
-            const c = runSummary.totalCompliance || 0;
-            if (v === 0) return '\u2014';
-            return `1:${Math.round(c / v)}`;
-          })()}
+          {complianceRatio(runSummary.totalViolations || 0, runSummary.totalCompliance || 0)}
         </span>
       </div>
       <div className="acc-eval-stat-block">

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -55,20 +55,20 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
     setSelectedDims(new Set());
   }
 
-  function handleStart() {
-    const payload = { repo: info.path };
+  function buildPayload(extra) {
+    const payload = { repo: info.path, ...extra };
     if (selectedDims.size > 0 && selectedDims.size < allDimensions.length) {
       payload.dimensions = [...selectedDims];
     }
-    onStart(payload);
+    return payload;
+  }
+
+  function handleStart() {
+    onStart(buildPayload());
   }
 
   function handleIncremental() {
-    const payload = { repo: info.path, incremental: true };
-    if (selectedDims.size > 0 && selectedDims.size < allDimensions.length) {
-      payload.dimensions = [...selectedDims];
-    }
-    onStart(payload);
+    onStart(buildPayload({ incremental: true }));
   }
 
   const canStart = !disabled && selectedDims.size > 0;

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -6,6 +6,10 @@ import { copyToClipboard } from '../../../utils/clipboard.js';
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
 
+function filterValidRefs(refs) {
+  return (refs || []).filter((r) => r.url && /^https?:\/\//.test(r.url));
+}
+
 export function EvalViolationCard({ v, principle, buildViolationPlanText, index }) {
   const { filePath, line } = parseFileRef(v.file, v.line);
   const filename = filePath ? filePath.split('/').pop() : null;
@@ -24,8 +28,8 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index 
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {v.title && <span className="vlive-detail-section-label">Reason</span>}
-              {v.reqRefs?.filter(r => r.url && /^https?:\/\//.test(r.url))?.length > 0 &&
-                <span className="cwe-link-group">{v.reqRefs.filter(r => r.url && /^https?:\/\//.test(r.url)).map((ref, i) => (
+              {filterValidRefs(v.reqRefs).length > 0 &&
+                <span className="cwe-link-group">{filterValidRefs(v.reqRefs).map((ref, i) => (
                   <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
                 ))}</span>
               }
@@ -60,8 +64,8 @@ export function ComplianceCard({ c, principle, index }) {
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {c.title && <span className="vlive-detail-section-label">Reason</span>}
-              {c.reqRefs?.filter(r => r.url && /^https?:\/\//.test(r.url))?.length > 0 &&
-                <span className="cwe-link-group">{c.reqRefs.filter(r => r.url && /^https?:\/\//.test(r.url)).map((ref, i) => (
+              {filterValidRefs(c.reqRefs).length > 0 &&
+                <span className="cwe-link-group">{filterValidRefs(c.reqRefs).map((ref, i) => (
                   <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
                 ))}</span>
               }

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -3,7 +3,7 @@ import { getDimensionEval } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
-import { gradeColorClass, scoreColorClass } from '../../../utils/formatters.js';
+import { gradeColorClass, scoreColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 
@@ -147,12 +147,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
           <div className="acc-eval-stat-block">
             <span className="acc-eval-stat-label">Ratio</span>
             <span className="acc-eval-stat-value">
-              {(() => {
-                const v = allViolations.length;
-                const c = totalCompliant;
-                if (v === 0) return '—';
-                return `1:${Math.round(c / v)}`;
-              })()}
+              {complianceRatio(allViolations.length, totalCompliant)}
             </span>
           </div>
           <div className="acc-eval-stat-block">

--- a/src/quodeq/ui/src/utils/dimensionUtils.js
+++ b/src/quodeq/ui/src/utils/dimensionUtils.js
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for dimension data used by dashboard overview panels.
+ */
+
+/**
+ * Augment file objects with a comma-separated dimensions string.
+ */
+export function withDimensionsStr(files) {
+  return files.map((f) => ({
+    ...f,
+    dimensionsStr: f.dimensions?.length > 0 ? f.dimensions.join(', ') : '',
+  }));
+}
+
+/**
+ * Sort dimensions by violation severity (critical > major > minor),
+ * keeping only dimensions that have at least one violation.
+ */
+export function sortDimensionsByViolationSeverity(dimensions) {
+  return [...dimensions]
+    .filter((d) => (d.violations || []).length > 0)
+    .map((d) => {
+      const counts = { critical: 0, major: 0, minor: 0 };
+      (d.violations || []).forEach((v) => {
+        const s = (v.severity || 'minor').toLowerCase();
+        if (counts[s] !== undefined) counts[s]++;
+      });
+      return { ...d, _c: counts };
+    })
+    .sort((a, b) => {
+      if (b._c.critical !== a._c.critical) return b._c.critical - a._c.critical;
+      if (b._c.major !== a._c.major) return b._c.major - a._c.major;
+      return b._c.minor - a._c.minor;
+    });
+}


### PR DESCRIPTION
## Summary
- Fixes 10 reusability violations (3 major, 7 minor)
- 11 files modified, 1 new shared utility created
- Net: -23 lines (deduplication)

## Key changes
- **Global state**: Replace module-level findings cache with injectable dict parameter
- **DRY**: Extract shared `dimensionUtils.js` eliminating duplicate helpers across 2 components
- **Testability**: Add `env` parameter to `_build_run_config`, add `_reset_config_for_testing()`
- **Shared utilities**: Use `validate_path_segment`, `complianceRatio`, `filterValidRefs` instead of inline duplicates
- **Helper extraction**: `buildPayload` in ReEvaluateCard, `_check_tool_version` in prereqs

## Test plan
- [x] 548 Python tests pass
- [x] No functional changes