### PR TITLE
feat: theme system redesign with family+mode architecture

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -39,7 +39,7 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject }) {
 function SettingsCase({ settings, analysisPower, setAnalysisPower }) {
   return (
     <SettingsPage
-      theme={{ preference: settings.themePreference, onApply: settings.applyTheme }}
+      theme={{ mode: settings.themeMode, family: settings.themeFamily, onApplyMode: settings.applyMode, onApplyFamily: settings.applyFamily }}
       models={{
         aiCmd: settings.aiCmd, onApplyAiCmd: settings.applyAiCmd,
         aiModel: settings.aiModel, onAiModelChange: settings.setAiModel,

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionScorePanel.jsx
@@ -11,15 +11,10 @@ import {
 } from 'recharts';
 import { formatShortDate, angleFromDelta } from '../../../utils/formatters.js';
 
-const cssVar = (() => {
-  const cache = {};
-  return (name, fallback) => {
-    if (!(name in cache)) {
-      cache[name] = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-    }
-    return cache[name] || fallback;
-  };
-})();
+const cssVar = (name, fallback) => {
+  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return val || fallback;
+};
 
 const SCORE_THRESHOLDS = { exemplary: 9, good: 7, adequate: 5, poor: 3 };
 const CHART_LEFT_MARGIN = -16;

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -18,15 +18,10 @@ const CHART_HEIGHT = 160;
 const REF_LINE_LOW = 2.5;
 const REF_LINE_MID = 5;
 const REF_LINE_HIGH = 7.5;
-const cssVar = (() => {
-  const cache = {};
-  return (name, fallback) => {
-    if (!(name in cache)) {
-      cache[name] = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-    }
-    return cache[name] || fallback;
-  };
-})();
+const cssVar = (name, fallback) => {
+  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return val || fallback;
+};
 
 const SCORE_EXEMPLARY = 9;
 const SCORE_GOOD = 7;

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -20,12 +20,12 @@ const MODE_OPTIONS = [
 ];
 
 const FAMILY_OPTIONS = [
-  { value: 'default',  label: 'Default',  accent: ['#d80c18', '#e82030'] },
-  { value: 'midnight', label: 'Midnight', accent: ['#4f46e5', '#00d4ff'] },
-  { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
-  { value: 'forest',   label: 'Forest',   accent: ['#1b6b3a', '#4caf7d'] },
-  { value: 'ember',    label: 'Ember',    accent: ['#c85a10', '#e88030'] },
-  { value: 'cyber',    label: 'Cyber',    accent: ['#d020a0', '#ff40c0'] },
+  { value: 'daruma',    label: 'Daruma',    accent: ['#d80c18', '#e82030'] },
+  { value: 'flynn',     label: 'Flynn',     accent: ['#4f46e5', '#00d4ff'] },
+  { value: 'neo',       label: 'Neo',       accent: ['#008833', '#00ff41'] },
+  { value: 'galadriel', label: 'Galadriel', accent: ['#1b6b3a', '#4caf7d'] },
+  { value: 'ifrit',     label: 'Ifrit',     accent: ['#c85a10', '#e88030'] },
+  { value: 'deckard',   label: 'Deckard',   accent: ['#d020a0', '#ff40c0'] },
 ];
 
 const _SETTINGS_PHRASES = [

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -24,7 +24,7 @@ const FAMILY_OPTIONS = [
   { value: 'midnight', label: 'Midnight', accent: ['#6366f1', '#00d4ff'] },
   { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
   { value: 'forest',   label: 'Forest',   accent: ['#2d6a4f', '#4caf7d'] },
-  { value: 'ember',    label: 'Ember',    accent: ['#c0392b', '#d80c18'] },
+  { value: 'ember',    label: 'Ember',    accent: ['#c06810', '#e8922a'] },
 ];
 
 const _SETTINGS_PHRASES = [

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -13,15 +13,18 @@ const MIN_POOL_BUDGET_MINS = 1;
 const MAX_POOL_BUDGET_MINS = 60;
 const DEFAULT_POOL_BUDGET_MINS = 10;
 
-const THEME_OPTIONS = [
+const MODE_OPTIONS = [
   { value: 'system',   label: 'System' },
   { value: 'light',    label: 'Light' },
   { value: 'dark',     label: 'Dark' },
-  { value: 'ember',    label: 'Ember' },
-  { value: 'forest',   label: 'Forest' },
-  { value: 'midnight', label: 'Midnight' },
-  { value: 'slate',    label: 'Slate' },
-  { value: 'horizon',  label: 'Horizon' },
+];
+
+const FAMILY_OPTIONS = [
+  { value: 'default',  label: 'Default',  accent: ['#d80c18', '#e82030'] },
+  { value: 'midnight', label: 'Midnight', accent: ['#6366f1', '#00d4ff'] },
+  { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
+  { value: 'forest',   label: 'Forest',   accent: ['#2d6a4f', '#4caf7d'] },
+  { value: 'ember',    label: 'Ember',    accent: ['#c0392b', '#d80c18'] },
 ];
 
 const _SETTINGS_PHRASES = [
@@ -32,7 +35,7 @@ const _SETTINGS_PHRASES = [
   'code quality compass',
 ];
 
-function ThemeSection({ themePreference, onApplyTheme }) {
+function ThemeSection({ themeMode, themeFamily, onApplyMode, onApplyFamily }) {
   return (
     <section className="panel settings-section">
       <div className="panel-header">
@@ -40,18 +43,40 @@ function ThemeSection({ themePreference, onApplyTheme }) {
       </div>
       <div className="settings-row">
         <div className="settings-row-label">
-          <span className="settings-label">Theme</span>
-          <span className="settings-description">Choose how Quodeq looks to you</span>
+          <span className="settings-label">Mode</span>
+          <span className="settings-description">Choose light, dark, or follow your system</span>
         </div>
         <div className="theme-toggle">
-          {THEME_OPTIONS.map(({ value, label }) => (
+          {MODE_OPTIONS.map(({ value, label }) => (
             <button
               key={value}
               type="button"
-              className={`theme-toggle-btn${themePreference === value ? ' active' : ''}`}
-              onClick={() => onApplyTheme(value)}
+              className={`theme-toggle-btn${themeMode === value ? ' active' : ''}`}
+              onClick={() => onApplyMode(value)}
             >
               {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Theme</span>
+          <span className="settings-description">Pick a color palette</span>
+        </div>
+        <div className="theme-family-picker">
+          {FAMILY_OPTIONS.map(({ value, label, accent }) => (
+            <button
+              key={value}
+              type="button"
+              className={`theme-family-card${themeFamily === value ? ' active' : ''}`}
+              onClick={() => onApplyFamily(value)}
+            >
+              <span className="theme-family-swatches">
+                <span className="theme-family-swatch" style={{ background: accent[0] }} />
+                <span className="theme-family-swatch" style={{ background: accent[1] }} />
+              </span>
+              <span className="theme-family-label">{label}</span>
             </button>
           ))}
         </div>
@@ -214,7 +239,7 @@ function useSettingsState(aiCmd, onApplyAiCmd) {
 }
 
 export default function SettingsPage({ theme, models, analysis, verification }) {
-  const { preference: themePreference, onApply: onApplyTheme } = theme;
+  const { mode: themeMode, family: themeFamily, onApplyMode, onApplyFamily } = theme;
   const { aiCmd, onApplyAiCmd } = models;
   const { power: analysisPower, onPowerChange: onAnalysisPowerChange } = analysis;
   const { enabled: verifyFindings, onApply: onApplyVerifyFindings } = verification;
@@ -225,7 +250,7 @@ export default function SettingsPage({ theme, models, analysis, verification }) 
       <SettingsHeader />
       <div className="settings-layout">
       <div className="settings-body">
-        <ThemeSection themePreference={themePreference} onApplyTheme={onApplyTheme} />
+        <ThemeSection themeMode={themeMode} themeFamily={themeFamily} onApplyMode={onApplyMode} onApplyFamily={onApplyFamily} />
 
         <section className="panel settings-section">
           <div className="panel-header">

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -24,7 +24,7 @@ const FAMILY_OPTIONS = [
   { value: 'midnight', label: 'Midnight', accent: ['#4f46e5', '#00d4ff'] },
   { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
   { value: 'forest',   label: 'Forest',   accent: ['#1b6b3a', '#4caf7d'] },
-  { value: 'classic',  label: 'Classic',  accent: ['#c06810', '#e8922a'] },
+  { value: 'ember',    label: 'Ember',    accent: ['#c85a10', '#e88030'] },
 ];
 
 const _SETTINGS_PHRASES = [

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -25,6 +25,7 @@ const FAMILY_OPTIONS = [
   { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
   { value: 'forest',   label: 'Forest',   accent: ['#1b6b3a', '#4caf7d'] },
   { value: 'ember',    label: 'Ember',    accent: ['#c85a10', '#e88030'] },
+  { value: 'cyber',    label: 'Cyber',    accent: ['#d020a0', '#ff40c0'] },
 ];
 
 const _SETTINGS_PHRASES = [

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -24,7 +24,7 @@ const FAMILY_OPTIONS = [
   { value: 'midnight', label: 'Midnight', accent: ['#4f46e5', '#00d4ff'] },
   { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
   { value: 'forest',   label: 'Forest',   accent: ['#1b6b3a', '#4caf7d'] },
-  { value: 'ember',    label: 'Ember',    accent: ['#c06810', '#e8922a'] },
+  { value: 'classic',  label: 'Classic',  accent: ['#c06810', '#e8922a'] },
 ];
 
 const _SETTINGS_PHRASES = [

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -21,9 +21,9 @@ const MODE_OPTIONS = [
 
 const FAMILY_OPTIONS = [
   { value: 'default',  label: 'Default',  accent: ['#d80c18', '#e82030'] },
-  { value: 'midnight', label: 'Midnight', accent: ['#6366f1', '#00d4ff'] },
+  { value: 'midnight', label: 'Midnight', accent: ['#4f46e5', '#00d4ff'] },
   { value: 'neo',      label: 'Neo',      accent: ['#008833', '#00ff41'] },
-  { value: 'forest',   label: 'Forest',   accent: ['#2d6a4f', '#4caf7d'] },
+  { value: 'forest',   label: 'Forest',   accent: ['#1b6b3a', '#4caf7d'] },
   { value: 'ember',    label: 'Ember',    accent: ['#c06810', '#e8922a'] },
 ];
 

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -20,12 +20,12 @@ const MODE_OPTIONS = [
 ];
 
 const FAMILY_OPTIONS = [
-  { value: 'daruma',    label: 'Daruma',    accent: ['#d80c18', '#e82030'] },
-  { value: 'flynn',     label: 'Flynn',     accent: ['#4f46e5', '#00d4ff'] },
-  { value: 'neo',       label: 'Neo',       accent: ['#008833', '#00ff41'] },
-  { value: 'galadriel', label: 'Galadriel', accent: ['#1b6b3a', '#4caf7d'] },
-  { value: 'ifrit',     label: 'Ifrit',     accent: ['#c85a10', '#e88030'] },
-  { value: 'deckard',   label: 'Deckard',   accent: ['#d020a0', '#ff40c0'] },
+  { value: 'daruma',    label: 'Daruma' },
+  { value: 'flynn',     label: 'Flynn' },
+  { value: 'neo',       label: 'Neo' },
+  { value: 'ifrit',     label: 'Ifrit' },
+  { value: 'deckard',   label: 'Deckard' },
+  { value: 'galadriel', label: 'Galadriel' },
 ];
 
 const _SETTINGS_PHRASES = [
@@ -66,17 +66,13 @@ function ThemeSection({ themeMode, themeFamily, onApplyMode, onApplyFamily }) {
           <span className="settings-description">Pick a color palette</span>
         </div>
         <div className="theme-family-picker">
-          {FAMILY_OPTIONS.map(({ value, label, accent }) => (
+          {FAMILY_OPTIONS.map(({ value, label }) => (
             <button
               key={value}
               type="button"
               className={`theme-family-card${themeFamily === value ? ' active' : ''}`}
               onClick={() => onApplyFamily(value)}
             >
-              <span className="theme-family-swatches">
-                <span className="theme-family-swatch" style={{ background: accent[0] }} />
-                <span className="theme-family-swatch" style={{ background: accent[1] }} />
-              </span>
               <span className="theme-family-label">{label}</span>
             </button>
           ))}

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -1,16 +1,67 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { MODEL_STORAGE_PREFIX } from '../features/evaluation/components/powerLevels.js';
 
-const THEME_KEY = 'cc-theme';
+const MODE_KEY = 'cc-theme-mode';
+const FAMILY_KEY = 'cc-theme-family';
+const OLD_THEME_KEY = 'cc-theme';
 const AI_CMD_KEY = 'cc-ai-cmd';
 const AI_MODEL_KEY = 'cc-ai-model';
 const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
+
+const VALID_MODES = ['system', 'light', 'dark'];
+const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember'];
+
+const MIGRATION_MAP = {
+  system:   { mode: 'system', family: 'default' },
+  light:    { mode: 'light',  family: 'default' },
+  dark:     { mode: 'dark',   family: 'default' },
+  ember:    { mode: 'dark',   family: 'ember' },
+  forest:   { mode: 'light',  family: 'forest' },
+  midnight: { mode: 'dark',   family: 'midnight' },
+  slate:    { mode: 'light',  family: 'default' },
+  horizon:  { mode: 'light',  family: 'midnight' },
+};
+
+function migrateOldTheme() {
+  try {
+    const old = localStorage.getItem(OLD_THEME_KEY);
+    if (old === null) return;
+    const mapped = MIGRATION_MAP[old] || { mode: 'system', family: 'default' };
+    localStorage.setItem(MODE_KEY, mapped.mode);
+    localStorage.setItem(FAMILY_KEY, mapped.family);
+    localStorage.removeItem(OLD_THEME_KEY);
+  } catch (e) {
+    console.warn('Theme migration failed:', e);
+  }
+}
+
+/** Compute the data-theme attribute value from mode + family + OS preference. */
+export function resolveDataTheme(mode, family, prefersDark) {
+  const effectiveMode = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
+  if (family === 'default') {
+    return effectiveMode === 'light' ? null : 'dark';
+  }
+  return `${family}-${effectiveMode}`;
+}
+
+function applyDataTheme(value) {
+  if (value === null) {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', value);
+  }
+}
 
 export function useAppSettings() {
   function safeGet(key, fallback = '') {
     try { return localStorage.getItem(key) || fallback; } catch (e) { console.warn('localStorage unavailable:', e); return fallback; }
   }
-  const [themePreference, setThemePreference] = useState(safeGet(THEME_KEY, 'system'));
+
+  // Run migration once before reading new keys
+  useState(() => migrateOldTheme());
+
+  const [themeMode, setThemeMode] = useState(safeGet(MODE_KEY, 'system'));
+  const [themeFamily, setThemeFamily] = useState(safeGet(FAMILY_KEY, 'default'));
   const [aiCmd, setAiCmd] = useState(safeGet(AI_CMD_KEY));
   const [aiModel, setAiModel] = useState(safeGet(AI_MODEL_KEY));
   const [modelFast, setModelFast] = useState(safeGet(`${MODEL_STORAGE_PREFIX}1`));
@@ -20,15 +71,32 @@ export function useAppSettings() {
     try { const v = localStorage.getItem(VERIFY_FINDINGS_KEY); return v === null ? true : v === 'true'; } catch { return true; }
   });
 
-  function applyTheme(value) {
-    setThemePreference(value);
-    if (value === 'system') {
-      localStorage.removeItem(THEME_KEY);
-      document.documentElement.removeAttribute('data-theme');
-    } else {
-      localStorage.setItem(THEME_KEY, value);
-      document.documentElement.setAttribute('data-theme', value);
-    }
+  // Listen for OS color scheme changes when in system mode
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => {
+      if (themeMode === 'system') {
+        applyDataTheme(resolveDataTheme('system', themeFamily, e.matches));
+      }
+    };
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [themeMode, themeFamily]);
+
+  function applyMode(value) {
+    if (!VALID_MODES.includes(value)) return;
+    setThemeMode(value);
+    localStorage.setItem(MODE_KEY, value);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyDataTheme(resolveDataTheme(value, themeFamily, prefersDark));
+  }
+
+  function applyFamily(value) {
+    if (!VALID_FAMILIES.includes(value)) return;
+    setThemeFamily(value);
+    localStorage.setItem(FAMILY_KEY, value);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyDataTheme(resolveDataTheme(themeMode, value, prefersDark));
   }
 
   function applyAiCmd(value) {
@@ -46,7 +114,8 @@ export function useAppSettings() {
   }
 
   return {
-    themePreference, applyTheme,
+    themeMode, applyMode,
+    themeFamily, applyFamily,
     aiCmd, applyAiCmd,
     aiModel, setAiModel,
     modelFast, setModelFast,

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -9,24 +9,32 @@ const AI_MODEL_KEY = 'cc-ai-model';
 const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
 
 const VALID_MODES = ['system', 'light', 'dark'];
-const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember', 'cyber'];
+const VALID_FAMILIES = ['daruma', 'flynn', 'neo', 'galadriel', 'ifrit', 'deckard'];
 
 const MIGRATION_MAP = {
-  system:   { mode: 'system', family: 'default' },
-  light:    { mode: 'light',  family: 'default' },
-  dark:     { mode: 'dark',   family: 'default' },
-  ember:    { mode: 'dark',   family: 'ember' },
-  forest:   { mode: 'light',  family: 'forest' },
-  midnight: { mode: 'dark',   family: 'midnight' },
-  slate:    { mode: 'light',  family: 'default' },
-  horizon:  { mode: 'light',  family: 'midnight' },
+  system:   { mode: 'system', family: 'daruma' },
+  light:    { mode: 'light',  family: 'daruma' },
+  dark:     { mode: 'dark',   family: 'daruma' },
+  ember:    { mode: 'dark',   family: 'ifrit' },
+  forest:   { mode: 'light',  family: 'galadriel' },
+  midnight: { mode: 'dark',   family: 'flynn' },
+  slate:    { mode: 'light',  family: 'daruma' },
+  horizon:  { mode: 'light',  family: 'flynn' },
 };
 
 function migrateOldTheme() {
   try {
     const old = localStorage.getItem(OLD_THEME_KEY);
-    if (old === null) return;
-    const mapped = MIGRATION_MAP[old] || { mode: 'system', family: 'default' };
+    if (old === null) {
+      // Migrate old family names to character names
+      const currentFamily = localStorage.getItem(FAMILY_KEY);
+      const familyRenames = { 'default': 'daruma', 'midnight': 'flynn', 'forest': 'galadriel', 'ember': 'ifrit', 'cyber': 'deckard' };
+      if (currentFamily && familyRenames[currentFamily]) {
+        localStorage.setItem(FAMILY_KEY, familyRenames[currentFamily]);
+      }
+      return;
+    }
+    const mapped = MIGRATION_MAP[old] || { mode: 'system', family: 'daruma' };
     localStorage.setItem(MODE_KEY, mapped.mode);
     localStorage.setItem(FAMILY_KEY, mapped.family);
     localStorage.removeItem(OLD_THEME_KEY);
@@ -38,7 +46,7 @@ function migrateOldTheme() {
 /** Compute the data-theme attribute value from mode + family + OS preference. */
 export function resolveDataTheme(mode, family, prefersDark) {
   const effectiveMode = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
-  if (family === 'default') {
+  if (family === 'daruma') {
     // System mode: return null so @media (prefers-color-scheme) drives the theme
     // Explicit mode: return 'light' or 'dark' to override OS preference
     return mode === 'system' ? null : effectiveMode;
@@ -63,7 +71,7 @@ export function useAppSettings() {
   useState(() => migrateOldTheme());
 
   const [themeMode, setThemeMode] = useState(safeGet(MODE_KEY, 'system'));
-  const [themeFamily, setThemeFamily] = useState(safeGet(FAMILY_KEY, 'default'));
+  const [themeFamily, setThemeFamily] = useState(safeGet(FAMILY_KEY, 'daruma'));
   const [aiCmd, setAiCmd] = useState(safeGet(AI_CMD_KEY));
   const [aiModel, setAiModel] = useState(safeGet(AI_MODEL_KEY));
   const [modelFast, setModelFast] = useState(safeGet(`${MODEL_STORAGE_PREFIX}1`));

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -9,7 +9,7 @@ const AI_MODEL_KEY = 'cc-ai-model';
 const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
 
 const VALID_MODES = ['system', 'light', 'dark'];
-const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember'];
+const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember', 'cyber'];
 
 const MIGRATION_MAP = {
   system:   { mode: 'system', family: 'default' },

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -39,7 +39,9 @@ function migrateOldTheme() {
 export function resolveDataTheme(mode, family, prefersDark) {
   const effectiveMode = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
   if (family === 'default') {
-    return effectiveMode === 'light' ? null : 'dark';
+    // System mode: return null so @media (prefers-color-scheme) drives the theme
+    // Explicit mode: return 'light' or 'dark' to override OS preference
+    return mode === 'system' ? null : effectiveMode;
   }
   return `${family}-${effectiveMode}`;
 }

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -9,13 +9,13 @@ const AI_MODEL_KEY = 'cc-ai-model';
 const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
 
 const VALID_MODES = ['system', 'light', 'dark'];
-const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'classic'];
+const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember'];
 
 const MIGRATION_MAP = {
   system:   { mode: 'system', family: 'default' },
   light:    { mode: 'light',  family: 'default' },
   dark:     { mode: 'dark',   family: 'default' },
-  ember:    { mode: 'dark',   family: 'classic' },
+  ember:    { mode: 'dark',   family: 'ember' },
   forest:   { mode: 'light',  family: 'forest' },
   midnight: { mode: 'dark',   family: 'midnight' },
   slate:    { mode: 'light',  family: 'default' },

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -9,13 +9,13 @@ const AI_MODEL_KEY = 'cc-ai-model';
 const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
 
 const VALID_MODES = ['system', 'light', 'dark'];
-const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'ember'];
+const VALID_FAMILIES = ['default', 'midnight', 'neo', 'forest', 'classic'];
 
 const MIGRATION_MAP = {
   system:   { mode: 'system', family: 'default' },
   light:    { mode: 'light',  family: 'default' },
   dark:     { mode: 'dark',   family: 'default' },
-  ember:    { mode: 'dark',   family: 'ember' },
+  ember:    { mode: 'dark',   family: 'classic' },
   forest:   { mode: 'light',  family: 'forest' },
   midnight: { mode: 'dark',   family: 'midnight' },
   slate:    { mode: 'light',  family: 'default' },

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -7,20 +7,26 @@ import './styles/index.css';
 // Migration: if old key exists, migrate to new keys
 const _oldTheme = localStorage.getItem('cc-theme');
 if (_oldTheme !== null) {
-  const _map = { system: ['system','default'], light: ['light','default'], dark: ['dark','default'],
-    ember: ['dark','ember'], forest: ['light','forest'], midnight: ['dark','midnight'],
-    slate: ['light','default'], horizon: ['light','midnight'] };
-  const [_m, _f] = _map[_oldTheme] || ['system','default'];
+  const _map = { system: ['system','daruma'], light: ['light','daruma'], dark: ['dark','daruma'],
+    ember: ['dark','ifrit'], forest: ['light','galadriel'], midnight: ['dark','flynn'],
+    slate: ['light','daruma'], horizon: ['light','flynn'] };
+  const [_m, _f] = _map[_oldTheme] || ['system','daruma'];
   localStorage.setItem('cc-theme-mode', _m);
   localStorage.setItem('cc-theme-family', _f);
   localStorage.removeItem('cc-theme');
 }
+// Migrate old family names to character names
+const _oldFamily = localStorage.getItem('cc-theme-family');
+const _familyMap = { 'default': 'daruma', 'midnight': 'flynn', 'forest': 'galadriel', 'ember': 'ifrit', 'cyber': 'deckard' };
+if (_oldFamily && _familyMap[_oldFamily]) {
+  localStorage.setItem('cc-theme-family', _familyMap[_oldFamily]);
+}
 const _mode = localStorage.getItem('cc-theme-mode') || 'system';
-const _family = localStorage.getItem('cc-theme-family') || 'default';
+const _family = localStorage.getItem('cc-theme-family') || 'daruma';
 const _prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 const _effectiveMode = _mode === 'system' ? (_prefersDark ? 'dark' : 'light') : _mode;
 // NOTE: This logic must mirror resolveDataTheme() in useAppSettings.js
-if (_family === 'default') {
+if (_family === 'daruma') {
   // System mode: don't set attribute, let @media (prefers-color-scheme) drive
   // Explicit mode: set 'light' or 'dark' to override OS preference
   if (_mode !== 'system') document.documentElement.setAttribute('data-theme', _effectiveMode);

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -8,7 +8,7 @@ import './styles/index.css';
 const _oldTheme = localStorage.getItem('cc-theme');
 if (_oldTheme !== null) {
   const _map = { system: ['system','default'], light: ['light','default'], dark: ['dark','default'],
-    ember: ['dark','classic'], forest: ['light','forest'], midnight: ['dark','midnight'],
+    ember: ['dark','ember'], forest: ['light','forest'], midnight: ['dark','midnight'],
     slate: ['light','default'], horizon: ['light','midnight'] };
   const [_m, _f] = _map[_oldTheme] || ['system','default'];
   localStorage.setItem('cc-theme-mode', _m);

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -4,11 +4,25 @@ import App from './App.jsx';
 import './styles/index.css';
 
 // Apply saved theme before first render (prevents flash)
-const THEME_STORAGE_KEY = 'cc-theme';
-const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
-const VALID_THEMES = ['dark', 'light', 'ember', 'forest', 'midnight', 'slate', 'horizon'];
-if (VALID_THEMES.includes(savedTheme)) {
-  document.documentElement.setAttribute('data-theme', savedTheme);
+// Migration: if old key exists, migrate to new keys
+const _oldTheme = localStorage.getItem('cc-theme');
+if (_oldTheme !== null) {
+  const _map = { system: ['system','default'], light: ['light','default'], dark: ['dark','default'],
+    ember: ['dark','ember'], forest: ['light','forest'], midnight: ['dark','midnight'],
+    slate: ['light','default'], horizon: ['light','midnight'] };
+  const [_m, _f] = _map[_oldTheme] || ['system','default'];
+  localStorage.setItem('cc-theme-mode', _m);
+  localStorage.setItem('cc-theme-family', _f);
+  localStorage.removeItem('cc-theme');
+}
+const _mode = localStorage.getItem('cc-theme-mode') || 'system';
+const _family = localStorage.getItem('cc-theme-family') || 'default';
+const _prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const _effectiveMode = _mode === 'system' ? (_prefersDark ? 'dark' : 'light') : _mode;
+if (_family === 'default') {
+  if (_effectiveMode === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+} else {
+  document.documentElement.setAttribute('data-theme', `${_family}-${_effectiveMode}`);
 }
 
 const rootEl = document.getElementById('root');

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -19,8 +19,11 @@ const _mode = localStorage.getItem('cc-theme-mode') || 'system';
 const _family = localStorage.getItem('cc-theme-family') || 'default';
 const _prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 const _effectiveMode = _mode === 'system' ? (_prefersDark ? 'dark' : 'light') : _mode;
+// NOTE: This logic must mirror resolveDataTheme() in useAppSettings.js
 if (_family === 'default') {
-  if (_effectiveMode === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+  // System mode: don't set attribute, let @media (prefers-color-scheme) drive
+  // Explicit mode: set 'light' or 'dark' to override OS preference
+  if (_mode !== 'system') document.documentElement.setAttribute('data-theme', _effectiveMode);
 } else {
   document.documentElement.setAttribute('data-theme', `${_family}-${_effectiveMode}`);
 }

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -8,7 +8,7 @@ import './styles/index.css';
 const _oldTheme = localStorage.getItem('cc-theme');
 if (_oldTheme !== null) {
   const _map = { system: ['system','default'], light: ['light','default'], dark: ['dark','default'],
-    ember: ['dark','ember'], forest: ['light','forest'], midnight: ['dark','midnight'],
+    ember: ['dark','classic'], forest: ['light','forest'], midnight: ['dark','midnight'],
     slate: ['light','default'], horizon: ['light','midnight'] };
   const [_m, _f] = _map[_oldTheme] || ['system','default'];
   localStorage.setItem('cc-theme-mode', _m);

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1402,6 +1402,8 @@ textarea:focus {
 
 .theme-toggle-btn.active {
   border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
   font-weight: var(--weight-semibold);
 }
 
@@ -1430,6 +1432,7 @@ textarea:focus {
 
 .theme-family-card.active {
   border-color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .theme-family-swatches {
@@ -1445,12 +1448,14 @@ textarea:focus {
 }
 
 .theme-family-label {
-  font-size: 0.75rem;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   color: var(--color-text-muted);
 }
 
 .theme-family-card.active .theme-family-label {
-  color: var(--color-text);
+  color: var(--color-accent);
+  font-weight: var(--weight-semibold);
 }
 
 /* Responsive breakpoints (app shell / layout) */

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -835,7 +835,7 @@ textarea:focus {
 }
 
 .severity-tag.compliance {
-  color: color-mix(in srgb, var(--color-compliance) 65%, black);
+  color: var(--color-compliance);
   background: var(--color-compliance-bg);
   border-color: var(--color-compliance-border);
 }
@@ -853,8 +853,8 @@ textarea:focus {
   border: 1px solid transparent;
 }
 
-.chip.grade-top    { color: color-mix(in srgb, var(--color-grade-top-text) 65%, black);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
-.chip.grade-high   { color: color-mix(in srgb, var(--color-grade-high-text) 75%, black);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 38%, transparent); }
+.chip.grade-top    { color: var(--color-grade-top-text);    background: var(--color-grade-top-bg);    border-color: color-mix(in srgb, var(--color-grade-top-text) 48%, transparent); }
+.chip.grade-high   { color: var(--color-grade-high-text);   background: var(--color-grade-high-bg);   border-color: color-mix(in srgb, var(--color-grade-high-text) 38%, transparent); }
 .chip.grade-mid    { color: var(--color-grade-mid-text);    background: var(--color-grade-mid-bg);    border-color: color-mix(in srgb, var(--color-grade-mid-text) 28%, transparent); }
 .chip.grade-low    { color: var(--color-grade-low-text);    background: var(--color-grade-low-bg);    border-color: color-mix(in srgb, var(--color-grade-low-text) 28%, transparent); }
 .chip.grade-bottom { color: var(--color-grade-bottom-text); background: var(--color-grade-bottom-bg); border-color: color-mix(in srgb, var(--color-grade-bottom-text) 28%, transparent); }

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1411,7 +1411,7 @@ textarea:focus {
 
 .theme-family-picker {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  grid-template-columns: repeat(6, 1fr);
   gap: 8px;
 }
 

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1409,6 +1409,54 @@ textarea:focus {
   font-weight: var(--weight-semibold);
 }
 
+.theme-family-picker {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.theme-family-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.theme-family-card:hover {
+  border-color: var(--color-text-muted);
+}
+
+.theme-family-card.active {
+  border-color: var(--color-accent);
+}
+
+.theme-family-swatches {
+  display: flex;
+  gap: 4px;
+}
+
+.theme-family-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+}
+
+.theme-family-label {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.theme-family-card.active .theme-family-label {
+  color: var(--color-text);
+}
+
 /* Responsive breakpoints (app shell / layout) */
 
 @media (max-width: 900px) {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1410,22 +1410,22 @@ textarea:focus {
 }
 
 .theme-family-picker {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 8px;
-  flex-wrap: wrap;
 }
 
 .theme-family-card {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
   padding: 10px 14px;
   border-radius: 8px;
   border: 2px solid var(--color-border);
   background: var(--color-surface);
   cursor: pointer;
   transition: border-color 0.15s;
+  text-align: center;
 }
 
 .theme-family-card:hover {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1377,15 +1377,15 @@ textarea:focus {
 /* ─── Theme toggle ─── */
 
 .theme-toggle {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
 }
 
 .theme-toggle-btn {
-  padding: 4px var(--space-3);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-full);
+  padding: 10px 14px;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
   background: var(--color-surface);
   color: var(--color-text-muted);
   font-family: var(--font-sans);
@@ -1397,14 +1397,10 @@ textarea:focus {
 }
 
 .theme-toggle-btn:hover {
-  background: var(--color-surface-alt);
-  color: var(--color-text);
   border-color: var(--color-text-muted);
 }
 
 .theme-toggle-btn.active {
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
   border-color: var(--color-accent);
   font-weight: var(--weight-semibold);
 }

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -627,9 +627,9 @@
 .qd-card-stat-compliance {
   font-size: var(--text-xs);
   font-weight: var(--weight-medium);
-  color: color-mix(in srgb, var(--color-grade-top-text) 65%, black);
-  background: var(--color-grade-top-bg);
-  border: 1px solid color-mix(in srgb, var(--color-grade-top-text) 48%, transparent);
+  color: var(--color-compliance);
+  background: var(--color-compliance-bg);
+  border: 1px solid var(--color-compliance-border);
   border-radius: var(--radius-sm);
   padding: 2px var(--space-2);
   white-space: nowrap;
@@ -2400,8 +2400,8 @@
   flex-shrink: 0;
 }
 
-.projects-grade--a { color: color-mix(in srgb, var(--color-grade-top-text) 65%, black); }
-.projects-grade--b { color: color-mix(in srgb, var(--color-grade-high-text) 75%, black); }
+.projects-grade--a { color: var(--color-grade-top-text); }
+.projects-grade--b { color: var(--color-grade-high-text); }
 .projects-grade--c { color: var(--color-grade-mid-text); }
 .projects-grade--d { color: var(--color-grade-low-text); }
 .projects-grade--f { color: var(--color-grade-bottom-text); }

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -241,6 +241,14 @@
   --primitive-amber-800:   #a16207;
   --primitive-daruma-600:  #d9a010;  /* warm yellow-gold — daruma eye rings */
   --primitive-daruma-400:  #d4d8e0;  /* light gray for dark backgrounds — visibly lighter than grade-high */
+
+  /* Daruma dark palette (warm ink) */
+  --primitive-daruma-950: #121010;
+  --primitive-daruma-900: #1a1816;
+  --primitive-daruma-800: #242220;
+  --primitive-daruma-700: #343230;
+  --primitive-daruma-500: #9a9490;
+  --primitive-daruma-200: #e8e2d8;
   --primitive-brand-300:   #b8bec8;  /* mid gray for dark grade-high — between brand-400 (text-muted) and brand-200 */
   --primitive-emerald-300: #6ee7a0;
   --primitive-rust-700:    #9f3a28;
@@ -359,15 +367,15 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg:           var(--primitive-brand-950);
-    --color-surface:      var(--primitive-brand-900);
-    --color-surface-alt:  var(--primitive-brand-800);
-    --color-border:       var(--primitive-brand-700);
+    --color-bg:           var(--primitive-daruma-950);
+    --color-surface:      var(--primitive-daruma-900);
+    --color-surface-alt:  var(--primitive-daruma-800);
+    --color-border:       var(--primitive-daruma-700);
     --color-border-focus: var(--primitive-crimson-500);
 
-    --color-text:         var(--primitive-brand-200);
-    --color-text-muted:   var(--primitive-brand-400);
-    --color-text-subtle:  var(--primitive-brand-500);
+    --color-text:         var(--primitive-daruma-200);
+    --color-text-muted:   var(--primitive-daruma-500);
+    --color-text-subtle:  #6a6460;
 
     --color-accent:       var(--primitive-crimson-400);
     --color-accent-hover: var(--primitive-crimson-300);
@@ -389,8 +397,8 @@
 
     --color-grade-top-text:    var(--primitive-daruma-400);
     --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-    --color-grade-high-text:   var(--primitive-brand-300);
-    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
+    --color-grade-high-text:   var(--primitive-daruma-500);
+    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-daruma-500) 14%, transparent);
     --color-grade-mid-text:    var(--primitive-ired-300);
     --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
     --color-grade-low-text:    var(--primitive-ired-400);
@@ -419,22 +427,22 @@
     --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
     /* Chart */
-    --color-chart-grid:   var(--primitive-brand-700);
-    --color-chart-axis:   var(--primitive-brand-500);
-    --color-chart-line:   var(--primitive-brand-200);
+    --color-chart-grid:   var(--primitive-daruma-700);
+    --color-chart-axis:   var(--primitive-daruma-500);
+    --color-chart-line:   var(--primitive-daruma-200);
     --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
     /* Trend — gray → crimson on dark backgrounds */
-    --color-trend-strong-up:   var(--primitive-brand-300);
+    --color-trend-strong-up:   var(--primitive-daruma-200);
     --color-trend-up:          var(--primitive-ired-200);
-    --color-trend-soft-up:     var(--primitive-brand-500);
+    --color-trend-soft-up:     var(--primitive-daruma-500);
     --color-trend-soft-down:   var(--primitive-ired-300);
     --color-trend-down:        var(--primitive-ired-400);
     --color-trend-strong-down: var(--primitive-crimson-200);
 
     /* Logo — monochrome light */
     --logo-q:              var(--primitive-brand-200);
-    --logo-chevron:        var(--primitive-brand-200);
+    --logo-chevron:        var(--primitive-daruma-200);
     --logo-chevron-hover:  var(--primitive-crimson-300);
     --logo-needle:         var(--primitive-brand-200);
     --logo-needle-dark:    var(--primitive-brand-400);
@@ -447,15 +455,15 @@
    ──────────────────────────────────────────────────────── */
 
 html[data-theme="dark"]:root {
-  --color-bg:           var(--primitive-brand-950);
-  --color-surface:      var(--primitive-brand-900);
-  --color-surface-alt:  var(--primitive-brand-800);
-  --color-border:       var(--primitive-brand-700);
+  --color-bg:           var(--primitive-daruma-950);
+  --color-surface:      var(--primitive-daruma-900);
+  --color-surface-alt:  var(--primitive-daruma-800);
+  --color-border:       var(--primitive-daruma-700);
   --color-border-focus: var(--primitive-crimson-500);
 
-  --color-text:         var(--primitive-brand-200);
-  --color-text-muted:   var(--primitive-brand-400);
-  --color-text-subtle:  var(--primitive-brand-500);
+  --color-text:         var(--primitive-daruma-200);
+  --color-text-muted:   var(--primitive-daruma-500);
+  --color-text-subtle:  #6a6460;
 
   --color-accent:       var(--primitive-crimson-400);
   --color-accent-hover: var(--primitive-crimson-300);
@@ -477,8 +485,8 @@ html[data-theme="dark"]:root {
 
   --color-grade-top-text:    var(--primitive-daruma-400);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-  --color-grade-high-text:   var(--primitive-brand-300);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
+  --color-grade-high-text:   var(--primitive-daruma-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-daruma-500) 14%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
@@ -507,15 +515,15 @@ html[data-theme="dark"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
   /* Chart */
-  --color-chart-grid:   var(--primitive-brand-700);
-  --color-chart-axis:   var(--primitive-brand-500);
-  --color-chart-line:   var(--primitive-brand-200);
+  --color-chart-grid:   var(--primitive-daruma-700);
+  --color-chart-axis:   var(--primitive-daruma-500);
+  --color-chart-line:   var(--primitive-daruma-200);
   --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
   /* Trend — gray → crimson on dark backgrounds */
-  --color-trend-strong-up:   var(--primitive-brand-300);
+  --color-trend-strong-up:   var(--primitive-daruma-200);
   --color-trend-up:          var(--primitive-ired-200);
-  --color-trend-soft-up:     var(--primitive-brand-500);
+  --color-trend-soft-up:     var(--primitive-daruma-500);
   --color-trend-soft-down:   var(--primitive-ired-300);
   --color-trend-down:        var(--primitive-ired-400);
   --color-trend-strong-down: var(--primitive-crimson-200);
@@ -525,7 +533,7 @@ html[data-theme="dark"]:root {
 
   /* Logo — monochrome light */
   --logo-q:              var(--primitive-brand-200);
-  --logo-chevron:        var(--primitive-brand-200);
+  --logo-chevron:        var(--primitive-daruma-200);
   --logo-chevron-hover:  var(--primitive-crimson-300);
   --logo-needle:         var(--primitive-brand-200);
   --logo-needle-dark:    var(--primitive-brand-400);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -268,9 +268,9 @@
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  /* Grade tier colors */
-  --color-grade-top-text:    #c49000;
-  --color-grade-top-bg:      color-mix(in srgb, #c49000 12%, transparent);
+  /* Grade tier colors — Daruma Fire: vivid gold top, warm gray high */
+  --color-grade-top-text:    #e0a800;
+  --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
   --color-grade-high-text:   #6c7078;
   --color-grade-high-bg:     color-mix(in srgb, #6c7078 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-800);
@@ -281,7 +281,7 @@
   --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
   /* Trend — default is light; dark themes override below */
-  --color-trend-strong-up:   #c49000;
+  --color-trend-strong-up:   #e0a800;
   --color-trend-up:          var(--primitive-ired-700);
   --color-trend-soft-up:     var(--primitive-brand-400);
   --color-trend-soft-down:   var(--primitive-ired-800);
@@ -364,10 +364,10 @@
     --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
     --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-    --color-grade-top-text:    #f0be28;
-    --color-grade-top-bg:      color-mix(in srgb, #f0be28 14%, transparent);
-    --color-grade-high-text:   #a0a4ae;
-    --color-grade-high-bg:     color-mix(in srgb, #a0a4ae 14%, transparent);
+    --color-grade-top-text:    var(--primitive-daruma-400);
+    --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
+    --color-grade-high-text:   var(--primitive-brand-300);
+    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
     --color-grade-mid-text:    var(--primitive-ired-300);
     --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
     --color-grade-low-text:    var(--primitive-ired-400);
@@ -385,11 +385,6 @@
     --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
     --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
-    /* Compliance — teal (Daruma Fire direction) */
-    --color-compliance:        #28d2b4;
-    --color-compliance-bg:     color-mix(in srgb, #28d2b4 4%, transparent);
-    --color-compliance-border: color-mix(in srgb, #28d2b4 38%, transparent);
-
     /* Overlays */
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
     --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -402,7 +397,7 @@
     --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
     /* Trend — gray → crimson on dark backgrounds */
-    --color-trend-strong-up:   #f0be28;
+    --color-trend-strong-up:   var(--primitive-brand-300);
     --color-trend-up:          var(--primitive-ired-200);
     --color-trend-soft-up:     var(--primitive-brand-500);
     --color-trend-soft-down:   var(--primitive-ired-300);
@@ -452,10 +447,10 @@ html[data-theme="dark"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-  --color-grade-top-text:    #f0be28;
-  --color-grade-top-bg:      color-mix(in srgb, #f0be28 14%, transparent);
-  --color-grade-high-text:   #a0a4ae;
-  --color-grade-high-bg:     color-mix(in srgb, #a0a4ae 14%, transparent);
+  --color-grade-top-text:    var(--primitive-daruma-400);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
+  --color-grade-high-text:   var(--primitive-brand-300);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
@@ -473,11 +468,6 @@ html[data-theme="dark"]:root {
   --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
-  /* Compliance — teal (Daruma Fire direction) */
-  --color-compliance:        #28d2b4;
-  --color-compliance-bg:     color-mix(in srgb, #28d2b4 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #28d2b4 38%, transparent);
-
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -490,7 +480,7 @@ html[data-theme="dark"]:root {
   --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
   /* Trend — gray → crimson on dark backgrounds */
-  --color-trend-strong-up:   #f0be28;
+  --color-trend-strong-up:   var(--primitive-brand-300);
   --color-trend-up:          var(--primitive-ired-200);
   --color-trend-soft-up:     var(--primitive-brand-500);
   --color-trend-soft-down:   var(--primitive-ired-300);
@@ -541,8 +531,8 @@ html[data-theme="light"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    #c49000;
-  --color-grade-top-bg:      color-mix(in srgb, #c49000 12%, transparent);
+  --color-grade-top-text:    #e0a800;
+  --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
   --color-grade-high-text:   #6c7078;
   --color-grade-high-bg:     color-mix(in srgb, #6c7078 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-800);
@@ -579,7 +569,7 @@ html[data-theme="light"]:root {
   --color-chart-stroke: transparent;
 
   /* Trend — gray → crimson on light backgrounds */
-  --color-trend-strong-up:   #c49000;
+  --color-trend-strong-up:   #e0a800;
   --color-trend-up:          var(--primitive-ired-700);
   --color-trend-soft-up:     var(--primitive-brand-400);
   --color-trend-soft-down:   var(--primitive-ired-800);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -87,6 +87,32 @@
   --primitive-horizon-800: #4338ca;
   --primitive-horizon-900: #111827;
 
+  /* Neo palette (Matrix terminal) */
+  --primitive-neo-950:  #0a0a0a;
+  --primitive-neo-900:  #111111;
+  --primitive-neo-800:  #1a1a1a;
+  --primitive-neo-700:  #282828;
+  --primitive-neo-500:  #608060;
+  --primitive-neo-200:  #b0ffb0;
+  --primitive-neo-accent: #00ff41;
+  --primitive-neo-accent-dark: #008833;
+  --primitive-neo-50:   #f0f5f0;
+  --primitive-neo-100:  #e4ede4;
+  --primitive-neo-border-light: #c0d4c0;
+  --primitive-neo-text-dark: #0a2010;
+
+  /* Forest dark extensions */
+  --primitive-forest-950:      #0e1610;
+  --primitive-forest-900-dark: #152018;
+  --primitive-forest-800-dark: #1e2c20;
+  --primitive-forest-700-dark: #2e4230;
+
+  /* Ember light extensions */
+  --primitive-ember-50:  #faf6f2;
+  --primitive-ember-100: #f0ebe4;
+  --primitive-ember-border-light: #ddd4c8;
+  --primitive-ember-text-dark: #2a2018;
+
   /* Brand neutrals (cool near-black, logo-derived) */
   --primitive-brand-950: #0d1014;
   --primitive-brand-900: #14161b;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -45,27 +45,27 @@
   --primitive-dark-500: #9a9490;
   --primitive-dark-200: #f0ece6;
 
-  /* Ember palette (warm dark, logo-derived) */
-  --primitive-ember-950: #12100e;
-  --primitive-ember-900: #1c1916;
-  --primitive-ember-800: #262220;
-  --primitive-ember-700: #3a3330;
-  --primitive-ember-500: #9a8e84;
-  --primitive-ember-200: #f0e8e0;
+  /* Classic palette (warm dark, logo-derived) */
+  --primitive-classic-950: #12100e;
+  --primitive-classic-900: #1c1916;
+  --primitive-classic-800: #262220;
+  --primitive-classic-700: #3a3330;
+  --primitive-classic-500: #9a8e84;
+  --primitive-classic-200: #f0e8e0;
 
-  /* Ember Campfire palette */
-  --primitive-ember-campfire-950: #14100a;
-  --primitive-ember-campfire-900: #1e1810;
-  --primitive-ember-campfire-800: #2a2218;
-  --primitive-ember-campfire-700: #3e3428;
-  --primitive-ember-campfire-500: #9a8570;
-  --primitive-ember-campfire-200: #f0e4d4;
-  --primitive-ember-campfire-accent-light: #c06810;
-  --primitive-ember-campfire-accent-dark: #e8922a;
-  --primitive-ember-campfire-50: #fdf8f0;
-  --primitive-ember-campfire-100: #f5ece0;
-  --primitive-ember-campfire-border-light: #e0d0be;
-  --primitive-ember-campfire-text-dark: #2c1e10;
+  /* Classic Campfire palette */
+  --primitive-classic-campfire-950: #14100a;
+  --primitive-classic-campfire-900: #1e1810;
+  --primitive-classic-campfire-800: #2a2218;
+  --primitive-classic-campfire-700: #3e3428;
+  --primitive-classic-campfire-500: #9a8570;
+  --primitive-classic-campfire-200: #f0e4d4;
+  --primitive-classic-campfire-accent-light: #c06810;
+  --primitive-classic-campfire-accent-dark: #e8922a;
+  --primitive-classic-campfire-50: #fdf8f0;
+  --primitive-classic-campfire-100: #f5ece0;
+  --primitive-classic-campfire-border-light: #e0d0be;
+  --primitive-classic-campfire-text-dark: #2c1e10;
 
   /* Forest palette (nature greens, sage) */
   --primitive-forest-50:  #f4f7f4;
@@ -121,11 +121,11 @@
   --primitive-forest-800-dark: #1e2c20;
   --primitive-forest-700-dark: #2e4230;
 
-  /* Ember light extensions */
-  --primitive-ember-50:  #faf6f2;
-  --primitive-ember-100: #f0ebe4;
-  --primitive-ember-border-light: #ddd4c8;
-  --primitive-ember-text-dark: #2a2018;
+  /* Classic light extensions */
+  --primitive-classic-50:  #faf6f2;
+  --primitive-classic-100: #f0ebe4;
+  --primitive-classic-border-light: #ddd4c8;
+  --primitive-classic-text-dark: #2a2018;
 
   /* Brand neutrals (cool near-black, logo-derived) */
   --primitive-brand-950: #0d1014;
@@ -205,13 +205,13 @@
   --primitive-forest-sev-major-dark:     #d28c50;
   --primitive-forest-sev-minor-dark:     #b49664;
 
-  /* Ember traffic-light severity (minor is warm gray, green reserved for compliance) */
-  --primitive-ember-sev-critical-light: #c01e14;
-  --primitive-ember-sev-major-light:    #b89800;
-  --primitive-ember-sev-minor-light:    #9a8a70;
-  --primitive-ember-sev-critical-dark:  #ff4632;
-  --primitive-ember-sev-major-dark:     #f0c832;
-  --primitive-ember-sev-minor-dark:     #b0a088;
+  /* Classic traffic-light severity (minor is warm gray, green reserved for compliance) */
+  --primitive-classic-sev-critical-light: #c01e14;
+  --primitive-classic-sev-major-light:    #b89800;
+  --primitive-classic-sev-minor-light:    #9a8a70;
+  --primitive-classic-sev-critical-dark:  #ff4632;
+  --primitive-classic-sev-major-dark:     #f0c832;
+  --primitive-classic-sev-minor-dark:     #b0a088;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
@@ -596,43 +596,43 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Ember Dark — campfire, amber glow ─────────────────── */
+/* ── Classic Dark — campfire, amber glow ───────────────── */
 
-html[data-theme="ember-dark"]:root {
-  --color-bg:           var(--primitive-ember-campfire-950);
-  --color-surface:      var(--primitive-ember-campfire-900);
-  --color-surface-alt:  var(--primitive-ember-campfire-800);
-  --color-border:       var(--primitive-ember-campfire-700);
-  --color-border-focus: var(--primitive-ember-campfire-accent-dark);
+html[data-theme="classic-dark"]:root {
+  --color-bg:           var(--primitive-classic-campfire-950);
+  --color-surface:      var(--primitive-classic-campfire-900);
+  --color-surface-alt:  var(--primitive-classic-campfire-800);
+  --color-border:       var(--primitive-classic-campfire-700);
+  --color-border-focus: var(--primitive-classic-campfire-accent-dark);
 
-  --color-text:         var(--primitive-ember-campfire-200);
-  --color-text-muted:   var(--primitive-ember-campfire-500);
+  --color-text:         var(--primitive-classic-campfire-200);
+  --color-text-muted:   var(--primitive-classic-campfire-500);
   --color-text-subtle:  #706050;
 
-  --color-accent:       var(--primitive-ember-campfire-accent-dark);
+  --color-accent:       var(--primitive-classic-campfire-accent-dark);
   --color-accent-hover: #f0a030;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-campfire-accent-dark) 14%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-campfire-accent-dark) 14%, transparent);
 
   --color-danger:  #ff4632;
   --color-success: #50c850;
 
-  --color-sev-critical-text:   var(--primitive-ember-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ember-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-ember-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-classic-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-classic-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-classic-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-classic-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-classic-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-classic-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 32%, transparent);
 
   /* Grades — traffic light: green → yellow → orange → red */
   --color-grade-top-text:    #50c850;
   --color-grade-top-bg:      color-mix(in srgb, #50c850 12%, transparent);
   --color-grade-high-text:   #f0c832;
   --color-grade-high-bg:     color-mix(in srgb, #f0c832 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ember-campfire-accent-dark);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ember-campfire-accent-dark) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-classic-campfire-accent-dark);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-campfire-accent-dark) 12%, transparent);
   --color-grade-low-text:    #f0643c;
   --color-grade-low-bg:      color-mix(in srgb, #f0643c 13%, transparent);
   --color-grade-bottom-text: #ff4632;
@@ -650,15 +650,15 @@ html[data-theme="ember-dark"]:root {
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-ember-campfire-700);
-  --color-chart-axis:   var(--primitive-ember-campfire-500);
-  --color-chart-line:   var(--primitive-ember-campfire-200);
+  --color-chart-grid:   var(--primitive-classic-campfire-700);
+  --color-chart-axis:   var(--primitive-classic-campfire-500);
+  --color-chart-line:   var(--primitive-classic-campfire-200);
   --color-chart-stroke: rgba(232, 146, 42, 0.25);
 
   /* Trend — traffic light: green up, yellow mid, red down */
   --color-trend-strong-up:   #50c850;
   --color-trend-up:          #f0c832;
-  --color-trend-soft-up:     var(--primitive-ember-campfire-500);
+  --color-trend-soft-up:     var(--primitive-classic-campfire-500);
   --color-trend-soft-down:   #f0643c;
   --color-trend-down:        #ff4632;
   --color-trend-strong-down: #ff2020;
@@ -671,10 +671,10 @@ html[data-theme="ember-dark"]:root {
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-ember-campfire-accent-dark);
-  --logo-chevron:        var(--primitive-ember-campfire-200);
-  --logo-chevron-hover:  var(--primitive-ember-campfire-accent-dark);
-  --logo-needle:         var(--primitive-ember-campfire-accent-dark);
+  --logo-q:              var(--primitive-classic-campfire-accent-dark);
+  --logo-chevron:        var(--primitive-classic-campfire-200);
+  --logo-chevron-hover:  var(--primitive-classic-campfire-accent-dark);
+  --logo-needle:         var(--primitive-classic-campfire-accent-dark);
   --logo-needle-dark:    #a06010;
 }
 
@@ -1117,43 +1117,43 @@ html[data-theme="forest-dark"]:root {
   --logo-needle-dark:    var(--primitive-forest-700);
 }
 
-/* ── Ember Light — campfire, warm parchment ────────────── */
+/* ── Classic Light — campfire, warm parchment ──────────── */
 
-html[data-theme="ember-light"]:root {
-  --color-bg:           var(--primitive-ember-campfire-50);
+html[data-theme="classic-light"]:root {
+  --color-bg:           var(--primitive-classic-campfire-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-ember-campfire-100);
-  --color-border:       var(--primitive-ember-campfire-border-light);
-  --color-border-focus: var(--primitive-ember-campfire-accent-light);
+  --color-surface-alt:  var(--primitive-classic-campfire-100);
+  --color-border:       var(--primitive-classic-campfire-border-light);
+  --color-border-focus: var(--primitive-classic-campfire-accent-light);
 
-  --color-text:         var(--primitive-ember-campfire-text-dark);
-  --color-text-muted:   var(--primitive-ember-campfire-500);
+  --color-text:         var(--primitive-classic-campfire-text-dark);
+  --color-text-muted:   var(--primitive-classic-campfire-500);
   --color-text-subtle:  #b0a090;
 
-  --color-accent:       var(--primitive-ember-campfire-accent-light);
+  --color-accent:       var(--primitive-classic-campfire-accent-light);
   --color-accent-hover: #a05808;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-campfire-accent-light) 8%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-campfire-accent-light) 8%, transparent);
 
   --color-danger:  #c01e14;
   --color-success: #3c8c3c;
 
-  --color-sev-critical-text:   var(--primitive-ember-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ember-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ember-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-classic-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-classic-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-classic-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-classic-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-classic-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-classic-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-light) 30%, transparent);
 
   /* Grades — traffic light: green → yellow → orange → red */
   --color-grade-top-text:    #3c8c3c;
   --color-grade-top-bg:      color-mix(in srgb, #3c8c3c 12%, transparent);
   --color-grade-high-text:   #b89800;
   --color-grade-high-bg:     color-mix(in srgb, #b89800 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-ember-campfire-accent-light);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ember-campfire-accent-light) 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-classic-campfire-accent-light);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-campfire-accent-light) 10%, transparent);
   --color-grade-low-text:    #c05030;
   --color-grade-low-bg:      color-mix(in srgb, #c05030 10%, transparent);
   --color-grade-bottom-text: #c01e14;
@@ -1172,8 +1172,8 @@ html[data-theme="ember-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-ember-campfire-500);
-  --color-chart-line:   var(--primitive-ember-campfire-text-dark);
+  --color-chart-axis:   var(--primitive-classic-campfire-500);
+  --color-chart-line:   var(--primitive-classic-campfire-text-dark);
   --color-chart-stroke: transparent;
 
   /* Trend — traffic light: green up, yellow mid, red down */
@@ -1189,10 +1189,10 @@ html[data-theme="ember-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
 
   /* Logo */
-  --logo-q:              var(--primitive-ember-campfire-accent-light);
-  --logo-chevron:        var(--primitive-ember-campfire-text-dark);
-  --logo-chevron-hover:  var(--primitive-ember-campfire-accent-light);
-  --logo-needle:         var(--primitive-ember-campfire-accent-light);
+  --logo-q:              var(--primitive-classic-campfire-accent-light);
+  --logo-chevron:        var(--primitive-classic-campfire-text-dark);
+  --logo-chevron-hover:  var(--primitive-classic-campfire-accent-light);
+  --logo-needle:         var(--primitive-classic-campfire-accent-light);
   --logo-needle-dark:    #a05808;
 }
 

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -45,27 +45,20 @@
   --primitive-dark-500: #9a9490;
   --primitive-dark-200: #f0ece6;
 
-  /* Classic palette (warm dark, logo-derived) */
-  --primitive-classic-950: #12100e;
-  --primitive-classic-900: #1c1916;
-  --primitive-classic-800: #262220;
-  --primitive-classic-700: #3a3330;
-  --primitive-classic-500: #9a8e84;
-  --primitive-classic-200: #f0e8e0;
-
-  /* Classic Campfire palette */
-  --primitive-classic-campfire-950: #14100a;
-  --primitive-classic-campfire-900: #1e1810;
-  --primitive-classic-campfire-800: #2a2218;
-  --primitive-classic-campfire-700: #3e3428;
-  --primitive-classic-campfire-500: #9a8570;
-  --primitive-classic-campfire-200: #f0e4d4;
-  --primitive-classic-campfire-accent-light: #c06810;
-  --primitive-classic-campfire-accent-dark: #e8922a;
-  --primitive-classic-campfire-50: #fdf8f0;
-  --primitive-classic-campfire-100: #f5ece0;
-  --primitive-classic-campfire-border-light: #e0d0be;
-  --primitive-classic-campfire-text-dark: #2c1e10;
+  /* Classic palette (neutral gray, traffic light) */
+  --primitive-classic-950: #141413;
+  --primitive-classic-900: #1e1e1c;
+  --primitive-classic-800: #282826;
+  --primitive-classic-700: #3a3a36;
+  --primitive-classic-500: #90908a;
+  --primitive-classic-200: #e8e8e4;
+  --primitive-classic-accent-light: #c07800;
+  --primitive-classic-accent-dark: #e8a020;
+  --primitive-classic-50: #f5f5f4;
+  --primitive-classic-100: #eaeae8;
+  --primitive-classic-border-light: #d4d4d0;
+  --primitive-classic-text-dark: #1c1c1a;
+  --primitive-classic-text-muted-light: #808078;
 
   /* Forest palette (nature greens, sage) */
   --primitive-forest-50:  #f4f7f4;
@@ -120,12 +113,6 @@
   --primitive-forest-900-dark: #152018;
   --primitive-forest-800-dark: #1e2c20;
   --primitive-forest-700-dark: #2e4230;
-
-  /* Classic light extensions */
-  --primitive-classic-50:  #faf6f2;
-  --primitive-classic-100: #f0ebe4;
-  --primitive-classic-border-light: #ddd4c8;
-  --primitive-classic-text-dark: #2a2018;
 
   /* Brand neutrals (cool near-black, logo-derived) */
   --primitive-brand-950: #0d1014;
@@ -205,13 +192,13 @@
   --primitive-forest-sev-major-dark:     #d28c50;
   --primitive-forest-sev-minor-dark:     #b49664;
 
-  /* Classic traffic-light severity (minor is warm gray, green reserved for compliance) */
-  --primitive-classic-sev-critical-light: #c01e14;
-  --primitive-classic-sev-major-light:    #b89800;
-  --primitive-classic-sev-minor-light:    #9a8a70;
-  --primitive-classic-sev-critical-dark:  #ff4632;
+  /* Classic traffic-light severity */
+  --primitive-classic-sev-critical-light: #c82020;
+  --primitive-classic-sev-major-light:    #a08000;
+  --primitive-classic-sev-minor-light:    #808078;
+  --primitive-classic-sev-critical-dark:  #ff4040;
   --primitive-classic-sev-major-dark:     #f0c832;
-  --primitive-classic-sev-minor-dark:     #b0a088;
+  --primitive-classic-sev-minor-dark:     #b0b0a0;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
@@ -596,25 +583,25 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Classic Dark — campfire, amber glow ───────────────── */
+/* ── Classic Dark — neutral gray, traffic light ────────── */
 
 html[data-theme="classic-dark"]:root {
-  --color-bg:           var(--primitive-classic-campfire-950);
-  --color-surface:      var(--primitive-classic-campfire-900);
-  --color-surface-alt:  var(--primitive-classic-campfire-800);
-  --color-border:       var(--primitive-classic-campfire-700);
-  --color-border-focus: var(--primitive-classic-campfire-accent-dark);
+  --color-bg:           var(--primitive-classic-950);
+  --color-surface:      var(--primitive-classic-900);
+  --color-surface-alt:  var(--primitive-classic-800);
+  --color-border:       var(--primitive-classic-700);
+  --color-border-focus: var(--primitive-classic-accent-dark);
 
-  --color-text:         var(--primitive-classic-campfire-200);
-  --color-text-muted:   var(--primitive-classic-campfire-500);
-  --color-text-subtle:  #706050;
+  --color-text:         var(--primitive-classic-200);
+  --color-text-muted:   var(--primitive-classic-500);
+  --color-text-subtle:  #606058;
 
-  --color-accent:       var(--primitive-classic-campfire-accent-dark);
-  --color-accent-hover: #f0a030;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-campfire-accent-dark) 14%, transparent);
+  --color-accent:       var(--primitive-classic-accent-dark);
+  --color-accent-hover: #f0b030;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-accent-dark) 14%, transparent);
 
-  --color-danger:  #ff4632;
-  --color-success: #50c850;
+  --color-danger:  #ff4040;
+  --color-success: #50d050;
 
   --color-sev-critical-text:   var(--primitive-classic-sev-critical-dark);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-dark) 4%, transparent);
@@ -626,55 +613,55 @@ html[data-theme="classic-dark"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 32%, transparent);
 
-  /* Grades — traffic light: green → yellow → orange → red */
-  --color-grade-top-text:    #50c850;
-  --color-grade-top-bg:      color-mix(in srgb, #50c850 12%, transparent);
+  /* Grades — traffic light: green → yellow → amber → orange → red */
+  --color-grade-top-text:    #50d050;
+  --color-grade-top-bg:      color-mix(in srgb, #50d050 12%, transparent);
   --color-grade-high-text:   #f0c832;
   --color-grade-high-bg:     color-mix(in srgb, #f0c832 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-classic-campfire-accent-dark);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-campfire-accent-dark) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-classic-accent-dark);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-accent-dark) 12%, transparent);
   --color-grade-low-text:    #f0643c;
   --color-grade-low-bg:      color-mix(in srgb, #f0643c 13%, transparent);
-  --color-grade-bottom-text: #ff4632;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff4632 4%, transparent);
+  --color-grade-bottom-text: #ff4040;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff4040 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   #ff4632;
-  --color-danger-bg:     color-mix(in srgb, #ff4632 15%, transparent);
-  --color-danger-border: color-mix(in srgb, #ff4632 30%, transparent);
+  --color-danger-text:   #ff4040;
+  --color-danger-bg:     color-mix(in srgb, #ff4040 15%, transparent);
+  --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-classic-campfire-700);
-  --color-chart-axis:   var(--primitive-classic-campfire-500);
-  --color-chart-line:   var(--primitive-classic-campfire-200);
-  --color-chart-stroke: rgba(232, 146, 42, 0.25);
+  --color-chart-grid:   var(--primitive-classic-700);
+  --color-chart-axis:   var(--primitive-classic-500);
+  --color-chart-line:   var(--primitive-classic-200);
+  --color-chart-stroke: rgba(232, 160, 32, 0.25);
 
   /* Trend — traffic light: green up, yellow mid, red down */
-  --color-trend-strong-up:   #50c850;
+  --color-trend-strong-up:   #50d050;
   --color-trend-up:          #f0c832;
-  --color-trend-soft-up:     var(--primitive-classic-campfire-500);
+  --color-trend-soft-up:     var(--primitive-classic-500);
   --color-trend-soft-down:   #f0643c;
-  --color-trend-down:        #ff4632;
+  --color-trend-down:        #ff4040;
   --color-trend-strong-down: #ff2020;
 
-  /* Console — warm tint */
-  --color-console-bg: #0c0806;
+  /* Console */
+  --color-console-bg: #0c0c0b;
 
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-classic-campfire-accent-dark);
-  --logo-chevron:        var(--primitive-classic-campfire-200);
-  --logo-chevron-hover:  var(--primitive-classic-campfire-accent-dark);
-  --logo-needle:         var(--primitive-classic-campfire-accent-dark);
+  --logo-q:              var(--primitive-classic-accent-dark);
+  --logo-chevron:        var(--primitive-classic-200);
+  --logo-chevron-hover:  var(--primitive-classic-accent-dark);
+  --logo-needle:         var(--primitive-classic-accent-dark);
   --logo-needle-dark:    #a06010;
 }
 
@@ -1117,25 +1104,25 @@ html[data-theme="forest-dark"]:root {
   --logo-needle-dark:    var(--primitive-forest-700);
 }
 
-/* ── Classic Light — campfire, warm parchment ──────────── */
+/* ── Classic Light — neutral gray, traffic light ───────── */
 
 html[data-theme="classic-light"]:root {
-  --color-bg:           var(--primitive-classic-campfire-50);
+  --color-bg:           var(--primitive-classic-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-classic-campfire-100);
-  --color-border:       var(--primitive-classic-campfire-border-light);
-  --color-border-focus: var(--primitive-classic-campfire-accent-light);
+  --color-surface-alt:  var(--primitive-classic-100);
+  --color-border:       var(--primitive-classic-border-light);
+  --color-border-focus: var(--primitive-classic-accent-light);
 
-  --color-text:         var(--primitive-classic-campfire-text-dark);
-  --color-text-muted:   var(--primitive-classic-campfire-500);
-  --color-text-subtle:  #b0a090;
+  --color-text:         var(--primitive-classic-text-dark);
+  --color-text-muted:   var(--primitive-classic-text-muted-light);
+  --color-text-subtle:  #a0a098;
 
-  --color-accent:       var(--primitive-classic-campfire-accent-light);
-  --color-accent-hover: #a05808;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-campfire-accent-light) 8%, transparent);
+  --color-accent:       var(--primitive-classic-accent-light);
+  --color-accent-hover: #a06000;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-accent-light) 8%, transparent);
 
-  --color-danger:  #c01e14;
-  --color-success: #3c8c3c;
+  --color-danger:  #c82020;
+  --color-success: #2a8a2a;
 
   --color-sev-critical-text:   var(--primitive-classic-sev-critical-light);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-light) 4%, transparent);
@@ -1147,17 +1134,17 @@ html[data-theme="classic-light"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-light) 30%, transparent);
 
-  /* Grades — traffic light: green → yellow → orange → red */
-  --color-grade-top-text:    #3c8c3c;
-  --color-grade-top-bg:      color-mix(in srgb, #3c8c3c 12%, transparent);
-  --color-grade-high-text:   #b89800;
-  --color-grade-high-bg:     color-mix(in srgb, #b89800 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-classic-campfire-accent-light);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-campfire-accent-light) 10%, transparent);
-  --color-grade-low-text:    #c05030;
-  --color-grade-low-bg:      color-mix(in srgb, #c05030 10%, transparent);
-  --color-grade-bottom-text: #c01e14;
-  --color-grade-bottom-bg:   color-mix(in srgb, #c01e14 12%, transparent);
+  /* Grades — traffic light: green → yellow → amber → orange → red */
+  --color-grade-top-text:    #2a8a2a;
+  --color-grade-top-bg:      color-mix(in srgb, #2a8a2a 12%, transparent);
+  --color-grade-high-text:   #a08000;
+  --color-grade-high-bg:     color-mix(in srgb, #a08000 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-classic-accent-light);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-accent-light) 10%, transparent);
+  --color-grade-low-text:    #c83c14;
+  --color-grade-low-bg:      color-mix(in srgb, #c83c14 10%, transparent);
+  --color-grade-bottom-text: #c82020;
+  --color-grade-bottom-bg:   color-mix(in srgb, #c82020 12%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
   --color-warning-text: var(--primitive-amber-700);
@@ -1172,16 +1159,16 @@ html[data-theme="classic-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-classic-campfire-500);
-  --color-chart-line:   var(--primitive-classic-campfire-text-dark);
+  --color-chart-axis:   var(--primitive-classic-text-muted-light);
+  --color-chart-line:   var(--primitive-classic-text-dark);
   --color-chart-stroke: transparent;
 
   /* Trend — traffic light: green up, yellow mid, red down */
-  --color-trend-strong-up:   #3c8c3c;
-  --color-trend-up:          #b89800;
-  --color-trend-soft-up:     #b0a090;
-  --color-trend-soft-down:   #c05030;
-  --color-trend-down:        #c01e14;
+  --color-trend-strong-up:   #2a8a2a;
+  --color-trend-up:          #a08000;
+  --color-trend-soft-up:     #a0a098;
+  --color-trend-soft-down:   #c83c14;
+  --color-trend-down:        #c82020;
   --color-trend-strong-down: #a00000;
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
@@ -1189,11 +1176,11 @@ html[data-theme="classic-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
 
   /* Logo */
-  --logo-q:              var(--primitive-classic-campfire-accent-light);
-  --logo-chevron:        var(--primitive-classic-campfire-text-dark);
-  --logo-chevron-hover:  var(--primitive-classic-campfire-accent-light);
-  --logo-needle:         var(--primitive-classic-campfire-accent-light);
-  --logo-needle-dark:    #a05808;
+  --logo-q:              var(--primitive-classic-accent-light);
+  --logo-chevron:        var(--primitive-classic-text-dark);
+  --logo-chevron-hover:  var(--primitive-classic-accent-light);
+  --logo-needle:         var(--primitive-classic-accent-light);
+  --logo-needle-dark:    #a06000;
 }
 
 /* ── 5. Typography ────────────────────────────────────────

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -53,6 +53,20 @@
   --primitive-ember-500: #9a8e84;
   --primitive-ember-200: #f0e8e0;
 
+  /* Ember Campfire palette */
+  --primitive-ember-campfire-950: #14100a;
+  --primitive-ember-campfire-900: #1e1810;
+  --primitive-ember-campfire-800: #2a2218;
+  --primitive-ember-campfire-700: #3e3428;
+  --primitive-ember-campfire-500: #9a8570;
+  --primitive-ember-campfire-200: #f0e4d4;
+  --primitive-ember-campfire-accent-light: #c06810;
+  --primitive-ember-campfire-accent-dark: #e8922a;
+  --primitive-ember-campfire-50: #fdf8f0;
+  --primitive-ember-campfire-100: #f5ece0;
+  --primitive-ember-campfire-border-light: #e0d0be;
+  --primitive-ember-campfire-text-dark: #2c1e10;
+
   /* Forest palette (nature greens, sage) */
   --primitive-forest-50:  #f4f7f4;
   --primitive-forest-100: #e8ede8;
@@ -191,13 +205,13 @@
   --primitive-forest-sev-major-dark:     #d28c50;
   --primitive-forest-sev-minor-dark:     #b49664;
 
-  /* Ember severity — deep warm reds */
-  --primitive-ember-sev-critical-light: #aa0000;
-  --primitive-ember-sev-major-light:    #b43c1e;
-  --primitive-ember-sev-minor-light:    #8c503c;
-  --primitive-ember-sev-critical-dark:  #ff4a4a;
-  --primitive-ember-sev-major-dark:     #f07846;
-  --primitive-ember-sev-minor-dark:     #c8966e;
+  /* Ember traffic-light severity */
+  --primitive-ember-sev-critical-light: #c01e14;
+  --primitive-ember-sev-major-light:    #b89800;
+  --primitive-ember-sev-minor-light:    #3c8c3c;
+  --primitive-ember-sev-critical-dark:  #ff4632;
+  --primitive-ember-sev-major-dark:     #f0c832;
+  --primitive-ember-sev-minor-dark:     #50c850;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
@@ -582,25 +596,25 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Ember Dark — warm dark, logo-derived ──────────────── */
+/* ── Ember Dark — campfire, amber glow ─────────────────── */
 
 html[data-theme="ember-dark"]:root {
-  --color-bg:           var(--primitive-ember-950);
-  --color-surface:      var(--primitive-ember-900);
-  --color-surface-alt:  var(--primitive-ember-800);
-  --color-border:       var(--primitive-ember-700);
-  --color-border-focus: var(--primitive-crimson-300);
+  --color-bg:           var(--primitive-ember-campfire-950);
+  --color-surface:      var(--primitive-ember-campfire-900);
+  --color-surface-alt:  var(--primitive-ember-campfire-800);
+  --color-border:       var(--primitive-ember-campfire-700);
+  --color-border-focus: var(--primitive-ember-campfire-accent-dark);
 
-  --color-text:         var(--primitive-ember-200);
-  --color-text-muted:   var(--primitive-ember-500);
+  --color-text:         var(--primitive-ember-campfire-200);
+  --color-text-muted:   var(--primitive-ember-campfire-500);
   --color-text-subtle:  #706050;
 
-  --color-accent:       var(--primitive-crimson-500);
-  --color-accent-hover: var(--primitive-crimson-300);
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 14%, transparent);
+  --color-accent:       var(--primitive-ember-campfire-accent-dark);
+  --color-accent-hover: #f0a030;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-campfire-accent-dark) 14%, transparent);
 
-  --color-danger:  #e05c4b;
-  --color-success: #4caf7d;
+  --color-danger:  #ff4632;
+  --color-success: #50c850;
 
   --color-sev-critical-text:   var(--primitive-ember-sev-critical-dark);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 4%, transparent);
@@ -612,55 +626,55 @@ html[data-theme="ember-dark"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
 
-  --color-grade-top-text:    var(--primitive-emerald-300);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-emerald-300) 12%, transparent);
-  --color-grade-high-text:   #c0b5ae;
-  --color-grade-high-bg:     color-mix(in srgb, #c0b5ae 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-300);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-400);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-200);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-grade-top-text:    #f0c060;
+  --color-grade-top-bg:      color-mix(in srgb, #f0c060 12%, transparent);
+  --color-grade-high-text:   var(--primitive-ember-campfire-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-campfire-500) 12%, transparent);
+  --color-grade-mid-text:    #f0643c;
+  --color-grade-mid-bg:      color-mix(in srgb, #f0643c 12%, transparent);
+  --color-grade-low-text:    #ff4632;
+  --color-grade-low-bg:      color-mix(in srgb, #ff4632 13%, transparent);
+  --color-grade-bottom-text: #ff2020;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff2020 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   var(--primitive-crimson-200);
-  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
-  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
+  --color-danger-text:   #ff4632;
+  --color-danger-bg:     color-mix(in srgb, #ff4632 15%, transparent);
+  --color-danger-border: color-mix(in srgb, #ff4632 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-ember-700);
-  --color-chart-axis:   var(--primitive-ember-500);
-  --color-chart-line:   var(--primitive-ember-200);
-  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+  --color-chart-grid:   var(--primitive-ember-campfire-700);
+  --color-chart-axis:   var(--primitive-ember-campfire-500);
+  --color-chart-line:   var(--primitive-ember-campfire-200);
+  --color-chart-stroke: rgba(232, 146, 42, 0.25);
 
-  /* Trend — emerald reward up, ired chain down */
-  --color-trend-strong-up:   var(--primitive-emerald-300);
-  --color-trend-up:          var(--primitive-amber-400);
-  --color-trend-soft-up:     var(--primitive-ember-500);
-  --color-trend-soft-down:   var(--primitive-ired-200);
-  --color-trend-down:        var(--primitive-ired-300);
-  --color-trend-strong-down: var(--primitive-crimson-300);
+  /* Trend — gold up, red down */
+  --color-trend-strong-up:   #f0c060;
+  --color-trend-up:          var(--primitive-ember-campfire-accent-dark);
+  --color-trend-soft-up:     var(--primitive-ember-campfire-500);
+  --color-trend-soft-down:   #f0643c;
+  --color-trend-down:        #ff4632;
+  --color-trend-strong-down: #ff2020;
 
   /* Console — warm tint */
-  --color-console-bg: #100c06;
+  --color-console-bg: #0c0806;
 
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-crimson-500);
-  --logo-chevron:        var(--primitive-ember-200);
-  --logo-chevron-hover:  var(--primitive-crimson-500);
-  --logo-needle:         var(--primitive-crimson-300);
-  --logo-needle-dark:    var(--primitive-crimson-700);
+  --logo-q:              var(--primitive-ember-campfire-accent-dark);
+  --logo-chevron:        var(--primitive-ember-campfire-200);
+  --logo-chevron-hover:  var(--primitive-ember-campfire-accent-dark);
+  --logo-needle:         var(--primitive-ember-campfire-accent-dark);
+  --logo-needle-dark:    #a06010;
 }
 
 /* ── Forest Light — nature greens, sage ─────────────────── */
@@ -1102,22 +1116,26 @@ html[data-theme="forest-dark"]:root {
   --logo-needle-dark:    var(--primitive-forest-700);
 }
 
-/* ── Ember Light — warm parchment ──────────────────────── */
+/* ── Ember Light — campfire, warm parchment ────────────── */
 
 html[data-theme="ember-light"]:root {
-  --color-bg:           var(--primitive-ember-50);
+  --color-bg:           var(--primitive-ember-campfire-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-ember-100);
-  --color-border:       var(--primitive-ember-border-light);
-  --color-border-focus: var(--primitive-crimson-500);
-  --color-text:         var(--primitive-ember-text-dark);
-  --color-text-muted:   var(--primitive-ember-500);
+  --color-surface-alt:  var(--primitive-ember-campfire-100);
+  --color-border:       var(--primitive-ember-campfire-border-light);
+  --color-border-focus: var(--primitive-ember-campfire-accent-light);
+
+  --color-text:         var(--primitive-ember-campfire-text-dark);
+  --color-text-muted:   var(--primitive-ember-campfire-500);
   --color-text-subtle:  #b0a090;
-  --color-accent:       #c0392b;
-  --color-accent-hover: #a02e22;
-  --color-accent-soft:  color-mix(in srgb, #c0392b 8%, transparent);
-  --color-danger:  #c0392b;
-  --color-success: #2d7a4f;
+
+  --color-accent:       var(--primitive-ember-campfire-accent-light);
+  --color-accent-hover: #a05808;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-campfire-accent-light) 8%, transparent);
+
+  --color-danger:  #c01e14;
+  --color-success: #3c8c3c;
+
   --color-sev-critical-text:   var(--primitive-ember-sev-critical-light);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-light) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-light) 38%, transparent);
@@ -1127,45 +1145,53 @@ html[data-theme="ember-light"]:root {
   --color-sev-minor-text:      var(--primitive-ember-sev-minor-light);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
-  --color-grade-top-text:    var(--primitive-daruma-600);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
-  --color-grade-high-text:   #7a6e64;
-  --color-grade-high-bg:     color-mix(in srgb, #7a6e64 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+
+  --color-grade-top-text:    #b08000;
+  --color-grade-top-bg:      color-mix(in srgb, #b08000 12%, transparent);
+  --color-grade-high-text:   var(--primitive-ember-campfire-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-campfire-500) 10%, transparent);
+  --color-grade-mid-text:    #c05030;
+  --color-grade-mid-bg:      color-mix(in srgb, #c05030 10%, transparent);
+  --color-grade-low-text:    #c01e14;
+  --color-grade-low-bg:      color-mix(in srgb, #c01e14 10%, transparent);
+  --color-grade-bottom-text: #a00000;
+  --color-grade-bottom-bg:   color-mix(in srgb, #a00000 12%, transparent);
+
   --color-warning:      var(--primitive-amber-700);
   --color-warning-text: var(--primitive-amber-700);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
+
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-ember-500);
-  --color-chart-line:   var(--primitive-ember-text-dark);
+  --color-chart-axis:   var(--primitive-ember-campfire-500);
+  --color-chart-line:   var(--primitive-ember-campfire-text-dark);
   --color-chart-stroke: transparent;
-  /* Trend — warm up, ired down */
-  --color-trend-strong-up:   var(--primitive-daruma-600);
-  --color-trend-up:          var(--primitive-ember-500);
+
+  /* Trend — gold up, red down */
+  --color-trend-strong-up:   #b08000;
+  --color-trend-up:          var(--primitive-ember-campfire-accent-light);
   --color-trend-soft-up:     #b0a090;
-  --color-trend-soft-down:   var(--primitive-ired-700);
-  --color-trend-down:        var(--primitive-ired-900);
-  --color-trend-strong-down: var(--primitive-crimson-600);
+  --color-trend-soft-down:   #c05030;
+  --color-trend-down:        #c01e14;
+  --color-trend-strong-down: #a00000;
+
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+
   /* Logo */
-  --logo-q:              #c0392b;
-  --logo-chevron:        var(--primitive-ember-text-dark);
-  --logo-chevron-hover:  #c0392b;
-  --logo-needle:         var(--primitive-crimson-300);
-  --logo-needle-dark:    var(--primitive-crimson-700);
+  --logo-q:              var(--primitive-ember-campfire-accent-light);
+  --logo-chevron:        var(--primitive-ember-campfire-text-dark);
+  --logo-chevron-hover:  var(--primitive-ember-campfire-accent-light);
+  --logo-needle:         var(--primitive-ember-campfire-accent-light);
+  --logo-needle-dark:    #a05808;
 }
 
 /* ── 5. Typography ────────────────────────────────────────

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -166,6 +166,10 @@
   /* Compliance */
   --primitive-compliance: #5ee6a0;
 
+  /* Major severity — orange-red (replacing brownish ired for major tags) */
+  --primitive-major-light: #c05030;
+  --primitive-major-dark:  #e87850;
+
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
   --primitive-ired-300: #d86060;   /* dark C: rose-red */
@@ -203,16 +207,16 @@
 
 :root {
   /* Surface */
-  --color-bg:           var(--primitive-cool-50);
+  --color-bg:           var(--primitive-sand-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-cool-100);
-  --color-border:       var(--primitive-cool-200);
+  --color-surface-alt:  var(--primitive-sand-100);
+  --color-border:       var(--primitive-sand-200);
   --color-border-focus: var(--primitive-crimson-500);
 
   /* Text */
-  --color-text:         var(--primitive-brand-900);
-  --color-text-muted:   var(--primitive-brand-500);
-  --color-text-subtle:  var(--primitive-brand-400);
+  --color-text:         var(--primitive-gray-900);
+  --color-text-muted:   var(--primitive-gray-500);
+  --color-text-subtle:  var(--primitive-gray-400);
 
   /* Accent */
   --color-accent:       var(--primitive-crimson-500);
@@ -227,9 +231,9 @@
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
@@ -263,7 +267,7 @@
 
   /* Logo (defaults for themes that don't override) */
   --logo-q:              var(--primitive-crimson-500);
-  --logo-chevron:        var(--primitive-brand-900);
+  --logo-chevron:        var(--primitive-gray-900);
   --logo-chevron-hover:  var(--primitive-crimson-500);
   --logo-needle:         var(--primitive-crimson-300);
   --logo-needle-dark:    var(--primitive-crimson-700);
@@ -289,9 +293,9 @@
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   /* Chart */
-  --color-chart-grid:   var(--primitive-cool-200);
-  --color-chart-axis:   var(--primitive-brand-500);
-  --color-chart-line:   var(--primitive-brand-900);
+  --color-chart-grid:   var(--primitive-sand-200);
+  --color-chart-axis:   var(--primitive-gray-500);
+  --color-chart-line:   var(--primitive-gray-900);
   --color-chart-stroke: transparent;
 }
 
@@ -323,9 +327,9 @@
     --color-sev-critical-text:   var(--primitive-crimson-200);
     --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
     --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-    --color-sev-major-text:      var(--primitive-ired-300);
-    --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
-    --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+    --color-sev-major-text:      var(--primitive-major-dark);
+    --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
+    --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
     --color-sev-minor-text:      var(--primitive-ired-200);
     --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
     --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
@@ -406,9 +410,9 @@ html[data-theme="dark"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-200);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-300);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-200);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
@@ -469,15 +473,15 @@ html[data-theme="dark"]:root {
 }
 
 html[data-theme="light"]:root {
-  --color-bg:           var(--primitive-cool-50);
+  --color-bg:           var(--primitive-sand-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-cool-100);
-  --color-border:       var(--primitive-cool-200);
+  --color-surface-alt:  var(--primitive-sand-100);
+  --color-border:       var(--primitive-sand-200);
   --color-border-focus: var(--primitive-crimson-500);
 
-  --color-text:         var(--primitive-brand-900);
-  --color-text-muted:   var(--primitive-brand-500);
-  --color-text-subtle:  var(--primitive-brand-400);
+  --color-text:         var(--primitive-gray-900);
+  --color-text-muted:   var(--primitive-gray-500);
+  --color-text-subtle:  var(--primitive-gray-400);
 
   --color-accent:       var(--primitive-crimson-500);
   --color-accent-hover: var(--primitive-crimson-600);
@@ -490,9 +494,9 @@ html[data-theme="light"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
@@ -524,9 +528,9 @@ html[data-theme="light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   /* Chart */
-  --color-chart-grid:   var(--primitive-cool-200);
-  --color-chart-axis:   var(--primitive-brand-500);
-  --color-chart-line:   var(--primitive-brand-900);
+  --color-chart-grid:   var(--primitive-sand-200);
+  --color-chart-axis:   var(--primitive-gray-500);
+  --color-chart-line:   var(--primitive-gray-900);
   --color-chart-stroke: transparent;
 
   /* Trend — gray → crimson on light backgrounds */
@@ -543,7 +547,7 @@ html[data-theme="light"]:root {
 
   /* Logo — force light values regardless of system theme */
   --logo-q:              var(--primitive-crimson-500);
-  --logo-chevron:        var(--primitive-brand-900);
+  --logo-chevron:        var(--primitive-gray-900);
   --logo-chevron-hover:  var(--primitive-crimson-500);
   --logo-needle:         var(--primitive-crimson-300);
   --logo-needle-dark:    var(--primitive-crimson-700);
@@ -572,9 +576,9 @@ html[data-theme="ember-dark"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-200);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-300);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-200);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
@@ -653,9 +657,9 @@ html[data-theme="forest-light"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
@@ -731,9 +735,9 @@ html[data-theme="midnight-dark"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-200);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-300);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-200);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
@@ -812,9 +816,9 @@ html[data-theme="midnight-light"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
@@ -954,9 +958,9 @@ html[data-theme="neo-light"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
@@ -1020,9 +1024,9 @@ html[data-theme="forest-dark"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-200);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-300);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-200);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
@@ -1088,9 +1092,9 @@ html[data-theme="ember-light"]:root {
   --color-sev-critical-text:   var(--primitive-crimson-600);
   --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
   --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-major-text:      var(--primitive-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
   --color-sev-minor-text:      var(--primitive-ired-700);
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -626,16 +626,17 @@ html[data-theme="ember-dark"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
 
-  --color-grade-top-text:    #f0c060;
-  --color-grade-top-bg:      color-mix(in srgb, #f0c060 12%, transparent);
-  --color-grade-high-text:   var(--primitive-ember-campfire-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-campfire-500) 12%, transparent);
-  --color-grade-mid-text:    #f0643c;
-  --color-grade-mid-bg:      color-mix(in srgb, #f0643c 12%, transparent);
-  --color-grade-low-text:    #ff4632;
-  --color-grade-low-bg:      color-mix(in srgb, #ff4632 13%, transparent);
-  --color-grade-bottom-text: #ff2020;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff2020 4%, transparent);
+  /* Grades — traffic light: green → yellow → orange → red */
+  --color-grade-top-text:    #50c850;
+  --color-grade-top-bg:      color-mix(in srgb, #50c850 12%, transparent);
+  --color-grade-high-text:   #f0c832;
+  --color-grade-high-bg:     color-mix(in srgb, #f0c832 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-ember-campfire-accent-dark);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ember-campfire-accent-dark) 12%, transparent);
+  --color-grade-low-text:    #f0643c;
+  --color-grade-low-bg:      color-mix(in srgb, #f0643c 13%, transparent);
+  --color-grade-bottom-text: #ff4632;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff4632 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);
@@ -654,9 +655,9 @@ html[data-theme="ember-dark"]:root {
   --color-chart-line:   var(--primitive-ember-campfire-200);
   --color-chart-stroke: rgba(232, 146, 42, 0.25);
 
-  /* Trend — gold up, red down */
-  --color-trend-strong-up:   #f0c060;
-  --color-trend-up:          var(--primitive-ember-campfire-accent-dark);
+  /* Trend — traffic light: green up, yellow mid, red down */
+  --color-trend-strong-up:   #50c850;
+  --color-trend-up:          #f0c832;
   --color-trend-soft-up:     var(--primitive-ember-campfire-500);
   --color-trend-soft-down:   #f0643c;
   --color-trend-down:        #ff4632;
@@ -1146,16 +1147,17 @@ html[data-theme="ember-light"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
 
-  --color-grade-top-text:    #b08000;
-  --color-grade-top-bg:      color-mix(in srgb, #b08000 12%, transparent);
-  --color-grade-high-text:   var(--primitive-ember-campfire-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-campfire-500) 10%, transparent);
-  --color-grade-mid-text:    #c05030;
-  --color-grade-mid-bg:      color-mix(in srgb, #c05030 10%, transparent);
-  --color-grade-low-text:    #c01e14;
-  --color-grade-low-bg:      color-mix(in srgb, #c01e14 10%, transparent);
-  --color-grade-bottom-text: #a00000;
-  --color-grade-bottom-bg:   color-mix(in srgb, #a00000 12%, transparent);
+  /* Grades — traffic light: green → yellow → orange → red */
+  --color-grade-top-text:    #3c8c3c;
+  --color-grade-top-bg:      color-mix(in srgb, #3c8c3c 12%, transparent);
+  --color-grade-high-text:   #b89800;
+  --color-grade-high-bg:     color-mix(in srgb, #b89800 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-ember-campfire-accent-light);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ember-campfire-accent-light) 10%, transparent);
+  --color-grade-low-text:    #c05030;
+  --color-grade-low-bg:      color-mix(in srgb, #c05030 10%, transparent);
+  --color-grade-bottom-text: #c01e14;
+  --color-grade-bottom-bg:   color-mix(in srgb, #c01e14 12%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
   --color-warning-text: var(--primitive-amber-700);
@@ -1174,9 +1176,9 @@ html[data-theme="ember-light"]:root {
   --color-chart-line:   var(--primitive-ember-campfire-text-dark);
   --color-chart-stroke: transparent;
 
-  /* Trend — gold up, red down */
-  --color-trend-strong-up:   #b08000;
-  --color-trend-up:          var(--primitive-ember-campfire-accent-light);
+  /* Trend — traffic light: green up, yellow mid, red down */
+  --color-trend-strong-up:   #3c8c3c;
+  --color-trend-up:          #b89800;
   --color-trend-soft-up:     #b0a090;
   --color-trend-soft-down:   #c05030;
   --color-trend-down:        #c01e14;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -671,6 +671,11 @@ html[data-theme="ember-dark"]:root {
   --color-danger-bg:     color-mix(in srgb, #ff5030 15%, transparent);
   --color-danger-border: color-mix(in srgb, #ff5030 30%, transparent);
 
+  /* Compliance — warm gold */
+  --color-compliance:        #f0b830;
+  --color-compliance-bg:     color-mix(in srgb, #f0b830 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #f0b830 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
@@ -752,6 +757,11 @@ html[data-theme="forest-light"]:root {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
+  /* Compliance — forest green */
+  --color-compliance:        #1b6b3a;
+  --color-compliance-bg:     color-mix(in srgb, #1b6b3a 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #1b6b3a 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
@@ -829,6 +839,11 @@ html[data-theme="midnight-dark"]:root {
   --color-danger-text:   var(--primitive-red-300);
   --color-danger-bg:     color-mix(in srgb, var(--primitive-red-300) 15%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-red-300) 30%, transparent);
+
+  /* Compliance — cool cyan */
+  --color-compliance:        #00d4ff;
+  --color-compliance-bg:     color-mix(in srgb, #00d4ff 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #00d4ff 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -911,6 +926,11 @@ html[data-theme="midnight-light"]:root {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
+  /* Compliance — deep indigo-teal */
+  --color-compliance:        #0078a0;
+  --color-compliance-bg:     color-mix(in srgb, #0078a0 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0078a0 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
@@ -981,6 +1001,12 @@ html[data-theme="neo-dark"]:root {
   --color-danger-text:   #ff4040;
   --color-danger-bg:     color-mix(in srgb, #ff4040 15%, transparent);
   --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
+
+  /* Compliance — matrix green */
+  --color-compliance:        #00ff41;
+  --color-compliance-bg:     color-mix(in srgb, #00ff41 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #00ff41 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.92);
   --color-overlay-medium: rgba(0, 0, 0, 0.85);
   --color-overlay-light:  rgba(0, 0, 0, 0.75);
@@ -1049,6 +1075,12 @@ html[data-theme="neo-light"]:root {
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
+
+  /* Compliance — deep green */
+  --color-compliance:        #008833;
+  --color-compliance-bg:     color-mix(in srgb, #008833 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #008833 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
@@ -1115,6 +1147,12 @@ html[data-theme="forest-dark"]:root {
   --color-danger-text:   var(--primitive-crimson-200);
   --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
+
+  /* Compliance — bright sage */
+  --color-compliance:        #4caf7d;
+  --color-compliance-bg:     color-mix(in srgb, #4caf7d 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #4caf7d 38%, transparent);
+
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
@@ -1191,6 +1229,11 @@ html[data-theme="ember-light"]:root {
   --color-danger-text:   var(--color-danger);
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
+
+  /* Compliance — deep amber */
+  --color-compliance:        #c08000;
+  --color-compliance-bg:     color-mix(in srgb, #c08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #c08000 38%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -45,20 +45,20 @@
   --primitive-dark-500: #9a9490;
   --primitive-dark-200: #f0ece6;
 
-  /* Classic palette (neutral gray, traffic light) */
-  --primitive-classic-950: #141413;
-  --primitive-classic-900: #1e1e1c;
-  --primitive-classic-800: #282826;
-  --primitive-classic-700: #3a3a36;
-  --primitive-classic-500: #90908a;
-  --primitive-classic-200: #e8e8e4;
-  --primitive-classic-accent-light: #c07800;
-  --primitive-classic-accent-dark: #e8a020;
-  --primitive-classic-50: #f5f5f4;
-  --primitive-classic-100: #eaeae8;
-  --primitive-classic-border-light: #d4d4d0;
-  --primitive-classic-text-dark: #1c1c1a;
-  --primitive-classic-text-muted-light: #808078;
+  /* Ember palette (warm charcoal, glowing fire) */
+  --primitive-ember-950: #161010;
+  --primitive-ember-900: #201614;
+  --primitive-ember-800: #2c201c;
+  --primitive-ember-700: #3e302a;
+  --primitive-ember-500: #9a7a68;
+  --primitive-ember-200: #f0dcc8;
+  --primitive-ember-accent-light: #c85a10;
+  --primitive-ember-accent-dark: #e88030;
+  --primitive-ember-50: #faf5f0;
+  --primitive-ember-100: #f0e8de;
+  --primitive-ember-border-light: #dcc8b4;
+  --primitive-ember-text-dark: #241810;
+  --primitive-ember-text-muted-light: #8a7060;
 
   /* Forest palette (nature greens, sage) */
   --primitive-forest-50:  #f4f7f4;
@@ -192,13 +192,13 @@
   --primitive-forest-sev-major-dark:     #d28c50;
   --primitive-forest-sev-minor-dark:     #b49664;
 
-  /* Classic traffic-light severity */
-  --primitive-classic-sev-critical-light: #c82020;
-  --primitive-classic-sev-major-light:    #a08000;
-  --primitive-classic-sev-minor-light:    #808078;
-  --primitive-classic-sev-critical-dark:  #ff4040;
-  --primitive-classic-sev-major-dark:     #f0c832;
-  --primitive-classic-sev-minor-dark:     #b0b0a0;
+  /* Ember severity — warm fire scale */
+  --primitive-ember-sev-critical-light: #b82010;
+  --primitive-ember-sev-major-light:    #c87020;
+  --primitive-ember-sev-minor-light:    #8a7060;
+  --primitive-ember-sev-critical-dark:  #ff5030;
+  --primitive-ember-sev-major-dark:     #f0a040;
+  --primitive-ember-sev-minor-dark:     #b09880;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
@@ -598,86 +598,86 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Classic Dark — neutral gray, traffic light ────────── */
+/* ── Ember Dark — glowing coals ────────────────────────── */
 
-html[data-theme="classic-dark"]:root {
-  --color-bg:           var(--primitive-classic-950);
-  --color-surface:      var(--primitive-classic-900);
-  --color-surface-alt:  var(--primitive-classic-800);
-  --color-border:       var(--primitive-classic-700);
-  --color-border-focus: var(--primitive-classic-accent-dark);
+html[data-theme="ember-dark"]:root {
+  --color-bg:           var(--primitive-ember-950);
+  --color-surface:      var(--primitive-ember-900);
+  --color-surface-alt:  var(--primitive-ember-800);
+  --color-border:       var(--primitive-ember-700);
+  --color-border-focus: var(--primitive-ember-accent-dark);
 
-  --color-text:         var(--primitive-classic-200);
-  --color-text-muted:   var(--primitive-classic-500);
-  --color-text-subtle:  #606058;
+  --color-text:         var(--primitive-ember-200);
+  --color-text-muted:   var(--primitive-ember-500);
+  --color-text-subtle:  #6a5448;
 
-  --color-accent:       var(--primitive-classic-accent-dark);
-  --color-accent-hover: #f0b030;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-accent-dark) 14%, transparent);
+  --color-accent:       var(--primitive-ember-accent-dark);
+  --color-accent-hover: #f09040;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-accent-dark) 14%, transparent);
 
-  --color-danger:  #ff4040;
-  --color-success: #50d050;
+  --color-danger:  #ff5030;
+  --color-success: #50b868;
 
-  --color-sev-critical-text:   var(--primitive-classic-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-classic-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-classic-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-classic-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-classic-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-classic-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-ember-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ember-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ember-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
 
-  /* Grades — traffic light: green → yellow → amber → orange → red */
-  --color-grade-top-text:    #50d050;
-  --color-grade-top-bg:      color-mix(in srgb, #50d050 12%, transparent);
-  --color-grade-high-text:   #f0c832;
-  --color-grade-high-bg:     color-mix(in srgb, #f0c832 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-classic-accent-dark);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-accent-dark) 12%, transparent);
-  --color-grade-low-text:    #f0643c;
-  --color-grade-low-bg:      color-mix(in srgb, #f0643c 13%, transparent);
-  --color-grade-bottom-text: #ff4040;
-  --color-grade-bottom-bg:   color-mix(in srgb, #ff4040 4%, transparent);
+  /* Grades — ember glow: gold → amber → orange → red */
+  --color-grade-top-text:    #f0b830;
+  --color-grade-top-bg:      color-mix(in srgb, #f0b830 12%, transparent);
+  --color-grade-high-text:   var(--primitive-ember-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-500) 12%, transparent);
+  --color-grade-mid-text:    #f07030;
+  --color-grade-mid-bg:      color-mix(in srgb, #f07030 12%, transparent);
+  --color-grade-low-text:    #ff5030;
+  --color-grade-low-bg:      color-mix(in srgb, #ff5030 13%, transparent);
+  --color-grade-bottom-text: #ff2820;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff2820 4%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);
   --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
 
-  --color-danger-text:   #ff4040;
-  --color-danger-bg:     color-mix(in srgb, #ff4040 15%, transparent);
-  --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
+  --color-danger-text:   #ff5030;
+  --color-danger-bg:     color-mix(in srgb, #ff5030 15%, transparent);
+  --color-danger-border: color-mix(in srgb, #ff5030 30%, transparent);
 
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-classic-700);
-  --color-chart-axis:   var(--primitive-classic-500);
-  --color-chart-line:   var(--primitive-classic-200);
-  --color-chart-stroke: rgba(232, 160, 32, 0.25);
+  --color-chart-grid:   var(--primitive-ember-700);
+  --color-chart-axis:   var(--primitive-ember-500);
+  --color-chart-line:   var(--primitive-ember-200);
+  --color-chart-stroke: rgba(232, 128, 48, 0.25);
 
-  /* Trend — traffic light: green up, yellow mid, red down */
-  --color-trend-strong-up:   #50d050;
-  --color-trend-up:          #f0c832;
-  --color-trend-soft-up:     var(--primitive-classic-500);
-  --color-trend-soft-down:   #f0643c;
-  --color-trend-down:        #ff4040;
-  --color-trend-strong-down: #ff2020;
+  /* Trend — gold up, red down */
+  --color-trend-strong-up:   #f0b830;
+  --color-trend-up:          var(--primitive-ember-accent-dark);
+  --color-trend-soft-up:     var(--primitive-ember-500);
+  --color-trend-soft-down:   #f07030;
+  --color-trend-down:        #ff5030;
+  --color-trend-strong-down: #ff2820;
 
-  /* Console */
-  --color-console-bg: #0c0c0b;
+  /* Console — warm tint */
+  --color-console-bg: #0e0a06;
 
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-classic-accent-dark);
-  --logo-chevron:        var(--primitive-classic-200);
-  --logo-chevron-hover:  var(--primitive-classic-accent-dark);
-  --logo-needle:         var(--primitive-classic-accent-dark);
-  --logo-needle-dark:    #a06010;
+  --logo-q:              var(--primitive-ember-accent-dark);
+  --logo-chevron:        var(--primitive-ember-200);
+  --logo-chevron-hover:  var(--primitive-ember-accent-dark);
+  --logo-needle:         var(--primitive-ember-accent-dark);
+  --logo-needle-dark:    #a05810;
 }
 
 /* ── Forest Light — mossy greens ────────────────────────── */
@@ -1119,47 +1119,47 @@ html[data-theme="forest-dark"]:root {
   --logo-needle-dark:    var(--primitive-forest-700);
 }
 
-/* ── Classic Light — neutral gray, traffic light ───────── */
+/* ── Ember Light — warm parchment ──────────────────────── */
 
-html[data-theme="classic-light"]:root {
-  --color-bg:           var(--primitive-classic-50);
+html[data-theme="ember-light"]:root {
+  --color-bg:           var(--primitive-ember-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-classic-100);
-  --color-border:       var(--primitive-classic-border-light);
-  --color-border-focus: var(--primitive-classic-accent-light);
+  --color-surface-alt:  var(--primitive-ember-100);
+  --color-border:       var(--primitive-ember-border-light);
+  --color-border-focus: var(--primitive-ember-accent-light);
 
-  --color-text:         var(--primitive-classic-text-dark);
-  --color-text-muted:   var(--primitive-classic-text-muted-light);
-  --color-text-subtle:  #a0a098;
+  --color-text:         var(--primitive-ember-text-dark);
+  --color-text-muted:   var(--primitive-ember-text-muted-light);
+  --color-text-subtle:  #b0a090;
 
-  --color-accent:       var(--primitive-classic-accent-light);
-  --color-accent-hover: #a06000;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-classic-accent-light) 8%, transparent);
+  --color-accent:       var(--primitive-ember-accent-light);
+  --color-accent-hover: #a84a08;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-accent-light) 8%, transparent);
 
-  --color-danger:  #c82020;
-  --color-success: #2a8a2a;
+  --color-danger:  #b82010;
+  --color-success: #2a8a40;
 
-  --color-sev-critical-text:   var(--primitive-classic-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-classic-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-classic-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-classic-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-classic-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-classic-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-classic-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-classic-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-classic-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-ember-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ember-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ember-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
 
-  /* Grades — traffic light: green → yellow → amber → orange → red */
-  --color-grade-top-text:    #2a8a2a;
-  --color-grade-top-bg:      color-mix(in srgb, #2a8a2a 12%, transparent);
-  --color-grade-high-text:   #a08000;
-  --color-grade-high-bg:     color-mix(in srgb, #a08000 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-classic-accent-light);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-classic-accent-light) 10%, transparent);
-  --color-grade-low-text:    #c83c14;
-  --color-grade-low-bg:      color-mix(in srgb, #c83c14 10%, transparent);
-  --color-grade-bottom-text: #c82020;
-  --color-grade-bottom-bg:   color-mix(in srgb, #c82020 12%, transparent);
+  /* Grades — ember glow: gold → warm gray → orange → red */
+  --color-grade-top-text:    #c08000;
+  --color-grade-top-bg:      color-mix(in srgb, #c08000 14%, transparent);
+  --color-grade-high-text:   var(--primitive-ember-text-muted-light);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-text-muted-light) 10%, transparent);
+  --color-grade-mid-text:    #c05020;
+  --color-grade-mid-bg:      color-mix(in srgb, #c05020 10%, transparent);
+  --color-grade-low-text:    #b82010;
+  --color-grade-low-bg:      color-mix(in srgb, #b82010 10%, transparent);
+  --color-grade-bottom-text: #a01008;
+  --color-grade-bottom-bg:   color-mix(in srgb, #a01008 12%, transparent);
 
   --color-warning:      var(--primitive-amber-700);
   --color-warning-text: var(--primitive-amber-700);
@@ -1174,28 +1174,28 @@ html[data-theme="classic-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-classic-text-muted-light);
-  --color-chart-line:   var(--primitive-classic-text-dark);
+  --color-chart-axis:   var(--primitive-ember-text-muted-light);
+  --color-chart-line:   var(--primitive-ember-text-dark);
   --color-chart-stroke: transparent;
 
-  /* Trend — traffic light: green up, yellow mid, red down */
-  --color-trend-strong-up:   #2a8a2a;
-  --color-trend-up:          #a08000;
-  --color-trend-soft-up:     #a0a098;
-  --color-trend-soft-down:   #c83c14;
-  --color-trend-down:        #c82020;
-  --color-trend-strong-down: #a00000;
+  /* Trend — gold up, red down */
+  --color-trend-strong-up:   #c08000;
+  --color-trend-up:          var(--primitive-ember-accent-light);
+  --color-trend-soft-up:     #b0a090;
+  --color-trend-soft-down:   #c05020;
+  --color-trend-down:        #b82010;
+  --color-trend-strong-down: #a01008;
 
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
 
   /* Logo */
-  --logo-q:              var(--primitive-classic-accent-light);
-  --logo-chevron:        var(--primitive-classic-text-dark);
-  --logo-chevron-hover:  var(--primitive-classic-accent-light);
-  --logo-needle:         var(--primitive-classic-accent-light);
-  --logo-needle-dark:    #a06000;
+  --logo-q:              var(--primitive-ember-accent-light);
+  --logo-chevron:        var(--primitive-ember-text-dark);
+  --logo-chevron-hover:  var(--primitive-ember-accent-light);
+  --logo-needle:         var(--primitive-ember-accent-light);
+  --logo-needle-dark:    #a84a08;
 }
 
 /* ── 5. Typography ────────────────────────────────────────

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -205,13 +205,13 @@
   --primitive-forest-sev-major-dark:     #d28c50;
   --primitive-forest-sev-minor-dark:     #b49664;
 
-  /* Ember traffic-light severity */
+  /* Ember traffic-light severity (minor is warm gray, green reserved for compliance) */
   --primitive-ember-sev-critical-light: #c01e14;
   --primitive-ember-sev-major-light:    #b89800;
-  --primitive-ember-sev-minor-light:    #3c8c3c;
+  --primitive-ember-sev-minor-light:    #9a8a70;
   --primitive-ember-sev-critical-dark:  #ff4632;
   --primitive-ember-sev-major-dark:     #f0c832;
-  --primitive-ember-sev-minor-dark:     #50c850;
+  --primitive-ember-sev-minor-dark:     #b0a088;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -333,10 +333,10 @@
   --logo-needle:         var(--primitive-crimson-300);
   --logo-needle-dark:    var(--primitive-crimson-700);
 
-  /* Compliance — teal (Daruma Fire direction) */
-  --color-compliance:        #0e8a7a;
-  --color-compliance-bg:     color-mix(in srgb, #0e8a7a 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #0e8a7a 38%, transparent);
+  /* Compliance — rich gold */
+  --color-compliance:        #b08000;
+  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
@@ -593,10 +593,10 @@ html[data-theme="light"]:root {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
-  /* Compliance — teal (Daruma Fire direction) */
-  --color-compliance:        #0e8a7a;
-  --color-compliance-bg:     color-mix(in srgb, #0e8a7a 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, #0e8a7a 38%, transparent);
+  /* Compliance — rich gold */
+  --color-compliance:        #b08000;
+  --color-compliance-bg:     color-mix(in srgb, #b08000 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #b08000 38%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -549,9 +549,9 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Ember — warm dark, logo-derived ────────────────────── */
+/* ── Ember Dark — warm dark, logo-derived ──────────────── */
 
-html[data-theme="ember"]:root {
+html[data-theme="ember-dark"]:root {
   --color-bg:           var(--primitive-ember-950);
   --color-surface:      var(--primitive-ember-900);
   --color-surface-alt:  var(--primitive-ember-800);
@@ -630,9 +630,9 @@ html[data-theme="ember"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Forest — nature greens, sage ───────────────────────── */
+/* ── Forest Light — nature greens, sage ─────────────────── */
 
-html[data-theme="forest"]:root {
+html[data-theme="forest-light"]:root {
   --color-bg:           var(--primitive-forest-50);
   --color-surface:      #ffffff;
   --color-surface-alt:  var(--primitive-forest-100);
@@ -708,9 +708,9 @@ html[data-theme="forest"]:root {
   --logo-needle-dark:    var(--primitive-forest-800);
 }
 
-/* ── Midnight — deep navy, cyan accents ─────────────────── */
+/* ── Midnight Dark — deep navy, cyan accents ────────────── */
 
-html[data-theme="midnight"]:root {
+html[data-theme="midnight-dark"]:root {
   --color-bg:           var(--primitive-midnight-950);
   --color-surface:      var(--primitive-midnight-900);
   --color-surface-alt:  var(--primitive-midnight-800);
@@ -789,87 +789,9 @@ html[data-theme="midnight"]:root {
   --logo-needle-dark:    #0090b0;
 }
 
-/* ── Slate — minimal monochrome, logo red accent ────────── */
+/* ── Midnight Light — cool whites, indigo accent ────────── */
 
-html[data-theme="slate"]:root {
-  --color-bg:           var(--primitive-slate-50);
-  --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-slate-100);
-  --color-border:       var(--primitive-slate-200);
-  --color-border-focus: var(--primitive-crimson-500);
-
-  --color-text:         var(--primitive-slate-900);
-  --color-text-muted:   #6b6b6b;
-  --color-text-subtle:  #9a9a9a;
-
-  --color-accent:       var(--primitive-crimson-500);
-  --color-accent-hover: var(--primitive-crimson-600);
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
-
-  --color-danger:  #c0392b;
-  --color-success: #2d7a4f;
-
-  --color-sev-critical-text:   var(--primitive-crimson-600);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ired-800);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-700);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
-
-  --color-grade-top-text:    var(--primitive-green-900);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-900) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-slate-700);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-slate-700) 8%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
-  --color-grade-low-text:    var(--primitive-ired-900);
-  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-600);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
-
-  --color-warning:      var(--primitive-olive-700);
-  --color-warning-text: var(--primitive-olive-700);
-  --color-warning-bg:   color-mix(in srgb, var(--primitive-olive-700) 7%, transparent);
-
-  --color-danger-text:   var(--color-danger);
-  --color-danger-bg:     var(--color-sev-critical-bg);
-  --color-danger-border: var(--color-sev-critical-border);
-
-  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
-  --color-overlay-medium: rgba(0, 0, 0, 0.5);
-  --color-overlay-light:  rgba(0, 0, 0, 0.3);
-
-  --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--color-text-muted);
-  --color-chart-line:   var(--primitive-slate-900);
-  --color-chart-stroke: transparent;
-
-  /* Trend — green reward up, ired chain down */
-  --color-trend-strong-up:   var(--primitive-green-900);
-  --color-trend-up:          var(--primitive-slate-700);
-  --color-trend-soft-up:     var(--primitive-slate-300);
-  --color-trend-soft-down:   var(--primitive-ired-700);
-  --color-trend-down:        var(--primitive-ired-900);
-  --color-trend-strong-down: var(--primitive-crimson-600);
-
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
-
-  /* Logo */
-  --logo-q:              var(--primitive-crimson-500);
-  --logo-chevron:        #333333;
-  --logo-chevron-hover:  var(--primitive-crimson-500);
-  --logo-needle:         var(--primitive-crimson-500);
-  --logo-needle-dark:    var(--primitive-crimson-700);
-}
-
-/* ── Horizon — AI/tech, cool whites, indigo accent ──────── */
-
-html[data-theme="horizon"]:root {
+html[data-theme="midnight-light"]:root {
   --color-bg:           var(--primitive-horizon-50);
   --color-surface:      #ffffff;
   --color-surface-alt:  var(--primitive-horizon-100);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -867,6 +867,274 @@ html[data-theme="midnight-light"]:root {
   --logo-needle-dark:    var(--primitive-horizon-800);
 }
 
+/* ── Neo Dark — Matrix terminal ─────────────────────────── */
+
+html[data-theme="neo-dark"]:root {
+  --color-bg:           var(--primitive-neo-950);
+  --color-surface:      var(--primitive-neo-900);
+  --color-surface-alt:  var(--primitive-neo-800);
+  --color-border:       var(--primitive-neo-700);
+  --color-border-focus: var(--primitive-neo-accent);
+  --color-text:         var(--primitive-neo-200);
+  --color-text-muted:   var(--primitive-neo-500);
+  --color-text-subtle:  #405040;
+  --color-accent:       var(--primitive-neo-accent);
+  --color-accent-hover: #33ff66;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent) 14%, transparent);
+  --color-danger:  #ff4040;
+  --color-success: var(--primitive-neo-accent);
+  --color-sev-critical-text:   #ff4040;
+  --color-sev-critical-bg:     color-mix(in srgb, #ff4040 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, #ff4040 42%, transparent);
+  --color-sev-major-text:      #ff6432;
+  --color-sev-major-bg:        color-mix(in srgb, #ff6432 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, #ff6432 38%, transparent);
+  --color-sev-minor-text:      #b47850;
+  --color-sev-minor-bg:        color-mix(in srgb, #b47850 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, #b47850 32%, transparent);
+  --color-grade-top-text:    var(--primitive-neo-accent);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-neo-accent) 12%, transparent);
+  --color-grade-high-text:   #80ff80;
+  --color-grade-high-bg:     color-mix(in srgb, #80ff80 10%, transparent);
+  --color-grade-mid-text:    #ff6432;
+  --color-grade-mid-bg:      color-mix(in srgb, #ff6432 12%, transparent);
+  --color-grade-low-text:    #ff4040;
+  --color-grade-low-bg:      color-mix(in srgb, #ff4040 13%, transparent);
+  --color-grade-bottom-text: #ff2020;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff2020 4%, transparent);
+  --color-warning:      var(--primitive-amber-400);
+  --color-warning-text: var(--primitive-amber-400);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
+  --color-danger-text:   #ff4040;
+  --color-danger-bg:     color-mix(in srgb, #ff4040 15%, transparent);
+  --color-danger-border: color-mix(in srgb, #ff4040 30%, transparent);
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.92);
+  --color-overlay-medium: rgba(0, 0, 0, 0.85);
+  --color-overlay-light:  rgba(0, 0, 0, 0.75);
+  --color-chart-grid:   var(--primitive-neo-700);
+  --color-chart-axis:   var(--primitive-neo-500);
+  --color-chart-line:   var(--primitive-neo-200);
+  --color-chart-stroke: rgba(0, 255, 65, 0.25);
+  /* Trend — green up, red down */
+  --color-trend-strong-up:   var(--primitive-neo-accent);
+  --color-trend-up:          #80ff80;
+  --color-trend-soft-up:     var(--primitive-neo-500);
+  --color-trend-soft-down:   #b47850;
+  --color-trend-down:        #ff6432;
+  --color-trend-strong-down: #ff4040;
+  /* Console — pure black */
+  --color-console-bg: #000000;
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+  /* Logo */
+  --logo-q:              var(--primitive-neo-accent);
+  --logo-chevron:        var(--primitive-neo-accent);
+  --logo-chevron-hover:  #33ff66;
+  --logo-needle:         var(--primitive-neo-accent);
+  --logo-needle-dark:    #008833;
+}
+
+/* ── Neo Light — white hat, mint-tinted ────────────────── */
+
+html[data-theme="neo-light"]:root {
+  --color-bg:           var(--primitive-neo-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-neo-100);
+  --color-border:       var(--primitive-neo-border-light);
+  --color-border-focus: var(--primitive-neo-accent-dark);
+  --color-text:         var(--primitive-neo-text-dark);
+  --color-text-muted:   #5a7a5a;
+  --color-text-subtle:  #7a9a7a;
+  --color-accent:       var(--primitive-neo-accent-dark);
+  --color-accent-hover: #006622;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent-dark) 8%, transparent);
+  --color-danger:  #c0392b;
+  --color-success: #2d7a4f;
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-grade-top-text:    #006622;
+  --color-grade-top-bg:      color-mix(in srgb, #006622 12%, transparent);
+  --color-grade-high-text:   #338844;
+  --color-grade-high-bg:     color-mix(in srgb, #338844 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  --color-warning:      var(--primitive-amber-700);
+  --color-warning-text: var(--primitive-amber-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   #5a7a5a;
+  --color-chart-line:   var(--primitive-neo-text-dark);
+  --color-chart-stroke: transparent;
+  /* Trend — green up, ired down */
+  --color-trend-strong-up:   #006622;
+  --color-trend-up:          var(--primitive-neo-accent-dark);
+  --color-trend-soft-up:     #5a7a5a;
+  --color-trend-soft-down:   var(--primitive-ired-700);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+  /* Logo */
+  --logo-q:              var(--primitive-neo-accent-dark);
+  --logo-chevron:        var(--primitive-neo-text-dark);
+  --logo-chevron-hover:  var(--primitive-neo-accent-dark);
+  --logo-needle:         var(--primitive-neo-accent-dark);
+  --logo-needle-dark:    #006622;
+}
+
+/* ── Forest Dark — deep woodland ───────────────────────── */
+
+html[data-theme="forest-dark"]:root {
+  --color-bg:           var(--primitive-forest-950);
+  --color-surface:      var(--primitive-forest-900-dark);
+  --color-surface-alt:  var(--primitive-forest-800-dark);
+  --color-border:       var(--primitive-forest-700-dark);
+  --color-border-focus: var(--primitive-green-400);
+  --color-text:         #c8d4c8;
+  --color-text-muted:   #5a7a5a;
+  --color-text-subtle:  #3a5a3a;
+  --color-accent:       var(--primitive-green-400);
+  --color-accent-hover: #6ee7a0;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
+  --color-danger:  #e05c4b;
+  --color-success: var(--primitive-green-400);
+  --color-sev-critical-text:   var(--primitive-crimson-200);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-300);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-300) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-300) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-200);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
+  --color-grade-top-text:    var(--primitive-green-400);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-400) 12%, transparent);
+  --color-grade-high-text:   #6a9678;
+  --color-grade-high-bg:     color-mix(in srgb, #6a9678 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-300);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-400);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-200);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-warning:      var(--primitive-amber-400);
+  --color-warning-text: var(--primitive-amber-400);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-400) 10%, transparent);
+  --color-danger-text:   var(--primitive-crimson-200);
+  --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 15%, transparent);
+  --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 30%, transparent);
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
+  --color-overlay-medium: rgba(0, 0, 0, 0.82);
+  --color-overlay-light:  rgba(0, 0, 0, 0.72);
+  --color-chart-grid:   var(--primitive-forest-700-dark);
+  --color-chart-axis:   #5a7a5a;
+  --color-chart-line:   #c8d4c8;
+  --color-chart-stroke: rgba(255, 255, 255, 0.25);
+  /* Trend — green up, ired down */
+  --color-trend-strong-up:   var(--primitive-green-400);
+  --color-trend-up:          #6a9678;
+  --color-trend-soft-up:     #5a7a5a;
+  --color-trend-soft-down:   var(--primitive-ired-200);
+  --color-trend-down:        var(--primitive-ired-300);
+  --color-trend-strong-down: var(--primitive-crimson-300);
+  /* Console — deep green tint */
+  --color-console-bg: #060e06;
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+  /* Logo */
+  --logo-q:              var(--primitive-green-400);
+  --logo-chevron:        #c8d4c8;
+  --logo-chevron-hover:  var(--primitive-green-400);
+  --logo-needle:         var(--primitive-green-400);
+  --logo-needle-dark:    var(--primitive-forest-700);
+}
+
+/* ── Ember Light — warm parchment ──────────────────────── */
+
+html[data-theme="ember-light"]:root {
+  --color-bg:           var(--primitive-ember-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-ember-100);
+  --color-border:       var(--primitive-ember-border-light);
+  --color-border-focus: var(--primitive-crimson-500);
+  --color-text:         var(--primitive-ember-text-dark);
+  --color-text-muted:   var(--primitive-ember-500);
+  --color-text-subtle:  #b0a090;
+  --color-accent:       #c0392b;
+  --color-accent-hover: #a02e22;
+  --color-accent-soft:  color-mix(in srgb, #c0392b 8%, transparent);
+  --color-danger:  #c0392b;
+  --color-success: #2d7a4f;
+  --color-sev-critical-text:   var(--primitive-crimson-600);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ired-800);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ired-800) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ired-800) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ired-700);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-grade-top-text:    var(--primitive-daruma-600);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
+  --color-grade-high-text:   #7a6e64;
+  --color-grade-high-bg:     color-mix(in srgb, #7a6e64 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-ired-800);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
+  --color-grade-low-text:    var(--primitive-ired-900);
+  --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 10%, transparent);
+  --color-grade-bottom-text: var(--primitive-crimson-600);
+  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
+  --color-warning:      var(--primitive-amber-700);
+  --color-warning-text: var(--primitive-amber-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--primitive-ember-500);
+  --color-chart-line:   var(--primitive-ember-text-dark);
+  --color-chart-stroke: transparent;
+  /* Trend — warm up, ired down */
+  --color-trend-strong-up:   var(--primitive-daruma-600);
+  --color-trend-up:          var(--primitive-ember-500);
+  --color-trend-soft-up:     #b0a090;
+  --color-trend-soft-down:   var(--primitive-ired-700);
+  --color-trend-down:        var(--primitive-ired-900);
+  --color-trend-strong-down: var(--primitive-crimson-600);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
+  /* Logo */
+  --logo-q:              #c0392b;
+  --logo-chevron:        var(--primitive-ember-text-dark);
+  --logo-chevron-hover:  #c0392b;
+  --logo-needle:         var(--primitive-crimson-300);
+  --logo-needle-dark:    var(--primitive-crimson-700);
+}
+
 /* ── 5. Typography ────────────────────────────────────────
    Font families, scale, line-height, weight.
    ──────────────────────────────────────────────────────── */

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -200,6 +200,29 @@
   --primitive-ember-sev-major-dark:     #f0a040;
   --primitive-ember-sev-minor-dark:     #b09880;
 
+  /* Cyber palette (neon magenta, purple-chrome) */
+  --primitive-cyber-950: #0c0a12;
+  --primitive-cyber-900: #141220;
+  --primitive-cyber-800: #1e1a2c;
+  --primitive-cyber-700: #302a40;
+  --primitive-cyber-500: #8a80a0;
+  --primitive-cyber-200: #e0dce8;
+  --primitive-cyber-accent-light: #d020a0;
+  --primitive-cyber-accent-dark: #ff40c0;
+  --primitive-cyber-50: #f4f2f6;
+  --primitive-cyber-100: #e8e4ee;
+  --primitive-cyber-border-light: #c8c2d0;
+  --primitive-cyber-text-dark: #18141e;
+  --primitive-cyber-text-muted-light: #7a7088;
+
+  /* Cyber severity — neon pink-red scale */
+  --primitive-cyber-sev-critical-light: #e02050;
+  --primitive-cyber-sev-major-light:    #b01888;
+  --primitive-cyber-sev-minor-light:    #7a7088;
+  --primitive-cyber-sev-critical-dark:  #ff4060;
+  --primitive-cyber-sev-major-dark:     #ff40c0;
+  --primitive-cyber-sev-minor-dark:     #a098b8;
+
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
   --primitive-ired-300: #d86060;   /* dark C: rose-red */
@@ -1196,6 +1219,177 @@ html[data-theme="ember-light"]:root {
   --logo-chevron-hover:  var(--primitive-ember-accent-light);
   --logo-needle:         var(--primitive-ember-accent-light);
   --logo-needle-dark:    #a84a08;
+}
+
+/* ── Cyber Dark — neon magenta, purple-chrome ──────────── */
+
+html[data-theme="cyber-dark"]:root {
+  --color-bg:           var(--primitive-cyber-950);
+  --color-surface:      var(--primitive-cyber-900);
+  --color-surface-alt:  var(--primitive-cyber-800);
+  --color-border:       var(--primitive-cyber-700);
+  --color-border-focus: var(--primitive-cyber-accent-dark);
+
+  --color-text:         var(--primitive-cyber-200);
+  --color-text-muted:   var(--primitive-cyber-500);
+  --color-text-subtle:  #58506a;
+
+  --color-accent:       var(--primitive-cyber-accent-dark);
+  --color-accent-hover: #ff60d0;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-cyber-accent-dark) 14%, transparent);
+
+  --color-danger:  #ff4060;
+  --color-success: #00dce0;
+
+  --color-sev-critical-text:   var(--primitive-cyber-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-cyber-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-cyber-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-cyber-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-cyber-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-cyber-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-cyber-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-cyber-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-cyber-sev-minor-dark) 32%, transparent);
+
+  /* Grades — neon spectrum: violet → purple-gray → pink → red */
+  --color-grade-top-text:    #b040ff;
+  --color-grade-top-bg:      color-mix(in srgb, #b040ff 12%, transparent);
+  --color-grade-high-text:   #a098b8;
+  --color-grade-high-bg:     color-mix(in srgb, #a098b8 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-cyber-accent-dark);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-cyber-accent-dark) 12%, transparent);
+  --color-grade-low-text:    #ff4060;
+  --color-grade-low-bg:      color-mix(in srgb, #ff4060 13%, transparent);
+  --color-grade-bottom-text: #ff2040;
+  --color-grade-bottom-bg:   color-mix(in srgb, #ff2040 4%, transparent);
+
+  /* Compliance — neon cyan */
+  --color-compliance:        #00dce0;
+  --color-compliance-bg:     color-mix(in srgb, #00dce0 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #00dce0 38%, transparent);
+
+  --color-warning:      #f0b428;
+  --color-warning-text: #f0b428;
+  --color-warning-bg:   color-mix(in srgb, #f0b428 10%, transparent);
+
+  --color-danger-text:   #ff4060;
+  --color-danger-bg:     color-mix(in srgb, #ff4060 15%, transparent);
+  --color-danger-border: color-mix(in srgb, #ff4060 30%, transparent);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.92);
+  --color-overlay-medium: rgba(0, 0, 0, 0.85);
+  --color-overlay-light:  rgba(0, 0, 0, 0.75);
+
+  --color-chart-grid:   var(--primitive-cyber-700);
+  --color-chart-axis:   var(--primitive-cyber-500);
+  --color-chart-line:   var(--primitive-cyber-200);
+  --color-chart-stroke: rgba(255, 64, 192, 0.25);
+
+  /* Trend — violet up, red down */
+  --color-trend-strong-up:   #b040ff;
+  --color-trend-up:          var(--primitive-cyber-accent-dark);
+  --color-trend-soft-up:     var(--primitive-cyber-500);
+  --color-trend-soft-down:   #ff40c0;
+  --color-trend-down:        #ff4060;
+  --color-trend-strong-down: #ff2040;
+
+  /* Console — deep purple */
+  --color-console-bg: #06040a;
+
+  --shadow-sm: none;
+  --shadow-md: none;
+  --shadow-lg: none;
+
+  /* Logo */
+  --logo-q:              var(--primitive-cyber-accent-dark);
+  --logo-chevron:        var(--primitive-cyber-accent-dark);
+  --logo-chevron-hover:  #ff60d0;
+  --logo-needle:         var(--primitive-cyber-accent-dark);
+  --logo-needle-dark:    #a01880;
+}
+
+/* ── Cyber Light — frosted lavender, neon magenta ──────── */
+
+html[data-theme="cyber-light"]:root {
+  --color-bg:           var(--primitive-cyber-50);
+  --color-surface:      #ffffff;
+  --color-surface-alt:  var(--primitive-cyber-100);
+  --color-border:       var(--primitive-cyber-border-light);
+  --color-border-focus: var(--primitive-cyber-accent-light);
+
+  --color-text:         var(--primitive-cyber-text-dark);
+  --color-text-muted:   var(--primitive-cyber-text-muted-light);
+  --color-text-subtle:  #9a90a8;
+
+  --color-accent:       var(--primitive-cyber-accent-light);
+  --color-accent-hover: #b01888;
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-cyber-accent-light) 8%, transparent);
+
+  --color-danger:  #e02050;
+  --color-success: #0098a8;
+
+  --color-sev-critical-text:   var(--primitive-cyber-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-cyber-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-cyber-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-cyber-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-cyber-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-cyber-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-cyber-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-cyber-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-cyber-sev-minor-light) 30%, transparent);
+
+  /* Grades — neon spectrum: purple → gray → magenta → red */
+  --color-grade-top-text:    #8020d0;
+  --color-grade-top-bg:      color-mix(in srgb, #8020d0 12%, transparent);
+  --color-grade-high-text:   var(--primitive-cyber-text-muted-light);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-cyber-text-muted-light) 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-cyber-accent-light);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-cyber-accent-light) 10%, transparent);
+  --color-grade-low-text:    #e03060;
+  --color-grade-low-bg:      color-mix(in srgb, #e03060 10%, transparent);
+  --color-grade-bottom-text: #c02040;
+  --color-grade-bottom-bg:   color-mix(in srgb, #c02040 12%, transparent);
+
+  /* Compliance — teal-cyan */
+  --color-compliance:        #0098a8;
+  --color-compliance-bg:     color-mix(in srgb, #0098a8 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0098a8 38%, transparent);
+
+  --color-warning:      var(--primitive-amber-700);
+  --color-warning-text: var(--primitive-amber-700);
+  --color-warning-bg:   color-mix(in srgb, var(--primitive-amber-700) 8%, transparent);
+
+  --color-danger-text:   var(--color-danger);
+  --color-danger-bg:     var(--color-sev-critical-bg);
+  --color-danger-border: var(--color-sev-critical-border);
+
+  --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
+  --color-overlay-medium: rgba(0, 0, 0, 0.5);
+  --color-overlay-light:  rgba(0, 0, 0, 0.3);
+
+  --color-chart-grid:   var(--color-border);
+  --color-chart-axis:   var(--primitive-cyber-text-muted-light);
+  --color-chart-line:   var(--primitive-cyber-text-dark);
+  --color-chart-stroke: transparent;
+
+  /* Trend — purple up, red down */
+  --color-trend-strong-up:   #8020d0;
+  --color-trend-up:          var(--primitive-cyber-accent-light);
+  --color-trend-soft-up:     #9a90a8;
+  --color-trend-soft-down:   #e03060;
+  --color-trend-down:        #c02040;
+  --color-trend-strong-down: #a01830;
+
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
+
+  /* Logo */
+  --logo-q:              var(--primitive-cyber-accent-light);
+  --logo-chevron:        var(--primitive-cyber-text-dark);
+  --logo-chevron-hover:  var(--primitive-cyber-accent-light);
+  --logo-needle:         var(--primitive-cyber-accent-light);
+  --logo-needle-dark:    #b01888;
 }
 
 /* ── 5. Typography ────────────────────────────────────────

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -269,10 +269,10 @@
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
   /* Grade tier colors */
-  --color-grade-top-text:    var(--primitive-daruma-600);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-brand-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-500) 12%, transparent);
+  --color-grade-top-text:    #c49000;
+  --color-grade-top-bg:      color-mix(in srgb, #c49000 12%, transparent);
+  --color-grade-high-text:   #6c7078;
+  --color-grade-high-bg:     color-mix(in srgb, #6c7078 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-800);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-900);
@@ -281,7 +281,7 @@
   --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-600) 12%, transparent);
 
   /* Trend — default is light; dark themes override below */
-  --color-trend-strong-up:   var(--primitive-brand-500);
+  --color-trend-strong-up:   #c49000;
   --color-trend-up:          var(--primitive-ired-700);
   --color-trend-soft-up:     var(--primitive-brand-400);
   --color-trend-soft-down:   var(--primitive-ired-800);
@@ -302,10 +302,10 @@
   --logo-needle:         var(--primitive-crimson-300);
   --logo-needle-dark:    var(--primitive-crimson-700);
 
-  /* Compliance — inherits grade-top hue so it adapts per theme */
-  --color-compliance:        var(--color-grade-top-text);
-  --color-compliance-bg:     color-mix(in srgb, var(--color-grade-top-text) 4%, transparent);
-  --color-compliance-border: color-mix(in srgb, var(--color-grade-top-text) 38%, transparent);
+  /* Compliance — teal (Daruma Fire direction) */
+  --color-compliance:        #0e8a7a;
+  --color-compliance-bg:     color-mix(in srgb, #0e8a7a 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0e8a7a 38%, transparent);
 
   /* Warning */
   --color-warning:      var(--primitive-amber-700);
@@ -364,10 +364,10 @@
     --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
     --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-    --color-grade-top-text:    var(--primitive-daruma-400);
-    --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-    --color-grade-high-text:   var(--primitive-brand-300);
-    --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
+    --color-grade-top-text:    #f0be28;
+    --color-grade-top-bg:      color-mix(in srgb, #f0be28 14%, transparent);
+    --color-grade-high-text:   #a0a4ae;
+    --color-grade-high-bg:     color-mix(in srgb, #a0a4ae 14%, transparent);
     --color-grade-mid-text:    var(--primitive-ired-300);
     --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
     --color-grade-low-text:    var(--primitive-ired-400);
@@ -385,6 +385,11 @@
     --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
     --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
+    /* Compliance — teal (Daruma Fire direction) */
+    --color-compliance:        #28d2b4;
+    --color-compliance-bg:     color-mix(in srgb, #28d2b4 4%, transparent);
+    --color-compliance-border: color-mix(in srgb, #28d2b4 38%, transparent);
+
     /* Overlays */
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
     --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -397,7 +402,7 @@
     --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
     /* Trend — gray → crimson on dark backgrounds */
-    --color-trend-strong-up:   var(--primitive-brand-300);
+    --color-trend-strong-up:   #f0be28;
     --color-trend-up:          var(--primitive-ired-200);
     --color-trend-soft-up:     var(--primitive-brand-500);
     --color-trend-soft-down:   var(--primitive-ired-300);
@@ -447,10 +452,10 @@ html[data-theme="dark"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
 
-  --color-grade-top-text:    var(--primitive-daruma-400);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-400) 14%, transparent);
-  --color-grade-high-text:   var(--primitive-brand-300);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-300) 14%, transparent);
+  --color-grade-top-text:    #f0be28;
+  --color-grade-top-bg:      color-mix(in srgb, #f0be28 14%, transparent);
+  --color-grade-high-text:   #a0a4ae;
+  --color-grade-high-bg:     color-mix(in srgb, #a0a4ae 14%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-300);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 14%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
@@ -468,6 +473,11 @@ html[data-theme="dark"]:root {
   --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
+  /* Compliance — teal (Daruma Fire direction) */
+  --color-compliance:        #28d2b4;
+  --color-compliance-bg:     color-mix(in srgb, #28d2b4 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #28d2b4 38%, transparent);
+
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -480,7 +490,7 @@ html[data-theme="dark"]:root {
   --color-chart-stroke: rgba(255, 255, 255, 0.2);
 
   /* Trend — gray → crimson on dark backgrounds */
-  --color-trend-strong-up:   var(--primitive-brand-300);
+  --color-trend-strong-up:   #f0be28;
   --color-trend-up:          var(--primitive-ired-200);
   --color-trend-soft-up:     var(--primitive-brand-500);
   --color-trend-soft-down:   var(--primitive-ired-300);
@@ -531,10 +541,10 @@ html[data-theme="light"]:root {
   --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
   --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
 
-  --color-grade-top-text:    var(--primitive-daruma-600);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-brand-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-brand-500) 12%, transparent);
+  --color-grade-top-text:    #c49000;
+  --color-grade-top-bg:      color-mix(in srgb, #c49000 12%, transparent);
+  --color-grade-high-text:   #6c7078;
+  --color-grade-high-bg:     color-mix(in srgb, #6c7078 12%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-800);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-900);
@@ -552,6 +562,11 @@ html[data-theme="light"]:root {
   --color-danger-bg:     var(--color-sev-critical-bg);
   --color-danger-border: var(--color-sev-critical-border);
 
+  /* Compliance — teal (Daruma Fire direction) */
+  --color-compliance:        #0e8a7a;
+  --color-compliance-bg:     color-mix(in srgb, #0e8a7a 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, #0e8a7a 38%, transparent);
+
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.7);
   --color-overlay-medium: rgba(0, 0, 0, 0.5);
@@ -564,7 +579,7 @@ html[data-theme="light"]:root {
   --color-chart-stroke: transparent;
 
   /* Trend — gray → crimson on light backgrounds */
-  --color-trend-strong-up:   var(--primitive-brand-500);
+  --color-trend-strong-up:   #c49000;
   --color-trend-up:          var(--primitive-ired-700);
   --color-trend-soft-up:     var(--primitive-brand-400);
   --color-trend-soft-down:   var(--primitive-ired-800);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -170,6 +170,35 @@
   --primitive-major-light: #c05030;
   --primitive-major-dark:  #e87850;
 
+  /* Midnight severity — cool magenta-reds */
+  --primitive-midnight-sev-critical-light: #b42850;
+  --primitive-midnight-sev-major-light:    #a0466e;
+  --primitive-midnight-sev-minor-light:    #786482;
+  --primitive-midnight-sev-critical-dark:  #f05078;
+  --primitive-midnight-sev-major-dark:     #d26e96;
+  --primitive-midnight-sev-minor-dark:     #aa8caa;
+
+  /* Neo severity — warm amber-reds (light); already has dark hardcoded */
+  --primitive-neo-sev-critical-light: #c81e1e;
+  --primitive-neo-sev-major-light:    #c85a28;
+  --primitive-neo-sev-minor-light:    #8c6e46;
+
+  /* Forest severity — earthy reds and ambers */
+  --primitive-forest-sev-critical-light: #a83228;
+  --primitive-forest-sev-major-light:    #b05828;
+  --primitive-forest-sev-minor-light:    #8c643c;
+  --primitive-forest-sev-critical-dark:  #e06450;
+  --primitive-forest-sev-major-dark:     #d28c50;
+  --primitive-forest-sev-minor-dark:     #b49664;
+
+  /* Ember severity — deep warm reds */
+  --primitive-ember-sev-critical-light: #aa0000;
+  --primitive-ember-sev-major-light:    #b43c1e;
+  --primitive-ember-sev-minor-light:    #8c503c;
+  --primitive-ember-sev-critical-dark:  #ff4a4a;
+  --primitive-ember-sev-major-dark:     #f07846;
+  --primitive-ember-sev-minor-dark:     #c8966e;
+
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
   --primitive-ired-300: #d86060;   /* dark C: rose-red */
@@ -573,15 +602,15 @@ html[data-theme="ember-dark"]:root {
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   var(--primitive-crimson-200);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-200);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-ember-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ember-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ember-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
 
   --color-grade-top-text:    var(--primitive-emerald-300);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-emerald-300) 12%, transparent);
@@ -654,15 +683,15 @@ html[data-theme="forest-light"]:root {
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
 
-  --color-sev-critical-text:   var(--primitive-crimson-600);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-700);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-forest-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-forest-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-forest-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-forest-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-forest-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-forest-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-forest-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-forest-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-forest-sev-minor-light) 30%, transparent);
 
   --color-grade-top-text:    var(--primitive-forest-800);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-forest-800) 12%, transparent);
@@ -732,15 +761,15 @@ html[data-theme="midnight-dark"]:root {
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   var(--primitive-crimson-200);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-200);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-midnight-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-midnight-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-midnight-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-midnight-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-midnight-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-midnight-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-midnight-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-midnight-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-midnight-sev-minor-dark) 32%, transparent);
 
   --color-grade-top-text:    #00d4ff;
   --color-grade-top-bg:      color-mix(in srgb, #00d4ff 12%, transparent);
@@ -813,15 +842,15 @@ html[data-theme="midnight-light"]:root {
   --color-danger:  var(--primitive-red-500);
   --color-success: #16a34a;
 
-  --color-sev-critical-text:   var(--primitive-crimson-600);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-700);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-midnight-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-midnight-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-midnight-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-midnight-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-midnight-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-midnight-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-midnight-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-midnight-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-midnight-sev-minor-light) 30%, transparent);
 
   --color-grade-top-text:    var(--primitive-green-electric);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-electric) 12%, transparent);
@@ -955,15 +984,15 @@ html[data-theme="neo-light"]:root {
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent-dark) 8%, transparent);
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
-  --color-sev-critical-text:   var(--primitive-crimson-600);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-700);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-neo-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-neo-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-neo-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-neo-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-neo-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-neo-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-neo-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-neo-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-neo-sev-minor-light) 30%, transparent);
   --color-grade-top-text:    #006622;
   --color-grade-top-bg:      color-mix(in srgb, #006622 12%, transparent);
   --color-grade-high-text:   #338844;
@@ -1021,15 +1050,15 @@ html[data-theme="forest-dark"]:root {
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
   --color-danger:  #e05c4b;
   --color-success: var(--primitive-green-400);
-  --color-sev-critical-text:   var(--primitive-crimson-200);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-200) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-200);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-200) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-200) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-forest-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-forest-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-forest-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-forest-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-forest-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-forest-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-forest-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-forest-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-forest-sev-minor-dark) 32%, transparent);
   --color-grade-top-text:    var(--primitive-green-400);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-400) 12%, transparent);
   --color-grade-high-text:   #6a9678;
@@ -1089,15 +1118,15 @@ html[data-theme="ember-light"]:root {
   --color-accent-soft:  color-mix(in srgb, #c0392b 8%, transparent);
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
-  --color-sev-critical-text:   var(--primitive-crimson-600);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-crimson-600) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-crimson-600) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ired-700);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ired-700) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ired-700) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-ember-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ember-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ember-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
   --color-grade-top-text:    var(--primitive-daruma-600);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-daruma-600) 12%, transparent);
   --color-grade-high-text:   #7a6e64;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -677,22 +677,22 @@ html[data-theme="ember-dark"]:root {
   --logo-needle-dark:    #a06010;
 }
 
-/* ── Forest Light — nature greens, sage ─────────────────── */
+/* ── Forest Light — mossy greens ────────────────────────── */
 
 html[data-theme="forest-light"]:root {
-  --color-bg:           var(--primitive-forest-50);
+  --color-bg:           #f0f5ef;
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-forest-100);
-  --color-border:       var(--primitive-forest-200);
-  --color-border-focus: var(--primitive-forest-700);
+  --color-surface-alt:  #e0eadf;
+  --color-border:       #c0d4be;
+  --color-border-focus: #1b6b3a;
 
-  --color-text:         var(--primitive-forest-900);
+  --color-text:         #162016;
   --color-text-muted:   #5a7a5a;
   --color-text-subtle:  #7a9a7a;
 
-  --color-accent:       var(--primitive-forest-700);
-  --color-accent-hover: var(--primitive-forest-800);
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-forest-700) 8%, transparent);
+  --color-accent:       #1b6b3a;
+  --color-accent-hover: #145228;
+  --color-accent-soft:  color-mix(in srgb, #1b6b3a 8%, transparent);
 
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
@@ -732,7 +732,7 @@ html[data-theme="forest-light"]:root {
 
   --color-chart-grid:   var(--color-border);
   --color-chart-axis:   var(--color-text-muted);
-  --color-chart-line:   var(--primitive-forest-900);
+  --color-chart-line:   #162016;
   --color-chart-stroke: transparent;
 
   /* Trend — forest greens up, ired chain down */
@@ -748,11 +748,11 @@ html[data-theme="forest-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              var(--primitive-forest-700);
-  --logo-chevron:        var(--primitive-forest-800);
-  --logo-chevron-hover:  var(--primitive-forest-700);
-  --logo-needle:         var(--primitive-forest-700);
-  --logo-needle-dark:    var(--primitive-forest-800);
+  --logo-q:              #1b6b3a;
+  --logo-chevron:        #162016;
+  --logo-chevron-hover:  #1b6b3a;
+  --logo-needle:         #1b6b3a;
+  --logo-needle-dark:    #145228;
 }
 
 /* ── Midnight Dark — deep navy, cyan accents ────────────── */
@@ -836,22 +836,22 @@ html[data-theme="midnight-dark"]:root {
   --logo-needle-dark:    #0090b0;
 }
 
-/* ── Midnight Light — cool whites, indigo accent ────────── */
+/* ── Midnight Light — twilight, deep indigo ───────────── */
 
 html[data-theme="midnight-light"]:root {
-  --color-bg:           var(--primitive-horizon-50);
+  --color-bg:           #f4f6fc;
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-horizon-100);
-  --color-border:       var(--primitive-horizon-200);
-  --color-border-focus: var(--primitive-horizon-600);
+  --color-surface-alt:  #e8ecf8;
+  --color-border:       #c8d0e8;
+  --color-border-focus: #4f46e5;
 
-  --color-text:         var(--primitive-horizon-900);
-  --color-text-muted:   #6b7280;
-  --color-text-subtle:  #9ca3af;
+  --color-text:         #0e1228;
+  --color-text-muted:   #6070a0;
+  --color-text-subtle:  #8890b0;
 
-  --color-accent:       var(--primitive-horizon-600);
-  --color-accent-hover: var(--primitive-horizon-700);
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-horizon-600) 8%, transparent);
+  --color-accent:       #4f46e5;
+  --color-accent-hover: #4338ca;
+  --color-accent-soft:  color-mix(in srgb, #4f46e5 8%, transparent);
 
   --color-danger:  var(--primitive-red-500);
   --color-success: #16a34a;
@@ -890,8 +890,8 @@ html[data-theme="midnight-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--color-text-muted);
-  --color-chart-line:   var(--primitive-horizon-900);
+  --color-chart-axis:   #6070a0;
+  --color-chart-line:   #0e1228;
   --color-chart-stroke: transparent;
 
   /* Trend — electric green up, ired chain down */
@@ -907,11 +907,11 @@ html[data-theme="midnight-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              var(--primitive-horizon-600);
-  --logo-chevron:        var(--primitive-horizon-700);
-  --logo-chevron-hover:  var(--primitive-horizon-600);
-  --logo-needle:         var(--primitive-horizon-600);
-  --logo-needle-dark:    var(--primitive-horizon-800);
+  --logo-q:              #4f46e5;
+  --logo-chevron:        #0e1228;
+  --logo-chevron-hover:  #4f46e5;
+  --logo-needle:         #4f46e5;
+  --logo-needle-dark:    #4338ca;
 }
 
 /* ── Neo Dark — Matrix terminal ─────────────────────────── */

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -385,6 +385,11 @@
     --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
     --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
 
+    /* Compliance — light gray, matching exemplary tone */
+    --color-compliance:        var(--primitive-daruma-400);
+    --color-compliance-bg:     color-mix(in srgb, var(--primitive-daruma-400) 4%, transparent);
+    --color-compliance-border: color-mix(in srgb, var(--primitive-daruma-400) 38%, transparent);
+
     /* Overlays */
     --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
     --color-overlay-medium: rgba(0, 0, 0, 0.82);
@@ -467,6 +472,11 @@ html[data-theme="dark"]:root {
   --color-danger-text:   var(--primitive-crimson-200);
   --color-danger-bg:     color-mix(in srgb, var(--primitive-crimson-200) 12%, transparent);
   --color-danger-border: color-mix(in srgb, var(--primitive-crimson-200) 25%, transparent);
+
+  /* Compliance — light gray, matching exemplary tone */
+  --color-compliance:        var(--primitive-daruma-400);
+  --color-compliance-bg:     color-mix(in srgb, var(--primitive-daruma-400) 4%, transparent);
+  --color-compliance-border: color-mix(in srgb, var(--primitive-daruma-400) 38%, transparent);
 
   /* Overlays */
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -45,37 +45,37 @@
   --primitive-dark-500: #9a9490;
   --primitive-dark-200: #f0ece6;
 
-  /* Ember palette (warm charcoal, glowing fire) */
-  --primitive-ember-950: #161010;
-  --primitive-ember-900: #201614;
-  --primitive-ember-800: #2c201c;
-  --primitive-ember-700: #3e302a;
-  --primitive-ember-500: #9a7a68;
-  --primitive-ember-200: #f0dcc8;
-  --primitive-ember-accent-light: #c85a10;
-  --primitive-ember-accent-dark: #e88030;
-  --primitive-ember-50: #faf5f0;
-  --primitive-ember-100: #f0e8de;
-  --primitive-ember-border-light: #dcc8b4;
-  --primitive-ember-text-dark: #241810;
-  --primitive-ember-text-muted-light: #8a7060;
+  /* Ifrit palette (warm charcoal, glowing fire) */
+  --primitive-ifrit-950: #161010;
+  --primitive-ifrit-900: #201614;
+  --primitive-ifrit-800: #2c201c;
+  --primitive-ifrit-700: #3e302a;
+  --primitive-ifrit-500: #9a7a68;
+  --primitive-ifrit-200: #f0dcc8;
+  --primitive-ifrit-accent-light: #c85a10;
+  --primitive-ifrit-accent-dark: #e88030;
+  --primitive-ifrit-50: #faf5f0;
+  --primitive-ifrit-100: #f0e8de;
+  --primitive-ifrit-border-light: #dcc8b4;
+  --primitive-ifrit-text-dark: #241810;
+  --primitive-ifrit-text-muted-light: #8a7060;
 
-  /* Forest palette (nature greens, sage) */
-  --primitive-forest-50:  #f4f7f4;
-  --primitive-forest-100: #e8ede8;
-  --primitive-forest-200: #c8d4c8;
-  --primitive-forest-300: #a8bca8;
-  --primitive-forest-700: #2d6a4f;
-  --primitive-forest-800: #1b4332;
-  --primitive-forest-900: #1a2e1a;
+  /* Galadriel palette (nature greens, sage) */
+  --primitive-galadriel-50:  #f4f7f4;
+  --primitive-galadriel-100: #e8ede8;
+  --primitive-galadriel-200: #c8d4c8;
+  --primitive-galadriel-300: #a8bca8;
+  --primitive-galadriel-700: #2d6a4f;
+  --primitive-galadriel-800: #1b4332;
+  --primitive-galadriel-900: #1a2e1a;
 
-  /* Midnight palette (deep navy, cyan accents) */
-  --primitive-midnight-950: #0a0e14;
-  --primitive-midnight-900: #111822;
-  --primitive-midnight-800: #1a2230;
-  --primitive-midnight-700: #2a3545;
-  --primitive-midnight-500: #6a8aaa;
-  --primitive-midnight-200: #d4e0f0;
+  /* Flynn palette (deep navy, cyan accents) */
+  --primitive-flynn-950: #0a0e14;
+  --primitive-flynn-900: #111822;
+  --primitive-flynn-800: #1a2230;
+  --primitive-flynn-700: #2a3545;
+  --primitive-flynn-500: #6a8aaa;
+  --primitive-flynn-200: #d4e0f0;
 
   /* Slate palette (neutral monochrome) */
   --primitive-slate-50:  #f5f5f5;
@@ -108,11 +108,11 @@
   --primitive-neo-border-light: #c0d4c0;
   --primitive-neo-text-dark: #0a2010;
 
-  /* Forest dark extensions */
-  --primitive-forest-950:      #0e1610;
-  --primitive-forest-900-dark: #152018;
-  --primitive-forest-800-dark: #1e2c20;
-  --primitive-forest-700-dark: #2e4230;
+  /* Galadriel dark extensions */
+  --primitive-galadriel-950:      #0e1610;
+  --primitive-galadriel-900-dark: #152018;
+  --primitive-galadriel-800-dark: #1e2c20;
+  --primitive-galadriel-700-dark: #2e4230;
 
   /* Brand neutrals (cool near-black, logo-derived) */
   --primitive-brand-950: #0d1014;
@@ -171,57 +171,57 @@
   --primitive-major-light: #c05030;
   --primitive-major-dark:  #e87850;
 
-  /* Midnight severity — cool magenta-reds */
-  --primitive-midnight-sev-critical-light: #b42850;
-  --primitive-midnight-sev-major-light:    #a0466e;
-  --primitive-midnight-sev-minor-light:    #786482;
-  --primitive-midnight-sev-critical-dark:  #f05078;
-  --primitive-midnight-sev-major-dark:     #d26e96;
-  --primitive-midnight-sev-minor-dark:     #aa8caa;
+  /* Flynn severity — cool magenta-reds */
+  --primitive-flynn-sev-critical-light: #b42850;
+  --primitive-flynn-sev-major-light:    #a0466e;
+  --primitive-flynn-sev-minor-light:    #786482;
+  --primitive-flynn-sev-critical-dark:  #f05078;
+  --primitive-flynn-sev-major-dark:     #d26e96;
+  --primitive-flynn-sev-minor-dark:     #aa8caa;
 
   /* Neo severity — warm amber-reds (light); already has dark hardcoded */
   --primitive-neo-sev-critical-light: #c81e1e;
   --primitive-neo-sev-major-light:    #c85a28;
   --primitive-neo-sev-minor-light:    #8c6e46;
 
-  /* Forest severity — earthy reds and ambers */
-  --primitive-forest-sev-critical-light: #a83228;
-  --primitive-forest-sev-major-light:    #b05828;
-  --primitive-forest-sev-minor-light:    #8c643c;
-  --primitive-forest-sev-critical-dark:  #e06450;
-  --primitive-forest-sev-major-dark:     #d28c50;
-  --primitive-forest-sev-minor-dark:     #b49664;
+  /* Galadriel severity — earthy reds and ambers */
+  --primitive-galadriel-sev-critical-light: #a83228;
+  --primitive-galadriel-sev-major-light:    #b05828;
+  --primitive-galadriel-sev-minor-light:    #8c643c;
+  --primitive-galadriel-sev-critical-dark:  #e06450;
+  --primitive-galadriel-sev-major-dark:     #d28c50;
+  --primitive-galadriel-sev-minor-dark:     #b49664;
 
-  /* Ember severity — warm fire scale */
-  --primitive-ember-sev-critical-light: #b82010;
-  --primitive-ember-sev-major-light:    #c87020;
-  --primitive-ember-sev-minor-light:    #8a7060;
-  --primitive-ember-sev-critical-dark:  #ff5030;
-  --primitive-ember-sev-major-dark:     #f0a040;
-  --primitive-ember-sev-minor-dark:     #b09880;
+  /* Ifrit severity — warm fire scale */
+  --primitive-ifrit-sev-critical-light: #b82010;
+  --primitive-ifrit-sev-major-light:    #c87020;
+  --primitive-ifrit-sev-minor-light:    #8a7060;
+  --primitive-ifrit-sev-critical-dark:  #ff5030;
+  --primitive-ifrit-sev-major-dark:     #f0a040;
+  --primitive-ifrit-sev-minor-dark:     #b09880;
 
-  /* Cyber palette (neon magenta, purple-chrome) */
-  --primitive-cyber-950: #0c0a12;
-  --primitive-cyber-900: #141220;
-  --primitive-cyber-800: #1e1a2c;
-  --primitive-cyber-700: #302a40;
-  --primitive-cyber-500: #8a80a0;
-  --primitive-cyber-200: #e0dce8;
-  --primitive-cyber-accent-light: #d020a0;
-  --primitive-cyber-accent-dark: #ff40c0;
-  --primitive-cyber-50: #f4f2f6;
-  --primitive-cyber-100: #e8e4ee;
-  --primitive-cyber-border-light: #c8c2d0;
-  --primitive-cyber-text-dark: #18141e;
-  --primitive-cyber-text-muted-light: #7a7088;
+  /* Deckard palette (neon magenta, purple-chrome) */
+  --primitive-deckard-950: #0c0a12;
+  --primitive-deckard-900: #141220;
+  --primitive-deckard-800: #1e1a2c;
+  --primitive-deckard-700: #302a40;
+  --primitive-deckard-500: #8a80a0;
+  --primitive-deckard-200: #e0dce8;
+  --primitive-deckard-accent-light: #d020a0;
+  --primitive-deckard-accent-dark: #ff40c0;
+  --primitive-deckard-50: #f4f2f6;
+  --primitive-deckard-100: #e8e4ee;
+  --primitive-deckard-border-light: #c8c2d0;
+  --primitive-deckard-text-dark: #18141e;
+  --primitive-deckard-text-muted-light: #7a7088;
 
-  /* Cyber severity — neon pink-red scale */
-  --primitive-cyber-sev-critical-light: #e02050;
-  --primitive-cyber-sev-major-light:    #b01888;
-  --primitive-cyber-sev-minor-light:    #7a7088;
-  --primitive-cyber-sev-critical-dark:  #ff4060;
-  --primitive-cyber-sev-major-dark:     #ff40c0;
-  --primitive-cyber-sev-minor-dark:     #a098b8;
+  /* Deckard severity — neon pink-red scale */
+  --primitive-deckard-sev-critical-light: #e02050;
+  --primitive-deckard-sev-major-light:    #b01888;
+  --primitive-deckard-sev-minor-light:    #7a7088;
+  --primitive-deckard-sev-critical-dark:  #ff4060;
+  --primitive-deckard-sev-major-dark:     #ff40c0;
+  --primitive-deckard-sev-minor-dark:     #a098b8;
 
   /* Issue-intensity heat scale (gray → crimson, default light + dark) */
   --primitive-ired-200: #c09090;   /* dark B: muted rose-gray */
@@ -232,7 +232,7 @@
   --primitive-ired-900: #c02020;   /* light D: medium red */
 
   /* Extended gamma palette (theme-native grade / severity / trend) */
-  --primitive-forest-500:  #5a7a5a;
+  --primitive-galadriel-500:  #5a7a5a;
   --primitive-cyan-700:    #0e6d8a;
   --primitive-cyan-400:    #22d3ee;
   --primitive-cyan-300:    #67e8f9;
@@ -621,41 +621,41 @@ html[data-theme="light"]:root {
   --logo-needle-dark:    var(--primitive-crimson-700);
 }
 
-/* ── Ember Dark — glowing coals ────────────────────────── */
+/* ── Ifrit Dark — glowing coals ────────────────────────── */
 
-html[data-theme="ember-dark"]:root {
-  --color-bg:           var(--primitive-ember-950);
-  --color-surface:      var(--primitive-ember-900);
-  --color-surface-alt:  var(--primitive-ember-800);
-  --color-border:       var(--primitive-ember-700);
-  --color-border-focus: var(--primitive-ember-accent-dark);
+html[data-theme="ifrit-dark"]:root {
+  --color-bg:           var(--primitive-ifrit-950);
+  --color-surface:      var(--primitive-ifrit-900);
+  --color-surface-alt:  var(--primitive-ifrit-800);
+  --color-border:       var(--primitive-ifrit-700);
+  --color-border-focus: var(--primitive-ifrit-accent-dark);
 
-  --color-text:         var(--primitive-ember-200);
-  --color-text-muted:   var(--primitive-ember-500);
+  --color-text:         var(--primitive-ifrit-200);
+  --color-text-muted:   var(--primitive-ifrit-500);
   --color-text-subtle:  #6a5448;
 
-  --color-accent:       var(--primitive-ember-accent-dark);
+  --color-accent:       var(--primitive-ifrit-accent-dark);
   --color-accent-hover: #f09040;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-accent-dark) 14%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-dark) 14%, transparent);
 
   --color-danger:  #ff5030;
   --color-success: #50b868;
 
-  --color-sev-critical-text:   var(--primitive-ember-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-ember-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-ember-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-ifrit-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ifrit-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ifrit-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-ifrit-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ifrit-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-ifrit-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ifrit-sev-minor-dark) 32%, transparent);
 
   /* Grades — ember glow: gold → amber → orange → red */
   --color-grade-top-text:    #f0b830;
   --color-grade-top-bg:      color-mix(in srgb, #f0b830 12%, transparent);
-  --color-grade-high-text:   var(--primitive-ember-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-500) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-ifrit-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ifrit-500) 12%, transparent);
   --color-grade-mid-text:    #f07030;
   --color-grade-mid-bg:      color-mix(in srgb, #f07030 12%, transparent);
   --color-grade-low-text:    #ff5030;
@@ -680,15 +680,15 @@ html[data-theme="ember-dark"]:root {
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-ember-700);
-  --color-chart-axis:   var(--primitive-ember-500);
-  --color-chart-line:   var(--primitive-ember-200);
+  --color-chart-grid:   var(--primitive-ifrit-700);
+  --color-chart-axis:   var(--primitive-ifrit-500);
+  --color-chart-line:   var(--primitive-ifrit-200);
   --color-chart-stroke: rgba(232, 128, 48, 0.25);
 
   /* Trend — gold up, red down */
   --color-trend-strong-up:   #f0b830;
-  --color-trend-up:          var(--primitive-ember-accent-dark);
-  --color-trend-soft-up:     var(--primitive-ember-500);
+  --color-trend-up:          var(--primitive-ifrit-accent-dark);
+  --color-trend-soft-up:     var(--primitive-ifrit-500);
   --color-trend-soft-down:   #f07030;
   --color-trend-down:        #ff5030;
   --color-trend-strong-down: #ff2820;
@@ -701,16 +701,16 @@ html[data-theme="ember-dark"]:root {
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-ember-accent-dark);
-  --logo-chevron:        var(--primitive-ember-200);
-  --logo-chevron-hover:  var(--primitive-ember-accent-dark);
-  --logo-needle:         var(--primitive-ember-accent-dark);
+  --logo-q:              var(--primitive-ifrit-accent-dark);
+  --logo-chevron:        var(--primitive-ifrit-200);
+  --logo-chevron-hover:  var(--primitive-ifrit-accent-dark);
+  --logo-needle:         var(--primitive-ifrit-accent-dark);
   --logo-needle-dark:    #a05810;
 }
 
-/* ── Forest Light — mossy greens ────────────────────────── */
+/* ── Galadriel Light — mossy greens ────────────────────────── */
 
-html[data-theme="forest-light"]:root {
+html[data-theme="galadriel-light"]:root {
   --color-bg:           #f0f5ef;
   --color-surface:      #ffffff;
   --color-surface-alt:  #e0eadf;
@@ -728,20 +728,20 @@ html[data-theme="forest-light"]:root {
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
 
-  --color-sev-critical-text:   var(--primitive-forest-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-forest-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-forest-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-forest-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-forest-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-forest-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-forest-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-forest-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-forest-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-galadriel-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-galadriel-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-galadriel-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-galadriel-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-galadriel-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-galadriel-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-galadriel-sev-minor-light) 30%, transparent);
 
-  --color-grade-top-text:    var(--primitive-forest-800);
-  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-forest-800) 12%, transparent);
-  --color-grade-high-text:   var(--primitive-forest-500);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-forest-500) 10%, transparent);
+  --color-grade-top-text:    var(--primitive-galadriel-800);
+  --color-grade-top-bg:      color-mix(in srgb, var(--primitive-galadriel-800) 12%, transparent);
+  --color-grade-high-text:   var(--primitive-galadriel-500);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-galadriel-500) 10%, transparent);
   --color-grade-mid-text:    var(--primitive-ired-800);
   --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 10%, transparent);
   --color-grade-low-text:    var(--primitive-ired-900);
@@ -772,9 +772,9 @@ html[data-theme="forest-light"]:root {
   --color-chart-stroke: transparent;
 
   /* Trend — forest greens up, ired chain down */
-  --color-trend-strong-up:   var(--primitive-forest-800);
-  --color-trend-up:          var(--primitive-forest-700);
-  --color-trend-soft-up:     var(--primitive-forest-500);
+  --color-trend-strong-up:   var(--primitive-galadriel-800);
+  --color-trend-up:          var(--primitive-galadriel-700);
+  --color-trend-soft-up:     var(--primitive-galadriel-500);
   --color-trend-soft-down:   var(--primitive-ired-700);
   --color-trend-down:        var(--primitive-ired-900);
   --color-trend-strong-down: var(--primitive-crimson-600);
@@ -791,17 +791,17 @@ html[data-theme="forest-light"]:root {
   --logo-needle-dark:    #145228;
 }
 
-/* ── Midnight Dark — deep navy, cyan accents ────────────── */
+/* ── Flynn Dark — deep navy, cyan accents ────────────── */
 
-html[data-theme="midnight-dark"]:root {
-  --color-bg:           var(--primitive-midnight-950);
-  --color-surface:      var(--primitive-midnight-900);
-  --color-surface-alt:  var(--primitive-midnight-800);
-  --color-border:       var(--primitive-midnight-700);
+html[data-theme="flynn-dark"]:root {
+  --color-bg:           var(--primitive-flynn-950);
+  --color-surface:      var(--primitive-flynn-900);
+  --color-surface-alt:  var(--primitive-flynn-800);
+  --color-border:       var(--primitive-flynn-700);
   --color-border-focus: #00d4ff;
 
-  --color-text:         var(--primitive-midnight-200);
-  --color-text-muted:   var(--primitive-midnight-500);
+  --color-text:         var(--primitive-flynn-200);
+  --color-text-muted:   var(--primitive-flynn-500);
   --color-text-subtle:  #4a6a88;
 
   --color-accent:       #00d4ff;
@@ -811,15 +811,15 @@ html[data-theme="midnight-dark"]:root {
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
 
-  --color-sev-critical-text:   var(--primitive-midnight-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-midnight-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-midnight-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-midnight-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-midnight-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-midnight-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-midnight-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-midnight-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-midnight-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-flynn-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-flynn-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-flynn-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-flynn-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-flynn-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-flynn-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-flynn-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-flynn-sev-minor-dark) 32%, transparent);
 
   --color-grade-top-text:    #00d4ff;
   --color-grade-top-bg:      color-mix(in srgb, #00d4ff 12%, transparent);
@@ -849,15 +849,15 @@ html[data-theme="midnight-dark"]:root {
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
 
-  --color-chart-grid:   var(--primitive-midnight-700);
-  --color-chart-axis:   var(--primitive-midnight-500);
-  --color-chart-line:   var(--primitive-midnight-200);
+  --color-chart-grid:   var(--primitive-flynn-700);
+  --color-chart-axis:   var(--primitive-flynn-500);
+  --color-chart-line:   var(--primitive-flynn-200);
   --color-chart-stroke: rgba(255, 255, 255, 0.25);
 
   /* Trend — cyan reward up, ired chain down */
   --color-trend-strong-up:   #00d4ff;
   --color-trend-up:          var(--primitive-cyan-300);
-  --color-trend-soft-up:     var(--primitive-midnight-500);
+  --color-trend-soft-up:     var(--primitive-flynn-500);
   --color-trend-soft-down:   var(--primitive-ired-200);
   --color-trend-down:        var(--primitive-ired-300);
   --color-trend-strong-down: var(--primitive-crimson-300);
@@ -877,9 +877,9 @@ html[data-theme="midnight-dark"]:root {
   --logo-needle-dark:    #0090b0;
 }
 
-/* ── Midnight Light — twilight, deep indigo ───────────── */
+/* ── Flynn Light — twilight, deep indigo ───────────── */
 
-html[data-theme="midnight-light"]:root {
+html[data-theme="flynn-light"]:root {
   --color-bg:           #f4f6fc;
   --color-surface:      #ffffff;
   --color-surface-alt:  #e8ecf8;
@@ -897,15 +897,15 @@ html[data-theme="midnight-light"]:root {
   --color-danger:  var(--primitive-red-500);
   --color-success: #16a34a;
 
-  --color-sev-critical-text:   var(--primitive-midnight-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-midnight-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-midnight-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-midnight-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-midnight-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-midnight-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-midnight-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-midnight-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-midnight-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-flynn-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-flynn-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-flynn-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-flynn-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-flynn-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-flynn-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-flynn-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-flynn-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-flynn-sev-minor-light) 30%, transparent);
 
   --color-grade-top-text:    var(--primitive-green-electric);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-electric) 12%, transparent);
@@ -1106,13 +1106,13 @@ html[data-theme="neo-light"]:root {
   --logo-needle-dark:    #006622;
 }
 
-/* ── Forest Dark — deep woodland ───────────────────────── */
+/* ── Galadriel Dark — deep woodland ───────────────────────── */
 
-html[data-theme="forest-dark"]:root {
-  --color-bg:           var(--primitive-forest-950);
-  --color-surface:      var(--primitive-forest-900-dark);
-  --color-surface-alt:  var(--primitive-forest-800-dark);
-  --color-border:       var(--primitive-forest-700-dark);
+html[data-theme="galadriel-dark"]:root {
+  --color-bg:           var(--primitive-galadriel-950);
+  --color-surface:      var(--primitive-galadriel-900-dark);
+  --color-surface-alt:  var(--primitive-galadriel-800-dark);
+  --color-border:       var(--primitive-galadriel-700-dark);
   --color-border-focus: var(--primitive-green-400);
   --color-text:         #c8d4c8;
   --color-text-muted:   #5a7a5a;
@@ -1122,15 +1122,15 @@ html[data-theme="forest-dark"]:root {
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
   --color-danger:  #e05c4b;
   --color-success: var(--primitive-green-400);
-  --color-sev-critical-text:   var(--primitive-forest-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-forest-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-forest-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-forest-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-forest-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-forest-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-forest-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-forest-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-forest-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-galadriel-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-galadriel-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-galadriel-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-galadriel-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-galadriel-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-galadriel-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-galadriel-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-galadriel-sev-minor-dark) 32%, transparent);
   --color-grade-top-text:    var(--primitive-green-400);
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-green-400) 12%, transparent);
   --color-grade-high-text:   #6a9678;
@@ -1156,7 +1156,7 @@ html[data-theme="forest-dark"]:root {
   --color-overlay-heavy:  rgba(0, 0, 0, 0.88);
   --color-overlay-medium: rgba(0, 0, 0, 0.82);
   --color-overlay-light:  rgba(0, 0, 0, 0.72);
-  --color-chart-grid:   var(--primitive-forest-700-dark);
+  --color-chart-grid:   var(--primitive-galadriel-700-dark);
   --color-chart-axis:   #5a7a5a;
   --color-chart-line:   #c8d4c8;
   --color-chart-stroke: rgba(255, 255, 255, 0.25);
@@ -1177,44 +1177,44 @@ html[data-theme="forest-dark"]:root {
   --logo-chevron:        #c8d4c8;
   --logo-chevron-hover:  var(--primitive-green-400);
   --logo-needle:         var(--primitive-green-400);
-  --logo-needle-dark:    var(--primitive-forest-700);
+  --logo-needle-dark:    var(--primitive-galadriel-700);
 }
 
-/* ── Ember Light — warm parchment ──────────────────────── */
+/* ── Ifrit Light — warm parchment ──────────────────────── */
 
-html[data-theme="ember-light"]:root {
-  --color-bg:           var(--primitive-ember-50);
+html[data-theme="ifrit-light"]:root {
+  --color-bg:           var(--primitive-ifrit-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-ember-100);
-  --color-border:       var(--primitive-ember-border-light);
-  --color-border-focus: var(--primitive-ember-accent-light);
+  --color-surface-alt:  var(--primitive-ifrit-100);
+  --color-border:       var(--primitive-ifrit-border-light);
+  --color-border-focus: var(--primitive-ifrit-accent-light);
 
-  --color-text:         var(--primitive-ember-text-dark);
-  --color-text-muted:   var(--primitive-ember-text-muted-light);
+  --color-text:         var(--primitive-ifrit-text-dark);
+  --color-text-muted:   var(--primitive-ifrit-text-muted-light);
   --color-text-subtle:  #b0a090;
 
-  --color-accent:       var(--primitive-ember-accent-light);
+  --color-accent:       var(--primitive-ifrit-accent-light);
   --color-accent-hover: #a84a08;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-ember-accent-light) 8%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-light) 8%, transparent);
 
   --color-danger:  #b82010;
   --color-success: #2a8a40;
 
-  --color-sev-critical-text:   var(--primitive-ember-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ember-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ember-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-ember-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ember-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ember-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-ember-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ember-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ember-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-ifrit-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-ifrit-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-ifrit-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-ifrit-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-ifrit-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-ifrit-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-ifrit-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-ifrit-sev-minor-light) 30%, transparent);
 
   /* Grades — ember glow: gold → warm gray → orange → red */
   --color-grade-top-text:    #c08000;
   --color-grade-top-bg:      color-mix(in srgb, #c08000 14%, transparent);
-  --color-grade-high-text:   var(--primitive-ember-text-muted-light);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ember-text-muted-light) 10%, transparent);
+  --color-grade-high-text:   var(--primitive-ifrit-text-muted-light);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-ifrit-text-muted-light) 10%, transparent);
   --color-grade-mid-text:    #c05020;
   --color-grade-mid-bg:      color-mix(in srgb, #c05020 10%, transparent);
   --color-grade-low-text:    #b82010;
@@ -1240,13 +1240,13 @@ html[data-theme="ember-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-ember-text-muted-light);
-  --color-chart-line:   var(--primitive-ember-text-dark);
+  --color-chart-axis:   var(--primitive-ifrit-text-muted-light);
+  --color-chart-line:   var(--primitive-ifrit-text-dark);
   --color-chart-stroke: transparent;
 
   /* Trend — gold up, red down */
   --color-trend-strong-up:   #c08000;
-  --color-trend-up:          var(--primitive-ember-accent-light);
+  --color-trend-up:          var(--primitive-ifrit-accent-light);
   --color-trend-soft-up:     #b0a090;
   --color-trend-soft-down:   #c05020;
   --color-trend-down:        #b82010;
@@ -1257,50 +1257,50 @@ html[data-theme="ember-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.08);
 
   /* Logo */
-  --logo-q:              var(--primitive-ember-accent-light);
-  --logo-chevron:        var(--primitive-ember-text-dark);
-  --logo-chevron-hover:  var(--primitive-ember-accent-light);
-  --logo-needle:         var(--primitive-ember-accent-light);
+  --logo-q:              var(--primitive-ifrit-accent-light);
+  --logo-chevron:        var(--primitive-ifrit-text-dark);
+  --logo-chevron-hover:  var(--primitive-ifrit-accent-light);
+  --logo-needle:         var(--primitive-ifrit-accent-light);
   --logo-needle-dark:    #a84a08;
 }
 
-/* ── Cyber Dark — neon magenta, purple-chrome ──────────── */
+/* ── Deckard Dark — neon magenta, purple-chrome ──────────── */
 
-html[data-theme="cyber-dark"]:root {
-  --color-bg:           var(--primitive-cyber-950);
-  --color-surface:      var(--primitive-cyber-900);
-  --color-surface-alt:  var(--primitive-cyber-800);
-  --color-border:       var(--primitive-cyber-700);
-  --color-border-focus: var(--primitive-cyber-accent-dark);
+html[data-theme="deckard-dark"]:root {
+  --color-bg:           var(--primitive-deckard-950);
+  --color-surface:      var(--primitive-deckard-900);
+  --color-surface-alt:  var(--primitive-deckard-800);
+  --color-border:       var(--primitive-deckard-700);
+  --color-border-focus: var(--primitive-deckard-accent-dark);
 
-  --color-text:         var(--primitive-cyber-200);
-  --color-text-muted:   var(--primitive-cyber-500);
+  --color-text:         var(--primitive-deckard-200);
+  --color-text-muted:   var(--primitive-deckard-500);
   --color-text-subtle:  #58506a;
 
-  --color-accent:       var(--primitive-cyber-accent-dark);
+  --color-accent:       var(--primitive-deckard-accent-dark);
   --color-accent-hover: #ff60d0;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-cyber-accent-dark) 14%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-dark) 14%, transparent);
 
   --color-danger:  #ff4060;
   --color-success: #00dce0;
 
-  --color-sev-critical-text:   var(--primitive-cyber-sev-critical-dark);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-cyber-sev-critical-dark) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-cyber-sev-critical-dark) 42%, transparent);
-  --color-sev-major-text:      var(--primitive-cyber-sev-major-dark);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-cyber-sev-major-dark) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-cyber-sev-major-dark) 38%, transparent);
-  --color-sev-minor-text:      var(--primitive-cyber-sev-minor-dark);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-cyber-sev-minor-dark) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-cyber-sev-minor-dark) 32%, transparent);
+  --color-sev-critical-text:   var(--primitive-deckard-sev-critical-dark);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-deckard-sev-critical-dark) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-deckard-sev-critical-dark) 42%, transparent);
+  --color-sev-major-text:      var(--primitive-deckard-sev-major-dark);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-deckard-sev-major-dark) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-deckard-sev-major-dark) 38%, transparent);
+  --color-sev-minor-text:      var(--primitive-deckard-sev-minor-dark);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-deckard-sev-minor-dark) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-deckard-sev-minor-dark) 32%, transparent);
 
   /* Grades — neon spectrum: violet → purple-gray → pink → red */
   --color-grade-top-text:    #b040ff;
   --color-grade-top-bg:      color-mix(in srgb, #b040ff 12%, transparent);
   --color-grade-high-text:   #a098b8;
   --color-grade-high-bg:     color-mix(in srgb, #a098b8 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-cyber-accent-dark);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-cyber-accent-dark) 12%, transparent);
+  --color-grade-mid-text:    var(--primitive-deckard-accent-dark);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-deckard-accent-dark) 12%, transparent);
   --color-grade-low-text:    #ff4060;
   --color-grade-low-bg:      color-mix(in srgb, #ff4060 13%, transparent);
   --color-grade-bottom-text: #ff2040;
@@ -1323,15 +1323,15 @@ html[data-theme="cyber-dark"]:root {
   --color-overlay-medium: rgba(0, 0, 0, 0.85);
   --color-overlay-light:  rgba(0, 0, 0, 0.75);
 
-  --color-chart-grid:   var(--primitive-cyber-700);
-  --color-chart-axis:   var(--primitive-cyber-500);
-  --color-chart-line:   var(--primitive-cyber-200);
+  --color-chart-grid:   var(--primitive-deckard-700);
+  --color-chart-axis:   var(--primitive-deckard-500);
+  --color-chart-line:   var(--primitive-deckard-200);
   --color-chart-stroke: rgba(255, 64, 192, 0.25);
 
   /* Trend — violet up, red down */
   --color-trend-strong-up:   #b040ff;
-  --color-trend-up:          var(--primitive-cyber-accent-dark);
-  --color-trend-soft-up:     var(--primitive-cyber-500);
+  --color-trend-up:          var(--primitive-deckard-accent-dark);
+  --color-trend-soft-up:     var(--primitive-deckard-500);
   --color-trend-soft-down:   #ff40c0;
   --color-trend-down:        #ff4060;
   --color-trend-strong-down: #ff2040;
@@ -1344,50 +1344,50 @@ html[data-theme="cyber-dark"]:root {
   --shadow-lg: none;
 
   /* Logo */
-  --logo-q:              var(--primitive-cyber-accent-dark);
-  --logo-chevron:        var(--primitive-cyber-accent-dark);
+  --logo-q:              var(--primitive-deckard-accent-dark);
+  --logo-chevron:        var(--primitive-deckard-accent-dark);
   --logo-chevron-hover:  #ff60d0;
-  --logo-needle:         var(--primitive-cyber-accent-dark);
+  --logo-needle:         var(--primitive-deckard-accent-dark);
   --logo-needle-dark:    #a01880;
 }
 
-/* ── Cyber Light — frosted lavender, neon magenta ──────── */
+/* ── Deckard Light — frosted lavender, neon magenta ──────── */
 
-html[data-theme="cyber-light"]:root {
-  --color-bg:           var(--primitive-cyber-50);
+html[data-theme="deckard-light"]:root {
+  --color-bg:           var(--primitive-deckard-50);
   --color-surface:      #ffffff;
-  --color-surface-alt:  var(--primitive-cyber-100);
-  --color-border:       var(--primitive-cyber-border-light);
-  --color-border-focus: var(--primitive-cyber-accent-light);
+  --color-surface-alt:  var(--primitive-deckard-100);
+  --color-border:       var(--primitive-deckard-border-light);
+  --color-border-focus: var(--primitive-deckard-accent-light);
 
-  --color-text:         var(--primitive-cyber-text-dark);
-  --color-text-muted:   var(--primitive-cyber-text-muted-light);
+  --color-text:         var(--primitive-deckard-text-dark);
+  --color-text-muted:   var(--primitive-deckard-text-muted-light);
   --color-text-subtle:  #9a90a8;
 
-  --color-accent:       var(--primitive-cyber-accent-light);
+  --color-accent:       var(--primitive-deckard-accent-light);
   --color-accent-hover: #b01888;
-  --color-accent-soft:  color-mix(in srgb, var(--primitive-cyber-accent-light) 8%, transparent);
+  --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-light) 8%, transparent);
 
   --color-danger:  #e02050;
   --color-success: #0098a8;
 
-  --color-sev-critical-text:   var(--primitive-cyber-sev-critical-light);
-  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-cyber-sev-critical-light) 4%, transparent);
-  --color-sev-critical-border: color-mix(in srgb, var(--primitive-cyber-sev-critical-light) 38%, transparent);
-  --color-sev-major-text:      var(--primitive-cyber-sev-major-light);
-  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-cyber-sev-major-light) 4%, transparent);
-  --color-sev-major-border:    color-mix(in srgb, var(--primitive-cyber-sev-major-light) 35%, transparent);
-  --color-sev-minor-text:      var(--primitive-cyber-sev-minor-light);
-  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-cyber-sev-minor-light) 4%, transparent);
-  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-cyber-sev-minor-light) 30%, transparent);
+  --color-sev-critical-text:   var(--primitive-deckard-sev-critical-light);
+  --color-sev-critical-bg:     color-mix(in srgb, var(--primitive-deckard-sev-critical-light) 4%, transparent);
+  --color-sev-critical-border: color-mix(in srgb, var(--primitive-deckard-sev-critical-light) 38%, transparent);
+  --color-sev-major-text:      var(--primitive-deckard-sev-major-light);
+  --color-sev-major-bg:        color-mix(in srgb, var(--primitive-deckard-sev-major-light) 4%, transparent);
+  --color-sev-major-border:    color-mix(in srgb, var(--primitive-deckard-sev-major-light) 35%, transparent);
+  --color-sev-minor-text:      var(--primitive-deckard-sev-minor-light);
+  --color-sev-minor-bg:        color-mix(in srgb, var(--primitive-deckard-sev-minor-light) 4%, transparent);
+  --color-sev-minor-border:    color-mix(in srgb, var(--primitive-deckard-sev-minor-light) 30%, transparent);
 
   /* Grades — neon spectrum: purple → gray → magenta → red */
   --color-grade-top-text:    #8020d0;
   --color-grade-top-bg:      color-mix(in srgb, #8020d0 12%, transparent);
-  --color-grade-high-text:   var(--primitive-cyber-text-muted-light);
-  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-cyber-text-muted-light) 10%, transparent);
-  --color-grade-mid-text:    var(--primitive-cyber-accent-light);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-cyber-accent-light) 10%, transparent);
+  --color-grade-high-text:   var(--primitive-deckard-text-muted-light);
+  --color-grade-high-bg:     color-mix(in srgb, var(--primitive-deckard-text-muted-light) 10%, transparent);
+  --color-grade-mid-text:    var(--primitive-deckard-accent-light);
+  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-deckard-accent-light) 10%, transparent);
   --color-grade-low-text:    #e03060;
   --color-grade-low-bg:      color-mix(in srgb, #e03060 10%, transparent);
   --color-grade-bottom-text: #c02040;
@@ -1411,13 +1411,13 @@ html[data-theme="cyber-light"]:root {
   --color-overlay-light:  rgba(0, 0, 0, 0.3);
 
   --color-chart-grid:   var(--color-border);
-  --color-chart-axis:   var(--primitive-cyber-text-muted-light);
-  --color-chart-line:   var(--primitive-cyber-text-dark);
+  --color-chart-axis:   var(--primitive-deckard-text-muted-light);
+  --color-chart-line:   var(--primitive-deckard-text-dark);
   --color-chart-stroke: transparent;
 
   /* Trend — purple up, red down */
   --color-trend-strong-up:   #8020d0;
-  --color-trend-up:          var(--primitive-cyber-accent-light);
+  --color-trend-up:          var(--primitive-deckard-accent-light);
   --color-trend-soft-up:     #9a90a8;
   --color-trend-soft-down:   #e03060;
   --color-trend-down:        #c02040;
@@ -1428,10 +1428,10 @@ html[data-theme="cyber-light"]:root {
   --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.10);
 
   /* Logo */
-  --logo-q:              var(--primitive-cyber-accent-light);
-  --logo-chevron:        var(--primitive-cyber-text-dark);
-  --logo-chevron-hover:  var(--primitive-cyber-accent-light);
-  --logo-needle:         var(--primitive-cyber-accent-light);
+  --logo-q:              var(--primitive-deckard-accent-light);
+  --logo-chevron:        var(--primitive-deckard-text-dark);
+  --logo-chevron-hover:  var(--primitive-deckard-accent-light);
+  --logo-needle:         var(--primitive-deckard-accent-light);
   --logo-needle-dark:    #b01888;
 }
 


### PR DESCRIPTION
## Summary

- Restructures the theme system from 8 standalone themes into **5 families** (Default, Midnight, Neo, Forest, Ember) each with **light and dark variants**
- Adds separate **mode toggle** (System/Light/Dark) and **theme family picker** in Settings
- Fixes **chart color cache bug** — charts no longer require hard refresh on theme change
- **Default light** redesigned with warm sand tones (distinct from cool dark)
- **Severity colors** adapted per theme family (midnight=magenta, neo=amber, forest=earthy, ember=warm reds)
- **Storage migration** from old `cc-theme` key to new `cc-theme-mode` + `cc-theme-family`

### New themes
- Neo Dark (Matrix terminal: black + green)
- Neo Light (white hat: mint-tinted + deep green)
- Forest Dark (deep woodland: earthy greens)
- Ember Light (warm parchment: cream + crimson)

### Removed
- Slate theme (dropped)
- Horizon theme (absorbed into Midnight Light)

## Test plan
- [x] Switch between all 5 families in Settings — verify distinct look per family
- [x] Toggle System/Light/Dark mode — verify each family adapts correctly
- [x] System mode: change OS dark/light preference — verify live update without refresh
- [x] Charts update colors on theme switch without hard refresh
- [x] Migration: clear localStorage, set `cc-theme=ember`, reload — verify migrates to mode=dark, family=ember
- [x] Severity pills: verify critical/major/minor colors feel native per theme
- [x] Flash prevention: hard reload on each theme — verify no white flash