### PR TITLE
feat: add code context field to evaluation findings

### DIFF
--- a/src/quodeq/analysis/mcp/dispatch.py
+++ b/src/quodeq/analysis/mcp/dispatch.py
@@ -35,6 +35,7 @@ REPORT_FINDING_SCHEMA = {
         "severity": {"type": "string", "enum": ["critical", "major", "minor"], "description": "Severity level"},
         "w": {"type": "string", "description": "Short description of the finding"},
         "reason": {"type": "string", "description": "Why this is a violation or compliance"},
+        "context": {"type": "string", "description": "~10 lines of surrounding code with violation line marked by >>>"},
         "p": {"type": "string", "description": "Sub-characteristic name — auto-filled from req if omitted"},
         "d": {"type": "string", "description": "Dimension — auto-filled from server config if omitted"},
     },

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -35,7 +35,9 @@ For each file in the verification manifest at `{manifest_path}`:
 2. Look up its findings in the manifest
 3. For each finding, check if the violation/compliance condition **still applies**
    to the current code — not just whether the line exists, but whether the
-   underlying issue is still present
+   underlying issue is still present. Each finding may include a `context` field
+   with ~10 lines of surrounding code that can help assess whether the violation
+   still applies
 4. If the finding still applies, report it using the `report_finding` tool
    with the same fields (principle, type, severity, file, line, reason, snippet)
 5. If the issue has been fixed or no longer applies, skip it silently

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -32,6 +32,7 @@ class Judgment:
     req_refs: list[dict] | None = None
     violation_type: str = ""
     title: str = ""
+    context: str = ""
 
 
 @dataclass

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -113,6 +113,7 @@ def _parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
         reason=obj.get("reason", ""),
         req=obj.get("req"),
         title=obj.get("w", ""),
+        context=obj.get("context", ""),
     )
     # Pre-resolved req_refs from MCP server enrichment take priority
     pre_resolved = obj.get("req_refs")
@@ -124,7 +125,7 @@ def _parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
 def _judgment_to_dict(j: Judgment) -> dict:
     """Convert a Judgment to the dict format used in PrincipleEvidence lists."""
     d: dict = {"file": j.file}
-    _optional = {"line": j.line, "snippet": j.snippet, "severity": j.severity, "violation_type": j.violation_type}
+    _optional = {"line": j.line, "snippet": j.snippet, "severity": j.severity, "violation_type": j.violation_type, "context": j.context}
     d.update({k: v for k, v in _optional.items() if v})
     if j.req:
         d["req"] = j.req

--- a/src/quodeq/core/finding_builder.py
+++ b/src/quodeq/core/finding_builder.py
@@ -27,6 +27,7 @@ class FindingSpec:
     cwe: int | str | None = None
     req: str | None = None
     req_refs: list[dict] | None = None
+    context: str | None = None
     include_severity: bool = True
 
 
@@ -53,6 +54,7 @@ def build_finding_base(spec: FindingSpec) -> Finding:
         cwe=spec.cwe if spec.cwe else None,
         req=spec.req if spec.req else None,
         req_refs=req_refs,
+        context=spec.context if spec.context else None,
     )
 
 

--- a/src/quodeq/core/types/finding.py
+++ b/src/quodeq/core/types/finding.py
@@ -36,5 +36,6 @@ class Finding:
     cwe: int | str | None = None
     req: str | None = None
     req_refs: list[ReqRef] = field(default_factory=list)
+    context: str | None = None
     dimension: str | None = None
     violation_type: str | None = None

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -25,7 +25,7 @@ For EVERY finding (violation or compliance), call `report_finding` with:
 - `severity` — `critical`, `major`, or `minor`
 - `w` — short description of what you found
 
-**Optional:** `reason` — why this is a violation or compliance
+**Optional:** `reason` — why this is a violation or compliance, `context` — ~10 lines of surrounding code centered on the violation line, with the violation line prefixed by ">>>" to mark it
 
 ## Severity Definitions
 

--- a/src/quodeq/data/prompts/consolidated.md
+++ b/src/quodeq/data/prompts/consolidated.md
@@ -22,7 +22,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 
 **Required:** `req` (the **bold requirement ID**, e.g. `M-MOD-1`, `S-CON-3` — server auto-fills principle name and dimension), `t` (`violation` or `compliance`), `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `w` (short description)
 
-**Optional:** `reason` (why this is a violation or compliance)
+**Optional:** `reason` (why this is a violation or compliance), `context` (~10 lines of surrounding code centered on the violation line, with the violation line prefixed by ">>>" to mark it)
 
 ## Rules
 

--- a/src/quodeq/data/prompts/subagent.md
+++ b/src/quodeq/data/prompts/subagent.md
@@ -22,7 +22,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 **Required:** `req` (the **bold requirement ID**, e.g. `M-MOD-1`, `S-CON-3` — server auto-fills principle name and dimension), `t` (`violation` or `compliance`), `file`, `line`, `snippet` (under 200 chars), `severity` (`critical`/`major`/`minor`), `w` (short description)
 
-**Optional:** `reason` (why this is a violation or compliance)
+**Optional:** `reason` (why this is a violation or compliance), `context` (~10 lines of surrounding code centered on the violation line, with the violation line prefixed by ">>>" to mark it)
 
 ## Rules
 

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -76,6 +76,7 @@ def _build_finding_entry(obj: dict, dimension: str, req_refs_lookup: dict[str, l
         cwe=obj.get("cwe"),
         req=req,
         req_refs=req_refs,
+        context=obj.get("context"),
     ))
     return replace(entry, dimension=obj.get("d", dimension), violation_type=obj.get("vt"))
 

--- a/src/quodeq/ui/src/components/ContextBlock.jsx
+++ b/src/quodeq/ui/src/components/ContextBlock.jsx
@@ -1,0 +1,26 @@
+/**
+ * Renders ~10 lines of surrounding code context with the violation line
+ * (prefixed by ">>>") highlighted. Falls back to snippet display if no
+ * context is available.
+ */
+export default function ContextBlock({ context, snippet }) {
+  if (context) {
+    const lines = context.replace(/\\n/g, '\n').split('\n');
+    return (
+      <pre className="finding-context">{lines.map((line, i) => {
+        const isHighlighted = line.startsWith('>>>');
+        const display = isHighlighted ? line.slice(3) : line;
+        return (
+          <span
+            key={i}
+            className={isHighlighted ? 'finding-context-line--highlighted' : 'finding-context-line'}
+          >{display}{'\n'}</span>
+        );
+      })}</pre>
+    );
+  }
+  if (snippet) {
+    return <pre className="vlive-snippet">{snippet.replace(/\\n/g, '\n')}</pre>;
+  }
+  return null;
+}

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
+import ContextBlock from '../../../components/ContextBlock.jsx';
 import { parseFileRef } from '../../../utils/formatters.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 40;
@@ -63,7 +64,7 @@ function ViolationLiveRow({ violation, index }) {
               </>}
             </div>
           )}
-          {v.snippet && <pre className="vlive-snippet">{v.snippet.replace(/\\n/g, '\n')}</pre>}
+          <ContextBlock context={v.context} snippet={v.snippet} />
         </div>
       )}
     </div>

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -1,6 +1,7 @@
 import { parseFileRef } from '../../../utils/formatters.js';
 import CopyButton from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
+import ContextBlock from '../../../components/ContextBlock.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
@@ -52,7 +53,7 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index 
             </>}
           </div>
         )}
-        {v.snippet && <pre className="vlive-snippet">{v.snippet.replace(/\\n/g, '\n')}</pre>}
+        <ContextBlock context={v.context} snippet={v.snippet} />
       </div>
     </div>
   );
@@ -81,7 +82,7 @@ export function ComplianceCard({ c, principle, index }) {
             </>}
           </div>
         )}
-        {c.snippet && <pre className="vlive-snippet">{c.snippet.replace(/\\n/g, '\n')}</pre>}
+        <ContextBlock context={c.context} snippet={c.snippet} />
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -4,6 +4,7 @@ import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
 import CopyButton from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
+import ContextBlock from '../../../components/ContextBlock.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
@@ -51,7 +52,7 @@ function ViolationCard({ v, index }) {
             </>}
           </div>
         )}
-        {v.snippet && <pre className="vlive-snippet">{v.snippet.replace(/\\n/g, '\n')}</pre>}
+        <ContextBlock context={v.context} snippet={v.snippet} />
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1836,6 +1836,32 @@
 }
 
 
+.finding-context {
+  margin: 10px 0 0;
+  padding: 0;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--color-text);
+  white-space: pre;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.finding-context-line {
+  display: block;
+  padding: 0 12px;
+}
+
+.finding-context-line--highlighted {
+  display: block;
+  padding: 0 12px;
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+  font-weight: 600;
+}
+
 /* Detail rows (explorer detail pages) */
 .vdetail-row {
   animation: vlive-enter 200ms ease-out both;


### PR DESCRIPTION
## Summary

- New `context` field in evaluation findings — ~10 lines of surrounding code with the violation line marked by `>>>`
- Existing `snippet` field unchanged (short, <200 chars)
- UI renders context block with highlighted violation line, falls back to snippet for older findings
- Verification prompt references context for better accuracy

### Changes
- **Prompts**: instruct AI to report `context` alongside `snippet`
- **MCP schema**: `context` added as optional field to `report_finding`
- **Evidence model**: `context` field on `Judgment` and `Finding` dataclasses
- **Parser**: reads/writes `context` from JSONL
- **UI**: new `ContextBlock` component shared across LiveViolationsFeed, EvalCards, FileDetailPage
- **Verification**: prompt mentions context field for re-assessment

Fully backward compatible — `context` is optional, old findings display as before.

## Test plan
- [x] All 612 tests pass
- [x] Frontend builds cleanly
- [x] Run evaluation and verify context appears in findings
- [x] Dashboard shows context with highlighted line
- [x] Old findings without context still display snippet correctly