### PR TITLE
fix: resolve 4 reusability violations (round 2)

### DIFF
--- a/packaging/macos/_helpers.py
+++ b/packaging/macos/_helpers.py
@@ -1,6 +1,7 @@
 """Helper functions for the macOS menu bar app — command discovery and health checks."""
 from __future__ import annotations
 
+import functools
 import json
 import os
 import subprocess
@@ -21,9 +22,6 @@ def _homebrew_bin_dirs() -> str:
     elif arch == "x86_64":
         return _HOMEBREW_X86
     return f"{_HOMEBREW_ARM64}:{_HOMEBREW_X86}"
-
-_cached_commands: dict[str, str | None] | None = None
-
 
 def source_user_path() -> None:
     """Load the user's shell PATH since .app bundles don't inherit it."""
@@ -51,11 +49,9 @@ def find_icon(name: str) -> str | None:
     return None
 
 
+@functools.lru_cache(maxsize=1)
 def find_commands() -> dict[str, str | None]:
     """Check which required commands are available (cached after first call)."""
-    global _cached_commands
-    if _cached_commands is not None:
-        return _cached_commands
     cmds = {}
     for name in ("python3", "node", "claude", "quodeq"):
         try:
@@ -65,7 +61,6 @@ def find_commands() -> dict[str, str | None]:
             cmds[name] = result.stdout.strip() if result.returncode == 0 else None
         except (subprocess.TimeoutExpired, OSError):
             cmds[name] = None
-    _cached_commands = cmds
     return cmds
 
 

--- a/src/quodeq/shared/config_loader.py
+++ b/src/quodeq/shared/config_loader.py
@@ -63,8 +63,14 @@ _config_lock = threading.Lock()
 _config_instance: Config | None = None
 
 
-def _get_config() -> Config:
-    """Return the lazily-loaded singleton Config instance (thread-safe)."""
+def _get_config(override: Config | None = None) -> Config:
+    """Return the lazily-loaded singleton Config instance (thread-safe).
+
+    Pass *override* to use a specific Config without touching the singleton
+    (useful for testing and dependency injection).
+    """
+    if override is not None:
+        return override
     global _config_instance
     if _config_instance is None:
         with _config_lock:

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -10,11 +10,26 @@ function filterValidRefs(refs) {
   return (refs || []).filter((r) => r.url && /^https?:\/\//.test(r.url));
 }
 
-export function EvalViolationCard({ v, principle, buildViolationPlanText, index }) {
-  const { filePath, line } = parseFileRef(v.file, v.line);
+function useFileInfo(file, fileLine) {
+  const { filePath, line } = parseFileRef(file, fileLine);
   const filename = filePath ? filePath.split('/').pop() : null;
   const ref = line != null ? `${filePath}:${line}` : filePath;
   const display = line != null ? `${filename}:${line}` : filename;
+  return { filePath, filename, ref, display };
+}
+
+function RefsLinks({ reqRefs }) {
+  const valid = filterValidRefs(reqRefs);
+  if (valid.length === 0) return null;
+  return (
+    <span className="cwe-link-group">{valid.map((r, i) => (
+      <a key={i} className="cwe-link" href={r.url} target="_blank" rel="noopener noreferrer">{r.label}</a>
+    ))}</span>
+  );
+}
+
+export function EvalViolationCard({ v, principle, buildViolationPlanText, index }) {
+  const { filename, ref, display } = useFileInfo(v.file, v.line);
   return (
     <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
       <div className="vdetail-row-main">
@@ -28,11 +43,7 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index 
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {v.title && <span className="vlive-detail-section-label">Reason</span>}
-              {filterValidRefs(v.reqRefs).length > 0 &&
-                <span className="cwe-link-group">{filterValidRefs(v.reqRefs).map((ref, i) => (
-                  <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                ))}</span>
-              }
+              <RefsLinks reqRefs={v.reqRefs} />
             </div>
             {v.title && <p className="vlive-detail-title">{v.title}</p>}
             {v.reason && <>
@@ -48,10 +59,7 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index 
 }
 
 export function ComplianceCard({ c, principle, index }) {
-  const { filePath, line } = parseFileRef(c.file, c.line);
-  const filename = filePath ? filePath.split('/').pop() : null;
-  const ref = line != null ? `${filePath}:${line}` : filePath;
-  const display = line != null ? `${filename}:${line}` : filename;
+  const { filename, ref, display } = useFileInfo(c.file, c.line);
   return (
     <div className="vdetail-row vdetail-row--compliant" style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
       <div className="vdetail-row-main">
@@ -64,11 +72,7 @@ export function ComplianceCard({ c, principle, index }) {
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {c.title && <span className="vlive-detail-section-label">Reason</span>}
-              {filterValidRefs(c.reqRefs).length > 0 &&
-                <span className="cwe-link-group">{filterValidRefs(c.reqRefs).map((ref, i) => (
-                  <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
-                ))}</span>
-              }
+              <RefsLinks reqRefs={c.reqRefs} />
             </div>
             {c.title && <p className="vlive-detail-title">{c.title}</p>}
             {c.reason && <>


### PR DESCRIPTION
## Summary
- Add `override` parameter to `_get_config()` for dependency injection
- Extract `useFileInfo` helper and `RefsLinks` component from duplicated code in EvalCards
- Replace global `_cached_commands` dict with `functools.lru_cache`

## Test plan
- [x] 548 tests pass