### PR TITLE
fix: backfill efficiency — accurate analyzed_files + skip verification

### DIFF
--- a/src/quodeq/analysis/_incremental.py
+++ b/src/quodeq/analysis/_incremental.py
@@ -208,12 +208,15 @@ def _run_backfill_phase(
     )
     config.options.incremental_file_filter = set(backfill_candidates)
     saved_budget = config.options.pool_budget
+    saved_verify = config.options.verify_findings
     config.options.pool_budget = remaining_budget
+    config.options.verify_findings = False
     try:
         _process_single_dimension(config, dimension, idx, ctx, emit_log=False)
     finally:
         config.options.incremental_file_filter = None
         config.options.pool_budget = saved_budget
+        config.options.verify_findings = saved_verify
 
     # Read which backfill files were actually taken from queue
     backfill_queue = backfill.evidence_dir / f"{dimension}_queue.json"

--- a/src/quodeq/analysis/_incremental.py
+++ b/src/quodeq/analysis/_incremental.py
@@ -1,6 +1,7 @@
 """Incremental dimension analysis — extracted from runner.py for file-length limits."""
 from __future__ import annotations
 
+import json as _json
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from quodeq.analysis.fingerprint import build_fingerprint, find_previous_fingerprint, load_fingerprint, save_fingerprint
 from quodeq.analysis.incremental import classify_files, carry_forward_findings, identify_backfill_files
+from quodeq.analysis.subagents.runner import _list_source_files
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.services.base import _DEFAULT_POOL_BUDGET
@@ -15,6 +17,33 @@ from quodeq.shared.logging import log_debug, log_info, log_warning
 
 if TYPE_CHECKING:
     from quodeq.analysis.runner import RunConfig, _AnalysisContext
+
+def _extract_files_from_jsonl(jsonl_path: Path) -> set[str]:
+    """Extract unique file paths from an evidence JSONL file.
+
+    Returns all distinct ``file`` values found in JSONL entries.
+    Skips malformed lines and entries without a valid file path.
+    """
+    if not jsonl_path.exists():
+        return set()
+    files: set[str] = set()
+    try:
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = _json.loads(line)
+                except _json.JSONDecodeError:
+                    continue
+                file_path = obj.get("file")
+                if file_path:
+                    files.add(file_path)
+    except OSError:
+        pass
+    return files
+
 
 _MIN_BACKFILL_BUDGET_S = 60
 
@@ -74,20 +103,23 @@ def save_dimension_fingerprint(
     try:
         evidence_dir = config.work_dir or config.src
         if files is None:
-            from quodeq.analysis.subagents.runner import _list_source_files
             saved_filter = config.options.incremental_file_filter
             config.options.incremental_file_filter = None
             files, _ = _list_source_files(config, dimension)
             config.options.incremental_file_filter = saved_filter
         if analyzed_files is None:
+            queue_files: set[str] = set()
             queue_path = evidence_dir / f"{dimension}_queue.json"
             if queue_path.exists():
                 from quodeq.analysis.subagents.file_queue import FileQueue
                 try:
-                    queue = FileQueue(queue_path)
-                    analyzed_files = set(queue.all_taken_files())
+                    queue_files = set(FileQueue(queue_path).all_taken_files())
                 except Exception:
                     pass
+            # Include files with findings in the evidence JSONL — covers
+            # carry-forward and verification results not tracked by the queue.
+            jsonl_files = _extract_files_from_jsonl(evidence_dir / f"{dimension}_evidence.jsonl")
+            analyzed_files = queue_files | jsonl_files
         fp = build_fingerprint(config.src, files, dimension, config.standards_dir, analyzed_files=analyzed_files)
         save_fingerprint(fp, evidence_dir)
     except Exception as exc:
@@ -239,7 +271,6 @@ def run_dimension_incremental(
     prev_fp, prev_evidence_dir = find_previous_fingerprint(evidence_dir, dimension)
 
     # Get full source files list (for classification)
-    from quodeq.analysis.subagents.runner import _list_source_files
     saved_filter = config.options.incremental_file_filter
     config.options.incremental_file_filter = None
     files, extensions = _list_source_files(config, dimension)

--- a/tests/engine/test_incremental.py
+++ b/tests/engine/test_incremental.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from quodeq.analysis.incremental import detect_changed_files, ChangeDetectionResult, find_dependents, carry_forward_findings, classify_files, ClassificationInput, FileClassification, identify_backfill_files
-from quodeq.analysis._incremental import save_dimension_fingerprint, _extract_files_from_jsonl
+from quodeq.analysis._incremental import save_dimension_fingerprint, _extract_files_from_jsonl, _run_backfill_phase, BackfillContext
 
 
 class TestDetectChangedFiles:
@@ -303,3 +304,68 @@ class TestSaveDimensionFingerprintJsonlUnion:
         call_kwargs = mock_build.call_args
         analyzed = call_kwargs.kwargs.get("analyzed_files") or call_kwargs[1].get("analyzed_files")
         assert analyzed == {"a.py", "b.py"}
+
+
+class TestBackfillSkipsVerification:
+    @patch("quodeq.analysis.runner._process_single_dimension")
+    def test_verify_findings_disabled_during_backfill(self, mock_process, tmp_path):
+        """Backfill disables verify_findings before calling _process_single_dimension."""
+        config = MagicMock()
+        config.options.pool_budget = 600
+        config.options.verify_findings = True
+        config.options.incremental_file_filter = None
+
+        captured_verify = []
+
+        def capture_config(*args, **kwargs):
+            captured_verify.append(config.options.verify_findings)
+
+        mock_process.side_effect = capture_config
+
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+
+        ctx = MagicMock()
+        backfill_ctx = BackfillContext(
+            files=["a.py", "b.py", "c.py"],
+            prev_analyzed=set(),
+            phase1_files=set(),
+            evidence_dir=evidence_dir,
+            phase_start=time.monotonic() - 10,  # 10s elapsed, plenty of budget
+        )
+
+        _run_backfill_phase(config, "security", 1, ctx, backfill_ctx)
+
+        # verify_findings should have been False when _process_single_dimension was called
+        assert captured_verify == [False]
+        # verify_findings should be restored after
+        assert config.options.verify_findings is True
+
+    @patch("quodeq.analysis.runner._process_single_dimension")
+    def test_verify_findings_restored_on_error(self, mock_process, tmp_path):
+        """verify_findings is restored even if _process_single_dimension raises."""
+        config = MagicMock()
+        config.options.pool_budget = 600
+        config.options.verify_findings = True
+        config.options.incremental_file_filter = None
+
+        mock_process.side_effect = RuntimeError("boom")
+
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+
+        ctx = MagicMock()
+        backfill_ctx = BackfillContext(
+            files=["a.py"],
+            prev_analyzed=set(),
+            phase1_files=set(),
+            evidence_dir=evidence_dir,
+            phase_start=time.monotonic() - 10,
+        )
+
+        try:
+            _run_backfill_phase(config, "security", 1, ctx, backfill_ctx)
+        except RuntimeError:
+            pass
+
+        assert config.options.verify_findings is True

--- a/tests/engine/test_incremental.py
+++ b/tests/engine/test_incremental.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from quodeq.analysis.incremental import detect_changed_files, ChangeDetectionResult, find_dependents, carry_forward_findings, classify_files, ClassificationInput, FileClassification, identify_backfill_files
+from quodeq.analysis._incremental import save_dimension_fingerprint, _extract_files_from_jsonl
 
 
 class TestDetectChangedFiles:
@@ -183,3 +184,122 @@ class TestIncrementalRunnerIntegration:
             standards_dir=None, dimension="security", language="python"))
         assert len(result.to_analyze) == 0
         assert result.unchanged == {"a.py"}
+
+
+class TestExtractFilesFromJsonl:
+    def test_extracts_unique_file_paths(self, tmp_path):
+        """Extracts unique file paths from evidence JSONL."""
+        jsonl = tmp_path / "security_evidence.jsonl"
+        jsonl.write_text(
+            '{"p":"Mod","t":"violation","file":"a.py","line":1}\n'
+            '{"p":"Mod","t":"compliance","file":"b.py","line":2}\n'
+            '{"p":"Mod","t":"violation","file":"a.py","line":5}\n'
+        )
+        files = _extract_files_from_jsonl(jsonl)
+        assert files == {"a.py", "b.py"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        """Non-existent JSONL returns empty set."""
+        files = _extract_files_from_jsonl(tmp_path / "missing.jsonl")
+        assert files == set()
+
+    def test_skips_malformed_lines(self, tmp_path):
+        """Malformed JSON lines are skipped gracefully."""
+        jsonl = tmp_path / "security_evidence.jsonl"
+        jsonl.write_text(
+            '{"p":"Mod","t":"violation","file":"a.py","line":1}\n'
+            'not valid json\n'
+            '\n'
+            '{"p":"Mod","t":"violation","line":1}\n'
+            '{"p":"Mod","t":"violation","file":"","line":1}\n'
+        )
+        files = _extract_files_from_jsonl(jsonl)
+        assert files == {"a.py"}
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        """Empty JSONL returns empty set."""
+        jsonl = tmp_path / "security_evidence.jsonl"
+        jsonl.write_text("")
+        files = _extract_files_from_jsonl(jsonl)
+        assert files == set()
+
+
+class TestSaveDimensionFingerprintJsonlUnion:
+    @patch("quodeq.analysis._incremental._list_source_files")
+    @patch("quodeq.analysis._incremental.save_fingerprint")
+    @patch("quodeq.analysis._incremental.build_fingerprint")
+    def test_includes_files_from_jsonl_not_in_queue(
+        self, mock_build, mock_save, mock_list_files, tmp_path,
+    ):
+        """Files in JSONL but not in queue are included in analyzed_files."""
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+
+        # Queue has only file_a
+        queue_data = {
+            "version": 1,
+            "pending": [],
+            "taken": [{"files": ["a.py"], "agent": "agent-0", "ts": 1.0}],
+        }
+        (evidence_dir / "security_queue.json").write_text(json.dumps(queue_data))
+
+        # JSONL has file_a and file_b (file_b came from verification carry-forward)
+        (evidence_dir / "security_evidence.jsonl").write_text(
+            '{"p":"Mod","t":"violation","file":"a.py","line":1}\n'
+            '{"p":"Mod","t":"violation","file":"b.py","line":1}\n'
+        )
+
+        mock_list_files.return_value = (["a.py", "b.py", "c.py"], set())
+        mock_build.return_value = {"dimension": "security"}
+
+        config = MagicMock()
+        config.work_dir = evidence_dir
+        config.src = tmp_path
+        config.options.incremental_file_filter = None
+        config.standards_dir = None
+
+        save_dimension_fingerprint(config, "security")
+
+        # build_fingerprint should receive analyzed_files containing both a.py and b.py
+        call_kwargs = mock_build.call_args
+        analyzed = call_kwargs.kwargs.get("analyzed_files") or call_kwargs[1].get("analyzed_files")
+        assert "a.py" in analyzed
+        assert "b.py" in analyzed
+        assert "c.py" not in analyzed  # not in queue or JSONL
+
+    @patch("quodeq.analysis._incremental._list_source_files")
+    @patch("quodeq.analysis._incremental.save_fingerprint")
+    @patch("quodeq.analysis._incremental.build_fingerprint")
+    def test_no_duplicates_in_union(
+        self, mock_build, mock_save, mock_list_files, tmp_path,
+    ):
+        """Files in both queue and JSONL produce a clean set (no duplicates)."""
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+
+        queue_data = {
+            "version": 1,
+            "pending": [],
+            "taken": [{"files": ["a.py", "b.py"], "agent": "agent-0", "ts": 1.0}],
+        }
+        (evidence_dir / "security_queue.json").write_text(json.dumps(queue_data))
+
+        (evidence_dir / "security_evidence.jsonl").write_text(
+            '{"p":"Mod","t":"violation","file":"a.py","line":1}\n'
+            '{"p":"Mod","t":"violation","file":"b.py","line":1}\n'
+        )
+
+        mock_list_files.return_value = (["a.py", "b.py"], set())
+        mock_build.return_value = {"dimension": "security"}
+
+        config = MagicMock()
+        config.work_dir = evidence_dir
+        config.src = tmp_path
+        config.options.incremental_file_filter = None
+        config.standards_dir = None
+
+        save_dimension_fingerprint(config, "security")
+
+        call_kwargs = mock_build.call_args
+        analyzed = call_kwargs.kwargs.get("analyzed_files") or call_kwargs[1].get("analyzed_files")
+        assert analyzed == {"a.py", "b.py"}


### PR DESCRIPTION
## Summary

- Fix `save_dimension_fingerprint` to union queue-taken files with files found in the evidence JSONL, so carry-forward and verified files are correctly recorded in `analyzed_files`
- Skip verification during backfill phase — backfill files are unevaluated by definition, no previous findings to verify

## Problem

`analyzed_files` in the fingerprint only tracked files consumed from the main analysis queue. Files covered by verification carry-forward were missing, causing the next run's backfill to treat them as "unevaluated." For a 370-file project, this resulted in 232 files unnecessarily flagged for backfill re-analysis.

Additionally, backfill called `_process_single_dimension` which triggered full verification — loading hundreds of findings and writing duplicate JSONL entries for no benefit.

## Test plan

- [x] 4 unit tests for `_extract_files_from_jsonl` (unique paths, missing file, malformed lines, empty)
- [x] 2 unit tests for `save_dimension_fingerprint` JSONL union (JSONL-only files included, no duplicates)
- [x] 2 unit tests for backfill verification skip (verify_findings=False during call, restored on error)
- [x] Full suite: 573/573 passing, zero regressions