### PR TITLE
feat: Standards Browser & Editor

### DIFF
--- a/src/quodeq/analysis/_incremental.py
+++ b/src/quodeq/analysis/_incremental.py
@@ -43,6 +43,25 @@ def load_analysis_context(config: "RunConfig") -> tuple[list[str], "_AnalysisCon
         raise ValueError("RunConfig.dimensions_data is required")
 
     all_dims_raw = [d.get("id") for d in dims_data.get("applies", []) if d.get("id")]
+
+    # Include custom evaluators from evaluators directory (only when dimensions are explicitly requested)
+    if config.options.dimensions:
+        _evaluators_dir = getattr(config, 'evaluators_dir', None)
+        if _evaluators_dir is None:
+            from quodeq.config.paths import default_paths
+            _evaluators_dir = default_paths().evaluators_dir
+    else:
+        _evaluators_dir = None
+    if _evaluators_dir and _evaluators_dir.is_dir():
+        import json as _json
+        for _p in _evaluators_dir.glob("*.json"):
+            try:
+                _eid = _json.loads(_p.read_text()).get("id")
+                if _eid and _eid not in all_dims_raw:
+                    all_dims_raw.append(_eid)
+            except (OSError, ValueError, KeyError):
+                pass
+
     if config.options.dimensions:
         all_dims_set = set(all_dims_raw)
         unknown = [d for d in config.options.dimensions if d not in all_dims_set]

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -45,9 +45,9 @@ def _load_dimension_data(
         return None
 
 
-def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
+def render_compiled_standards(compiled_dir: Path, dimension: str, evaluators_dir: Path | None = None) -> str:
     """Render compiled standards as a requirements checklist organized by principle."""
-    data = _load_dimension_data(compiled_dir, dimension)
+    data = _load_dimension_data(compiled_dir, dimension, evaluators_dir=evaluators_dir)
     if data is None:
         return _NO_STANDARDS_FOR_DIM
     lines = []
@@ -67,14 +67,14 @@ def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
     return "\n".join(lines)
 
 
-def render_compact_standards(compiled_dir: Path, dimension: str) -> str:
+def render_compact_standards(compiled_dir: Path, dimension: str, evaluators_dir: Path | None = None) -> str:
     """Render a compact standards checklist for the AI analyzer.
 
     One line per requirement: ``REQ-ID: text``.
     No principle headings (server derives principle from req ID),
     no markdown formatting, no CWE refs (server enriches at report time).
     """
-    data = _load_dimension_data(compiled_dir, dimension)
+    data = _load_dimension_data(compiled_dir, dimension, evaluators_dir=evaluators_dir)
     if data is None:
         return _NO_STANDARDS_FOR_DIM
     lines = []
@@ -228,9 +228,10 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
     standards_checklist = _NO_STANDARDS
     if context.standards_dir:
         compiled_dir = context.standards_dir / "compiled"
-        if compiled_dir.exists():
+        _eval_dir = default_paths().evaluators_dir
+        if compiled_dir.exists() or (_eval_dir.is_dir()):
             if context.work_dir:
-                compact = render_compact_standards(compiled_dir, context.dimension)
+                compact = render_compact_standards(compiled_dir, context.dimension, evaluators_dir=_eval_dir)
                 if compact not in (_NO_STANDARDS_FOR_DIM,):
                     standards_path = _write_standards_file(
                         context.work_dir, context.dimension, compact,
@@ -239,7 +240,7 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
                 else:
                     standards_checklist = compact
             else:
-                standards_checklist = render_compiled_standards(compiled_dir, context.dimension)
+                standards_checklist = render_compiled_standards(compiled_dir, context.dimension, evaluators_dir=_eval_dir)
 
     manifest_context = _render_manifest_context(context)
 
@@ -263,11 +264,12 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
 def _render_all_standards(standards_dir: Path, dimensions: list[str]) -> str:
     """Render compact standards for all dimensions, separated by headers."""
     compiled_dir = standards_dir / "compiled"
-    if not compiled_dir.exists():
+    _eval_dir = default_paths().evaluators_dir
+    if not compiled_dir.exists() and not _eval_dir.is_dir():
         return _NO_STANDARDS
     sections = []
     for dim in dimensions:
-        compact = render_compact_standards(compiled_dir, dim)
+        compact = render_compact_standards(compiled_dir, dim, evaluators_dir=_eval_dir)
         if compact != _NO_STANDARDS_FOR_DIM:
             sections.append(f"## {dim.title()}\n\n{compact}")
     return "\n\n".join(sections) if sections else _NO_STANDARDS

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -56,8 +56,13 @@ def render_compiled_standards(compiled_dir: Path, dimension: str) -> str:
         if not reqs:
             continue
         lines.append(f"### {principle['name']}")
+        if principle.get("description"):
+            lines.append(principle["description"])
         for req in reqs:
-            lines.append(f"- **{req['id']}**: {req['text']}")
+            req_line = f"- **{req['id']}**: {req['text']}"
+            if req.get("description"):
+                req_line += f" — {req['description']}"
+            lines.append(req_line)
         lines.append("")
     return "\n".join(lines)
 
@@ -75,7 +80,10 @@ def render_compact_standards(compiled_dir: Path, dimension: str) -> str:
     lines = []
     for principle in data.get("principles", []):
         for req in principle.get("requirements", []):
-            lines.append(f"{req['id']}: {req['text']}")
+            line = f"{req['id']}: {req['text']}"
+            if req.get("description"):
+                line += f" — {req['description']}"
+            lines.append(line)
     return "\n".join(lines)
 
 

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -23,15 +23,25 @@ _NO_STANDARDS_FOR_DIM = "_No compiled standards for this dimension._"
 _STANDARDS_READ_ERROR = "_Could not read compiled standards._"
 
 
-def _load_dimension_data(compiled_dir: Path, dimension: str) -> dict | None:
-    """Load compiled standards JSON for a dimension, or None on error."""
-    compiled_file = compiled_dir / f"{dimension}.json"
-    if not compiled_file.exists():
+def _load_dimension_data(
+    compiled_dir: Path,
+    dimension: str,
+    evaluators_dir: Path | None = None,
+) -> dict | None:
+    """Load compiled standards JSON for a dimension, or None on error.
+
+    Falls back to *evaluators_dir* when the compiled file does not exist and
+    *evaluators_dir* is provided (supports custom / user-supplied standards).
+    """
+    path = compiled_dir / f"{dimension}.json"
+    if not path.is_file() and evaluators_dir is not None:
+        path = evaluators_dir / f"{dimension}.json"
+    if not path.is_file():
         return None
     try:
-        return read_json(compiled_file)
+        return read_json(path)
     except (OSError, ValueError) as exc:
-        _logger.warning("Could not read compiled standards %s: %s", compiled_file, exc)
+        _logger.warning("Failed to load dimension %s: %s", dimension, exc)
         return None
 
 

--- a/src/quodeq/analysis/runner.py
+++ b/src/quodeq/analysis/runner.py
@@ -57,6 +57,7 @@ class RunConfig:
     manifest: SourceManifest | None = None
     dimensions_data: DimensionsConfig | None = None
     target: AnalysisTarget | None = None
+    evaluators_dir: Path | None = None
 
     @property
     def source_file_count(self) -> int:

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -26,6 +26,7 @@ from quodeq.api.routes import (
     register_discovery_routes,
     register_static_routes,
 )
+from quodeq.api.standards_routes import register_standards_routes
 
 _HEALTH_PATH = "/api/health"
 _RATE_LIMITED_GET_PATHS = frozenset({"/api/browse"})
@@ -216,14 +217,24 @@ def create_app(
     static_dist: str | None = None,
     rate_limit_store: RateLimitStore | None = None,
     api_key: str | None = None,
+    test_config: dict | None = None,
 ) -> Flask:
     """Create and configure the Flask application with all API routes."""
     app = Flask(__name__)
+    if test_config is not None:
+        app.config.update(test_config)
     provider = provider or _default_provider()
     store = rate_limit_store or create_rate_limit_store()
     eval_store = InMemoryRateLimitStore(
         window=_EVALUATION_RATE_LIMIT_WINDOW, max_requests=_EVALUATION_RATE_LIMIT_MAX,
     )
+    if "STANDARDS_EVALUATORS_DIR" not in app.config:
+        from quodeq.config.paths import default_paths
+        paths = default_paths()
+        app.config["STANDARDS_EVALUATORS_DIR"] = str(paths.evaluators_dir)
+        app.config["STANDARDS_COMPILED_DIR"] = str(paths.standards_dir / "compiled")
+        app.config["STANDARDS_DIMENSIONS_FILE"] = str(paths.dimensions_file)
+
     if api_key is None:
         _logger.warning(
             "QUODEQ_API_KEY is not set — API restricted to localhost only. "
@@ -270,6 +281,7 @@ def _register_all_routes(
     register_evaluation_list_routes(app, provider, eval_store)
     register_evaluation_item_routes(app, provider)
     register_discovery_routes(app, provider)
+    register_standards_routes(app)
     register_static_routes(app, static_dist)
 
 

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -32,3 +32,49 @@ def register_standards_routes(app: Flask) -> None:
         except FileNotFoundError:
             return error_response(f"Standard not found: {standard_id}", 404, "not_found")
         return jsonify(to_camel_dict(detail))
+
+    @app.post("/api/standards")
+    def create_standard() -> tuple[Response, int]:
+        svc = _get_service(app)
+        payload = request.get_json(force=True)
+        try:
+            detail = svc.create_standard(payload)
+        except ValueError as exc:
+            return error_response(str(exc), 400, "bad_request")
+        return jsonify(to_camel_dict(detail)), 201
+
+    @app.put("/api/standards/<standard_id>")
+    def update_standard(standard_id: str) -> Response:
+        svc = _get_service(app)
+        payload = request.get_json(force=True)
+        try:
+            detail = svc.update_standard(standard_id, payload)
+        except FileNotFoundError:
+            return error_response(f"Standard not found: {standard_id}", 404, "not_found")
+        except PermissionError as exc:
+            return error_response(str(exc), 403, "forbidden")
+        return jsonify(to_camel_dict(detail))
+
+    @app.delete("/api/standards/<standard_id>")
+    def delete_standard(standard_id: str) -> tuple[str, int]:
+        svc = _get_service(app)
+        try:
+            svc.delete_standard(standard_id)
+        except FileNotFoundError:
+            return error_response(f"Standard not found: {standard_id}", 404, "not_found")
+        except PermissionError as exc:
+            return error_response(str(exc), 403, "forbidden")
+        return "", 204
+
+    @app.post("/api/standards/<standard_id>/duplicate")
+    def duplicate_standard(standard_id: str) -> tuple[Response, int]:
+        svc = _get_service(app)
+        payload = request.get_json(force=True)
+        new_id = payload.get("newId") or payload.get("new_id")
+        if not new_id:
+            return error_response("newId is required", 400, "bad_request")
+        try:
+            detail = svc.duplicate_standard(standard_id, new_id)
+        except (FileNotFoundError, ValueError) as exc:
+            return error_response(str(exc), 400, "bad_request")
+        return jsonify(to_camel_dict(detail)), 201

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -1,0 +1,34 @@
+"""API routes for the Standards Browser & Editor."""
+from __future__ import annotations
+import logging
+from pathlib import Path
+from flask import Flask, Response, jsonify, request
+from quodeq.api.helpers import error_response
+from quodeq.core.types import to_camel_dict
+from quodeq.services.standards import StandardsService
+
+logger = logging.getLogger(__name__)
+
+def _get_service(app: Flask) -> StandardsService:
+    if not hasattr(app, "_standards_service"):
+        app._standards_service = StandardsService(
+            evaluators_dir=Path(app.config["STANDARDS_EVALUATORS_DIR"]),
+            compiled_dir=Path(app.config["STANDARDS_COMPILED_DIR"]),
+            dimensions_file=Path(app.config["STANDARDS_DIMENSIONS_FILE"]),
+        )
+    return app._standards_service
+
+def register_standards_routes(app: Flask) -> None:
+    @app.get("/api/standards")
+    def list_standards() -> Response:
+        svc = _get_service(app)
+        return jsonify([to_camel_dict(s) for s in svc.list_standards()])
+
+    @app.get("/api/standards/<standard_id>")
+    def get_standard(standard_id: str) -> Response:
+        svc = _get_service(app)
+        try:
+            detail = svc.get_standard(standard_id)
+        except FileNotFoundError:
+            return error_response(f"Standard not found: {standard_id}", 404, "not_found")
+        return jsonify(to_camel_dict(detail))

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -33,7 +33,7 @@ def _load_cwe_list(app: Flask) -> list[dict]:
         if cwe_path.is_file():
             import json as _json
             entries = _json.loads(cwe_path.read_text())
-            app._cwe_list = [{"id": e["id"], "name": e["name"]} for e in entries]
+            app._cwe_list = [{"id": e["id"], "name": e["name"], "abstraction": e.get("abstraction", ""), "dimensions": e.get("dimensions", [])} for e in entries]
         else:
             app._cwe_list = []
     return app._cwe_list

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -26,7 +26,24 @@ def _get_library_client(app: Flask):
     token = app.config.get("STANDARDS_LIBRARY_TOKEN")
     return StandardsLibraryClient(base_url=base_url, http_client=UrllibJsonClient(), token=token)
 
+def _load_cwe_list(app: Flask) -> list[dict]:
+    """Load and cache the CWE list."""
+    if not hasattr(app, "_cwe_list"):
+        cwe_path = Path(app.config["STANDARDS_COMPILED_DIR"]).parent / "cwe" / "audit.json"
+        if cwe_path.is_file():
+            import json as _json
+            entries = _json.loads(cwe_path.read_text())
+            app._cwe_list = [{"id": e["id"], "name": e["name"]} for e in entries]
+        else:
+            app._cwe_list = []
+    return app._cwe_list
+
+
 def register_standards_routes(app: Flask) -> None:
+    @app.get("/api/standards/refs/cwe")
+    def list_cwes() -> Response:
+        return jsonify(_load_cwe_list(app))
+
     @app.get("/api/standards")
     def list_standards() -> Response:
         svc = _get_service(app)

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -55,6 +55,8 @@ def register_standards_routes(app: Flask) -> None:
             return error_response("file is required", 400, "bad_request")
         try:
             library.import_standard(file_path, Path(app.config["STANDARDS_EVALUATORS_DIR"]))
+        except ValueError as exc:
+            return error_response(str(exc), 409, "conflict")
         except Exception as exc:
             logger.warning("Failed to import standard: %s", exc)
             return error_response(f"Import failed: {exc}", 502, "import_error")

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -18,11 +18,47 @@ def _get_service(app: Flask) -> StandardsService:
         )
     return app._standards_service
 
+def _get_library_client(app: Flask):
+    base_url = app.config.get("STANDARDS_LIBRARY_URL")
+    if not base_url:
+        return None
+    from quodeq.services.standards_library import StandardsLibraryClient, UrllibJsonClient
+    token = app.config.get("STANDARDS_LIBRARY_TOKEN")
+    return StandardsLibraryClient(base_url=base_url, http_client=UrllibJsonClient(), token=token)
+
 def register_standards_routes(app: Flask) -> None:
     @app.get("/api/standards")
     def list_standards() -> Response:
         svc = _get_service(app)
         return jsonify([to_camel_dict(s) for s in svc.list_standards()])
+
+    @app.get("/api/standards/library")
+    def list_library() -> Response:
+        library = _get_library_client(app)
+        if library is None:
+            return jsonify([])
+        try:
+            index = library.fetch_index()
+        except Exception as exc:
+            logger.warning("Failed to fetch library index: %s", exc)
+            return error_response("Failed to connect to standards library", 502, "library_error")
+        return jsonify(index)
+
+    @app.post("/api/standards/library/import")
+    def import_from_library() -> tuple[Response, int]:
+        library = _get_library_client(app)
+        if library is None:
+            return error_response("Standards library not configured", 400, "library_not_configured")
+        payload = request.get_json(force=True)
+        file_path = payload.get("file")
+        if not file_path:
+            return error_response("file is required", 400, "bad_request")
+        try:
+            library.import_standard(file_path, Path(app.config["STANDARDS_EVALUATORS_DIR"]))
+        except Exception as exc:
+            logger.warning("Failed to import standard: %s", exc)
+            return error_response(f"Import failed: {exc}", 502, "import_error")
+        return jsonify({"status": "imported"}), 201
 
     @app.get("/api/standards/<standard_id>")
     def get_standard(standard_id: str) -> Response:

--- a/src/quodeq/config/paths.py
+++ b/src/quodeq/config/paths.py
@@ -22,10 +22,15 @@ class ConfigPaths:
     """Immutable set of resolved paths to all configuration directories and files."""
 
     root: Path
-    prompts_dir: Path
-    standards_dir: Path
-    env_file: Path
-    gitignore_file: Path
+    prompts_dir: Path | None = None
+    standards_dir: Path | None = None
+    env_file: Path | None = None
+    gitignore_file: Path | None = None
+
+    @property
+    def evaluators_dir(self) -> Path:
+        """Global directory for custom evaluator JSON files."""
+        return Path.home() / ".quodeq" / "evaluators"
 
     @property
     def vroot(self) -> Path:

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -150,13 +150,38 @@ class _GroupedJudgments:
     severity: dict[str, str]
 
 
-def _group_judgments(judgments: list[Judgment]) -> _GroupedJudgments:
+def _build_req_to_principle_map(dimension: str) -> dict[str, str]:
+    """Build a mapping from requirement IDs to principle names for custom evaluators."""
+    from quodeq.config.paths import default_paths
+    evaluators_dir = default_paths().evaluators_dir
+    if not evaluators_dir.is_dir():
+        return {}
+    path = evaluators_dir / f"{dimension}.json"
+    if not path.is_file():
+        return {}
+    try:
+        import json as _json
+        data = _json.loads(path.read_text())
+        mapping: dict[str, str] = {}
+        for principle in data.get("principles", []):
+            pname = principle.get("name", "")
+            for req in principle.get("requirements", []):
+                rid = req.get("id", "")
+                if rid and pname:
+                    mapping[rid] = pname
+        return mapping
+    except (OSError, ValueError):
+        return {}
+
+
+def _group_judgments(judgments: list[Judgment], dimension: str = "") -> _GroupedJudgments:
+    req_to_principle = _build_req_to_principle_map(dimension) if dimension else {}
     sc_violations: dict[str, list[Judgment]] = {}
     sc_compliance: dict[str, list[Judgment]] = {}
     sc_severity: dict[str, str] = {}
 
     for j in judgments:
-        principle = j.practice_id
+        principle = req_to_principle.get(j.practice_id, j.practice_id)
         if j.verdict == "violation":
             sc_violations.setdefault(principle, []).append(j)
         elif j.verdict == "compliance":
@@ -251,7 +276,7 @@ def parse_jsonl_to_evidence_by_dimension(
 
     result: dict[str, Evidence] = {}
     for dim, dim_judgments in by_dim.items():
-        grouped = _group_judgments(dim_judgments)
+        grouped = _group_judgments(dim_judgments, dimension=dim)
         principles = _build_principles(grouped, dim)
         result[dim] = Evidence(
             repository=context.repository,
@@ -274,8 +299,8 @@ def parse_jsonl_to_evidence(
 ) -> Evidence:
     """Parse extracted JSONL file into a complete Evidence object."""
     judgments = _read_judgments(jsonl_file, compiled_dir)
-    grouped = _group_judgments(judgments)
     dimension_name = judgments[0].dimension if judgments else ""
+    grouped = _group_judgments(judgments, dimension=dimension_name)
     principles = _build_principles(grouped, dimension_name)
 
     source_file_count = context.source_file_count

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -95,7 +95,7 @@ def _parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
         _logger.warning("Skipping malformed JSONL line: %s", exc)
         return None
 
-    practice_id = obj.get("p")
+    practice_id = obj.get("p") or obj.get("req")
     verdict = obj.get("t")
     if not practice_id or verdict not in ("violation", "compliance"):
         return None

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -1,6 +1,7 @@
 """Evidence parser -- converts extracted JSONL lines into V2 Evidence model."""
 from __future__ import annotations
 
+import functools
 import json
 import logging
 from dataclasses import dataclass
@@ -150,8 +151,12 @@ class _GroupedJudgments:
     severity: dict[str, str]
 
 
+@functools.lru_cache(maxsize=32)
 def _build_req_to_principle_map(dimension: str) -> dict[str, str]:
-    """Build a mapping from requirement IDs to principle names for custom evaluators."""
+    """Build a mapping from requirement IDs to principle names for custom evaluators.
+
+    Cached per dimension — evaluator files don't change during a single run.
+    """
     from quodeq.config.paths import default_paths
     evaluators_dir = default_paths().evaluators_dir
     if not evaluators_dir.is_dir():

--- a/src/quodeq/core/types/standard.py
+++ b/src/quodeq/core/types/standard.py
@@ -1,0 +1,42 @@
+"""Data types for custom standards / evaluators."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class StandardReference:
+    type: str          # "cwe" | "book" | "url" | "custom"
+    label: str
+    url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StandardMeta:
+    """Lightweight metadata for listing standards."""
+    id: str
+    name: str
+    description: str
+    weight: float
+    source: str
+    type: str           # "builtin" | "custom" | "community"
+    managed: bool
+    origin: str | None
+    origin_hash: str | None
+    principle_count: int = 0
+    requirement_count: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class StandardDetail:
+    """Full standard with principles and requirements."""
+    id: str
+    name: str
+    description: str
+    weight: float
+    source: str
+    type: str
+    managed: bool
+    origin: str | None
+    origin_hash: str | None
+    principles: list[dict] = field(default_factory=list)

--- a/src/quodeq/services/standards.py
+++ b/src/quodeq/services/standards.py
@@ -1,0 +1,115 @@
+"""Service for managing standards (built-in and custom evaluators)."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.core.types.standard import StandardDetail, StandardMeta
+
+logger = logging.getLogger(__name__)
+
+
+class StandardsService:
+    def __init__(self, evaluators_dir: Path, compiled_dir: Path, dimensions_file: Path) -> None:
+        self._evaluators_dir = evaluators_dir
+        self._compiled_dir = compiled_dir
+        self._dimensions_file = dimensions_file
+
+    def list_standards(self) -> list[StandardMeta]:
+        result: list[StandardMeta] = []
+        result.extend(self._list_builtin())
+        result.extend(self._list_custom())
+        return result
+
+    def _list_builtin(self) -> list[StandardMeta]:
+        try:
+            data = json.loads(self._dimensions_file.read_text())
+        except (OSError, ValueError) as exc:
+            logger.warning("Cannot read dimensions file: %s", exc)
+            return []
+        out: list[StandardMeta] = []
+        for dim in data.get("applies", []):
+            p_count, r_count = self._count_compiled(dim["id"])
+            out.append(StandardMeta(
+                id=dim["id"], name=dim.get("iso_25010", dim["id"]),
+                description=f'{dim.get("source", "Built-in")} standard',
+                weight=dim.get("weight", 1.0), source=dim.get("source", ""),
+                type="builtin", managed=True, origin=None, origin_hash=None,
+                principle_count=p_count, requirement_count=r_count,
+            ))
+        return out
+
+    def _count_compiled(self, dimension_id: str) -> tuple[int, int]:
+        path = self._compiled_dir / f"{dimension_id}.json"
+        if not path.is_file():
+            return 0, 0
+        try:
+            data = json.loads(path.read_text())
+            principles = data.get("principles", [])
+            req_count = sum(len(p.get("requirements", [])) for p in principles)
+            return len(principles), req_count
+        except (OSError, ValueError):
+            return 0, 0
+
+    def _list_custom(self) -> list[StandardMeta]:
+        if not self._evaluators_dir.is_dir():
+            return []
+        out: list[StandardMeta] = []
+        for path in sorted(self._evaluators_dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text())
+                principles = data.get("principles", [])
+                req_count = sum(len(p.get("requirements", [])) for p in principles)
+                out.append(StandardMeta(
+                    id=data["id"], name=data.get("name", data["id"]),
+                    description=data.get("description", ""),
+                    weight=data.get("weight", 1.0), source=data.get("source", ""),
+                    type=data.get("type", "custom"), managed=data.get("managed", False),
+                    origin=data.get("origin"), origin_hash=data.get("origin_hash"),
+                    principle_count=len(principles), requirement_count=req_count,
+                ))
+            except (OSError, ValueError, KeyError) as exc:
+                logger.warning("Skipping invalid evaluator %s: %s", path.name, exc)
+        return out
+
+    def get_standard(self, standard_id: str) -> StandardDetail:
+        custom_path = self._evaluators_dir / f"{standard_id}.json"
+        if custom_path.is_file():
+            return self._load_detail(custom_path)
+        compiled_path = self._compiled_dir / f"{standard_id}.json"
+        if compiled_path.is_file():
+            return self._load_builtin_detail(compiled_path, standard_id)
+        raise FileNotFoundError(f"Standard not found: {standard_id}")
+
+    def _load_detail(self, path: Path) -> StandardDetail:
+        data = json.loads(path.read_text())
+        return StandardDetail(
+            id=data["id"], name=data.get("name", data["id"]),
+            description=data.get("description", ""),
+            weight=data.get("weight", 1.0), source=data.get("source", ""),
+            type=data.get("type", "custom"), managed=data.get("managed", False),
+            origin=data.get("origin"), origin_hash=data.get("origin_hash"),
+            principles=data.get("principles", []),
+        )
+
+    def _load_builtin_detail(self, path: Path, standard_id: str) -> StandardDetail:
+        data = json.loads(path.read_text())
+        return StandardDetail(
+            id=standard_id, name=data.get("name", standard_id),
+            description=f"Built-in {data.get('name', standard_id)} standard",
+            weight=self._get_builtin_weight(standard_id),
+            source=", ".join(data.get("sources", [])),
+            type="builtin", managed=True, origin=None, origin_hash=None,
+            principles=data.get("principles", []),
+        )
+
+    def _get_builtin_weight(self, dimension_id: str) -> float:
+        try:
+            data = json.loads(self._dimensions_file.read_text())
+            for dim in data.get("applies", []):
+                if dim["id"] == dimension_id:
+                    return dim.get("weight", 1.0)
+        except (OSError, ValueError):
+            pass
+        return 1.0

--- a/src/quodeq/services/standards.py
+++ b/src/quodeq/services/standards.py
@@ -104,6 +104,66 @@ class StandardsService:
             principles=data.get("principles", []),
         )
 
+    def create_standard(self, data: dict) -> StandardDetail:
+        standard_id = data["id"]
+        self._validate_id(standard_id)
+        path = self._evaluators_dir / f"{standard_id}.json"
+        if path.exists():
+            raise ValueError(f"Standard '{standard_id}' already exists")
+        self._evaluators_dir.mkdir(parents=True, exist_ok=True)
+        payload = {**data, "type": "custom", "managed": False, "origin": None, "origin_hash": None}
+        path.write_text(json.dumps(payload, indent=2))
+        return self._load_detail(path)
+
+    def update_standard(self, standard_id: str, data: dict) -> StandardDetail:
+        path = self._evaluators_dir / f"{standard_id}.json"
+        if not path.is_file():
+            raise FileNotFoundError(f"Standard not found: {standard_id}")
+        existing = json.loads(path.read_text())
+        if existing.get("managed", False):
+            raise PermissionError(f"Cannot edit managed standard '{standard_id}'")
+        payload = {**data, "id": standard_id, "type": "custom", "managed": False}
+        path.write_text(json.dumps(payload, indent=2))
+        return self._load_detail(path)
+
+    def delete_standard(self, standard_id: str) -> None:
+        path = self._evaluators_dir / f"{standard_id}.json"
+        if not path.is_file():
+            if (self._compiled_dir / f"{standard_id}.json").is_file() or self._is_builtin_id(standard_id):
+                raise PermissionError(f"Cannot delete built-in standard '{standard_id}'")
+            raise FileNotFoundError(f"Standard not found: {standard_id}")
+        existing = json.loads(path.read_text())
+        if existing.get("managed", False):
+            raise PermissionError(f"Cannot delete managed standard '{standard_id}'")
+        path.unlink()
+
+    def duplicate_standard(self, standard_id: str, new_id: str) -> StandardDetail:
+        self._validate_id(new_id)
+        new_path = self._evaluators_dir / f"{new_id}.json"
+        if new_path.exists():
+            raise ValueError(f"Standard '{new_id}' already exists")
+        source = self.get_standard(standard_id)
+        self._evaluators_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "id": new_id, "name": source.name, "description": source.description,
+            "weight": source.weight, "source": source.source, "type": "custom",
+            "managed": False, "origin": None, "origin_hash": None, "principles": source.principles,
+        }
+        new_path.write_text(json.dumps(payload, indent=2))
+        return self._load_detail(new_path)
+
+    def _is_builtin_id(self, standard_id: str) -> bool:
+        try:
+            data = json.loads(self._dimensions_file.read_text())
+            return any(dim["id"] == standard_id for dim in data.get("applies", []))
+        except (OSError, ValueError):
+            return False
+
+    @staticmethod
+    def _validate_id(standard_id: str) -> None:
+        if not standard_id or "/" in standard_id or "\\" in standard_id or ".." in standard_id:
+            raise ValueError(f"Invalid standard ID: {standard_id}")
+
     def _get_builtin_weight(self, dimension_id: str) -> float:
         try:
             data = json.loads(self._dimensions_file.read_text())

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -37,8 +37,16 @@ class StandardsLibraryClient:
     def fetch_standard(self, file_path: str) -> dict:
         return self._http.get_json(f"{self._base_url}/{file_path}", headers=self._headers())
 
+    @staticmethod
+    def _validate_id(standard_id: str) -> None:
+        if not standard_id or "/" in standard_id or "\\" in standard_id or ".." in standard_id:
+            raise ValueError(f"Invalid standard ID from library: {standard_id}")
+
     def import_standard(self, file_path: str, evaluators_dir: Path) -> Path:
+        if ".." in file_path:
+            raise ValueError(f"Invalid library file path: {file_path}")
         data = self.fetch_standard(file_path)
+        self._validate_id(data.get("id", ""))
         content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:16]
         evaluators_dir.mkdir(parents=True, exist_ok=True)
         dest = evaluators_dir / f"{data['id']}.json"

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -1,0 +1,50 @@
+"""Client for fetching standards from a remote GitHub-hosted library."""
+from __future__ import annotations
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+class HttpClient(Protocol):
+    def get_json(self, url: str, headers: dict[str, str] | None = None) -> Any: ...
+
+class UrllibJsonClient:
+    def get_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
+        import urllib.request
+        req = urllib.request.Request(url, headers=headers or {})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+
+class StandardsLibraryClient:
+    def __init__(self, base_url: str, http_client: HttpClient, token: str | None = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._http = http_client
+        self._token = token
+
+    def _headers(self) -> dict[str, str]:
+        h: dict[str, str] = {}
+        if self._token:
+            h["Authorization"] = f"Bearer {self._token}"
+        return h
+
+    def fetch_index(self) -> list[dict]:
+        data = self._http.get_json(f"{self._base_url}/index.json", headers=self._headers())
+        return data.get("standards", [])
+
+    def fetch_standard(self, file_path: str) -> dict:
+        return self._http.get_json(f"{self._base_url}/{file_path}", headers=self._headers())
+
+    def import_standard(self, file_path: str, evaluators_dir: Path) -> Path:
+        data = self.fetch_standard(file_path)
+        content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:16]
+        data["type"] = "community"
+        data["managed"] = True
+        data["origin"] = file_path
+        data["origin_hash"] = content_hash
+        evaluators_dir.mkdir(parents=True, exist_ok=True)
+        dest = evaluators_dir / f"{data['id']}.json"
+        dest.write_text(json.dumps(data, indent=2))
+        return dest

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -40,11 +40,23 @@ class StandardsLibraryClient:
     def import_standard(self, file_path: str, evaluators_dir: Path) -> Path:
         data = self.fetch_standard(file_path)
         content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:16]
+        evaluators_dir.mkdir(parents=True, exist_ok=True)
+        dest = evaluators_dir / f"{data['id']}.json"
+        # Check for collision with existing standard
+        if dest.is_file():
+            existing = json.loads(dest.read_text())
+            if existing.get("origin") == file_path:
+                # Same origin — update in place
+                pass
+            else:
+                raise ValueError(
+                    f"A standard with ID '{data['id']}' already exists "
+                    f"from a different source. Duplicate to customize it first, "
+                    f"or delete the existing one."
+                )
         data["type"] = "community"
         data["managed"] = True
         data["origin"] = file_path
         data["origin_hash"] = content_hash
-        evaluators_dir.mkdir(parents=True, exist_ok=True)
-        dest = evaluators_dir / f"{data['id']}.json"
         dest.write_text(json.dumps(data, indent=2))
         return dest

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -11,6 +11,7 @@ import ProjectsPage from './features/dashboard/components/ProjectsPage.jsx';
 import HistoryPage from './features/history/components/HistoryPage.jsx';
 import EvaluateScreen from './features/evaluation/components/EvaluateScreen.jsx';
 import SettingsPage from './features/settings/components/SettingsPage.jsx';
+import StandardsPage from './features/standards/StandardsPage.jsx';
 import ViolationsPage from './features/violations/components/ViolationsPage.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
 import LoadingScreen from './components/LoadingScreen.jsx';
@@ -115,11 +116,12 @@ const ROUTE_RENDERERS = {
   'eval-principle-detail': (params) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} />,
   settings: (params, props) => <SettingsCase settings={props.settings} analysisPower={props.evaluation.analysisPower} setAnalysisPower={props.evaluation.setAnalysisPower} />,
   projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
+  standards: () => <StandardsPage />,
 };
 
 function MainContent({ activePage, props }) {
   const { page, ...params } = activePage;
-  const noProjectTabs = ['evaluate', 'settings'];
+  const noProjectTabs = ['evaluate', 'standards', 'settings'];
   if (!noProjectTabs.includes(page)) {
     const projects = props.navigation?.projects;
     if (!projects || projects.length === 0) {
@@ -204,7 +206,7 @@ function useAppState() {
     return { headerMeta: meta, ...display };
   }, [accumulated, dashboard, selectedProject, projects]);
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
-  const knownTabs = ['overview', 'violations', 'history', 'projects', 'evaluate', 'settings'];
+  const knownTabs = ['overview', 'violations', 'history', 'projects', 'evaluate', 'standards', 'settings'];
   const activeTab = knownTabs.includes(activePage.page) ? activePage.page
     : activePage.sourceTab && knownTabs.includes(activePage.sourceTab) ? activePage.sourceTab
     : activePage.page === 'history-run' ? 'history'

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -144,3 +144,29 @@ export function getAiClients() {
 export function getClientModels(clientId) {
   return request(`/ai-clients/${encodeURIComponent(clientId)}/models`);
 }
+
+// ── Standards ──────────────────────────────────────────────
+export async function listStandards() {
+  return request('/standards');
+}
+export async function getStandard(standardId) {
+  return request(`/standards/${encodeURIComponent(standardId)}`);
+}
+export async function createStandard(data) {
+  return request('/standards', { method: 'POST', body: JSON.stringify(data) });
+}
+export async function updateStandard(standardId, data) {
+  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'PUT', body: JSON.stringify(data) });
+}
+export async function deleteStandard(standardId) {
+  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'DELETE' });
+}
+export async function duplicateStandard(standardId, newId) {
+  return request(`/standards/${encodeURIComponent(standardId)}/duplicate`, { method: 'POST', body: JSON.stringify({ newId }) });
+}
+export async function listLibrary() {
+  return request('/standards/library');
+}
+export async function importFromLibrary(file) {
+  return request('/standards/library/import', { method: 'POST', body: JSON.stringify({ file }) });
+}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -167,6 +167,9 @@ export async function duplicateStandard(standardId, newId) {
 export async function listLibrary() {
   return request('/standards/library');
 }
+export async function listCwes() {
+  return request('/standards/refs/cwe');
+}
 export async function importFromLibrary(file) {
   return request('/standards/library/import', { method: 'POST', body: JSON.stringify({ file }) });
 }

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_HISTORY, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS } from '../constants/navigation.jsx';
+import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_HISTORY, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS, ICON_STANDARDS } from '../constants/navigation.jsx';
 
 function Logo() {
   return (
@@ -52,6 +52,7 @@ export default function Sidebar({ activeTab, onNavTab }) {
         <NavButton id="violations" label="Violations" icon={ICON_VIOLATIONS} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="history" label="History" icon={ICON_HISTORY} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="evaluate" label="Evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={onNavTab} />
+        <NavButton id="standards" label="Standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="projects" label="Projects" icon={ICON_PROJECTS} activeTab={activeTab} onNavTab={onNavTab} />
       </nav>
 

--- a/src/quodeq/ui/src/constants/navigation.jsx
+++ b/src/quodeq/ui/src/constants/navigation.jsx
@@ -51,3 +51,9 @@ export const ICON_SETTINGS = (
     <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77" />
   </svg>
 );
+
+export const ICON_STANDARDS = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7l3-7z" />
+  </svg>
+);

--- a/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
@@ -1,0 +1,56 @@
+import { ISO_25010_URL } from '../../../constants.js';
+
+function DimensionChip({ dim, isSelected, onToggle }) {
+  return (
+    <button
+      type="button"
+      className={`dimension-chip-btn ${isSelected ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
+      title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
+      aria-pressed={isSelected}
+      onClick={() => onToggle(dim.id)}
+    >
+      {dim.label || dim.id}
+    </button>
+  );
+}
+
+export default function DimensionSelector({ allDimensions, selectedDims, onToggle, onSelectAll, onClearAll }) {
+  const builtin = [...allDimensions].filter((d) => !d.standardType).sort((a, b) => a.id.localeCompare(b.id));
+  const custom = [...allDimensions].filter((d) => d.standardType).sort((a, b) => (a.label || a.id).localeCompare(b.label || b.id));
+
+  return (
+    <div className="form-group">
+      <div className="dimension-label-row">
+        <label>Dimensions</label>
+        <div className="dimension-chip-actions">
+          <button type="button" className="dim-action-btn" onClick={onSelectAll}>All</button>
+          <button type="button" className="dim-action-btn" onClick={onClearAll}>Clear</button>
+        </div>
+      </div>
+
+      {builtin.length > 0 && (
+        <div className="dimension-section">
+          <div className="dimension-section-label">
+            <a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a>
+          </div>
+          <div className="dimension-grid">
+            {builtin.map((dim) => (
+              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {custom.length > 0 && (
+        <div className="dimension-section">
+          <div className="dimension-section-label">Custom Standards</div>
+          <div className="dimension-grid">
+            {custom.map((dim) => (
+              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import FolderBrowser from './FolderBrowser.jsx';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
-import { ISO_25010_URL } from '../../../constants.js';
+import DimensionSelector from './DimensionSelector.jsx';
 
 const FOLDER_MARGIN_BOTTOM = 8;
 
@@ -41,61 +41,6 @@ function RepoInput({ repo, onRepoChange, onClear, onBrowse }) {
           Local
         </button>
       </div>
-    </div>
-  );
-}
-
-function DimensionChip({ dim, isSelected, onToggle }) {
-  return (
-    <button
-      type="button"
-      className={`dimension-chip-btn ${isSelected ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
-      title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
-      aria-pressed={isSelected}
-      onClick={() => onToggle(dim.id)}
-    >
-      {dim.label || dim.id}
-    </button>
-  );
-}
-
-function DimensionGrid({ allDimensions, selectedDims, onToggle, onSelectAll, onClearAll }) {
-  const builtin = [...allDimensions].filter((d) => !d.standardType).sort((a, b) => a.id.localeCompare(b.id));
-  const custom = [...allDimensions].filter((d) => d.standardType).sort((a, b) => (a.label || a.id).localeCompare(b.label || b.id));
-
-  return (
-    <div className="form-group">
-      <div className="dimension-label-row">
-        <label>Dimensions</label>
-        <div className="dimension-chip-actions">
-          <button type="button" className="dim-action-btn" onClick={onSelectAll}>All</button>
-          <button type="button" className="dim-action-btn" onClick={onClearAll}>Clear</button>
-        </div>
-      </div>
-
-      {builtin.length > 0 && (
-        <div className="dimension-section">
-          <div className="dimension-section-label">
-            <a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a>
-          </div>
-          <div className="dimension-grid">
-            {builtin.map((dim) => (
-              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {custom.length > 0 && (
-        <div className="dimension-section">
-          <div className="dimension-section-label">Custom Standards</div>
-          <div className="dimension-grid">
-            {custom.map((dim) => (
-              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -147,7 +92,7 @@ export default function EvaluationForm({ onStart, disabled }) {
 
         {dimLoadError && <p className="inline-error" style={{ marginBottom: FOLDER_MARGIN_BOTTOM }}>{dimLoadError}</p>}
         {repo && allDimensions.length > 0 && (
-          <DimensionGrid
+          <DimensionSelector
             allDimensions={allDimensions}
             selectedDims={selectedDims}
             onToggle={toggleDim}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -60,12 +60,15 @@ function DimensionGrid({ allDimensions, selectedDims, onToggle, onSelectAll, onC
           <button
             key={dim.id}
             type="button"
-            className={`dimension-chip-btn ${selectedDims.has(dim.id) ? 'selected' : ''}`}
-            title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : undefined}
+            className={`dimension-chip-btn ${selectedDims.has(dim.id) ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
+            title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
             aria-pressed={selectedDims.has(dim.id)}
             onClick={() => onToggle(dim.id)}
           >
             {dim.id}
+            {dim.standardType && (
+              <span className={`dim-chip-badge dim-chip-badge--${dim.standardType}`} aria-hidden="true" />
+            )}
           </button>
         ))}
       </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -45,33 +45,57 @@ function RepoInput({ repo, onRepoChange, onClear, onBrowse }) {
   );
 }
 
+function DimensionChip({ dim, isSelected, onToggle }) {
+  return (
+    <button
+      type="button"
+      className={`dimension-chip-btn ${isSelected ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
+      title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
+      aria-pressed={isSelected}
+      onClick={() => onToggle(dim.id)}
+    >
+      {dim.label || dim.id}
+    </button>
+  );
+}
+
 function DimensionGrid({ allDimensions, selectedDims, onToggle, onSelectAll, onClearAll }) {
+  const builtin = [...allDimensions].filter((d) => !d.standardType).sort((a, b) => a.id.localeCompare(b.id));
+  const custom = [...allDimensions].filter((d) => d.standardType).sort((a, b) => (a.label || a.id).localeCompare(b.label || b.id));
+
   return (
     <div className="form-group">
       <div className="dimension-label-row">
-        <label><a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
+        <label>Dimensions</label>
         <div className="dimension-chip-actions">
           <button type="button" className="dim-action-btn" onClick={onSelectAll}>All</button>
           <button type="button" className="dim-action-btn" onClick={onClearAll}>Clear</button>
         </div>
       </div>
-      <div className="dimension-grid">
-        {[...allDimensions].sort((a, b) => a.id.localeCompare(b.id)).map((dim) => (
-          <button
-            key={dim.id}
-            type="button"
-            className={`dimension-chip-btn ${selectedDims.has(dim.id) ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
-            title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
-            aria-pressed={selectedDims.has(dim.id)}
-            onClick={() => onToggle(dim.id)}
-          >
-            {dim.id}
-            {dim.standardType && (
-              <span className={`dim-chip-badge dim-chip-badge--${dim.standardType}`} aria-hidden="true" />
-            )}
-          </button>
-        ))}
-      </div>
+
+      {builtin.length > 0 && (
+        <div className="dimension-section">
+          <div className="dimension-section-label">
+            <a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a>
+          </div>
+          <div className="dimension-grid">
+            {builtin.map((dim) => (
+              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {custom.length > 0 && (
+        <div className="dimension-section">
+          <div className="dimension-section-label">Custom Standards</div>
+          <div className="dimension-grid">
+            {custom.map((dim) => (
+              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getProjectInfo } from '../../../api/index.js';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
-import { ISO_25010_URL } from '../../../constants.js';
+import DimensionSelector from './DimensionSelector.jsx';
 
 const BUTTON_GAP = '8px';
 const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: BUTTON_GAP, alignItems: 'center' };
@@ -75,28 +75,13 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
         </div>
 
         {allDimensions.length > 0 && (
-          <div className="form-group">
-            <div className="dimension-label-row">
-              <label><a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a> Dimensions</label>
-              <div className="dimension-chip-actions">
-                <button type="button" className="dim-action-btn" onClick={selectAll}>All</button>
-                <button type="button" className="dim-action-btn" onClick={clearAll}>Clear</button>
-              </div>
-            </div>
-            <div className="dimension-grid">
-              {[...allDimensions].sort((a, b) => a.id.localeCompare(b.id)).map((dim) => (
-                <button
-                  key={dim.id}
-                  type="button"
-                  className={`dimension-chip-btn ${selectedDims.has(dim.id) ? 'selected' : ''}`}
-                  title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : undefined}
-                  onClick={() => toggleDim(dim.id)}
-                >
-                  {dim.id}
-                </button>
-              ))}
-            </div>
-          </div>
+          <DimensionSelector
+            allDimensions={allDimensions}
+            selectedDims={selectedDims}
+            onToggle={toggleDim}
+            onSelectAll={selectAll}
+            onClearAll={clearAll}
+          />
         )}
 
         <div style={buttonRowStyle}>

--- a/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
@@ -1,27 +1,45 @@
 import { useState, useEffect } from 'react';
-import { listPlugins } from '../../../api/index.js';
+import { listPlugins, listStandards } from '../../../api/index.js';
 
 export function usePluginDimensions() {
   const [allDimensions, setAllDimensions] = useState([]);
   const [dimLoadError, setDimLoadError] = useState(null);
 
   useEffect(() => {
-    listPlugins()
-      .then((plugins) => {
-        const seen = new Map();
-        for (const p of plugins) {
-          for (const d of p.dimensions) {
-            if (!seen.has(d.id)) seen.set(d.id, d);
+    Promise.all([
+      listPlugins().catch(() => []),
+      listStandards().catch(() => []),
+    ]).then(([plugins, standards]) => {
+      const seen = new Map();
+
+      // Add plugin dimensions first
+      for (const p of plugins) {
+        for (const d of p.dimensions) {
+          if (!seen.has(d.id)) seen.set(d.id, d);
+        }
+      }
+
+      // Merge custom and community standards as selectable dimensions
+      for (const s of standards) {
+        if (s.type === 'custom' || s.type === 'community') {
+          if (!seen.has(s.id)) {
+            seen.set(s.id, {
+              id: s.id,
+              label: s.name,
+              iso_25010: null,
+              standardType: s.type,
+            });
           }
         }
-        setAllDimensions([...seen.values()]);
-        setDimLoadError(null);
-      })
-      .catch((err) => {
-        console.warn('Failed to load dimensions:', err);
-        setAllDimensions([]);
-        setDimLoadError('Failed to load dimensions. Using defaults.');
-      });
+      }
+
+      setAllDimensions([...seen.values()]);
+      setDimLoadError(null);
+    }).catch((err) => {
+      console.warn('Failed to load dimensions:', err);
+      setAllDimensions([]);
+      setDimLoadError('Failed to load dimensions. Using defaults.');
+    });
   }, []);
 
   return { allDimensions, dimLoadError };

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { useStandards } from './hooks/useStandards.js';
+import StandardsList from './components/StandardsList.jsx';
+import StandardEditor from './components/StandardEditor.jsx';
+import LibraryBrowser from './components/LibraryBrowser.jsx';
+
+export default function StandardsPage() {
+  const { grouped, loading, error, refresh, handleDelete, handleDuplicate } = useStandards();
+  const [view, setView] = useState({ mode: 'list' }); // { mode: 'list' | 'edit' | 'new', standardId?: string }
+  const [showLibrary, setShowLibrary] = useState(false);
+
+  const handleEdit = (standardId) => {
+    setView({ mode: 'edit', standardId });
+  };
+
+  const handleNewStandard = () => {
+    setView({ mode: 'new' });
+  };
+
+  const handleEditorBack = () => {
+    setView({ mode: 'list' });
+    refresh();
+  };
+
+  const handleSaved = () => {
+    setView({ mode: 'list' });
+    refresh();
+  };
+
+  if (view.mode === 'edit' || view.mode === 'new') {
+    return (
+      <StandardEditor
+        standardId={view.standardId}
+        isNew={view.mode === 'new'}
+        onBack={handleEditorBack}
+        onSaved={handleSaved}
+      />
+    );
+  }
+
+  return (
+    <div className="standards-page">
+      <div className="standards-page-header">
+        <div>
+          <h1 className="standards-page-title">Standards</h1>
+          <p className="standards-page-subtitle">
+            Manage evaluation standards and quality criteria.
+          </p>
+        </div>
+        <div className="standards-page-header-actions">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => setShowLibrary(true)}
+          >
+            Browse Library
+          </button>
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={handleNewStandard}
+          >
+            + New Standard
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="inline-error" style={{ marginBottom: 16 }}>{error}</p>}
+
+      {loading ? (
+        <div className="standards-loading">Loading standards...</div>
+      ) : (
+        <StandardsList
+          grouped={grouped}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          onDuplicate={handleDuplicate}
+        />
+      )}
+
+      {showLibrary && (
+        <LibraryBrowser
+          onClose={() => setShowLibrary(false)}
+          onImported={() => { setShowLibrary(false); refresh(); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -50,13 +50,6 @@ export default function StandardsPage() {
         <div className="standards-page-header-actions">
           <button
             type="button"
-            className="btn-secondary"
-            onClick={() => setShowLibrary(true)}
-          >
-            Browse Library
-          </button>
-          <button
-            type="button"
             className="btn-primary"
             onClick={handleNewStandard}
           >

--- a/src/quodeq/ui/src/features/standards/components/LibraryBrowser.jsx
+++ b/src/quodeq/ui/src/features/standards/components/LibraryBrowser.jsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { useLibrary } from '../hooks/useLibrary.js';
+
+function LibraryCard({ standard, onImport, importing }) {
+  const principleCount = standard.principles?.length ?? 0;
+  const requirementCount = (standard.principles || []).reduce(
+    (sum, p) => sum + (p.requirements?.length ?? 0),
+    0
+  );
+
+  return (
+    <div className="library-card">
+      <div className="library-card-header">
+        <h4 className="library-card-name">{standard.name}</h4>
+        {standard.id && <span className="library-card-id">{standard.id}</span>}
+      </div>
+      {standard.description && (
+        <p className="library-card-description">{standard.description}</p>
+      )}
+      <div className="library-card-counts">
+        <span>{principleCount} {principleCount === 1 ? 'principle' : 'principles'}</span>
+        <span className="library-card-counts-sep">·</span>
+        <span>{requirementCount} {requirementCount === 1 ? 'requirement' : 'requirements'}</span>
+      </div>
+      <div className="library-card-footer">
+        <button
+          type="button"
+          className="btn-primary library-import-btn"
+          onClick={() => onImport(standard.file || standard.id)}
+          disabled={importing}
+        >
+          Import
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function LibraryBrowser({ onClose, onImported }) {
+  const { libraryStandards, loading, error, fetchLibrary, importStandard } = useLibrary();
+
+  useEffect(() => { fetchLibrary(); }, [fetchLibrary]);
+
+  const handleImport = async (file) => {
+    try {
+      await importStandard(file);
+      if (onImported) onImported();
+      onClose();
+    } catch (err) {
+      console.error('Import failed:', err);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-dialog modal-dialog--wide" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <h2 className="modal-title">Standards Library</h2>
+          <button type="button" className="modal-close-btn" onClick={onClose} aria-label="Close">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <p className="library-browser-subtitle">
+          Import community and reference standards into your workspace.
+        </p>
+
+        {loading && <div className="library-loading">Loading library...</div>}
+        {error && <p className="inline-error">{error}</p>}
+
+        {!loading && !error && libraryStandards.length === 0 && (
+          <p className="library-empty">No community standards available.</p>
+        )}
+
+        {!loading && libraryStandards.length > 0 && (
+          <div className="library-grid">
+            {libraryStandards.map((s) => (
+              <LibraryCard
+                key={s.id || s.file}
+                standard={s}
+                onImport={handleImport}
+                importing={false}
+              />
+            ))}
+          </div>
+        )}
+
+        <div className="modal-actions modal-actions--end">
+          <button type="button" className="btn-secondary" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
@@ -1,0 +1,38 @@
+export default function PrincipleForm({ principle, principleIndex, onUpdateField, editable }) {
+  return (
+    <div className="principle-form">
+      <h3 className="detail-form-title">Principle</h3>
+
+      <div className="form-group">
+        <label htmlFor={`principle-name-${principleIndex}`}>Name</label>
+        <input
+          id={`principle-name-${principleIndex}`}
+          className="form-input"
+          value={principle.name || ''}
+          onChange={(e) => onUpdateField(['principles', principleIndex, 'name'], e.target.value)}
+          disabled={!editable}
+          placeholder="Principle name"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor={`principle-desc-${principleIndex}`}>Description</label>
+        <textarea
+          id={`principle-desc-${principleIndex}`}
+          className="form-textarea"
+          value={principle.description || ''}
+          onChange={(e) => onUpdateField(['principles', principleIndex, 'description'], e.target.value)}
+          disabled={!editable}
+          placeholder="Describe this principle..."
+          rows={4}
+        />
+      </div>
+
+      <div className="principle-form-meta">
+        <span className="principle-form-req-count">
+          {principle.requirements?.length ?? 0} requirement{(principle.requirements?.length ?? 0) === 1 ? '' : 's'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
@@ -1,4 +1,12 @@
+import { useRef, useEffect } from 'react';
+
 export default function PrincipleForm({ principle, principleIndex, onUpdateField, editable }) {
+  const nameRef = useRef(null);
+
+  useEffect(() => {
+    if (!principle.name && nameRef.current) nameRef.current.focus();
+  }, [principleIndex]);
+
   return (
     <div className="principle-form">
       <h3 className="detail-form-title">Principle</h3>
@@ -6,13 +14,13 @@ export default function PrincipleForm({ principle, principleIndex, onUpdateField
       <div className="form-group">
         <label htmlFor={`principle-name-${principleIndex}`}>Name</label>
         <input
+          ref={nameRef}
           id={`principle-name-${principleIndex}`}
           className="form-input"
           value={principle.name || ''}
           onChange={(e) => onUpdateField(['principles', principleIndex, 'name'], e.target.value)}
           disabled={!editable}
           placeholder="e.g. Dependency Rule"
-          autoFocus={!principle.name}
         />
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/PrincipleForm.jsx
@@ -11,7 +11,8 @@ export default function PrincipleForm({ principle, principleIndex, onUpdateField
           value={principle.name || ''}
           onChange={(e) => onUpdateField(['principles', principleIndex, 'name'], e.target.value)}
           disabled={!editable}
-          placeholder="Principle name"
+          placeholder="e.g. Dependency Rule"
+          autoFocus={!principle.name}
         />
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,6 +1,7 @@
 const REF_TYPES = ['url', 'rfc', 'cwe', 'cve', 'owasp', 'nist', 'iso', 'other'];
 
-function ReferenceRow({ ref, index, onChange, onRemove }) {
+function ReferenceRow({ refData, index, onChange, onRemove }) {
+  const ref = refData;
   return (
     <div className="ref-row">
       <select
@@ -72,7 +73,7 @@ export default function ReferenceEditor({ refs, onChange, disabled }) {
       {refs.map((ref, i) => (
         <ReferenceRow
           key={i}
-          ref={ref}
+          refData={ref}
           index={i}
           onChange={disabled ? () => {} : handleChange}
           onRemove={disabled ? () => {} : handleRemove}

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -22,54 +22,102 @@ function formatRefDisplay(ref) {
   return n.name ? `${id}: ${n.name}` : id;
 }
 
-function CweSearch({ value, onSelect, disabled }) {
+const ABSTRACTION_ORDER = ['Base', 'Variant', 'Class', 'Compound', 'Pillar', 'Category'];
+
+function CweBrowserModal({ onSelect, onClose }) {
   const [cwes, setCwes] = useState([]);
   const [query, setQuery] = useState('');
-  const [open, setOpen] = useState(false);
-  const wrapperRef = useRef(null);
+  const [filterAbstraction, setFilterAbstraction] = useState('');
+  const searchRef = useRef(null);
 
   useEffect(() => {
     listCwes().then(setCwes).catch(() => setCwes([]));
   }, []);
 
   useEffect(() => {
-    function handleClickOutside(e) {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    if (searchRef.current) searchRef.current.focus();
   }, []);
 
-  const filtered = query
-    ? cwes.filter((c) => String(c.id).includes(query) || c.name.toLowerCase().includes(query.toLowerCase())).slice(0, 20)
-    : cwes.slice(0, 20);
+  const filtered = cwes.filter((c) => {
+    if (filterAbstraction && c.abstraction !== filterAbstraction) return false;
+    if (!query) return true;
+    return String(c.id).includes(query) || c.name.toLowerCase().includes(query.toLowerCase());
+  });
 
   return (
-    <div className="cwe-search" ref={wrapperRef}>
-      <input
-        className="ref-id-input"
-        placeholder="Search CWE..."
-        value={open ? query : (value ? `CWE-${value}` : '')}
-        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
-        onFocus={() => setOpen(true)}
-        disabled={disabled}
-        aria-label="Search CWE"
-      />
-      {open && filtered.length > 0 && (
-        <div className="cwe-search-dropdown">
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="cwe-browser-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="cwe-browser-header">
+          <h3 className="cwe-browser-title">Select CWE</h3>
+          <button type="button" className="modal-close-btn" onClick={onClose}>&times;</button>
+        </div>
+
+        <div className="cwe-browser-toolbar">
+          <input
+            ref={searchRef}
+            className="cwe-browser-search"
+            placeholder="Search by ID or name..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <select
+            className="cwe-browser-filter"
+            value={filterAbstraction}
+            onChange={(e) => setFilterAbstraction(e.target.value)}
+          >
+            <option value="">All types</option>
+            {ABSTRACTION_ORDER.map((a) => (
+              <option key={a} value={a}>{a}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="cwe-browser-count">{filtered.length} of {cwes.length} CWEs</div>
+
+        <div className="cwe-browser-list">
           {filtered.map((c) => (
             <div
               key={c.id}
-              className={`cwe-search-option${String(c.id) === String(value) ? ' cwe-search-option--selected' : ''}`}
-              onClick={() => { onSelect(c); setQuery(''); setOpen(false); }}
+              className="cwe-browser-item"
+              onClick={() => { onSelect(c); onClose(); }}
             >
-              <span className="cwe-search-id">CWE-{c.id}</span>
-              <span className="cwe-search-name">{c.name}</span>
+              <div className="cwe-browser-item-header">
+                <span className="cwe-browser-item-id">CWE-{c.id}</span>
+                <span className="cwe-browser-item-abstraction">{c.abstraction}</span>
+              </div>
+              <div className="cwe-browser-item-name">{c.name}</div>
             </div>
           ))}
+          {filtered.length === 0 && (
+            <div className="cwe-browser-empty">No CWEs match your search.</div>
+          )}
         </div>
-      )}
+      </div>
     </div>
+  );
+}
+
+function CweSelector({ value, name, onSelect, disabled }) {
+  const [showBrowser, setShowBrowser] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="cwe-select-btn"
+        onClick={() => !disabled && setShowBrowser(true)}
+        disabled={disabled}
+      >
+        {value ? `CWE-${value}` : 'Select CWE...'}
+      </button>
+      {name && <span className="ref-cwe-name" title={name}>{name}</span>}
+      {showBrowser && (
+        <CweBrowserModal
+          onSelect={onSelect}
+          onClose={() => setShowBrowser(false)}
+        />
+      )}
+    </>
   );
 }
 
@@ -115,10 +163,7 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
       </select>
 
       {isCwe ? (
-        <>
-          <CweSearch value={ref.refId} onSelect={handleCweSelect} disabled={disabled} />
-          {ref.name && <span className="ref-cwe-name" title={ref.name}>{ref.name}</span>}
-        </>
+        <CweSelector value={ref.refId} name={ref.name} onSelect={handleCweSelect} disabled={disabled} />
       ) : (
         <input
           className="ref-name-input"

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,23 +1,58 @@
 const REF_TYPES = ['cwe', 'cve', 'owasp', 'nist', 'iso', 'rfc', 'book', 'url', 'other'];
 
-/** Normalize built-in format {source, id, name, url} to editor format {type, label, url} */
+const URL_TEMPLATES = {
+  cwe: (id) => `https://cwe.mitre.org/data/definitions/${id}.html`,
+  cve: (id) => `https://www.cve.org/CVERecord?id=CVE-${id}`,
+};
+
+/** Normalize built-in format {source, id, name, url} to editor format {type, refId, name, url} */
 function normalizeRef(ref) {
   if (ref.source && !ref.type) {
-    const id = ref.id ? `${ref.source.toUpperCase()}-${ref.id}` : '';
-    const label = ref.name ? `${id}: ${ref.name}`.trim() : id;
-    return { type: ref.source, label: label || '', url: ref.url || '' };
+    return {
+      type: ref.source,
+      refId: ref.id || '',
+      name: ref.name || '',
+      url: ref.url || '',
+    };
   }
-  return { type: ref.type || 'url', label: ref.label || ref.name || '', url: ref.url || '' };
+  return {
+    type: ref.type || 'url',
+    refId: ref.refId || ref.id || '',
+    name: ref.name || ref.label || '',
+    url: ref.url || '',
+  };
 }
 
 function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
   const ref = normalizeRef(refData);
+  const showId = ['cwe', 'cve', 'owasp', 'nist', 'iso', 'rfc'].includes(ref.type);
+
+  const handleTypeChange = (newType) => {
+    const updated = { ...ref, type: newType };
+    if (URL_TEMPLATES[newType] && ref.refId) {
+      updated.url = URL_TEMPLATES[newType](ref.refId);
+    }
+    onChange(index, updated);
+  };
+
+  const handleIdChange = (newId) => {
+    const updated = { ...ref, refId: newId };
+    if (URL_TEMPLATES[ref.type] && newId) {
+      updated.url = URL_TEMPLATES[ref.type](newId);
+    }
+    onChange(index, updated);
+  };
+
+  const handleFieldChange = (field, value) => {
+    onChange(index, { ...ref, [field]: value });
+  };
+
   return (
     <div className="ref-row">
       <select
         className="ref-type-select"
         value={ref.type}
-        onChange={(e) => onChange(index, 'type', e.target.value)}
+        onChange={(e) => handleTypeChange(e.target.value)}
         disabled={disabled}
         aria-label="Reference type"
       >
@@ -25,19 +60,29 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
           <option key={t} value={t}>{t.toUpperCase()}</option>
         ))}
       </select>
+      {showId && (
+        <input
+          className="ref-id-input"
+          placeholder="ID (e.g. 209)"
+          value={ref.refId}
+          onChange={(e) => handleIdChange(e.target.value)}
+          disabled={disabled}
+          aria-label="Reference ID"
+        />
+      )}
       <input
-        className="ref-label-input"
-        placeholder="Label (e.g. CWE-798: Hardcoded Credentials)"
-        value={ref.label}
-        onChange={(e) => onChange(index, 'label', e.target.value)}
+        className="ref-name-input"
+        placeholder={showId ? 'Name (e.g. Hardcoded Credentials)' : 'Description'}
+        value={ref.name}
+        onChange={(e) => handleFieldChange('name', e.target.value)}
         disabled={disabled}
-        aria-label="Reference label"
+        aria-label="Reference name"
       />
       <input
         className="ref-url-input"
         placeholder="URL (optional)"
         value={ref.url}
-        onChange={(e) => onChange(index, 'url', e.target.value)}
+        onChange={(e) => handleFieldChange('url', e.target.value)}
         disabled={disabled}
         aria-label="Reference URL"
       />
@@ -59,13 +104,13 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
 }
 
 export default function ReferenceEditor({ refs, onChange, disabled }) {
-  const handleChange = (index, field, value) => {
-    const updated = refs.map((r, i) => i === index ? { ...normalizeRef(r), [field]: value } : r);
+  const handleChange = (index, updatedRef) => {
+    const updated = refs.map((r, i) => i === index ? updatedRef : r);
     onChange(updated);
   };
 
   const handleAdd = () => {
-    onChange([...refs, { type: 'cwe', label: '', url: '' }]);
+    onChange([...refs, { type: 'cwe', refId: '', name: '', url: '' }]);
   };
 
   const handleRemove = (index) => {

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,46 +1,98 @@
-const REF_TYPES = ['cwe', 'cve', 'owasp', 'nist', 'iso', 'rfc', 'book', 'url', 'other'];
+import { useState, useEffect, useRef } from 'react';
+import { listCwes } from '../../../api/index.js';
+
+const REF_TYPES = ['cwe', 'owasp', 'nist', 'iso', 'rfc', 'book', 'url', 'other'];
 
 const URL_TEMPLATES = {
   cwe: (id) => `https://cwe.mitre.org/data/definitions/${id}.html`,
-  cve: (id) => `https://www.cve.org/CVERecord?id=CVE-${id}`,
 };
 
-/** Normalize built-in format {source, id, name, url} to editor format {type, refId, name, url} */
+/** Normalize built-in format {source, id, name, url} to editor format */
 function normalizeRef(ref) {
   if (ref.source && !ref.type) {
-    return {
-      type: ref.source,
-      refId: ref.id || '',
-      name: ref.name || '',
-      url: ref.url || '',
-    };
+    return { type: ref.source, refId: String(ref.id || ''), name: ref.name || '', url: ref.url || '' };
   }
-  return {
-    type: ref.type || 'url',
-    refId: ref.refId || ref.id || '',
-    name: ref.name || ref.label || '',
-    url: ref.url || '',
-  };
+  return { type: ref.type || 'url', refId: ref.refId || ref.id || '', name: ref.name || ref.label || '', url: ref.url || '' };
+}
+
+function formatRefDisplay(ref) {
+  const n = normalizeRef(ref);
+  const prefix = n.type ? n.type.toUpperCase() : '';
+  const id = n.refId ? `${prefix}-${n.refId}` : prefix;
+  return n.name ? `${id}: ${n.name}` : id;
+}
+
+function CweSearch({ value, onSelect, disabled }) {
+  const [cwes, setCwes] = useState([]);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+
+  useEffect(() => {
+    listCwes().then(setCwes).catch(() => setCwes([]));
+  }, []);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const filtered = query
+    ? cwes.filter((c) => String(c.id).includes(query) || c.name.toLowerCase().includes(query.toLowerCase())).slice(0, 20)
+    : cwes.slice(0, 20);
+
+  return (
+    <div className="cwe-search" ref={wrapperRef}>
+      <input
+        className="ref-id-input"
+        placeholder="Search CWE..."
+        value={open ? query : (value ? `CWE-${value}` : '')}
+        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        disabled={disabled}
+        aria-label="Search CWE"
+      />
+      {open && filtered.length > 0 && (
+        <div className="cwe-search-dropdown">
+          {filtered.map((c) => (
+            <div
+              key={c.id}
+              className={`cwe-search-option${String(c.id) === String(value) ? ' cwe-search-option--selected' : ''}`}
+              onClick={() => { onSelect(c); setQuery(''); setOpen(false); }}
+            >
+              <span className="cwe-search-id">CWE-{c.id}</span>
+              <span className="cwe-search-name">{c.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
   const ref = normalizeRef(refData);
-  const showId = ['cwe', 'cve', 'owasp', 'nist', 'iso', 'rfc'].includes(ref.type);
+  const isCwe = ref.type === 'cwe';
+  const showFreeId = !isCwe && ['owasp', 'nist', 'iso', 'rfc'].includes(ref.type);
 
   const handleTypeChange = (newType) => {
-    const updated = { ...ref, type: newType };
-    if (URL_TEMPLATES[newType] && ref.refId) {
-      updated.url = URL_TEMPLATES[newType](ref.refId);
-    }
-    onChange(index, updated);
+    onChange(index, { ...ref, type: newType, refId: '', name: '', url: '' });
+  };
+
+  const handleCweSelect = (cwe) => {
+    onChange(index, {
+      type: 'cwe',
+      refId: String(cwe.id),
+      name: cwe.name,
+      url: URL_TEMPLATES.cwe(cwe.id),
+    });
   };
 
   const handleIdChange = (newId) => {
-    const updated = { ...ref, refId: newId };
-    if (URL_TEMPLATES[ref.type] && newId) {
-      updated.url = URL_TEMPLATES[ref.type](newId);
-    }
-    onChange(index, updated);
+    onChange(index, { ...ref, refId: newId });
   };
 
   const handleFieldChange = (field, value) => {
@@ -60,32 +112,46 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
           <option key={t} value={t}>{t.toUpperCase()}</option>
         ))}
       </select>
-      {showId && (
+
+      {isCwe && (
+        <CweSearch value={ref.refId} onSelect={handleCweSelect} disabled={disabled} />
+      )}
+
+      {showFreeId && (
         <input
           className="ref-id-input"
-          placeholder="ID (e.g. 209)"
+          placeholder="ID"
           value={ref.refId}
           onChange={(e) => handleIdChange(e.target.value)}
           disabled={disabled}
           aria-label="Reference ID"
         />
       )}
-      <input
-        className="ref-name-input"
-        placeholder={showId ? 'Name (e.g. Hardcoded Credentials)' : 'Description'}
-        value={ref.name}
-        onChange={(e) => handleFieldChange('name', e.target.value)}
-        disabled={disabled}
-        aria-label="Reference name"
-      />
+
+      {!isCwe && (
+        <input
+          className="ref-name-input"
+          placeholder={ref.type === 'book' ? 'Title (e.g. Clean Architecture Ch.22)' : ref.type === 'url' ? 'Description' : 'Name'}
+          value={ref.name}
+          onChange={(e) => handleFieldChange('name', e.target.value)}
+          disabled={disabled}
+          aria-label="Reference name"
+        />
+      )}
+
+      {isCwe && ref.name && (
+        <span className="ref-cwe-name" title={ref.name}>{ref.name}</span>
+      )}
+
       <input
         className="ref-url-input"
-        placeholder="URL (optional)"
+        placeholder="URL"
         value={ref.url}
         onChange={(e) => handleFieldChange('url', e.target.value)}
         disabled={disabled}
         aria-label="Reference URL"
       />
+
       {!disabled && (
         <button
           type="button"

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,13 +1,24 @@
-const REF_TYPES = ['url', 'rfc', 'cwe', 'cve', 'owasp', 'nist', 'iso', 'other'];
+const REF_TYPES = ['cwe', 'cve', 'owasp', 'nist', 'iso', 'rfc', 'book', 'url', 'other'];
 
-function ReferenceRow({ refData, index, onChange, onRemove }) {
-  const ref = refData;
+/** Normalize built-in format {source, id, name, url} to editor format {type, label, url} */
+function normalizeRef(ref) {
+  if (ref.source && !ref.type) {
+    const id = ref.id ? `${ref.source.toUpperCase()}-${ref.id}` : '';
+    const label = ref.name ? `${id}: ${ref.name}`.trim() : id;
+    return { type: ref.source, label: label || '', url: ref.url || '' };
+  }
+  return { type: ref.type || 'url', label: ref.label || ref.name || '', url: ref.url || '' };
+}
+
+function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
+  const ref = normalizeRef(refData);
   return (
     <div className="ref-row">
       <select
         className="ref-type-select"
-        value={ref.type || 'url'}
+        value={ref.type}
         onChange={(e) => onChange(index, 'type', e.target.value)}
+        disabled={disabled}
         aria-label="Reference type"
       >
         {REF_TYPES.map((t) => (
@@ -16,41 +27,45 @@ function ReferenceRow({ refData, index, onChange, onRemove }) {
       </select>
       <input
         className="ref-label-input"
-        placeholder="Label"
-        value={ref.label || ''}
+        placeholder="Label (e.g. CWE-798: Hardcoded Credentials)"
+        value={ref.label}
         onChange={(e) => onChange(index, 'label', e.target.value)}
+        disabled={disabled}
         aria-label="Reference label"
       />
       <input
         className="ref-url-input"
-        placeholder="URL or identifier"
-        value={ref.url || ''}
+        placeholder="URL (optional)"
+        value={ref.url}
         onChange={(e) => onChange(index, 'url', e.target.value)}
+        disabled={disabled}
         aria-label="Reference URL"
       />
-      <button
-        type="button"
-        className="ref-remove-btn"
-        onClick={() => onRemove(index)}
-        aria-label="Remove reference"
-        title="Remove"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-          <path d="M18 6L6 18M6 6l12 12" />
-        </svg>
-      </button>
+      {!disabled && (
+        <button
+          type="button"
+          className="ref-remove-btn"
+          onClick={() => onRemove(index)}
+          aria-label="Remove reference"
+          title="Remove"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }
 
 export default function ReferenceEditor({ refs, onChange, disabled }) {
   const handleChange = (index, field, value) => {
-    const updated = refs.map((r, i) => i === index ? { ...r, [field]: value } : r);
+    const updated = refs.map((r, i) => i === index ? { ...normalizeRef(r), [field]: value } : r);
     onChange(updated);
   };
 
   const handleAdd = () => {
-    onChange([...refs, { type: 'url', label: '', url: '' }]);
+    onChange([...refs, { type: 'cwe', label: '', url: '' }]);
   };
 
   const handleRemove = (index) => {
@@ -75,8 +90,9 @@ export default function ReferenceEditor({ refs, onChange, disabled }) {
           key={i}
           refData={ref}
           index={i}
-          onChange={disabled ? () => {} : handleChange}
-          onRemove={disabled ? () => {} : handleRemove}
+          onChange={handleChange}
+          onRemove={handleRemove}
+          disabled={disabled}
         />
       ))}
     </div>

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,0 +1,83 @@
+const REF_TYPES = ['url', 'rfc', 'cwe', 'cve', 'owasp', 'nist', 'iso', 'other'];
+
+function ReferenceRow({ ref, index, onChange, onRemove }) {
+  return (
+    <div className="ref-row">
+      <select
+        className="ref-type-select"
+        value={ref.type || 'url'}
+        onChange={(e) => onChange(index, 'type', e.target.value)}
+        aria-label="Reference type"
+      >
+        {REF_TYPES.map((t) => (
+          <option key={t} value={t}>{t.toUpperCase()}</option>
+        ))}
+      </select>
+      <input
+        className="ref-label-input"
+        placeholder="Label"
+        value={ref.label || ''}
+        onChange={(e) => onChange(index, 'label', e.target.value)}
+        aria-label="Reference label"
+      />
+      <input
+        className="ref-url-input"
+        placeholder="URL or identifier"
+        value={ref.url || ''}
+        onChange={(e) => onChange(index, 'url', e.target.value)}
+        aria-label="Reference URL"
+      />
+      <button
+        type="button"
+        className="ref-remove-btn"
+        onClick={() => onRemove(index)}
+        aria-label="Remove reference"
+        title="Remove"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d="M18 6L6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+export default function ReferenceEditor({ refs, onChange, disabled }) {
+  const handleChange = (index, field, value) => {
+    const updated = refs.map((r, i) => i === index ? { ...r, [field]: value } : r);
+    onChange(updated);
+  };
+
+  const handleAdd = () => {
+    onChange([...refs, { type: 'url', label: '', url: '' }]);
+  };
+
+  const handleRemove = (index) => {
+    onChange(refs.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="reference-editor">
+      <div className="reference-editor-header">
+        <span className="reference-editor-label">References</span>
+        {!disabled && (
+          <button type="button" className="ref-add-btn" onClick={handleAdd}>
+            + Add Reference
+          </button>
+        )}
+      </div>
+      {refs.length === 0 && (
+        <p className="reference-editor-empty">No references yet.</p>
+      )}
+      {refs.map((ref, i) => (
+        <ReferenceRow
+          key={i}
+          ref={ref}
+          index={i}
+          onChange={disabled ? () => {} : handleChange}
+          onRemove={disabled ? () => {} : handleRemove}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { listCwes } from '../../../api/index.js';
 
-const REF_TYPES = ['cwe', 'owasp', 'nist', 'iso', 'rfc', 'book', 'url', 'other'];
+const REF_TYPES = ['cwe', 'book', 'url', 'other'];
 
 const URL_TEMPLATES = {
   cwe: (id) => `https://cwe.mitre.org/data/definitions/${id}.html`,
@@ -73,10 +73,15 @@ function CweSearch({ value, onSelect, disabled }) {
   );
 }
 
+const NAME_PLACEHOLDERS = {
+  book: 'Title (e.g. Clean Architecture Ch.22)',
+  url: 'Description',
+  other: 'Description',
+};
+
 function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
   const ref = normalizeRef(refData);
   const isCwe = ref.type === 'cwe';
-  const showFreeId = !isCwe && ['owasp', 'nist', 'iso', 'rfc'].includes(ref.type);
 
   const handleTypeChange = (newType) => {
     onChange(index, { ...ref, type: newType, refId: '', name: '', url: '' });
@@ -91,10 +96,6 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
     });
   };
 
-  const handleIdChange = (newId) => {
-    onChange(index, { ...ref, refId: newId });
-  };
-
   const handleFieldChange = (field, value) => {
     onChange(index, { ...ref, [field]: value });
   };
@@ -103,7 +104,7 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
     <div className="ref-row">
       <select
         className="ref-type-select"
-        value={ref.type}
+        value={REF_TYPES.includes(ref.type) ? ref.type : 'other'}
         onChange={(e) => handleTypeChange(e.target.value)}
         disabled={disabled}
         aria-label="Reference type"
@@ -113,25 +114,15 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
         ))}
       </select>
 
-      {isCwe && (
-        <CweSearch value={ref.refId} onSelect={handleCweSelect} disabled={disabled} />
-      )}
-
-      {showFreeId && (
-        <input
-          className="ref-id-input"
-          placeholder="ID"
-          value={ref.refId}
-          onChange={(e) => handleIdChange(e.target.value)}
-          disabled={disabled}
-          aria-label="Reference ID"
-        />
-      )}
-
-      {!isCwe && (
+      {isCwe ? (
+        <>
+          <CweSearch value={ref.refId} onSelect={handleCweSelect} disabled={disabled} />
+          {ref.name && <span className="ref-cwe-name" title={ref.name}>{ref.name}</span>}
+        </>
+      ) : (
         <input
           className="ref-name-input"
-          placeholder={ref.type === 'book' ? 'Title (e.g. Clean Architecture Ch.22)' : ref.type === 'url' ? 'Description' : 'Name'}
+          placeholder={NAME_PLACEHOLDERS[ref.type] || 'Description'}
           value={ref.name}
           onChange={(e) => handleFieldChange('name', e.target.value)}
           disabled={disabled}
@@ -139,13 +130,9 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
         />
       )}
 
-      {isCwe && ref.name && (
-        <span className="ref-cwe-name" title={ref.name}>{ref.name}</span>
-      )}
-
       <input
         className="ref-url-input"
-        placeholder="URL"
+        placeholder="URL (optional)"
         value={ref.url}
         onChange={(e) => handleFieldChange('url', e.target.value)}
         disabled={disabled}

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { listCwes } from '../../../api/index.js';
 
-const REF_TYPES = ['cwe', 'book', 'url', 'other'];
+const EDITABLE_REF_TYPES = ['cwe', 'book', 'url', 'other'];
+const BUILTIN_REF_TYPES = ['cwe', 'asvs', 'cert', 'cisq', 'wcag22'];
 
 const URL_TEMPLATES = {
   cwe: (id) => `https://cwe.mitre.org/data/definitions/${id}.html`,
@@ -131,6 +132,11 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
   const ref = normalizeRef(refData);
   const isCwe = ref.type === 'cwe';
 
+  // Build type options: editable types for custom, include current type for built-in
+  const typeOptions = disabled
+    ? [...new Set([ref.type, ...BUILTIN_REF_TYPES, ...EDITABLE_REF_TYPES])]
+    : EDITABLE_REF_TYPES;
+
   const handleTypeChange = (newType) => {
     onChange(index, { ...ref, type: newType, refId: '', name: '', url: '' });
   };
@@ -152,12 +158,12 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
     <div className="ref-row">
       <select
         className="ref-type-select"
-        value={REF_TYPES.includes(ref.type) ? ref.type : 'other'}
+        value={typeOptions.includes(ref.type) ? ref.type : 'other'}
         onChange={(e) => handleTypeChange(e.target.value)}
         disabled={disabled}
         aria-label="Reference type"
       >
-        {REF_TYPES.map((t) => (
+        {typeOptions.map((t) => (
           <option key={t} value={t}>{t.toUpperCase()}</option>
         ))}
       </select>
@@ -165,14 +171,19 @@ function ReferenceRow({ refData, index, onChange, onRemove, disabled }) {
       {isCwe ? (
         <CweSelector value={ref.refId} name={ref.name} onSelect={handleCweSelect} disabled={disabled} />
       ) : (
-        <input
-          className="ref-name-input"
-          placeholder={NAME_PLACEHOLDERS[ref.type] || 'Description'}
-          value={ref.name}
-          onChange={(e) => handleFieldChange('name', e.target.value)}
-          disabled={disabled}
-          aria-label="Reference name"
-        />
+        <>
+          {ref.refId && (
+            <span className="ref-builtin-id">{ref.type.toUpperCase()}-{ref.refId}</span>
+          )}
+          <input
+            className="ref-name-input"
+            placeholder={NAME_PLACEHOLDERS[ref.type] || 'Description'}
+            value={ref.name}
+            onChange={(e) => handleFieldChange('name', e.target.value)}
+            disabled={disabled}
+            aria-label="Reference name"
+          />
+        </>
       )}
 
       <input

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -1,0 +1,42 @@
+import ReferenceEditor from './ReferenceEditor.jsx';
+
+export default function RequirementForm({ requirement, principleIndex, reqIndex, onUpdateField, editable }) {
+  const basePath = ['principles', principleIndex, 'requirements', reqIndex];
+
+  return (
+    <div className="requirement-form">
+      <h3 className="detail-form-title">Requirement</h3>
+
+      <div className="form-group">
+        <label htmlFor={`req-id-${principleIndex}-${reqIndex}`}>ID</label>
+        <input
+          id={`req-id-${principleIndex}-${reqIndex}`}
+          className="form-input"
+          value={requirement.id || ''}
+          onChange={(e) => onUpdateField([...basePath, 'id'], e.target.value)}
+          disabled={!editable}
+          placeholder="e.g. REQ-001"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor={`req-text-${principleIndex}-${reqIndex}`}>Text</label>
+        <textarea
+          id={`req-text-${principleIndex}-${reqIndex}`}
+          className="form-textarea"
+          value={requirement.text || ''}
+          onChange={(e) => onUpdateField([...basePath, 'text'], e.target.value)}
+          disabled={!editable}
+          placeholder="Describe the requirement..."
+          rows={5}
+        />
+      </div>
+
+      <ReferenceEditor
+        refs={requirement.refs || []}
+        onChange={(updated) => onUpdateField([...basePath, 'refs'], updated)}
+        disabled={!editable}
+      />
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -8,18 +8,6 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
       <h3 className="detail-form-title">Requirement</h3>
 
       <div className="form-group">
-        <label htmlFor={`req-id-${principleIndex}-${reqIndex}`}>ID</label>
-        <input
-          id={`req-id-${principleIndex}-${reqIndex}`}
-          className="form-input"
-          value={requirement.id || ''}
-          onChange={(e) => onUpdateField([...basePath, 'id'], e.target.value)}
-          disabled={!editable}
-          placeholder="e.g. REQ-001"
-        />
-      </div>
-
-      <div className="form-group">
         <label htmlFor={`req-text-${principleIndex}-${reqIndex}`}>Text</label>
         <textarea
           id={`req-text-${principleIndex}-${reqIndex}`}

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -8,16 +8,28 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
       <h3 className="detail-form-title">Requirement</h3>
 
       <div className="form-group">
-        <label htmlFor={`req-text-${principleIndex}-${reqIndex}`}>Text</label>
-        <textarea
+        <label htmlFor={`req-text-${principleIndex}-${reqIndex}`}>Rule</label>
+        <input
           id={`req-text-${principleIndex}-${reqIndex}`}
-          className="form-textarea"
+          className="form-input"
           value={requirement.text || ''}
           onChange={(e) => onUpdateField([...basePath, 'text'], e.target.value)}
           disabled={!editable}
           placeholder="e.g. Source code dependencies must point inward only"
-          rows={5}
           autoFocus={!requirement.text}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor={`req-desc-${principleIndex}-${reqIndex}`}>Description</label>
+        <textarea
+          id={`req-desc-${principleIndex}-${reqIndex}`}
+          className="form-textarea"
+          value={requirement.description || ''}
+          onChange={(e) => onUpdateField([...basePath, 'description'], e.target.value)}
+          disabled={!editable}
+          placeholder="Context and rationale for this rule..."
+          rows={3}
         />
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -1,7 +1,13 @@
+import { useRef, useEffect } from 'react';
 import ReferenceEditor from './ReferenceEditor.jsx';
 
 export default function RequirementForm({ requirement, principleIndex, reqIndex, onUpdateField, editable }) {
   const basePath = ['principles', principleIndex, 'requirements', reqIndex];
+  const ruleRef = useRef(null);
+
+  useEffect(() => {
+    if (!requirement.text && ruleRef.current) ruleRef.current.focus();
+  }, [principleIndex, reqIndex]);
 
   return (
     <div className="requirement-form">
@@ -10,13 +16,13 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
       <div className="form-group">
         <label htmlFor={`req-text-${principleIndex}-${reqIndex}`}>Rule</label>
         <input
+          ref={ruleRef}
           id={`req-text-${principleIndex}-${reqIndex}`}
           className="form-input"
           value={requirement.text || ''}
           onChange={(e) => onUpdateField([...basePath, 'text'], e.target.value)}
           disabled={!editable}
           placeholder="e.g. Source code dependencies must point inward only"
-          autoFocus={!requirement.text}
         />
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
+++ b/src/quodeq/ui/src/features/standards/components/RequirementForm.jsx
@@ -27,8 +27,9 @@ export default function RequirementForm({ requirement, principleIndex, reqIndex,
           value={requirement.text || ''}
           onChange={(e) => onUpdateField([...basePath, 'text'], e.target.value)}
           disabled={!editable}
-          placeholder="Describe the requirement..."
+          placeholder="e.g. Source code dependencies must point inward only"
           rows={5}
+          autoFocus={!requirement.text}
         />
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -79,7 +79,7 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
 
   return (
     <>
-      <div className={`standard-card standard-card--${standard.type}`} onClick={() => standard.type !== 'builtin' && onEdit(standard.id)}>
+      <div className={`standard-card standard-card--${standard.type}`} onClick={() => onEdit(standard.id)}>
         <div className="standard-card-header">
           <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
             {TYPE_LABELS[standard.type] || standard.type}
@@ -104,20 +104,25 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
         </div>
 
         <div className="standard-card-actions" onClick={(e) => e.stopPropagation()}>
-          {standard.type !== 'builtin' && (
-            <button
-              type="button"
-              className="card-action-btn"
-              onClick={() => onEdit(standard.id)}
-              title="Edit"
-            >
+          <button
+            type="button"
+            className="card-action-btn"
+            onClick={() => onEdit(standard.id)}
+            title={standard.type === 'builtin' ? 'View' : 'Edit'}
+          >
+            {standard.type === 'builtin' ? (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            ) : (
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
                 <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
               </svg>
-              Edit
-            </button>
-          )}
+            )}
+            {standard.type === 'builtin' ? 'View' : 'Edit'}
+          </button>
           <button
             type="button"
             className="card-action-btn"

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -70,8 +70,8 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
-  const principleCount = standard.principles?.length ?? 0;
-  const requirementCount = (standard.principles || []).reduce(
+  const principleCount = standard.principleCount ?? standard.principles?.length ?? 0;
+  const requirementCount = standard.requirementCount ?? (standard.principles || []).reduce(
     (sum, p) => sum + (p.requirements?.length ?? 0),
     0
   );

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -2,17 +2,40 @@ import { useState } from 'react';
 
 const TYPE_LABELS = { builtin: 'Built-in', community: 'Community', custom: 'Custom' };
 
-function ConfirmDeleteModal({ standardName, onConfirm, onCancel }) {
+function ConfirmDeleteModal({ standardName, principleCount, requirementCount, onConfirm, onCancel }) {
+  const [typed, setTyped] = useState('');
+  const hasContent = principleCount > 0 || requirementCount > 0;
+  const confirmText = standardName.toLowerCase().trim();
+  const canDelete = !hasContent || typed.toLowerCase().trim() === confirmText;
+
   return (
     <div className="modal-overlay" onClick={onCancel}>
       <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
         <h3 className="modal-title">Delete Standard</h3>
-        <p className="modal-body">
-          Are you sure you want to delete <strong>{standardName}</strong>? This action cannot be undone.
-        </p>
+        {hasContent ? (
+          <>
+            <p className="modal-body modal-body--warning">
+              <strong>{standardName}</strong> contains <strong>{principleCount} principle{principleCount !== 1 ? 's' : ''}</strong> and <strong>{requirementCount} requirement{requirementCount !== 1 ? 's' : ''}</strong>. This action cannot be undone.
+            </p>
+            <p className="modal-body">
+              Type <strong>{standardName}</strong> to confirm:
+            </p>
+            <input
+              className="modal-input"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={standardName}
+              autoFocus
+            />
+          </>
+        ) : (
+          <p className="modal-body">
+            Are you sure you want to delete <strong>{standardName}</strong>?
+          </p>
+        )}
         <div className="modal-actions">
           <button type="button" className="btn-secondary" onClick={onCancel}>Cancel</button>
-          <button type="button" className="btn-danger" onClick={onConfirm}>Delete</button>
+          <button type="button" className="btn-danger" onClick={onConfirm} disabled={!canDelete}>Delete</button>
         </div>
       </div>
     </div>
@@ -127,6 +150,8 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
       {showDeleteModal && (
         <ConfirmDeleteModal
           standardName={standard.name}
+          principleCount={principleCount}
+          requirementCount={requirementCount}
           onConfirm={() => { setShowDeleteModal(false); onDelete(standard.id); }}
           onCancel={() => setShowDeleteModal(false)}
         />

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -90,7 +90,7 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
         </div>
 
         <h3 className="standard-card-name">{standard.name}</h3>
-        {standard.id && (
+        {standard.type !== 'builtin' && standard.id && (
           <p className="standard-card-id">{standard.id}</p>
         )}
         {standard.description && (

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+
+const TYPE_LABELS = { builtin: 'Built-in', community: 'Community', custom: 'Custom' };
+
+function ConfirmDeleteModal({ standardName, onConfirm, onCancel }) {
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+        <h3 className="modal-title">Delete Standard</h3>
+        <p className="modal-body">
+          Are you sure you want to delete <strong>{standardName}</strong>? This action cannot be undone.
+        </p>
+        <div className="modal-actions">
+          <button type="button" className="btn-secondary" onClick={onCancel}>Cancel</button>
+          <button type="button" className="btn-danger" onClick={onConfirm}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DuplicateModal({ standardId, onConfirm, onCancel }) {
+  const [newId, setNewId] = useState(`${standardId}-copy`);
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal-dialog" onClick={(e) => e.stopPropagation()}>
+        <h3 className="modal-title">Duplicate Standard</h3>
+        <p className="modal-body">Enter an ID for the new standard:</p>
+        <input
+          className="modal-input"
+          value={newId}
+          onChange={(e) => setNewId(e.target.value)}
+          autoFocus
+        />
+        <div className="modal-actions">
+          <button type="button" className="btn-secondary" onClick={onCancel}>Cancel</button>
+          <button type="button" className="btn-primary" onClick={() => onConfirm(newId)} disabled={!newId.trim()}>
+            Duplicate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }) {
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+
+  const principleCount = standard.principles?.length ?? 0;
+  const requirementCount = (standard.principles || []).reduce(
+    (sum, p) => sum + (p.requirements?.length ?? 0),
+    0
+  );
+  const isDeletable = standard.type !== 'builtin';
+
+  return (
+    <>
+      <div className={`standard-card standard-card--${standard.type}`} onClick={() => onEdit(standard.id)}>
+        <div className="standard-card-header">
+          <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
+            {TYPE_LABELS[standard.type] || standard.type}
+          </span>
+          {standard.managed && (
+            <span className="standard-managed-badge" title="Managed standard — read-only">managed</span>
+          )}
+        </div>
+
+        <h3 className="standard-card-name">{standard.name}</h3>
+        {standard.id && (
+          <p className="standard-card-id">{standard.id}</p>
+        )}
+        {standard.description && (
+          <p className="standard-card-description">{standard.description}</p>
+        )}
+
+        <div className="standard-card-counts">
+          <span>{principleCount} {principleCount === 1 ? 'principle' : 'principles'}</span>
+          <span className="standard-card-counts-sep">·</span>
+          <span>{requirementCount} {requirementCount === 1 ? 'requirement' : 'requirements'}</span>
+        </div>
+
+        <div className="standard-card-actions" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            className="card-action-btn"
+            onClick={() => onEdit(standard.id)}
+            title="View / Edit"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+            </svg>
+            Edit
+          </button>
+          <button
+            type="button"
+            className="card-action-btn"
+            onClick={() => setShowDuplicateModal(true)}
+            title="Duplicate"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+            Duplicate
+          </button>
+          {isDeletable && (
+            <button
+              type="button"
+              className="card-action-btn card-action-btn--danger"
+              onClick={() => setShowDeleteModal(true)}
+              title="Delete"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                <path d="M10 11v6M14 11v6" />
+                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+              </svg>
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showDeleteModal && (
+        <ConfirmDeleteModal
+          standardName={standard.name}
+          onConfirm={() => { setShowDeleteModal(false); onDelete(standard.id); }}
+          onCancel={() => setShowDeleteModal(false)}
+        />
+      )}
+      {showDuplicateModal && (
+        <DuplicateModal
+          standardId={standard.id}
+          onConfirm={(newId) => { setShowDuplicateModal(false); onDuplicate(standard.id, newId); }}
+          onCancel={() => setShowDuplicateModal(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -79,7 +79,7 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
 
   return (
     <>
-      <div className={`standard-card standard-card--${standard.type}`} onClick={() => onEdit(standard.id)}>
+      <div className={`standard-card standard-card--${standard.type}`} onClick={() => standard.type !== 'builtin' && onEdit(standard.id)}>
         <div className="standard-card-header">
           <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
             {TYPE_LABELS[standard.type] || standard.type}
@@ -104,18 +104,20 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
         </div>
 
         <div className="standard-card-actions" onClick={(e) => e.stopPropagation()}>
-          <button
-            type="button"
-            className="card-action-btn"
-            onClick={() => onEdit(standard.id)}
-            title="View / Edit"
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-            </svg>
-            Edit
-          </button>
+          {standard.type !== 'builtin' && (
+            <button
+              type="button"
+              className="card-action-btn"
+              onClick={() => onEdit(standard.id)}
+              title="Edit"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+              Edit
+            </button>
+          )}
           <button
             type="button"
             className="card-action-btn"

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -90,9 +90,6 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
         </div>
 
         <h3 className="standard-card-name">{standard.name}</h3>
-        {standard.type !== 'builtin' && standard.id && (
-          <p className="standard-card-id">{standard.id}</p>
-        )}
         {standard.description && (
           <p className="standard-card-description">{standard.description}</p>
         )}

--- a/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
@@ -58,21 +58,6 @@ function RootDetail({ standard, onUpdateField, editable, isNew }) {
         />
       </div>
 
-      <div className="form-group">
-        <label htmlFor="std-weight">Weight</label>
-        <input
-          id="std-weight"
-          className="form-input form-input--narrow"
-          type="number"
-          min="0"
-          max="10"
-          step="0.1"
-          value={standard.weight ?? 1.0}
-          onChange={(e) => onUpdateField(['weight'], parseFloat(e.target.value))}
-          disabled={!editable}
-        />
-      </div>
-
       {standard.managed && (
         <p className="detail-managed-notice">
           This is a managed standard. Fields are read-only to preserve upstream compatibility.

--- a/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
@@ -1,22 +1,22 @@
 import PrincipleForm from './PrincipleForm.jsx';
 import RequirementForm from './RequirementForm.jsx';
 
-function RootDetail({ standard, onUpdateField, editable }) {
+function slugify(text) {
+  return text.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+
+function RootDetail({ standard, onUpdateField, editable, isNew }) {
+  const handleNameChange = (e) => {
+    const name = e.target.value;
+    onUpdateField(['name'], name);
+    if (isNew || !standard.id || standard.id === slugify(standard.name || '')) {
+      onUpdateField(['id'], slugify(name));
+    }
+  };
+
   return (
     <div className="standard-root-detail">
       <h3 className="detail-form-title">Standard Details</h3>
-
-      <div className="form-group">
-        <label htmlFor="std-id">ID</label>
-        <input
-          id="std-id"
-          className="form-input"
-          value={standard.id || ''}
-          onChange={(e) => onUpdateField(['id'], e.target.value)}
-          disabled={!editable}
-          placeholder="e.g. my-standard"
-        />
-      </div>
 
       <div className="form-group">
         <label htmlFor="std-name">Name</label>
@@ -24,9 +24,22 @@ function RootDetail({ standard, onUpdateField, editable }) {
           id="std-name"
           className="form-input"
           value={standard.name || ''}
-          onChange={(e) => onUpdateField(['name'], e.target.value)}
+          onChange={handleNameChange}
           disabled={!editable}
-          placeholder="Standard name"
+          placeholder="e.g. Clean Architecture"
+          autoFocus={isNew}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="std-id">ID <span className="form-hint">(auto-generated from name)</span></label>
+        <input
+          id="std-id"
+          className="form-input form-input--muted"
+          value={standard.id || ''}
+          onChange={(e) => onUpdateField(['id'], e.target.value)}
+          disabled={!editable}
+          placeholder="auto-generated"
         />
       </div>
 
@@ -79,11 +92,11 @@ function RootDetail({ standard, onUpdateField, editable }) {
   );
 }
 
-export default function StandardDetail({ standard, selectedNode, onUpdateField, editable }) {
+export default function StandardDetail({ standard, selectedNode, onUpdateField, editable, isNew }) {
   if (!selectedNode || !standard) return null;
 
   if (selectedNode.type === 'root') {
-    return <RootDetail standard={standard} onUpdateField={onUpdateField} editable={editable} />;
+    return <RootDetail standard={standard} onUpdateField={onUpdateField} editable={editable} isNew={isNew} />;
   }
 
   if (selectedNode.type === 'principle') {

--- a/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
@@ -1,0 +1,119 @@
+import PrincipleForm from './PrincipleForm.jsx';
+import RequirementForm from './RequirementForm.jsx';
+
+function RootDetail({ standard, onUpdateField, editable }) {
+  return (
+    <div className="standard-root-detail">
+      <h3 className="detail-form-title">Standard Details</h3>
+
+      <div className="form-group">
+        <label htmlFor="std-id">ID</label>
+        <input
+          id="std-id"
+          className="form-input"
+          value={standard.id || ''}
+          onChange={(e) => onUpdateField(['id'], e.target.value)}
+          disabled={!editable}
+          placeholder="e.g. my-standard"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="std-name">Name</label>
+        <input
+          id="std-name"
+          className="form-input"
+          value={standard.name || ''}
+          onChange={(e) => onUpdateField(['name'], e.target.value)}
+          disabled={!editable}
+          placeholder="Standard name"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="std-description">Description</label>
+        <textarea
+          id="std-description"
+          className="form-textarea"
+          value={standard.description || ''}
+          onChange={(e) => onUpdateField(['description'], e.target.value)}
+          disabled={!editable}
+          placeholder="Describe this standard..."
+          rows={4}
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="std-source">Source</label>
+        <input
+          id="std-source"
+          className="form-input"
+          value={standard.source || ''}
+          onChange={(e) => onUpdateField(['source'], e.target.value)}
+          disabled={!editable}
+          placeholder="e.g. https://example.com/standard"
+        />
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="std-weight">Weight</label>
+        <input
+          id="std-weight"
+          className="form-input form-input--narrow"
+          type="number"
+          min="0"
+          max="10"
+          step="0.1"
+          value={standard.weight ?? 1.0}
+          onChange={(e) => onUpdateField(['weight'], parseFloat(e.target.value))}
+          disabled={!editable}
+        />
+      </div>
+
+      {standard.managed && (
+        <p className="detail-managed-notice">
+          This is a managed standard. Fields are read-only to preserve upstream compatibility.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function StandardDetail({ standard, selectedNode, onUpdateField, editable }) {
+  if (!selectedNode || !standard) return null;
+
+  if (selectedNode.type === 'root') {
+    return <RootDetail standard={standard} onUpdateField={onUpdateField} editable={editable} />;
+  }
+
+  if (selectedNode.type === 'principle') {
+    const principle = standard.principles[selectedNode.index];
+    if (!principle) return null;
+    return (
+      <PrincipleForm
+        principle={principle}
+        principleIndex={selectedNode.index}
+        onUpdateField={onUpdateField}
+        editable={editable}
+      />
+    );
+  }
+
+  if (selectedNode.type === 'requirement') {
+    const principle = standard.principles[selectedNode.principleIndex];
+    if (!principle) return null;
+    const requirement = principle.requirements[selectedNode.reqIndex];
+    if (!requirement) return null;
+    return (
+      <RequirementForm
+        requirement={requirement}
+        principleIndex={selectedNode.principleIndex}
+        reqIndex={selectedNode.reqIndex}
+        onUpdateField={onUpdateField}
+        editable={editable}
+      />
+    );
+  }
+
+  return null;
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
@@ -31,17 +31,7 @@ function RootDetail({ standard, onUpdateField, editable, isNew }) {
         />
       </div>
 
-      <div className="form-group">
-        <label htmlFor="std-id">ID <span className="form-hint">(auto-generated from name)</span></label>
-        <input
-          id="std-id"
-          className="form-input form-input--muted"
-          value={standard.id || ''}
-          onChange={(e) => onUpdateField(['id'], e.target.value)}
-          disabled={!editable}
-          placeholder="auto-generated"
-        />
-      </div>
+      <input type="hidden" value={standard.id || ''} />
 
       <div className="form-group">
         <label htmlFor="std-description">Description</label>

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -1,6 +1,49 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useStandardDetail } from '../hooks/useStandardDetail.js';
 import StandardTree from './StandardTree.jsx';
 import StandardDetail from './StandardDetail.jsx';
+
+const MIN_TREE_WIDTH = 180;
+const MAX_TREE_WIDTH = 600;
+const DEFAULT_TREE_WIDTH = 280;
+
+function useResizable(defaultWidth) {
+  const [width, setWidth] = useState(defaultWidth);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+
+  const onMouseDown = useCallback((e) => {
+    e.preventDefault();
+    dragging.current = true;
+    startX.current = e.clientX;
+    startWidth.current = width;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, [width]);
+
+  useEffect(() => {
+    const onMouseMove = (e) => {
+      if (!dragging.current) return;
+      const delta = e.clientX - startX.current;
+      const newWidth = Math.min(MAX_TREE_WIDTH, Math.max(MIN_TREE_WIDTH, startWidth.current + delta));
+      setWidth(newWidth);
+    };
+    const onMouseUp = () => {
+      dragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, []);
+
+  return { width, onMouseDown };
+}
 
 export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
   const {
@@ -9,6 +52,8 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
     updateField, addPrinciple, removePrinciple, addRequirement, removeRequirement,
     save,
   } = useStandardDetail(standardId, isNew);
+
+  const { width: treeWidth, onMouseDown: onDividerMouseDown } = useResizable(DEFAULT_TREE_WIDTH);
 
   const handleSave = async () => {
     await save();
@@ -65,7 +110,7 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
       {error && <p className="inline-error" style={{ margin: '8px 16px' }}>{error}</p>}
 
       <div className="standard-editor-body">
-        <div className="standard-editor-tree-panel">
+        <div className="standard-editor-tree-panel" style={{ width: treeWidth, minWidth: MIN_TREE_WIDTH, maxWidth: MAX_TREE_WIDTH }}>
           <StandardTree
             standard={standard}
             selectedNode={selectedNode}
@@ -77,6 +122,8 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
             editable={editable}
           />
         </div>
+
+        <div className="standard-editor-divider" onMouseDown={onDividerMouseDown} />
 
         <div className="standard-editor-detail-panel">
           <StandardDetail

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -84,6 +84,7 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
             selectedNode={selectedNode}
             onUpdateField={updateField}
             editable={editable}
+            isNew={isNew}
           />
         </div>
       </div>

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -1,0 +1,92 @@
+import { useStandardDetail } from '../hooks/useStandardDetail.js';
+import StandardTree from './StandardTree.jsx';
+import StandardDetail from './StandardDetail.jsx';
+
+export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
+  const {
+    standard, loading, error, dirty, editable,
+    selectedNode, setSelectedNode,
+    updateField, addPrinciple, removePrinciple, addRequirement, removeRequirement,
+    save,
+  } = useStandardDetail(standardId, isNew);
+
+  const handleSave = async () => {
+    await save();
+    if (onSaved) onSaved(standard?.id);
+  };
+
+  if (loading) {
+    return <div className="standard-editor-loading">Loading standard...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="standard-editor-error">
+        <p className="inline-error">{error}</p>
+        <button type="button" className="btn-secondary" onClick={onBack}>Back</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="standard-editor">
+      <div className="standard-editor-toolbar">
+        <button type="button" className="editor-back-btn" onClick={onBack}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M19 12H5M12 5l-7 7 7 7" />
+          </svg>
+          Back
+        </button>
+
+        <div className="editor-toolbar-center">
+          <h2 className="editor-title">
+            {isNew ? 'New Standard' : (standard?.name || standardId)}
+            {dirty && <span className="editor-dirty-indicator" title="Unsaved changes">*</span>}
+          </h2>
+          {standard?.managed && (
+            <span className="editor-managed-badge">managed</span>
+          )}
+        </div>
+
+        <div className="editor-toolbar-actions">
+          {editable && (
+            <button
+              type="button"
+              className="btn-primary"
+              onClick={handleSave}
+              disabled={!dirty}
+            >
+              Save
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="inline-error" style={{ margin: '8px 16px' }}>{error}</p>}
+
+      <div className="standard-editor-body">
+        <div className="standard-editor-tree-panel">
+          <StandardTree
+            standard={standard}
+            selectedNode={selectedNode}
+            onSelectNode={setSelectedNode}
+            onAddPrinciple={addPrinciple}
+            onRemovePrinciple={removePrinciple}
+            onAddRequirement={addRequirement}
+            onRemoveRequirement={removeRequirement}
+            editable={editable}
+          />
+        </div>
+
+        <div className="standard-editor-detail-panel">
+          <StandardDetail
+            standard={standard}
+            selectedNode={selectedNode}
+            onUpdateField={updateField}
+            editable={editable}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -104,7 +104,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
                 return (
                   <TreeNode
                     key={ri}
-                    label={req.text ? (req.text.length > 50 ? req.text.slice(0, 50) + '...' : req.text) : `Requirement ${ri + 1}`}
+                    label={req.text || `Requirement ${ri + 1}`}
                     isSelected={isReqSelected}
                     onClick={() => onSelectNode({ type: 'requirement', principleIndex: pi, reqIndex: ri })}
                     onRemove={editable ? handleRemoveReq : undefined}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -71,6 +71,13 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
       >
         {(standard.principles || []).map((principle, pi) => {
           const isPrincipleSelected = selectedNode?.type === 'principle' && selectedNode.index === pi;
+          const reqCount = principle.requirements?.length || 0;
+          const handleRemovePrinciple = () => {
+            if (reqCount > 0) {
+              if (!window.confirm(`Delete "${principle.name || 'Untitled'}" and its ${reqCount} requirement${reqCount !== 1 ? 's' : ''}? This cannot be undone.`)) return;
+            }
+            onRemovePrinciple(pi);
+          };
           return (
             <TreeNode
               key={pi}
@@ -78,20 +85,27 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
               isSelected={isPrincipleSelected}
               onClick={() => onSelectNode({ type: 'principle', index: pi })}
               onAdd={editable ? () => onAddRequirement(pi) : undefined}
-              onRemove={editable ? () => onRemovePrinciple(pi) : undefined}
+              onRemove={editable ? handleRemovePrinciple : undefined}
               addTitle="Add Requirement"
               removeTitle="Remove Principle"
               depth={1}
             >
               {(principle.requirements || []).map((req, ri) => {
                 const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;
+                const hasContent = req.text || req.description || (req.refs && req.refs.length > 0);
+                const handleRemoveReq = () => {
+                  if (hasContent) {
+                    if (!window.confirm(`Delete requirement "${req.text ? (req.text.length > 40 ? req.text.slice(0, 40) + '...' : req.text) : 'Untitled'}"?`)) return;
+                  }
+                  onRemoveRequirement(pi, ri);
+                };
                 return (
                   <TreeNode
                     key={ri}
                     label={req.text ? (req.text.length > 50 ? req.text.slice(0, 50) + '...' : req.text) : `Requirement ${ri + 1}`}
                     isSelected={isReqSelected}
                     onClick={() => onSelectNode({ type: 'requirement', principleIndex: pi, reqIndex: ri })}
-                    onRemove={editable ? () => onRemoveRequirement(pi, ri) : undefined}
+                    onRemove={editable ? handleRemoveReq : undefined}
                     removeTitle="Remove Requirement"
                     depth={2}
                   />

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
-function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, removeTitle, children, depth = 0 }) {
-  const [expanded, setExpanded] = useState(true);
+function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, removeTitle, children, depth = 0, alwaysExpanded = false, defaultExpanded = true }) {
+  const [expanded, setExpanded] = useState(alwaysExpanded || defaultExpanded);
   const hasChildren = children && children.length > 0;
+  const showExpand = hasChildren && !alwaysExpanded;
 
   return (
     <div className={`tree-node tree-node--depth-${depth}`}>
@@ -13,17 +14,21 @@ function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, remov
         tabIndex={0}
         onKeyDown={(e) => e.key === 'Enter' && onClick()}
       >
-        <button
-          type="button"
-          className={`tree-expand-btn${hasChildren ? '' : ' tree-expand-btn--invisible'}`}
-          onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
-          aria-label={expanded ? 'Collapse' : 'Expand'}
-        >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
-            style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
-            <path d="M3 2l4 3-4 3V2z" />
-          </svg>
-        </button>
+        {showExpand ? (
+          <button
+            type="button"
+            className="tree-expand-btn"
+            onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
+              style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
+              <path d="M3 2l4 3-4 3V2z" />
+            </svg>
+          </button>
+        ) : (
+          <span className="tree-expand-btn tree-expand-btn--invisible" />
+        )}
 
         <span className="tree-node-label">{label}</span>
 
@@ -45,7 +50,7 @@ function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, remov
         </div>
       </div>
 
-      {expanded && hasChildren && (
+      {(alwaysExpanded || expanded) && hasChildren && (
         <div className="tree-node-children">
           {children}
         </div>
@@ -68,6 +73,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
         onAdd={editable ? onAddPrinciple : undefined}
         addTitle="Add Principle"
         depth={0}
+        alwaysExpanded
       >
         {(standard.principles || []).map((principle, pi) => {
           const isPrincipleSelected = selectedNode?.type === 'principle' && selectedNode.index === pi;
@@ -89,6 +95,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
               addTitle="Add Requirement"
               removeTitle="Remove Principle"
               depth={1}
+              defaultExpanded={false}
             >
               {(principle.requirements || []).map((req, ri) => {
                 const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -88,7 +88,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, onA
                 return (
                   <TreeNode
                     key={ri}
-                    label={req.id ? `${req.id}` : `Requirement ${ri + 1}`}
+                    label={req.text ? (req.text.length > 50 ? req.text.slice(0, 50) + '...' : req.text) : `Requirement ${ri + 1}`}
                     isSelected={isReqSelected}
                     onClick={() => onSelectNode({ type: 'requirement', principleIndex: pi, reqIndex: ri })}
                     onRemove={editable ? () => onRemoveRequirement(pi, ri) : undefined}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -9,23 +9,18 @@ function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, remov
     <div className={`tree-node tree-node--depth-${depth}`}>
       <div
         className={`tree-node-row${isSelected ? ' tree-node-row--selected' : ''}`}
-        onClick={onClick}
+        onClick={() => { onClick(); if (showExpand) setExpanded((v) => !v); }}
         role="button"
         tabIndex={0}
         onKeyDown={(e) => e.key === 'Enter' && onClick()}
       >
         {showExpand ? (
-          <button
-            type="button"
-            className="tree-expand-btn"
-            onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
-            aria-label={expanded ? 'Collapse' : 'Expand'}
-          >
+          <span className="tree-expand-btn" aria-hidden="true">
             <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
               style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
               <path d="M3 2l4 3-4 3V2z" />
             </svg>
-          </button>
+          </span>
         ) : (
           <span className="tree-expand-btn tree-expand-btn--invisible" />
         )}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+
+function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, removeTitle, children, depth = 0 }) {
+  const [expanded, setExpanded] = useState(true);
+  const hasChildren = children && children.length > 0;
+
+  return (
+    <div className={`tree-node tree-node--depth-${depth}`}>
+      <div
+        className={`tree-node-row${isSelected ? ' tree-node-row--selected' : ''}`}
+        onClick={onClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === 'Enter' && onClick()}
+      >
+        <button
+          type="button"
+          className={`tree-expand-btn${hasChildren ? '' : ' tree-expand-btn--invisible'}`}
+          onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
+            style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
+            <path d="M3 2l4 3-4 3V2z" />
+          </svg>
+        </button>
+
+        <span className="tree-node-label">{label}</span>
+
+        <div className="tree-node-actions" onClick={(e) => e.stopPropagation()}>
+          {onAdd && (
+            <button type="button" className="tree-action-btn" onClick={onAdd} title={addTitle || 'Add'}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+                <path d="M12 5v14M5 12h14" />
+              </svg>
+            </button>
+          )}
+          {onRemove && (
+            <button type="button" className="tree-action-btn tree-action-btn--remove" onClick={onRemove} title={removeTitle || 'Remove'}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+                <path d="M5 12h14" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {expanded && hasChildren && (
+        <div className="tree-node-children">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function StandardTree({ standard, selectedNode, onSelectNode, onAddPrinciple, onRemovePrinciple, onAddRequirement, onRemoveRequirement, editable }) {
+  if (!standard) return null;
+
+  const isRootSelected = selectedNode?.type === 'root';
+
+  return (
+    <div className="standard-tree">
+      <TreeNode
+        label={standard.name || 'Standard'}
+        isSelected={isRootSelected}
+        onClick={() => onSelectNode({ type: 'root' })}
+        onAdd={editable ? onAddPrinciple : undefined}
+        addTitle="Add Principle"
+        depth={0}
+      >
+        {(standard.principles || []).map((principle, pi) => {
+          const isPrincipleSelected = selectedNode?.type === 'principle' && selectedNode.index === pi;
+          return (
+            <TreeNode
+              key={pi}
+              label={principle.name || `Principle ${pi + 1}`}
+              isSelected={isPrincipleSelected}
+              onClick={() => onSelectNode({ type: 'principle', index: pi })}
+              onAdd={editable ? () => onAddRequirement(pi) : undefined}
+              onRemove={editable ? () => onRemovePrinciple(pi) : undefined}
+              addTitle="Add Requirement"
+              removeTitle="Remove Principle"
+              depth={1}
+            >
+              {(principle.requirements || []).map((req, ri) => {
+                const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;
+                return (
+                  <TreeNode
+                    key={ri}
+                    label={req.id ? `${req.id}` : `Requirement ${ri + 1}`}
+                    isSelected={isReqSelected}
+                    onClick={() => onSelectNode({ type: 'requirement', principleIndex: pi, reqIndex: ri })}
+                    onRemove={editable ? () => onRemoveRequirement(pi, ri) : undefined}
+                    removeTitle="Remove Requirement"
+                    depth={2}
+                  />
+                );
+              })}
+            </TreeNode>
+          );
+        })}
+      </TreeNode>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
@@ -1,0 +1,68 @@
+import StandardCard from './StandardCard.jsx';
+
+function SectionHeader({ title, count }) {
+  return (
+    <div className="standards-section-header">
+      <h2 className="standards-section-title">{title}</h2>
+      <span className="standards-section-count">{count}</span>
+    </div>
+  );
+}
+
+function StandardsSection({ title, standards, onEdit, onDelete, onDuplicate }) {
+  if (standards.length === 0) return null;
+  return (
+    <section className="standards-section">
+      <SectionHeader title={title} count={standards.length} />
+      <div className="standards-grid">
+        {standards.map((s) => (
+          <StandardCard
+            key={s.id}
+            standard={s}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onDuplicate={onDuplicate}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate }) {
+  const total = (grouped.builtin?.length ?? 0) + (grouped.community?.length ?? 0) + (grouped.custom?.length ?? 0);
+
+  if (total === 0) {
+    return (
+      <div className="standards-empty">
+        <p>No standards found. Import from the library or create a custom standard.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="standards-list">
+      <StandardsSection
+        title="Built-in"
+        standards={grouped.builtin || []}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onDuplicate={onDuplicate}
+      />
+      <StandardsSection
+        title="Community"
+        standards={grouped.community || []}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onDuplicate={onDuplicate}
+      />
+      <StandardsSection
+        title="Custom"
+        standards={grouped.custom || []}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onDuplicate={onDuplicate}
+      />
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
@@ -43,7 +43,7 @@ export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate }
   return (
     <div className="standards-list">
       <StandardsSection
-        title="Built-in"
+        title="ISO 25010"
         standards={grouped.builtin || []}
         onEdit={onEdit}
         onDelete={onDelete}
@@ -57,7 +57,7 @@ export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate }
         onDuplicate={onDuplicate}
       />
       <StandardsSection
-        title="Custom"
+        title="Custom Standards"
         standards={grouped.custom || []}
         onEdit={onEdit}
         onDelete={onDelete}

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
@@ -1,0 +1,19 @@
+import { useState, useCallback } from 'react';
+import { listLibrary, importFromLibrary } from '../../../api/index.js';
+
+export function useLibrary() {
+  const [libraryStandards, setLibraryStandards] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchLibrary = useCallback(async () => {
+    setLoading(true);
+    try { const data = await listLibrary(); setLibraryStandards(data); setError(null); }
+    catch (err) { setError(err.message); }
+    finally { setLoading(false); }
+  }, []);
+
+  const importStandard = useCallback(async (filePath) => { await importFromLibrary(filePath); }, []);
+
+  return { libraryStandards, loading, error, fetchLibrary, importStandard };
+}

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -1,0 +1,85 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getStandard, createStandard, updateStandard } from '../../../api/index.js';
+
+export function useStandardDetail(standardId, isNew) {
+  const [standard, setStandard] = useState(null);
+  const [loading, setLoading] = useState(!isNew);
+  const [error, setError] = useState(null);
+  const [dirty, setDirty] = useState(false);
+  const [selectedNode, setSelectedNode] = useState(null);
+
+  useEffect(() => {
+    if (isNew) {
+      setStandard({ id: '', name: '', description: '', weight: 1.0, source: '', type: 'custom', managed: false, origin: null, originHash: null, principles: [] });
+      setSelectedNode({ type: 'root' });
+      return;
+    }
+    if (!standardId) return;
+    setLoading(true);
+    getStandard(standardId)
+      .then((data) => { setStandard(data); setSelectedNode({ type: 'root' }); setError(null); })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [standardId, isNew]);
+
+  const updateField = useCallback((path, value) => {
+    setStandard((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      let target = next;
+      for (let i = 0; i < path.length - 1; i++) target = target[path[i]];
+      target[path[path.length - 1]] = value;
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const addPrinciple = useCallback(() => {
+    setStandard((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      next.principles.push({ name: 'New Principle', description: '', requirements: [] });
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const removePrinciple = useCallback((index) => {
+    setStandard((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      next.principles.splice(index, 1);
+      return next;
+    });
+    setDirty(true);
+    setSelectedNode({ type: 'root' });
+  }, []);
+
+  const addRequirement = useCallback((principleIndex) => {
+    setStandard((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      next.principles[principleIndex].requirements.push({ id: '', text: '', refs: [] });
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const removeRequirement = useCallback((principleIndex, reqIndex) => {
+    setStandard((prev) => {
+      const next = JSON.parse(JSON.stringify(prev));
+      next.principles[principleIndex].requirements.splice(reqIndex, 1);
+      return next;
+    });
+    setDirty(true);
+    setSelectedNode({ type: 'principle', index: principleIndex });
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!standard) return;
+    try {
+      if (isNew) { await createStandard(standard); } else { await updateStandard(standard.id, standard); }
+      setDirty(false);
+    } catch (err) { setError(err.message); }
+  }, [standard, isNew]);
+
+  const editable = standard && !standard.managed;
+
+  return { standard, loading, error, dirty, editable, selectedNode, setSelectedNode, updateField, addPrinciple, removePrinciple, addRequirement, removeRequirement, save };
+}

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -54,7 +54,6 @@ export function useStandardDetail(standardId, isNew) {
   }, []);
 
   const addRequirement = useCallback((principleIndex) => {
-    let newReqIndex = 0;
     setStandard((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       const principle = next.principles[principleIndex];
@@ -62,11 +61,10 @@ export function useStandardDetail(standardId, isNew) {
       const pPrefix = (principle.name || 'P').replace(/[^a-zA-Z]/g, '').slice(0, 3).toUpperCase();
       const seq = (principle.requirements?.length || 0) + 1;
       const autoId = `${prefix}-${pPrefix}-${String(seq).padStart(2, '0')}`;
-      principle.requirements.push({ id: autoId, text: '', refs: [] });
-      newReqIndex = principle.requirements.length - 1;
+      principle.requirements.push({ id: autoId, text: '', description: '', refs: [] });
+      setSelectedNode({ type: 'requirement', principleIndex, reqIndex: principle.requirements.length - 1 });
       return next;
     });
-    setSelectedNode({ type: 'requirement', principleIndex, reqIndex: newReqIndex });
     setDirty(true);
   }, []);
 

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -37,11 +37,11 @@ export function useStandardDetail(standardId, isNew) {
     setStandard((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       next.principles.push({ name: '', description: '', requirements: [] });
+      setSelectedNode({ type: 'principle', index: next.principles.length - 1 });
       return next;
     });
-    setSelectedNode({ type: 'principle', index: standard?.principles?.length || 0 });
     setDirty(true);
-  }, [standard]);
+  }, []);
 
   const removePrinciple = useCallback((index) => {
     setStandard((prev) => {

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -36,11 +36,12 @@ export function useStandardDetail(standardId, isNew) {
   const addPrinciple = useCallback(() => {
     setStandard((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
-      next.principles.push({ name: 'New Principle', description: '', requirements: [] });
+      next.principles.push({ name: '', description: '', requirements: [] });
       return next;
     });
+    setSelectedNode({ type: 'principle', index: standard?.principles?.length || 0 });
     setDirty(true);
-  }, []);
+  }, [standard]);
 
   const removePrinciple = useCallback((index) => {
     setStandard((prev) => {
@@ -53,6 +54,7 @@ export function useStandardDetail(standardId, isNew) {
   }, []);
 
   const addRequirement = useCallback((principleIndex) => {
+    let newReqIndex = 0;
     setStandard((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
       const principle = next.principles[principleIndex];
@@ -61,8 +63,10 @@ export function useStandardDetail(standardId, isNew) {
       const seq = (principle.requirements?.length || 0) + 1;
       const autoId = `${prefix}-${pPrefix}-${String(seq).padStart(2, '0')}`;
       principle.requirements.push({ id: autoId, text: '', refs: [] });
+      newReqIndex = principle.requirements.length - 1;
       return next;
     });
+    setSelectedNode({ type: 'requirement', principleIndex, reqIndex: newReqIndex });
     setDirty(true);
   }, []);
 

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -55,7 +55,12 @@ export function useStandardDetail(standardId, isNew) {
   const addRequirement = useCallback((principleIndex) => {
     setStandard((prev) => {
       const next = JSON.parse(JSON.stringify(prev));
-      next.principles[principleIndex].requirements.push({ id: '', text: '', refs: [] });
+      const principle = next.principles[principleIndex];
+      const prefix = (next.id || 'std').toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 4);
+      const pPrefix = (principle.name || 'P').replace(/[^a-zA-Z]/g, '').slice(0, 3).toUpperCase();
+      const seq = (principle.requirements?.length || 0) + 1;
+      const autoId = `${prefix}-${pPrefix}-${String(seq).padStart(2, '0')}`;
+      principle.requirements.push({ id: autoId, text: '', refs: [] });
       return next;
     });
     setDirty(true);
@@ -73,9 +78,12 @@ export function useStandardDetail(standardId, isNew) {
 
   const save = useCallback(async () => {
     if (!standard) return;
+    if (!standard.id) { setError('ID is required'); return; }
+    if (!standard.name) { setError('Name is required'); return; }
     try {
       if (isNew) { await createStandard(standard); } else { await updateStandard(standard.id, standard); }
       setDirty(false);
+      setError(null);
     } catch (err) { setError(err.message); }
   }, [standard, isNew]);
 

--- a/src/quodeq/ui/src/features/standards/hooks/useStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandards.js
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { listStandards, deleteStandard, duplicateStandard } from '../../../api/index.js';
+
+export function useStandards() {
+  const [standards, setStandards] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    listStandards()
+      .then((data) => { setStandards(data); setError(null); })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const handleDelete = useCallback(async (id) => { await deleteStandard(id); refresh(); }, [refresh]);
+  const handleDuplicate = useCallback(async (id, newId) => { await duplicateStandard(id, newId); refresh(); }, [refresh]);
+
+  const grouped = {
+    builtin: standards.filter((s) => s.type === 'builtin'),
+    community: standards.filter((s) => s.type === 'community'),
+    custom: standards.filter((s) => s.type === 'custom'),
+  };
+
+  return { standards, grouped, loading, error, refresh, handleDelete, handleDuplicate };
+}

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -923,6 +923,33 @@
 }
 
 /* Dimension grid */
+.dimension-section {
+  margin-bottom: 12px;
+}
+
+.dimension-section:last-child {
+  margin-bottom: 0;
+}
+
+.dimension-section-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary, #888);
+  margin-bottom: 6px;
+  padding-left: 2px;
+}
+
+.dimension-section-label .iso-link {
+  color: var(--color-text-secondary, #888);
+  text-decoration: none;
+}
+
+.dimension-section-label .iso-link:hover {
+  color: var(--color-accent, #58a6ff);
+  text-decoration: underline;
+}
+
 .dimension-grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
@@ -931,6 +958,19 @@
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+}
+
+.dimension-chip-btn--custom,
+.dimension-chip-btn--community {
+  border-color: var(--color-success, #2d5a3d);
+  color: var(--color-success-text, #6fcf97);
+}
+
+.dimension-chip-btn--custom.selected,
+.dimension-chip-btn--community.selected {
+  background: var(--color-success, #2d5a3d);
+  border-color: var(--color-success-text, #6fcf97);
+  color: #fff;
 }
 
 .dimension-chip-btn {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -941,12 +941,12 @@
 }
 
 .dimension-section-label .iso-link {
-  color: var(--color-text-secondary, #888);
+  color: var(--color-accent, #58a6ff);
   text-decoration: none;
+  font-size: inherit;
 }
 
 .dimension-section-label .iso-link:hover {
-  color: var(--color-accent, #58a6ff);
   text-decoration: underline;
 }
 

--- a/src/quodeq/ui/src/styles/index.css
+++ b/src/quodeq/ui/src/styles/index.css
@@ -4,3 +4,4 @@
 @import './evaluation.css';
 @import './explorer.css';
 @import './history.css';
+@import './standards.css';

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -655,6 +655,69 @@
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
 }
 
+/* ── CWE Search ─────────────────────────────────────────── */
+
+.cwe-search {
+  position: relative;
+  flex: 0 0 160px;
+}
+
+.cwe-search-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  margin-top: 2px;
+}
+
+.cwe-search-option {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.cwe-search-option:hover {
+  background: var(--color-surface-alt);
+}
+
+.cwe-search-option--selected {
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+}
+
+.cwe-search-id {
+  font-weight: 600;
+  color: var(--color-accent);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.cwe-search-name {
+  color: var(--color-text-secondary, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ref-cwe-name {
+  flex: 1;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 6px 0;
+}
+
 /* ── Library Browser ─────────────────────────────────────── */
 
 .library-browser-subtitle {

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -794,6 +794,15 @@
   margin: 0 0 16px 0;
   color: var(--color-text);
   font-size: 0.9rem;
+}
+
+.modal-body--warning {
+  background: rgba(220, 60, 60, 0.1);
+  border: 1px solid rgba(220, 60, 60, 0.3);
+  border-radius: var(--radius-md, 6px);
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  font-size: 0.9rem;
   line-height: 1.5;
 }
 

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -486,6 +486,16 @@
   max-width: 120px;
 }
 
+.form-input--muted {
+  opacity: 0.7;
+}
+
+.form-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #888);
+  font-weight: normal;
+}
+
 .form-textarea {
   padding: 10px 12px;
   background: var(--color-bg);

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -655,57 +655,21 @@
   background: color-mix(in srgb, var(--color-danger) 10%, transparent);
 }
 
-/* ── CWE Search ─────────────────────────────────────────── */
+/* ── CWE Browser ────────────────────────────────────────── */
 
-.cwe-search {
-  position: relative;
-  flex: 0 0 160px;
-}
-
-.cwe-search-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  max-height: 240px;
-  overflow-y: auto;
-  background: var(--color-surface);
+.cwe-select-btn {
+  padding: 6px 12px;
+  background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md, 6px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-  z-index: 100;
-  margin-top: 2px;
-}
-
-.cwe-search-option {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  padding: 6px 10px;
+  color: var(--color-accent, #58a6ff);
+  font-size: 0.85rem;
   cursor: pointer;
-  font-size: 0.8rem;
-}
-
-.cwe-search-option:hover {
-  background: var(--color-surface-alt);
-}
-
-.cwe-search-option--selected {
-  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
-}
-
-.cwe-search-id {
-  font-weight: 600;
-  color: var(--color-accent);
   white-space: nowrap;
-  flex-shrink: 0;
 }
 
-.cwe-search-name {
-  color: var(--color-text-secondary, #888);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.cwe-select-btn:hover:not(:disabled) {
+  border-color: var(--color-accent);
 }
 
 .ref-cwe-name {
@@ -716,6 +680,120 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   padding: 6px 0;
+}
+
+.cwe-browser-modal {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg, 10px);
+  width: 600px;
+  max-width: 90vw;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.cwe-browser-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cwe-browser-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.cwe-browser-toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px;
+}
+
+.cwe-browser-search {
+  flex: 1;
+  padding: 8px 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.9rem;
+}
+
+.cwe-browser-search:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.cwe-browser-filter {
+  padding: 8px 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.85rem;
+}
+
+.cwe-browser-count {
+  padding: 0 20px 8px;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #888);
+}
+
+.cwe-browser-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 12px 12px;
+}
+
+.cwe-browser-item {
+  padding: 10px 12px;
+  border-radius: var(--radius-md, 6px);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.cwe-browser-item:hover {
+  background: var(--color-surface-alt);
+}
+
+.cwe-browser-item-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+
+.cwe-browser-item-id {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-accent, #58a6ff);
+}
+
+.cwe-browser-item-abstraction {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary, #888);
+  background: var(--color-surface-alt);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.cwe-browser-item-name {
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.cwe-browser-empty {
+  text-align: center;
+  padding: 32px;
+  color: var(--color-text-secondary, #888);
+  font-size: 0.9rem;
 }
 
 /* ── Library Browser ─────────────────────────────────────── */

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -306,21 +306,34 @@
 }
 
 .standard-editor-body {
-  display: grid;
-  grid-template-columns: 260px 1fr;
+  display: flex;
   flex: 1;
   min-height: 0;
   overflow: hidden;
 }
 
 .standard-editor-tree-panel {
-  border-right: 1px solid var(--color-border);
+  flex-shrink: 0;
   overflow-y: auto;
   padding: 16px 0;
   background: var(--color-surface);
 }
 
+.standard-editor-divider {
+  flex-shrink: 0;
+  width: 4px;
+  cursor: col-resize;
+  background: var(--color-border);
+  transition: background 0.15s;
+}
+
+.standard-editor-divider:hover {
+  background: var(--color-accent, #58a6ff);
+}
+
 .standard-editor-detail-panel {
+  flex: 1;
+  min-width: 0;
   overflow-y: auto;
   padding: 24px;
 }

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -113,14 +113,6 @@
   box-shadow: 0 2px 12px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
-.standard-card--builtin {
-  cursor: default;
-}
-
-.standard-card--builtin:hover {
-  border-color: var(--color-border);
-  box-shadow: none;
-}
 
 .standard-card-header {
   display: flex;

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -602,6 +602,17 @@
   font-family: var(--font-sans);
 }
 
+.ref-id-input {
+  padding: 6px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  max-width: 90px;
+}
+
+.ref-name-input,
 .ref-label-input,
 .ref-url-input {
   padding: 6px 10px;
@@ -615,6 +626,8 @@
   box-sizing: border-box;
 }
 
+.ref-id-input:focus,
+.ref-name-input:focus,
 .ref-label-input:focus,
 .ref-url-input:focus,
 .ref-type-select:focus {

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -341,7 +341,7 @@
 /* ── Standard Tree ───────────────────────────────────────── */
 
 .standard-tree {
-  padding: 0 8px;
+  padding: 0 6px;
 }
 
 .tree-node {
@@ -350,18 +350,43 @@
 }
 
 .tree-node--depth-1 {
-  padding-left: 8px;
+  padding-left: 6px;
+  border-left: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  margin-left: 8px;
 }
 
 .tree-node--depth-2 {
-  padding-left: 16px;
+  padding-left: 6px;
+  border-left: 1px solid color-mix(in srgb, var(--color-border) 40%, transparent);
+  margin-left: 8px;
+}
+
+/* ── Root node ── */
+.tree-node--depth-0 > .tree-node-row .tree-node-label {
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+/* ── Principle nodes ── */
+.tree-node--depth-1 > .tree-node-row .tree-node-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+/* ── Requirement nodes ── */
+.tree-node--depth-2 > .tree-node-row .tree-node-label {
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--color-text-secondary, #aaa);
 }
 
 .tree-node-row {
   display: flex;
   align-items: center;
-  gap: 3px;
-  padding: 4px 6px;
+  gap: 4px;
+  padding: 5px 8px;
   border-radius: var(--radius-md, 6px);
   cursor: pointer;
   user-select: none;
@@ -369,11 +394,11 @@
 }
 
 .tree-node-row:hover {
-  background: var(--color-border);
+  background: color-mix(in srgb, var(--color-border) 50%, transparent);
 }
 
 .tree-node-row--selected {
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 .tree-node-row--selected .tree-node-label {
@@ -385,8 +410,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
   background: transparent;
   border: none;
@@ -394,6 +419,12 @@
   cursor: pointer;
   padding: 0;
   border-radius: 3px;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+
+.tree-node-row:hover .tree-expand-btn {
+  opacity: 1;
 }
 
 .tree-expand-btn--invisible {
@@ -402,18 +433,23 @@
 
 .tree-node-label {
   flex: 1;
-  font-size: 0.82rem;
   color: var(--color-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  line-height: 1.4;
+}
+
+.tree-node-children {
+  padding-top: 1px;
 }
 
 .tree-node-actions {
   display: none;
   gap: 2px;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .tree-node-row:hover .tree-node-actions {
@@ -428,8 +464,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   background: transparent;
   border: none;
   border-radius: 3px;
@@ -440,11 +476,12 @@
 }
 
 .tree-action-btn:hover {
-  background: var(--color-border);
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
   color: var(--color-accent);
 }
 
 .tree-action-btn--remove:hover {
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
   color: var(--color-danger);
 }
 

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -404,9 +404,10 @@
   flex: 1;
   font-size: 0.82rem;
   color: var(--color-text);
-  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   min-width: 0;
-  overflow-wrap: break-word;
 }
 
 .tree-node-actions {

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -684,6 +684,17 @@
   border-color: var(--color-accent);
 }
 
+.ref-builtin-id {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-accent, #58a6ff);
+  white-space: nowrap;
+  padding: 6px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+}
+
 .ref-cwe-name {
   flex: 1;
   min-width: 150px;

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -315,7 +315,7 @@
 .standard-editor-tree-panel {
   flex-shrink: 0;
   overflow-y: auto;
-  padding: 16px 0;
+  padding: 8px 0;
   background: var(--color-surface);
 }
 
@@ -350,18 +350,18 @@
 }
 
 .tree-node--depth-1 {
-  padding-left: 12px;
+  padding-left: 8px;
 }
 
 .tree-node--depth-2 {
-  padding-left: 24px;
+  padding-left: 16px;
 }
 
 .tree-node-row {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 5px 8px;
+  gap: 3px;
+  padding: 4px 6px;
   border-radius: var(--radius-md, 6px);
   cursor: pointer;
   user-select: none;
@@ -402,11 +402,11 @@
 
 .tree-node-label {
   flex: 1;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: var(--color-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.3;
+  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .tree-node-actions {

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -113,6 +113,15 @@
   box-shadow: 0 2px 12px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
+.standard-card--builtin {
+  cursor: default;
+}
+
+.standard-card--builtin:hover {
+  border-color: var(--color-border);
+  box-shadow: none;
+}
+
 .standard-card-header {
   display: flex;
   align-items: center;

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -456,7 +456,6 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  max-width: 640px;
 }
 
 .form-input {
@@ -586,8 +585,8 @@
 }
 
 .ref-row {
-  display: grid;
-  grid-template-columns: 90px 1fr 2fr 28px;
+  display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   align-items: center;
 }
@@ -613,7 +612,19 @@
 }
 
 .ref-name-input,
-.ref-label-input,
+.ref-label-input {
+  padding: 6px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.82rem;
+  font-family: var(--font-sans);
+  flex: 1;
+  min-width: 150px;
+  box-sizing: border-box;
+}
+
 .ref-url-input {
   padding: 6px 10px;
   background: var(--color-bg);
@@ -622,7 +633,8 @@
   color: var(--color-text);
   font-size: 0.82rem;
   font-family: var(--font-sans);
-  width: 100%;
+  flex: 1;
+  min-width: 120px;
   box-sizing: border-box;
 }
 
@@ -674,12 +686,16 @@
 
 .ref-cwe-name {
   flex: 1;
-  font-size: 0.8rem;
+  min-width: 150px;
+  font-size: 0.85rem;
   color: var(--color-text-secondary, #888);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  padding: 6px 0;
+  padding: 6px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
 }
 
 .cwe-browser-modal {

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -1,0 +1,917 @@
+/* ============================================================
+   Standards Browser & Editor Styles
+   ============================================================ */
+
+/* ── Standards Page ──────────────────────────────────────── */
+
+.standards-page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.standards-page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  margin-bottom: 28px;
+  gap: 16px;
+}
+
+.standards-page-title {
+  margin: 0 0 6px 0;
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.standards-page-subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+.standards-page-header-actions {
+  display: flex;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.standards-loading,
+.standards-empty {
+  padding: 48px 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+/* ── Standards List / Sections ───────────────────────────── */
+
+.standards-list {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.standards-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.standards-section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.standards-section-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.standards-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  background: var(--color-border);
+  border-radius: 11px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.standards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+/* ── Standard Card ───────────────────────────────────────── */
+
+.standard-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 18px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  position: relative;
+}
+
+.standard-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 12px color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+.standard-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.standard-type-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.standard-type-badge--builtin {
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent);
+}
+
+.standard-type-badge--community {
+  background: color-mix(in srgb, var(--primitive-green-400) 15%, transparent);
+  color: var(--primitive-green-700);
+}
+
+.standard-type-badge--custom {
+  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
+  color: var(--color-text-muted);
+}
+
+.standard-managed-badge {
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  color: var(--color-text-muted);
+}
+
+.standard-card-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+.standard-card-id {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+}
+
+.standard-card-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.standard-card-counts {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  margin-top: auto;
+  padding-top: 8px;
+}
+
+.standard-card-counts-sep {
+  margin: 0 4px;
+  opacity: 0.5;
+}
+
+.standard-card-actions {
+  display: flex;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+  margin-top: 4px;
+}
+
+.card-action-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.card-action-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+}
+
+.card-action-btn--danger:hover {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 6%, transparent);
+}
+
+/* ── Standard Editor ─────────────────────────────────────── */
+
+.standard-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.standard-editor-loading,
+.standard-editor-error {
+  padding: 48px;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.standard-editor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+  flex-shrink: 0;
+}
+
+.editor-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.editor-back-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.editor-toolbar-center {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.editor-dirty-indicator {
+  color: var(--color-accent);
+  margin-left: 2px;
+}
+
+.editor-managed-badge {
+  font-size: 0.7rem;
+  padding: 2px 6px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  color: var(--color-text-muted);
+}
+
+.editor-toolbar-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.standard-editor-body {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.standard-editor-tree-panel {
+  border-right: 1px solid var(--color-border);
+  overflow-y: auto;
+  padding: 16px 0;
+  background: var(--color-surface);
+}
+
+.standard-editor-detail-panel {
+  overflow-y: auto;
+  padding: 24px;
+}
+
+/* ── Standard Tree ───────────────────────────────────────── */
+
+.standard-tree {
+  padding: 0 8px;
+}
+
+.tree-node {
+  display: flex;
+  flex-direction: column;
+}
+
+.tree-node--depth-1 {
+  padding-left: 12px;
+}
+
+.tree-node--depth-2 {
+  padding-left: 24px;
+}
+
+.tree-node-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px;
+  border-radius: var(--radius-md, 6px);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.1s;
+}
+
+.tree-node-row:hover {
+  background: var(--color-border);
+}
+
+.tree-node-row--selected {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+}
+
+.tree-node-row--selected .tree-node-label {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.tree-expand-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  border-radius: 3px;
+}
+
+.tree-expand-btn--invisible {
+  visibility: hidden;
+}
+
+.tree-node-label {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tree-node-actions {
+  display: none;
+  gap: 2px;
+  align-items: center;
+}
+
+.tree-node-row:hover .tree-node-actions {
+  display: flex;
+}
+
+.tree-node-row--selected .tree-node-actions {
+  display: flex;
+}
+
+.tree-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.1s, color 0.1s;
+}
+
+.tree-action-btn:hover {
+  background: var(--color-border);
+  color: var(--color-accent);
+}
+
+.tree-action-btn--remove:hover {
+  color: var(--color-danger);
+}
+
+.tree-node-children {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Detail Forms ────────────────────────────────────────── */
+
+.detail-form-title {
+  margin: 0 0 20px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.standard-root-detail,
+.principle-form,
+.requirement-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+}
+
+.form-input {
+  padding: 10px 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.form-input:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.form-input--narrow {
+  max-width: 120px;
+}
+
+.form-textarea {
+  padding: 10px 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  resize: vertical;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.form-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.form-textarea:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.principle-form-meta {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.principle-form-req-count {
+  font-style: italic;
+}
+
+.detail-managed-notice {
+  margin: 0;
+  padding: 10px 14px;
+  background: color-mix(in srgb, var(--color-text-muted) 8%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+}
+
+/* ── Reference Editor ────────────────────────────────────── */
+
+.reference-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.reference-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.reference-editor-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.ref-add-btn {
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text-muted);
+  font-size: 0.78rem;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.ref-add-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.reference-editor-empty {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.ref-row {
+  display: grid;
+  grid-template-columns: 90px 1fr 2fr 28px;
+  gap: 6px;
+  align-items: center;
+}
+
+.ref-type-select {
+  padding: 6px 8px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.78rem;
+  font-family: var(--font-sans);
+}
+
+.ref-label-input,
+.ref-url-input {
+  padding: 6px 10px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.82rem;
+  font-family: var(--font-sans);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ref-label-input:focus,
+.ref-url-input:focus,
+.ref-type-select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.ref-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.ref-remove-btn:hover {
+  color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 10%, transparent);
+}
+
+/* ── Library Browser ─────────────────────────────────────── */
+
+.library-browser-subtitle {
+  margin: 0 0 20px 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.library-loading,
+.library-empty {
+  padding: 32px 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.library-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 16px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.library-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.library-card-name {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.library-card-id {
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono, monospace);
+}
+
+.library-card-description {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.library-card-counts {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.library-card-counts-sep {
+  margin: 0 4px;
+  opacity: 0.5;
+}
+
+.library-card-footer {
+  margin-top: auto;
+  padding-top: 8px;
+}
+
+.library-import-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+/* ── Modal Shared Styles ─────────────────────────────────── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--color-bg) 40%, transparent);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.modal-dialog {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  width: 100%;
+  max-width: 440px;
+  box-shadow: 0 16px 48px color-mix(in srgb, #000 24%, transparent);
+}
+
+.modal-dialog--wide {
+  max-width: 760px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.modal-title {
+  margin: 0 0 16px 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.modal-header .modal-title {
+  margin-bottom: 0;
+}
+
+.modal-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.modal-close-btn:hover {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.modal-body {
+  margin: 0 0 16px 0;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.modal-input {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: var(--font-sans);
+  margin-bottom: 16px;
+  box-sizing: border-box;
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 20%, transparent);
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.modal-actions--end {
+  justify-content: flex-end;
+  padding-top: 8px;
+}
+
+/* ── Shared Buttons ──────────────────────────────────────── */
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  background: var(--color-accent);
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-bg);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s, box-shadow 0.15s;
+}
+
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+
+.btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 6px);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.btn-secondary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  background: var(--color-danger);
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  color: #fff;
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.btn-danger:hover {
+  opacity: 0.88;
+}
+
+/* ── Chip Badges for Evaluate Tab ────────────────────────── */
+
+.dimension-chip-btn {
+  position: relative;
+}
+
+.dim-chip-badge {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-left: 4px;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.dim-chip-badge--custom {
+  background: var(--color-text-muted);
+}
+
+.dim-chip-badge--community {
+  background: var(--primitive-green-400, #4caf7d);
+}

--- a/tests/test_prompt_builder_fallback.py
+++ b/tests/test_prompt_builder_fallback.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+from quodeq.analysis.prompts.builder import _load_dimension_data
+
+def test_load_dimension_data_from_compiled(tmp_path):
+    compiled = tmp_path / "compiled"
+    compiled.mkdir()
+    compiled.joinpath("security.json").write_text(json.dumps({"id": "security", "principles": []}))
+    result = _load_dimension_data(compiled, "security")
+    assert result is not None
+    assert result["id"] == "security"
+
+def test_load_dimension_data_fallback_to_evaluators(tmp_path):
+    compiled = tmp_path / "compiled"
+    compiled.mkdir()
+    result = _load_dimension_data(compiled, "nonexistent", evaluators_dir=tmp_path / "evals")
+    assert result is None
+
+def test_load_dimension_data_custom_evaluator(tmp_path):
+    compiled = tmp_path / "compiled"
+    compiled.mkdir()
+    evals = tmp_path / "evaluators"
+    evals.mkdir()
+    evals.joinpath("clean-arch.json").write_text(json.dumps({
+        "id": "clean-arch", "principles": [{"name": "SoC", "requirements": []}]
+    }))
+    result = _load_dimension_data(compiled, "clean-arch", evaluators_dir=evals)
+    assert result is not None
+    assert result["id"] == "clean-arch"

--- a/tests/test_standards_library.py
+++ b/tests/test_standards_library.py
@@ -46,3 +46,22 @@ def test_import_standard(tmp_path):
     assert saved["type"] == "community"
     assert saved["origin"] == "standards/clean-arch.json"
     assert saved["origin_hash"] is not None
+
+
+def test_reimport_same_origin_updates(tmp_path):
+    http = FakeHttpClient({"https://example.com/standards/clean-arch.json": STANDARD_DATA})
+    client = StandardsLibraryClient(base_url="https://example.com", http_client=http)
+    client.import_standard("standards/clean-arch.json", tmp_path)
+    # Re-import same origin should succeed (update)
+    client.import_standard("standards/clean-arch.json", tmp_path)
+    assert (tmp_path / "clean-arch.json").is_file()
+
+
+def test_import_collision_different_origin_raises(tmp_path):
+    # Pre-create a standard with a different origin
+    existing = {**STANDARD_DATA, "origin": "other-repo/clean-arch.json", "managed": False, "type": "custom"}
+    (tmp_path / "clean-arch.json").write_text(json.dumps(existing))
+    http = FakeHttpClient({"https://example.com/standards/clean-arch.json": STANDARD_DATA})
+    client = StandardsLibraryClient(base_url="https://example.com", http_client=http)
+    with pytest.raises(ValueError, match="already exists"):
+        client.import_standard("standards/clean-arch.json", tmp_path)

--- a/tests/test_standards_library.py
+++ b/tests/test_standards_library.py
@@ -1,0 +1,48 @@
+# tests/test_standards_library.py
+import json
+import pytest
+from quodeq.services.standards_library import StandardsLibraryClient
+
+class FakeHttpClient:
+    def __init__(self, responses=None):
+        self._responses = responses or {}
+    def get_json(self, url, headers=None):
+        if url in self._responses:
+            return self._responses[url]
+        raise ConnectionError(f"Not found: {url}")
+
+INDEX = {
+    "version": 1,
+    "standards": [
+        {"id": "clean-arch", "name": "Clean Architecture", "description": "Test", "principleCount": 2, "requirementCount": 8, "file": "standards/clean-arch.json"},
+    ],
+}
+
+STANDARD_DATA = {
+    "id": "clean-arch", "name": "Clean Architecture", "description": "Test",
+    "weight": 1.0, "source": "Martin", "principles": [],
+}
+
+def test_fetch_index():
+    http = FakeHttpClient({"https://example.com/index.json": INDEX})
+    client = StandardsLibraryClient(base_url="https://example.com", http_client=http)
+    index = client.fetch_index()
+    assert len(index) == 1
+    assert index[0]["id"] == "clean-arch"
+
+def test_fetch_standard():
+    http = FakeHttpClient({"https://example.com/standards/clean-arch.json": STANDARD_DATA})
+    client = StandardsLibraryClient(base_url="https://example.com", http_client=http)
+    data = client.fetch_standard("standards/clean-arch.json")
+    assert data["id"] == "clean-arch"
+
+def test_import_standard(tmp_path):
+    http = FakeHttpClient({"https://example.com/standards/clean-arch.json": STANDARD_DATA})
+    client = StandardsLibraryClient(base_url="https://example.com", http_client=http)
+    result = client.import_standard("standards/clean-arch.json", tmp_path)
+    assert (tmp_path / "clean-arch.json").is_file()
+    saved = json.loads((tmp_path / "clean-arch.json").read_text())
+    assert saved["managed"] is True
+    assert saved["type"] == "community"
+    assert saved["origin"] == "standards/clean-arch.json"
+    assert saved["origin_hash"] is not None

--- a/tests/test_standards_routes.py
+++ b/tests/test_standards_routes.py
@@ -1,0 +1,51 @@
+"""Tests for Standards API read and write endpoints."""
+import json
+from pathlib import Path
+import pytest
+from quodeq.api.app import create_app
+
+@pytest.fixture()
+def dirs(tmp_path):
+    evaluators = tmp_path / "evaluators"
+    evaluators.mkdir()
+    compiled = tmp_path / "compiled"
+    compiled.mkdir()
+    dims = tmp_path / "dimensions.json"
+    dims.write_text(json.dumps({
+        "applies": [{"id": "security", "weight": 1.2, "iso_25010": "Security", "source": "ISO/IEC 25010:2023"}]
+    }))
+    compiled.joinpath("security.json").write_text(json.dumps({
+        "id": "security", "name": "Security", "sources": ["iso25010"],
+        "principles": [{"name": "Confidentiality", "requirements": [{"id": "S-1", "text": "Test req", "refs": []}]}],
+    }))
+    return {"evaluators": evaluators, "compiled": compiled, "dimensions": dims}
+
+@pytest.fixture()
+def client(dirs):
+    app = create_app(test_config={
+        "TESTING": True,
+        "STANDARDS_EVALUATORS_DIR": str(dirs["evaluators"]),
+        "STANDARDS_COMPILED_DIR": str(dirs["compiled"]),
+        "STANDARDS_DIMENSIONS_FILE": str(dirs["dimensions"]),
+    })
+    with app.test_client() as c:
+        yield c
+
+# Read endpoints
+def test_list_standards(client):
+    resp = client.get("/api/standards")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, list)
+    assert any(s["id"] == "security" for s in data)
+
+def test_get_standard_detail(client):
+    resp = client.get("/api/standards/security")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["id"] == "security"
+    assert "principles" in data
+
+def test_get_standard_not_found(client):
+    resp = client.get("/api/standards/nonexistent")
+    assert resp.status_code == 404

--- a/tests/test_standards_routes.py
+++ b/tests/test_standards_routes.py
@@ -49,3 +49,33 @@ def test_get_standard_detail(client):
 def test_get_standard_not_found(client):
     resp = client.get("/api/standards/nonexistent")
     assert resp.status_code == 404
+
+# Write endpoints
+def test_create_standard(client):
+    payload = {"id": "my-std", "name": "My Standard", "description": "Test standard", "weight": 1.0, "source": "Test", "principles": []}
+    resp = client.post("/api/standards", json=payload, headers={"Origin": "http://localhost"})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["id"] == "my-std"
+    assert data["type"] == "custom"
+
+def test_update_standard(client):
+    client.post("/api/standards", json={"id": "upd-std", "name": "Original", "description": "", "weight": 1.0, "source": "", "principles": []}, headers={"Origin": "http://localhost"})
+    resp = client.put("/api/standards/upd-std", json={"id": "upd-std", "name": "Updated", "description": "", "weight": 1.0, "source": "", "principles": []}, headers={"Origin": "http://localhost"})
+    assert resp.status_code == 200
+    assert resp.get_json()["name"] == "Updated"
+
+def test_delete_standard(client):
+    client.post("/api/standards", json={"id": "del-std", "name": "Delete Me", "description": "", "weight": 1.0, "source": "", "principles": []}, headers={"Origin": "http://localhost"})
+    resp = client.delete("/api/standards/del-std", headers={"Origin": "http://localhost"})
+    assert resp.status_code == 204
+
+def test_delete_builtin_forbidden(client):
+    resp = client.delete("/api/standards/security", headers={"Origin": "http://localhost"})
+    assert resp.status_code == 403
+
+def test_duplicate_standard(client):
+    client.post("/api/standards", json={"id": "src-std", "name": "Source", "description": "", "weight": 1.0, "source": "", "principles": []}, headers={"Origin": "http://localhost"})
+    resp = client.post("/api/standards/src-std/duplicate", json={"newId": "copy-std"}, headers={"Origin": "http://localhost"})
+    assert resp.status_code == 201
+    assert resp.get_json()["id"] == "copy-std"

--- a/tests/test_standards_service.py
+++ b/tests/test_standards_service.py
@@ -105,3 +105,62 @@ def test_get_standard_builtin(service, compiled_dir):
 def test_get_standard_not_found(service):
     with pytest.raises(FileNotFoundError):
         service.get_standard("nonexistent")
+
+
+def test_create_standard(service, evaluators_dir):
+    new = {"id": "my-standard", "name": "My Standard", "description": "Test", "weight": 1.0, "source": "Me", "principles": []}
+    detail = service.create_standard(new)
+    assert detail.id == "my-standard"
+    assert detail.type == "custom"
+    assert not detail.managed
+    assert (evaluators_dir / "my-standard.json").is_file()
+
+def test_create_standard_duplicate_id_raises(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    with pytest.raises(ValueError, match="already exists"):
+        service.create_standard({"id": "clean-arch", "name": "Dup", "description": "", "weight": 1.0, "source": "", "principles": []})
+
+def test_update_standard(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    updated = {**CUSTOM_STANDARD, "name": "Updated Name"}
+    detail = service.update_standard("clean-arch", updated)
+    assert detail.name == "Updated Name"
+
+def test_update_managed_raises(service, evaluators_dir):
+    managed = {**CUSTOM_STANDARD, "id": "managed-one", "managed": True, "type": "community"}
+    _write_custom(evaluators_dir, managed)
+    with pytest.raises(PermissionError, match="managed"):
+        service.update_standard("managed-one", {**managed, "name": "Hacked"})
+
+def test_delete_standard(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    service.delete_standard("clean-arch")
+    assert not (evaluators_dir / "clean-arch.json").is_file()
+
+def test_delete_managed_raises(service, evaluators_dir):
+    managed = {**CUSTOM_STANDARD, "id": "managed-one", "managed": True}
+    _write_custom(evaluators_dir, managed)
+    with pytest.raises(PermissionError, match="managed"):
+        service.delete_standard("managed-one")
+
+def test_delete_builtin_raises(service):
+    with pytest.raises(PermissionError, match="built-in"):
+        service.delete_standard("security")
+
+def test_duplicate_standard(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    detail = service.duplicate_standard("clean-arch", new_id="clean-arch-copy")
+    assert detail.id == "clean-arch-copy"
+    assert detail.type == "custom"
+    assert not detail.managed
+    assert (evaluators_dir / "clean-arch-copy.json").is_file()
+
+def test_duplicate_builtin(service, compiled_dir):
+    compiled_dir.joinpath("security.json").write_text(json.dumps({
+        "id": "security", "name": "Security", "sources": ["iso25010"],
+        "principles": [{"name": "Confidentiality", "requirements": []}],
+    }))
+    detail = service.duplicate_standard("security", new_id="my-security")
+    assert detail.id == "my-security"
+    assert detail.type == "custom"
+    assert not detail.managed

--- a/tests/test_standards_service.py
+++ b/tests/test_standards_service.py
@@ -1,0 +1,107 @@
+"""Tests for StandardsService — list and read standards."""
+import json
+from pathlib import Path
+import pytest
+from quodeq.services.standards import StandardsService
+
+
+@pytest.fixture()
+def evaluators_dir(tmp_path):
+    d = tmp_path / "evaluators"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def compiled_dir(tmp_path):
+    d = tmp_path / "compiled"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def dimensions_file(tmp_path):
+    f = tmp_path / "dimensions.json"
+    f.write_text(json.dumps({
+        "applies": [
+            {"id": "security", "weight": 1.2, "iso_25010": "Security", "source": "ISO/IEC 25010:2023"}
+        ]
+    }))
+    return f
+
+
+@pytest.fixture()
+def service(evaluators_dir, compiled_dir, dimensions_file):
+    return StandardsService(
+        evaluators_dir=evaluators_dir,
+        compiled_dir=compiled_dir,
+        dimensions_file=dimensions_file,
+    )
+
+
+def _write_custom(evaluators_dir, data):
+    path = evaluators_dir / f"{data['id']}.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+CUSTOM_STANDARD = {
+    "id": "clean-arch",
+    "name": "Clean Architecture",
+    "description": "Clean Architecture principles",
+    "weight": 1.0,
+    "source": "Robert C. Martin",
+    "type": "custom",
+    "managed": False,
+    "origin": None,
+    "origin_hash": None,
+    "principles": [
+        {
+            "name": "Separation of Concerns",
+            "requirements": [
+                {"id": "CA-1", "text": "Use cases independent of frameworks", "refs": []}
+            ],
+        }
+    ],
+}
+
+
+def test_list_standards_empty(service):
+    standards = service.list_standards()
+    assert len(standards) == 1
+    assert standards[0].id == "security"
+    assert standards[0].type == "builtin"
+    assert standards[0].managed is True
+
+
+def test_list_standards_includes_custom(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    standards = service.list_standards()
+    ids = {s.id for s in standards}
+    assert "clean-arch" in ids
+    assert "security" in ids
+
+
+def test_get_standard_custom(service, evaluators_dir):
+    _write_custom(evaluators_dir, CUSTOM_STANDARD)
+    detail = service.get_standard("clean-arch")
+    assert detail.id == "clean-arch"
+    assert detail.type == "custom"
+    assert len(detail.principles) == 1
+
+
+def test_get_standard_builtin(service, compiled_dir):
+    compiled_dir.joinpath("security.json").write_text(json.dumps({
+        "id": "security",
+        "name": "Security",
+        "sources": ["iso25010"],
+        "principles": [{"name": "Confidentiality", "requirements": []}],
+    }))
+    detail = service.get_standard("security")
+    assert detail.id == "security"
+    assert detail.type == "builtin"
+
+
+def test_get_standard_not_found(service):
+    with pytest.raises(FileNotFoundError):
+        service.get_standard("nonexistent")

--- a/tests/test_standards_types.py
+++ b/tests/test_standards_types.py
@@ -1,0 +1,40 @@
+from quodeq.core.types.standard import StandardMeta, StandardDetail, StandardReference
+
+
+def test_standard_meta_creation():
+    meta = StandardMeta(
+        id="clean-architecture",
+        name="Clean Architecture",
+        description="Clean Architecture principles",
+        weight=1.0,
+        source="Robert C. Martin",
+        type="custom",
+        managed=False,
+        origin=None,
+        origin_hash=None,
+        principle_count=4,
+        requirement_count=18,
+    )
+    assert meta.id == "clean-architecture"
+    assert meta.type == "custom"
+    assert not meta.managed
+
+
+def test_standard_reference_creation():
+    ref = StandardReference(type="cwe", label="CWE-798", url="https://cwe.mitre.org/data/definitions/798.html")
+    assert ref.type == "cwe"
+    assert ref.url is not None
+
+
+def test_standard_reference_no_url():
+    ref = StandardReference(type="book", label="Clean Architecture Ch.22", url=None)
+    assert ref.url is None
+
+
+from pathlib import Path
+from quodeq.config.paths import ConfigPaths
+
+
+def test_config_paths_has_evaluators_dir():
+    cp = ConfigPaths(root=Path("/tmp/fake"))
+    assert cp.evaluators_dir == Path.home() / ".quodeq" / "evaluators"

--- a/uv.lock
+++ b/uv.lock
@@ -307,21 +307,21 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
 name = "quodeq"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
@@ -343,7 +343,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = "==9.0.2" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- New **Standards** tab in the sidebar — browse built-in ISO 25010 standards, create/edit custom evaluators, import from a library
- **Tree + detail panel editor** — IDE-style interface for building standards with principles, requirements, and references (CWE searchable browser, book, URL, other)
- **Custom evaluators run in the evaluation engine** — select alongside built-in dimensions in the Evaluate tab, results display in dashboard with proper principle names
- **Evaluate tab grouping** — ISO 25010 and Custom Standards in labeled sections with shared `DimensionSelector` component

### Backend
- `StandardsService` with full CRUD (create, update, delete, duplicate) + ID validation
- `StandardsLibraryClient` for importing from a remote GitHub repo (with collision handling: same-origin updates, different-origin rejects)
- `/api/standards/*` endpoints (list, detail, create, update, delete, duplicate, library, CWE refs)
- Evidence parser reads `req` field for custom evaluator findings
- Prompt builder includes principle/requirement descriptions when present
- Evaluation engine validates custom dimension IDs and loads from `~/.quodeq/evaluators/`

### Frontend
- Standards list page with cards grouped by type (ISO 25010, Community, Custom)
- Tree + detail editor with resizable divider, auto-generated IDs, autofocus on new items
- CWE browser modal (368 CWEs, searchable with abstraction filter)
- Reference editor with type-specific fields (CWE dropdown, Book title, URL, Other)
- Delete confirmation requires typing name for standards with content
- Built-in standards: view-only with Duplicate button

### Tests
- 34 new tests covering service CRUD, library import/collision, API routes, data types, prompt builder fallback
- All 612 tests pass

## Test plan
- [x] Standards tab shows built-in ISO dimensions + custom standards
- [x] Create "Clean Architecture" standard with 8 principles, 32 requirements
- [x] Evaluate with custom standard — findings parsed and scored correctly
- [x] Dashboard shows proper principle names (not requirement IDs)
- [x] Duplicate built-in standard creates editable copy
- [x] Delete confirmation on standards with content
- [x] CWE browser search works
- [x] Evaluate tab groups ISO and Custom sections
- [x] Re-evaluate panel uses shared DimensionSelector
- [x] Path traversal validation on library import