### PR TITLE
fix: resolve 51 maintainability violations

### DIFF
--- a/packaging/macos/_helpers.py
+++ b/packaging/macos/_helpers.py
@@ -13,15 +13,22 @@ _HOMEBREW_ARM64 = "/opt/homebrew/bin"
 _HOMEBREW_X86 = "/usr/local/bin"
 
 
-def _homebrew_bin_dirs() -> str:
-    """Return Homebrew bin directories based on the CPU architecture."""
+def _homebrew_bin_dirs(
+    arm64_path: str = _HOMEBREW_ARM64,
+    x86_path: str = _HOMEBREW_X86,
+) -> str:
+    """Return Homebrew bin directories based on the CPU architecture.
+
+    *arm64_path* and *x86_path* can be overridden for testing or
+    non-standard Homebrew installations.
+    """
     import platform
     arch = platform.machine()
     if arch == "arm64":
-        return _HOMEBREW_ARM64
+        return arm64_path
     elif arch == "x86_64":
-        return _HOMEBREW_X86
-    return f"{_HOMEBREW_ARM64}:{_HOMEBREW_X86}"
+        return x86_path
+    return f"{arm64_path}:{x86_path}"
 
 def source_user_path() -> None:
     """Load the user's shell PATH since .app bundles don't inherit it."""
@@ -49,14 +56,31 @@ def find_icon(name: str) -> str | None:
     return None
 
 
+def find_commands(env: dict[str, str] | None = None) -> dict[str, str | None]:
+    """Check which required commands are available.
+
+    An optional *env* mapping can be passed to override the subprocess
+    environment (useful for testing).  When *env* is ``None`` the result
+    is cached; when a custom *env* is supplied the cache is bypassed so
+    callers can test with different PATH values.
+    """
+    if env is None:
+        return _find_commands_cached()
+    return _find_commands_uncached(env)
+
+
 @functools.lru_cache(maxsize=1)
-def find_commands() -> dict[str, str | None]:
-    """Check which required commands are available (cached after first call)."""
-    cmds = {}
+def _find_commands_cached() -> dict[str, str | None]:
+    return _find_commands_uncached(env=None)
+
+
+def _find_commands_uncached(env: dict[str, str] | None) -> dict[str, str | None]:
+    cmds: dict[str, str | None] = {}
     for name in ("python3", "node", "claude", "quodeq"):
         try:
             result = subprocess.run(
                 ["which", name], capture_output=True, text=True, timeout=5,
+                env=env,
             )
             cmds[name] = result.stdout.strip() if result.returncode == 0 else None
         except (subprocess.TimeoutExpired, OSError):

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 # Quodeq macOS launcher — starts the dashboard and opens the browser.
 
+# Default ports for the Vite preview server range.
+_DEFAULT_PORTS="4173 4174 4175"
+
 # macOS .app bundles don't inherit the user's shell PATH.
 if [ -f "$HOME/.zprofile" ]; then source "$HOME/.zprofile" 2>/dev/null; fi
 if [ -f "$HOME/.zshrc" ]; then source "$HOME/.zshrc" 2>/dev/null; fi
@@ -18,7 +21,7 @@ export PATH="$PATH:$HOME/.local/bin:$_HOMEBREW_BIN"
 
 # If dashboard is already running, just open the browser.
 # Ports 4173-4175 are the Vite preview server default range.
-QUODEQ_PORTS="${QUODEQ_PORTS:-4173 4174 4175}"
+QUODEQ_PORTS="${QUODEQ_PORTS:-$_DEFAULT_PORTS}"
 for PORT in $QUODEQ_PORTS; do
     if curl -s --max-time 3 "http://127.0.0.1:$PORT/api/health" 2>/dev/null | grep -q '"ok"'; then
         open "http://127.0.0.1:$PORT"

--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -26,13 +26,14 @@ _AUTO_START_DELAY_S = 1.5
 _HEALTH_POLL_INTERVAL_S = 0.5
 _STDERR_READ_MAX = 500
 _ERROR_DISPLAY_MAX = 200
+_DEFAULT_PORTS = "4173,4174,4175,4180,4181,4182,4183"
 
 
 def _load_config(env=None):
     """Read port configuration from the environment (or an injected mapping)."""
     env = env or os.environ
     app_port = int(env.get("QUODEQ_PORT", "4173"))
-    ports = tuple(int(p) for p in env.get("QUODEQ_PORTS", "4173,4174,4175,4180,4181,4182,4183").split(","))
+    ports = tuple(int(p) for p in env.get("QUODEQ_PORTS", _DEFAULT_PORTS).split(","))
     return app_port, ports
 
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,8 +16,10 @@ cp -r "$UI_WEB/dist" "$STATIC_DEST"
 
 echo "==> Syncing engine_version in plugin files..."
 VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('$ROOT/pyproject.toml','rb'))['project']['version'])")
+ENGINE_VERSION_PATTERN='"engine_version": "==[^"]*"'
+ENGINE_VERSION_REPLACE="\"engine_version\": \"==$VERSION\""
 find "$ROOT/evaluators" "$ROOT/tests" -name "plugin.json" -exec \
-  sed -i '' "s/\"engine_version\": \"==[^\"]*\"/\"engine_version\": \"==$VERSION\"/" {} +
+  sed -i '' "s/$ENGINE_VERSION_PATTERN/$ENGINE_VERSION_REPLACE/" {} +
 echo "    engine_version set to ==$VERSION"
 
 echo "==> Building Python package..."

--- a/src/quodeq/analysis/_backfill.py
+++ b/src/quodeq/analysis/_backfill.py
@@ -64,7 +64,7 @@ def _collect_backfill_taken(evidence_dir: Path, dimension: str, output_jsonl: Pa
         from quodeq.analysis.subagents.file_queue import FileQueue
         try:
             backfill_taken = set(FileQueue(backfill_queue).all_taken_files())
-        except Exception as exc:
+        except (OSError, KeyError, ValueError, _json.JSONDecodeError) as exc:
             log_debug(f"Cannot read backfill queue {backfill_queue}: {exc}")
     from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
     if output_jsonl.exists():

--- a/src/quodeq/analysis/_incremental.py
+++ b/src/quodeq/analysis/_incremental.py
@@ -149,9 +149,6 @@ def _run_phase1_analysis(
     return ev
 
 
-_run_backfill_phase = run_backfill_phase
-
-
 def _finalize_incremental(
     config: RunConfig, dimension: str, ctx: _AnalysisContext,
     coverage: IncrementalCoverage,

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from copy import copy
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from quodeq.core.evidence.model import Evidence
 from quodeq.shared.logging import log_info, log_warning
@@ -35,12 +35,14 @@ def check_zero_findings(
 
 def run_incremental_loop(
     config: "RunConfig", dimensions: list[str], ctx: "_AnalysisContext",
+    *, process_fn: Callable[..., "Evidence | None"] | None = None,
 ) -> dict[str, "Evidence"]:
     """Run incremental per-dimension analysis."""
     from quodeq.analysis._incremental import run_dimension_incremental
     from quodeq.analysis.runner import _process_single_dimension, _log_dimension_result
     from quodeq.engine._runner_markers import emit_marker
 
+    _process = process_fn or _process_single_dimension
     result: dict[str, Evidence] = {}
     for idx, dimension in enumerate(dimensions, 1):
         emit_marker("analyzing", dimension=dimension)
@@ -53,7 +55,7 @@ def run_incremental_loop(
             config.options = copy(original_options)
             config.options.incremental_file_filter = None
             try:
-                ev = _process_single_dimension(config, dimension, idx, ctx)
+                ev = _process(config, dimension, idx, ctx)
             finally:
                 config.options = original_options
         if ev:
@@ -65,15 +67,17 @@ def run_incremental_loop(
 
 def run_per_dimension_loop(
     config: "RunConfig", dimensions: list[str], ctx: "_AnalysisContext",
+    *, process_fn: Callable[..., "Evidence | None"] | None = None,
 ) -> dict[str, "Evidence"]:
     """Per-dimension loop (fallback or single-dimension)."""
     from quodeq.analysis.runner import _process_single_dimension
 
+    _process = process_fn or _process_single_dimension
     result: dict[str, Evidence] = {}
     skipped_count = 0
     for idx, dimension in enumerate(dimensions, 1):
         try:
-            ev = _process_single_dimension(config, dimension, idx, ctx)
+            ev = _process(config, dimension, idx, ctx)
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 failed: {exc}")
             skipped_count += 1

--- a/src/quodeq/analysis/subagents/_file_lock.py
+++ b/src/quodeq/analysis/subagents/_file_lock.py
@@ -7,23 +7,32 @@ from __future__ import annotations
 
 import sys
 
-if sys.platform == "win32":
-    import msvcrt as _lock_mod
-else:
-    import fcntl as _lock_mod  # type: ignore[no-redef]
+
+def _make_lock_ops() -> tuple:
+    """Return (lock_fn, unlock_fn) for the current platform."""
+    if sys.platform == "win32":
+        import msvcrt
+        def _lock(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        def _unlock(fd: int) -> None:
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+        def _lock(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        def _unlock(fd: int) -> None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    return _lock, _unlock
+
+
+_lock_impl, _unlock_impl = _make_lock_ops()
 
 
 def lock_file(fd: int) -> None:
     """Acquire an exclusive lock on the file descriptor."""
-    if sys.platform == "win32":
-        _lock_mod.locking(fd, _lock_mod.LK_LOCK, 1)
-    else:
-        _lock_mod.flock(fd, _lock_mod.LOCK_EX)
+    _lock_impl(fd)
 
 
 def unlock_file(fd: int) -> None:
     """Release the lock on the file descriptor."""
-    if sys.platform == "win32":
-        _lock_mod.locking(fd, _lock_mod.LK_UNLCK, 1)
-    else:
-        _lock_mod.flock(fd, _lock_mod.LOCK_UN)
+    _unlock_impl(fd)

--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -1,0 +1,86 @@
+"""Verification step helpers — extracted from runner.py for file-length limits."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from quodeq.shared.logging import log_info, log_success
+
+if TYPE_CHECKING:
+    from quodeq.analysis.runner import RunConfig
+
+
+def _run_verification_pool(
+    config: RunConfig, dim_id: str, evidence_dir: Path,
+    files_to_verify: list[str], manifest_path: Path,
+) -> list[Any]:
+    """Launch a fast verification pool to re-check previous findings."""
+    from quodeq.analysis.subagents._verify_pool import run_verification_pool
+    return run_verification_pool(config, dim_id, evidence_dir, files_to_verify, manifest_path)
+
+
+def _load_and_filter_previous(
+    config: RunConfig, dim_id: str, evidence_dir: Path,
+) -> list[dict]:
+    """Load previous findings and apply incremental file filter if active."""
+    from quodeq.analysis.subagents.verify import load_previous_findings_for_dimension
+
+    prev_findings = load_previous_findings_for_dimension(config, dim_id, evidence_dir)
+    if not prev_findings:
+        return []
+    if config.options.incremental_file_filter is not None:
+        filter_set = config.options.incremental_file_filter
+        prev_findings = [f for f in prev_findings if f.get("file") in filter_set]
+    return prev_findings
+
+
+def _dispatch_verification_pool(
+    config: RunConfig, dim_id: str, evidence_dir: Path, needs_verify: list[dict],
+) -> list:
+    """Write manifest and launch the AI verification pool for changed-file findings."""
+    from quodeq.analysis.subagents.verify import _group_by_file, _write_verify_manifest
+
+    grouped = _group_by_file(needs_verify)
+    manifest_path = evidence_dir / f"{dim_id}_verify_manifest.json"
+    _write_verify_manifest(grouped, manifest_path)
+    files_to_verify = list(grouped.keys())
+    log_info(f"  [{dim_id}] Launching fast verification pool for {len(needs_verify)} findings across {len(files_to_verify)} files")
+    verify_results = _run_verification_pool(config, dim_id, evidence_dir, files_to_verify, manifest_path)
+    log_success(f"  [{dim_id}] Verification pool complete")
+    return verify_results
+
+
+def _run_verification_step(
+    config: RunConfig, dim_id: str, evidence_dir: Path, files: list[str],
+    prev_fingerprint: dict | None = None,
+) -> list:
+    """Load previous findings and run AI verification pool if needed.
+
+    Uses fingerprint hashes to skip verification for unchanged files —
+    their findings are carried forward directly to the evidence JSONL.
+    Only changed-file findings are sent to the AI verification pool.
+    """
+    from quodeq.analysis.subagents.verify import (
+        partition_findings_by_fingerprint, write_carry_forward_findings,
+    )
+
+    prev_findings = _load_and_filter_previous(config, dim_id, evidence_dir)
+    if not prev_findings:
+        return []
+
+    if prev_fingerprint is None:
+        from quodeq.analysis.fingerprint import find_previous_fingerprint
+        prev_fingerprint, _ = find_previous_fingerprint(evidence_dir, dim_id)
+
+    carry_forward, needs_verify = partition_findings_by_fingerprint(
+        prev_findings, prev_fingerprint, config.src,
+        standards_dir=config.standards_dir, dimension=dim_id,
+    )
+    if carry_forward:
+        written = write_carry_forward_findings(carry_forward, evidence_dir, dim_id)
+        log_info(f"  [{dim_id}] {written} findings carried forward (unchanged files)")
+    if not needs_verify:
+        log_info(f"  [{dim_id}] All previous findings carried forward — skipping verification pool")
+        return []
+
+    return _dispatch_verification_pool(config, dim_id, evidence_dir, needs_verify)

--- a/src/quodeq/analysis/subagents/priority.py
+++ b/src/quodeq/analysis/subagents/priority.py
@@ -120,18 +120,27 @@ def compute_fan_in(
         except OSError:
             continue
         for line in content.splitlines():
-            for pattern in compiled:
-                m = pattern.search(line)
-                if m:
-                    imported = m.group(1)
-                    module_name = imported.rsplit(".", 1)[-1].rsplit("/", 1)[-1]
-                    if module_name in stem_to_file:
-                        target = stem_to_file[module_name]
-                        if target != f:
-                            counts[target] = counts.get(target, 0) + 1
-                    break
+            target = _match_import_target(line, compiled, stem_to_file, f)
+            if target is not None:
+                counts[target] = counts.get(target, 0) + 1
 
     return counts
+
+
+def _match_import_target(
+    line: str, compiled: list[re.Pattern], stem_to_file: dict[str, str], current_file: str,
+) -> str | None:
+    """Match a single line against import patterns and return the target file, or None."""
+    for pattern in compiled:
+        m = pattern.search(line)
+        if m:
+            imported = m.group(1)
+            module_name = imported.rsplit(".", 1)[-1].rsplit("/", 1)[-1]
+            target = stem_to_file.get(module_name)
+            if target is not None and target != current_file:
+                return target
+            return None
+    return None
 
 
 def _run_git_log(src: Path, months: int = 3) -> str | None:

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -20,11 +20,21 @@ if TYPE_CHECKING:
     from quodeq.analysis.runner import RunConfig
 
 _MAX_FILES_PER_AGENT = 30
+_MAX_FILES_PER_AGENT_CAP = 50
 
 
 def _compute_files_per_agent(total_files: int) -> int:
-    """Compute adaptive max files per agent. Capped at 50 to avoid turn limits."""
-    return min(total_files, 50) if total_files > 0 else 0
+    """Compute adaptive max files per agent. Capped to avoid turn limits."""
+    return min(total_files, _MAX_FILES_PER_AGENT_CAP) if total_files > 0 else 0
+
+
+# Re-export verification helpers (extracted to _verification.py for file-length limits)
+from quodeq.analysis.subagents._verification import (  # noqa: E402,F401
+    _dispatch_verification_pool,
+    _load_and_filter_previous,
+    _run_verification_pool,
+    _run_verification_step,
+)
 
 
 @dataclass
@@ -135,15 +145,6 @@ def _launch_pool(config: RunConfig, dim_id: str, params: LaunchPoolParams) -> tu
     return pool, pool.run()
 
 
-def _run_verification_pool(
-    config: RunConfig, dim_id: str, evidence_dir: Path,
-    files_to_verify: list[str], manifest_path: Path,
-) -> list[Any]:
-    """Launch a fast verification pool to re-check previous findings."""
-    from quodeq.analysis.subagents._verify_pool import run_verification_pool
-    return run_verification_pool(config, dim_id, evidence_dir, files_to_verify, manifest_path)
-
-
 def _collect_evidence(config: RunConfig, dim_id: str, evidence_dir: Path, results: list[Any], ctx: Any) -> Evidence:
     """Deduplicate JSONL, count files read, and parse into Evidence."""
     from quodeq.engine._runner_markers import cleanup_stream
@@ -179,73 +180,6 @@ def process_consolidated_dimensions(
     """Run all dimensions in a single pass -- files read once, not per dimension."""
     from quodeq.analysis.subagents._consolidated import process_consolidated_dimensions as _impl
     return _impl(config, dimensions, ctx)
-
-
-def _load_and_filter_previous(
-    config: RunConfig, dim_id: str, evidence_dir: Path,
-) -> list[dict]:
-    """Load previous findings and apply incremental file filter if active."""
-    from quodeq.analysis.subagents.verify import load_previous_findings_for_dimension
-
-    prev_findings = load_previous_findings_for_dimension(config, dim_id, evidence_dir)
-    if not prev_findings:
-        return []
-    if config.options.incremental_file_filter is not None:
-        filter_set = config.options.incremental_file_filter
-        prev_findings = [f for f in prev_findings if f.get("file") in filter_set]
-    return prev_findings
-
-
-def _dispatch_verification_pool(
-    config: RunConfig, dim_id: str, evidence_dir: Path, needs_verify: list[dict],
-) -> list:
-    """Write manifest and launch the AI verification pool for changed-file findings."""
-    from quodeq.analysis.subagents.verify import _group_by_file, _write_verify_manifest
-
-    grouped = _group_by_file(needs_verify)
-    manifest_path = evidence_dir / f"{dim_id}_verify_manifest.json"
-    _write_verify_manifest(grouped, manifest_path)
-    files_to_verify = list(grouped.keys())
-    log_info(f"  [{dim_id}] Launching fast verification pool for {len(needs_verify)} findings across {len(files_to_verify)} files")
-    verify_results = _run_verification_pool(config, dim_id, evidence_dir, files_to_verify, manifest_path)
-    log_success(f"  [{dim_id}] Verification pool complete")
-    return verify_results
-
-
-def _run_verification_step(
-    config: RunConfig, dim_id: str, evidence_dir: Path, files: list[str],
-    prev_fingerprint: dict | None = None,
-) -> list:
-    """Load previous findings and run AI verification pool if needed.
-
-    Uses fingerprint hashes to skip verification for unchanged files —
-    their findings are carried forward directly to the evidence JSONL.
-    Only changed-file findings are sent to the AI verification pool.
-    """
-    from quodeq.analysis.subagents.verify import (
-        partition_findings_by_fingerprint, write_carry_forward_findings,
-    )
-
-    prev_findings = _load_and_filter_previous(config, dim_id, evidence_dir)
-    if not prev_findings:
-        return []
-
-    if prev_fingerprint is None:
-        from quodeq.analysis.fingerprint import find_previous_fingerprint
-        prev_fingerprint, _ = find_previous_fingerprint(evidence_dir, dim_id)
-
-    carry_forward, needs_verify = partition_findings_by_fingerprint(
-        prev_findings, prev_fingerprint, config.src,
-        standards_dir=config.standards_dir, dimension=dim_id,
-    )
-    if carry_forward:
-        written = write_carry_forward_findings(carry_forward, evidence_dir, dim_id)
-        log_info(f"  [{dim_id}] {written} findings carried forward (unchanged files)")
-    if not needs_verify:
-        log_info(f"  [{dim_id}] All previous findings carried forward — skipping verification pool")
-        return []
-
-    return _dispatch_verification_pool(config, dim_id, evidence_dir, needs_verify)
 
 
 def process_dimension_with_subagents(

--- a/src/quodeq/analysis/subagents/verify.py
+++ b/src/quodeq/analysis/subagents/verify.py
@@ -14,6 +14,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from quodeq.analysis.subagents._verify_pool import build_verify_prompt  # noqa: F401 — re-export
 from quodeq.data.fs.report_parser.runs import list_runs
 from quodeq.shared.logging import log_debug, log_info, log_success
 from quodeq.shared.utils import open_text
@@ -178,9 +179,6 @@ def _write_verify_manifest(
     Each verification subagent reads this to know which findings to re-check.
     """
     output_path.write_text(json.dumps(grouped, indent=2))
-
-
-from quodeq.analysis.subagents._verify_pool import build_verify_prompt  # noqa: F401 — re-export
 
 
 def _resolve_evidence_paths(evidence_dir: Path) -> tuple[str, str, Path] | None:

--- a/src/quodeq/core/scoring/engine.py
+++ b/src/quodeq/core/scoring/engine.py
@@ -186,22 +186,30 @@ def _compute_tallies(
     return vt_counts, ct_counts, using_taxonomy
 
 
+def _extract_metrics(pdata: dict) -> tuple[float, str, bool, int]:
+    """Extract compliance percentage, confidence level, balance, and instance count from principle data."""
+    metrics = pdata.get("metrics", {})
+    return (
+        metrics.get("compliance_percentage", 0.0),
+        metrics.get("confidence_level", "medium"),
+        metrics.get("is_balanced", True),
+        metrics.get("total_instances", 0),
+    )
+
+
 def _build_principle_context(
     key: str, pdata: dict, scale_mult: int, files_read: int,
 ) -> _PrincipleContext:
     """Extract evidence data for a single principle and return a scoring context."""
-    metrics = pdata.get("metrics", {})
-    pct = metrics.get("compliance_percentage", 0.0)
-    conf_level = metrics.get("confidence_level", "medium")
-
+    pct, conf_level, is_balanced, total_instances = _extract_metrics(pdata)
     vt_counts, ct_counts, using_taxonomy = _compute_tallies(
         pdata.get("violations", []), pdata.get("compliance", []),
     )
     dampen = compliance_dampening(ct_counts, vt_counts)
     ci = confidence_interval_for(
         confidence_level=conf_level,
-        is_balanced=metrics.get("is_balanced", True),
-        total_instances=metrics.get("total_instances", 0),
+        is_balanced=is_balanced,
+        total_instances=total_instances,
         files_read=files_read,
     )
     return _PrincipleContext(

--- a/src/quodeq/core/types/_mapper_entities.py
+++ b/src/quodeq/core/types/_mapper_entities.py
@@ -138,8 +138,8 @@ def parse_plugin_info(raw: dict[str, object]) -> PluginInfo:
 def _parse_progress_info(raw: dict[str, object]) -> ProgressInfo:
     return ProgressInfo(
         files_read=_int(raw, "filesRead"),
-        violations=_int(raw, "violations"),
-        compliance=_int(raw, "compliance"),
+        violation_count=_int(raw, "violationCount") or _int(raw, "violations"),
+        compliance_count=_int(raw, "complianceCount") or _int(raw, "compliance"),
     )
 
 

--- a/src/quodeq/core/types/mappers.py
+++ b/src/quodeq/core/types/mappers.py
@@ -57,7 +57,7 @@ def _extract_totals(raw: dict[str, object]) -> Totals | None:
 
 def parse_principle_grade(raw: dict[str, object]) -> PrincipleGrade:
     return PrincipleGrade(
-        name=_opt_str(raw.get("name")),
+        principle=_opt_str(raw.get("name")) or _opt_str(raw.get("principle")),
         score=_opt_str(raw.get("score")),
         grade=_opt_str(raw.get("grade")),
     )

--- a/src/quodeq/core/types/report.py
+++ b/src/quodeq/core/types/report.py
@@ -7,7 +7,7 @@ from .finding import Finding, Totals
 
 @dataclass(frozen=True, slots=True)
 class PrincipleGrade:
-    name: str | None = None
+    principle: str | None = None
     score: str | None = None
     grade: str | None = None
 

--- a/src/quodeq/core/types/violation.py
+++ b/src/quodeq/core/types/violation.py
@@ -8,8 +8,8 @@ from .finding import Finding
 @dataclass(frozen=True, slots=True)
 class ProgressInfo:
     files_read: int = 0
-    violations: int = 0
-    compliance: int = 0
+    violation_count: int = 0
+    compliance_count: int = 0
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -32,9 +32,15 @@ from quodeq.shared.prereqs import check_dashboard_prereqs
 from quodeq.shared.utils import IS_WIN32
 
 
-def _local_hosts(env: dict[str, str] | None = None) -> frozenset[str]:
+_DEFAULT_LOCAL_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
+
+
+def _local_hosts(
+    env: dict[str, str] | None = None,
+    defaults: frozenset[str] | None = None,
+) -> frozenset[str]:
     extra = (env if env is not None else os.environ).get("QUODEQ_LOCAL_HOSTS", "")
-    base = {"127.0.0.1", "localhost", "::1", "0.0.0.0"}
+    base = set(defaults or _DEFAULT_LOCAL_HOSTS)
     if extra:
         base.update(h.strip() for h in extra.split(",") if h.strip())
     return frozenset(base)

--- a/src/quodeq/services/_dashboard_trend.py
+++ b/src/quodeq/services/_dashboard_trend.py
@@ -1,0 +1,82 @@
+"""Accumulated-trend builder for the dashboard module."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from quodeq.adapters.fs.report_parser import RunInfo, most_frequent_grade
+from quodeq.core.scoring.internals import score_to_grade_label
+from quodeq.core.types import DimensionResult
+from quodeq.data.fs.report_parser.grades import parse_numeric_score
+from quodeq.services.accumulated import numeric_average
+
+
+def _build_dimension_details(
+    run_dims: list[DimensionResult],
+    prev_by_dim: dict[str, DimensionResult],
+) -> list[dict[str, Any]]:
+    """Build per-dimension detail dicts with score deltas for a single run."""
+    details = []
+    for dim in sorted(run_dims, key=lambda d: d.dimension or ""):
+        if not dim.dimension:
+            continue
+        prev = prev_by_dim.get(dim.dimension)
+        score = parse_numeric_score(dim.overall_score) if dim.overall_score else None
+        prev_score = parse_numeric_score(prev.overall_score) if prev and prev.overall_score else None
+        delta = round(score - prev_score, 2) if score is not None and prev_score is not None else None
+        details.append({
+            "dimension": dim.dimension,
+            "score": score,
+            "grade": dim.overall_grade,
+            "delta": delta,
+        })
+    return details
+
+
+def build_accumulated_trend(
+    runs: list[RunInfo],
+    get_run_dimensions: Callable[[str], list[DimensionResult]],
+) -> list[dict[str, Any]]:
+    """Build trend using accumulated scores across all runs (oldest to newest)."""
+    trend: list[dict[str, Any]] = []
+    acc_by_dim: dict[str, DimensionResult] = {}
+    prev_by_dim: dict[str, DimensionResult] = {}
+    for item in reversed(runs):  # oldest -> newest
+        run_dims = get_run_dimensions(item.run_id)
+        for dim in run_dims:
+            if dim.dimension:
+                acc_by_dim[dim.dimension] = dim
+        if not run_dims:
+            continue
+        acc_dims = list(acc_by_dim.values())
+        acc_grades = [d.overall_grade for d in acc_dims if d.overall_grade]
+        acc_avg = numeric_average(acc_dims)
+        run_avg = numeric_average(run_dims)
+        run_grades = [d.overall_grade for d in run_dims if d.overall_grade]
+        run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
+        dim_details = _build_dimension_details(run_dims, prev_by_dim)
+        for dim in run_dims:
+            if dim.dimension:
+                prev_by_dim[dim.dimension] = dim
+        trend.append(
+            {
+                "runId": item.run_id,
+                "dateISO": item.date_iso,
+                "dateLabel": item.date_label,
+                "dimensionsCount": len(run_dim_names),
+                "dimensions": run_dim_names,
+                "dimensionDetails": dim_details,
+                "accumulatedDimensionsCount": len(acc_by_dim),
+                "runNumericAverage": run_avg,
+                "runOverallGrade": (
+                    score_to_grade_label(run_avg) if run_avg is not None
+                    else (most_frequent_grade(run_grades) if run_grades else None)
+                ),
+                "numericAverage": acc_avg,
+                "overallGrade": (
+                    score_to_grade_label(acc_avg) if acc_avg is not None
+                    else (most_frequent_grade(acc_grades) if acc_grades else None)
+                ),
+            }
+        )
+    trend.reverse()
+    return trend

--- a/src/quodeq/services/_filesystem_helpers.py
+++ b/src/quodeq/services/_filesystem_helpers.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import functools
 import json
-import os
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 from quodeq.config.paths import default_paths
 from quodeq.core.types import ProjectEntry
+from quodeq.shared.utils import _env_int
 from quodeq.adapters.fs.report_parser import (
     RunInfo,
     read_run_data,
@@ -119,13 +119,7 @@ def _max_projects_listed(override: int | None = None, env: dict[str, str] | None
     """Return the max number of projects to list. *override* bypasses env."""
     if override is not None:
         return override
-    raw = (env or os.environ).get("QUODEQ_MAX_PROJECTS_LISTED")
-    if raw is None:
-        return _DEFAULT_MAX_PROJECTS_LISTED
-    try:
-        return int(raw)
-    except ValueError:
-        return _DEFAULT_MAX_PROJECTS_LISTED
+    return _env_int("QUODEQ_MAX_PROJECTS_LISTED", _DEFAULT_MAX_PROJECTS_LISTED, env=env)
 
 
 def _auto_detect_parents(projects: list[ProjectEntry]) -> list[ProjectEntry]:

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -1,7 +1,6 @@
 """Accumulated (cross-run) view logic for the filesystem action provider."""
 from __future__ import annotations
 
-import os
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass, field, replace
@@ -19,28 +18,44 @@ from quodeq.adapters.fs.report_parser import (
 from quodeq.core.types import DimensionResult, to_camel_dict
 from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.shared.utils import _env_int
+
+_DEFAULT_ACC_CACHE_MAX = 256
 
 
 def create_accumulated_cache() -> tuple[OrderedDict[tuple, list[DimensionResult]], threading.Lock]:
-    """Create the default accumulated-view LRU cache and its lock.
-
-    Override this factory to plug in a shared backend (e.g. a Redis-backed
-    OrderedDict wrapper) for multi-worker deployments.
-    """
+    """Create the default accumulated-view LRU cache and its lock."""
     return OrderedDict(), threading.Lock()
-
-
-_DEFAULT_ACC_CACHE_MAX = 256
 
 
 def _acc_dim_cache_max(override: int | None = None, env: dict[str, str] | None = None) -> int:
     """Return the accumulated-view cache size limit. *override* bypasses env for testing."""
     if override is not None:
         return override
-    try:
-        return int((env or os.environ).get("QUODEQ_ACC_CACHE_MAX", str(_DEFAULT_ACC_CACHE_MAX)))
-    except (ValueError, TypeError):
-        return _DEFAULT_ACC_CACHE_MAX
+    return _env_int("QUODEQ_ACC_CACHE_MAX", _DEFAULT_ACC_CACHE_MAX, env=env)
+
+
+def _classify_dimension(
+    dim: DimensionResult, run_id: str, run_info: RunInfo | None, is_first_run: bool,
+    latest_by_dimension: dict[str, DimensionResult],
+    prev_occurrence: dict[str, DimensionResult],
+    prev_run_latest_map: dict[str, DimensionResult],
+) -> None:
+    """Classify a single dimension into latest, previous-occurrence, or previous-run buckets."""
+    dim_name = dim.dimension
+    if not dim_name:
+        return
+    if dim_name not in latest_by_dimension:
+        latest_by_dimension[dim_name] = replace(
+            dim,
+            from_run_id=run_id,
+            from_date_iso=run_info.date_iso if run_info else None,
+            from_date_label=run_info.date_label if run_info else None,
+        )
+    elif dim_name not in prev_occurrence:
+        prev_occurrence[dim_name] = replace(dim, run_id=run_id)
+    if not is_first_run and dim_name not in prev_run_latest_map:
+        prev_run_latest_map[dim_name] = dim
 
 
 def _read_all_run_data(
@@ -52,7 +67,7 @@ def _read_all_run_data(
     Returns:
         latest_by_dimension: most recent dimension data, keyed by dimension name.
         prev_occurrence: for each dimension, its data from the next-older run
-            (used for trend computation — replaces the O(n^2) _find_previous_run).
+            (used for trend computation).
         prev_run_latest: most recent dimension data from runs[1:] (for previous average).
     """
     run_lookup = {r.run_id: r for r in all_run_infos}
@@ -62,26 +77,12 @@ def _read_all_run_data(
     _fetch = get_run_data or (lambda rid: read_run_data(reports_root, project, rid))
 
     for run_idx_i, run_id in enumerate(runs):
-        dims = _fetch(run_id)
         run_info = run_lookup.get(run_id)
-        is_first_run = (run_idx_i == 0)
-
-        for dim in dims:
-            dim_name = dim.dimension
-            if not dim_name:
-                continue
-            if dim_name not in latest_by_dimension:
-                latest_by_dimension[dim_name] = replace(
-                    dim,
-                    from_run_id=run_id,
-                    from_date_iso=run_info.date_iso if run_info else None,
-                    from_date_label=run_info.date_label if run_info else None,
-                )
-            elif dim_name not in prev_occurrence:
-                prev_occurrence[dim_name] = replace(dim, run_id=run_id)
-
-            if not is_first_run and dim_name not in prev_run_latest_map:
-                prev_run_latest_map[dim_name] = dim
+        for dim in _fetch(run_id):
+            _classify_dimension(
+                dim, run_id, run_info, run_idx_i == 0,
+                latest_by_dimension, prev_occurrence, prev_run_latest_map,
+            )
 
     return latest_by_dimension, prev_occurrence, list(prev_run_latest_map.values())
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -14,15 +14,12 @@ from quodeq.adapters.fs.report_parser import (
     RunInfo,
     calculate_trend,
     list_runs,
-    most_frequent_grade,
     read_run_data,
     summarize_dimensions,
 )
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
-from quodeq.core.scoring.internals import score_to_grade_label
-from quodeq.services.accumulated import numeric_average
-from quodeq.data.fs.report_parser.grades import parse_numeric_score
+from quodeq.services._dashboard_trend import build_accumulated_trend
 
 
 @dataclass
@@ -102,71 +99,6 @@ def _enrich_dimensions_with_trend(
             )
         )
     return result
-
-
-def _build_accumulated_trend(
-    runs: list[RunInfo],
-    get_run_dimensions: Callable[[str], list[DimensionResult]],
-) -> list[dict[str, Any]]:
-    """Build trend using accumulated scores across all runs (oldest to newest)."""
-    trend: list[dict[str, Any]] = []
-    acc_by_dim: dict[str, DimensionResult] = {}
-    prev_by_dim: dict[str, DimensionResult] = {}
-    for item in reversed(runs):  # oldest -> newest
-        run_dims = get_run_dimensions(item.run_id)
-        for dim in run_dims:
-            if dim.dimension:
-                acc_by_dim[dim.dimension] = dim
-        if not run_dims:
-            continue
-        acc_dims = list(acc_by_dim.values())
-        acc_grades = [d.overall_grade for d in acc_dims if d.overall_grade]
-        acc_avg = numeric_average(acc_dims)
-        run_avg = numeric_average(run_dims)
-        run_grades = [d.overall_grade for d in run_dims if d.overall_grade]
-        run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
-        dim_details = []
-        for dim in sorted(run_dims, key=lambda d: d.dimension or ""):
-            if not dim.dimension:
-                continue
-            prev = prev_by_dim.get(dim.dimension)
-            score = parse_numeric_score(dim.overall_score) if dim.overall_score else None
-            prev_score = parse_numeric_score(prev.overall_score) if prev and prev.overall_score else None
-            delta = round(score - prev_score, 2) if score is not None and prev_score is not None else None
-            dim_details.append({
-                "dimension": dim.dimension,
-                "score": score,
-                "grade": dim.overall_grade,
-                "delta": delta,
-            })
-        for dim in run_dims:
-            if dim.dimension:
-                prev_by_dim[dim.dimension] = dim
-        trend.append(
-            {
-                "runId": item.run_id,
-                "dateISO": item.date_iso,
-                "dateLabel": item.date_label,
-                "dimensionsCount": len(run_dim_names),
-                "dimensions": run_dim_names,
-                "dimensionDetails": dim_details,
-                "accumulatedDimensionsCount": len(acc_by_dim),
-                # Per-run grade/score (this evaluation only)
-                "runNumericAverage": run_avg,
-                "runOverallGrade": (
-                    score_to_grade_label(run_avg) if run_avg is not None
-                    else (most_frequent_grade(run_grades) if run_grades else None)
-                ),
-                # Accumulated grade/score (all runs up to this point)
-                "numericAverage": acc_avg,
-                "overallGrade": (
-                    score_to_grade_label(acc_avg) if acc_avg is not None
-                    else (most_frequent_grade(acc_grades) if acc_grades else None)
-                ),
-            }
-        )
-    trend.reverse()
-    return trend
 
 
 def _make_run_dimension_fetcher(
@@ -270,7 +202,7 @@ def _compute_dashboard_payload(
     )
     return _DashboardPayload(
         selected_summary=ctx.summary,
-        trend=_build_accumulated_trend(history_runs, get_run_dimensions),
+        trend=build_accumulated_trend(history_runs, get_run_dimensions),
         dimensions_with_trend=_enrich_dimensions_with_trend(ctx.dimensions, previous_by_dimension),
         previous_by_dimension=previous_by_dimension,
         stale_previous_by_dimension=stale_previous_by_dimension,

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -81,15 +81,17 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         projects.sort(key=lambda p: p.name)
         return _auto_detect_parents(projects)
 
+    def _is_cache_valid(self) -> bool:
+        return self._project_cache is not None and (time.monotonic() - self._project_cache_time) < _PROJECT_CACHE_TTL_S
+
     def list_projects(self, reports_dir: str) -> dict[str, Any]:
         """Return all projects found under the reports directory (TTL-cached)."""
-        now = time.monotonic()
-        if self._project_cache is not None and (now - self._project_cache_time) < _PROJECT_CACHE_TTL_S:
+        if self._is_cache_valid():
             return self._project_cache
         projects = self._build_project_list(Path(reports_dir))
         result = {"projects": [to_camel_dict(p) for p in projects]}
         self._project_cache = result
-        self._project_cache_time = now
+        self._project_cache_time = time.monotonic()
         return result
 
     def update_project_path(self, reports_dir: str, project: str, new_path: str) -> bool:

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -103,13 +103,9 @@ class FsToolingMixin:
         directories.sort(key=lambda item: item["name"])
         return directories
 
-    def browse_repo(self, path: str | None) -> dict[str, Any]:
-        """List directories at the given path for repository browsing."""
-        target, error = self._validate_browse_path(path)
-        if error is not None:
-            return error
-
-        directories = self._list_directories(target)
+    @staticmethod
+    def _build_browse_response(target: Path, directories: list[dict[str, Any]]) -> dict[str, Any]:
+        """Assemble a browse_repo response from a validated target and directory list."""
         truncated = len(directories) > _BROWSE_DIR_LIMIT
         if truncated:
             directories = directories[:_BROWSE_DIR_LIMIT]
@@ -121,6 +117,13 @@ class FsToolingMixin:
             "isGitRepo": (target / ".git").exists(),
             "truncated": truncated,
         }
+
+    def browse_repo(self, path: str | None) -> dict[str, Any]:
+        """List directories at the given path for repository browsing."""
+        target, error = self._validate_browse_path(path)
+        if error is not None:
+            return error
+        return self._build_browse_response(target, self._list_directories(target))
 
     # Default AI CLI candidates. Override via the QUODEQ_AI_CLIENTS env var
     # (comma-separated list of client IDs, e.g. "claude,codex").

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -1,13 +1,12 @@
 """Violation resolution and aggregation for the filesystem action provider."""
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
 from quodeq.adapters.fs.report_parser import parse_eval_from_json, parse_eval_markdown
 from quodeq.core.types import ViolationFileEntry, ViolationResponse, ViolationSummary
-from quodeq.shared.utils import read_text
+from quodeq.shared.utils import _env_int, read_text
 from quodeq.services.violation_context import ViolationContext  # noqa: F401 — re-export
 from quodeq.services.violations_parsing import (
     parse_violations_from_evidence,
@@ -22,7 +21,7 @@ def _max_violation_files(override: int | None = None, env: dict[str, str] | None
     """Return the max number of violation files to include. *override* bypasses env for testing."""
     if override is not None:
         return override
-    return int((env or os.environ).get("QUODEQ_MAX_VIOLATION_FILES", str(_DEFAULT_MAX_VIOLATION_FILES)))
+    return _env_int("QUODEQ_MAX_VIOLATION_FILES", _DEFAULT_MAX_VIOLATION_FILES, env=env)
 
 
 def resolve_dimension_eval(

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -9,7 +9,7 @@ from typing import Iterable
 
 from quodeq.core.types import Finding, ProgressInfo, ViolationResponse
 from quodeq.analysis.stream.event_text import TEXT_EXTRACTORS
-from quodeq.engine.analysis_stream import count_files_in_stream, extract_files_from_event
+from quodeq.analysis.stream.counters import count_files_in_stream, extract_files_from_event
 from quodeq.core.evidence.parser import build_req_refs_lookup, resolve_llm_refs
 from quodeq.services.violation_context import FindingSpec, ViolationContext, build_finding_base, format_file_line
 from quodeq.shared.utils import open_text, read_json
@@ -40,8 +40,8 @@ def _build_violation_response(
     if opts.progress is not None:
         progress = ProgressInfo(
             files_read=opts.progress.get("filesRead", 0),
-            violations=opts.progress.get("violations", 0),
-            compliance=opts.progress.get("compliance", 0),
+            violation_count=opts.progress.get("violations", 0),
+            compliance_count=opts.progress.get("compliance", 0),
         )
     return ViolationResponse(
         dimension=ctx.dimension,

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -83,8 +83,10 @@ const ROUTE_RENDERERS = {
     return (
       <HistoryPage
         trend={trend}
-        selectedRunId={resolveHistorySelectedRunId(props.dashboardData.selectedRun, trend)}
-        selectedRunScore={props.dashboardData.accumulated?.summary?.numericAverage}
+        selection={{
+          selectedRunId: resolveHistorySelectedRunId(props.dashboardData.selectedRun, trend),
+          selectedRunScore: props.dashboardData.accumulated?.summary?.numericAverage,
+        }}
         runNav={runs.length > 0 ? {
           currentRun: formatHistoryRunLabel(trend, runs, idx, props.navigation.currentOverviewRun),
           isLatest: idx === 0,
@@ -94,11 +96,15 @@ const ROUTE_RENDERERS = {
           onLatest: props.navigation.handleRunLatest,
           onView: () => { const run = props.dashboardData.selectedRun || (runs[idx] && runs[idx].runId); if (run) props.navigation.handleNavigate('history-run', { runId: run }); },
         } : null}
-        accumulatedDimensions={props.dashboardData.accumulated?.dimensions || []}
-        lastRun={{ date: props.dashboardData.accumulated?.dimensions?.[0]?.fromDateLabel, runId: props.dashboardData.accumulated?.dimensions?.[0]?.fromRunId }}
-        onRunClick={(runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel })}
-        onBarClick={props.navigation.handleRunSelect}
-        onDimensionClick={(dim) => props.navigation.handleNavigate('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel })}
+        dimensions={{
+          accumulatedDimensions: props.dashboardData.accumulated?.dimensions || [],
+          lastRun: { date: props.dashboardData.accumulated?.dimensions?.[0]?.fromDateLabel, runId: props.dashboardData.accumulated?.dimensions?.[0]?.fromRunId },
+        }}
+        callbacks={{
+          onRunClick: (runId, dateLabel) => props.navigation.handleNavigate('history-run', { runId, dateLabel }),
+          onBarClick: props.navigation.handleRunSelect,
+          onDimensionClick: (dim) => props.navigation.handleNavigate('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel }),
+        }}
       />
     );
   },
@@ -167,13 +173,20 @@ function useProjects({ onNoProjects }) {
   return { ...projectState, ...projectActions };
 }
 
-function useAppState() {
+function useAppNavigation() {
   const [serverConnected, setServerConnected] = useServerHealth();
   const { navStack, activePage, navPush, navPop, navGoTo, navReset, navTab } = useNavStack();
   const projectBundle = useProjects({ onNoProjects: () => navTab('evaluate') });
-  const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, handleRunChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
-  const settings = useAppSettings();
+  const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
   function handleNavigate(page, params = {}) { if ((page === 'run' || page === 'history-run') && params.runId) setSelectedRun(params.runId); navPush({ page, ...params }); }
+  return { serverConnected, setServerConnected, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange };
+}
+
+function useAppState() {
+  const nav = useAppNavigation();
+  const { serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange } = nav;
+  const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
+  const settings = useAppSettings();
   const { dashboard, accumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun });
   const dailyRuns = useMemo(() => buildDailyRuns(availableRuns, dashboard?.trend || []), [availableRuns, dashboard]);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: dailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -151,7 +151,8 @@ function CardFooter({ name, confirming, setConfirming, onDelete, onExport }) {
   );
 }
 
-function ProjectPathContent({ id, p, relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate }) {
+function ProjectPathContent({ id, p, relocateActions }) {
+  const { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate } = relocateActions;
   const path = formatPath(p.path);
   const pathMissing = p.location === 'local' && p.pathExists === false;
   if (relocating === id) {
@@ -180,7 +181,8 @@ function ProjectPathContent({ id, p, relocating, relocatePath, setRelocatePath, 
   );
 }
 
-function ProjectCardGroup({ p, children: childProjects, selectedProject, onSelect, confirming, setConfirming, onDelete, onExport, relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate }) {
+function ProjectCardGroup({ p, children: childProjects, selectedProject, onSelect, confirmActions, relocateActions }) {
+  const { confirming, setConfirming, onDelete, onExport } = confirmActions;
   const id = p.id || p.name || p;
   const isSelected = id === selectedProject;
   const hasChildren = !!(childProjects?.[id]?.length);
@@ -188,7 +190,7 @@ function ProjectCardGroup({ p, children: childProjects, selectedProject, onSelec
   return (
     <div key={id} className={`project-card-group${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}>
       <ProjectCard project={p} isSelected={isSelected} onSelect={onSelect} footer={<CardFooter name={id} confirming={confirming} setConfirming={setConfirming} onDelete={onDelete} onExport={onExport} />}>
-        <ProjectPathContent id={id} p={p} relocating={relocating} relocatePath={relocatePath} setRelocatePath={setRelocatePath} submitRelocate={submitRelocate} setRelocating={setRelocating} startRelocate={startRelocate} />
+        <ProjectPathContent id={id} p={p} relocateActions={relocateActions} />
       </ProjectCard>
       {hasChildren && (
         <div className="project-children-outer">
@@ -232,7 +234,7 @@ export default function ProjectsPage({ projects = [], selectedProject, actions }
       ) : (
         <div className="projects-cards">
           {roots.map((p) => (
-            <ProjectCardGroup key={p.id || p.name || p} p={p} children={children} selectedProject={selectedProject} onSelect={onSelect} confirming={confirming} setConfirming={setConfirming} onDelete={onDelete} onExport={onExport} relocating={relocating} relocatePath={relocatePath} setRelocatePath={setRelocatePath} submitRelocate={submitRelocate} setRelocating={setRelocating} startRelocate={startRelocate} />
+            <ProjectCardGroup key={p.id || p.name || p} p={p} children={children} selectedProject={selectedProject} onSelect={onSelect} confirmActions={{ confirming, setConfirming, onDelete, onExport }} relocateActions={{ relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate }} />
           ))}
         </div>
       )}

--- a/src/quodeq/ui/src/features/dashboard/components/ViolationsByPrincipleTable.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ViolationsByPrincipleTable.jsx
@@ -4,6 +4,8 @@
 
 import { memo, useMemo, useState } from 'react';
 
+const DEFAULT_PAGE_SIZE = 20;
+
 function PrincipleRow({ p, idx, onPrincipleClick }) {
   return (
     <li
@@ -61,7 +63,7 @@ function groupViolationsByPrinciple(violations) {
   });
 }
 
-const ViolationsByPrincipleTable = memo(function ViolationsByPrincipleTable({ violations, onPrincipleClick, pageSize = 20 }) {
+const ViolationsByPrincipleTable = memo(function ViolationsByPrincipleTable({ violations, onPrincipleClick, pageSize = DEFAULT_PAGE_SIZE }) {
   const [showAll, setShowAll] = useState(false);
 
   const grouped = useMemo(() => groupViolationsByPrinciple(violations), [violations]);

--- a/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -1,5 +1,6 @@
 import { memo, useState } from 'react';
-import { buildGroupPlanText, buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
@@ -52,15 +53,6 @@ function ComplianceListSection({ data, controls }) {
       )}
     </div>
   );
-}
-
-function buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData) {
-  return buildGroupPlanText({
-    title: principle,
-    violations,
-    violationsBySeverity,
-    context: principleData?.findings || undefined,
-  });
 }
 
 function buildViolationPlanText(v, principle) {

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -203,6 +203,15 @@ function buildEvalPrincipalFn(evalData, complianceByPrinciple) {
   };
 }
 
+function useDerivedExplorerStats(evalData, allViolations) {
+  const topFiles = useMemo(() => evalData ? buildTopOffendingFiles([{ dimension: evalData.dimension, violations: allViolations }]) : [], [evalData, allViolations]);
+  const severityCounts = useMemo(() => computeSeverityCounts(allViolations), [allViolations]);
+  const uniquePrinciples = useMemo(() => new Set(allViolations.map((v) => v.principle).filter(Boolean)).size, [allViolations]);
+  const totalCompliant = useMemo(() => (evalData?.principles || []).reduce((sum, p) => sum + (p.compliance?.length || 0), 0), [evalData]);
+  const complianceByPrinciple = useMemo(() => computeComplianceByPrinciple(evalData), [evalData]);
+  return { topFiles, severityCounts, uniquePrinciples, totalCompliant, complianceByPrinciple };
+}
+
 function useExplorerData(project, dimension, runId) {
   const [evalData, setEvalData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -216,12 +225,8 @@ function useExplorerData(project, dimension, runId) {
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);
-  const topFiles = useMemo(() => evalData ? buildTopOffendingFiles([{ dimension: evalData.dimension, violations: allViolations }]) : [], [evalData, allViolations]);
-  const severityCounts = useMemo(() => computeSeverityCounts(allViolations), [allViolations]);
-  const uniquePrinciples = useMemo(() => new Set(allViolations.map((v) => v.principle).filter(Boolean)).size, [allViolations]);
-  const totalCompliant = useMemo(() => (evalData?.principles || []).reduce((sum, p) => sum + (p.compliance?.length || 0), 0), [evalData]);
-  const complianceByPrinciple = useMemo(() => computeComplianceByPrinciple(evalData), [evalData]);
-  return { evalData, loading, error, overallGrade, principleGrades, allViolations, topFiles, severityCounts, uniquePrinciples, totalCompliant, complianceByPrinciple };
+  const stats = useDerivedExplorerStats(evalData, allViolations);
+  return { evalData, loading, error, overallGrade, principleGrades, allViolations, ...stats };
 }
 
 export default function ExplorerPage({ project, dimension, runId, dateLabel, onNavigate }) {

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import { buildGroupPlanText, buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
 import CopyButton from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
@@ -7,21 +8,6 @@ import { copyToClipboard } from '../../../utils/clipboard.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
-
-function buildFilePlanText(file) {
-  const allViolations = SEVERITY_ORDER.flatMap((sev) =>
-    (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }))
-  );
-  const violationsBySeverity = {};
-  for (const sev of SEVERITY_ORDER) {
-    violationsBySeverity[sev] = (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }));
-  }
-  return buildGroupPlanText({
-    title: `\`${file.file}\``,
-    violations: allViolations,
-    violationsBySeverity,
-  });
-}
 
 function buildViolationPlanText(v) {
   const title = [v.dimension, v.principle].filter(Boolean).join(' / ') || 'Violation';

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -1,23 +1,10 @@
 import { memo } from 'react';
-import { buildGroupPlanText, buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
+import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
 import CopyButton from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
-
-function buildPrinciplePlanText(principle) {
-  const violationsBySeverity = {};
-  for (const sev of SEVERITY_ORDER) {
-    violationsBySeverity[sev] = (principle.violations || []).filter(
-      (v) => (v.severity || 'minor').toLowerCase() === sev
-    );
-  }
-  return buildGroupPlanText({
-    title: principle.principle,
-    violations: principle.violations || [],
-    violationsBySeverity,
-  });
-}
 
 function buildViolationPlanText(v, principleName) {
   return buildSingleViolationPlanText(v, principleName || 'Violation');
@@ -26,11 +13,16 @@ function buildViolationPlanText(v, principleName) {
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
 
+function filterHttpRefs(reqRefs) {
+  return (reqRefs || []).filter(r => r.url && /^https?:\/\//.test(r.url));
+}
+
 function ViolationCard({ v, principleName, index }) {
   const { filePath, line } = parseFileRef(v.file, v.line);
   const filename = filePath ? filePath.split('/').pop() : null;
   const ref = line != null ? `${filePath}:${line}` : filePath;
   const display = line != null ? `${filename}:${line}` : filename;
+  const linkedRefs = filterHttpRefs(v.reqRefs);
   return (
     <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
       <div className="vdetail-row-main">
@@ -49,8 +41,8 @@ function ViolationCard({ v, principleName, index }) {
           <div className="vlive-detail-section">
             <div className="vlive-detail-section-header">
               {v.title && <span className="vlive-detail-section-label">Reason</span>}
-              {v.reqRefs?.filter(r => r.url && /^https?:\/\//.test(r.url))?.length > 0 &&
-                <span className="cwe-link-group">{v.reqRefs.filter(r => r.url && /^https?:\/\//.test(r.url)).map((ref, i) => (
+              {linkedRefs.length > 0 &&
+                <span className="cwe-link-group">{linkedRefs.map((ref, i) => (
                   <a key={i} className="cwe-link" href={ref.url} target="_blank" rel="noopener noreferrer">{ref.label}</a>
                 ))}</span>
               }

--- a/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
@@ -18,6 +18,11 @@ const cssVar = (name, fallback) => {
 
 const SCORE_THRESHOLDS = { exemplary: 9, good: 7, adequate: 5, poor: 3 };
 const CHART_LEFT_MARGIN = -16;
+const CHART_HEIGHT = 160;
+const CHART_MAX_BAR_SIZE = 40;
+const CHART_CELL_OPACITY = 0.85;
+const CHART_Y_TICKS = [0, 2.5, 5, 7.5, 10];
+const CHART_BAR_RADIUS = [3, 3, 0, 0];
 const TREND_UP_ANGLE = 70;
 const TREND_SOFT_UP = 88;
 const TREND_DOWN = 110;
@@ -136,7 +141,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
           </span>
         )}
       </div>
-      <ResponsiveContainer width="100%" height={160}>
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
         <BarChart data={data} margin={{ top: 32, right: 8, bottom: 0, left: CHART_LEFT_MARGIN }}>
           <CartesianGrid vertical={false} stroke={cssVar('--color-chart-grid')} />
           <XAxis
@@ -149,7 +154,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
           />
           <YAxis
             domain={[0, 10]}
-            ticks={[0, 2.5, 5, 7.5, 10]}
+            ticks={CHART_Y_TICKS}
             tick={{ fontSize: 11, fill: cssVar('--color-chart-axis') }}
             axisLine={false}
             tickLine={false}
@@ -160,8 +165,8 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
           <ReferenceLine y={7.5} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.15} />
           <Bar
             dataKey="numericScore"
-            radius={[3, 3, 0, 0]}
-            maxBarSize={40}
+            radius={CHART_BAR_RADIUS}
+            maxBarSize={CHART_MAX_BAR_SIZE}
             label={renderTrendLabel}
             isAnimationActive={false}
             cursor={onBarClick ? 'pointer' : 'default'}
@@ -171,7 +176,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
               <Cell
                 key={entry.dimension ?? i}
                 fill={scoreBarColor(entry.numericScore)}
-                opacity={0.85}
+                opacity={CHART_CELL_OPACITY}
               />
             ))}
           </Bar>

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -16,7 +16,10 @@ function computeDeltas(trend) {
   });
 }
 
-export default function HistoryPage({ trend, selectedRunId, selectedRunScore, accumulatedDimensions, lastRun, runNav, onRunClick, onBarClick, onDimensionClick }) {
+export default function HistoryPage({ trend, selection, runNav, dimensions, callbacks }) {
+  const { selectedRunId, selectedRunScore } = selection;
+  const { accumulatedDimensions, lastRun } = dimensions;
+  const { onRunClick, onBarClick, onDimensionClick } = callbacks;
   const [showAll, setShowAll] = useState(false);
   const [listCollapsed, setListCollapsed] = useState(false);
 

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
@@ -3,6 +3,10 @@ import { DEFAULT_MODELS, MODEL_STORAGE_PREFIX } from '../../evaluation/component
 const AI_MODEL_STORAGE_KEY = 'cc-ai-model';
 const AI_CMD_STORAGE_KEY = 'cc-ai-cmd';
 
+const MODEL_LEVEL_FAST = 1;
+const MODEL_LEVEL_BALANCED = 2;
+const MODEL_LEVEL_THOROUGH = 3;
+
 export { AI_MODEL_STORAGE_KEY, AI_CMD_STORAGE_KEY };
 
 function ClientSelector({ aiCmd, availableClients }) {
@@ -112,9 +116,9 @@ function ModelSettings({ aiCmd, models }) {
           </span>
         </div>
         <div className="settings-model-overrides">
-          <ModelOverrideInput label="Fast" value={fast} setter={onFastChange} level={1} placeholder={DEFAULT_MODELS[1]} />
-          <ModelOverrideInput label="Balanced" value={balanced} setter={onBalancedChange} level={2} placeholder={DEFAULT_MODELS[2]} />
-          <ModelOverrideInput label="Thorough" value={thorough} setter={onThoroughChange} level={3} placeholder={DEFAULT_MODELS[3]} />
+          <ModelOverrideInput label="Fast" value={fast} setter={onFastChange} level={MODEL_LEVEL_FAST} placeholder={DEFAULT_MODELS[MODEL_LEVEL_FAST]} />
+          <ModelOverrideInput label="Balanced" value={balanced} setter={onBalancedChange} level={MODEL_LEVEL_BALANCED} placeholder={DEFAULT_MODELS[MODEL_LEVEL_BALANCED]} />
+          <ModelOverrideInput label="Thorough" value={thorough} setter={onThoroughChange} level={MODEL_LEVEL_THOROUGH} placeholder={DEFAULT_MODELS[MODEL_LEVEL_THOROUGH]} />
         </div>
       </div>
     </>

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -86,6 +86,12 @@ function clampSubagents(value) {
   return Math.max(MIN_SUBAGENTS, Math.min(MAX_SUBAGENTS, parseInt(value, 10) || DEFAULT_MAX_SUBAGENTS));
 }
 
+function persistSubagents(value, setter) {
+  const v = clampSubagents(value);
+  setter(v);
+  localStorage.setItem(SUBAGENTS_STORAGE_KEY, String(v));
+}
+
 function SubagentsRow({ subagents }) {
   const { max, setMax } = subagents;
   return (
@@ -102,11 +108,7 @@ function SubagentsRow({ subagents }) {
         min={MIN_SUBAGENTS}
         max={MAX_SUBAGENTS}
         value={max}
-        onChange={(e) => {
-          const v = clampSubagents(e.target.value);
-          setMax(v);
-          localStorage.setItem(SUBAGENTS_STORAGE_KEY, String(v));
-        }}
+        onChange={(e) => persistSubagents(e.target.value, setMax)}
       />
     </div>
   );

--- a/src/quodeq/ui/src/hooks/useProjectState.js
+++ b/src/quodeq/ui/src/hooks/useProjectState.js
@@ -2,18 +2,21 @@ import { useState, useEffect, useCallback } from 'react';
 import { listProjects } from '../api/index.js';
 
 const STORAGE_KEY = 'quodeq_selected_project';
+const DEFAULT_RUN = 'latest';
 
 function persistProject(setter, name) {
   setter(name);
   try { localStorage.setItem(STORAGE_KEY, name); } catch { /* private browsing */ }
 }
 
+function readStoredProject() {
+  try { return localStorage.getItem(STORAGE_KEY) || ''; } catch { return ''; }
+}
+
 export function useProjectState({ onNoProjects }) {
   const [projects, setProjects] = useState([]);
-  const [selectedProject, setSelectedProject] = useState(() => {
-    try { return localStorage.getItem(STORAGE_KEY) || ''; } catch { return ''; }
-  });
-  const [selectedRun, setSelectedRun] = useState('latest');
+  const [selectedProject, setSelectedProject] = useState(readStoredProject);
+  const [selectedRun, setSelectedRun] = useState(DEFAULT_RUN);
 
   const loadProjects = useCallback(() => {
     return listProjects()
@@ -42,14 +45,14 @@ export function useProjectState({ onNoProjects }) {
 
   function handleProjectChange(name) {
     persistProject(setSelectedProject, name);
-    setSelectedRun('latest');
+    setSelectedRun(DEFAULT_RUN);
   }
 
   function handleRunChange(runId) { setSelectedRun(runId); }
 
   function selectProjectAndRun(project, runId) {
     persistProject(setSelectedProject, project);
-    setSelectedRun(runId || 'latest');
+    setSelectedRun(runId || DEFAULT_RUN);
   }
 
   return {

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -3,36 +3,35 @@ import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 import './styles/index.css';
 
-// Apply saved theme before first render (prevents flash)
-// Migration: if old key exists, migrate to new keys
-const _oldTheme = localStorage.getItem('cc-theme');
-if (_oldTheme !== null) {
-  const _map = { system: ['system','daruma'], light: ['light','daruma'], dark: ['dark','daruma'],
-    ember: ['dark','ifrit'], forest: ['light','galadriel'], midnight: ['dark','flynn'],
-    slate: ['light','daruma'], horizon: ['light','flynn'] };
-  const [_m, _f] = _map[_oldTheme] || ['system','daruma'];
-  localStorage.setItem('cc-theme-mode', _m);
-  localStorage.setItem('cc-theme-family', _f);
-  localStorage.removeItem('cc-theme');
+function applyInitialTheme() {
+  const oldTheme = localStorage.getItem('cc-theme');
+  if (oldTheme !== null) {
+    const map = { system: ['system','daruma'], light: ['light','daruma'], dark: ['dark','daruma'],
+      ember: ['dark','ifrit'], forest: ['light','galadriel'], midnight: ['dark','flynn'],
+      slate: ['light','daruma'], horizon: ['light','flynn'] };
+    const [m, f] = map[oldTheme] || ['system','daruma'];
+    localStorage.setItem('cc-theme-mode', m);
+    localStorage.setItem('cc-theme-family', f);
+    localStorage.removeItem('cc-theme');
+  }
+  const oldFamily = localStorage.getItem('cc-theme-family');
+  const familyMap = { 'default': 'daruma', 'midnight': 'flynn', 'forest': 'galadriel', 'ember': 'ifrit', 'cyber': 'deckard' };
+  if (oldFamily && familyMap[oldFamily]) {
+    localStorage.setItem('cc-theme-family', familyMap[oldFamily]);
+  }
+  const mode = localStorage.getItem('cc-theme-mode') || 'system';
+  const family = localStorage.getItem('cc-theme-family') || 'daruma';
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const effectiveMode = mode === 'system' ? (prefersDark ? 'dark' : 'light') : mode;
+  // NOTE: This logic must mirror resolveDataTheme() in useAppSettings.js
+  if (family === 'daruma') {
+    if (mode !== 'system') document.documentElement.setAttribute('data-theme', effectiveMode);
+  } else {
+    document.documentElement.setAttribute('data-theme', `${family}-${effectiveMode}`);
+  }
 }
-// Migrate old family names to character names
-const _oldFamily = localStorage.getItem('cc-theme-family');
-const _familyMap = { 'default': 'daruma', 'midnight': 'flynn', 'forest': 'galadriel', 'ember': 'ifrit', 'cyber': 'deckard' };
-if (_oldFamily && _familyMap[_oldFamily]) {
-  localStorage.setItem('cc-theme-family', _familyMap[_oldFamily]);
-}
-const _mode = localStorage.getItem('cc-theme-mode') || 'system';
-const _family = localStorage.getItem('cc-theme-family') || 'daruma';
-const _prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-const _effectiveMode = _mode === 'system' ? (_prefersDark ? 'dark' : 'light') : _mode;
-// NOTE: This logic must mirror resolveDataTheme() in useAppSettings.js
-if (_family === 'daruma') {
-  // System mode: don't set attribute, let @media (prefers-color-scheme) drive
-  // Explicit mode: set 'light' or 'dark' to override OS preference
-  if (_mode !== 'system') document.documentElement.setAttribute('data-theme', _effectiveMode);
-} else {
-  document.documentElement.setAttribute('data-theme', `${_family}-${_effectiveMode}`);
-}
+
+applyInitialTheme();
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element #root not found in DOM');

--- a/src/quodeq/ui/src/utils/planBuilder.js
+++ b/src/quodeq/ui/src/utils/planBuilder.js
@@ -1,4 +1,11 @@
 import { SEVERITY_ORDER } from './formatters.js';
+import {
+  PLAN_SYSTEM_PREAMBLE,
+  PLAN_OUTPUT_INSTRUCTIONS,
+  GROUP_PLAN_PREAMBLE,
+  GROUP_PLAN_OUTPUT,
+  FIX_HINTS,
+} from './planConstants.js';
 
 // ---------------------------------------------------------------------------
 // Plan text constants (authoritative home — re-exported by explorerUtils.js)
@@ -20,49 +27,7 @@ export const PLAN_COMPLETION_CHECKLIST = [
   '- [ ] **Verify metrics.** For each function-length or file-length violation, confirm the result is within limits (e.g., `wc -l`, AST line count).',
 ].join('\n');
 
-export const FIX_HINTS = {
-  // Maintainability
-  'M-ANA-1': 'Split file or extract code to a new module to reduce line count below 300',
-  'M-ANA-2': 'Extract a helper function to bring the function under 50 lines',
-  'M-ANA':   'Improve code clarity — reduce nesting, add structure, simplify control flow',
-  'M-MOD-1': 'Reduce callees by extracting a helper that groups related calls',
-  'M-MOD-4': 'Group related parameters into an object or dataclass (max 5)',
-  'M-MOD-5': 'Extract into a configurable constant or injectable function',
-  'M-MOD':   'Reduce coupling — extract dependency, use injection, or narrow the interface',
-  'M-REU-1': 'Extract duplicated code into a shared function or hook',
-  'M-REU-2': 'Add an injectable parameter so the default can be overridden for testing',
-  'M-REU':   'Make the code reusable — extract shared logic or add injection points',
-  'M-MDF-1': 'Replace the hard-coded literal with a named constant',
-  'M-MDF':   'Make the code easier to modify — extract constants, reduce coupling',
-  'M-TST':   'Improve testability — add injection points, reduce hidden dependencies',
-  // Reliability
-  'R-MAT':   'Add error handling, input validation, or defensive checks',
-  'R-FT':    'Add fault tolerance — retry logic, fallback, or graceful degradation',
-  'R-REC':   'Add recovery mechanism — cleanup, state restoration, or rollback',
-  'R-AVL':   'Improve availability — reduce single points of failure',
-  // Security
-  'S-CON':   'Fix confidentiality issue — sanitize output, restrict access, encrypt data',
-  'S-INT':   'Fix integrity issue — validate input, use parameterized queries, check boundaries',
-  'S-AUT':   'Fix authentication issue — strengthen auth checks, secure token handling',
-  'S-ACC':   'Fix accountability issue — add logging, audit trail, or access tracking',
-  'S-NRP':   'Fix non-repudiation — add tamper-evident logging or signing',
-  // Performance
-  'P-TIM':   'Optimize time behavior — reduce unnecessary computation, cache, or batch',
-  'P-RES':   'Reduce resource usage — close handles, limit allocations, pool connections',
-  'P-CAP':   'Improve capacity — add pagination, streaming, or bounded data structures',
-  // Flexibility
-  'F-ADP':   'Improve adaptability — make configurable, use abstraction, externalize settings',
-  'F-SCL':   'Improve scalability — avoid bottlenecks, support horizontal growth',
-  'F-INS':   'Improve installability — simplify setup, reduce hard-coded paths',
-  'F-RPL':   'Improve replaceability — use interfaces, reduce tight coupling',
-  // Usability
-  'U-APR':   'Improve recognizability — add labels, descriptions, or help text',
-  'U-LRN':   'Improve learnability — add examples, defaults, or progressive disclosure',
-  'U-OPR':   'Improve operability — simplify controls, reduce steps, add feedback',
-  'U-UEP':   'Add user error protection — validate input, confirm destructive actions',
-  'U-UIA':   'Improve aesthetics — fix layout, spacing, or visual consistency',
-  'U-ACC':   'Improve accessibility — add ARIA labels, keyboard nav, or contrast',
-};
+export { FIX_HINTS };
 
 export function getFixHint(req) {
   if (!req) return null;
@@ -76,30 +41,6 @@ export function getFixHint(req) {
 // ---------------------------------------------------------------------------
 
 const KNOWN_SEVERITIES = ['critical', 'major', 'minor', 'unknown'];
-
-const PLAN_SYSTEM_PREAMBLE = [
-  'You are a senior software engineer resolving verified code-quality violations.',
-  '',
-  '## Operating Rules',
-  '',
-  '1. **Read before writing.** Before modifying any file, read it in full. Never guess at contents.',
-  '2. **Scope.** Fix only the listed violations. Do not rename, restyle, or refactor anything else.',
-  '3. **Structural changes are allowed when required.** Some violations (e.g., "file too long", "duplicated code") explicitly require splitting files, extracting helpers, or moving data to config. Apply those changes — but go no further than what the violation describes.',
-  '4. **Dependency order.** When one fix creates infrastructure another fix depends on (shared helpers, centralized config), complete the foundational fix first.',
-  '5. **Test after each logical group.** Run the project\'s test suite after every cluster of related changes. Fix breakage immediately before proceeding.',
-  '6. **Verify each fix.** After applying a fix, confirm it resolves the violation (e.g., re-count lines, re-check nesting depth, grep for the removed pattern).',
-  '7. **Tests are not targets.** Only modify a test if it explicitly asserts the violated pattern you just changed. Explain your reasoning before touching any test.',
-];
-
-const PLAN_OUTPUT_INSTRUCTIONS = [
-  '---', '', '## How to apply these fixes', '',
-  '**For each violation above:**',
-  '1. Read the affected file(s) in full.',
-  '2. Identify the minimal change that resolves the stated violation.',
-  '3. Apply the fix as an exact replacement block (showing before \u2192 after) or a unified diff.',
-  '4. State a one-line verification step (e.g., `wc -l file.py` should be \u2264 300, `grep -c "except Exception.*pass" file.py` should be 0).',
-  '', '**Sequencing:** If multiple violations touch the same file or one fix creates infrastructure for another, group them and apply in dependency order \u2014 foundational changes first.', '',
-];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -214,17 +155,6 @@ export function buildDimensionPlanFromViolations(dimName, violations) {
 // ---------------------------------------------------------------------------
 // Shared group plan builder (used by PrincipleDetailPage, EvalPrincipleDetailPage, FileDetailPage)
 // ---------------------------------------------------------------------------
-
-const GROUP_PLAN_PREAMBLE = [
-  'You are a senior software engineer performing a targeted code review.',
-  'Apply minimal, surgical fixes — no refactoring, no style changes beyond what is required.',
-];
-
-const GROUP_PLAN_OUTPUT = [
-  '---', '',
-  'For each violation above, provide a concrete, step-by-step fix.',
-  'Return each fix as an exact replacement block or unified diff. No explanations beyond what is needed to apply the fix.',
-];
 
 /**
  * Build a markdown fix-plan for a group of violations (principle or file).

--- a/src/quodeq/ui/src/utils/planConstants.js
+++ b/src/quodeq/ui/src/utils/planConstants.js
@@ -1,0 +1,78 @@
+export const PLAN_SYSTEM_PREAMBLE = [
+  'You are a senior software engineer resolving verified code-quality violations.',
+  '',
+  '## Operating Rules',
+  '',
+  '1. **Read before writing.** Before modifying any file, read it in full. Never guess at contents.',
+  '2. **Scope.** Fix only the listed violations. Do not rename, restyle, or refactor anything else.',
+  '3. **Structural changes are allowed when required.** Some violations (e.g., "file too long", "duplicated code") explicitly require splitting files, extracting helpers, or moving data to config. Apply those changes — but go no further than what the violation describes.',
+  '4. **Dependency order.** When one fix creates infrastructure another fix depends on (shared helpers, centralized config), complete the foundational fix first.',
+  '5. **Test after each logical group.** Run the project\'s test suite after every cluster of related changes. Fix breakage immediately before proceeding.',
+  '6. **Verify each fix.** After applying a fix, confirm it resolves the violation (e.g., re-count lines, re-check nesting depth, grep for the removed pattern).',
+  '7. **Tests are not targets.** Only modify a test if it explicitly asserts the violated pattern you just changed. Explain your reasoning before touching any test.',
+];
+
+export const PLAN_OUTPUT_INSTRUCTIONS = [
+  '---', '', '## How to apply these fixes', '',
+  '**For each violation above:**',
+  '1. Read the affected file(s) in full.',
+  '2. Identify the minimal change that resolves the stated violation.',
+  '3. Apply the fix as an exact replacement block (showing before \u2192 after) or a unified diff.',
+  '4. State a one-line verification step (e.g., `wc -l file.py` should be \u2264 300, `grep -c "except Exception.*pass" file.py` should be 0).',
+  '', '**Sequencing:** If multiple violations touch the same file or one fix creates infrastructure for another, group them and apply in dependency order \u2014 foundational changes first.', '',
+];
+
+export const GROUP_PLAN_PREAMBLE = [
+  'You are a senior software engineer performing a targeted code review.',
+  'Apply minimal, surgical fixes — no refactoring, no style changes beyond what is required.',
+];
+
+export const GROUP_PLAN_OUTPUT = [
+  '---', '',
+  'For each violation above, provide a concrete, step-by-step fix.',
+  'Return each fix as an exact replacement block or unified diff. No explanations beyond what is needed to apply the fix.',
+];
+
+export const FIX_HINTS = {
+  // Maintainability
+  'M-ANA-1': 'Split file or extract code to a new module to reduce line count below 300',
+  'M-ANA-2': 'Extract a helper function to bring the function under 50 lines',
+  'M-ANA':   'Improve code clarity — reduce nesting, add structure, simplify control flow',
+  'M-MOD-1': 'Reduce callees by extracting a helper that groups related calls',
+  'M-MOD-4': 'Group related parameters into an object or dataclass (max 5)',
+  'M-MOD-5': 'Extract into a configurable constant or injectable function',
+  'M-MOD':   'Reduce coupling — extract dependency, use injection, or narrow the interface',
+  'M-REU-1': 'Extract duplicated code into a shared function or hook',
+  'M-REU-2': 'Add an injectable parameter so the default can be overridden for testing',
+  'M-REU':   'Make the code reusable — extract shared logic or add injection points',
+  'M-MDF-1': 'Replace the hard-coded literal with a named constant',
+  'M-MDF':   'Make the code easier to modify — extract constants, reduce coupling',
+  'M-TST':   'Improve testability — add injection points, reduce hidden dependencies',
+  // Reliability
+  'R-MAT':   'Add error handling, input validation, or defensive checks',
+  'R-FT':    'Add fault tolerance — retry logic, fallback, or graceful degradation',
+  'R-REC':   'Add recovery mechanism — cleanup, state restoration, or rollback',
+  'R-AVL':   'Improve availability — reduce single points of failure',
+  // Security
+  'S-CON':   'Fix confidentiality issue — sanitize output, restrict access, encrypt data',
+  'S-INT':   'Fix integrity issue — validate input, use parameterized queries, check boundaries',
+  'S-AUT':   'Fix authentication issue — strengthen auth checks, secure token handling',
+  'S-ACC':   'Fix accountability issue — add logging, audit trail, or access tracking',
+  'S-NRP':   'Fix non-repudiation — add tamper-evident logging or signing',
+  // Performance
+  'P-TIM':   'Optimize time behavior — reduce unnecessary computation, cache, or batch',
+  'P-RES':   'Reduce resource usage — close handles, limit allocations, pool connections',
+  'P-CAP':   'Improve capacity — add pagination, streaming, or bounded data structures',
+  // Flexibility
+  'F-ADP':   'Improve adaptability — make configurable, use abstraction, externalize settings',
+  'F-SCL':   'Improve scalability — avoid bottlenecks, support horizontal growth',
+  'F-INS':   'Improve installability — simplify setup, reduce hard-coded paths',
+  'F-RPL':   'Improve replaceability — use interfaces, reduce tight coupling',
+  // Usability
+  'U-APR':   'Improve recognizability — add labels, descriptions, or help text',
+  'U-LRN':   'Improve learnability — add examples, defaults, or progressive disclosure',
+  'U-OPR':   'Improve operability — simplify controls, reduce steps, add feedback',
+  'U-UEP':   'Add user error protection — validate input, confirm destructive actions',
+  'U-UIA':   'Improve aesthetics — fix layout, spacing, or visual consistency',
+  'U-ACC':   'Improve accessibility — add ARIA labels, keyboard nav, or contrast',
+};

--- a/src/quodeq/ui/src/utils/planTextBuilders.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.js
@@ -1,0 +1,39 @@
+import { buildGroupPlanText } from './planBuilder.js';
+import { SEVERITY_ORDER } from './formatters.js';
+
+export function buildFilePlanText(file) {
+  const allViolations = SEVERITY_ORDER.flatMap((sev) =>
+    (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }))
+  );
+  const violationsBySeverity = {};
+  for (const sev of SEVERITY_ORDER) {
+    violationsBySeverity[sev] = (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }));
+  }
+  return buildGroupPlanText({
+    title: `\`${file.file}\``,
+    violations: allViolations,
+    violationsBySeverity,
+  });
+}
+
+export function buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData) {
+  if (violations !== undefined) {
+    return buildGroupPlanText({
+      title: principle,
+      violations,
+      violationsBySeverity,
+      context: principleData?.findings || undefined,
+    });
+  }
+  const bySeverity = {};
+  for (const sev of SEVERITY_ORDER) {
+    bySeverity[sev] = (principle.violations || []).filter(
+      (v) => (v.severity || 'minor').toLowerCase() === sev
+    );
+  }
+  return buildGroupPlanText({
+    title: principle.principle,
+    violations: principle.violations || [],
+    violationsBySeverity: bySeverity,
+  });
+}

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -60,7 +60,7 @@ TOTALS = Totals(
     severity=SeverityTally(critical=1, major=2, minor=2, unknown=0),
 )
 
-PRINCIPLE = PrincipleGrade(name="Naming", score="85", grade="B")
+PRINCIPLE = PrincipleGrade(principle="Naming", score="85", grade="B")
 
 DIMENSION_RESULT = DimensionResult(
     dimension="maintainability",
@@ -151,7 +151,7 @@ VIOLATION_RESPONSE = ViolationResponse(
     violations=[FINDING],
     compliance=[],
     partial=True,
-    progress=ProgressInfo(files_read=10, violations=3, compliance=7),
+    progress=ProgressInfo(files_read=10, violation_count=3, compliance_count=7),
 )
 
 VIOLATION_SUMMARY = ViolationSummary(

--- a/tests/engine/test_adaptive_scaling_integration.py
+++ b/tests/engine/test_adaptive_scaling_integration.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from quodeq.analysis.subprocess import AnalysisConfig
 from quodeq.engine.file_queue import FileQueue
-from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool
+from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 
 
 def _counting_run_analysis(call_log):

--- a/tests/engine/test_mechanical_verify_fingerprint.py
+++ b/tests/engine/test_mechanical_verify_fingerprint.py
@@ -59,7 +59,7 @@ class TestRunVerificationStepFingerprint:
         config.standards_dir = None
         return config
 
-    @patch("quodeq.analysis.subagents.runner._run_verification_pool")
+    @patch("quodeq.analysis.subagents._verification._run_verification_pool")
     @patch("quodeq.analysis.subagents.verify.load_previous_findings_for_dimension")
     @patch("quodeq.analysis.fingerprint.find_previous_fingerprint")
     def test_unchanged_files_carried_forward_not_sent_to_pool(
@@ -108,7 +108,7 @@ class TestRunVerificationStepFingerprint:
         unchanged_findings = [l for l in lines if l.get("file") == "unchanged.py"]
         assert len(unchanged_findings) == 1
 
-    @patch("quodeq.analysis.subagents.runner._run_verification_pool")
+    @patch("quodeq.analysis.subagents._verification._run_verification_pool")
     @patch("quodeq.analysis.subagents.verify.load_previous_findings_for_dimension")
     @patch("quodeq.analysis.fingerprint.find_previous_fingerprint")
     def test_incremental_filters_to_file_filter_only(

--- a/tests/engine/test_prioritization_integration.py
+++ b/tests/engine/test_prioritization_integration.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from quodeq.analysis.subprocess import AnalysisConfig
 from quodeq.engine.file_queue import FileQueue
-from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool
+from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 
 
 class TestPrioritizationInFileQueue:

--- a/tests/engine/test_standards.py
+++ b/tests/engine/test_standards.py
@@ -45,9 +45,12 @@ def test_load_cisq_maintainability():
 
 
 def test_load_cisq_all_characteristics():
+    # Each CISQ characteristic must have at least this many CWE entries;
+    # guards against accidental truncation of the standards data.
+    _MIN_CWES_PER_CHARACTERISTIC = 12
     for char in ["maintainability", "reliability", "security", "performance"]:
         cisq = load_cisq(char)
-        assert len(cisq["cwes"]) >= 12, f"{char}: expected ≥12 CWEs, got {len(cisq['cwes'])}"
+        assert len(cisq["cwes"]) >= _MIN_CWES_PER_CHARACTERISTIC, f"{char}: expected ≥{_MIN_CWES_PER_CHARACTERISTIC} CWEs, got {len(cisq['cwes'])}"
         for cwe in cisq["cwes"]:
             assert "id" in cwe
             assert "name" in cwe

--- a/tests/engine/test_subagent_pool.py
+++ b/tests/engine/test_subagent_pool.py
@@ -9,7 +9,7 @@ import pytest
 
 from quodeq.analysis.subprocess import AnalysisConfig, AnalysisError
 from quodeq.engine.file_queue import FileQueue
-from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool, SubagentResult
+from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 
 
 def _fake_run_analysis(work_dir, prompt, stream_file, config):
@@ -118,70 +118,5 @@ class TestSubagentPool:
             results = pool.run()
 
         assert len(results) == 1
-
-
-class TestMergeJsonl:
-    def _make_result(self, tmp_path: Path, agent_id: str, findings: list[dict]) -> SubagentResult:
-        jsonl = tmp_path / f"{agent_id}.jsonl"
-        with open(jsonl, "w") as f:
-            for finding in findings:
-                f.write(json.dumps(finding) + "\n")
-        return SubagentResult(
-            agent_id=agent_id, jsonl_file=jsonl,
-            stream_file=tmp_path / f"{agent_id}.stream", success=True,
-        )
-
-    def test_merges_unique_findings(self, tmp_path: Path) -> None:
-        r1 = self._make_result(tmp_path, "a0", [
-            {"p": "P1", "t": "violation", "file": "a.py", "line": 1},
-            {"p": "P2", "t": "compliance", "file": "b.py", "line": 2},
-        ])
-        r2 = self._make_result(tmp_path, "a1", [
-            {"p": "P3", "t": "violation", "file": "c.py", "line": 3},
-        ])
-
-        output = tmp_path / "merged.jsonl"
-        SubagentPool.merge_jsonl([r1, r2], output)
-
-        lines = output.read_text().strip().splitlines()
-        assert len(lines) == 3
-
-    def test_deduplicates_across_agents(self, tmp_path: Path) -> None:
-        finding = {"p": "P1", "t": "violation", "file": "a.py", "line": 10}
-        r1 = self._make_result(tmp_path, "a0", [finding])
-        r2 = self._make_result(tmp_path, "a1", [finding])
-
-        output = tmp_path / "merged.jsonl"
-        SubagentPool.merge_jsonl([r1, r2], output)
-
-        lines = output.read_text().strip().splitlines()
-        assert len(lines) == 1
-
-    def test_skips_missing_jsonl(self, tmp_path: Path) -> None:
-        r = SubagentResult(
-            agent_id="a0",
-            jsonl_file=tmp_path / "nonexistent.jsonl",
-            stream_file=tmp_path / "a0.stream",
-            success=False,
-        )
-        output = tmp_path / "merged.jsonl"
-        SubagentPool.merge_jsonl([r], output)
-        assert output.read_text() == ""
-
-    def test_empty_results_produce_empty_file(self, tmp_path: Path) -> None:
-        output = tmp_path / "merged.jsonl"
-        SubagentPool.merge_jsonl([], output)
-        assert output.read_text() == ""
-
-    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
-        jsonl = tmp_path / "bad.jsonl"
-        jsonl.write_text("not json\n" + json.dumps({"p": "P1", "t": "violation", "file": "a.py", "line": 1}) + "\n")
-        r = SubagentResult(agent_id="a0", jsonl_file=jsonl, stream_file=tmp_path / "a0.stream", success=True)
-
-        output = tmp_path / "merged.jsonl"
-        SubagentPool.merge_jsonl([r], output)
-
-        lines = output.read_text().strip().splitlines()
-        assert len(lines) == 1
 
 

--- a/tests/engine/test_subagent_pool_advanced.py
+++ b/tests/engine/test_subagent_pool_advanced.py
@@ -9,7 +9,7 @@ import pytest
 
 from quodeq.analysis.subprocess import AnalysisConfig, AnalysisError
 from quodeq.engine.file_queue import FileQueue
-from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool, SubagentResult
+from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool, SubagentResult
 
 
 def _fake_run_analysis(work_dir, prompt, stream_file, config):

--- a/tests/engine/test_subagent_pool_merge.py
+++ b/tests/engine/test_subagent_pool_merge.py
@@ -1,0 +1,72 @@
+"""Tests for SubagentPool.merge_jsonl — JSONL merging and deduplication."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.analysis.subagents.pool import SubagentPool, SubagentResult
+
+
+class TestMergeJsonl:
+    def _make_result(self, tmp_path: Path, agent_id: str, findings: list[dict]) -> SubagentResult:
+        jsonl = tmp_path / f"{agent_id}.jsonl"
+        with open(jsonl, "w") as f:
+            for finding in findings:
+                f.write(json.dumps(finding) + "\n")
+        return SubagentResult(
+            agent_id=agent_id, jsonl_file=jsonl,
+            stream_file=tmp_path / f"{agent_id}.stream", success=True,
+        )
+
+    def test_merges_unique_findings(self, tmp_path: Path) -> None:
+        r1 = self._make_result(tmp_path, "a0", [
+            {"p": "P1", "t": "violation", "file": "a.py", "line": 1},
+            {"p": "P2", "t": "compliance", "file": "b.py", "line": 2},
+        ])
+        r2 = self._make_result(tmp_path, "a1", [
+            {"p": "P3", "t": "violation", "file": "c.py", "line": 3},
+        ])
+
+        output = tmp_path / "merged.jsonl"
+        SubagentPool.merge_jsonl([r1, r2], output)
+
+        lines = output.read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    def test_deduplicates_across_agents(self, tmp_path: Path) -> None:
+        finding = {"p": "P1", "t": "violation", "file": "a.py", "line": 10}
+        r1 = self._make_result(tmp_path, "a0", [finding])
+        r2 = self._make_result(tmp_path, "a1", [finding])
+
+        output = tmp_path / "merged.jsonl"
+        SubagentPool.merge_jsonl([r1, r2], output)
+
+        lines = output.read_text().strip().splitlines()
+        assert len(lines) == 1
+
+    def test_skips_missing_jsonl(self, tmp_path: Path) -> None:
+        r = SubagentResult(
+            agent_id="a0",
+            jsonl_file=tmp_path / "nonexistent.jsonl",
+            stream_file=tmp_path / "a0.stream",
+            success=False,
+        )
+        output = tmp_path / "merged.jsonl"
+        SubagentPool.merge_jsonl([r], output)
+        assert output.read_text() == ""
+
+    def test_empty_results_produce_empty_file(self, tmp_path: Path) -> None:
+        output = tmp_path / "merged.jsonl"
+        SubagentPool.merge_jsonl([], output)
+        assert output.read_text() == ""
+
+    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
+        jsonl = tmp_path / "bad.jsonl"
+        jsonl.write_text("not json\n" + json.dumps({"p": "P1", "t": "violation", "file": "a.py", "line": 1}) + "\n")
+        r = SubagentResult(agent_id="a0", jsonl_file=jsonl, stream_file=tmp_path / "a0.stream", success=True)
+
+        output = tmp_path / "merged.jsonl"
+        SubagentPool.merge_jsonl([r], output)
+
+        lines = output.read_text().strip().splitlines()
+        assert len(lines) == 1

--- a/tests/provider/test_dashboard.py
+++ b/tests/provider/test_dashboard.py
@@ -11,9 +11,9 @@ from quodeq.core.types import DimensionResult, DimensionSummary
 from quodeq.services.dashboard import (
     _collect_previous_scores,
     _enrich_dimensions_with_trend,
-    _build_accumulated_trend,
     build_dashboard,
 )
+from quodeq.services._dashboard_trend import build_accumulated_trend as _build_accumulated_trend
 from quodeq.services._dashboard_stale import collect_stale_dimensions as _collect_stale_dimensions
 
 

--- a/tests/test_action_provider_fs_dashboard.py
+++ b/tests/test_action_provider_fs_dashboard.py
@@ -12,9 +12,9 @@ from quodeq.services._dashboard_stale import collect_stale_dimensions as _collec
 from quodeq.services.dashboard import (
     _collect_previous_scores,
     _enrich_dimensions_with_trend,
-    _build_accumulated_trend,
     build_dashboard,
 )
+from quodeq.services._dashboard_trend import build_accumulated_trend as _build_accumulated_trend
 from quodeq.adapters.fs.report_parser.runs import RunInfo
 
 

--- a/tests/test_power_selector_e2e.py
+++ b/tests/test_power_selector_e2e.py
@@ -104,7 +104,7 @@ class TestSubagentPoolModelPropagation:
 
     def test_pool_agents_inherit_model(self, tmp_path: Path) -> None:
         from quodeq.engine.file_queue import FileQueue
-        from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool
+        from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 
         queue_path = tmp_path / "queue.json"
         FileQueue(queue_path, ["a.py", "b.py"])
@@ -124,7 +124,7 @@ class TestSubagentPoolModelPropagation:
 
     def test_pool_agents_inherit_haiku(self, tmp_path: Path) -> None:
         from quodeq.engine.file_queue import FileQueue
-        from quodeq.engine.subagent_pool import PoolOptions, PoolPaths, SubagentPool
+        from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 
         queue_path = tmp_path / "queue.json"
         FileQueue(queue_path, ["x.py"])


### PR DESCRIPTION
## Summary
- Resolves 51 code-quality violations (4 major, 47 minor) from maintainability evaluation
- 53 files changed across Python backend, React UI, packaging scripts, and tests
- All 573 tests pass, UI builds clean

## Changes by category

**File splits (4 files over 300-line limit):**
- `runner.py` → extracted `_verification.py` (226 lines, was 304)
- `dashboard.py` → extracted `_dashboard_trend.py` (239 lines, was 308)
- `test_subagent_pool.py` → extracted `test_subagent_pool_merge.py`
- `planBuilder.js` → extracted `planConstants.js` (256 lines, was 327)

**Prop grouping (components over 5-param limit):**
- `ProjectsPage.jsx`: 15→5 props, 8→3 props
- `FolderBrowser.jsx`: 7→2 params, 10→5 props
- `HistoryPage.jsx`: 9→5 props

**Code deduplication:**
- `planTextBuilders.js`: shared builders for 3 explorer components
- `_env_int` helper: shared env-reading for violations.py + _filesystem_helpers.py

**Other:** magic numbers → constants, bare Exception → specific types, dead alias removal, nesting reduction (6→4 levels), injectable params for testability, re-export callers updated to canonical imports

## Test plan
- [x] 573 pytest tests pass
- [x] UI builds successfully (vite production build)
- [x] Manual smoke test of dashboard and explorer pages
