### PR TITLE
fix: blank screen when switching between parent/child projects

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getDashboard, getAccumulated } from '../../../api/index.js';
 
 /**
@@ -75,6 +75,16 @@ export function useDashboard({ selectedProject, selectedRun }) {
   const [latestAccumulated, setLatestAccumulated] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
+  // Clear stale data immediately when project changes to prevent rendering old data for a new project
+  const prevProjectRef = useRef(selectedProject);
+  if (prevProjectRef.current !== selectedProject) {
+    prevProjectRef.current = selectedProject;
+    setDashboard(null);
+    setAccumulated(null);
+    setLatestAccumulated(null);
+    setError(null);
+  }
 
   useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun]);

--- a/src/quodeq/ui/src/hooks/useVisibleRuns.js
+++ b/src/quodeq/ui/src/hooks/useVisibleRuns.js
@@ -27,11 +27,14 @@ export function useVisibleRuns(dailyRuns, dashboard, activePage, setSelectedRun)
   const visibleRunIdsKey = visibleDailyRuns.map((r) => r.runId).join(',');
   const prevRunIdsKeyRef = useRef(visibleRunIdsKey);
   useEffect(() => {
-    if (prevRunIdsKeyRef.current !== visibleRunIdsKey && visibleDailyRuns.length > 0) {
+    // Only reset when the visible runs actually change content (not when transitioning through empty during project switch)
+    if (prevRunIdsKeyRef.current !== visibleRunIdsKey && visibleRunIdsKey !== '' && prevRunIdsKeyRef.current !== '') {
       setSelectedRun('latest');
     }
-    prevRunIdsKeyRef.current = visibleRunIdsKey;
-  }, [visibleRunIdsKey, visibleDailyRuns.length, setSelectedRun]);
+    if (visibleRunIdsKey !== '') {
+      prevRunIdsKeyRef.current = visibleRunIdsKey;
+    }
+  }, [visibleRunIdsKey, setSelectedRun]);
 
   return visibleDailyRuns;
 }


### PR DESCRIPTION
## Summary

Fixes blank screen + React error #310 when navigating between parent and child projects (e.g., feature-overview → selectives-android).

## Root Cause

Two issues compounding:

1. **Stale data on project switch** — `useDashboard` didn't clear old dashboard/accumulated state when `selectedProject` changed. The old project's data persisted during the new fetch, causing `AccumulatedOverviewPanel` to render with mismatched data.

2. **Spurious run reset** — `useVisibleRuns` triggered `setSelectedRun('latest')` when visible runs went empty (transition from old→empty→new during project switch), causing a cascade of re-renders.

## Fix

- Clear `dashboard`, `accumulated`, `latestAccumulated`, and `error` immediately when `selectedProject` changes (synchronous state reset before effects)
- Only reset selected run when visible runs change from non-empty to a **different** non-empty set (ignore transitions through empty)

## Test plan
- [x] Switch from child project to parent project — no blank screen
- [x] Switch from parent to child — no blank screen
- [x] Switch between projects without children — still works
- [x] Overview data loads correctly after switch