### PR TITLE
feat: overview daily grouping — chart and navigator step by day, dimension highlights

### DIFF
--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -308,7 +308,7 @@ def _compute_dashboard_payload(
     )
     return _DashboardPayload(
         selected_summary=ctx.summary,
-        trend=_collapse_by_day(_build_accumulated_trend(history_runs, get_run_dimensions)),
+        trend=_build_accumulated_trend(history_runs, get_run_dimensions),
         dimensions_with_trend=_enrich_dimensions_with_trend(ctx.dimensions, previous_by_dimension),
         previous_by_dimension=previous_by_dimension,
         stale_previous_by_dimension=stale_previous_by_dimension,

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -169,6 +169,44 @@ def _build_accumulated_trend(
     return trend
 
 
+def _collapse_by_day(trend: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse consecutive same-day trend entries into one entry per day.
+
+    The last entry of each day wins (has the most up-to-date accumulated state).
+    dayDimensions = union of all dimensions evaluated on that day.
+    dayDimensionDetails = merged details (latest per dimension within the day).
+    """
+    if not trend:
+        return trend
+    collapsed: list[dict[str, Any]] = []
+    current_day: str | None = None
+    day_dims: set[str] = set()
+    day_dim_details: dict[str, dict] = {}
+
+    for entry in trend:
+        date_part = (entry.get("dateISO") or "")[:10]
+        if date_part != current_day:
+            if current_day is not None and collapsed:
+                collapsed[-1]["dayDimensions"] = sorted(day_dims)
+                collapsed[-1]["dayDimensionDetails"] = sorted(day_dim_details.values(), key=lambda d: d.get("dimension", ""))
+            current_day = date_part
+            day_dims = set()
+            day_dim_details = {}
+            collapsed.append(entry)
+        else:
+            collapsed[-1] = entry  # last entry of the day wins
+        for d in entry.get("dimensions", []):
+            day_dims.add(d)
+        for d in entry.get("dimensionDetails", []):
+            day_dim_details[d.get("dimension", "")] = d
+
+    if collapsed:
+        collapsed[-1]["dayDimensions"] = sorted(day_dims)
+        collapsed[-1]["dayDimensionDetails"] = sorted(day_dim_details.values(), key=lambda d: d.get("dimension", ""))
+
+    return collapsed
+
+
 def _make_run_dimension_fetcher(
     reports_root: Path,
     project: str,
@@ -270,7 +308,7 @@ def _compute_dashboard_payload(
     )
     return _DashboardPayload(
         selected_summary=ctx.summary,
-        trend=_build_accumulated_trend(history_runs, get_run_dimensions),
+        trend=_collapse_by_day(_build_accumulated_trend(history_runs, get_run_dimensions)),
         dimensions_with_trend=_enrich_dimensions_with_trend(ctx.dimensions, previous_by_dimension),
         previous_by_dimension=previous_by_dimension,
         stale_previous_by_dimension=stale_previous_by_dimension,

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -169,44 +169,6 @@ def _build_accumulated_trend(
     return trend
 
 
-def _collapse_by_day(trend: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Collapse consecutive same-day trend entries into one entry per day.
-
-    The last entry of each day wins (has the most up-to-date accumulated state).
-    dayDimensions = union of all dimensions evaluated on that day.
-    dayDimensionDetails = merged details (latest per dimension within the day).
-    """
-    if not trend:
-        return trend
-    collapsed: list[dict[str, Any]] = []
-    current_day: str | None = None
-    day_dims: set[str] = set()
-    day_dim_details: dict[str, dict] = {}
-
-    for entry in trend:
-        date_part = (entry.get("dateISO") or "")[:10]
-        if date_part != current_day:
-            if current_day is not None and collapsed:
-                collapsed[-1]["dayDimensions"] = sorted(day_dims)
-                collapsed[-1]["dayDimensionDetails"] = sorted(day_dim_details.values(), key=lambda d: d.get("dimension", ""))
-            current_day = date_part
-            day_dims = set()
-            day_dim_details = {}
-            collapsed.append(entry)
-        else:
-            collapsed[-1] = entry  # last entry of the day wins
-        for d in entry.get("dimensions", []):
-            day_dims.add(d)
-        for d in entry.get("dimensionDetails", []):
-            day_dim_details[d.get("dimension", "")] = d
-
-    if collapsed:
-        collapsed[-1]["dayDimensions"] = sorted(day_dims)
-        collapsed[-1]["dayDimensionDetails"] = sorted(day_dim_details.values(), key=lambda d: d.get("dimension", ""))
-
-    return collapsed
-
-
 def _make_run_dimension_fetcher(
     reports_root: Path,
     project: str,

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -210,6 +210,7 @@ export default function App() {
             onProjectChange: state.handleProjectChange, showRunNav: state.showRunNav,
             runNavProps: {
               currentOverviewRun: state.currentOverviewRun, overviewRunIndex: state.overviewRunIndex, availableRuns: state.availableRuns,
+              currentDayLabel: (() => { const t = (state.dashboard?.trend || []).find(r => r.runId === state.currentOverviewRun); if (t?.dateISO) { try { return new Date(t.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }); } catch {} } return state.availableRuns[state.overviewRunIndex]?.dateLabel || state.currentOverviewRun; })(),
               onRunPrev: state.handleRunPrev, onRunNext: state.handleRunNext, onRunLatest: state.handleRunLatest,
               onViewRun: undefined,
             },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -156,7 +156,25 @@ function useAppState() {
   const settings = useAppSettings();
   function handleNavigate(page, params = {}) { if ((page === 'run' || page === 'history-run') && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
   const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun });
-  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
+  // Build day-level runs for Overview (collapse same-day runs, keep last of each day)
+  const dailyRuns = useMemo(() => {
+    if (!availableRuns.length) return [];
+    const trend = dashboard?.trend || [];
+    const byDay = [];
+    let lastDate = null;
+    for (const run of availableRuns) {
+      const t = trend.find(r => r.runId === run.runId);
+      const datePart = (t?.dateISO || '').slice(0, 10);
+      if (datePart !== lastDate) {
+        byDay.push(run);
+        lastDate = datePart;
+      } else {
+        byDay[byDay.length - 1] = run; // last run of the day wins
+      }
+    }
+    return byDay;
+  }, [availableRuns, dashboard]);
+  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: dailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => {
     const meta = computeHeaderMeta(accumulated, dashboard);
     const display = computeProjectDisplay(selectedProject, projects);
@@ -165,13 +183,13 @@ function useAppState() {
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
   const activeTab = ['overview', 'history', 'projects', 'evaluate', 'settings'].includes(activePage.page) ? activePage.page : activePage.page === 'history-run' ? 'history' : 'overview';
   const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
-  const showRunNav = showProjectHeader && availableRuns.length > 0 && navStack.length === 1;
+  const showRunNav = showProjectHeader && dailyRuns.length > 0 && navStack.length === 1;
 
   return {
     serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
     projects, selectedProject, selectedRun, handleProjectChange, handleNavigate,
     handleDeleteProject, handleExportProject, handleRelocateProject,
-    dashboard, accumulated, loading, error, availableRuns, overviewRunIndex,
+    dashboard, accumulated, loading, error, availableRuns, dailyRuns, overviewRunIndex,
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     evalLifecycle, settings, activeTab, showProjectHeader, showRunNav,
@@ -186,7 +204,7 @@ export default function App() {
     dashboardData: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
       dashboard: state.dashboard, accumulated: state.accumulated, loading: state.loading, error: state.error,
-      availableRuns: state.availableRuns, overviewRunIndex: state.overviewRunIndex,
+      availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
     },
     navigation: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
@@ -209,8 +227,8 @@ export default function App() {
           navigation={{
             onProjectChange: state.handleProjectChange, showRunNav: state.showRunNav,
             runNavProps: {
-              currentOverviewRun: state.currentOverviewRun, overviewRunIndex: state.overviewRunIndex, availableRuns: state.availableRuns,
-              currentDayLabel: (() => { const t = (state.dashboard?.trend || []).find(r => r.runId === state.currentOverviewRun); if (t?.dateISO) { try { return new Date(t.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }); } catch {} } return state.availableRuns[state.overviewRunIndex]?.dateLabel || state.currentOverviewRun; })(),
+              currentOverviewRun: state.currentOverviewRun, overviewRunIndex: state.overviewRunIndex, availableRuns: state.dailyRuns,
+              currentDayLabel: (() => { const t = (state.dashboard?.trend || []).find(r => r.runId === state.currentOverviewRun); if (t?.dateISO) { try { return new Date(t.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }); } catch {} } return state.dailyRuns[state.overviewRunIndex]?.dateLabel || state.currentOverviewRun; })(),
               onRunPrev: state.handleRunPrev, onRunNext: state.handleRunNext, onRunLatest: state.handleRunLatest,
               onViewRun: undefined,
             },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -211,7 +211,7 @@ export default function App() {
             runNavProps: {
               currentOverviewRun: state.currentOverviewRun, overviewRunIndex: state.overviewRunIndex, availableRuns: state.availableRuns,
               onRunPrev: state.handleRunPrev, onRunNext: state.handleRunNext, onRunLatest: state.handleRunLatest,
-              onViewRun: activePage.page === 'overview' ? state.handleRunView : undefined,
+              onViewRun: undefined,
             },
           }}
         />

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -156,7 +156,7 @@ function useAppState() {
   const settings = useAppSettings();
   function handleNavigate(page, params = {}) { if ((page === 'run' || page === 'history-run') && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
   const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun });
-  // Build day-level runs for Overview (collapse same-day runs, keep last of each day)
+  // Build day-level runs for Overview (collapse same-day runs, keep first/newest of each day)
   const dailyRuns = useMemo(() => {
     if (!availableRuns.length) return [];
     const trend = dashboard?.trend || [];
@@ -166,11 +166,10 @@ function useAppState() {
       const t = trend.find(r => r.runId === run.runId);
       const datePart = (t?.dateISO || '').slice(0, 10);
       if (datePart !== lastDate) {
-        byDay.push(run);
+        byDay.push(run); // first (newest) entry of the day wins
         lastDate = datePart;
-      } else {
-        byDay[byDay.length - 1] = run; // last run of the day wins
       }
+      // skip older runs of the same day
     }
     return byDay;
   }, [availableRuns, dashboard]);

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -54,6 +54,24 @@ function SettingsCase({ settings, analysisPower, setAnalysisPower }) {
   );
 }
 
+function resolveHistorySelectedRunId(selectedRun, trend) {
+  if (selectedRun && selectedRun !== 'latest' && trend.some((t) => t.runId === selectedRun)) return selectedRun;
+  return trend.length > 0 ? trend[0].runId : null;
+}
+
+function formatHistoryRunLabel(trend, runs, idx, fallbackLabel) {
+  const entry = trend.find((r) => r.runId === runs[idx]?.runId);
+  if (entry?.dateISO) {
+    try {
+      const d = new Date(entry.dateISO);
+      const date = d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+      const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+      return `${date} · ${time}`;
+    } catch { /* fall through */ }
+  }
+  return runs[idx]?.dateLabel || fallbackLabel;
+}
+
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
@@ -64,10 +82,10 @@ const ROUTE_RENDERERS = {
     return (
       <HistoryPage
         trend={trend}
-        selectedRunId={(() => { const sr = props.dashboardData.selectedRun; if (sr && sr !== 'latest' && trend.some(t => t.runId === sr)) return sr; return trend.length > 0 ? trend[0].runId : null; })()}
+        selectedRunId={resolveHistorySelectedRunId(props.dashboardData.selectedRun, trend)}
         selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
         runNav={runs.length > 0 ? {
-          currentRun: (() => { const t = trend.find(r => r.runId === (runs[idx]?.runId)); if (t?.dateISO) { try { const d = new Date(t.dateISO); return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }) + ' · ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' }); } catch {} } return runs[idx]?.dateLabel || props.navigation.currentOverviewRun; })(),
+          currentRun: formatHistoryRunLabel(trend, runs, idx, props.navigation.currentOverviewRun),
           isLatest: idx === 0,
           isOldest: idx >= runs.length - 1,
           onPrev: props.navigation.handleRunPrev,
@@ -180,7 +198,10 @@ function useAppState() {
     return { headerMeta: meta, ...display };
   }, [accumulated, dashboard, selectedProject, projects]);
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
-  const activeTab = ['overview', 'history', 'projects', 'evaluate', 'settings'].includes(activePage.page) ? activePage.page : activePage.page === 'history-run' ? 'history' : 'overview';
+  const knownTabs = ['overview', 'history', 'projects', 'evaluate', 'settings'];
+  const activeTab = knownTabs.includes(activePage.page) ? activePage.page
+    : activePage.page === 'history-run' ? 'history'
+    : 'overview';
   const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
   const showRunNav = showProjectHeader && dailyRuns.length > 0 && navStack.length === 1;
 
@@ -195,9 +216,24 @@ function useAppState() {
   };
 }
 
+function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
+  const entry = (trend || []).find((r) => r.runId === currentOverviewRun);
+  if (entry?.dateISO) {
+    try {
+      return new Date(entry.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+    } catch { /* fall through */ }
+  }
+  return dailyRuns[overviewRunIndex]?.dateLabel || currentOverviewRun;
+}
+
 export default function App() {
   const state = useAppState();
   const { activePage, navStack, navPop, navGoTo, navTab, activeTab } = state;
+
+  const currentDayLabel = useMemo(
+    () => formatDayLabel(state.dashboard?.trend, state.currentOverviewRun, state.dailyRuns, state.overviewRunIndex),
+    [state.dashboard?.trend, state.currentOverviewRun, state.dailyRuns, state.overviewRunIndex]
+  );
 
   const contentProps = {
     dashboardData: {
@@ -227,7 +263,7 @@ export default function App() {
             onProjectChange: state.handleProjectChange, showRunNav: state.showRunNav,
             runNavProps: {
               currentOverviewRun: state.currentOverviewRun, overviewRunIndex: state.overviewRunIndex, availableRuns: state.dailyRuns,
-              currentDayLabel: (() => { const t = (state.dashboard?.trend || []).find(r => r.runId === state.currentOverviewRun); if (t?.dateISO) { try { return new Date(t.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }); } catch {} } return state.dailyRuns[state.overviewRunIndex]?.dateLabel || state.currentOverviewRun; })(),
+              currentDayLabel,
               onRunPrev: state.handleRunPrev, onRunNext: state.handleRunNext, onRunLatest: state.handleRunLatest,
               onViewRun: undefined,
             },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
+import { buildDailyRuns } from './utils/dailyGrouping.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
@@ -174,23 +175,7 @@ function useAppState() {
   const settings = useAppSettings();
   function handleNavigate(page, params = {}) { if ((page === 'run' || page === 'history-run') && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
   const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun });
-  // Build day-level runs for Overview (collapse same-day runs, keep first/newest of each day)
-  const dailyRuns = useMemo(() => {
-    if (!availableRuns.length) return [];
-    const trend = dashboard?.trend || [];
-    const byDay = [];
-    let lastDate = null;
-    for (const run of availableRuns) {
-      const t = trend.find(r => r.runId === run.runId);
-      const datePart = (t?.dateISO || '').slice(0, 10);
-      if (datePart !== lastDate) {
-        byDay.push(run); // first (newest) entry of the day wins
-        lastDate = datePart;
-      }
-      // skip older runs of the same day
-    }
-    return byDay;
-  }, [availableRuns, dashboard]);
+  const dailyRuns = useMemo(() => buildDailyRuns(availableRuns, dashboard?.trend || []), [availableRuns, dashboard]);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: dailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => {
     const meta = computeHeaderMeta(accumulated, dashboard);

--- a/src/quodeq/ui/src/components/ProjectHeader.jsx
+++ b/src/quodeq/ui/src/components/ProjectHeader.jsx
@@ -50,7 +50,7 @@ export default function ProjectHeader({
       </div>
       {showRunNav && runNavProps && (
         <RunNavigator
-          currentRun={formatRunId(runNavProps.currentOverviewRun, runNavProps.availableRuns[runNavProps.overviewRunIndex]?.dateLabel)}
+          currentRun={runNavProps.currentDayLabel || formatRunId(runNavProps.currentOverviewRun, runNavProps.availableRuns[runNavProps.overviewRunIndex]?.dateLabel)}
           isLatest={runNavProps.overviewRunIndex === 0}
           isOldest={runNavProps.overviewRunIndex >= runNavProps.availableRuns.length - 1}
           actions={{

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -95,14 +95,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, topFilesCou
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations }) {
+function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, dayDimensions }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} dayDimensions={dayDimensions} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -174,6 +174,8 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
 
   const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? availableRuns[0]?.runId : currentOverviewRun;
+  const selectedTrend = trend.find((t) => t.runId === (availableRuns[overviewRunIndex]?.runId));
+  const dayDimensions = selectedTrend?.dayDimensions || [];
 
   const stats = useMemo(
     () => computeAccumulatedStats(accumulated, accumulatedDimensions),
@@ -200,6 +202,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={stats.dimsWithViolations}
+        dayDimensions={dayDimensions}
       />
 
       <AccumulatedDetailsSection

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -168,14 +168,45 @@ function AccumulatedDetailsSection({ topFiles, violationsByPrinciple, uniquePrin
 // Accumulated overview panel
 // ---------------------------------------------------------------------------
 
+function collapseByDay(trend) {
+  if (!trend || trend.length === 0) return trend;
+  const collapsed = [];
+  let currentDay = null;
+  let dayDims = new Set();
+  let dayDimDetails = {};
+  for (const entry of trend) {
+    const datePart = (entry.dateISO || '').slice(0, 10);
+    if (datePart !== currentDay) {
+      if (currentDay !== null && collapsed.length > 0) {
+        collapsed[collapsed.length - 1].dayDimensions = [...dayDims].sort();
+        collapsed[collapsed.length - 1].dayDimensionDetails = Object.values(dayDimDetails).sort((a, b) => (a.dimension || '').localeCompare(b.dimension || ''));
+      }
+      currentDay = datePart;
+      dayDims = new Set();
+      dayDimDetails = {};
+      collapsed.push({ ...entry });
+    } else {
+      collapsed[collapsed.length - 1] = { ...entry };
+    }
+    for (const d of entry.dimensions || []) dayDims.add(d);
+    for (const d of entry.dimensionDetails || []) dayDimDetails[d.dimension || ''] = d;
+  }
+  if (collapsed.length > 0) {
+    collapsed[collapsed.length - 1].dayDimensions = [...dayDims].sort();
+    collapsed[collapsed.length - 1].dayDimensionDetails = Object.values(dayDimDetails).sort((a, b) => (a.dimension || '').localeCompare(b.dimension || ''));
+  }
+  return collapsed;
+}
+
 export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { accumulated, accumulatedDimensions, availableRuns, overviewRunIndex, trend, selectedRunId } = data;
   const { onRunClick, onDimensionClick, onFileClick, onPrincipleClick } = callbacks;
 
+  const dailyTrend = useMemo(() => collapseByDay(trend), [trend]);
   const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? availableRuns[0]?.runId : currentOverviewRun;
-  const selectedTrend = trend.find((t) => t.runId === (availableRuns[overviewRunIndex]?.runId));
-  const dayDimensions = selectedTrend?.dayDimensions || [];
+  const selectedDay = dailyTrend.find((t) => t.runId === currentOverviewRun);
+  const dayDimensions = selectedDay?.dayDimensions || [];
 
   const stats = useMemo(
     () => computeAccumulatedStats(accumulated, accumulatedDimensions),
@@ -193,7 +224,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
       />
 
       <div className="history-panels-row">
-        <RunHistoryPanel trend={trend} selectedRunId={selectedRunId} selectedRunScore={accumulated?.summary?.numericAverage} onBarClick={onRunClick} />
+        <RunHistoryPanel trend={dailyTrend} selectedRunId={selectedRunId} selectedRunScore={accumulated?.summary?.numericAverage} onBarClick={onRunClick} />
         <DimensionScorePanel dimensions={accumulatedDimensions} onBarClick={onDimensionClick} runDate={stats.lastRun.date} runId={stats.lastRun.runId} />
       </div>
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -95,14 +95,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, topFilesCou
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayRunIds }) {
+function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDimNames }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayRunIds={selectedDayRunIds} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -229,18 +229,20 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
 
-  // Collect ALL runIds from the selected day — used to highlight dimension cards.
-  // A dimension is "active" if its fromRunId matches any run on this day.
-  const selectedDayRunIds = useMemo(() => {
+  // Collect ALL dimension NAMES evaluated on the selected day from the raw trend.
+  // This is independent of the accumulated API response, so it's always in sync.
+  const selectedDayDimNames = useMemo(() => {
     const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
     if (!entry) return new Set();
     const selectedDate = (entry.dateISO || '').slice(0, 10);
     if (!selectedDate) return new Set();
-    const ids = new Set();
+    const names = new Set();
     for (const t of trend) {
-      if ((t.dateISO || '').slice(0, 10) === selectedDate) ids.add(t.runId);
+      if ((t.dateISO || '').slice(0, 10) === selectedDate) {
+        for (const d of t.dimensions || []) names.add(d.toLowerCase());
+      }
     }
-    return ids;
+    return names;
   }, [trend, currentOverviewRun, selectedRunId]);
 
   const stats = useMemo(
@@ -268,7 +270,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={stats.dimsWithViolations}
-        selectedDayRunIds={selectedDayRunIds}
+        selectedDayDimNames={selectedDayDimNames}
       />
 
       <AccumulatedDetailsSection

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -235,7 +235,6 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
     const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
     if (!entry) return new Set();
     const selectedDate = (entry.dateISO || '').slice(0, 10);
-    if (!selectedDate) return new Set();
     const names = new Set();
     for (const t of trend) {
       if ((t.dateISO || '').slice(0, 10) === selectedDate) {

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -95,14 +95,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, topFilesCou
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDate }) {
+function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayRunIds }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDate={selectedDayDate} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayRunIds={selectedDayRunIds} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -229,11 +229,18 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
 
-  // Get the selected day's date for highlighting dimension cards.
-  // Each accumulated dimension has fromDateIso — if it matches the selected day, it was evaluated that day.
-  const selectedDayDate = useMemo(() => {
+  // Collect ALL runIds from the selected day — used to highlight dimension cards.
+  // A dimension is "active" if its fromRunId matches any run on this day.
+  const selectedDayRunIds = useMemo(() => {
     const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
-    return (entry?.dateISO || '').slice(0, 10) || null;
+    if (!entry) return new Set();
+    const selectedDate = (entry.dateISO || '').slice(0, 10);
+    if (!selectedDate) return new Set();
+    const ids = new Set();
+    for (const t of trend) {
+      if ((t.dateISO || '').slice(0, 10) === selectedDate) ids.add(t.runId);
+    }
+    return ids;
   }, [trend, currentOverviewRun, selectedRunId]);
 
   const stats = useMemo(
@@ -261,7 +268,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={stats.dimsWithViolations}
-        selectedDayDate={selectedDayDate}
+        selectedDayRunIds={selectedDayRunIds}
       />
 
       <AccumulatedDetailsSection

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -95,14 +95,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, topFilesCou
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, dayDimensions }) {
+function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDate }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} dayDimensions={dayDimensions} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDate={selectedDayDate} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -229,23 +229,11 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
 
-  // Find dayDimensions: collect ALL dimensions evaluated on the selected day
-  // by matching the date part, not just the runId
-  const dayDimensions = useMemo(() => {
-    if (!trend.length) return [];
-    // Find the date of the current selection
-    const selectedEntry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
-    if (!selectedEntry) return [];
-    const selectedDate = (selectedEntry.dateISO || '').slice(0, 10);
-    if (!selectedDate) return [];
-    // Collect ALL dimensions from ALL runs on that date
-    const dims = new Set();
-    for (const t of trend) {
-      if ((t.dateISO || '').slice(0, 10) === selectedDate) {
-        for (const d of t.dimensions || []) dims.add(d);
-      }
-    }
-    return [...dims];
+  // Get the selected day's date for highlighting dimension cards.
+  // Each accumulated dimension has fromDateISO — if it matches the selected day, it was evaluated that day.
+  const selectedDayDate = useMemo(() => {
+    const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
+    return (entry?.dateISO || '').slice(0, 10) || null;
   }, [trend, currentOverviewRun, selectedRunId]);
 
   const stats = useMemo(
@@ -273,7 +261,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={stats.dimsWithViolations}
-        dayDimensions={dayDimensions}
+        selectedDayDate={selectedDayDate}
       />
 
       <AccumulatedDetailsSection

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -208,7 +208,25 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { onRunClick, onDimensionClick, onFileClick, onPrincipleClick } = callbacks;
 
   const dailyTrend = useMemo(() => collapseByDay(trend), [trend]);
-  const currentOverviewRun = dayRuns[overviewRunIndex]?.runId || 'latest';
+
+  // Find which daily entry matches the current selection
+  // selectedRunId may be any runId — find the day it belongs to
+  const effectiveSelectedId = useMemo(() => {
+    if (!selectedRunId || !trend.length) return dailyTrend[0]?.runId || null;
+    // Check if selectedRunId is directly a daily entry
+    const direct = dailyTrend.find((t) => t.runId === selectedRunId);
+    if (direct) return direct.runId;
+    // Find which raw trend entry matches, then find its day
+    const rawEntry = trend.find((t) => t.runId === selectedRunId);
+    if (rawEntry) {
+      const datePart = (rawEntry.dateISO || '').slice(0, 10);
+      const dayEntry = dailyTrend.find((t) => (t.dateISO || '').slice(0, 10) === datePart);
+      if (dayEntry) return dayEntry.runId;
+    }
+    return dailyTrend[0]?.runId || null;
+  }, [selectedRunId, trend, dailyTrend]);
+
+  const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
   const selectedDay = dailyTrend.find((t) => t.runId === currentOverviewRun);
   const dayDimensions = selectedDay?.dayDimensions || [];

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -169,6 +169,9 @@ function AccumulatedDetailsSection({ topFiles, violationsByPrinciple, uniquePrin
 // ---------------------------------------------------------------------------
 
 function collapseByDay(trend) {
+  // trend is newest-first. For each day, keep the FIRST (newest) entry
+  // which has the most up-to-date accumulated state.
+  // Collect dayDimensions from all runs of that day.
   if (!trend || trend.length === 0) return trend;
   const collapsed = [];
   let currentDay = null;
@@ -184,12 +187,13 @@ function collapseByDay(trend) {
       currentDay = datePart;
       dayDims = new Set();
       dayDimDetails = {};
-      collapsed.push({ ...entry });
-    } else {
-      collapsed[collapsed.length - 1] = { ...entry };
+      collapsed.push({ ...entry }); // first (newest) entry of the day wins
     }
+    // Don't replace — just collect dimensions from all runs of this day
     for (const d of entry.dimensions || []) dayDims.add(d);
-    for (const d of entry.dimensionDetails || []) dayDimDetails[d.dimension || ''] = d;
+    for (const d of entry.dimensionDetails || []) {
+      if (!dayDimDetails[d.dimension || '']) dayDimDetails[d.dimension || ''] = d; // first (newest) wins
+    }
   }
   if (collapsed.length > 0) {
     collapsed[collapsed.length - 1].dayDimensions = [...dayDims].sort();
@@ -225,7 +229,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
       />
 
       <div className="history-panels-row">
-        <RunHistoryPanel trend={dailyTrend} selectedRunId={selectedRunId} selectedRunScore={accumulated?.summary?.numericAverage} onBarClick={onRunClick} />
+        <RunHistoryPanel trend={dailyTrend} selectedRunId={currentOverviewRun} selectedRunScore={accumulated?.summary?.numericAverage} onBarClick={onRunClick} />
         <DimensionScorePanel dimensions={accumulatedDimensions} onBarClick={onDimensionClick} runDate={stats.lastRun.date} runId={stats.lastRun.runId} />
       </div>
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -199,12 +199,13 @@ function collapseByDay(trend) {
 }
 
 export default function AccumulatedOverviewPanel({ data, callbacks }) {
-  const { accumulated, accumulatedDimensions, availableRuns, overviewRunIndex, trend, selectedRunId } = data;
+  const { accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, trend, selectedRunId } = data;
+  const dayRuns = dailyRuns || availableRuns;
   const { onRunClick, onDimensionClick, onFileClick, onPrincipleClick } = callbacks;
 
   const dailyTrend = useMemo(() => collapseByDay(trend), [trend]);
-  const currentOverviewRun = availableRuns[overviewRunIndex]?.runId || 'latest';
-  const referenceRun = overviewRunIndex === 0 ? availableRuns[0]?.runId : currentOverviewRun;
+  const currentOverviewRun = dayRuns[overviewRunIndex]?.runId || 'latest';
+  const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
   const selectedDay = dailyTrend.find((t) => t.runId === currentOverviewRun);
   const dayDimensions = selectedDay?.dayDimensions || [];
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -228,8 +228,25 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
 
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
-  const selectedDay = dailyTrend.find((t) => t.runId === currentOverviewRun);
-  const dayDimensions = selectedDay?.dayDimensions || [];
+
+  // Find dayDimensions: collect ALL dimensions evaluated on the selected day
+  // by matching the date part, not just the runId
+  const dayDimensions = useMemo(() => {
+    if (!trend.length) return [];
+    // Find the date of the current selection
+    const selectedEntry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
+    if (!selectedEntry) return [];
+    const selectedDate = (selectedEntry.dateISO || '').slice(0, 10);
+    if (!selectedDate) return [];
+    // Collect ALL dimensions from ALL runs on that date
+    const dims = new Set();
+    for (const t of trend) {
+      if ((t.dateISO || '').slice(0, 10) === selectedDate) {
+        for (const d of t.dimensions || []) dims.add(d);
+      }
+    }
+    return [...dims];
+  }, [trend, currentOverviewRun, selectedRunId]);
 
   const stats = useMemo(
     () => computeAccumulatedStats(accumulated, accumulatedDimensions),

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -171,33 +171,15 @@ function AccumulatedDetailsSection({ topFiles, violationsByPrinciple, uniquePrin
 function collapseByDay(trend) {
   // trend is newest-first. For each day, keep the FIRST (newest) entry
   // which has the most up-to-date accumulated state.
-  // Collect dayDimensions from all runs of that day.
   if (!trend || trend.length === 0) return trend;
   const collapsed = [];
   let currentDay = null;
-  let dayDims = new Set();
-  let dayDimDetails = {};
   for (const entry of trend) {
     const datePart = (entry.dateISO || '').slice(0, 10);
     if (datePart !== currentDay) {
-      if (currentDay !== null && collapsed.length > 0) {
-        collapsed[collapsed.length - 1].dayDimensions = [...dayDims].sort();
-        collapsed[collapsed.length - 1].dayDimensionDetails = Object.values(dayDimDetails).sort((a, b) => (a.dimension || '').localeCompare(b.dimension || ''));
-      }
       currentDay = datePart;
-      dayDims = new Set();
-      dayDimDetails = {};
-      collapsed.push({ ...entry }); // first (newest) entry of the day wins
+      collapsed.push({ ...entry });
     }
-    // Don't replace — just collect dimensions from all runs of this day
-    for (const d of entry.dimensions || []) dayDims.add(d);
-    for (const d of entry.dimensionDetails || []) {
-      if (!dayDimDetails[d.dimension || '']) dayDimDetails[d.dimension || ''] = d; // first (newest) wins
-    }
-  }
-  if (collapsed.length > 0) {
-    collapsed[collapsed.length - 1].dayDimensions = [...dayDims].sort();
-    collapsed[collapsed.length - 1].dayDimensionDetails = Object.values(dayDimDetails).sort((a, b) => (a.dimension || '').localeCompare(b.dimension || ''));
   }
   return collapsed;
 }

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -27,7 +27,7 @@ function computeAccumulatedStats(accumulated, accumulatedDimensions) {
 
   const withDates = accumulatedDimensions
     .filter((d) => d.fromRunId)
-    .map((d) => ({ runId: d.fromRunId, dateISO: d.fromDateISO, dateLabel: d.fromDateLabel }));
+    .map((d) => ({ runId: d.fromRunId, dateISO: d.fromDateIso, dateLabel: d.fromDateLabel }));
   withDates.sort((a, b) => (b.dateISO || '').localeCompare(a.dateISO || ''));
   const lastRun = withDates.length === 0
     ? { date: null, runId: null }
@@ -230,7 +230,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
 
   // Get the selected day's date for highlighting dimension cards.
-  // Each accumulated dimension has fromDateISO — if it matches the selected day, it was evaluated that day.
+  // Each accumulated dimension has fromDateIso — if it matches the selected day, it was evaluated that day.
   const selectedDayDate = useMemo(() => {
     const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
     return (entry?.dateISO || '').slice(0, 10) || null;

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -7,6 +7,7 @@ import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { formatRunId, scoreColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
+import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGrouping.js';
 import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 
@@ -168,22 +169,6 @@ function AccumulatedDetailsSection({ topFiles, violationsByPrinciple, uniquePrin
 // Accumulated overview panel
 // ---------------------------------------------------------------------------
 
-function collapseByDay(trend) {
-  // trend is newest-first. For each day, keep the FIRST (newest) entry
-  // which has the most up-to-date accumulated state.
-  if (!trend || trend.length === 0) return trend;
-  const collapsed = [];
-  let currentDay = null;
-  for (const entry of trend) {
-    const datePart = (entry.dateISO || '').slice(0, 10);
-    if (datePart !== currentDay) {
-      currentDay = datePart;
-      collapsed.push({ ...entry });
-    }
-  }
-  return collapsed;
-}
-
 export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, trend, selectedRunId } = data;
   const dayRuns = dailyRuns || availableRuns;
@@ -211,20 +196,10 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
 
-  // Collect ALL dimension NAMES evaluated on the selected day from the raw trend.
-  // This is independent of the accumulated API response, so it's always in sync.
-  const selectedDayDimNames = useMemo(() => {
-    const entry = trend.find((t) => t.runId === currentOverviewRun) || trend.find((t) => t.runId === selectedRunId);
-    if (!entry) return new Set();
-    const selectedDate = (entry.dateISO || '').slice(0, 10);
-    const names = new Set();
-    for (const t of trend) {
-      if ((t.dateISO || '').slice(0, 10) === selectedDate) {
-        for (const d of t.dimensions || []) names.add(d.toLowerCase());
-      }
-    }
-    return names;
-  }, [trend, currentOverviewRun, selectedRunId]);
+  const selectedDayDimNames = useMemo(
+    () => collectDayDimensions(trend, currentOverviewRun) || collectDayDimensions(trend, selectedRunId),
+    [trend, currentOverviewRun, selectedRunId]
+  );
 
   const stats = useMemo(
     () => computeAccumulatedStats(accumulated, accumulatedDimensions),

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -4,7 +4,7 @@ import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, overviewRunIndex } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onPrincipleClick } = callbacks;
   if (runMode) {
@@ -36,7 +36,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
   return (
     <AccumulatedOverviewPanel
       data={{
-        accumulated, accumulatedDimensions, availableRuns, overviewRunIndex,
+        accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
         trend: dashboard?.trend || [], selectedRunId,
       }}
       callbacks={{

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -73,7 +73,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const {
     selectedProject, selectedRun, projects = [],
     dashboard, accumulated, loading, error,
-    availableRuns = [], overviewRunIndex = 0,
+    availableRuns = [], dailyRuns, overviewRunIndex = 0,
   } = data;
   const { onNavigate, onRunSelect } = callbacks;
   const [focusedDimension, setFocusedDimension] = useState(null);
@@ -96,7 +96,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {!loading && dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, overviewRunIndex }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
           callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onPrincipleClick: handlers.handlePrincipleClick }}
         />

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -6,7 +6,7 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
   const prevScore = parseFloat(item.previousScore);
   const delta = !isNaN(currScore) && !isNaN(prevScore) ? currScore - prevScore : null;
   const score = splitScore(item.overallScore);
-  const cardClass = `qd-card${evaluatedToday ? ' qd-card--active' : ' qd-card--carried'}`;
+  const cardClass = `qd-card${evaluatedToday ? ' qd-card--active' : ' qd-card-stale qd-card--carried'}`;
   return (
     <article
       className={cardClass}
@@ -38,6 +38,7 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
       </div>
       <div className="qd-card-footer">
         <span className="qd-card-date">{item.fromDateLabel || formatRunId(item.fromRunId)}</span>
+        {!evaluatedToday && <span className="qd-card-stale-label">Older run</span>}
       </div>
     </article>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -45,13 +45,13 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayRunIds }) {
-  // A dimension is "active" if its fromRunId matches any run on the selected day
-  const runIdSet = selectedDayRunIds || new Set();
+export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDimNames }) {
+  // A dimension is "active" if its name appears in the selected day's evaluations
+  const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
   const sorted = [...sortedDimensions].sort((a, b) => {
-    if (runIdSet.size === 0) return a.dimension.localeCompare(b.dimension);
-    const aActive = runIdSet.has(a.fromRunId);
-    const bActive = runIdSet.has(b.fromRunId);
+    if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);
+    const aActive = dimNameSet.has((a.dimension || '').toLowerCase());
+    const bActive = dimNameSet.has((b.dimension || '').toLowerCase());
     if (aActive && !bActive) return -1;
     if (!aActive && bActive) return 1;
     return a.dimension.localeCompare(b.dimension);
@@ -59,7 +59,7 @@ export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onD
   return (
     <div className="dimensions-grid">
       {sorted.map((item) => {
-        const isActive = runIdSet.size === 0 || runIdSet.has(item.fromRunId);
+        const isActive = dimNameSet.size === 0 || dimNameSet.has((item.dimension || '').toLowerCase());
         return (
           <AccDimensionCard
             key={item.dimension}

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -46,11 +46,11 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday
 }
 
 export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDate }) {
-  // Each dimension has fromDateISO — compare its date to the selected day
+  // Each dimension has fromDateIso — compare its date to the selected day
   const sorted = [...sortedDimensions].sort((a, b) => {
     if (!selectedDayDate) return a.dimension.localeCompare(b.dimension);
-    const aDate = (a.fromDateISO || '').slice(0, 10);
-    const bDate = (b.fromDateISO || '').slice(0, 10);
+    const aDate = (a.fromDateIso || '').slice(0, 10);
+    const bDate = (b.fromDateIso || '').slice(0, 10);
     const aActive = aDate === selectedDayDate;
     const bActive = bDate === selectedDayDate;
     if (aActive && !bActive) return -1;
@@ -60,7 +60,7 @@ export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onD
   return (
     <div className="dimensions-grid">
       {sorted.map((item) => {
-        const dimDate = (item.fromDateISO || '').slice(0, 10);
+        const dimDate = (item.fromDateIso || '').slice(0, 10);
         const isActive = !selectedDayDate || dimDate === selectedDayDate;
         return (
           <AccDimensionCard

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -45,14 +45,13 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDate }) {
-  // Each dimension has fromDateIso — compare its date to the selected day
+export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayRunIds }) {
+  // A dimension is "active" if its fromRunId matches any run on the selected day
+  const runIdSet = selectedDayRunIds || new Set();
   const sorted = [...sortedDimensions].sort((a, b) => {
-    if (!selectedDayDate) return a.dimension.localeCompare(b.dimension);
-    const aDate = (a.fromDateIso || '').slice(0, 10);
-    const bDate = (b.fromDateIso || '').slice(0, 10);
-    const aActive = aDate === selectedDayDate;
-    const bActive = bDate === selectedDayDate;
+    if (runIdSet.size === 0) return a.dimension.localeCompare(b.dimension);
+    const aActive = runIdSet.has(a.fromRunId);
+    const bActive = runIdSet.has(b.fromRunId);
     if (aActive && !bActive) return -1;
     if (!aActive && bActive) return 1;
     return a.dimension.localeCompare(b.dimension);
@@ -60,8 +59,7 @@ export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onD
   return (
     <div className="dimensions-grid">
       {sorted.map((item) => {
-        const dimDate = (item.fromDateIso || '').slice(0, 10);
-        const isActive = !selectedDayDate || dimDate === selectedDayDate;
+        const isActive = runIdSet.size === 0 || runIdSet.has(item.fromRunId);
         return (
           <AccDimensionCard
             key={item.dimension}

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -45,26 +45,33 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, dayDimensions = [] }) {
-  const dayDimSet = new Set(dayDimensions.map((d) => d.toLowerCase()));
+export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDate }) {
+  // Each dimension has fromDateISO — compare its date to the selected day
   const sorted = [...sortedDimensions].sort((a, b) => {
-    const aActive = dayDimSet.has((a.dimension || '').toLowerCase());
-    const bActive = dayDimSet.has((b.dimension || '').toLowerCase());
+    if (!selectedDayDate) return a.dimension.localeCompare(b.dimension);
+    const aDate = (a.fromDateISO || '').slice(0, 10);
+    const bDate = (b.fromDateISO || '').slice(0, 10);
+    const aActive = aDate === selectedDayDate;
+    const bActive = bDate === selectedDayDate;
     if (aActive && !bActive) return -1;
     if (!aActive && bActive) return 1;
     return a.dimension.localeCompare(b.dimension);
   });
   return (
     <div className="dimensions-grid">
-      {sorted.map((item) => (
-        <AccDimensionCard
-          key={item.dimension}
-          item={item}
-          referenceRun={referenceRun}
-          onDimensionClick={onDimensionClick}
-          evaluatedToday={dayDimSet.size === 0 || dayDimSet.has((item.dimension || '').toLowerCase())}
-        />
-      ))}
+      {sorted.map((item) => {
+        const dimDate = (item.fromDateISO || '').slice(0, 10);
+        const isActive = !selectedDayDate || dimDate === selectedDayDate;
+        return (
+          <AccDimensionCard
+            key={item.dimension}
+            item={item}
+            referenceRun={referenceRun}
+            onDimensionClick={onDimensionClick}
+            evaluatedToday={isActive}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -1,13 +1,12 @@
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import { formatRunId, gradeColorClass, splitScore } from '../../../utils/formatters.js';
 
-function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday = true }) {
-  const isStale = item.fromRunId !== referenceRun;
+function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
   const currScore = parseFloat(item.overallScore);
   const prevScore = parseFloat(item.previousScore);
   const delta = !isNaN(currScore) && !isNaN(prevScore) ? currScore - prevScore : null;
   const score = splitScore(item.overallScore);
-  const cardClass = `qd-card${isStale ? ' qd-card-stale' : ''}${evaluatedToday ? ' qd-card--active' : ' qd-card--carried'}`;
+  const cardClass = `qd-card${evaluatedToday ? ' qd-card--active' : ' qd-card--carried'}`;
   return (
     <article
       className={cardClass}
@@ -39,7 +38,6 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday
       </div>
       <div className="qd-card-footer">
         <span className="qd-card-date">{item.fromDateLabel || formatRunId(item.fromRunId)}</span>
-        {isStale && <span className="qd-card-stale-label">Older run</span>}
       </div>
     </article>
   );
@@ -64,7 +62,6 @@ export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onD
           <AccDimensionCard
             key={item.dimension}
             item={item}
-            referenceRun={referenceRun}
             onDimensionClick={onDimensionClick}
             evaluatedToday={isActive}
           />

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -1,15 +1,16 @@
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import { formatRunId, gradeColorClass, splitScore } from '../../../utils/formatters.js';
 
-function AccDimensionCard({ item, referenceRun, onDimensionClick }) {
+function AccDimensionCard({ item, referenceRun, onDimensionClick, evaluatedToday = true }) {
   const isStale = item.fromRunId !== referenceRun;
   const currScore = parseFloat(item.overallScore);
   const prevScore = parseFloat(item.previousScore);
   const delta = !isNaN(currScore) && !isNaN(prevScore) ? currScore - prevScore : null;
   const score = splitScore(item.overallScore);
+  const cardClass = `qd-card${isStale ? ' qd-card-stale' : ''}${evaluatedToday ? ' qd-card--active' : ' qd-card--carried'}`;
   return (
     <article
-      className={`qd-card${isStale ? ' qd-card-stale' : ''}`}
+      className={cardClass}
       onClick={() => onDimensionClick(item)}
       role="button"
       tabIndex={0}
@@ -26,7 +27,7 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick }) {
           <span className="qd-card-score">{score.value}</span>
           {score.denom && <span className="qd-card-score-denom">{score.denom}</span>}
         </span>
-        <TrendBadge delta={delta} />
+        {evaluatedToday && <TrendBadge delta={delta} />}
       </div>
       <div className="qd-card-stats">
         {(item.totals?.violationCount ?? 0) > 0 && (
@@ -44,11 +45,25 @@ function AccDimensionCard({ item, referenceRun, onDimensionClick }) {
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick }) {
+export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, dayDimensions = [] }) {
+  const dayDimSet = new Set(dayDimensions.map((d) => d.toLowerCase()));
+  const sorted = [...sortedDimensions].sort((a, b) => {
+    const aActive = dayDimSet.has((a.dimension || '').toLowerCase());
+    const bActive = dayDimSet.has((b.dimension || '').toLowerCase());
+    if (aActive && !bActive) return -1;
+    if (!aActive && bActive) return 1;
+    return a.dimension.localeCompare(b.dimension);
+  });
   return (
     <div className="dimensions-grid">
-      {sortedDimensions.map((item) => (
-        <AccDimensionCard key={item.dimension} item={item} referenceRun={referenceRun} onDimensionClick={onDimensionClick} />
+      {sorted.map((item) => (
+        <AccDimensionCard
+          key={item.dimension}
+          item={item}
+          referenceRun={referenceRun}
+          onDimensionClick={onDimensionClick}
+          evaluatedToday={dayDimSet.size === 0 || dayDimSet.has((item.dimension || '').toLowerCase())}
+        />
       ))}
     </div>
   );

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -564,13 +564,12 @@
 
 /* Dimension card — evaluated today (accent tint) */
 .qd-card--active {
-  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
-  border-color: color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
+  background: color-mix(in srgb, var(--color-accent) 3%, var(--color-surface));
 }
 
 /* Dimension card — carried forward from previous day */
-.qd-card--carried {
-  opacity: 0.55;
+.qd-card--carried .qd-card-score {
+  opacity: 0.7;
 }
 
 .qd-card-header {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -562,6 +562,16 @@
   border-style: dashed;
 }
 
+/* Dimension card — evaluated today (accent tint) */
+.qd-card--active {
+  background: color-mix(in srgb, var(--color-accent) 3%, var(--color-surface));
+}
+
+/* Dimension card — carried forward from previous day */
+.qd-card--carried .qd-card-score {
+  opacity: 0.7;
+}
+
 .qd-card-header {
   display: flex;
   align-items: center;

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -564,12 +564,13 @@
 
 /* Dimension card — evaluated today (accent tint) */
 .qd-card--active {
-  background: color-mix(in srgb, var(--color-accent) 3%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
 }
 
 /* Dimension card — carried forward from previous day */
-.qd-card--carried .qd-card-score {
-  opacity: 0.7;
+.qd-card--carried {
+  opacity: 0.55;
 }
 
 .qd-card-header {

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -1,0 +1,67 @@
+/**
+ * Collapse trend entries (newest-first) into one entry per calendar day.
+ * Keeps the first (newest) entry of each day, which has the most
+ * up-to-date accumulated state.
+ *
+ * @param {Array} trend - Trend entries, newest first
+ * @returns {Array} Collapsed entries, one per day
+ */
+export function collapseByDay(trend) {
+  if (!trend || trend.length === 0) return trend;
+  const collapsed = [];
+  let currentDay = null;
+  for (const entry of trend) {
+    const datePart = (entry.dateISO || '').slice(0, 10);
+    if (datePart !== currentDay) {
+      currentDay = datePart;
+      collapsed.push({ ...entry });
+    }
+  }
+  return collapsed;
+}
+
+/**
+ * Build a Set of dimension names evaluated on the selected day.
+ * Scans all raw trend entries matching the selected date.
+ *
+ * @param {Array} trend - Raw trend entries (all runs)
+ * @param {string} selectedRunId - The runId to find the selected day
+ * @returns {Set<string>} Lowercase dimension names evaluated that day
+ */
+export function collectDayDimensions(trend, selectedRunId) {
+  if (!trend || !trend.length || !selectedRunId) return new Set();
+  const entry = trend.find((t) => t.runId === selectedRunId);
+  if (!entry) return new Set();
+  const selectedDate = (entry.dateISO || '').slice(0, 10);
+  if (!selectedDate) return new Set();
+  const names = new Set();
+  for (const t of trend) {
+    if ((t.dateISO || '').slice(0, 10) === selectedDate) {
+      for (const d of t.dimensions || []) names.add(d.toLowerCase());
+    }
+  }
+  return names;
+}
+
+/**
+ * Build day-level available runs from raw available runs + trend.
+ * Keeps the first (newest) run per calendar day.
+ *
+ * @param {Array} availableRuns - Raw available runs (newest first)
+ * @param {Array} trend - Trend entries with dateISO
+ * @returns {Array} One entry per day
+ */
+export function buildDailyRuns(availableRuns, trend) {
+  if (!availableRuns || !availableRuns.length) return [];
+  const byDay = [];
+  let lastDate = null;
+  for (const run of availableRuns) {
+    const t = trend.find((r) => r.runId === run.runId);
+    const datePart = (t?.dateISO || '').slice(0, 10);
+    if (datePart !== lastDate) {
+      byDay.push(run);
+      lastDate = datePart;
+    }
+  }
+  return byDay;
+}

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { collapseByDay, collectDayDimensions, buildDailyRuns } from './dailyGrouping.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TREND = [
+  { runId: 'r1', dateISO: '2026-03-25T14:00:00', numericAverage: 9.5, overallGrade: 'Exemplary', dimensions: ['maintainability'] },
+  { runId: 'r2', dateISO: '2026-03-25T10:00:00', numericAverage: 9.3, overallGrade: 'Exemplary', dimensions: ['security'] },
+  { runId: 'r3', dateISO: '2026-03-24T18:00:00', numericAverage: 9.0, overallGrade: 'Exemplary', dimensions: ['maintainability', 'reliability'] },
+  { runId: 'r4', dateISO: '2026-03-24T08:00:00', numericAverage: 8.8, overallGrade: 'Good', dimensions: ['security'] },
+  { runId: 'r5', dateISO: '2026-03-23T12:00:00', numericAverage: 8.5, overallGrade: 'Good', dimensions: ['maintainability'] },
+];
+
+const AVAILABLE_RUNS = [
+  { runId: 'r1', dateLabel: '2026-03-25' },
+  { runId: 'r2', dateLabel: '2026-03-25' },
+  { runId: 'r3', dateLabel: '2026-03-24' },
+  { runId: 'r4', dateLabel: '2026-03-24' },
+  { runId: 'r5', dateLabel: '2026-03-23' },
+];
+
+// ---------------------------------------------------------------------------
+// collapseByDay
+// ---------------------------------------------------------------------------
+
+test('collapseByDay: groups by day, keeps newest entry per day', () => {
+  const result = collapseByDay(TREND);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].runId, 'r1'); // Mar 25 newest
+  assert.equal(result[1].runId, 'r3'); // Mar 24 newest
+  assert.equal(result[2].runId, 'r5'); // Mar 23
+});
+
+test('collapseByDay: newest entry has correct accumulated score', () => {
+  const result = collapseByDay(TREND);
+  assert.equal(result[0].numericAverage, 9.5); // Mar 25 newest run's score
+  assert.equal(result[1].numericAverage, 9.0); // Mar 24 newest run's score
+});
+
+test('collapseByDay: returns empty for empty input', () => {
+  assert.deepEqual(collapseByDay([]), []);
+  assert.deepEqual(collapseByDay(null), null);
+  assert.deepEqual(collapseByDay(undefined), undefined);
+});
+
+test('collapseByDay: single entry returns as-is', () => {
+  const single = [{ runId: 'x', dateISO: '2026-01-01T00:00:00' }];
+  const result = collapseByDay(single);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].runId, 'x');
+});
+
+test('collapseByDay: entries without dateISO get their own group', () => {
+  const trend = [
+    { runId: 'a', dateISO: '2026-03-25T10:00:00' },
+    { runId: 'b', dateISO: null },
+    { runId: 'c', dateISO: '2026-03-25T08:00:00' },
+  ];
+  const result = collapseByDay(trend);
+  // 'a' = Mar 25, 'b' = empty string date (new group), 'c' = Mar 25 but after empty group = new group
+  assert.equal(result.length, 3);
+});
+
+// ---------------------------------------------------------------------------
+// collectDayDimensions
+// ---------------------------------------------------------------------------
+
+test('collectDayDimensions: collects all dims from all runs on the selected day', () => {
+  const dims = collectDayDimensions(TREND, 'r3'); // Mar 24
+  assert.equal(dims.size, 3); // maintainability, reliability, security
+  assert.ok(dims.has('maintainability'));
+  assert.ok(dims.has('reliability'));
+  assert.ok(dims.has('security'));
+});
+
+test('collectDayDimensions: Mar 25 has maintainability + security', () => {
+  const dims = collectDayDimensions(TREND, 'r1');
+  assert.equal(dims.size, 2);
+  assert.ok(dims.has('maintainability'));
+  assert.ok(dims.has('security'));
+});
+
+test('collectDayDimensions: single-run day returns just that run dims', () => {
+  const dims = collectDayDimensions(TREND, 'r5'); // Mar 23, only maintainability
+  assert.equal(dims.size, 1);
+  assert.ok(dims.has('maintainability'));
+});
+
+test('collectDayDimensions: unknown runId returns empty set', () => {
+  const dims = collectDayDimensions(TREND, 'unknown');
+  assert.equal(dims.size, 0);
+});
+
+test('collectDayDimensions: null/empty inputs return empty set', () => {
+  assert.equal(collectDayDimensions(null, 'r1').size, 0);
+  assert.equal(collectDayDimensions([], 'r1').size, 0);
+  assert.equal(collectDayDimensions(TREND, null).size, 0);
+});
+
+test('collectDayDimensions: dimension names are lowercased', () => {
+  const trend = [
+    { runId: 'a', dateISO: '2026-01-01T00:00:00', dimensions: ['Maintainability', 'SECURITY'] },
+  ];
+  const dims = collectDayDimensions(trend, 'a');
+  assert.ok(dims.has('maintainability'));
+  assert.ok(dims.has('security'));
+  assert.ok(!dims.has('Maintainability'));
+});
+
+// ---------------------------------------------------------------------------
+// buildDailyRuns
+// ---------------------------------------------------------------------------
+
+test('buildDailyRuns: keeps first (newest) run per day', () => {
+  const result = buildDailyRuns(AVAILABLE_RUNS, TREND);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].runId, 'r1'); // Mar 25
+  assert.equal(result[1].runId, 'r3'); // Mar 24
+  assert.equal(result[2].runId, 'r5'); // Mar 23
+});
+
+test('buildDailyRuns: empty input returns empty', () => {
+  assert.deepEqual(buildDailyRuns([], TREND), []);
+  assert.deepEqual(buildDailyRuns(null, TREND), []);
+});
+
+test('buildDailyRuns: all runs on same day returns one entry', () => {
+  const runs = [
+    { runId: 'r1', dateLabel: 'Mar 25' },
+    { runId: 'r2', dateLabel: 'Mar 25' },
+  ];
+  const trend = [
+    { runId: 'r1', dateISO: '2026-03-25T14:00:00' },
+    { runId: 'r2', dateISO: '2026-03-25T10:00:00' },
+  ];
+  const result = buildDailyRuns(runs, trend);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].runId, 'r1');
+});


### PR DESCRIPTION
## Summary

Groups the Overview page by calendar day instead of individual evaluation runs.

### Chart & Navigator
- **Score history chart** shows one bar per day (multiple same-day runs collapsed)
- **Day navigator** steps day by day: Latest | ‹ 25 March 2026 › — no "View run" button
- Chart bar highlights the selected day correctly when navigating

### Dimension Cards
- **Evaluated today**: subtle accent background tint (option G), solid border, trend arrows shown
- **Carried forward**: stale styling (dashed border, 85% opacity, "Older run" label), no trend arrows
- Active dimensions sorted first, carried forward after
- Highlight matches by dimension **name** from raw trend data (independent of accumulated API timing)

### Data Flow
- `dailyRuns` computed on frontend from `availableRuns` + `dashboard.trend` (keeps newest run per day)
- `collapseByDay` groups trend for chart display only — History tab still shows individual runs
- `collectDayDimensions` scans all runs on selected date to build dimension name set
- Accumulated API re-fetches with `asOf` parameter when navigating to past days

### Code Quality
- Extracted `collapseByDay`, `collectDayDimensions`, `buildDailyRuns` into `utils/dailyGrouping.js`
- **14 unit tests** covering all edge cases
- Removed dead backend `_collapse_by_day` function
- Extracted inline IIFEs into named functions

## Test plan
- [x] Overview chart shows one bar per day (verify days with multiple runs show single bar)
- [x] Day navigator steps day by day, not run by run
- [x] Navigate to a past day — verify dimension cards highlight correctly (accent tint for evaluated, dashed for carried)
- [x] Navigate to a day with multiple runs evaluating different dimensions — all should highlight
- [x] Verify accumulated scores update when navigating (hero section, dimension scores)
- [x] History tab still shows individual runs (not grouped)
- [x] Run all tests: `cd src/quodeq/ui && node --test src/utils/dailyGrouping.test.js`