### PR TITLE
feat: standards visibility toggle, bundled evaluators, filtered overview

### DIFF
--- a/src/quodeq/data/config/dimensions.json
+++ b/src/quodeq/data/config/dimensions.json
@@ -35,6 +35,20 @@
       "weight": 0.6,
       "iso_25010": "Flexibility",
       "source": "ISO/IEC 25010:2023"
+    },
+    {
+      "id": "clean-architecture",
+      "name": "Clean Architecture",
+      "weight": 1.0,
+      "source": "Robert C. Martin",
+      "type": "quodeq"
+    },
+    {
+      "id": "domain-driven-design",
+      "name": "Domain-Driven Design",
+      "weight": 1.0,
+      "source": "Eric Evans / Vaughn Vernon",
+      "type": "quodeq"
     }
   ]
 }

--- a/src/quodeq/data/standards/compiled/clean-architecture.json
+++ b/src/quodeq/data/standards/compiled/clean-architecture.json
@@ -1,0 +1,371 @@
+{
+  "id": "clean-architecture",
+  "name": "Clean Architecture",
+  "description": "Evaluates adherence to Robert C. Martin's Clean Architecture principles",
+  "managed": true,
+  "type": "quodeq",
+  "source": "Robert C. Martin",
+  "weight": 1.0,
+  "principles": [
+    {
+      "name": "Dependency Rule",
+      "description": "Source code dependencies must point inward. Inner layers must not know about outer layers",
+      "requirements": [
+        {
+          "id": "CLEA-DEP-01",
+          "text": "Source code dependencies must point inward only",
+          "description": "Outer layers (frameworks, UI, DB) may depend on inner layers (use cases, entities), never the reverse. An import from entities/ into controllers/ is fine; an import from controllers/ into entities/ is a violation",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-02",
+          "text": "Entities must not import from use case or adapter layers",
+          "description": "Domain entities should have zero imports from application or infrastructure code. Check import statements in entity files — they should only reference other entities, value objects, or standard library types",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-03",
+          "text": "Use cases must not reference framework-specific types",
+          "description": "Interactors/use cases should operate on plain domain objects, not framework classes. No HttpRequest, HttpResponse, DbSession, or framework DI decorators in use case files",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-04",
+          "text": "Data crosses boundaries through simple transfer objects",
+          "description": "Data passed between layers must use DTOs or plain data structures, not objects that carry framework dependencies. A use case returns a plain result object, not a Django QuerySet or an ORM model instance",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-05",
+          "text": "Inner layers must define interfaces that outer layers implement",
+          "description": "Dependency inversion: the use case layer defines a repository interface, the database layer implements it. The interface file lives in the use case layer, the implementation lives in the infrastructure layer",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-06",
+          "text": "No transitive framework dependencies in core layers",
+          "description": "Even indirect imports of framework packages in entities or use cases violate the rule. If entity A imports utility B, and utility B imports Flask, then entity A has a transitive framework dependency",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-07",
+          "text": "Configuration and environment variables are not read in inner layers",
+          "description": "Entities and use cases must not read from os.environ, config files, or settings modules directly. Configuration is injected from the outermost layer through constructor parameters or interfaces",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DEP-08",
+          "text": "Inner layers must not instantiate outer layer classes directly",
+          "description": "A use case must not do 'new PostgresRepository()' or 'new EmailService()' — it receives these through dependency injection. Direct instantiation of infrastructure classes in use cases breaks the dependency rule",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Separation of Concerns",
+      "description": "Each layer (entities, use cases, adapters, frameworks) has a distinct responsibility",
+      "requirements": [
+        {
+          "id": "CLEA-SEP-01",
+          "text": "Each layer has a single well-defined responsibility",
+          "description": "Entities hold business rules, use cases hold application logic, adapters handle format conversion, frameworks handle infrastructure. A file that does format conversion AND business logic violates separation",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-02",
+          "text": "UI logic must not exist in use case or entity layers",
+          "description": "Formatting, rendering decisions, user interaction handling, response status codes, and HTML/JSON construction belong exclusively in the presentation layer. A use case returning 'HTTP 404' is a violation",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-03",
+          "text": "Data access logic must be confined to the adapter layer",
+          "description": "SQL queries, API calls, file I/O, and ORM operations must not leak into use cases or entities. If a use case file contains 'SELECT', '.query()', or 'fetch()', data access logic has leaked",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-04",
+          "text": "No layer should bypass adjacent layers",
+          "description": "A controller must not directly access an entity without going through a use case. A use case must not directly write to a database without going through a repository interface. Skipped layers create hidden coupling",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-05",
+          "text": "Error handling respects layer boundaries",
+          "description": "Domain exceptions are thrown in entities/use cases, caught and translated in adapters. A use case must not catch SqlException (infrastructure) and an adapter must not throw InsufficientFundsError (domain). Each layer handles errors appropriate to its abstraction level",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-06",
+          "text": "Logging and monitoring instrumentation lives in the outer layers",
+          "description": "Entities and use cases must not import logging frameworks or emit metrics directly. Logging is a cross-cutting concern handled by adapters, middleware, or decorators wrapping use cases — not embedded in business logic",
+          "refs": []
+        },
+        {
+          "id": "CLEA-SEP-07",
+          "text": "Serialization and deserialization belong in the adapter layer",
+          "description": "JSON parsing, XML mapping, protobuf encoding — all format conversion belongs in adapters. Entities and use cases operate on domain objects, never on raw strings, dicts, or byte arrays from external formats",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Independence from Frameworks",
+      "description": "The architecture does not depend on the existence of any library or framework",
+      "requirements": [
+        {
+          "id": "CLEA-FRM-01",
+          "text": "Core business logic must not import framework packages",
+          "description": "Use case and entity files should have zero imports from web frameworks, ORMs, or DI containers. Check the import section of every file in domain/ and usecases/ — any framework import is a violation",
+          "refs": []
+        },
+        {
+          "id": "CLEA-FRM-02",
+          "text": "Framework-specific annotations must not appear on domain entities",
+          "description": "No ORM decorators (@Entity, @Column), serialization attributes (@JsonProperty), validation decorators (@NotNull), or framework markers on core domain classes. These belong on infrastructure mapping classes",
+          "refs": []
+        },
+        {
+          "id": "CLEA-FRM-03",
+          "text": "Swapping a framework should require changes only in the outermost layer",
+          "description": "Replacing Express with Fastify, Django with Flask, or Spring with Micronaut should not touch use cases or entities. If it does, the framework has penetrated too deep",
+          "refs": []
+        },
+        {
+          "id": "CLEA-FRM-04",
+          "text": "Framework base classes must not be extended by domain objects",
+          "description": "Entities must not extend Django Model, Spring JpaRepository base, or ActiveRecord. Domain objects are plain classes — ORM mapping is infrastructure's job, done through separate mapper classes or configuration",
+          "refs": []
+        },
+        {
+          "id": "CLEA-FRM-05",
+          "text": "Framework lifecycle hooks must not contain business logic",
+          "description": "Methods like @PostConstruct, on_save(), before_create() must not contain domain rules. They may trigger use cases, but the business logic itself lives in the domain layer",
+          "refs": []
+        },
+        {
+          "id": "CLEA-FRM-06",
+          "text": "Dependency injection is a mechanism, not an architecture",
+          "description": "DI container annotations (@Inject, @Autowired, @Service) must not appear in entities or use cases. Use constructor injection with plain parameters — the DI container wires things in the composition root (outermost layer)",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Independence from UI",
+      "description": "The UI can change without changing the rest of the system",
+      "requirements": [
+        {
+          "id": "CLEA-UI-01",
+          "text": "Use cases must not reference UI components or view models",
+          "description": "No imports of React components, view controllers, template engines, or UI state management in the application layer. A use case that knows about a ViewModel or a Component has UI coupling",
+          "refs": []
+        },
+        {
+          "id": "CLEA-UI-02",
+          "text": "Business logic must produce the same results regardless of presentation",
+          "description": "A use case should work identically whether called from a web app, CLI, mobile app, or test harness. If the use case's behavior changes based on the calling context, it has UI awareness it shouldn't",
+          "refs": []
+        },
+        {
+          "id": "CLEA-UI-03",
+          "text": "No UI state management in the domain layer",
+          "description": "Redux stores, view models, reactive state (RxJS observables, LiveData), or UI-specific caching must not exist in entities or use cases. These are presentation concerns",
+          "refs": []
+        },
+        {
+          "id": "CLEA-UI-04",
+          "text": "Response formatting is an adapter concern, not a use case concern",
+          "description": "Use cases return domain results. Converting them to JSON, HTML, or GraphQL responses happens in the adapter/presenter layer. A use case that builds a JSON string or sets HTTP headers has UI coupling",
+          "refs": []
+        },
+        {
+          "id": "CLEA-UI-05",
+          "text": "Validation of user input is distinct from domain validation",
+          "description": "Input format validation (is this a valid email format, is this field present) belongs in the adapter/controller. Domain validation (can this order be placed, is this account active) belongs in entities. Don't mix them",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Independence from Database",
+      "description": "Business rules are not bound to a specific database",
+      "requirements": [
+        {
+          "id": "CLEA-DB-01",
+          "text": "Entities must not use database-specific types or annotations",
+          "description": "No ORM decorators, column definitions, or database engine types on domain objects. A domain entity with @Column, @Table, or field(db_index=True) has database coupling",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DB-02",
+          "text": "Repository interfaces defined in the use case layer, implemented in the adapter layer",
+          "description": "The domain defines what data operations it needs; infrastructure decides how to fulfill them. The interface says 'findActiveOrdersByCustomer()', the implementation writes the SQL",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DB-03",
+          "text": "Changing database technology should not require changes to business rules",
+          "description": "Moving from PostgreSQL to MongoDB, or from SQL to in-memory storage, should only affect adapter implementations. If use case code changes when the database changes, the abstraction is leaking",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DB-04",
+          "text": "Database schema details must not drive domain model design",
+          "description": "Entity field names, relationships, and structure should reflect the domain — not the database schema. If your entity has a 'fk_customer_id' field or a 'order_tbl' name, the database is driving the model",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DB-05",
+          "text": "Transaction management is an outer layer concern",
+          "description": "Use cases define the logical unit of work, but the actual transaction begin/commit/rollback mechanism lives in the adapter or application service layer. No @Transactional on entities, no manual connection.commit() in use cases",
+          "refs": []
+        },
+        {
+          "id": "CLEA-DB-06",
+          "text": "Query optimization and database-specific features stay in the adapter",
+          "description": "Indexes, caching strategies, query hints, stored procedures, database-specific functions — these are all adapter implementation details. The domain interface says what it needs, the adapter optimizes how to deliver it",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Testability",
+      "description": "Business rules can be tested without UI, database, web server, or any external element",
+      "requirements": [
+        {
+          "id": "CLEA-TES-01",
+          "text": "Business rules testable without infrastructure",
+          "description": "Entity and use case tests must run without database connections, HTTP servers, or file systems. If a domain test requires Docker, a running database, or network access, the architecture has a testability problem",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-02",
+          "text": "All dependencies injected through interfaces",
+          "description": "No hard-coded instantiation of infrastructure classes inside use cases. Every external dependency (repository, gateway, service) is received through a constructor parameter typed as an interface",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-03",
+          "text": "No static or global state that prevents isolated testing",
+          "description": "Each test must be able to run independently without shared mutable state. Singletons, module-level caches, and global registries that persist between tests are testability violations",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-04",
+          "text": "Use cases testable with in-memory implementations",
+          "description": "Repository and gateway interfaces must be simple enough to implement as in-memory fakes in a few lines. If creating a test double for a repository requires hundreds of lines, the interface is too complex",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-05",
+          "text": "Domain tests verify behavior, not implementation details",
+          "description": "Tests assert on domain outcomes ('order is shipped', 'balance decreased by X') — not on internal state or method call sequences. Tests that break when refactoring internals without changing behavior are testing the wrong thing",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-06",
+          "text": "Each layer can be tested in isolation",
+          "description": "Entity tests need no mocks. Use case tests mock only the outer boundary interfaces. Adapter tests verify integration with the actual infrastructure. If testing one layer requires setting up another, the layers are too coupled",
+          "refs": []
+        },
+        {
+          "id": "CLEA-TES-07",
+          "text": "Test speed reflects architectural boundaries",
+          "description": "Domain and use case tests should execute in milliseconds (no I/O). Adapter tests may be slower (real DB, real HTTP). If the 'fast' tests are slow, infrastructure has likely leaked inward",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Entity Design",
+      "description": "Entities are the innermost layer containing enterprise-wide business rules that are independent of any single application",
+      "requirements": [
+        {
+          "id": "CLEA-ENT-01",
+          "text": "Entities encapsulate enterprise-wide business rules",
+          "description": "Entities represent core business concepts and rules that would exist even if no application existed — they are not application-specific. An entity's rules are true across all applications that use it",
+          "refs": []
+        },
+        {
+          "id": "CLEA-ENT-02",
+          "text": "Entities are plain objects with no framework dependencies",
+          "description": "No ORM base classes, framework annotations, serialization decorators, or infrastructure imports in entity code. An entity file's imports should only reference other domain types and standard library",
+          "refs": []
+        },
+        {
+          "id": "CLEA-ENT-03",
+          "text": "Entity logic is reusable across different applications",
+          "description": "The same entity classes could be used by a web app, CLI tool, batch job, or microservice without modification. If the entity only works within one framework or application, it's too coupled",
+          "refs": []
+        },
+        {
+          "id": "CLEA-ENT-04",
+          "text": "Entities validate their own invariants",
+          "description": "Business rule validation lives inside the entity, not scattered across use cases or controllers. An entity must reject invalid state transitions at the point of mutation, not rely on external code to check first",
+          "refs": []
+        },
+        {
+          "id": "CLEA-ENT-05",
+          "text": "Entities are not anemic data structures",
+          "description": "An entity with only getters/setters and no behavior is a data structure, not a domain entity. Business logic that operates on entity data but lives in a service indicates an anemic model — move the logic into the entity",
+          "refs": []
+        },
+        {
+          "id": "CLEA-ENT-06",
+          "text": "Entities do not depend on use case layer abstractions",
+          "description": "Entities must not import or reference interfaces defined in the use case layer (like repositories or output ports). The dependency points inward: use cases depend on entities, never the reverse",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Use Case Encapsulation",
+      "description": "Each use case represents a single application-specific action, orchestrating entities and defining clear input/output boundaries",
+      "requirements": [
+        {
+          "id": "CLEA-USE-01",
+          "text": "Each use case represents a single application action",
+          "description": "One class or function per use case — no god-objects handling multiple unrelated operations. 'PlaceOrderUseCase', 'CancelOrderUseCase' — not 'OrderService' with 20 methods",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-02",
+          "text": "Use cases define explicit input and output data structures",
+          "description": "Request and response models are defined at the use case boundary, not passed through from external layers. The use case declares what it needs (PlaceOrderRequest) and what it returns (PlaceOrderResult) — not raw dicts or framework objects",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-03",
+          "text": "Use cases orchestrate entities, not replace their logic",
+          "description": "Business rules belong in entities; use cases coordinate the flow between entities and external interfaces. If a use case contains complex conditionals about business state, that logic should move into an entity method",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-04",
+          "text": "Use cases must not contain presentation or persistence logic",
+          "description": "No HTML rendering, SQL queries, API response formatting, JSON serialization, or file I/O inside use case code. If a use case file imports json, requests, or an ORM, something belongs in the adapter layer",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-05",
+          "text": "Use case dependencies are abstract interfaces, not concrete implementations",
+          "description": "Repositories, gateways, and presenters are referenced as interfaces defined in the use case layer. Constructor parameters are typed as interfaces, never as concrete infrastructure classes",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-06",
+          "text": "Use cases are application-specific, not enterprise-wide",
+          "description": "Unlike entities (which hold universal business rules), use cases express what this specific application does. 'PlaceWebOrder' is application-specific even if the Order entity is shared across apps",
+          "refs": []
+        },
+        {
+          "id": "CLEA-USE-07",
+          "text": "Use case output does not include more data than the caller needs",
+          "description": "A use case returns only the data needed by its consumer — not entire entity graphs. If a use case returns a full Order object but the caller only needs the order ID and status, the boundary is leaking internal structure",
+          "refs": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/quodeq/data/standards/compiled/domain-driven-design.json
+++ b/src/quodeq/data/standards/compiled/domain-driven-design.json
@@ -1,0 +1,509 @@
+{
+  "id": "domain-driven-design",
+  "name": "Domain-Driven Design",
+  "description": "Evaluates adherence to Eric Evans' Domain-Driven Design tactical and strategic patterns",
+  "managed": true,
+  "type": "quodeq",
+  "source": "Eric Evans / Vaughn Vernon",
+  "weight": 1.0,
+  "principles": [
+    {
+      "name": "Ubiquitous Language",
+      "description": "The codebase must reflect the language of the business domain, shared between developers and domain experts",
+      "requirements": [
+        {
+          "id": "DDD-UBQ-01",
+          "text": "Class, method, and variable names must use domain terminology",
+          "description": "Code identifiers should match the vocabulary used by domain experts — not technical jargon, database column names, or generic terms like 'data', 'info', 'manager'",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-02",
+          "text": "No translation layers between domain concepts and code names",
+          "description": "If the business calls it an 'Invoice', the code must call it 'Invoice' — not 'BillingRecord', 'PaymentDocument', or 'bill_tbl'",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-03",
+          "text": "Domain operations named as verbs from the business process",
+          "description": "Methods like 'placeOrder', 'approveApplication', 'cancelReservation' — not 'processData', 'handleRequest', 'doAction'",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-04",
+          "text": "Avoid ambiguous or overloaded terms across bounded contexts",
+          "description": "If 'Account' means different things in billing vs authentication, each context must have its own explicit model — no shared ambiguous types",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-05",
+          "text": "No generic suffixes that obscure domain meaning",
+          "description": "Classes named 'OrderManager', 'UserHelper', 'DataProcessor', 'PaymentHandler' signal missing domain language — name them after what they actually do in the domain (e.g., 'OrderFulfillmentService', 'PricingPolicy')",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-06",
+          "text": "Boolean methods and properties express domain predicates",
+          "description": "'isOverdue()', 'canBeShipped()', 'hasReachedCreditLimit()' — not 'checkStatus()', 'getFlag()', 'isValid()' without context",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-07",
+          "text": "Enums and constants represent domain concepts, not technical states",
+          "description": "OrderStatus.AWAITING_PAYMENT, ShipmentState.IN_TRANSIT — not Status.ACTIVE, State.STEP_2, Type.TYPE_A",
+          "refs": []
+        },
+        {
+          "id": "DDD-UBQ-08",
+          "text": "Exceptions describe domain violations, not technical failures",
+          "description": "'InsufficientFundsException', 'OrderAlreadyShippedException' — not 'InvalidStateException', 'BusinessRuleException', 'Error400'",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Bounded Contexts",
+      "description": "The system is divided into explicit bounded contexts, each with its own model and clear boundaries",
+      "requirements": [
+        {
+          "id": "DDD-CTX-01",
+          "text": "Each bounded context has its own domain model with no shared mutable state",
+          "description": "Contexts do not share entity classes, database tables, or domain objects directly — each owns its data and schema",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-02",
+          "text": "Context boundaries are explicit in the codebase structure",
+          "description": "Separate modules, packages, or services per context — not mixed domain concepts in a single module. Look for top-level directories or packages named after business capabilities (ordering/, shipping/, billing/)",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-03",
+          "text": "Communication between contexts uses well-defined integration patterns",
+          "description": "Contexts interact through published interfaces, events, or anti-corruption layers — not direct imports of another context's internals. Imports crossing context boundaries are a violation",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-04",
+          "text": "No domain model leakage across context boundaries",
+          "description": "One context's entities, value objects, or aggregates must not appear in another context's code. A shipping context importing an ordering context's Order entity is a boundary violation",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-05",
+          "text": "Context mapping relationships are documented or enforced",
+          "description": "Relationships between contexts (shared kernel, customer-supplier, conformist, anti-corruption layer) should be explicit in code structure or documentation",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-06",
+          "text": "Shared data between contexts is exchanged through integration events or DTOs, not shared entities",
+          "description": "If ordering needs customer data, it receives a lightweight DTO or event payload — it does not import the customer context's Customer entity",
+          "refs": []
+        },
+        {
+          "id": "DDD-CTX-07",
+          "text": "Each context has independent persistence",
+          "description": "Contexts should not share database tables or schemas. If they use the same database, each context owns its own tables with no foreign keys crossing context boundaries",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Entities",
+      "description": "Objects defined by their identity rather than their attributes, with continuity through their lifecycle",
+      "requirements": [
+        {
+          "id": "DDD-ENT-01",
+          "text": "Entities have a unique, immutable identity",
+          "description": "Each entity must have a stable identifier (ID) that distinguishes it from all other entities, even if all other attributes are identical. The ID field must not have a setter",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-02",
+          "text": "Entity equality is based on identity, not attribute values",
+          "description": "Two entities with the same ID are the same entity regardless of attribute differences — equals/hashCode must be identity-based, not field-by-field comparison",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-03",
+          "text": "Entities encapsulate and enforce their own business rules",
+          "description": "Validation, state transitions, and invariant enforcement belong inside the entity — not in services, controllers, or external validators. If a service method checks entity state before mutating it, that logic should move into the entity",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-04",
+          "text": "Entities must not expose mutable internal state directly",
+          "description": "State changes happen through domain methods that enforce invariants — no public setters that bypass business rules. 'order.addLineItem(product, qty)' not 'order.setItems(list)'",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-05",
+          "text": "Entity constructors enforce creation invariants",
+          "description": "An entity must be valid from the moment of creation — constructors or factory methods must reject invalid initial state. No 'new Order()' followed by 'order.setCustomer()' — required fields go in the constructor",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-06",
+          "text": "Entities must not be anemic data holders",
+          "description": "An entity with only getters/setters and no behavior is an anemic domain model violation. Domain logic scattered in services that manipulate entity fields externally is a code smell",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-07",
+          "text": "State transitions are explicit domain operations with guard clauses",
+          "description": "'order.ship()' checks that order is paid and has items — it doesn't silently accept any transition. Invalid transitions throw domain exceptions, not generic errors",
+          "refs": []
+        },
+        {
+          "id": "DDD-ENT-08",
+          "text": "Entities must not depend on infrastructure or persistence concerns",
+          "description": "No ORM annotations, serialization decorators, database column mappings, or framework base classes on entity code. Persistence mapping belongs in the infrastructure layer",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Value Objects",
+      "description": "Immutable objects defined by their attributes, with no conceptual identity",
+      "requirements": [
+        {
+          "id": "DDD-VAL-01",
+          "text": "Value objects are immutable after creation",
+          "description": "No setters, no mutation methods — any change produces a new instance. 'price.withDiscount(10)' returns a new Money, does not mutate the original",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-02",
+          "text": "Value object equality is based on attribute values",
+          "description": "Two value objects with identical attributes are equal — equals/hashCode must compare all fields, not identity/reference. Money(100, 'USD') == Money(100, 'USD')",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-03",
+          "text": "Domain concepts that lack identity must be modeled as value objects, not entities",
+          "description": "Money, addresses, date ranges, email addresses, coordinates, phone numbers, measurement units — these are values, not things with lifecycles. If you wouldn't track its history, it's a value object",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-04",
+          "text": "Value objects must be self-validating",
+          "description": "A value object cannot exist in an invalid state — construction must fail if inputs are invalid (e.g., negative money, malformed email, end date before start date). No 'isValid()' method needed — invalid instances simply cannot exist",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-05",
+          "text": "Primitive obsession must be avoided for domain concepts",
+          "description": "Use value objects instead of raw strings, ints, or floats for domain concepts — 'EmailAddress' not 'string', 'Money' not 'float', 'CustomerId' not 'int'. Passing raw primitives between methods loses domain meaning and validation",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-06",
+          "text": "Value objects encapsulate domain-specific operations",
+          "description": "Money knows how to add, subtract, and convert currencies. DateRange knows if it overlaps another range. Don't put this logic in services that operate on raw fields",
+          "refs": []
+        },
+        {
+          "id": "DDD-VAL-07",
+          "text": "Value objects replace multi-field groupings that always travel together",
+          "description": "If you always pass (street, city, zip, country) together, that's an Address value object. If you always pass (amount, currency), that's Money. Repeated field groups without a wrapping type signal a missing value object",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Aggregates",
+      "description": "Clusters of entities and value objects with a root entity that controls access and enforces consistency boundaries",
+      "requirements": [
+        {
+          "id": "DDD-AGG-01",
+          "text": "Each aggregate has a single root entity",
+          "description": "External objects may only hold references to the aggregate root — never to internal entities or value objects. If external code can reach OrderLineItem without going through Order, the aggregate boundary is broken",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-02",
+          "text": "Aggregate boundaries enforce transactional consistency",
+          "description": "All invariants within an aggregate are enforced in a single transaction — cross-aggregate consistency is eventual. A single database transaction must not span multiple aggregates",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-03",
+          "text": "Aggregates reference other aggregates by identity only",
+          "description": "An aggregate must not hold direct object references to another aggregate — use IDs to reference across aggregate boundaries. 'order.customerId' not 'order.customer' (where customer is a full aggregate)",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-04",
+          "text": "Aggregates are kept small and focused",
+          "description": "Large aggregates cause contention and performance issues — prefer smaller aggregates with eventual consistency between them. An aggregate with more than 3-4 entity types inside it is likely too large",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-05",
+          "text": "Only the aggregate root exposes public modification methods",
+          "description": "All state changes to internal entities go through the root — external code must not reach inside to modify child entities directly. 'order.removeLineItem(itemId)' not 'order.getLineItems().remove(item)'",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-06",
+          "text": "Deleting an aggregate root cascades to all internal objects",
+          "description": "Internal entities and value objects have no independent lifecycle — they exist only within their aggregate. Orphaned child records in the database indicate a broken aggregate boundary",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-07",
+          "text": "Aggregate invariants are checked on every state change",
+          "description": "After any mutation, the aggregate must verify its internal consistency rules hold — e.g., order total matches sum of line items, reservation dates don't overlap. Invariant checks must not be optional or deferred",
+          "refs": []
+        },
+        {
+          "id": "DDD-AGG-08",
+          "text": "Loading an aggregate loads the entire aggregate, not partial projections",
+          "description": "Repositories return complete aggregates with all internal state. If you need partial data for reads, use a separate read model (CQRS) — don't break aggregate consistency by loading partial state for writes",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Domain Services",
+      "description": "Stateless operations that belong to the domain but don't naturally fit within an entity or value object",
+      "requirements": [
+        {
+          "id": "DDD-SVC-01",
+          "text": "Domain services are stateless",
+          "description": "A domain service must not hold mutable state between invocations — it receives inputs, performs logic, and returns results. No instance fields that accumulate state across calls",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-02",
+          "text": "Domain services express domain operations that span multiple aggregates",
+          "description": "Operations that don't belong to a single entity (e.g., transferring funds between accounts, matching a buyer with a seller) belong in a domain service",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-03",
+          "text": "Domain services use ubiquitous language in their interface",
+          "description": "Method names must be meaningful domain verbs — 'transferFunds', 'calculateShippingCost', 'matchOrder' — not 'processTransaction', 'handleData', 'execute'",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-04",
+          "text": "Domain services must not contain infrastructure concerns",
+          "description": "No database access, HTTP calls, or file I/O — only pure domain logic. Infrastructure is injected through interfaces. If a domain service imports a database client, it's misplaced",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-05",
+          "text": "Avoid overuse of services — prefer rich domain models",
+          "description": "If logic can live in an entity or value object, it should — domain services are for cross-aggregate or truly stateless operations only. A codebase with many domain services and anemic entities has inverted the model",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-06",
+          "text": "Domain services are distinct from application services",
+          "description": "Domain services contain business rules (pricing calculation, eligibility check). Application services orchestrate (load aggregate, call domain service, save, dispatch event). Don't mix orchestration with business logic in one class",
+          "refs": []
+        },
+        {
+          "id": "DDD-SVC-07",
+          "text": "Domain services operate on domain objects, not primitives or DTOs",
+          "description": "A domain service receives and returns entities, value objects, or domain types — not raw strings, maps, or infrastructure DTOs. 'calculateDiscount(Order, CustomerTier)' not 'calculateDiscount(double, String)'",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Repositories",
+      "description": "Abstractions that provide collection-like access to aggregates, hiding persistence details from the domain",
+      "requirements": [
+        {
+          "id": "DDD-REP-01",
+          "text": "Repositories provide collection-semantics for aggregate access",
+          "description": "The interface should feel like an in-memory collection (add, remove, findById, findBySpec) — not like a database API (executeQuery, commit, flush, getSession)",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-02",
+          "text": "Only aggregate roots have repositories",
+          "description": "Internal entities within an aggregate are accessed through the root — they must not have their own repository. A LineItemRepository is a violation; line items come from OrderRepository",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-03",
+          "text": "Repository interfaces are defined in the domain layer",
+          "description": "The domain declares what persistence operations it needs — the infrastructure layer provides the implementation. The interface file lives next to domain entities, not next to database code",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-04",
+          "text": "Repositories return fully reconstituted aggregates",
+          "description": "The domain receives complete aggregate objects — not partial DTOs, raw database rows, or lazy-loading proxies that leak persistence concerns. If an aggregate is returned half-loaded, the boundary is broken",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-05",
+          "text": "Repository implementations must not leak persistence details into the domain",
+          "description": "No ORM sessions, query builders, connection objects, or database transactions visible to domain code. The domain calls 'repository.save(order)' and doesn't know if it's SQL, NoSQL, or a file",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-06",
+          "text": "Repository methods accept domain-meaningful query criteria",
+          "description": "'findByCustomerAndStatus(customerId, OrderStatus.ACTIVE)' — not 'findByQuery(\"SELECT * FROM orders WHERE...\")'. Query criteria should be expressed in domain terms",
+          "refs": []
+        },
+        {
+          "id": "DDD-REP-07",
+          "text": "Repositories must not perform business logic",
+          "description": "A repository persists and retrieves — it does not validate, calculate, or enforce business rules. If the repository is checking business conditions before saving, that logic belongs in the domain",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Domain Events",
+      "description": "Explicit representation of something significant that happened in the domain, enabling decoupled communication",
+      "requirements": [
+        {
+          "id": "DDD-EVT-01",
+          "text": "Significant domain state changes are captured as domain events",
+          "description": "Events like 'OrderPlaced', 'PaymentReceived', 'AccountSuspended' are first-class objects — not implicit side effects buried in method bodies. If a state change triggers reactions elsewhere, it should raise an event",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-02",
+          "text": "Domain events are immutable and named in past tense",
+          "description": "Events represent facts that already happened — 'OrderShipped' not 'ShipOrder'. They must not be modified after creation. All fields should be final/readonly",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-03",
+          "text": "Domain events contain only the data needed to describe what happened",
+          "description": "Include the aggregate ID, relevant changed values, and timestamp — not entire entity graphs, infrastructure details, or data the consumer can look up themselves",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-04",
+          "text": "Cross-aggregate side effects are triggered through domain events, not direct calls",
+          "description": "When an order is placed, inventory adjustment happens via an event handler — not by the order aggregate directly calling inventory code. Direct cross-aggregate method calls create tight coupling",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-05",
+          "text": "Domain events are part of the domain model, not infrastructure",
+          "description": "Event classes live in the domain layer — the event bus/dispatcher is infrastructure, but the events themselves are domain concepts defined alongside the aggregates that emit them",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-06",
+          "text": "Event handlers must not modify the emitting aggregate",
+          "description": "An event handler for 'OrderPlaced' must not reach back and modify the Order that emitted it. If the Order needs to change, that's a separate command, not a handler side effect",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-07",
+          "text": "Events carry enough context to be processed without additional queries when possible",
+          "description": "If a handler needs the order total to proceed, include it in the event — don't force the handler to query the order aggregate. Minimize coupling between event producers and consumers",
+          "refs": []
+        },
+        {
+          "id": "DDD-EVT-08",
+          "text": "Domain events are distinct from integration events",
+          "description": "Internal domain events (within a bounded context) may carry rich domain types. Integration events (crossing context boundaries) should carry only primitive/serializable data and be versioned for evolution",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Anti-Corruption Layer",
+      "description": "A translation layer that protects the domain model from external systems and legacy code",
+      "requirements": [
+        {
+          "id": "DDD-ACL-01",
+          "text": "External system models must not pollute the domain model",
+          "description": "Third-party API responses, legacy database schemas, and external DTOs must be translated at the boundary — never used directly in domain code. Importing a Stripe SDK type in your domain layer is a violation",
+          "refs": []
+        },
+        {
+          "id": "DDD-ACL-02",
+          "text": "Integration adapters translate between external and domain models",
+          "description": "Adapter classes map external data structures to domain objects and vice versa — the domain never sees the external format. A PaymentGatewayAdapter converts Stripe responses to domain Payment objects",
+          "refs": []
+        },
+        {
+          "id": "DDD-ACL-03",
+          "text": "External API changes must not require domain model changes",
+          "description": "If a third-party API changes its response format, only the anti-corruption layer adapters need updating. If a Stripe API change forces you to modify your Payment entity, the ACL is missing or broken",
+          "refs": []
+        },
+        {
+          "id": "DDD-ACL-04",
+          "text": "Legacy system integration uses explicit translation, not shared models",
+          "description": "When integrating with legacy code, create adapters that translate — do not force the new domain to conform to legacy structures or naming",
+          "refs": []
+        },
+        {
+          "id": "DDD-ACL-05",
+          "text": "Anti-corruption layer handles data format differences and semantic mismatches",
+          "description": "If the external system uses 'client' where your domain uses 'customer', or uses cents where you use Money objects, the ACL translates — the domain code never adapts to external conventions",
+          "refs": []
+        },
+        {
+          "id": "DDD-ACL-06",
+          "text": "Each external system integration has its own dedicated adapter",
+          "description": "Don't create a generic 'ExternalServiceAdapter' that handles multiple systems — each integration gets its own adapter with its own translation logic. This prevents one external change from affecting other integrations",
+          "refs": []
+        }
+      ]
+    },
+    {
+      "name": "Application Layer",
+      "description": "Thin orchestration layer that coordinates domain objects to fulfill use cases without containing business logic",
+      "requirements": [
+        {
+          "id": "DDD-APP-01",
+          "text": "Application services orchestrate but do not contain business rules",
+          "description": "Application services coordinate entities, repositories, and domain services — business decisions live in the domain layer. If an application service has if/else logic about domain state, that logic is misplaced",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-02",
+          "text": "Application services manage transactions and cross-cutting concerns",
+          "description": "Transaction boundaries, authorization checks, logging, and event dispatching are application layer responsibilities — not domain layer concerns",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-03",
+          "text": "Application services define use case boundaries with explicit input/output",
+          "description": "Each application service method represents a use case with a clear command/query and response — not generic CRUD operations. 'placeOrder(PlaceOrderCommand)' not 'save(Order)'",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-04",
+          "text": "The application layer must not expose domain internals to external consumers",
+          "description": "API responses use DTOs assembled in the application layer — domain entities are never serialized directly to external clients. Returning an entity from a REST controller leaks the domain model",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-05",
+          "text": "Application layer is thin — if it grows complex, logic likely belongs in the domain",
+          "description": "Complex conditionals, calculations, or multi-step business rules in application services are a smell — push them into entities or domain services. An application service method longer than 10-15 lines often contains escaped domain logic",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-06",
+          "text": "Commands and queries are separate concerns",
+          "description": "Methods that change state (commands) should not return domain data. Methods that return data (queries) should not change state. Mixing reads and writes in a single method obscures intent and makes the system harder to reason about",
+          "refs": []
+        },
+        {
+          "id": "DDD-APP-07",
+          "text": "Application services receive commands/queries, not raw HTTP or framework objects",
+          "description": "The controller layer converts HTTP requests to command/query objects — the application service never sees HttpRequest, FormData, or framework types. This ensures the application layer is framework-independent",
+          "refs": []
+        }
+      ]
+    }
+  ]
+}

--- a/src/quodeq/services/standards.py
+++ b/src/quodeq/services/standards.py
@@ -48,11 +48,12 @@ class StandardsService:
         out: list[StandardMeta] = []
         for dim in data.get("applies", []):
             p_count, r_count = self._count_compiled(dim["id"])
+            dim_type = dim.get("type", "builtin")
             out.append(StandardMeta(
-                id=dim["id"], name=dim.get("iso_25010", dim["id"]),
+                id=dim["id"], name=dim.get("iso_25010") or dim.get("name", dim["id"]),
                 description=f'{dim.get("source", "Built-in")} standard',
                 weight=dim.get("weight", 1.0), source=dim.get("source", ""),
-                type="builtin", managed=True, origin=None, origin_hash=None,
+                type=dim_type, managed=True, origin=None, origin_hash=None,
                 principle_count=p_count, requirement_count=r_count,
             ))
         return out
@@ -112,12 +113,14 @@ class StandardsService:
 
     def _load_builtin_detail(self, path: Path, standard_id: str) -> StandardDetail:
         data = self._read_json(path)
+        dim_type = data.get("type", "builtin")
+        source = data.get("source", "") or ", ".join(data.get("sources", []))
         return StandardDetail(
             id=standard_id, name=data.get("name", standard_id),
-            description=f"Built-in {data.get('name', standard_id)} standard",
+            description=f"{data.get('name', standard_id)} standard",
             weight=self._get_builtin_weight(standard_id),
-            source=", ".join(data.get("sources", [])),
-            type="builtin", managed=True, origin=None, origin_hash=None,
+            source=source,
+            type=dim_type, managed=True, origin=None, origin_hash=None,
             principles=data.get("principles", []),
         )
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
 import { buildDailyRuns } from './utils/dailyGrouping.js';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
@@ -23,6 +23,7 @@ import { useRunNavigator } from './hooks/useRunNavigator.js';
 import { useProjectState } from './hooks/useProjectState.js';
 import { useAppSettings } from './hooks/useAppSettings.js';
 import { useEvaluationLifecycle } from './hooks/useEvaluationLifecycle.js';
+import { readVisibleStandardIds } from './utils/visibleStandards.js';
 import { useProjectActions } from './hooks/useProjectActions.js';
 
 
@@ -204,7 +205,32 @@ function useAppState() {
   const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
   const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun: effectiveRun });
   const dailyRuns = useMemo(() => buildDailyRuns(availableRuns, dashboard?.trend || []), [availableRuns, dashboard]);
-  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: dailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
+  const visibleDailyRuns = useMemo(() => {
+    const visibleSet = new Set(readVisibleStandardIds());
+    const trendEntries = dashboard?.trend || [];
+    // Build set of dates where at least one visible dimension was evaluated
+    const visibleDates = new Set();
+    for (const entry of trendEntries) {
+      if ((entry.dimensions || []).some((d) => visibleSet.has(d.toLowerCase()))) {
+        visibleDates.add((entry.dateISO || '').slice(0, 10));
+      }
+    }
+    const trendByRunId = new Map(trendEntries.map((t) => [t.runId, t]));
+    return dailyRuns.filter((run) => {
+      const datePart = (trendByRunId.get(run.runId)?.dateISO || '').slice(0, 10);
+      return visibleDates.has(datePart);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dailyRuns, dashboard, activePage.page]);
+  const visibleRunIdsKey = visibleDailyRuns.map((r) => r.runId).join(',');
+  const prevRunIdsKeyRef = useRef(visibleRunIdsKey);
+  useEffect(() => {
+    if (prevRunIdsKeyRef.current !== visibleRunIdsKey && visibleDailyRuns.length > 0) {
+      setSelectedRun('latest');
+    }
+    prevRunIdsKeyRef.current = visibleRunIdsKey;
+  }, [visibleRunIdsKey, visibleDailyRuns.length, setSelectedRun]);
+  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => {
     const meta = computeHeaderMeta(accumulated, dashboard, selectedProject, projects);
     const display = computeProjectDisplay(selectedProject, projects);
@@ -217,13 +243,13 @@ function useAppState() {
     : activePage.page === 'history-run' ? 'history'
     : 'overview';
   const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
-  const showRunNav = showProjectHeader && dailyRuns.length > 0 && navStack.length === 1;
+  const showRunNav = showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
 
   return {
     serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
     projects, selectedProject, selectedRun, handleProjectChange, handleNavigate,
     handleDeleteProject, handleExportProject, handleRelocateProject,
-    dashboard, accumulated, latestAccumulated, loading, error, availableRuns, dailyRuns, overviewRunIndex,
+    dashboard, accumulated, latestAccumulated, loading, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,

--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -5,3 +5,8 @@ export const DEFAULT_MAX_SUBAGENTS = 5;
 export const DEFAULT_POOL_BUDGET = 600;
 export const SUBAGENTS_STORAGE_KEY = 'cc-max-subagents';
 export const POOL_BUDGET_STORAGE_KEY = 'cc-pool-budget';
+
+export const VISIBLE_STANDARDS_STORAGE_KEY = 'quodeq-visible-standards';
+export const DEFAULT_VISIBLE_STANDARDS = [
+  'security', 'reliability', 'maintainability', 'performance', 'usability', 'flexibility',
+];

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -8,19 +8,22 @@ import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGroupin
 import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
+import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
 
 // ---------------------------------------------------------------------------
 // Accumulated overview panel helpers
 // ---------------------------------------------------------------------------
 
-function computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend) {
+function computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend, selectedRunId) {
   const curr = parseFloat(accumulated?.summary?.numericAverage);
-  // Derive delta from trend data (same source as the bar chart)
+  // Derive delta from the selected run vs its predecessor in the trend
   let scoreDelta = null;
   if (dailyTrend && dailyTrend.length >= 2) {
-    const latest = parseFloat(dailyTrend[0]?.numericAverage);
-    const previous = parseFloat(dailyTrend[1]?.numericAverage);
-    if (!isNaN(latest) && !isNaN(previous)) scoreDelta = (latest - previous).toFixed(1);
+    const selectedIdx = selectedRunId ? dailyTrend.findIndex((t) => t.runId === selectedRunId) : 0;
+    const idx = selectedIdx >= 0 ? selectedIdx : 0;
+    const current = parseFloat(dailyTrend[idx]?.numericAverage);
+    const previous = idx + 1 < dailyTrend.length ? parseFloat(dailyTrend[idx + 1]?.numericAverage) : NaN;
+    if (!isNaN(current) && !isNaN(previous)) scoreDelta = (current - previous).toFixed(1);
   }
   if (scoreDelta === null) {
     const prev = parseFloat(accumulated?.summary?.previousNumericAverage);
@@ -169,32 +172,100 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
     [trend, currentOverviewRun, selectedRunId]
   );
 
-  const stats = useMemo(
-    () => computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend),
-    [accumulated, accumulatedDimensions, dailyTrend]
+  const visibleIds = useMemo(() => readVisibleStandardIds(), [accumulatedDimensions]);
+  const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
+
+  const filteredDailyTrend = useMemo(() => {
+    const accByDim = {};
+    const accByDate = new Map(); // date string → { accAvg, latestRunId }
+    const visibleDates = new Set();
+    const rawReversed = [...trend].reverse(); // oldest first
+    for (const entry of rawReversed) {
+      let hasVisible = false;
+      for (const d of (entry.dimensionDetails || [])) {
+        const dimId = (d.dimension || '').toLowerCase();
+        if (visibleSet.has(dimId) && d.score != null) {
+          accByDim[dimId] = d.score;
+          hasVisible = true;
+        }
+      }
+      if (hasVisible) {
+        const accScores = Object.values(accByDim).filter((s) => s != null);
+        const accAvg = accScores.length > 0 ? Math.round((accScores.reduce((a, b) => a + b, 0) / accScores.length) * 10) / 10 : null;
+        const datePart = (entry.dateISO || '').slice(0, 10);
+        accByDate.set(datePart, accAvg);
+        visibleDates.add(datePart);
+      }
+    }
+    // Match daily entries by date, only include days with visible evaluations
+    return dailyTrend
+      .filter((entry) => visibleDates.has((entry.dateISO || '').slice(0, 10)))
+      .map((entry) => {
+        const datePart = (entry.dateISO || '').slice(0, 10);
+        const accAvg = accByDate.get(datePart) ?? null;
+        const details = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
+        const runScores = details.map((d) => d.score).filter((s) => s != null);
+        const runAvg = runScores.length > 0 ? Math.round((runScores.reduce((a, b) => a + b, 0) / runScores.length) * 10) / 10 : null;
+        const dims = (entry.dimensions || []).filter((d) => visibleSet.has(d.toLowerCase()));
+        return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: details, dimensions: dims, dimensionsCount: dims.length };
+      });
+  }, [trend, dailyTrend, visibleSet]);
+
+  const filteredDimensions = useMemo(
+    () => accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase())),
+    [accumulatedDimensions, visibleIds]
+  );
+
+  const filteredAccumulated = useMemo(() => {
+    if (!accumulated) return accumulated;
+    const scores = filteredDimensions
+      .map((d) => parseFloat(d.overallScore))
+      .filter((s) => !isNaN(s));
+    const numericAverage = scores.length > 0
+      ? Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 10) / 10
+      : null;
+    const selectedIdx = currentOverviewRun ? filteredDailyTrend.findIndex((t) => t.runId === currentOverviewRun) : 0;
+    const prevIdx = (selectedIdx >= 0 ? selectedIdx : 0) + 1;
+    const prevAvg = prevIdx < filteredDailyTrend.length ? parseFloat(filteredDailyTrend[prevIdx]?.numericAverage) : null;
+    const { totalViolations, totalCompliance, severity } = computeSummaryFromDimensions(filteredDimensions);
+    return {
+      ...accumulated,
+      summary: {
+        ...accumulated.summary,
+        numericAverage,
+        previousNumericAverage: prevAvg,
+        totalViolations,
+        totalCompliance,
+        severity,
+      },
+    };
+  }, [accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
+
+  const filteredStats = useMemo(
+    () => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun),
+    [filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]
   );
 
   return (
     <>
       <AccumulatedHeroSection
-        accumulated={accumulated}
-        scoreDelta={stats.scoreDelta}
-        lastDate={stats.lastRun.date}
+        accumulated={filteredAccumulated}
+        scoreDelta={filteredStats.scoreDelta}
+        lastDate={filteredStats.lastRun.date}
       />
 
       <div className="history-panels-row">
-        <RunHistoryPanel trend={dailyTrend} selectedRunId={currentOverviewRun} selectedRunScore={accumulated?.summary?.numericAverage} onBarClick={onRunClick} />
-        <DimensionScorePanel dimensions={accumulatedDimensions} onBarClick={onDimensionClick} runDate={stats.lastRun.date} runId={stats.lastRun.runId} />
+        <RunHistoryPanel trend={filteredDailyTrend} selectedRunId={currentOverviewRun} onBarClick={onRunClick} />
+        <DimensionScorePanel dimensions={filteredDimensions} onBarClick={onDimensionClick} runDate={filteredStats.lastRun.date} runId={filteredStats.lastRun.runId} />
       </div>
 
       <AccumulatedDimensionsSection
-        sortedDimensions={stats.sorted}
+        sortedDimensions={filteredStats.sorted}
         referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
-        dimensionsWithViolations={stats.dimsWithViolations}
+        dimensionsWithViolations={filteredStats.dimsWithViolations}
         selectedDayDimNames={selectedDayDimNames}
       />
-
     </>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { formatShortDate, gradeLetter, scoreColorClass } from '../../../utils/formatters.js';
 import {
   ComposedChart,
@@ -50,12 +50,9 @@ function scoreBarColor(score) {
 }
 
 
-function buildTrendData(trend, selectedRunId, selectedRunScore) {
+function buildTrendData(trend, selectedRunId) {
   return [...trend].slice(0, MAX_CHART_RUNS).reverse().map((row, i, arr) => {
-    const isSelected = row.runId === selectedRunId;
-    const numericAverage = isSelected && selectedRunScore != null
-      ? parseFloat(selectedRunScore)
-      : parseFloat(row.numericAverage);
+    const numericAverage = parseFloat(row.numericAverage);
     return {
       ...row,
       numericAverage,
@@ -160,12 +157,12 @@ function ScoreHistoryChart({ data, interaction }) {
   );
 }
 
-export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
+export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBarClick }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
 
   if (!trend || trend.length < 2) return null;
 
-  const data = buildTrendData(trend, selectedRunId, selectedRunScore);
+  const data = useMemo(() => buildTrendData(trend, selectedRunId), [trend, selectedRunId]);
 
   return (
     <section className="run-history-panel panel" aria-label="Score history chart">

--- a/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
@@ -1,22 +1,34 @@
-import { ISO_25010_URL } from '../../../constants.js';
+function typeLabel(dim) {
+  if (dim.standardType === 'quodeq') return 'Quodeq';
+  if (dim.standardType === 'custom') return 'Custom';
+  if (dim.standardType === 'community') return 'Community';
+  return 'ISO';
+}
+
+function typeClass(dim) {
+  if (dim.standardType === 'quodeq') return 'dimension-chip-type--quodeq';
+  if (dim.standardType === 'custom') return 'dimension-chip-type--custom';
+  if (dim.standardType === 'community') return 'dimension-chip-type--community';
+  return 'dimension-chip-type--builtin';
+}
 
 function DimensionChip({ dim, isSelected, onToggle }) {
   return (
     <button
       type="button"
-      className={`dimension-chip-btn ${isSelected ? 'selected' : ''}${dim.standardType ? ` dimension-chip-btn--${dim.standardType}` : ''}`}
+      className={`dimension-chip-btn ${isSelected ? 'selected' : ''}`}
       title={dim.iso_25010 ? `ISO 25010: ${dim.iso_25010}` : dim.label || dim.id}
       aria-pressed={isSelected}
       onClick={() => onToggle(dim.id)}
     >
       {dim.label || dim.id}
+      <span className={`dimension-chip-type ${typeClass(dim)}`}>{typeLabel(dim)}</span>
     </button>
   );
 }
 
 export default function DimensionSelector({ allDimensions, selectedDims, onToggle, onSelectAll, onClearAll }) {
-  const builtin = [...allDimensions].filter((d) => !d.standardType).sort((a, b) => a.id.localeCompare(b.id));
-  const custom = [...allDimensions].filter((d) => d.standardType).sort((a, b) => (a.label || a.id).localeCompare(b.label || b.id));
+  const sorted = [...allDimensions].sort((a, b) => (a.label || a.id).localeCompare(b.label || b.id));
 
   return (
     <div className="form-group">
@@ -28,29 +40,11 @@ export default function DimensionSelector({ allDimensions, selectedDims, onToggl
         </div>
       </div>
 
-      {builtin.length > 0 && (
-        <div className="dimension-section">
-          <div className="dimension-section-label">
-            <a className="iso-link" href={ISO_25010_URL} target="_blank" rel="noopener noreferrer">ISO 25010</a>
-          </div>
-          <div className="dimension-grid">
-            {builtin.map((dim) => (
-              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {custom.length > 0 && (
-        <div className="dimension-section">
-          <div className="dimension-section-label">Custom Standards</div>
-          <div className="dimension-grid">
-            {custom.map((dim) => (
-              <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
-            ))}
-          </div>
-        </div>
-      )}
+      <div className="dimension-grid">
+        {sorted.map((dim) => (
+          <DimensionChip key={dim.id} dim={dim} isSelected={selectedDims.has(dim.id)} onToggle={onToggle} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -3,6 +3,7 @@ import FolderBrowser from './FolderBrowser.jsx';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import DimensionSelector from './DimensionSelector.jsx';
 
+
 const FOLDER_MARGIN_BOTTOM = 8;
 
 function RepoInput({ repo, onRepoChange, onClear, onBrowse }) {

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -3,6 +3,7 @@ import { getProjectInfo } from '../../../api/index.js';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import DimensionSelector from './DimensionSelector.jsx';
 
+
 const BUTTON_GAP = '8px';
 const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: BUTTON_GAP, alignItems: 'center' };
 const flexButtonStyle = { flex: 1, marginTop: 0 };

--- a/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/usePluginDimensions.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { listPlugins, listStandards } from '../../../api/index.js';
+import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 
 export function usePluginDimensions() {
   const [allDimensions, setAllDimensions] = useState([]);
@@ -19,21 +20,26 @@ export function usePluginDimensions() {
         }
       }
 
-      // Merge custom and community standards as selectable dimensions
+      // Merge standards — set standardType for all, add new ones
       for (const s of standards) {
-        if (s.type === 'custom' || s.type === 'community') {
-          if (!seen.has(s.id)) {
-            seen.set(s.id, {
-              id: s.id,
-              label: s.name,
-              iso_25010: null,
-              standardType: s.type,
-            });
+        if (seen.has(s.id)) {
+          const existing = seen.get(s.id);
+          if (!existing.standardType) {
+            existing.standardType = s.type === 'builtin' ? null : s.type;
+            if (s.name && !existing.label) existing.label = s.name;
           }
+        } else if (s.type === 'custom' || s.type === 'community' || s.type === 'quodeq') {
+          seen.set(s.id, {
+            id: s.id,
+            label: s.name,
+            iso_25010: null,
+            standardType: s.type,
+          });
         }
       }
 
-      setAllDimensions([...seen.values()]);
+      const visibleSet = new Set(readVisibleStandardIds());
+      setAllDimensions([...seen.values()].filter((d) => visibleSet.has(d.id)));
       setDimLoadError(null);
     }).catch((err) => {
       console.warn('Failed to load dimensions:', err);

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { formatShortDate, angleFromDelta, scoreTierLabel, gradeLetter } from '../../../utils/formatters.js';
 import {
   ComposedChart,
@@ -13,7 +13,7 @@ import {
   ReferenceLine,
 } from 'recharts';
 
-const MAX_CHART_RUNS = 20;
+const MAX_CHART_RUNS = 40;
 const CHART_HEIGHT = 160;
 const REF_LINE_LOW = 2.5;
 const REF_LINE_MID = 5;
@@ -80,17 +80,14 @@ function windowAroundSelected(trend, selectedRunId) {
   return trend.slice(start, end);
 }
 
-function buildTrendData(trend, selectedRunId, selectedRunScore) {
+function buildTrendData(trend, selectedRunId) {
   const windowed = windowAroundSelected(trend, selectedRunId);
   return [...windowed].reverse().map((row, i, arr) => {
-    const isSelected = row.runId === selectedRunId;
-    const numericAverage = isSelected && selectedRunScore != null
-      ? parseFloat(selectedRunScore)
-      : parseFloat(row.numericAverage);
+    const runScore = parseFloat(row.runNumericAverage ?? row.numericAverage);
     return {
       ...row,
-      numericAverage,
-      delta: i > 0 ? numericAverage - parseFloat(arr[i - 1].numericAverage) : null,
+      numericAverage: runScore,
+      delta: i > 0 ? runScore - parseFloat(arr[i - 1].numericAverage) : null,
     };
   });
 }
@@ -207,12 +204,12 @@ function ScoreHistoryChart({ data, interaction, renderTrendLabel }) {
   );
 }
 
-export default function RunHistoryPanel({ trend = [], selectedRunId = null, selectedRunScore, onBarClick }) {
+export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBarClick }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
 
   if (!trend || trend.length < 2) return null;
 
-  const data = buildTrendData(trend, selectedRunId, selectedRunScore);
+  const data = useMemo(() => buildTrendData(trend, selectedRunId), [trend, selectedRunId]);
   const renderTrendLabel = (props) => <TrendBarLabel {...props} data={data} />;
 
   return (

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import HistoryRunRow from './HistoryRunRow.jsx';
 import HistoryChartPanel from './HistoryChartPanel.jsx';
-import HistoryDimensionPanel from './HistoryDimensionPanel.jsx';
+
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
 
@@ -18,7 +18,7 @@ function computeDeltas(trend) {
 }
 
 export default function HistoryPage({ trend, selection, availableRuns, dimensions, callbacks }) {
-  const { selectedRunId, selectedRunScore } = selection;
+  const { selectedRunId } = selection;
   const { accumulatedDimensions, lastRun } = dimensions;
   const { onRunClick, onDimensionClick, onNavigate, onRunChange } = callbacks;
   const [showAll, setShowAll] = useState(false);
@@ -80,20 +80,11 @@ export default function HistoryPage({ trend, selection, availableRuns, dimension
           </div>
         )}
       </div>
-      <div className="history-panels-row">
-        <HistoryChartPanel
-          trend={trend}
-          selectedRunId={selectedRunId}
-          selectedRunScore={selectedRunScore}
-          onBarClick={(runId) => onRunChange(runId)}
-        />
-        <HistoryDimensionPanel
-          dimensions={accumulatedDimensions || []}
-          onBarClick={onDimensionClick}
-          runDate={lastRun?.date}
-          runId={lastRun?.runId}
-        />
-      </div>
+      <HistoryChartPanel
+        trend={trend}
+        selectedRunId={selectedRunId}
+        onBarClick={(runId) => onRunChange(runId)}
+      />
       <div className="dimensions-header">
         <h3 className="dimensions-title">Evaluations</h3>
       </div>

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useStandards } from './hooks/useStandards.js';
+import { useVisibleStandards } from './hooks/useVisibleStandards.js';
 import StandardsList from './components/StandardsList.jsx';
 import StandardEditor from './components/StandardEditor.jsx';
 import LibraryBrowser from './components/LibraryBrowser.jsx';
@@ -7,6 +8,7 @@ import ImportModal from './components/ImportModal.jsx';
 
 export default function StandardsPage() {
   const { grouped, loading, error, refresh, handleDelete, handleDuplicate } = useStandards();
+  const { isVisible, toggle, add: addVisible, remove: removeVisible } = useVisibleStandards();
   const [view, setView] = useState({ mode: 'list' }); // { mode: 'list' | 'edit' | 'new', standardId?: string }
   const [showLibrary, setShowLibrary] = useState(false);
   const [showImport, setShowImport] = useState(false);
@@ -24,9 +26,15 @@ export default function StandardsPage() {
     refresh();
   };
 
-  const handleSaved = () => {
+  const handleSaved = (savedId) => {
+    if (savedId) addVisible(savedId);
     setView({ mode: 'list' });
     refresh();
+  };
+
+  const handleDeleteWithCleanup = async (id) => {
+    removeVisible(id);
+    await handleDelete(id);
   };
 
   if (view.mode === 'edit' || view.mode === 'new') {
@@ -75,8 +83,10 @@ export default function StandardsPage() {
         <StandardsList
           grouped={grouped}
           onEdit={handleEdit}
-          onDelete={handleDelete}
+          onDelete={handleDeleteWithCleanup}
           onDuplicate={handleDuplicate}
+          isVisible={isVisible}
+          onToggleVisibility={toggle}
         />
       )}
 

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { downloadStandard } from '../../../api/index.js';
 
-const TYPE_LABELS = { builtin: 'Built-in', community: 'Community', custom: 'Custom' };
+const TYPE_LABELS = { builtin: 'ISO-25010', quodeq: 'Quodeq', community: 'Community', custom: 'Custom' };
 
 function ConfirmDeleteModal({ standardName, principleCount, requirementCount, onConfirm, onCancel }) {
   const [typed, setTyped] = useState('');
@@ -67,7 +67,7 @@ function DuplicateModal({ standardId, onConfirm, onCancel }) {
   );
 }
 
-export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }) {
+export default function StandardCard({ standard, onEdit, onDelete, onDuplicate, isVisible, onToggleVisibility }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
 
@@ -76,11 +76,12 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
     (sum, p) => sum + (p.requirements?.length ?? 0),
     0
   );
-  const isDeletable = standard.type !== 'builtin';
+  const isDeletable = standard.type !== 'builtin' && standard.type !== 'quodeq';
+  const visClass = isVisible ? 'standard-card--visible' : 'standard-card--hidden';
 
   return (
     <>
-      <div className={`standard-card standard-card--${standard.type}`} onClick={() => onEdit(standard.id)}>
+      <div className={`standard-card ${visClass}`} onClick={() => onEdit(standard.id)}>
         <div className="standard-card-header">
           <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
             {TYPE_LABELS[standard.type] || standard.type}
@@ -88,6 +89,26 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
           {standard.managed && (
             <span className="standard-managed-badge" title="Managed standard — read-only">managed</span>
           )}
+          <button
+            type="button"
+            className={`eye-toggle-btn${isVisible ? ' eye-toggle-btn--on' : ''}`}
+            title={isVisible ? 'Visible on Overview — click to hide' : 'Hidden from Overview — click to show'}
+            onClick={(e) => { e.stopPropagation(); onToggleVisibility(standard.id); }}
+          >
+            {isVisible ? (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            ) : (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+                <line x1="1" y1="1" x2="23" y2="23" />
+              </svg>
+            )}
+          </button>
         </div>
 
         <h3 className="standard-card-name">{standard.name}</h3>
@@ -105,25 +126,6 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
           <button
             type="button"
             className="card-action-btn"
-            onClick={() => onEdit(standard.id)}
-            title={standard.type === 'builtin' ? 'View' : 'Edit'}
-          >
-            {standard.type === 'builtin' ? (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                <circle cx="12" cy="12" r="3" />
-              </svg>
-            ) : (
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-              </svg>
-            )}
-            {standard.type === 'builtin' ? 'View' : 'Edit'}
-          </button>
-          <button
-            type="button"
-            className="card-action-btn"
             onClick={() => setShowDuplicateModal(true)}
             title="Duplicate"
           >
@@ -131,7 +133,6 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
             </svg>
-            Duplicate
           </button>
           <button
             type="button"
@@ -144,7 +145,6 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
               <polyline points="7 10 12 15 17 10" />
               <line x1="12" y1="15" x2="12" y2="3" />
             </svg>
-            Download
           </button>
           {isDeletable && (
             <button
@@ -159,7 +159,6 @@ export default function StandardCard({ standard, onEdit, onDelete, onDuplicate }
                 <path d="M10 11v6M14 11v6" />
                 <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
               </svg>
-              Delete
             </button>
           )}
         </div>

--- a/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardDetail.jsx
@@ -63,6 +63,18 @@ function RootDetail({ standard, onUpdateField, editable, isNew }) {
           This is a managed standard. Fields are read-only to preserve upstream compatibility.
         </p>
       )}
+
+      {editable && (!standard.principles || standard.principles.length === 0) && (
+        <div className="detail-empty-state">
+          <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="16" />
+            <line x1="8" y1="12" x2="16" y2="12" />
+          </svg>
+          <h4>Start building your evaluator</h4>
+          <p>Add your first principle from the tree panel, then define requirements for each one.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -76,34 +76,42 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
   return (
     <div className="standard-editor">
       <div className="standard-editor-toolbar">
-        <button type="button" className="editor-back-btn" onClick={onBack}>
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-            <path d="M19 12H5M12 5l-7 7 7 7" />
-          </svg>
-          Back
-        </button>
+        <div className="editor-toolbar-top">
+          <button type="button" className="editor-back-btn" onClick={onBack}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path d="M19 12H5M12 5l-7 7 7 7" />
+            </svg>
+            Back
+          </button>
 
-        <div className="editor-toolbar-center">
-          <h2 className="editor-title">
-            {isNew ? 'New Standard' : (standard?.name || standardId)}
-            {dirty && <span className="editor-dirty-indicator" title="Unsaved changes">*</span>}
-          </h2>
-          {standard?.managed && (
-            <span className="editor-managed-badge">managed</span>
-          )}
+          <div className="editor-toolbar-center">
+            <h2 className="editor-title">
+              {isNew ? 'New Standard' : (standard?.name || standardId)}
+              {dirty && <span className="editor-dirty-indicator" title="Unsaved changes">*</span>}
+            </h2>
+          </div>
+
+          <div className="editor-toolbar-actions">
+            {editable && (
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={handleSave}
+                disabled={!dirty}
+              >
+                Save
+              </button>
+            )}
+          </div>
         </div>
-
-        <div className="editor-toolbar-actions">
-          {editable && (
-            <button
-              type="button"
-              className="btn-primary"
-              onClick={handleSave}
-              disabled={!dirty}
-            >
-              Save
-            </button>
-          )}
+        <div className="editor-toolbar-stats">
+          <span className="editor-stat"><strong>{standard?.principles?.length || 0}</strong> principles</span>
+          <span className="editor-stat-dot" />
+          <span className="editor-stat"><strong>{(standard?.principles || []).reduce((sum, p) => sum + (p.requirements?.length || 0), 0)}</strong> requirements</span>
+          <span className="editor-stat-dot" />
+          <span className={`editor-stat-type editor-stat-type--${standard?.type || 'custom'}`}>
+            {standard?.type === 'builtin' ? 'ISO-25010' : standard?.type === 'quodeq' ? 'Quodeq' : standard?.type === 'community' ? 'Community' : 'Custom'}
+          </span>
         </div>
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,7 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 function TreeNode({ label, isSelected, onClick, onAdd, onRemove, addTitle, removeTitle, children, depth = 0, alwaysExpanded = false, defaultExpanded = true }) {
   const [expanded, setExpanded] = useState(alwaysExpanded || defaultExpanded);
+
+  useEffect(() => {
+    if (isSelected && !expanded) setExpanded(true);
+  }, [isSelected, expanded]);
   const hasChildren = children && children.length > 0;
   const showExpand = hasChildren && !alwaysExpanded;
 

--- a/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsList.jsx
@@ -9,7 +9,7 @@ function SectionHeader({ title, count }) {
   );
 }
 
-function StandardsSection({ title, standards, onEdit, onDelete, onDuplicate }) {
+function StandardsSection({ title, standards, onEdit, onDelete, onDuplicate, isVisible, onToggleVisibility }) {
   if (standards.length === 0) return null;
   return (
     <section className="standards-section">
@@ -22,6 +22,8 @@ function StandardsSection({ title, standards, onEdit, onDelete, onDuplicate }) {
             onEdit={onEdit}
             onDelete={onDelete}
             onDuplicate={onDuplicate}
+            isVisible={isVisible(s.id)}
+            onToggleVisibility={onToggleVisibility}
           />
         ))}
       </div>
@@ -29,10 +31,10 @@ function StandardsSection({ title, standards, onEdit, onDelete, onDuplicate }) {
   );
 }
 
-export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate }) {
-  const total = (grouped.builtin?.length ?? 0) + (grouped.community?.length ?? 0) + (grouped.custom?.length ?? 0);
+export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate, isVisible, onToggleVisibility }) {
+  const all = [...(grouped.builtin || []), ...(grouped.quodeq || []), ...(grouped.community || []), ...(grouped.custom || [])];
 
-  if (total === 0) {
+  if (all.length === 0) {
     return (
       <div className="standards-empty">
         <p>No standards found. Import from the library or create a custom standard.</p>
@@ -43,25 +45,13 @@ export default function StandardsList({ grouped, onEdit, onDelete, onDuplicate }
   return (
     <div className="standards-list">
       <StandardsSection
-        title="ISO 25010"
-        standards={grouped.builtin || []}
+        title="Standards"
+        standards={all}
         onEdit={onEdit}
         onDelete={onDelete}
         onDuplicate={onDuplicate}
-      />
-      <StandardsSection
-        title="Community"
-        standards={grouped.community || []}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onDuplicate={onDuplicate}
-      />
-      <StandardsSection
-        title="Custom Standards"
-        standards={grouped.custom || []}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onDuplicate={onDuplicate}
+        isVisible={isVisible}
+        onToggleVisibility={onToggleVisibility}
       />
     </div>
   );

--- a/src/quodeq/ui/src/features/standards/hooks/useStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandards.js
@@ -21,6 +21,7 @@ export function useStandards() {
 
   const grouped = {
     builtin: standards.filter((s) => s.type === 'builtin'),
+    quodeq: standards.filter((s) => s.type === 'quodeq'),
     community: standards.filter((s) => s.type === 'community'),
     custom: standards.filter((s) => s.type === 'custom'),
   };

--- a/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useVisibleStandards.js
@@ -1,0 +1,42 @@
+import { useState, useCallback, useMemo } from 'react';
+import { VISIBLE_STANDARDS_STORAGE_KEY } from '../../../constants.js';
+import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
+
+function writeToStorage(ids) {
+  localStorage.setItem(VISIBLE_STANDARDS_STORAGE_KEY, JSON.stringify(ids));
+}
+
+export function useVisibleStandards() {
+  const [visibleIds, setVisibleIds] = useState(readVisibleStandardIds);
+
+  const toggle = useCallback((id) => {
+    setVisibleIds((prev) => {
+      const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
+  const isVisible = useCallback((id) => visibleSet.has(id), [visibleSet]);
+
+  const add = useCallback((id) => {
+    setVisibleIds((prev) => {
+      if (prev.includes(id)) return prev;
+      const next = [...prev, id];
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const remove = useCallback((id) => {
+    setVisibleIds((prev) => {
+      if (!prev.includes(id)) return prev;
+      const next = prev.filter((x) => x !== id);
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  return { visibleIds, toggle, isVisible, add, remove };
+}

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -5,6 +5,7 @@ import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByP
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import { complianceRatio } from '../../../utils/formatters.js';
+import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
 
 const SUB_TABS = [
   { id: 'dimension', label: 'By Dimension' },
@@ -159,29 +160,49 @@ export default function ViolationsPage({ data, callbacks }) {
   const { onDimensionClick, onFileClick, onPrincipleClick } = callbacks;
   const [activeSubTab, setActiveSubTab] = useState('dimension');
 
+  const visibleDimensions = useMemo(() => {
+    const visibleSet = new Set(readVisibleStandardIds());
+    return accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
+  }, [accumulatedDimensions]);
+
   const topFilesCount = useMemo(
     () => new Set(
-      accumulatedDimensions.flatMap((d) => (d.violations || []).map((v) => v.file)).filter(Boolean)
+      visibleDimensions.flatMap((d) => (d.violations || []).map((v) => v.file)).filter(Boolean)
     ).size,
-    [accumulatedDimensions]
+    [visibleDimensions]
   );
 
   const uniquePrinciples = useMemo(
     () => new Set(
-      accumulatedDimensions.flatMap((d) => (d.violations || []).map((v) => v.principle)).filter(Boolean)
+      visibleDimensions.flatMap((d) => (d.violations || []).map((v) => v.principle)).filter(Boolean)
     ).size,
-    [accumulatedDimensions]
+    [visibleDimensions]
   );
+
+  const filteredAccumulated = useMemo(() => {
+    if (!accumulated) return accumulated;
+    const { totalViolations, totalCompliance, severity } = computeSummaryFromDimensions(visibleDimensions);
+    return {
+      ...accumulated,
+      summary: {
+        ...accumulated.summary,
+        totalViolations,
+        totalCompliance,
+        dimensionCount: visibleDimensions.length,
+        severity,
+      },
+    };
+  }, [accumulated, visibleDimensions]);
 
   return (
     <div className="violations-page">
-      <ViolationsHeader accumulated={accumulated} topFilesCount={topFilesCount} uniquePrinciples={uniquePrinciples} />
+      <ViolationsHeader accumulated={filteredAccumulated} topFilesCount={topFilesCount} uniquePrinciples={uniquePrinciples} />
       <ViolationsPillNav activeSubTab={activeSubTab} onSubTabChange={setActiveSubTab} />
       {activeSubTab === 'dimension' && (
-        <DimensionSubTab dimensions={accumulatedDimensions} onDimensionClick={onDimensionClick} onPrincipleClick={onPrincipleClick} />
+        <DimensionSubTab dimensions={visibleDimensions} onDimensionClick={onDimensionClick} onPrincipleClick={onPrincipleClick} />
       )}
       {activeSubTab === 'file' && (
-        <FileSubTab dimensions={accumulatedDimensions} onFileClick={onFileClick} />
+        <FileSubTab dimensions={visibleDimensions} onFileClick={onFileClick} />
       )}
     </div>
   );

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -559,7 +559,6 @@
 /* --- Power Selector (signal-bars) --- */
 .power-selector {
   display: flex;
-  flex-direction: row-reverse;
   align-items: flex-end;
   gap: 10px;
   flex-shrink: 0;
@@ -923,61 +922,21 @@
 }
 
 /* Dimension grid */
-.dimension-section {
-  margin-bottom: 12px;
-}
-
-.dimension-section:last-child {
-  margin-bottom: 0;
-}
-
-.dimension-section-label {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-secondary, #888);
-  margin-bottom: 6px;
-  padding-left: 2px;
-}
-
-.dimension-section-label .iso-link {
-  color: var(--color-accent, #58a6ff);
-  text-decoration: none;
-  font-size: inherit;
-}
-
-.dimension-section-label .iso-link:hover {
-  text-decoration: underline;
-}
-
 .dimension-grid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 12px;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
 }
 
-.dimension-chip-btn--custom,
-.dimension-chip-btn--community {
-  border-color: var(--color-success, #2d5a3d);
-  color: var(--color-success-text, #6fcf97);
-}
-
-.dimension-chip-btn--custom.selected,
-.dimension-chip-btn--community.selected {
-  background: var(--color-success, #2d5a3d);
-  border-color: var(--color-success-text, #6fcf97);
-  color: #fff;
-}
-
 .dimension-chip-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  padding: 7px 10px;
+  gap: 6px;
+  padding: 7px 12px;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -985,12 +944,9 @@
   font-size: var(--text-sm);
   font-weight: var(--weight-medium);
   color: var(--color-text-muted);
-  text-align: center;
   cursor: pointer;
   transition: border-color 150ms, background 150ms, color 150ms, box-shadow 150ms;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .dimension-chip-btn:hover:not(:disabled) {
@@ -2028,3 +1984,35 @@
   margin-top: 4px;
 }
 .vdetail-row--compliant { border-color: color-mix(in srgb, var(--color-grade-top-text) 55%, transparent); }
+
+/* ── Dimension chip type badge ──────────────────────────── */
+
+.dimension-chip-type {
+  font-size: 0.55rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: 4px;
+}
+
+.dimension-chip-type--builtin {
+  background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+  color: var(--color-accent);
+}
+
+.dimension-chip-type--quodeq {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 15%, transparent);
+  color: var(--color-warning, #f59e0b);
+}
+
+.dimension-chip-type--custom {
+  background: color-mix(in srgb, var(--color-text-muted) 15%, transparent);
+  color: var(--color-text-muted);
+}
+
+.dimension-chip-type--community {
+  background: color-mix(in srgb, var(--primitive-green-400, #4ade80) 15%, transparent);
+  color: var(--primitive-green-700, #4ade80);
+}

--- a/src/quodeq/ui/src/styles/standards.css
+++ b/src/quodeq/ui/src/styles/standards.css
@@ -120,6 +120,10 @@
   gap: 8px;
 }
 
+.standard-card-header .eye-toggle-btn {
+  margin-left: auto;
+}
+
 .standard-type-badge {
   display: inline-block;
   padding: 2px 8px;
@@ -133,6 +137,11 @@
 .standard-type-badge--builtin {
   background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   color: var(--color-accent);
+}
+
+.standard-type-badge--quodeq {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 15%, transparent);
+  color: var(--color-warning, #f59e0b);
 }
 
 .standard-type-badge--community {
@@ -193,6 +202,7 @@
 
 .standard-card-actions {
   display: flex;
+  justify-content: flex-end;
   gap: 6px;
   padding-top: 8px;
   border-top: 1px solid var(--color-border);
@@ -244,13 +254,53 @@
 
 .standard-editor-toolbar {
   display: flex;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
   padding: 12px 20px;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-surface);
   flex-shrink: 0;
 }
+
+.editor-toolbar-top {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.editor-toolbar-stats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.editor-stat {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.editor-stat strong {
+  color: var(--color-text-secondary);
+}
+
+.editor-stat-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--color-border);
+}
+
+.editor-stat-type {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.editor-stat-type--builtin { color: var(--color-accent); }
+.editor-stat-type--quodeq { color: var(--color-warning, #f59e0b); }
+.editor-stat-type--community { color: var(--primitive-green-700, #4ade80); }
+.editor-stat-type--custom { color: var(--color-text-muted); }
 
 .editor-back-btn {
   display: inline-flex;
@@ -589,6 +639,30 @@
   border-radius: var(--radius-md, 6px);
   font-size: 0.82rem;
   color: var(--color-text-muted);
+}
+
+.detail-empty-state {
+  text-align: center;
+  padding: 32px 20px;
+  margin-top: 16px;
+  color: var(--color-text-muted);
+}
+
+.detail-empty-state svg {
+  opacity: 0.3;
+  margin-bottom: 12px;
+}
+
+.detail-empty-state h4 {
+  margin: 0 0 8px 0;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.detail-empty-state p {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.5;
 }
 
 /* ── Reference Editor ────────────────────────────────────── */
@@ -1166,4 +1240,60 @@
 
 .dim-chip-badge--community {
   background: var(--primitive-green-400, #4caf7d);
+}
+
+/* ── Visibility toggle ────────────────────────────────────── */
+
+.standard-card--visible {
+  border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
+}
+
+.standard-card--hidden {
+  border-color: var(--color-border);
+  background: color-mix(in srgb, var(--color-text) 1%, var(--color-surface));
+}
+
+.standard-card--hidden .standard-card-name,
+.standard-card--hidden .standard-card-description,
+.standard-card--hidden .standard-card-counts,
+.standard-card--hidden .standard-type-badge,
+.standard-card--hidden .standard-managed-badge,
+.standard-card--hidden .standard-card-actions {
+  opacity: 0.35;
+}
+
+.standard-card--hidden:hover .standard-card-name,
+.standard-card--hidden:hover .standard-card-description,
+.standard-card--hidden:hover .standard-card-counts,
+.standard-card--hidden:hover .standard-type-badge,
+.standard-card--hidden:hover .standard-managed-badge,
+.standard-card--hidden:hover .standard-card-actions {
+  opacity: 0.55;
+}
+
+.eye-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 32px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--color-text-muted) 40%, transparent);
+  background: color-mix(in srgb, var(--color-text-muted) 8%, transparent);
+  cursor: pointer;
+  padding: 0;
+  color: var(--color-text-muted);
+  transition: all 0.15s;
+}
+
+.eye-toggle-btn:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.eye-toggle-btn--on {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
 }

--- a/src/quodeq/ui/src/utils/visibleStandards.js
+++ b/src/quodeq/ui/src/utils/visibleStandards.js
@@ -1,0 +1,32 @@
+import { VISIBLE_STANDARDS_STORAGE_KEY, DEFAULT_VISIBLE_STANDARDS } from '../constants.js';
+
+/**
+ * Read the visible standard IDs from localStorage.
+ * Returns the default ISO dimensions if nothing is stored.
+ */
+export function readVisibleStandardIds() {
+  try {
+    const raw = localStorage.getItem(VISIBLE_STANDARDS_STORAGE_KEY);
+    if (!raw) return DEFAULT_VISIBLE_STANDARDS;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : DEFAULT_VISIBLE_STANDARDS;
+  } catch {
+    return DEFAULT_VISIBLE_STANDARDS;
+  }
+}
+
+/**
+ * Compute summary stats from a filtered dimensions array.
+ */
+export function computeSummaryFromDimensions(dimensions) {
+  const allViolations = dimensions.flatMap((d) => d.violations || []);
+  const totalCompliance = dimensions.reduce((sum, d) => sum + (d.compliance?.length || 0), 0);
+  const severity = { critical: 0, major: 0, minor: 0 };
+  for (const v of allViolations) {
+    const s = (v.severity || '').toLowerCase();
+    if (s === 'critical') severity.critical++;
+    else if (s === 'major') severity.major++;
+    else if (s === 'minor') severity.minor++;
+  }
+  return { totalViolations: allViolations.length, totalCompliance, severity };
+}


### PR DESCRIPTION
## Summary

Per-standard visibility toggle on the Standards page. Only visible standards appear on Overview, Violations, and Evaluate tabs. Bundled Clean Architecture and Domain-Driven Design evaluators.

### Standards Page
- Eye toggle pill button on every card (open eye = visible on Overview, crossed eye = hidden)
- Visible cards: accent tint background + border. Hidden: faded content, eye stays visible
- `[ISO-25010]` / `[QUODEQ]` / `[Community]` / `[Custom]` type badges
- Single unified "Standards" section (no more separate ISO/Community/Custom)
- Quodeq and builtin types are non-deletable
- Auto-show on create, remove from visible on delete
- Two-line editor toolbar with live principle/requirement counts + type badge
- Guided empty state for new standard creation
- Auto-expand tree node on selection

### Overview
- Hero panel stats (score, violations, compliance, severity) filtered by visible
- Dimension cards, score panel, violations table filtered
- Run history chart: accumulated scores per visible dimension, simulated from raw trend
- Trend badge delta computed from selected run vs previous (not always latest)
- Run navigator only steps through days with visible evaluations
- Resets to latest when visibility changes

### Violations Tab
- All stats, dimensions, principles, files filtered by visible standards

### Evaluate Tab
- Only visible standards shown as selectable dimension chips
- Chips start unselected (user picks which to run)
- Unified grid with type suffix badges (ISO, Quodeq, Custom, Community)
- Flex-wrap layout for breathing room

### History Tab
- Shows all runs unfiltered
- Chart bars show per-run grade (not accumulated)
- Dimension score panel removed, chart limit bumped to 40

### Bundled Evaluators
- **Clean Architecture** — 8 principles, 52 requirements (Robert C. Martin)
- **Domain-Driven Design** — 10 principles, 73 requirements (Eric Evans / Vaughn Vernon)
- Both `type: "quodeq"`, `managed: true`, hidden by default

### Other
- Power label moved to right of selector bars
- Backend: `quodeq` type support in dimensions.json and StandardsService
- Shared `readVisibleStandardIds()` and `computeSummaryFromDimensions()` utilities
- localStorage persistence (`quodeq-visible-standards` key, defaults to 6 ISO dimensions)

## Test plan
- [x] Toggle eye on/off for various standards, verify overview updates
- [x] Verify grade recalculates with only visible dimensions
- [x] Navigate runs — only days with visible standards appear
- [x] Check violations tab filters correctly
- [x] Evaluate tab shows only visible chips, none pre-selected
- [x] History shows all runs with per-run grades
- [x] Create new standard — auto-shows in visible list
- [x] Delete standard — removed from visible list
- [x] Clean Architecture and DDD appear with QUODEQ badge, hidden by default
- [x] Verify no regressions with all standards visible (default state)