### PR TITLE
fix: raise default max export size from 100MB to 500MB

### DIFF
--- a/src/quodeq/api/zip.py
+++ b/src/quodeq/api/zip.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 
 from quodeq.api.helpers import error_response
 
-_DEFAULT_MAX_ZIP_SIZE_MB = 100
+_DEFAULT_MAX_ZIP_SIZE_MB = 500
 
 
 def _max_zip_size_bytes(max_mb: int | None = None, env: dict[str, str] | None = None) -> int:


### PR DESCRIPTION
## Summary
- Project export was failing with 413 for the quodeq project (128MB raw data)
- The size check sums uncompressed file sizes against a 100MB limit, but evaluation data is mostly JSON/text that compresses heavily
- Raised default to 500MB (still overridable via `QUODEQ_MAX_ZIP_SIZE_MB`)

## Test plan
- [x] Export quodeq project data — should download successfully now