### PR TITLE
fix: right-size verification pool agent count

### DIFF
--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -183,7 +183,10 @@ def _run_verification_pool(
         dimension=dim_id,
     )
 
-    n_agents = min(_VERIFY_N_AGENTS, len(files_to_verify))
+    n_agents = min(
+        _VERIFY_N_AGENTS,
+        (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
+    )
     pool = SubagentPool(
         paths=PoolPaths(work_dir=config.src, evidence_dir=evidence_dir, queue_path=queue_path),
         options=PoolOptions(


### PR DESCRIPTION
## Summary

- Use `ceil(files / max_files_per_agent)` instead of `1 agent per file` for the verification pool
- For 2 files with 3 findings, this launches 1 agent instead of 2, halving the fixed session overhead (~8K tokens saved)

## Before/After

| Files to verify | Before (agents) | After (agents) |
|----------------|-----------------|----------------|
| 1-40           | 1-5 (one per file, capped at 5) | 1 |
| 41-80          | 5 | 2 |
| 81-120         | 5 | 3 |

## Test plan

- [x] All 24 verification tests pass
- [x] Full suite: 573/573 passing