### PR TITLE
feat: add History tab with evaluation run list and run navigator

### DIFF
--- a/src/quodeq/core/types/_mapper_entities.py
+++ b/src/quodeq/core/types/_mapper_entities.py
@@ -211,11 +211,15 @@ def parse_trend_point(raw: dict[str, object]) -> TrendPoint:
     if not isinstance(run_id, str):
         msg = f"TrendPoint.runId must be str, got {type(run_id).__name__}"
         raise TypeError(msg)
+    raw_dims = raw.get("dimensions")
+    dims = tuple(raw_dims) if isinstance(raw_dims, list) else ()
     return TrendPoint(
         run_id=run_id,
         date_iso=_opt_str(raw.get("dateIso")),
         date_label=_str(raw, "dateLabel"),
         dimensions_count=_int(raw, "dimensionsCount"),
+        dimensions=dims,
+        accumulated_dimensions_count=_int(raw, "accumulatedDimensionsCount"),
         overall_grade=_opt_str(raw.get("overallGrade")),
         numeric_average=_opt_float(raw.get("numericAverage")),
     )

--- a/src/quodeq/core/types/dashboard.py
+++ b/src/quodeq/core/types/dashboard.py
@@ -13,6 +13,8 @@ class TrendPoint:
     date_iso: str | None = None
     date_label: str = ""
     dimensions_count: int = 0
+    dimensions: tuple[str, ...] = ()
+    accumulated_dimensions_count: int = 0
     overall_grade: str | None = None
     numeric_average: float | None = None
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -120,12 +120,15 @@ def _build_accumulated_trend(
         acc_dims = list(acc_by_dim.values())
         acc_grades = [d.overall_grade for d in acc_dims if d.overall_grade]
         avg = numeric_average(acc_dims)
+        run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
         trend.append(
             {
                 "runId": item.run_id,
                 "dateISO": item.date_iso,
                 "dateLabel": item.date_label,
-                "dimensionsCount": len(acc_by_dim),
+                "dimensionsCount": len(run_dim_names),
+                "dimensions": run_dim_names,
+                "accumulatedDimensionsCount": len(acc_by_dim),
                 "numericAverage": avg,
                 "overallGrade": (
                     score_to_grade_label(avg) if avg is not None

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -139,7 +139,9 @@ def _build_accumulated_trend(
                 "grade": dim.overall_grade,
                 "delta": delta,
             })
-        prev_by_dim = {d.dimension: d for d in run_dims if d.dimension}
+        for dim in run_dims:
+            if dim.dimension:
+                prev_by_dim[dim.dimension] = dim
         trend.append(
             {
                 "runId": item.run_id,

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -22,6 +22,7 @@ from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.services.accumulated import numeric_average
+from quodeq.data.fs.report_parser.grades import parse_numeric_score
 
 
 @dataclass
@@ -110,6 +111,7 @@ def _build_accumulated_trend(
     """Build trend using accumulated scores across all runs (oldest to newest)."""
     trend: list[dict[str, Any]] = []
     acc_by_dim: dict[str, DimensionResult] = {}
+    prev_by_dim: dict[str, DimensionResult] = {}
     for item in reversed(runs):  # oldest -> newest
         run_dims = get_run_dimensions(item.run_id)
         for dim in run_dims:
@@ -123,6 +125,21 @@ def _build_accumulated_trend(
         run_avg = numeric_average(run_dims)
         run_grades = [d.overall_grade for d in run_dims if d.overall_grade]
         run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
+        dim_details = []
+        for dim in sorted(run_dims, key=lambda d: d.dimension or ""):
+            if not dim.dimension:
+                continue
+            prev = prev_by_dim.get(dim.dimension)
+            score = parse_numeric_score(dim.overall_score) if dim.overall_score else None
+            prev_score = parse_numeric_score(prev.overall_score) if prev and prev.overall_score else None
+            delta = round(score - prev_score, 2) if score is not None and prev_score is not None else None
+            dim_details.append({
+                "dimension": dim.dimension,
+                "score": score,
+                "grade": dim.overall_grade,
+                "delta": delta,
+            })
+        prev_by_dim = {d.dimension: d for d in run_dims if d.dimension}
         trend.append(
             {
                 "runId": item.run_id,
@@ -130,6 +147,7 @@ def _build_accumulated_trend(
                 "dateLabel": item.date_label,
                 "dimensionsCount": len(run_dim_names),
                 "dimensions": run_dim_names,
+                "dimensionDetails": dim_details,
                 "accumulatedDimensionsCount": len(acc_by_dim),
                 # Per-run grade/score (this evaluation only)
                 "runNumericAverage": run_avg,

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -119,7 +119,9 @@ def _build_accumulated_trend(
             continue
         acc_dims = list(acc_by_dim.values())
         acc_grades = [d.overall_grade for d in acc_dims if d.overall_grade]
-        avg = numeric_average(acc_dims)
+        acc_avg = numeric_average(acc_dims)
+        run_avg = numeric_average(run_dims)
+        run_grades = [d.overall_grade for d in run_dims if d.overall_grade]
         run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
         trend.append(
             {
@@ -129,9 +131,16 @@ def _build_accumulated_trend(
                 "dimensionsCount": len(run_dim_names),
                 "dimensions": run_dim_names,
                 "accumulatedDimensionsCount": len(acc_by_dim),
-                "numericAverage": avg,
+                # Per-run grade/score (this evaluation only)
+                "runNumericAverage": run_avg,
+                "runOverallGrade": (
+                    score_to_grade_label(run_avg) if run_avg is not None
+                    else (most_frequent_grade(run_grades) if run_grades else None)
+                ),
+                # Accumulated grade/score (all runs up to this point)
+                "numericAverage": acc_avg,
                 "overallGrade": (
-                    score_to_grade_label(avg) if avg is not None
+                    score_to_grade_label(acc_avg) if acc_avg is not None
                     else (most_frequent_grade(acc_grades) if acc_grades else None)
                 ),
             }

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -67,7 +67,7 @@ const ROUTE_RENDERERS = {
         selectedRunId={(() => { const sr = props.dashboardData.selectedRun; if (sr && sr !== 'latest' && trend.some(t => t.runId === sr)) return sr; return trend.length > 0 ? trend[0].runId : null; })()}
         selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
         runNav={runs.length > 0 ? {
-          currentRun: props.navigation.currentOverviewRun,
+          currentRun: (() => { const t = trend.find(r => r.runId === (runs[idx]?.runId)); if (t?.dateISO) { try { const d = new Date(t.dateISO); return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }) + ' · ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }); } catch {} } return runs[idx]?.dateLabel || props.navigation.currentOverviewRun; })(),
           isLatest: idx === 0,
           isOldest: idx >= runs.length - 1,
           onPrev: props.navigation.handleRunPrev,

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -64,7 +64,7 @@ const ROUTE_RENDERERS = {
     return (
       <HistoryPage
         trend={trend}
-        selectedRunId={props.dashboardData.selectedRun}
+        selectedRunId={props.dashboardData.selectedRun || (trend.length > 0 ? trend[0].runId : null)}
         selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
         runNav={runs.length > 0 ? {
           currentRun: props.navigation.currentOverviewRun,

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -73,6 +73,7 @@ const ROUTE_RENDERERS = {
           onPrev: props.navigation.handleRunPrev,
           onNext: props.navigation.handleRunNext,
           onLatest: props.navigation.handleRunLatest,
+          onView: () => { const run = props.dashboardData.selectedRun || (runs[idx] && runs[idx].runId); if (run) props.navigation.handleNavigate('history-run', { runId: run }); },
         } : null}
         onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })}
         onBarClick={props.navigation.handleRunSelect}

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -57,7 +57,28 @@ function SettingsCase({ settings, analysisPower, setAnalysisPower }) {
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
-  history: (params, props) => <HistoryPage trend={props.dashboardData.dashboard?.trend || []} onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })} />,
+  history: (params, props) => {
+    const trend = props.dashboardData.dashboard?.trend || [];
+    const runs = props.dashboardData.availableRuns || [];
+    const idx = props.dashboardData.overviewRunIndex || 0;
+    return (
+      <HistoryPage
+        trend={trend}
+        selectedRunId={props.dashboardData.selectedRun}
+        selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
+        runNav={runs.length > 0 ? {
+          currentRun: props.navigation.currentOverviewRun,
+          isLatest: idx === 0,
+          isOldest: idx >= runs.length - 1,
+          onPrev: props.navigation.handleRunPrev,
+          onNext: props.navigation.handleRunNext,
+          onLatest: props.navigation.handleRunLatest,
+        } : null}
+        onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })}
+        onBarClick={props.navigation.handleRunSelect}
+      />
+    );
+  },
   'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} onNavigate={props.navigation.handleNavigate} />,
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
@@ -168,6 +189,7 @@ export default function App() {
       handleNavigate: state.handleNavigate, handleRunSelect: state.handleRunSelect,
       handleProjectChange: state.handleProjectChange, navTab,
       handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject,
+      currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,
     },
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -7,6 +7,7 @@ import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
 import PrincipleDetailPage from './features/explorer/components/PrincipleDetailPage.jsx';
 import EvalPrincipleDetailPage from './features/explorer/components/EvalPrincipleDetailPage.jsx';
 import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
+import HistoryPage from './features/history/components/HistoryPage.jsx';
 import EvaluateScreen from './features/evaluation/components/EvaluateScreen.jsx';
 import SettingsPage from './features/settings/components/SettingsPage.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
@@ -56,6 +57,8 @@ function SettingsCase({ settings, analysisPower, setAnalysisPower }) {
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
+  history: (params, props) => <HistoryPage trend={props.dashboardData.dashboard?.trend || []} onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })} />,
+  'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} onNavigate={props.navigation.handleNavigate} />,
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
   file: (params) => <FileDetailPage file={params.file} />,
@@ -126,7 +129,7 @@ function useAppState() {
   const projectBundle = useProjects({ onNoProjects: () => navTab('evaluate') });
   const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, handleRunChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
   const settings = useAppSettings();
-  function handleNavigate(page, params = {}) { if (page === 'run' && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
+  function handleNavigate(page, params = {}) { if ((page === 'run' || page === 'history-run') && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
   const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun });
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => {
@@ -135,7 +138,7 @@ function useAppState() {
     return { headerMeta: meta, ...display };
   }, [accumulated, dashboard, selectedProject, projects]);
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
-  const activeTab = ['overview', 'projects', 'evaluate', 'settings'].includes(activePage.page) ? activePage.page : 'overview';
+  const activeTab = ['overview', 'history', 'projects', 'evaluate', 'settings'].includes(activePage.page) ? activePage.page : activePage.page === 'history-run' ? 'history' : 'overview';
   const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
   const showRunNav = showProjectHeader && availableRuns.length > 0 && navStack.length === 1;
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -75,8 +75,11 @@ const ROUTE_RENDERERS = {
           onLatest: props.navigation.handleRunLatest,
           onView: () => { const run = props.dashboardData.selectedRun || (runs[idx] && runs[idx].runId); if (run) props.navigation.handleNavigate('history-run', { runId: run }); },
         } : null}
+        accumulatedDimensions={props.dashboardData.accumulated?.dimensions || []}
+        lastRun={{ date: props.dashboardData.accumulated?.dimensions?.[0]?.fromDateLabel, runId: props.dashboardData.accumulated?.dimensions?.[0]?.fromRunId }}
         onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })}
         onBarClick={props.navigation.handleRunSelect}
+        onDimensionClick={(dim) => props.navigation.handleNavigate('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel })}
       />
     );
   },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -64,7 +64,7 @@ const ROUTE_RENDERERS = {
     return (
       <HistoryPage
         trend={trend}
-        selectedRunId={props.dashboardData.selectedRun || (trend.length > 0 ? trend[0].runId : null)}
+        selectedRunId={(() => { const sr = props.dashboardData.selectedRun; if (sr && sr !== 'latest' && trend.some(t => t.runId === sr)) return sr; return trend.length > 0 ? trend[0].runId : null; })()}
         selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
         runNav={runs.length > 0 ? {
           currentRun: props.navigation.currentOverviewRun,

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { ICON_OVERVIEW, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS } from '../constants/navigation.jsx';
+import { ICON_OVERVIEW, ICON_HISTORY, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS } from '../constants/navigation.jsx';
 
 function Logo() {
   return (
@@ -49,6 +49,7 @@ export default function Sidebar({ activeTab, onNavTab }) {
 
       <nav className="sidebar-nav">
         <NavButton id="overview" label="Overview" icon={ICON_OVERVIEW} activeTab={activeTab} onNavTab={onNavTab} />
+        <NavButton id="history" label="History" icon={ICON_HISTORY} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="evaluate" label="Evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="projects" label="Projects" icon={ICON_PROJECTS} activeTab={activeTab} onNavTab={onNavTab} />
       </nav>

--- a/src/quodeq/ui/src/constants/navigation.jsx
+++ b/src/quodeq/ui/src/constants/navigation.jsx
@@ -30,6 +30,13 @@ export const ICON_PROJECTS = (
   </svg>
 );
 
+export const ICON_HISTORY = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10" />
+    <polyline points="12 6 12 12 16 14" />
+  </svg>
+);
+
 export const ICON_SETTINGS = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="3" />

--- a/src/quodeq/ui/src/features/dashboard/components/RunNavigator.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunNavigator.jsx
@@ -7,7 +7,7 @@ export default function RunNavigator({ currentRun, isLatest, isOldest, actions: 
     <div className="run-navigator">
       <button
         type="button"
-        className="run-nav-action run-nav-action--danger"
+        className="run-nav-action run-nav-action--outline"
         onClick={onLatest}
         disabled={isLatest}
         title="Go to latest run"
@@ -42,11 +42,11 @@ export default function RunNavigator({ currentRun, isLatest, isOldest, actions: 
       {onView && (
         <button
           type="button"
-          className="run-nav-action"
+          className="run-nav-action run-nav-action--primary"
           onClick={onView}
           title="Open this run"
         >
-          View run
+          View →
         </button>
       )}
     </div>

--- a/src/quodeq/ui/src/features/dashboard/components/RunNavigator.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunNavigator.jsx
@@ -7,7 +7,7 @@ export default function RunNavigator({ currentRun, isLatest, isOldest, actions: 
     <div className="run-navigator">
       <button
         type="button"
-        className="run-nav-action run-nav-action--outline"
+        className="run-nav-action run-nav-action--primary"
         onClick={onLatest}
         disabled={isLatest}
         title="Go to latest run"
@@ -42,7 +42,7 @@ export default function RunNavigator({ currentRun, isLatest, isOldest, actions: 
       {onView && (
         <button
           type="button"
-          className="run-nav-action run-nav-action--primary"
+          className="run-nav-action run-nav-action--outline"
           onClick={onView}
           title="Open this run"
         >

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { formatShortDate, angleFromDelta, scoreTierLabel } from '../../../utils/formatters.js';
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  ReferenceLine,
+} from 'recharts';
+
+const MAX_CHART_RUNS = 20;
+const CHART_HEIGHT = 160;
+const REF_LINE_LOW = 2.5;
+const REF_LINE_MID = 5;
+const REF_LINE_HIGH = 7.5;
+const cssVar = (name, fallback) => {
+  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return val || fallback;
+};
+
+const SCORE_EXEMPLARY = 9;
+const SCORE_GOOD = 7;
+const SCORE_ADEQUATE = 5;
+const SCORE_POOR = 3;
+
+function scoreBarColor(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return cssVar('--color-accent');
+  if (n >= SCORE_EXEMPLARY) return cssVar('--color-grade-top-text');
+  if (n >= SCORE_GOOD)      return cssVar('--color-grade-high-text');
+  if (n >= SCORE_ADEQUATE)  return cssVar('--color-grade-mid-text');
+  if (n >= SCORE_POOR)      return cssVar('--color-grade-low-text');
+  return cssVar('--color-grade-bottom-text');
+}
+
+const DELTA_UP = 1;
+const DELTA_SOFT_UP = 0.1;
+const DELTA_DOWN = -1;
+const DELTA_SOFT_DOWN = -0.1;
+
+// Trend direction — mirrors TrendBadge thresholds
+function trendDir(delta) {
+  if (delta === null || delta === undefined) return null;
+  if (delta > DELTA_UP)        return 'up';
+  if (delta > DELTA_SOFT_UP)   return 'soft-up';
+  if (delta < DELTA_DOWN)      return 'down';
+  if (delta < DELTA_SOFT_DOWN) return 'soft-down';
+  return 'same';
+}
+
+function trendColor(dir) {
+  const map = {
+    'up':         '--color-trend-up',
+    'soft-up':    '--color-trend-soft-up',
+    'same':       '--color-text-muted',
+    'soft-down':  '--color-trend-soft-down',
+    'down':       '--color-trend-down',
+  };
+  return cssVar(map[dir] ?? '--color-text-muted');
+}
+
+
+function buildTrendData(trend, selectedRunId, selectedRunScore) {
+  return [...trend].slice(0, MAX_CHART_RUNS).reverse().map((row, i, arr) => {
+    const isSelected = row.runId === selectedRunId;
+    const numericAverage = isSelected && selectedRunScore != null
+      ? parseFloat(selectedRunScore)
+      : parseFloat(row.numericAverage);
+    return {
+      ...row,
+      numericAverage,
+      delta: i > 0 ? numericAverage - parseFloat(arr[i - 1].numericAverage) : null,
+    };
+  });
+}
+
+function TrendBarLabel({ x, y, width, height, index, data }) {
+  const entry = data[index];
+  const d = entry?.delta;
+  const tier = scoreTierLabel(entry?.numericAverage);
+  const cx = x + width / 2;
+  const hasDelta = d !== null && d !== undefined;
+  const dir = hasDelta ? (trendDir(d) ?? 'same') : null;
+  const color = hasDelta ? trendColor(dir) : null;
+  return (
+    <g>
+      {hasDelta && (
+        <>
+          <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={color}>
+            {d > 0 ? `+${d.toFixed(1)}` : d.toFixed(1)}
+          </text>
+          <text
+            x={cx} y={y - 14}
+            textAnchor="middle" dominantBaseline="central"
+            fontSize={11} fill={color}
+            transform={`rotate(${Math.round(angleFromDelta(d))}, ${cx}, ${y - 14})`}
+          >↑</text>
+        </>
+      )}
+      {tier && height > 12 && (
+        <text
+          x={cx} y={y + Math.min(height / 2, 9)}
+          textAnchor="middle" dominantBaseline="central"
+          fontSize={9} fill="white" fillOpacity={0.85}
+        >{tier}</text>
+      )}
+    </g>
+  );
+}
+
+function RunHistoryTooltip({ active, hoveredIndex, data }) {
+  if (!active || hoveredIndex === null) return null;
+  const entry = data[hoveredIndex];
+  if (!entry) return null;
+  return (
+    <div className="run-history-tooltip">
+      <span className="rht-date">{entry.dateLabel}</span>
+      <span className="rht-score">{entry.numericAverage.toFixed(1)} / 10</span>
+      <span className="rht-grade">{entry.overallGrade}</span>
+    </div>
+  );
+}
+
+function ScoreHistoryChart({ data, interaction, renderTrendLabel }) {
+  const { hoveredIndex, setHoveredIndex, selectedRunId, onBarClick } = interaction;
+  return (
+    <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+      <ComposedChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: -16 }}>
+        <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
+        <XAxis
+          dataKey="dateLabel"
+          tickFormatter={formatShortDate}
+          tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          domain={[0, 10]}
+          ticks={[0, REF_LINE_LOW, REF_LINE_MID, REF_LINE_HIGH, 10]}
+          tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <Tooltip
+          cursor={false}
+          isAnimationActive={false}
+          offset={20}
+          content={({ active }) => <RunHistoryTooltip active={active} hoveredIndex={hoveredIndex} data={data} />}
+        />
+        <ReferenceLine y={REF_LINE_LOW}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+        <ReferenceLine y={REF_LINE_MID}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.3} />
+        <ReferenceLine y={REF_LINE_HIGH} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+        <Bar
+          dataKey="numericAverage"
+          radius={[3, 3, 0, 0]}
+          maxBarSize={40}
+          label={renderTrendLabel}
+          isAnimationActive={false}
+          cursor={onBarClick ? 'pointer' : 'default'}
+          onMouseEnter={(_, index) => setHoveredIndex(index)}
+          onMouseLeave={() => setHoveredIndex(null)}
+          onClick={(entry) => onBarClick?.(entry.runId)}
+        >
+          {data.map((entry, i) => (
+            <Cell
+              key={entry.runId ?? i}
+              fill={scoreBarColor(entry.numericAverage)}
+              opacity={entry.runId === selectedRunId ? 1 : 0.55}
+              stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
+              strokeWidth={hoveredIndex === i ? 1.5 : 0}
+            />
+          ))}
+        </Bar>
+        <Line
+          isAnimationActive={false}
+          dataKey="numericAverage"
+          type="monotone"
+          stroke={cssVar('--color-chart-line')}
+          strokeOpacity={0.55}
+          strokeWidth={2.5}
+          dot={false}
+          activeDot={false}
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+
+  if (!trend || trend.length < 2) return null;
+
+  const data = buildTrendData(trend, selectedRunId, selectedRunScore);
+  const renderTrendLabel = (props) => <TrendBarLabel {...props} data={data} />;
+
+  return (
+    <section className="run-history-panel panel" aria-label="Score history chart">
+      <div className="run-history-header">
+        <span className="run-history-title">Score History</span>
+      </div>
+      <ScoreHistoryChart
+        data={data}
+        interaction={{ hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }}
+        renderTrendLabel={renderTrendLabel}
+      />
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -65,8 +65,24 @@ function trendColor(dir) {
 }
 
 
+function windowAroundSelected(trend, selectedRunId) {
+  if (trend.length <= MAX_CHART_RUNS) return trend;
+  const idx = trend.findIndex((r) => r.runId === selectedRunId);
+  if (idx < 0) return trend.slice(0, MAX_CHART_RUNS);
+  // Center the window on the selected run
+  const half = Math.floor(MAX_CHART_RUNS / 2);
+  let start = Math.max(0, idx - half);
+  let end = start + MAX_CHART_RUNS;
+  if (end > trend.length) {
+    end = trend.length;
+    start = Math.max(0, end - MAX_CHART_RUNS);
+  }
+  return trend.slice(start, end);
+}
+
 function buildTrendData(trend, selectedRunId, selectedRunScore) {
-  return [...trend].slice(0, MAX_CHART_RUNS).reverse().map((row, i, arr) => {
+  const windowed = windowAroundSelected(trend, selectedRunId);
+  return [...windowed].reverse().map((row, i, arr) => {
     const isSelected = row.runId === selectedRunId;
     const numericAverage = isSelected && selectedRunScore != null
       ? parseFloat(selectedRunScore)

--- a/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
@@ -1,0 +1,182 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  ReferenceLine,
+} from 'recharts';
+import { formatShortDate, angleFromDelta } from '../../../utils/formatters.js';
+
+const cssVar = (name, fallback) => {
+  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return val || fallback;
+};
+
+const SCORE_THRESHOLDS = { exemplary: 9, good: 7, adequate: 5, poor: 3 };
+const CHART_LEFT_MARGIN = -16;
+const TREND_UP_ANGLE = 70;
+const TREND_SOFT_UP = 88;
+const TREND_DOWN = 110;
+const TREND_SOFT_DOWN = 92;
+
+function scoreBarColor(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return cssVar('--color-accent');
+  if (n >= SCORE_THRESHOLDS.exemplary) return cssVar('--color-grade-top-text');
+  if (n >= SCORE_THRESHOLDS.good) return cssVar('--color-grade-high-text');
+  if (n >= SCORE_THRESHOLDS.adequate) return cssVar('--color-grade-mid-text');
+  if (n >= SCORE_THRESHOLDS.poor) return cssVar('--color-grade-low-text');
+  return cssVar('--color-grade-bottom-text');
+}
+
+function trendColorClass(angle) {
+  if (angle <= TREND_UP_ANGLE)  return 'trend-up';
+  if (angle <= TREND_SOFT_UP)   return 'trend-soft-up';
+  if (angle >= TREND_DOWN)      return 'trend-down';
+  if (angle >= TREND_SOFT_DOWN) return 'trend-soft-down';
+  return 'trend-same';
+}
+
+// Shortcodes mirror src/quodeq/config/dimensions.py
+const DIM_CODE = {
+  affordability:  'aff',
+  availability:   'avl',
+  configurability:'cfg',
+  efficiency:     'eff',
+  evolvability:   'evo',
+  extensibility:  'ext',
+  flexibility:    'flx',
+  maintainability:'mnt',
+  performance:    'perf',
+  recoverability: 'rcv',
+  resilience:     'res',
+  robustness:     'rob',
+  scalability:    'scl',
+  simplicity:     'sim',
+  usability:      'usx',
+};
+
+function dimCode(name) {
+  if (!name) return '';
+  return (DIM_CODE[name.toLowerCase()] ?? name.slice(0, 4)).toUpperCase();
+}
+
+function trendColorVar(colorClass) {
+  const map = {
+    'trend-up':        '--color-trend-up',
+    'trend-soft-up':   '--color-trend-soft-up',
+    'trend-same':      '--color-text-muted',
+    'trend-soft-down': '--color-trend-soft-down',
+    'trend-down':      '--color-trend-down',
+  };
+  return cssVar(map[colorClass] || '--color-text-muted');
+}
+
+function DimensionTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div className="run-history-tooltip">
+      <span className="rht-date">{d.dimension}</span>
+      <span className="rht-score">{parseFloat(d.overallScore).toFixed(1)} / 10</span>
+      <span className="rht-grade">{d.overallGrade}</span>
+    </div>
+  );
+}
+
+
+export default function DimensionScorePanel({ dimensions = [], onBarClick, runDate, runId }) {
+  if (!dimensions || dimensions.length === 0) return null;
+
+  const data = [...dimensions]
+    .sort((a, b) => a.dimension.localeCompare(b.dimension))
+    .map((d) => {
+      const curr = parseFloat(d.overallScore);
+      const prev = parseFloat(d.previousScore);
+      const delta = !isNaN(curr) && !isNaN(prev) ? curr - prev : null;
+      return { ...d, numericScore: isNaN(curr) ? 0 : curr, delta };
+    });
+
+  const renderTrendLabel = ({ x, y, width, index }) => {
+    const entry = data[index];
+    if (entry?.delta === null || entry?.delta === undefined) return null;
+    const cx = x + width / 2;
+    const angle = angleFromDelta(entry.delta);
+    const colorCls = trendColorClass(angle);
+    const fill = trendColorVar(colorCls);
+    const deltaStr = entry.delta > 0 ? `+${entry.delta.toFixed(1)}` : entry.delta.toFixed(1);
+    return (
+      <g>
+        <text x={cx} y={y - 25} textAnchor="middle" fontSize={9} fill={fill}>
+          {deltaStr}
+        </text>
+        <text
+          x={cx} y={y - 14}
+          textAnchor="middle" fontSize={11} fill={fill}
+          transform={`rotate(${Math.round(angle)}, ${cx}, ${y - 14})`}
+        >
+          ↑
+        </text>
+      </g>
+    );
+  };
+
+  return (
+    <section className="run-history-panel panel" aria-label="Dimension scores bar chart">
+      <div className="run-history-header">
+        <span className="run-history-title">Dimension Scores</span>
+        {(runDate || runId) && (
+          <span className="dim-panel-run-meta">
+            {runDate && <span className="dim-panel-run-date">{formatShortDate(runDate)}</span>}
+            {runId && <span className="dim-panel-run-id">{runId}</span>}
+          </span>
+        )}
+      </div>
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: CHART_LEFT_MARGIN }}>
+          <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
+          <XAxis
+            dataKey="dimension"
+            tickFormatter={dimCode}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
+            interval={0}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            domain={[0, 10]}
+            ticks={[0, 2.5, 5, 7.5, 10]}
+            tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <Tooltip content={DimensionTooltip} cursor={false} isAnimationActive={false} />
+          <ReferenceLine y={2.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <ReferenceLine y={5}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.3} />
+          <ReferenceLine y={7.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
+          <Bar
+            dataKey="numericScore"
+            radius={[3, 3, 0, 0]}
+            maxBarSize={40}
+            label={renderTrendLabel}
+            isAnimationActive={false}
+            cursor={onBarClick ? 'pointer' : 'default'}
+            onClick={(entry) => onBarClick?.(entry)}
+          >
+            {data.map((entry, i) => (
+              <Cell
+                key={entry.dimension ?? i}
+                fill={scoreBarColor(entry.numericScore)}
+                opacity={0.85}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import HistoryRunRow from './HistoryRunRow.jsx';
 import HistoryChartPanel from './HistoryChartPanel.jsx';
+import HistoryDimensionPanel from './HistoryDimensionPanel.jsx';
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 
 const MAX_VISIBLE = 20;
@@ -15,7 +16,7 @@ function computeDeltas(trend) {
   });
 }
 
-export default function HistoryPage({ trend, selectedRunId, selectedRunScore, runNav, onRunClick, onBarClick }) {
+export default function HistoryPage({ trend, selectedRunId, selectedRunScore, accumulatedDimensions, lastRun, runNav, onRunClick, onBarClick, onDimensionClick }) {
   const [showAll, setShowAll] = useState(false);
 
   if (!trend || trend.length === 0) {
@@ -51,12 +52,18 @@ export default function HistoryPage({ trend, selectedRunId, selectedRunScore, ru
           </div>
         )}
       </div>
-      <div className="history-chart-wrapper">
+      <div className="history-panels-row">
         <HistoryChartPanel
           trend={trend}
           selectedRunId={selectedRunId}
           selectedRunScore={selectedRunScore}
           onBarClick={onBarClick}
+        />
+        <HistoryDimensionPanel
+          dimensions={accumulatedDimensions || []}
+          onBarClick={onDimensionClick}
+          runDate={lastRun?.date}
+          runId={lastRun?.runId}
         />
       </div>
       <div className="history-list">

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -72,6 +72,7 @@ export default function HistoryPage({ trend, selectedRunId, selectedRunScore, ac
             key={entry.runId}
             entry={entry}
             delta={deltas[i]}
+            isSelected={entry.runId === selectedRunId}
             onClick={onRunClick}
           />
         ))}

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -18,6 +18,7 @@ function computeDeltas(trend) {
 
 export default function HistoryPage({ trend, selectedRunId, selectedRunScore, accumulatedDimensions, lastRun, runNav, onRunClick, onBarClick, onDimensionClick }) {
   const [showAll, setShowAll] = useState(false);
+  const [listCollapsed, setListCollapsed] = useState(false);
 
   if (!trend || trend.length === 0) {
     return (
@@ -66,23 +67,33 @@ export default function HistoryPage({ trend, selectedRunId, selectedRunScore, ac
           runId={lastRun?.runId}
         />
       </div>
-      <div className="history-list">
-        {visible.map((entry, i) => (
-          <HistoryRunRow
-            key={entry.runId}
-            entry={entry}
-            delta={deltas[i]}
-            isSelected={entry.runId === selectedRunId}
-            onClick={onRunClick}
-          />
-        ))}
+      <div className="history-list-header">
+        <button type="button" className="history-collapse-btn" onClick={() => setListCollapsed(!listCollapsed)}>
+          <span className={`history-collapse-icon${listCollapsed ? ' collapsed' : ''}`}>›</span>
+          Evaluations
+        </button>
       </div>
-      {hasMore && (
-        <div className="history-load-more">
-          <button type="button" className="history-load-more-btn" onClick={() => setShowAll(true)}>
-            Load all {trend.length} evaluations
-          </button>
-        </div>
+      {!listCollapsed && (
+        <>
+          <div className="history-list">
+            {visible.map((entry, i) => (
+              <HistoryRunRow
+                key={entry.runId}
+                entry={entry}
+                delta={deltas[i]}
+                isSelected={entry.runId === selectedRunId}
+                onClick={onRunClick}
+              />
+            ))}
+          </div>
+          {hasMore && (
+            <div className="history-load-more">
+              <button type="button" className="history-load-more-btn" onClick={() => setShowAll(true)}>
+                Load all {trend.length} evaluations
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,4 +1,7 @@
+import { useState } from 'react';
 import HistoryRunRow from './HistoryRunRow.jsx';
+
+const INITIAL_LIMIT = 20;
 
 function computeDeltas(trend) {
   return trend.map((entry, i) => {
@@ -11,6 +14,8 @@ function computeDeltas(trend) {
 }
 
 export default function HistoryPage({ trend, onRunClick }) {
+  const [showAll, setShowAll] = useState(false);
+
   if (!trend || trend.length === 0) {
     return (
       <div className="history-page">
@@ -25,6 +30,8 @@ export default function HistoryPage({ trend, onRunClick }) {
   }
 
   const deltas = computeDeltas(trend);
+  const visible = showAll ? trend : trend.slice(0, INITIAL_LIMIT);
+  const hasMore = trend.length > INITIAL_LIMIT && !showAll;
 
   return (
     <div className="history-page">
@@ -33,7 +40,7 @@ export default function HistoryPage({ trend, onRunClick }) {
         <span className="history-count">{trend.length} evaluation{trend.length !== 1 ? 's' : ''}</span>
       </div>
       <div className="history-list">
-        {trend.map((entry, i) => (
+        {visible.map((entry, i) => (
           <HistoryRunRow
             key={entry.runId}
             entry={entry}
@@ -42,6 +49,13 @@ export default function HistoryPage({ trend, onRunClick }) {
           />
         ))}
       </div>
+      {hasMore && (
+        <div className="history-load-more">
+          <button type="button" className="history-load-more-btn" onClick={() => setShowAll(true)}>
+            Load all {trend.length} evaluations
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import HistoryRunRow from './HistoryRunRow.jsx';
+import HistoryChartPanel from './HistoryChartPanel.jsx';
+import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 
-const INITIAL_LIMIT = 20;
+const MAX_VISIBLE = 20;
 
 function computeDeltas(trend) {
   return trend.map((entry, i) => {
@@ -13,7 +15,7 @@ function computeDeltas(trend) {
   });
 }
 
-export default function HistoryPage({ trend, onRunClick }) {
+export default function HistoryPage({ trend, selectedRunId, selectedRunScore, runNav, onRunClick, onBarClick }) {
   const [showAll, setShowAll] = useState(false);
 
   if (!trend || trend.length === 0) {
@@ -30,14 +32,32 @@ export default function HistoryPage({ trend, onRunClick }) {
   }
 
   const deltas = computeDeltas(trend);
-  const visible = showAll ? trend : trend.slice(0, INITIAL_LIMIT);
-  const hasMore = trend.length > INITIAL_LIMIT && !showAll;
+  const visible = showAll ? trend : trend.slice(0, MAX_VISIBLE);
+  const hasMore = trend.length > MAX_VISIBLE && !showAll;
 
   return (
     <div className="history-page">
       <div className="history-header">
         <h2 className="history-title">History</h2>
         <span className="history-count">{trend.length} evaluation{trend.length !== 1 ? 's' : ''}</span>
+        {runNav && (
+          <div className="history-run-nav">
+            <RunNavigator
+              currentRun={runNav.currentRun}
+              isLatest={runNav.isLatest}
+              isOldest={runNav.isOldest}
+              actions={{ onPrev: runNav.onPrev, onNext: runNav.onNext, onLatest: runNav.onLatest }}
+            />
+          </div>
+        )}
+      </div>
+      <div className="history-chart-wrapper">
+        <HistoryChartPanel
+          trend={trend}
+          selectedRunId={selectedRunId}
+          selectedRunScore={selectedRunScore}
+          onBarClick={onBarClick}
+        />
       </div>
       <div className="history-list">
         {visible.map((entry, i) => (

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,0 +1,47 @@
+import HistoryRunRow from './HistoryRunRow.jsx';
+
+function computeDeltas(trend) {
+  return trend.map((entry, i) => {
+    if (i >= trend.length - 1) return null;
+    const curr = parseFloat(entry.numericAverage);
+    const prev = parseFloat(trend[i + 1].numericAverage);
+    if (isNaN(curr) || isNaN(prev)) return null;
+    return curr - prev;
+  });
+}
+
+export default function HistoryPage({ trend, onRunClick }) {
+  if (!trend || trend.length === 0) {
+    return (
+      <div className="history-page">
+        <div className="history-header">
+          <h2 className="history-title">History</h2>
+        </div>
+        <div className="empty-state">
+          <p>No evaluations yet. Run one from the Evaluate tab.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const deltas = computeDeltas(trend);
+
+  return (
+    <div className="history-page">
+      <div className="history-header">
+        <h2 className="history-title">History</h2>
+        <span className="history-count">{trend.length} evaluation{trend.length !== 1 ? 's' : ''}</span>
+      </div>
+      <div className="history-list">
+        {trend.map((entry, i) => (
+          <HistoryRunRow
+            key={entry.runId}
+            entry={entry}
+            delta={deltas[i]}
+            onClick={onRunClick}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -46,7 +46,7 @@ export default function HistoryPage({ trend, selectedRunId, selectedRunScore, ru
               currentRun={runNav.currentRun}
               isLatest={runNav.isLatest}
               isOldest={runNav.isOldest}
-              actions={{ onPrev: runNav.onPrev, onNext: runNav.onNext, onLatest: runNav.onLatest }}
+              actions={{ onPrev: runNav.onPrev, onNext: runNav.onNext, onLatest: runNav.onLatest, onView: runNav.onView }}
             />
           </div>
         )}

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -25,7 +25,7 @@ function capitalize(name) {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
-export default function HistoryRunRow({ entry, delta, onClick }) {
+export default function HistoryRunRow({ entry, delta, isSelected, onClick }) {
   const {
     runId, dateLabel, dateISO,
     runNumericAverage, runOverallGrade,
@@ -39,7 +39,7 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
   const accLetter = gradeLabel(overallGrade) || '—';
   const runGradeWord = runOverallGrade ? capitalize(runOverallGrade) : '';
   return (
-    <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
+    <button type="button" className={`history-row${isSelected ? ' selected' : ''}`} onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
         <span className="history-row-date-main">{dateLabel}</span>
         <span className="history-row-date-time">{formatTime(dateISO)}</span>

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -1,5 +1,13 @@
 import { scoreColorClass, gradeLabel } from '../../../utils/formatters.js';
 
+function formatDate(dateISO) {
+  if (!dateISO) return '';
+  try {
+    const d = new Date(dateISO);
+    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+  } catch { return ''; }
+}
+
 function formatTime(dateISO) {
   if (!dateISO) return '';
   try {
@@ -41,7 +49,7 @@ export default function HistoryRunRow({ entry, delta, isSelected, onClick }) {
   return (
     <button type="button" className={`history-row${isSelected ? ' selected' : ''}`} onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
-        <span className="history-row-date-main">{dateLabel}</span>
+        <span className="history-row-date-main">{formatDate(dateISO) || dateLabel}</span>
         <span className="history-row-date-time">{formatTime(dateISO)}</span>
       </div>
       <div className="history-row-score">

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -37,26 +37,24 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
   const dimLabels = (dimensions || []).map(capitalize).join(', ');
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
-      <div className="history-row-left">
-        <div className="history-row-top">
-          <div className="history-row-date">
-            <span className="history-row-date-main">{dateLabel}</span>
-            <span className="history-row-date-time">{formatTime(dateISO)}</span>
-          </div>
-          <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
-          <span className="history-row-score">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
-        </div>
-        <div className="history-row-bottom">
-          <span className="history-row-dims">{dimLabels || '—'}</span>
-        </div>
+      <div className="history-row-date">
+        <span className="history-row-date-main">{dateLabel}</span>
+        <span className="history-row-date-time">{formatTime(dateISO)}</span>
       </div>
-      <div className="history-row-right">
-        <span className="history-row-acc-label">accumulated</span>
-        <div className="history-row-acc-grade">
-          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.7 }}>{overallGrade || '—'}</span>
-          <span className="history-row-acc-score">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
+      <div className="history-row-eval">
+        <div className="history-row-eval-top">
+          <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
+          <span className="history-row-eval-score">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
         </div>
-        <TrendBadge delta={delta} />
+        <div className="history-row-eval-dims">{dimLabels || '—'}</div>
+      </div>
+      <div className="history-row-acc">
+        <span className="history-row-acc-label">Accumulated</span>
+        <div className="history-row-acc-line">
+          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.65 }}>{overallGrade || '—'}</span>
+          <span className="history-row-acc-score">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
+          <TrendBadge delta={delta} />
+        </div>
       </div>
     </button>
   );

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -8,6 +8,16 @@ function formatTime(dateISO) {
   } catch { return ''; }
 }
 
+function scoreToGradeWord(score) {
+  const n = parseFloat(score);
+  if (isNaN(n)) return '';
+  if (n >= 9) return 'Exemplary';
+  if (n >= 7) return 'Good';
+  if (n >= 5) return 'Adequate';
+  if (n >= 3) return 'Poor';
+  return 'Critical';
+}
+
 function TrendBadge({ delta }) {
   if (delta == null) return <span className="history-trend">—</span>;
   const sign = delta > 0 ? '+' : '';
@@ -35,23 +45,27 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
   const runScore = parseFloat(runNumericAverage);
   const accScore = parseFloat(numericAverage);
   const dimLabels = (dimensions || []).map(capitalize).join(', ');
+  const gradeWord = runOverallGrade ? scoreToGradeWord(runScore) : '';
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
         <span className="history-row-date-main">{dateLabel}</span>
         <span className="history-row-date-time">{formatTime(dateISO)}</span>
       </div>
+      <div className="history-row-score">
+        <span className="history-row-score-val">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
+      </div>
       <div className="history-row-eval">
-        <div className="history-row-eval-top">
+        <div className="history-row-eval-grade">
           <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
-          <span className="history-row-eval-score">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
+          <span className={`history-row-eval-grade-label ${scoreColorClass(runScore)}-text`}>{gradeWord}</span>
         </div>
         <div className="history-row-eval-dims">{dimLabels || '—'}</div>
       </div>
       <div className="history-row-acc">
         <span className="history-row-acc-label">Accumulated</span>
         <div className="history-row-acc-line">
-          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.65 }}>{overallGrade || '—'}</span>
+          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.85 }}>{overallGrade || '—'}</span>
           <span className="history-row-acc-score">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
           <TrendBadge delta={delta} />
         </div>

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -20,9 +20,21 @@ function TrendBadge({ delta }) {
   );
 }
 
+function abbreviateDimension(name) {
+  if (!name) return '';
+  const abbrevMap = {
+    maintainability: 'mnt', modifiability: 'mod', reusability: 'reu',
+    analyzability: 'anz', reliability: 'rel', security: 'sec',
+    performance: 'prf', usability: 'usa', affinity: 'aff',
+    evolvability: 'evo', modularity: 'mdu', testability: 'tst',
+  };
+  return abbrevMap[name.toLowerCase()] || name.slice(0, 3);
+}
+
 export default function HistoryRunRow({ entry, delta, onClick }) {
-  const { runId, dateLabel, dateISO, numericAverage, overallGrade, dimensionsCount } = entry;
+  const { runId, dateLabel, dateISO, numericAverage, overallGrade, dimensions, accumulatedDimensionsCount } = entry;
   const score = parseFloat(numericAverage);
+  const dimLabels = (dimensions || []).map(abbreviateDimension).join(', ');
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
@@ -32,7 +44,12 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
       <span className={`chip small ${scoreColorClass(score)}`}>{overallGrade || '—'}</span>
       <span className="history-row-score">{isNaN(score) ? '—' : score.toFixed(1)}</span>
       <TrendBadge delta={delta} />
-      <span className="history-row-dims">{dimensionsCount || '—'} dims</span>
+      <div className="history-row-dims">
+        <span className="history-row-dims-run">{dimLabels || '—'}</span>
+        {accumulatedDimensionsCount != null && (
+          <span className="history-row-dims-acc">{accumulatedDimensionsCount} accumulated</span>
+        )}
+      </div>
     </button>
   );
 }

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -1,4 +1,4 @@
-import { scoreColorClass } from '../../../utils/formatters.js';
+import { scoreColorClass, gradeLabel } from '../../../utils/formatters.js';
 
 function formatTime(dateISO) {
   if (!dateISO) return '';
@@ -6,16 +6,6 @@ function formatTime(dateISO) {
     const d = new Date(dateISO);
     return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
   } catch { return ''; }
-}
-
-function scoreToGradeWord(score) {
-  const n = parseFloat(score);
-  if (isNaN(n)) return '';
-  if (n >= 9) return 'Exemplary';
-  if (n >= 7) return 'Good';
-  if (n >= 5) return 'Adequate';
-  if (n >= 3) return 'Poor';
-  return 'Critical';
 }
 
 function TrendBadge({ delta }) {
@@ -45,7 +35,9 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
   const runScore = parseFloat(runNumericAverage);
   const accScore = parseFloat(numericAverage);
   const dimLabels = (dimensions || []).map(capitalize).join(', ');
-  const gradeWord = runOverallGrade ? scoreToGradeWord(runScore) : '';
+  const runLetter = gradeLabel(runOverallGrade) || '—';
+  const accLetter = gradeLabel(overallGrade) || '—';
+  const runGradeWord = runOverallGrade ? capitalize(runOverallGrade) : '';
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
@@ -57,15 +49,15 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
       </div>
       <div className="history-row-eval">
         <div className="history-row-eval-grade">
-          <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
-          <span className={`history-row-eval-grade-label ${scoreColorClass(runScore)}-text`}>{gradeWord}</span>
+          <span className={`chip small ${scoreColorClass(runScore)}`}>{runLetter}</span>
+          <span className={`history-row-eval-grade-label ${scoreColorClass(runScore)}-text`}>{runGradeWord}</span>
         </div>
         <div className="history-row-eval-dims">{dimLabels || '—'}</div>
       </div>
       <div className="history-row-acc">
         <span className="history-row-acc-label">Accumulated</span>
         <div className="history-row-acc-line">
-          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.85 }}>{overallGrade || '—'}</span>
+          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.85 }}>{accLetter}</span>
           <span className="history-row-acc-score">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
           <TrendBadge delta={delta} />
         </div>

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -1,0 +1,38 @@
+import { scoreColorClass } from '../../../utils/formatters.js';
+
+function formatTime(dateISO) {
+  if (!dateISO) return '';
+  try {
+    const d = new Date(dateISO);
+    return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  } catch { return ''; }
+}
+
+function TrendBadge({ delta }) {
+  if (delta == null) return <span className="history-row-trend">—</span>;
+  const sign = delta > 0 ? '+' : '';
+  const cls = delta > 0 ? 'trend-up' : delta < 0 ? 'trend-down' : '';
+  const arrow = delta > 0 ? '▲' : delta < 0 ? '▼' : '—';
+  return (
+    <span className={`history-row-trend ${cls}`}>
+      {arrow} {sign}{delta.toFixed(1)}
+    </span>
+  );
+}
+
+export default function HistoryRunRow({ entry, delta, onClick }) {
+  const { runId, dateLabel, dateISO, numericAverage, overallGrade, dimensionsCount } = entry;
+  const score = parseFloat(numericAverage);
+  return (
+    <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
+      <div className="history-row-date">
+        <span className="history-row-date-main">{dateLabel}</span>
+        <span className="history-row-date-time">{formatTime(dateISO)}</span>
+      </div>
+      <span className={`chip small ${scoreColorClass(score)}`}>{overallGrade || '—'}</span>
+      <span className="history-row-score">{isNaN(score) ? '—' : score.toFixed(1)}</span>
+      <TrendBadge delta={delta} />
+      <span className="history-row-dims">{dimensionsCount || '—'} dims</span>
+    </button>
+  );
+}

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -20,35 +20,41 @@ function TrendBadge({ delta }) {
   );
 }
 
-function abbreviateDimension(name) {
+function capitalize(name) {
   if (!name) return '';
-  const abbrevMap = {
-    maintainability: 'mnt', modifiability: 'mod', reusability: 'reu',
-    analyzability: 'anz', reliability: 'rel', security: 'sec',
-    performance: 'prf', usability: 'usa', affinity: 'aff',
-    evolvability: 'evo', modularity: 'mdu', testability: 'tst',
-  };
-  return abbrevMap[name.toLowerCase()] || name.slice(0, 3);
+  return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
 export default function HistoryRunRow({ entry, delta, onClick }) {
-  const { runId, dateLabel, dateISO, numericAverage, overallGrade, dimensions, accumulatedDimensionsCount } = entry;
-  const score = parseFloat(numericAverage);
-  const dimLabels = (dimensions || []).map(abbreviateDimension).join(', ');
+  const {
+    runId, dateLabel, dateISO,
+    runNumericAverage, runOverallGrade,
+    numericAverage, overallGrade,
+    dimensions, accumulatedDimensionsCount,
+  } = entry;
+  const runScore = parseFloat(runNumericAverage);
+  const accScore = parseFloat(numericAverage);
+  const dimLabels = (dimensions || []).map(capitalize).join(', ');
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
       <div className="history-row-date">
         <span className="history-row-date-main">{dateLabel}</span>
         <span className="history-row-date-time">{formatTime(dateISO)}</span>
       </div>
-      <span className={`chip small ${scoreColorClass(score)}`}>{overallGrade || '—'}</span>
-      <span className="history-row-score">{isNaN(score) ? '—' : score.toFixed(1)}</span>
+      <div className="history-row-grades">
+        <div className="history-row-grade-run">
+          <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
+          <span className="history-row-score">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
+        </div>
+        <div className="history-row-grade-acc">
+          <span className={`chip small ${scoreColorClass(accScore)}`}>{overallGrade || '—'}</span>
+          <span className="history-row-score-acc">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
+          <span className="history-row-label-acc">acc</span>
+        </div>
+      </div>
       <TrendBadge delta={delta} />
       <div className="history-row-dims">
         <span className="history-row-dims-run">{dimLabels || '—'}</span>
-        {accumulatedDimensionsCount != null && (
-          <span className="history-row-dims-acc">{accumulatedDimensionsCount} accumulated</span>
-        )}
       </div>
     </button>
   );

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -9,12 +9,12 @@ function formatTime(dateISO) {
 }
 
 function TrendBadge({ delta }) {
-  if (delta == null) return <span className="history-row-trend">—</span>;
+  if (delta == null) return <span className="history-trend">—</span>;
   const sign = delta > 0 ? '+' : '';
   const cls = delta > 0 ? 'trend-up' : delta < 0 ? 'trend-down' : '';
   const arrow = delta > 0 ? '▲' : delta < 0 ? '▼' : '—';
   return (
-    <span className={`history-row-trend ${cls}`}>
+    <span className={`history-trend ${cls}`}>
       {arrow} {sign}{delta.toFixed(1)}
     </span>
   );
@@ -30,31 +30,33 @@ export default function HistoryRunRow({ entry, delta, onClick }) {
     runId, dateLabel, dateISO,
     runNumericAverage, runOverallGrade,
     numericAverage, overallGrade,
-    dimensions, accumulatedDimensionsCount,
+    dimensions,
   } = entry;
   const runScore = parseFloat(runNumericAverage);
   const accScore = parseFloat(numericAverage);
   const dimLabels = (dimensions || []).map(capitalize).join(', ');
   return (
     <button type="button" className="history-row" onClick={() => onClick(runId, dateLabel)}>
-      <div className="history-row-date">
-        <span className="history-row-date-main">{dateLabel}</span>
-        <span className="history-row-date-time">{formatTime(dateISO)}</span>
-      </div>
-      <div className="history-row-grades">
-        <div className="history-row-grade-run">
+      <div className="history-row-left">
+        <div className="history-row-top">
+          <div className="history-row-date">
+            <span className="history-row-date-main">{dateLabel}</span>
+            <span className="history-row-date-time">{formatTime(dateISO)}</span>
+          </div>
           <span className={`chip small ${scoreColorClass(runScore)}`}>{runOverallGrade || '—'}</span>
           <span className="history-row-score">{isNaN(runScore) ? '—' : runScore.toFixed(1)}</span>
         </div>
-        <div className="history-row-grade-acc">
-          <span className={`chip small ${scoreColorClass(accScore)}`}>{overallGrade || '—'}</span>
-          <span className="history-row-score-acc">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
-          <span className="history-row-label-acc">acc</span>
+        <div className="history-row-bottom">
+          <span className="history-row-dims">{dimLabels || '—'}</span>
         </div>
       </div>
-      <TrendBadge delta={delta} />
-      <div className="history-row-dims">
-        <span className="history-row-dims-run">{dimLabels || '—'}</span>
+      <div className="history-row-right">
+        <span className="history-row-acc-label">accumulated</span>
+        <div className="history-row-acc-grade">
+          <span className={`chip small ${scoreColorClass(accScore)}`} style={{ opacity: 0.7 }}>{overallGrade || '—'}</span>
+          <span className="history-row-acc-score">{isNaN(accScore) ? '—' : accScore.toFixed(1)}</span>
+        </div>
+        <TrendBadge delta={delta} />
       </div>
     </button>
   );

--- a/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryRunRow.jsx
@@ -38,11 +38,11 @@ export default function HistoryRunRow({ entry, delta, isSelected, onClick }) {
     runId, dateLabel, dateISO,
     runNumericAverage, runOverallGrade,
     numericAverage, overallGrade,
-    dimensions,
+    dimensionDetails,
   } = entry;
   const runScore = parseFloat(runNumericAverage);
   const accScore = parseFloat(numericAverage);
-  const dimLabels = (dimensions || []).map(capitalize).join(', ');
+  const dims = dimensionDetails || [];
   const runLetter = gradeLabel(runOverallGrade) || '—';
   const accLetter = gradeLabel(overallGrade) || '—';
   const runGradeWord = runOverallGrade ? capitalize(runOverallGrade) : '';
@@ -60,7 +60,19 @@ export default function HistoryRunRow({ entry, delta, isSelected, onClick }) {
           <span className={`chip small ${scoreColorClass(runScore)}`}>{runLetter}</span>
           <span className={`history-row-eval-grade-label ${scoreColorClass(runScore)}-text`}>{runGradeWord}</span>
         </div>
-        <div className="history-row-eval-dims">{dimLabels || '—'}</div>
+        <div className="history-row-eval-dims">
+          {dims.map((d) => (
+            <span key={d.dimension} className="history-dim-tag">
+              {capitalize(d.dimension)}
+              {d.score != null && <span className="history-dim-score">{d.score.toFixed(1)}</span>}
+              {d.delta != null && (
+                <span className={`history-dim-trend ${d.delta > 0 ? 'trend-up' : d.delta < 0 ? 'trend-down' : ''}`}>
+                  {d.delta > 0 ? '▲' : d.delta < 0 ? '▼' : '—'}{d.delta !== 0 ? Math.abs(d.delta).toFixed(1) : ''}
+                </span>
+              )}
+            </span>
+          ))}
+        </div>
       </div>
       <div className="history-row-acc">
         <span className="history-row-acc-label">Accumulated</span>

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -699,9 +699,9 @@
 }
 
 .run-navigator .run-nav-action--outline:hover:not(:disabled) {
-  background: var(--color-accent-soft);
+  background: var(--color-accent);
   border-color: var(--color-accent);
-  color: var(--color-accent);
+  color: var(--color-on-accent);
 }
 
 .run-navigator .run-nav-action--primary {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -681,7 +681,7 @@
   transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
 }
 
-.run-navigator .run-nav-action:hover:not(:disabled) {
+.run-navigator .run-nav-action:hover:not(:disabled):not(.run-nav-action--primary):not(.run-nav-action--outline) {
   border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
   color: var(--color-accent);
   background: var(--color-accent-soft);
@@ -713,6 +713,7 @@
 .run-navigator .run-nav-action--primary:hover:not(:disabled) {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
+  color: var(--color-on-accent);
 }
 
 /* Segmented pager: [‹][date][›] as one bordered unit */

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -693,16 +693,26 @@
   pointer-events: none;
 }
 
-.run-navigator .run-nav-action--danger {
+.run-navigator .run-nav-action--outline {
   color: var(--color-accent);
-  background: color-mix(in srgb, var(--color-accent) 13%, transparent);
   border-color: color-mix(in srgb, var(--color-accent) 38%, transparent);
 }
 
-.run-navigator .run-nav-action--danger:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+.run-navigator .run-nav-action--outline:hover:not(:disabled) {
+  background: var(--color-accent-soft);
   border-color: var(--color-accent);
   color: var(--color-accent);
+}
+
+.run-navigator .run-nav-action--primary {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border-color: var(--color-accent);
+}
+
+.run-navigator .run-nav-action--primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
 }
 
 /* Segmented pager: [‹][date][›] as one bordered unit */

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -67,11 +67,41 @@
   color: var(--color-text-muted);
 }
 
+.history-row-grades {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 100px;
+}
+
+.history-row-grade-run {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.history-row-grade-acc {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0.6;
+}
+
 .history-row-score {
   font-size: var(--text-base);
   font-weight: var(--weight-bold);
-  min-width: 40px;
   font-variant-numeric: tabular-nums;
+}
+
+.history-row-score-acc {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-row-label-acc {
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
 }
 
 .history-row-trend {
@@ -92,18 +122,10 @@
 
 .history-row-dims {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 2px;
+  text-align: right;
 }
 
 .history-row-dims-run {
   font-size: var(--text-sm);
   color: var(--color-text-muted);
-}
-
-.history-row-dims-acc {
-  font-size: var(--text-xs);
-  color: var(--color-text-subtle);
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -13,6 +13,14 @@
   margin-bottom: var(--space-4);
 }
 
+.history-run-nav {
+  margin-left: auto;
+}
+
+.history-chart-wrapper {
+  margin-bottom: var(--space-4);
+}
+
 .history-title {
   font-size: var(--text-xl);
   font-weight: var(--weight-bold);

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -17,8 +17,15 @@
   margin-left: auto;
 }
 
-.history-chart-wrapper {
+.history-panels-row {
+  display: flex;
+  gap: var(--space-4);
   margin-bottom: var(--space-4);
+}
+
+.history-panels-row > * {
+  flex: 1;
+  min-width: 0;
 }
 
 .history-title {

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -31,7 +31,7 @@
   gap: var(--space-2);
 }
 
-/* Row — split into left (eval) and right (accumulated) */
+/* Row — three columns: date | eval | accumulated */
 .history-row {
   display: flex;
   border-radius: var(--radius-lg);
@@ -52,30 +52,14 @@
   border-color: var(--color-text-muted);
 }
 
-/* Left side — evaluation info */
-.history-row-left {
-  flex: 1;
+/* Date column */
+.history-row-date {
+  min-width: 130px;
   padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-}
-
-.history-row-top {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-}
-
-.history-row-bottom {
-  display: flex;
-  align-items: center;
-}
-
-.history-row-date {
-  min-width: 120px;
-  display: flex;
-  flex-direction: column;
+  justify-content: center;
+  border-right: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 
 .history-row-date-main {
@@ -84,56 +68,69 @@
 
 .history-row-date-time {
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  color: var(--color-text-subtle);
 }
 
-.history-row-score {
-  font-size: var(--text-base);
+/* Eval column */
+.history-row-eval {
+  flex: 1;
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.history-row-eval-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.history-row-eval-score {
+  font-size: var(--text-lg);
   font-weight: var(--weight-bold);
   font-variant-numeric: tabular-nums;
 }
 
-.history-row-dims {
+.history-row-eval-dims {
   font-size: var(--text-sm);
   color: var(--color-text-muted);
 }
 
-/* Right side — accumulated panel */
-.history-row-right {
-  min-width: 120px;
+/* Accumulated column */
+.history-row-acc {
+  min-width: 150px;
   padding: var(--space-3) var(--space-4);
   border-left: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
-  justify-content: center;
-  gap: 4px;
+  gap: 6px;
   background: color-mix(in srgb, var(--color-surface-alt) 50%, transparent);
 }
 
 .history-row-acc-label {
   font-size: var(--text-xs);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: var(--weight-medium);
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
   color: var(--color-text-subtle);
 }
 
-.history-row-acc-grade {
+.history-row-acc-line {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .history-row-acc-score {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
+  font-size: var(--text-base);
+  font-weight: var(--weight-bold);
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
 }
 
 .history-trend {
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: var(--weight-medium);
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
@@ -145,4 +142,28 @@
 
 .history-trend.trend-down {
   color: var(--color-trend-down);
+}
+
+/* Load more */
+.history-load-more {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space-3);
+}
+
+.history-load-more-btn {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.history-load-more-btn:hover {
+  border-color: var(--color-text-muted);
+  color: var(--color-text);
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -64,8 +64,8 @@
 }
 
 .history-row.selected {
-  border-color: var(--color-accent);
-  background: var(--color-accent-soft);
+  border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+  background: color-mix(in srgb, var(--color-accent) 3%, var(--color-surface));
 }
 
 .history-row:hover {

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -31,7 +31,7 @@
   gap: var(--space-2);
 }
 
-/* Row — three columns: date | eval | accumulated */
+/* Row — four columns: date | score | eval | accumulated */
 .history-row {
   display: flex;
   border-radius: var(--radius-lg);
@@ -54,7 +54,7 @@
 
 /* Date column */
 .history-row-date {
-  min-width: 130px;
+  min-width: 120px;
   padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
@@ -71,26 +71,50 @@
   color: var(--color-text-subtle);
 }
 
+/* Score column */
+.history-row-score {
+  min-width: 50px;
+  padding: var(--space-3) var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid color-mix(in srgb, var(--color-border) 50%, transparent);
+}
+
+.history-row-score-val {
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Eval column */
 .history-row-eval {
   flex: 1;
   padding: var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
+  justify-content: center;
 }
 
-.history-row-eval-top {
+.history-row-eval-grade {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
-.history-row-eval-score {
-  font-size: var(--text-lg);
-  font-weight: var(--weight-bold);
-  font-variant-numeric: tabular-nums;
+.history-row-eval-grade-label {
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
 }
+
+/* Grade label inherits color from the grade tier */
+.history-row-eval-grade-label.grade-top-text    { color: var(--color-grade-top-text); }
+.history-row-eval-grade-label.grade-high-text   { color: var(--color-grade-high-text); }
+.history-row-eval-grade-label.grade-mid-text    { color: var(--color-grade-mid-text); }
+.history-row-eval-grade-label.grade-low-text    { color: var(--color-grade-low-text); }
+.history-row-eval-grade-label.grade-bottom-text { color: var(--color-grade-bottom-text); }
 
 .history-row-eval-dims {
   font-size: var(--text-sm);
@@ -124,7 +148,7 @@
 
 .history-row-acc-score {
   font-size: var(--text-base);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-extrabold);
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -17,6 +17,45 @@
   margin-left: auto;
 }
 
+.history-run-nav .run-navigator {
+  padding: var(--space-2) var(--space-3);
+  background: color-mix(in srgb, var(--color-surface-alt) 50%, transparent);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-accent);
+  border-radius: var(--radius-lg);
+  gap: var(--space-2);
+}
+
+.history-run-nav .run-nav-action {
+  padding: 4px 10px;
+  border-radius: var(--radius-md);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+}
+
+.history-run-nav .run-nav-action:not(.run-nav-action--danger) {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border-color: var(--color-accent);
+}
+
+.history-run-nav .run-nav-action:not(.run-nav-action--danger):hover {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+.history-run-nav .run-nav-btn {
+  padding: 4px 10px;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.history-run-nav .run-nav-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  padding: 0 var(--space-2);
+}
+
 .history-panels-row {
   display: flex;
   gap: var(--space-4);

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -91,8 +91,19 @@
 }
 
 .history-row-dims {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.history-row-dims-run {
   font-size: var(--text-sm);
   color: var(--color-text-muted);
-  flex: 1;
-  text-align: right;
+}
+
+.history-row-dims-acc {
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -33,21 +33,17 @@
   font-weight: var(--weight-semibold);
 }
 
-.history-run-nav .run-nav-action:not(.run-nav-action--danger) {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border-color: var(--color-accent);
-}
-
-.history-run-nav .run-nav-action:not(.run-nav-action--danger):hover {
-  background: var(--color-accent-hover);
-  border-color: var(--color-accent-hover);
-}
-
 .history-run-nav .run-nav-btn {
-  padding: 4px 10px;
+  width: 26px;
+  height: 26px;
+  padding: 0;
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
 }
 
 .history-run-nav .run-nav-label {

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -21,7 +21,6 @@
   padding: var(--space-2) var(--space-3);
   background: color-mix(in srgb, var(--color-surface-alt) 50%, transparent);
   border: 1px solid var(--color-border);
-  border-left: 3px solid var(--color-accent);
   border-radius: var(--radius-lg);
   gap: var(--space-2);
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -68,6 +68,11 @@
   background: var(--color-surface-alt);
 }
 
+.history-row.selected {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
 /* Date column */
 .history-row-date {
   min-width: 120px;

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -53,7 +53,7 @@
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   cursor: pointer;
-  transition: border-color 150ms ease;
+  transition: border-color 150ms ease, background 150ms ease;
   width: 100%;
   text-align: left;
   font-family: var(--font-sans);
@@ -64,7 +64,8 @@
 }
 
 .history-row:hover {
-  border-color: var(--color-text-muted);
+  border-color: var(--color-accent);
+  background: var(--color-surface-alt);
 }
 
 /* Date column */

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -51,9 +51,9 @@
   display: flex;
   border-radius: var(--radius-lg);
   background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  border: 2px solid var(--color-border);
   cursor: pointer;
-  transition: border-color 150ms ease, background 150ms ease;
+  transition: border-color 150ms ease, background 150ms ease, box-shadow 150ms ease;
   width: 100%;
   text-align: left;
   font-family: var(--font-sans);
@@ -71,6 +71,7 @@
 .history-row.selected {
   border-color: var(--color-accent);
   background: var(--color-accent-soft);
+  box-shadow: 0 0 0 1px var(--color-accent);
 }
 
 /* Date column */

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -63,14 +63,14 @@
   padding: 0;
 }
 
-.history-row:hover {
-  border-color: var(--color-accent);
-  background: var(--color-surface-alt);
-}
-
 .history-row.selected {
   border-color: var(--color-accent);
   background: var(--color-accent-soft);
+}
+
+.history-row:hover {
+  border-color: var(--color-accent);
+  background: var(--color-surface-alt);
   box-shadow: 0 0 0 1px var(--color-accent);
 }
 

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -117,8 +117,8 @@
 .history-row-eval-grade-label.grade-bottom-text { color: var(--color-grade-bottom-text); }
 
 .history-row-eval-dims {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
 }
 
 /* Accumulated column */

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -31,11 +31,9 @@
   gap: var(--space-2);
 }
 
+/* Row — split into left (eval) and right (accumulated) */
 .history-row {
   display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
   border-radius: var(--radius-lg);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -46,14 +44,36 @@
   font-family: var(--font-sans);
   font-size: var(--text-sm);
   color: var(--color-text);
+  overflow: hidden;
+  padding: 0;
 }
 
 .history-row:hover {
   border-color: var(--color-text-muted);
 }
 
+/* Left side — evaluation info */
+.history-row-left {
+  flex: 1;
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.history-row-top {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.history-row-bottom {
+  display: flex;
+  align-items: center;
+}
+
 .history-row-date {
-  min-width: 130px;
+  min-width: 120px;
   display: flex;
   flex-direction: column;
 }
@@ -67,65 +87,62 @@
   color: var(--color-text-muted);
 }
 
-.history-row-grades {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 100px;
-}
-
-.history-row-grade-run {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.history-row-grade-acc {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  opacity: 0.6;
-}
-
 .history-row-score {
   font-size: var(--text-base);
   font-weight: var(--weight-bold);
   font-variant-numeric: tabular-nums;
 }
 
-.history-row-score-acc {
-  font-size: var(--text-xs);
-  font-weight: var(--weight-medium);
-  font-variant-numeric: tabular-nums;
+.history-row-dims {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
 }
 
-.history-row-label-acc {
+/* Right side — accumulated panel */
+.history-row-right {
+  min-width: 120px;
+  padding: var(--space-3) var(--space-4);
+  border-left: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+  background: color-mix(in srgb, var(--color-surface-alt) 50%, transparent);
+}
+
+.history-row-acc-label {
   font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--weight-medium);
   color: var(--color-text-subtle);
 }
 
-.history-row-trend {
-  min-width: 60px;
+.history-row-acc-grade {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.history-row-acc-score {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-trend {
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
 }
 
-.history-row-trend.trend-up {
+.history-trend.trend-up {
   color: var(--color-trend-up);
 }
 
-.history-row-trend.trend-down {
+.history-trend.trend-down {
   color: var(--color-trend-down);
-}
-
-.history-row-dims {
-  flex: 1;
-  text-align: right;
-}
-
-.history-row-dims-run {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
 }

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -56,6 +56,39 @@
   padding: 0 var(--space-2);
 }
 
+.history-list-header {
+  margin-bottom: var(--space-2);
+}
+
+.history-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.history-collapse-btn:hover {
+  color: var(--color-text);
+}
+
+.history-collapse-icon {
+  display: inline-block;
+  font-size: 1.1em;
+  transition: transform 150ms ease;
+  transform: rotate(90deg);
+}
+
+.history-collapse-icon.collapsed {
+  transform: rotate(0deg);
+}
+
 .history-panels-row {
   display: flex;
   gap: var(--space-4);

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -139,8 +139,39 @@
 .history-row-eval-grade-label.grade-bottom-text { color: var(--color-grade-bottom-text); }
 
 .history-row-eval-dims {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.history-dim-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 6px;
   font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  background: color-mix(in srgb, var(--color-border) 40%, transparent);
+  color: var(--color-text-muted);
+}
+
+.history-dim-score {
+  font-weight: var(--weight-bold);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-dim-trend {
+  font-size: 0.85em;
   color: var(--color-text-subtle);
+}
+
+.history-dim-trend.trend-up {
+  color: var(--color-trend-up);
+}
+
+.history-dim-trend.trend-down {
+  color: var(--color-trend-down);
 }
 
 /* Accumulated column */

--- a/src/quodeq/ui/src/styles/history.css
+++ b/src/quodeq/ui/src/styles/history.css
@@ -1,0 +1,98 @@
+/* =============================================================
+   History — evaluation run list
+   ============================================================= */
+
+.history-page {
+  padding: var(--space-4);
+}
+
+.history-header {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.history-title {
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+  margin: 0;
+}
+
+.history-count {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.history-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  transition: border-color 150ms ease;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}
+
+.history-row:hover {
+  border-color: var(--color-text-muted);
+}
+
+.history-row-date {
+  min-width: 130px;
+  display: flex;
+  flex-direction: column;
+}
+
+.history-row-date-main {
+  font-weight: var(--weight-semibold);
+}
+
+.history-row-date-time {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.history-row-score {
+  font-size: var(--text-base);
+  font-weight: var(--weight-bold);
+  min-width: 40px;
+  font-variant-numeric: tabular-nums;
+}
+
+.history-row-trend {
+  min-width: 60px;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-row-trend.trend-up {
+  color: var(--color-trend-up);
+}
+
+.history-row-trend.trend-down {
+  color: var(--color-trend-down);
+}
+
+.history-row-dims {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  flex: 1;
+  text-align: right;
+}

--- a/src/quodeq/ui/src/styles/index.css
+++ b/src/quodeq/ui/src/styles/index.css
@@ -3,3 +3,4 @@
 @import './dashboard.css';
 @import './evaluation.css';
 @import './explorer.css';
+@import './history.css';

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -380,6 +380,7 @@
     --color-accent:       var(--primitive-crimson-400);
     --color-accent-hover: var(--primitive-crimson-300);
     --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-400) 14%, transparent);
+    --color-on-accent:    var(--primitive-daruma-950);
 
     --color-danger:  var(--primitive-red-400);
     --color-success: var(--primitive-green-400);
@@ -468,6 +469,7 @@ html[data-theme="dark"]:root {
   --color-accent:       var(--primitive-crimson-400);
   --color-accent-hover: var(--primitive-crimson-300);
   --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-400) 14%, transparent);
+  --color-on-accent:    var(--primitive-daruma-950);
 
   --color-danger:  var(--primitive-red-400);
   --color-success: var(--primitive-green-400);
@@ -645,7 +647,7 @@ html[data-theme="ifrit-dark"]:root {
   --color-accent:       var(--primitive-ifrit-accent-dark);
   --color-accent-hover: #f09040;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-dark) 14%, transparent);
-  --color-on-accent:    #111111;
+  --color-on-accent:    var(--primitive-ifrit-950);
 
   --color-danger:  #ff5030;
   --color-success: #50b868;
@@ -816,7 +818,7 @@ html[data-theme="flynn-dark"]:root {
   --color-accent:       #00d4ff;
   --color-accent-hover: #33e0ff;
   --color-accent-soft:  color-mix(in srgb, #00d4ff 10%, transparent);
-  --color-on-accent:    #111111;
+  --color-on-accent:    var(--primitive-flynn-950);
 
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
@@ -984,7 +986,7 @@ html[data-theme="neo-dark"]:root {
   --color-accent:       var(--primitive-neo-accent);
   --color-accent-hover: #33ff66;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent) 14%, transparent);
-  --color-on-accent:    #111111;
+  --color-on-accent:    var(--primitive-neo-950);
   --color-danger:  #ff4040;
   --color-success: var(--primitive-neo-accent);
   --color-sev-critical-text:   #ff4040;
@@ -1131,7 +1133,7 @@ html[data-theme="galadriel-dark"]:root {
   --color-accent:       var(--primitive-green-400);
   --color-accent-hover: #6ee7a0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
-  --color-on-accent:    #111111;
+  --color-on-accent:    var(--primitive-galadriel-950);
   --color-danger:  #e05c4b;
   --color-success: var(--primitive-green-400);
   --color-sev-critical-text:   var(--primitive-galadriel-sev-critical-dark);
@@ -1292,6 +1294,7 @@ html[data-theme="deckard-dark"]:root {
   --color-accent:       var(--primitive-deckard-accent-dark);
   --color-accent-hover: #ff60d0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-dark) 14%, transparent);
+  --color-on-accent:    var(--primitive-deckard-950);
 
   --color-danger:  #ff4060;
   --color-success: #00dce0;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -645,6 +645,7 @@ html[data-theme="ifrit-dark"]:root {
   --color-accent:       var(--primitive-ifrit-accent-dark);
   --color-accent-hover: #f09040;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-dark) 14%, transparent);
+  --color-on-accent:    #111111;
 
   --color-danger:  #ff5030;
   --color-success: #50b868;
@@ -815,6 +816,7 @@ html[data-theme="flynn-dark"]:root {
   --color-accent:       #00d4ff;
   --color-accent-hover: #33e0ff;
   --color-accent-soft:  color-mix(in srgb, #00d4ff 10%, transparent);
+  --color-on-accent:    #111111;
 
   --color-danger:  #e05c4b;
   --color-success: #4caf7d;
@@ -982,6 +984,7 @@ html[data-theme="neo-dark"]:root {
   --color-accent:       var(--primitive-neo-accent);
   --color-accent-hover: #33ff66;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent) 14%, transparent);
+  --color-on-accent:    #111111;
   --color-danger:  #ff4040;
   --color-success: var(--primitive-neo-accent);
   --color-sev-critical-text:   #ff4040;
@@ -1128,6 +1131,7 @@ html[data-theme="galadriel-dark"]:root {
   --color-accent:       var(--primitive-green-400);
   --color-accent-hover: #6ee7a0;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-green-400) 14%, transparent);
+  --color-on-accent:    #111111;
   --color-danger:  #e05c4b;
   --color-success: var(--primitive-green-400);
   --color-sev-critical-text:   var(--primitive-galadriel-sev-critical-dark);


### PR DESCRIPTION
## Summary

- Adds **History** sidebar tab (clock icon) between Overview and Evaluate
- Reverse-chronological list of all evaluation runs with four-column layout:
  - **Date** | **Score** | **Grade + dimension tags** (with per-dimension scores and trends) | **Accumulated** panel (grade, score, trend)
- **Score history chart** + **dimension scores chart** at the top
- **Run navigator** with accent-bordered card, Latest (filled) / View (outline) buttons
- Chart window slides to follow the selected run when navigating past 20 visible bars
- Collapsible evaluation list with "Load all X evaluations" button
- Selected row highlighted, hover with accent border + shadow
- Human-readable dates ("25 March 2026")
- Per-dimension trend deltas use last evaluation of that dimension (not just previous run)

### Backend changes
- `TrendPoint` now includes `dimensions` (list), `dimensionDetails` (per-dim score/grade/delta), `runNumericAverage`, `runOverallGrade`, `accumulatedDimensionsCount`

### Theme fixes
- `--color-on-accent` set per dark theme using each theme's darkest shade for contrast
- Outline button fills to accent on hover for readability on all themes
- Run navigator button styles swapped (Latest = filled primary, View = outline)

## Test plan
- [x] Click History tab — verify run list with charts and navigator
- [x] Click a run row — verify RunOverviewPanel loads within History stack
- [x] Use run navigator arrows — verify chart slides to follow selection
- [x] Verify dimension tags show correct scores and trend arrows
- [x] Verify "Load all" button appears when >20 runs
- [x] Collapse/expand the evaluation list
- [x] Test all 6 themes — verify on-accent text contrast on buttons
- [x] Verify hover and selected states on rows