### PR TITLE
fix: resolve 47 additional maintainability violations

### DIFF
--- a/packaging/macos/_dashboard.py
+++ b/packaging/macos/_dashboard.py
@@ -29,6 +29,12 @@ class DashboardCallbacks(NamedTuple):
     on_timeout: object     # () -> None
 
 
+class DashboardState(NamedTuple):
+    """Mutable port-discovery state passed through the wait loop."""
+    cache: dict
+    last_known: int | None
+
+
 def find_running_port(ports: tuple[int, ...], last_known: int | None, cache: dict) -> int | None:
     """Find the running dashboard port, checking last known port first (TTL-cached)."""
     now = time.monotonic()
@@ -99,8 +105,7 @@ def kill_port_processes(port: int) -> None:
 def wait_for_dashboard(
     process: subprocess.Popen,
     ports: tuple[int, ...],
-    cache: dict,
-    last_known: int | None,
+    state: DashboardState,
     stderr_log,
     callbacks: DashboardCallbacks,
 ) -> None:
@@ -111,7 +116,7 @@ def wait_for_dashboard(
             if process.poll() is not None:
                 callbacks.on_crash(stderr_log)
                 return
-            port = find_running_port(ports, last_known, cache)
+            port = find_running_port(ports, state.last_known, state.cache)
             if port:
                 callbacks.on_port_found(port, stderr_log)
                 return

--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -20,6 +20,7 @@ from _dashboard import (
     build_dashboard_cmd as _build_dashboard_cmd,
     cleanup_stderr_log as _cleanup_stderr_log_file,
     DashboardCallbacks as _DashboardCallbacks,
+    DashboardState as _DashboardState,
     find_pids_on_port as _find_pids_on_port,
     find_running_port as _find_running_port_cached,
     kill_port_processes as _kill_port_processes,
@@ -180,6 +181,21 @@ class QuodeqApp(rumps.App):
         _cleanup_stderr_log_file(self._stderr_log_path)
         self._stderr_log_path = None
 
+    def _launch_dashboard_process(self, quodeq_cmd: str, stderr_log) -> bool:
+        """Launch the dashboard subprocess. Returns True on success, False on failure."""
+        try:
+            cmd = _build_dashboard_cmd(quodeq_cmd, self._app_port)
+            self._process = subprocess.Popen(
+                cmd, stdout=subprocess.DEVNULL, stderr=stderr_log, start_new_session=True,
+            )
+            return True
+        except OSError as e:
+            stderr_log.close()
+            self._set_error(f"Failed: {e}")
+            self._status_item.title = "Stopped"
+            self._cleanup_stderr_log()
+            return False
+
     def _do_start_inner(self):
         cmds = self._cached_cmds
         quodeq_cmd = cmds.get("quodeq")
@@ -190,16 +206,7 @@ class QuodeqApp(rumps.App):
         self._status_item.title = "Starting..."
         stderr_log = _open_stderr_log()
         self._stderr_log_path = stderr_log.name
-        try:
-            cmd = _build_dashboard_cmd(quodeq_cmd, self._app_port)
-            self._process = subprocess.Popen(
-                cmd, stdout=subprocess.DEVNULL, stderr=stderr_log, start_new_session=True,
-            )
-        except OSError as e:
-            stderr_log.close()
-            self._set_error(f"Failed: {e}")
-            self._status_item.title = "Stopped"
-            self._cleanup_stderr_log()
+        if not self._launch_dashboard_process(quodeq_cmd, stderr_log):
             return
         self._wait_for_dashboard(stderr_log)
 
@@ -231,8 +238,7 @@ class QuodeqApp(rumps.App):
         _wait_for_dashboard(
             process=self._process,
             ports=self._ports,
-            cache=self._port_cache,
-            last_known=self._port_cache.get("last_known"),
+            state=_DashboardState(cache=self._port_cache, last_known=self._port_cache.get("last_known")),
             stderr_log=stderr_log,
             callbacks=_DashboardCallbacks(
                 on_port_found=on_port_found,

--- a/src/quodeq/analysis/manifest_render.py
+++ b/src/quodeq/analysis/manifest_render.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from quodeq.analysis.manifest import AnalysisTarget
 
+_MAX_LANGUAGE_EXTENSIONS = 8
+
 
 def render_target_prompt_context(
     target: AnalysisTarget,
@@ -29,7 +31,7 @@ def render_target_prompt_context(
     if target.language_stats:
         breakdown = ", ".join(
             f"{ext}: {count}" for ext, count in
-            sorted(target.language_stats.items(), key=lambda x: -x[1])[:8]
+            sorted(target.language_stats.items(), key=lambda x: -x[1])[:_MAX_LANGUAGE_EXTENSIONS]
         )
         lines.append(f"**Extension breakdown:** {breakdown}")
     return "\n".join(lines)

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -138,8 +138,23 @@ def _standards_read_instruction(standards_path: Path) -> str:
     )
 
 
+def _write_standards_and_instruction(work_dir: Path, dimension: str, content: str) -> str:
+    """Write standards to a file and return the read instruction for the prompt."""
+    standards_path = _write_standards_file(work_dir, dimension, content)
+    return _standards_read_instruction(standards_path)
+
+
 def build_analysis_prompt(template: str, context: PromptContext) -> str:
-    """Build a complete per-dimension analysis prompt from the template."""
+    """Build a complete per-dimension analysis prompt from the template.
+
+    Args:
+        template: Raw template string with ``{{PLACEHOLDER}}`` markers.
+        context: Populated :class:`PromptContext` providing all substitution
+            values (language, dimension, standards directory, etc.).
+
+    Returns:
+        Fully rendered prompt string with all placeholders resolved.
+    """
     dimensions_text = render_dimensions(context.dimensions_data, context.dimension)
     prompt_hash = _template_hash(template)
 
@@ -151,10 +166,9 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
             if context.work_dir:
                 compact = render_compact_standards(compiled_dir, context.dimension, evaluators_dir=_eval_dir)
                 if compact not in (_NO_STANDARDS_FOR_DIM,):
-                    standards_path = _write_standards_file(
+                    standards_checklist = _write_standards_and_instruction(
                         context.work_dir, context.dimension, compact,
                     )
-                    standards_checklist = _standards_read_instruction(standards_path)
                 else:
                     standards_checklist = compact
             else:
@@ -198,7 +212,16 @@ def build_consolidated_prompt(
     context: PromptContext,
     template: str | None = None,
 ) -> str:
-    """Build a multi-dimension analysis prompt with all standards inline."""
+    """Build a multi-dimension analysis prompt with all standards inline.
+
+    Args:
+        dimensions: List of dimension IDs to include (e.g. ``["security", "reliability"]``).
+        context: Populated :class:`PromptContext` with shared substitution values.
+        template: Optional pre-loaded template string; defaults to ``consolidated.md``.
+
+    Returns:
+        Fully rendered multi-dimension prompt string.
+    """
     if template is None:
         template = load_template(template_name="consolidated.md")
 

--- a/src/quodeq/analysis/stream/counters.py
+++ b/src/quodeq/analysis/stream/counters.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-# NOTE: logging in inner layer — tracked for middleware extraction
 from quodeq.shared.logging import log_debug
 from quodeq.shared.utils import open_text
 

--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -1,6 +1,7 @@
 """Consolidated multi-dimension analysis — extracted from subagents/runner.py."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -12,8 +13,14 @@ from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.prompts.builder import PromptContext, build_consolidated_prompt
 from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
-# NOTE: logging in inner layer — tracked for middleware extraction
 from quodeq.shared.logging import log_info, log_warning
+
+
+@dataclass(frozen=True)
+class _ConsolidatedPaths:
+    """Paths for consolidated evidence collection."""
+    evidence_dir: Path
+    compiled_dir: "Path | None" = None
 
 
 def _build_consolidated_config(
@@ -40,14 +47,13 @@ def _build_consolidated_config(
 
 def _collect_consolidated_results(
     config: "RunConfig", dimensions: list[str], ctx: Any,
-    results: list[Any], evidence_dir: Path,
-    compiled_dir: "Path | None" = None,
+    results: list[Any], paths: _ConsolidatedPaths,
 ) -> dict[str, Evidence]:
     """Deduplicate and parse consolidated results into per-dimension Evidence."""
     from quodeq.analysis.stream.counters import count_files_in_stream
     from quodeq.engine._runner_markers import cleanup_stream
 
-    merged_jsonl = evidence_dir / "consolidated_evidence.jsonl"
+    merged_jsonl = paths.evidence_dir / "consolidated_evidence.jsonl"
     SubagentPool.deduplicate_jsonl(merged_jsonl)
 
     total_files_read = 0
@@ -66,7 +72,7 @@ def _collect_consolidated_results(
     )
 
     return parse_jsonl_to_evidence_by_dimension(
-        merged_jsonl, ev_ctx, compiled_dir=compiled_dir,
+        merged_jsonl, ev_ctx, compiled_dir=paths.compiled_dir,
         evaluators_dir=config.evaluators_dir,
     )
 
@@ -127,4 +133,4 @@ def process_consolidated_dimensions(
     results = pool.run()
 
     # 4. Collect and return per-dimension evidence
-    return _collect_consolidated_results(config, dimensions, ctx, results, evidence_dir, compiled_dir=compiled_dir)
+    return _collect_consolidated_results(config, dimensions, ctx, results, _ConsolidatedPaths(evidence_dir=evidence_dir, compiled_dir=compiled_dir))

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -40,6 +40,20 @@ class FindingCounts:
     compliances: int = 0
 
 
+def _classify_jsonl_line(line: str, counts: FindingCounts) -> None:
+    """Classify a single non-empty JSONL line and update *counts* in place."""
+    counts.total += 1
+    try:
+        entry = json.loads(line)
+        t = entry.get("t")
+        if t == FINDING_TYPE_VIOLATION:
+            counts.violations += 1
+        elif t == FINDING_TYPE_COMPLIANCE:
+            counts.compliances += 1
+    except json.JSONDecodeError:
+        pass
+
+
 def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCounts:
     """Count total, violation, and compliance lines in a JSONL file under a lock."""
     try:
@@ -49,19 +63,9 @@ def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCoun
         with lock:
             with open_text(jsonl_path) as f:
                 for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    counts.total += 1
-                    try:
-                        entry = json.loads(line)
-                        t = entry.get("t")
-                        if t == FINDING_TYPE_VIOLATION:
-                            counts.violations += 1
-                        elif t == FINDING_TYPE_COMPLIANCE:
-                            counts.compliances += 1
-                    except json.JSONDecodeError:
-                        pass
+                    stripped = line.strip()
+                    if stripped:
+                        _classify_jsonl_line(stripped, counts)
         return counts
     except OSError:
         return FindingCounts()

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -5,7 +5,7 @@ import re
 from http import HTTPStatus
 from pathlib import Path
 
-from flask import Flask, Response, jsonify, request
+from flask import Flask, Response, abort, jsonify, request
 
 from quodeq.api.helpers import error_response, register_static_routes, validate_evaluation_payload
 from quodeq.api.zip import export_project_zip
@@ -40,7 +40,6 @@ def _reports_dir(default_path: str | None = None) -> str:
     resolved = Path(raw).resolve()
     default_resolved = Path(fallback).resolve()
     if not resolved.is_relative_to(default_resolved):
-        from flask import abort
         abort(HTTPStatus.FORBIDDEN)
     return str(resolved)
 
@@ -166,7 +165,7 @@ def _validate_ai_cmd(ai_cmd: str | None, env: dict[str, str] | None = None) -> t
 
 def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
     """Construct and validate EvaluationOptions from the request payload."""
-    from quodeq.provider.base import EvaluationOptions
+    from quodeq.provider.base import EvaluationOptions  # deferred: avoid circular import at module level
     max_subagents_raw = payload.get("maxSubagents", _DEFAULT_MAX_SUBAGENTS)
     max_subagents = max(_MIN_SUBAGENTS, min(_MAX_SUBAGENTS, int(max_subagents_raw)))
     pool_budget_raw = payload.get("poolBudget", _DEFAULT_POOL_BUDGET)
@@ -266,7 +265,7 @@ def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
 
     @app.get("/api/plugins")
     def plugins() -> Response:
-        from quodeq.provider.plugin_discovery import discover_plugins
+        from quodeq.provider.plugin_discovery import discover_plugins  # deferred: avoid circular import at module level
         return jsonify([to_camel_dict(p) for p in discover_plugins()])
 
     @app.get("/api/browse")

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -10,9 +10,13 @@ from quodeq.services.standards import StandardsService
 logger = logging.getLogger(__name__)
 
 def _get_service(app: Flask) -> StandardsService:
-    # Lazy initialization: ``_standards_service`` is set on first access and
-    # reused for the lifetime of the Flask app.  Tests can pre-set
-    # ``app._standards_service`` to inject a mock before any route runs.
+    """Return the lazily-initialized StandardsService for this Flask app.
+
+    Lifecycle: the ``_standards_service`` attribute is created on first
+    request and reused for the lifetime of the Flask app.  Tests can
+    pre-set ``app._standards_service`` before any route runs to inject a
+    mock or stub, bypassing the real filesystem entirely.
+    """
     if not hasattr(app, "_standards_service"):
         app._standards_service = StandardsService(
             evaluators_dir=Path(app.config["STANDARDS_EVALUATORS_DIR"]),

--- a/src/quodeq/core/types/_mapper_findings.py
+++ b/src/quodeq/core/types/_mapper_findings.py
@@ -30,7 +30,15 @@ def parse_req_ref(raw: dict[str, object]) -> ReqRef:
 
 
 def parse_finding(raw: dict[str, object]) -> Finding:
-    """Parse a raw dict into a Finding instance with nested ReqRef list."""
+    """Parse a raw dict into a Finding instance with nested ReqRef list.
+
+    Args:
+        raw: Dictionary with camelCase keys matching the Finding fields
+            (e.g. ``"principle"``, ``"severity"``, ``"reqRefs"``).
+
+    Returns:
+        A fully populated :class:`Finding` dataclass.
+    """
     req_refs_raw = raw.get("reqRefs")
     req_refs: list[ReqRef] = []
     if isinstance(req_refs_raw, list):
@@ -53,7 +61,15 @@ def parse_finding(raw: dict[str, object]) -> Finding:
 
 
 def parse_severity_tally(raw: dict[str, object]) -> SeverityTally:
-    """Parse a raw dict into a SeverityTally (critical/major/minor/unknown counts)."""
+    """Parse a raw dict into a SeverityTally (critical/major/minor/unknown counts).
+
+    Args:
+        raw: Dictionary with ``"critical"``, ``"major"``, ``"minor"``,
+            and ``"unknown"`` integer keys.
+
+    Returns:
+        A :class:`SeverityTally` with zero-defaulted counts.
+    """
     return SeverityTally(
         critical=_int(raw, "critical"),
         major=_int(raw, "major"),
@@ -63,7 +79,15 @@ def parse_severity_tally(raw: dict[str, object]) -> SeverityTally:
 
 
 def parse_totals(raw: dict[str, object]) -> Totals:
-    """Parse a raw dict into a Totals instance with embedded SeverityTally."""
+    """Parse a raw dict into a Totals instance with embedded SeverityTally.
+
+    Args:
+        raw: Dictionary with ``"violationCount"``, ``"complianceCount"``,
+            and an optional ``"severity"`` sub-dict.
+
+    Returns:
+        A :class:`Totals` with parsed severity breakdown.
+    """
     sev_raw = raw.get("severity")
     severity = parse_severity_tally(sev_raw) if isinstance(sev_raw, dict) else SeverityTally()
     return Totals(

--- a/src/quodeq/core/types/report.py
+++ b/src/quodeq/core/types/report.py
@@ -16,7 +16,14 @@ class PrincipleGrade:
 
 @dataclass(frozen=True, slots=True)
 class PrincipleGradeWithOverall:
-    """PrincipleGrade extended with an ``is_overall`` flag for aggregate rows."""
+    """PrincipleGrade extended with an ``is_overall`` flag for aggregate rows.
+
+    Attributes:
+        principle: Principle name or None for unnamed entries.
+        score: Numeric score as a string, e.g. ``"8.5"``.
+        grade: Letter grade, e.g. ``"A"``, ``"B+"``.
+        is_overall: True when this row represents the aggregate score.
+    """
 
     principle: str | None = None
     score: str | None = None
@@ -26,7 +33,18 @@ class PrincipleGradeWithOverall:
 
 @dataclass(frozen=True, slots=True)
 class ParsedReport:
-    """Fully parsed dimension report with grades, findings, and totals."""
+    """Fully parsed dimension report with grades, findings, and totals.
+
+    Attributes:
+        dimension: The quality dimension this report covers (e.g. ``"security"``).
+        overall_score: Aggregate numeric score as a string.
+        overall_grade: Aggregate letter grade.
+        principles: Per-principle grade breakdown.
+        detail_principles: Raw principle detail dicts from the source report.
+        violations: List of violation findings.
+        compliance: List of compliance findings.
+        totals: Aggregated violation/compliance counts and severity tally.
+    """
 
     dimension: str | None = None
     overall_score: str | None = None

--- a/src/quodeq/dashboard/_api_health.py
+++ b/src/quodeq/dashboard/_api_health.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import subprocess
 import sys
 import time
@@ -21,6 +22,7 @@ _HEALTH_CHECK_TIMEOUT_S = 0.5
 _HEALTH_POLL_INTERVAL_S = 0.2
 _DEFAULT_WAIT_TIMEOUT_S = 10
 _MAX_HEALTH_POLL_ATTEMPTS = 200
+_MAX_JITTER_DELAY_S = 2.0
 
 _ENV_ACTION_API_PORT = "QUODEQ_ACTION_API_PORT"
 _ENV_ACTION_API_HOST = "QUODEQ_ACTION_API_HOST"
@@ -59,12 +61,11 @@ def action_api_healthy(base_url: str) -> bool:
 
 def wait_for_action_api(base_url: str, timeout_s: float = _DEFAULT_WAIT_TIMEOUT_S) -> None:
     """Block until the action API becomes healthy, or raise TimeoutError."""
-    import random
     log_info(f"Waiting for Action API at {base_url}...")
     start = time.monotonic()
     attempts = 0
     delay = _HEALTH_POLL_INTERVAL_S
-    max_delay = 2.0
+    max_delay = _MAX_JITTER_DELAY_S
     while time.monotonic() - start < timeout_s and attempts < _MAX_HEALTH_POLL_ATTEMPTS:
         if action_api_healthy(base_url):
             return None

--- a/src/quodeq/provider/violations.py
+++ b/src/quodeq/provider/violations.py
@@ -1,5 +1,6 @@
 """Re-export for backward compatibility — moved to quodeq.services.violations."""
 from quodeq.services.violations import (  # noqa: F401
+    _ResolveOptions,
     resolve_dimension_eval,
     aggregate_violations,
     ViolationContext,

--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -60,6 +60,32 @@ def _cache_store(
             cache.popitem(last=False)
 
 
+def _wait_for_inflight(
+    key: tuple, event: threading.Event,
+    cache: OrderedDict, lock: threading.Lock,
+) -> list[DimensionResult]:
+    """Wait for another thread's in-flight fetch and return the cached result."""
+    event.wait(timeout=_CACHE_WAIT_TIMEOUT_S)
+    with lock:
+        return list(cache.get(key, []))
+
+
+def _fetch_and_store(
+    key: tuple, reports_root: Path, project: str, run_id: str,
+    cache: OrderedDict, lock: threading.Lock, max_size: int,
+    inflight: dict[tuple, threading.Event],
+) -> list[DimensionResult]:
+    """Perform the disk fetch, store in cache, and notify waiters."""
+    data = _fetch_dimensions_from_disk(reports_root, project, run_id)
+    if data:
+        _cache_store(key, data, cache, lock, max_size)
+    with lock:
+        notify_event = inflight.pop(key, None)
+    if notify_event is not None:
+        notify_event.set()
+    return data
+
+
 def make_lru_dimension_fetcher(
     reports_root: Path,
     project: str,
@@ -82,14 +108,11 @@ def make_lru_dimension_fetcher(
     def get_run_dimensions(run_id: str) -> list[DimensionResult]:
         key = (reports_root, project, run_id)
 
-        # Fast path: already cached
         cached = _cache_lookup(key, cache, lock)
         if cached is not None:
             return cached
 
-        # Coordinate concurrent misses via per-key events
         with lock:
-            # Double-check after acquiring lock
             if key in cache:
                 cache.move_to_end(key)
                 return cache[key]
@@ -101,21 +124,11 @@ def make_lru_dimension_fetcher(
                 _inflight[key] = threading.Event()
 
         if wait_event is not None:
-            wait_event.wait(timeout=_CACHE_WAIT_TIMEOUT_S)
-            with lock:
-                return list(cache.get(key, []))
+            return _wait_for_inflight(key, wait_event, cache, lock)
 
-        # This thread is responsible for the fetch
-        data = _fetch_dimensions_from_disk(reports_root, project, run_id)
-
-        if data:
-            _cache_store(key, data, cache, lock, max_size)
-
-        with lock:
-            notify_event = _inflight.pop(key, None)
-        if notify_event is not None:
-            notify_event.set()
-
-        return data
+        return _fetch_and_store(
+            key, reports_root, project, run_id,
+            cache, lock, max_size, _inflight,
+        )
 
     return get_run_dimensions

--- a/src/quodeq/services/_filesystem_helpers.py
+++ b/src/quodeq/services/_filesystem_helpers.py
@@ -220,12 +220,18 @@ def _read_dimensions_from_file(dims_file: str) -> tuple[str, ...]:
 
 
 class _DimensionsCache:
-    """Explicit holder for the mutable dimensions cache (testable, no bare globals)."""
+    """Explicit holder for the mutable dimensions cache (testable, no bare globals).
+
+    Encapsulates a single ``value`` slot that caches the resolved dimension
+    tuple.  Call :func:`reset_dimensions_cache` (or ``_dimensions_cache.reset()``)
+    to clear cached state between tests or after configuration changes.
+    """
 
     def __init__(self) -> None:
         self.value: tuple[str, ...] | None = None
 
     def reset(self) -> None:
+        """Clear the cached dimensions, forcing a re-read on next access."""
         self.value = None
 
 

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -162,7 +162,8 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         if not base.is_relative_to(Path(reports_dir).resolve()):
             return None
         compiled_dir = self._compiled_dir or default_paths().standards_dir / "compiled"
-        result = resolve_dimension_eval(base, project, run_id, dimension, compiled_dir=compiled_dir if compiled_dir.exists() else None)
+        from quodeq.services.violations import _ResolveOptions
+        result = resolve_dimension_eval(base, project, run_id, dimension, options=_ResolveOptions(compiled_dir=compiled_dir if compiled_dir.exists() else None))
         if result is not None:
             return to_camel_dict(result) if isinstance(result, ViolationResponse) else result
         # Run exists but dimension hasn't started yet

--- a/src/quodeq/services/plugin_discovery.py
+++ b/src/quodeq/services/plugin_discovery.py
@@ -93,20 +93,21 @@ def _discover_from_detection(detection_file: Path, dimensions_file: Path) -> lis
     return result
 
 
-def discover_plugins(*, cache: _PluginCache | None = None) -> list[PluginInfo]:
+def discover_plugins(*, cache: _PluginCache | None = None, paths: object | None = None) -> list[PluginInfo]:
     """Return available plugin metadata from detection.json + dimensions.json.
 
     Results are cached for _PLUGIN_CACHE_TTL seconds so that configuration
     changes are picked up on the next request after the TTL expires.
 
     Pass *cache* to override the module-level cache (useful for testing).
+    Pass *paths* to override path resolution (useful for testing).
     """
     _cache = cache if cache is not None else _get_plugin_cache()
     cached = _cache.get()
     if cached is not None:
         return cached
 
-    paths = default_paths()
+    paths = paths or default_paths()
     if paths.detection_file.exists() and paths.dimensions_file.exists():
         result = _discover_from_detection(paths.detection_file, paths.dimensions_file)
         _cache.set(result)

--- a/src/quodeq/services/standards.py
+++ b/src/quodeq/services/standards.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from quodeq.core.types.standard import StandardDetail, StandardMeta
+from quodeq.services.import_validator import validate_import, scan_injection
 
 logger = logging.getLogger(__name__)
 
@@ -185,8 +186,6 @@ class StandardsService:
         - ``existing``: existing :class:`StandardMeta` (on conflict) or ``None``
         - ``warnings``: list of injection scan warnings
         """
-        from quodeq.services.import_validator import validate_import, scan_injection
-
         validation = validate_import(data)
         if not validation["valid"]:
             raise ValueError("; ".join(validation["errors"]))

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -175,6 +175,11 @@ class FsToolingMixin:
         return fetcher(client_id)
 
     def _get_claude_models(self, _client_id: str = "claude", api_key: str | None = None) -> dict[str, list[str]]:
+        """Fetch Claude model list from the Anthropic API, with fallback.
+
+        Pass *api_key* to override the global ``get_anthropic_api_key()``
+        accessor, e.g. for testing or per-request credential injection.
+        """
         key = api_key or get_anthropic_api_key()
         if key:
             models = _fetch_anthropic_models(key)

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -27,25 +27,26 @@ def _max_violation_files(override: int | None = None, env: dict[str, str] | None
 
 
 @dataclass(frozen=True)
-class _FsCallbacks:
-    """Injectable filesystem callbacks for testing resolve_dimension_eval without a real FS."""
+class _ResolveOptions:
+    """Injectable options for resolve_dimension_eval: filesystem callbacks and paths."""
     exists_fn: Callable[[Path], bool] = Path.exists
     stat_fn: Callable[[Path], Any] = Path.stat
+    compiled_dir: Path | None = None
 
 
 def resolve_dimension_eval(
     base: Path, project: str, run_id: str, dimension: str,
-    compiled_dir: Path | None = None,
-    fs: _FsCallbacks | None = None,
+    options: _ResolveOptions | None = None,
 ) -> ViolationResponse | dict[str, Any] | None:
     """Try successive file formats to load evaluation data for a dimension.
 
-    *fs* provides injectable filesystem callbacks for testing without a real FS.
+    *options* bundles injectable filesystem callbacks and the compiled
+    standards directory for testing without a real FS.
     """
-    if fs is None:
-        fs = _FsCallbacks()
-    _exists = fs.exists_fn
-    _stat = fs.stat_fn
+    opts = options or _ResolveOptions()
+    _exists = opts.exists_fn
+    _stat = opts.stat_fn
+    compiled_dir = opts.compiled_dir
 
     eval_path = base / "evaluation" / f"{dimension}.json"
     if _exists(eval_path):

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -116,10 +116,17 @@ def _parse_jsonl_findings(
     return violations, compliance
 
 
-def _load_req_to_principle(dimension: str) -> dict[str, str]:
-    """Load req ID → principle name mapping for custom evaluators."""
-    from quodeq.config.paths import default_paths
-    evaluators_dir = default_paths().evaluators_dir
+def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None) -> dict[str, str]:
+    """Load req ID -> principle name mapping for custom evaluators.
+
+    Args:
+        dimension: The dimension ID to look up.
+        evaluators_dir: Directory containing evaluator JSON files.
+            Defaults to ``default_paths().evaluators_dir`` when not provided.
+    """
+    if evaluators_dir is None:
+        from quodeq.config.paths import default_paths
+        evaluators_dir = default_paths().evaluators_dir
     if not evaluators_dir.is_dir():
         return {}
     path = evaluators_dir / f"{dimension}.json"

--- a/src/quodeq/shared/utils.py
+++ b/src/quodeq/shared/utils.py
@@ -1,20 +1,25 @@
-"""Shared utilities — convenience façade consolidating config, env, I/O, and helpers.
+"""Shared utilities -- intentional convenience facade for the quodeq package.
 
-**Why a single façade?**  This module provides a stable public import surface so
-that callers can ``from quodeq.shared.utils import …`` without tracking which
-internal submodule each helper lives in.  The trade-off (broader module) is
-intentional: it keeps imports simple for a fast-moving CLI codebase.
+**Architectural rationale:**  This module provides a single, stable public
+import surface so that callers can write
+``from quodeq.shared.utils import ...`` without tracking which internal
+submodule each helper lives in.  The trade-off (broader module surface) is
+a deliberate design choice that keeps imports simple and predictable across
+a fast-moving CLI codebase.
 
-Organisation
-~~~~~~~~~~~~
-The re-exports and definitions are grouped by category:
+Categories of re-exported and defined utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1. **Re-exports** — I/O helpers (``_io.py``), security helpers (``_security.py``)
-2. **Config loading** — ``Config`` dataclass, lazy singleton, ``_get_config()``
-3. **Platform detection** — ``IS_WIN32``
-4. **Repository URL helpers** — ``is_repo_url``, ``project_name_from_repo``
-5. **Environment accessors** — ``get_ai_provider``, ``get_dashboard_port``, etc.
-6. **Diff display** — ``show_diff``
+1. **I/O helpers** -- ``read_text``, ``write_text``, ``open_text``, ``read_json``
+   (from ``_io.py``)
+2. **Security helpers** -- ``SENSITIVE_PATTERNS``, ``sanitize_sensitive``
+   (from ``_security.py``)
+3. **Config loading** -- ``Config`` dataclass, lazy singleton via ``_get_config()``
+4. **Platform detection** -- ``IS_WIN32``
+5. **Repository URL helpers** -- ``is_repo_url``, ``project_name_from_repo``
+6. **Environment accessors** -- ``get_ai_provider``, ``get_dashboard_port``,
+   ``get_evaluations_dir``, ``get_anthropic_api_key``, etc.
+7. **Diff display** -- ``show_diff``
 """
 from __future__ import annotations
 
@@ -261,3 +266,25 @@ def show_diff(path: Path, new_content: str) -> None:
         print("".join(diff))
     else:
         print(f"[no changes] {path}")
+
+
+__all__ = [
+    # I/O helpers (re-exported from _io.py)
+    "TEXT_ENCODING", "read_text", "write_text", "open_text", "read_json",
+    # Security helpers (re-exported from _security.py)
+    "SENSITIVE_PATTERNS", "sanitize_sensitive",
+    # Config
+    "Config", "ACTION_API_MODULE",
+    # Platform
+    "IS_WIN32",
+    # Repo URL helpers
+    "is_repo_url", "project_name_from_repo",
+    # Environment accessors
+    "get_ai_provider", "get_ai_cmd", "get_ai_model", "_env_int",
+    "get_action_api_port", "get_action_api_host",
+    "get_dashboard_port", "get_static_dist", "get_evaluations_dir",
+    "get_anthropic_api_key", "get_asvs_url",
+    "get_github_search_url", "get_github_raw_base_url", "get_findings_file",
+    # Diff
+    "show_diff",
+]

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-CPCgQ1yY.js"></script>
+    <script type="module" crossorigin src="/assets/index-DxiwchJi.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-BfapjkfH.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -209,13 +209,12 @@ function useAppState() {
   const settings = useAppSettings();
   const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
   const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun: effectiveRun });
-  const dailyRuns = useMemo(() => buildDailyRuns(availableRuns, dashboard?.trend || []), [availableRuns, dashboard]);
-  const visibleDailyRuns = useVisibleRuns(dailyRuns, dashboard, activePage.page, setSelectedRun);
+  const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
+    dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
+    ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
+  }), [availableRuns, dashboard, accumulated, selectedProject, projects]);
+  const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
-  const { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(
-    () => computeDerivedState(accumulated, dashboard, selectedProject, projects),
-    [accumulated, dashboard, selectedProject, projects]
-  );
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
   const knownTabs = ['overview', 'violations', 'history', 'projects', 'evaluate', 'standards', 'settings'];
   const activeTab = knownTabs.includes(activePage.page) ? activePage.page

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -98,7 +98,12 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
           runMode={runMode}
           data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
-          callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick }}
+          callbacks={{
+            onRunSelect,
+            onDimensionCardClick: handlers.handleDimensionCardClick,
+            onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick,
+            onFileClick: handlers.handleFileClick,
+          }}
         />
       )}
     </div>

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -260,7 +260,17 @@ export default function ProjectsPage({ projects = [], selectedProject, actions }
       ) : (
         <div className="projects-cards">
           {roots.map((p) => (
-            <ProjectCardGroup key={p.id || p.name || p} p={p} children={children} selectedProject={selectedProject} onSelect={onSelect} dialogActions={{ confirmActions: { confirming, setConfirming, onDelete, onExport }, relocateActions: { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate } }} />
+            <ProjectCardGroup
+              key={p.id || p.name || p}
+              p={p}
+              children={children}
+              selectedProject={selectedProject}
+              onSelect={onSelect}
+              dialogActions={{
+                confirmActions: { confirming, setConfirming, onDelete, onExport },
+                relocateActions: { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate },
+              }}
+            />
           ))}
         </div>
       )}

--- a/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/DimensionSelector.jsx
@@ -5,10 +5,10 @@ const TYPE_CONFIG = {
 };
 const DEFAULT_TYPE_CONFIG = { label: 'ISO', className: 'dimension-chip-type--builtin' };
 
-function typeLabel(dim) { return (TYPE_CONFIG[dim.standardType] || DEFAULT_TYPE_CONFIG).label; }
-function typeClass(dim) { return (TYPE_CONFIG[dim.standardType] || DEFAULT_TYPE_CONFIG).className; }
+function typeInfo(dim) { return TYPE_CONFIG[dim.standardType] || DEFAULT_TYPE_CONFIG; }
 
 function DimensionChip({ dim, isSelected, onToggle }) {
+  const info = typeInfo(dim);
   return (
     <button
       type="button"
@@ -18,7 +18,7 @@ function DimensionChip({ dim, isSelected, onToggle }) {
       onClick={() => onToggle(dim.id)}
     >
       {dim.label || dim.id}
-      <span className={`dimension-chip-type ${typeClass(dim)}`}>{typeLabel(dim)}</span>
+      <span className={`dimension-chip-type ${info.className}`}>{info.label}</span>
     </button>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -70,7 +70,13 @@ function useEvaluationForm(onStart) {
   const handleFolderSelect = (path) => { setRepo(path); setFolderBrowserOpen(false); };
   const handleRepoClear = () => { setRepo(''); setSelectedDims(new Set()); };
 
-  return { repo, setRepo, allDimensions, selectedDims, folderBrowserOpen, setFolderBrowserOpen, toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear, dimLoadError };
+  return {
+    repo, setRepo, allDimensions, selectedDims,
+    folderBrowserOpen, setFolderBrowserOpen,
+    toggleDim, selectAll, clearAll,
+    handleSubmit, handleFolderSelect, handleRepoClear,
+    dimLoadError,
+  };
 }
 
 export default function EvaluationForm({ onStart, disabled }) {

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -8,7 +8,7 @@ const BUTTON_GAP = '8px';
 const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: BUTTON_GAP, alignItems: 'center' };
 const flexButtonStyle = { flex: 1, marginTop: 0 };
 
-export default function ReEvaluateCard({ project, onStart, disabled }) {
+function useReEvaluateCard(project, onStart) {
   const [info, setInfo] = useState(null);
   const [error, setError] = useState(null);
   const { allDimensions } = usePluginDimensions();
@@ -25,42 +25,29 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
       });
   }, [project]);
 
-  if (error) return null;
-  if (!info) return null;
-
-  function toggleDim(id) {
+  const toggleDim = (id) => {
     setSelectedDims((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
       return next;
     });
-  }
-
-  function selectAll() {
-    setSelectedDims(new Set(allDimensions.map((d) => d.id)));
-  }
-
-  function clearAll() {
-    setSelectedDims(new Set());
-  }
-
-  function buildPayload(extra) {
+  };
+  const selectAll = () => setSelectedDims(new Set(allDimensions.map((d) => d.id)));
+  const clearAll = () => setSelectedDims(new Set());
+  const buildPayload = (extra) => {
     const payload = { repo: info.path, ...extra };
-    if (selectedDims.size > 0) {
-      payload.dimensions = [...selectedDims];
-    }
+    if (selectedDims.size > 0) payload.dimensions = [...selectedDims];
     return payload;
-  }
+  };
+  const handleStart = () => onStart(buildPayload());
+  const handleIncremental = () => onStart(buildPayload({ incremental: true }));
 
-  function handleStart() {
-    onStart(buildPayload());
-  }
+  return { info, error, allDimensions, selectedDims, toggleDim, selectAll, clearAll, handleStart, handleIncremental };
+}
 
-  function handleIncremental() {
-    onStart(buildPayload({ incremental: true }));
-  }
-
+function ReEvaluateCardView({ info, project, disabled, allDimensions, selectedDims, actions }) {
+  const { toggleDim, selectAll, clearAll, handleStart, handleIncremental } = actions;
   const canStart = !disabled && selectedDims.size > 0;
 
   return (
@@ -111,5 +98,25 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function ReEvaluateCard({ project, onStart, disabled }) {
+  const {
+    info, error, allDimensions, selectedDims,
+    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+  } = useReEvaluateCard(project, onStart);
+
+  if (error || !info) return null;
+
+  return (
+    <ReEvaluateCardView
+      info={info}
+      project={project}
+      disabled={disabled}
+      allDimensions={allDimensions}
+      selectedDims={selectedDims}
+      actions={{ toggleDim, selectAll, clearAll, handleStart, handleIncremental }}
+    />
   );
 }

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -12,6 +12,7 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+import { trendDirection } from '../../../utils/trendUtils.js';
 
 const MAX_CHART_RUNS = 40;
 const CHART_HEIGHT = 160;
@@ -37,8 +38,6 @@ function scoreBarColor(score) {
   if (n >= SCORE_POOR)      return cssVar('--color-grade-low-text');
   return cssVar('--color-grade-bottom-text');
 }
-
-import { trendDirection } from '../../../utils/trendUtils.js';
 
 function trendColor(dir) {
   const map = {

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -30,7 +30,9 @@ function HistoryEmpty() {
   );
 }
 
-function HistoryContent({ trend, selectedRunId, availableRuns, onRunClick, onRunChange, showAll, setShowAll, runNav }) {
+function HistoryContent({ data, callbacks, showAll, setShowAll, runNav }) {
+  const { trend, selectedRunId, availableRuns } = data;
+  const { onRunClick, onRunChange } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
   const deltas = computeDeltas(trend);
   const visible = showAll ? trend : trend.slice(0, MAX_VISIBLE);
@@ -90,8 +92,9 @@ export default function HistoryPage({ trend, selection, availableRuns, dimension
 
   return (
     <HistoryContent
-      trend={trend} selectedRunId={selectedRunId} availableRuns={availableRuns}
-      onRunClick={onRunClick} onRunChange={onRunChange} showAll={showAll} setShowAll={setShowAll}
+      data={{ trend, selectedRunId, availableRuns }}
+      callbacks={{ onRunClick, onRunChange }}
+      showAll={showAll} setShowAll={setShowAll}
       runNav={{ runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest }}
     />
   );

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -17,7 +17,12 @@ function useStandardsPageActions(refresh, handleDelete, addVisible, removeVisibl
   const handleSaved = (savedId) => { if (savedId) addVisible(savedId); setView({ mode: 'list' }); refresh(); };
   const handleDeleteWithCleanup = async (id) => { removeVisible(id); await handleDelete(id); };
 
-  return { view, showLibrary, setShowLibrary, showImport, setShowImport, handleEdit, handleNewStandard, handleEditorBack, handleSaved, handleDeleteWithCleanup };
+  return {
+    view, showLibrary, setShowLibrary,
+    showImport, setShowImport,
+    handleEdit, handleNewStandard, handleEditorBack,
+    handleSaved, handleDeleteWithCleanup,
+  };
 }
 
 function StandardsListView({ grouped, loading, error, actions }) {

--- a/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
@@ -95,19 +95,46 @@ function useImportModal(onImported) {
     setStep(STEP.IMPORTING);
     try {
       const result = await importStandard(data, force);
-      if (result._conflict) { setConflict(result.existing); setWarnings(result.warnings || []); setStep(STEP.CONFLICT); return; }
-      if (result.warnings?.length > 0 && !force) { setWarnings(result.warnings); setStep(STEP.WARNINGS); return; }
+      if (result._conflict) {
+        setConflict(result.existing);
+        setWarnings(result.warnings || []);
+        setStep(STEP.CONFLICT);
+        return;
+      }
+      if (result.warnings?.length > 0 && !force) {
+        setWarnings(result.warnings);
+        setStep(STEP.WARNINGS);
+        return;
+      }
       onImported();
-    } catch (err) { setError(err.message || 'Import failed'); setStep(STEP.ERROR); }
+    } catch (err) {
+      setError(err.message || 'Import failed');
+      setStep(STEP.ERROR);
+    }
   };
 
   const handleFile = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (file.size > MAX_FILE_SIZE) { setError(`File too large (${(file.size / 1024).toFixed(0)} KB). Maximum is 1 MB.`); setStep(STEP.ERROR); return; }
+    if (file.size > MAX_FILE_SIZE) {
+      setError(`File too large (${(file.size / 1024).toFixed(0)} KB). Maximum is 1 MB.`);
+      setStep(STEP.ERROR);
+      return;
+    }
     let data;
-    try { const text = await file.text(); data = JSON.parse(text); } catch { setError('Invalid file: could not parse as JSON.'); setStep(STEP.ERROR); return; }
-    if (typeof data !== 'object' || Array.isArray(data)) { setError('Invalid file: expected a JSON object.'); setStep(STEP.ERROR); return; }
+    try {
+      const text = await file.text();
+      data = JSON.parse(text);
+    } catch {
+      setError('Invalid file: could not parse as JSON.');
+      setStep(STEP.ERROR);
+      return;
+    }
+    if (typeof data !== 'object' || Array.isArray(data)) {
+      setError('Invalid file: expected a JSON object.');
+      setStep(STEP.ERROR);
+      return;
+    }
     setParsedData(data);
     await doImport(data, false);
   };

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -47,7 +47,8 @@ function useResizable(defaultWidth) {
   return { width, onMouseDown };
 }
 
-function EditorToolbar({ isNew, standard, standardId, dirty, editable, onBack, onSave }) {
+function EditorToolbar({ meta, dirty, editable, onBack, onSave }) {
+  const { isNew, standard, standardId } = meta;
   return (
     <div className="standard-editor-toolbar">
       <div className="editor-toolbar-top">
@@ -84,7 +85,9 @@ function EditorStatsRow({ standard }) {
   );
 }
 
-function EditorBody({ standard, selectedNode, setSelectedNode, treeWidth, onDividerMouseDown, actions, updateField, editable, isNew }) {
+function EditorBody({ treeProps, detailProps, treeWidth, onDividerMouseDown }) {
+  const { standard, selectedNode, setSelectedNode, actions, editable } = treeProps;
+  const { updateField, isNew } = detailProps;
   return (
     <div className="standard-editor-body">
       <div className="standard-editor-tree-panel" style={{ width: treeWidth, minWidth: MIN_TREE_WIDTH, maxWidth: MAX_TREE_WIDTH }}>
@@ -124,9 +127,18 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
 
   return (
     <div className="standard-editor">
-      <EditorToolbar isNew={isNew} standard={standard} standardId={standardId} dirty={dirty} editable={editable} onBack={onBack} onSave={handleSave} />
+      <EditorToolbar
+        meta={{ isNew, standard, standardId }}
+        dirty={dirty} editable={editable}
+        onBack={onBack} onSave={handleSave}
+      />
       {error && <p className="inline-error" style={{ margin: '8px 16px' }}>{error}</p>}
-      <EditorBody standard={standard} selectedNode={selectedNode} setSelectedNode={setSelectedNode} treeWidth={treeWidth} onDividerMouseDown={onDividerMouseDown} actions={treeActions} updateField={updateField} editable={editable} isNew={isNew} />
+      <EditorBody
+        treeProps={{ standard, selectedNode, setSelectedNode, actions: treeActions, editable }}
+        detailProps={{ updateField, isNew }}
+        treeWidth={treeWidth}
+        onDividerMouseDown={onDividerMouseDown}
+      />
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,9 +1,53 @@
 import { useState, useEffect } from 'react';
 
-function TreeNode({ node, actions, titles, children }) {
-  const { label, isSelected, depth = 0, alwaysExpanded = false, defaultExpanded = true } = node;
+function TreeNodeRow({ node, actions, titles, showExpand, expanded, setExpanded }) {
+  const { label, isSelected } = node;
   const { onClick, onAdd, onRemove } = actions;
   const { addTitle, removeTitle } = titles || {};
+
+  return (
+    <div
+      className={`tree-node-row${isSelected ? ' tree-node-row--selected' : ''}`}
+      onClick={() => { onClick(); if (showExpand) setExpanded((v) => !v); }}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === 'Enter' && onClick()}
+    >
+      {showExpand ? (
+        <span className="tree-expand-btn" aria-hidden="true">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
+            style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
+            <path d="M3 2l4 3-4 3V2z" />
+          </svg>
+        </span>
+      ) : (
+        <span className="tree-expand-btn tree-expand-btn--invisible" />
+      )}
+
+      <span className="tree-node-label">{label}</span>
+
+      <div className="tree-node-actions" onClick={(e) => e.stopPropagation()}>
+        {onAdd && (
+          <button type="button" className="tree-action-btn" onClick={onAdd} title={addTitle || 'Add'}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </button>
+        )}
+        {onRemove && (
+          <button type="button" className="tree-action-btn tree-action-btn--remove" onClick={onRemove} title={removeTitle || 'Remove'}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+              <path d="M5 12h14" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TreeNode({ node, actions, titles, children }) {
+  const { depth = 0, alwaysExpanded = false, defaultExpanded = true, isSelected } = node;
   const [expanded, setExpanded] = useState(alwaysExpanded || defaultExpanded);
 
   useEffect(() => {
@@ -14,44 +58,10 @@ function TreeNode({ node, actions, titles, children }) {
 
   return (
     <div className={`tree-node tree-node--depth-${depth}`}>
-      <div
-        className={`tree-node-row${isSelected ? ' tree-node-row--selected' : ''}`}
-        onClick={() => { onClick(); if (showExpand) setExpanded((v) => !v); }}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => e.key === 'Enter' && onClick()}
-      >
-        {showExpand ? (
-          <span className="tree-expand-btn" aria-hidden="true">
-            <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true"
-              style={{ transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)', transition: 'transform 150ms' }}>
-              <path d="M3 2l4 3-4 3V2z" />
-            </svg>
-          </span>
-        ) : (
-          <span className="tree-expand-btn tree-expand-btn--invisible" />
-        )}
-
-        <span className="tree-node-label">{label}</span>
-
-        <div className="tree-node-actions" onClick={(e) => e.stopPropagation()}>
-          {onAdd && (
-            <button type="button" className="tree-action-btn" onClick={onAdd} title={addTitle || 'Add'}>
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
-                <path d="M12 5v14M5 12h14" />
-              </svg>
-            </button>
-          )}
-          {onRemove && (
-            <button type="button" className="tree-action-btn tree-action-btn--remove" onClick={onRemove} title={removeTitle || 'Remove'}>
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
-                <path d="M5 12h14" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
-
+      <TreeNodeRow
+        node={node} actions={actions} titles={titles}
+        showExpand={showExpand} expanded={expanded} setExpanded={setExpanded}
+      />
       {(alwaysExpanded || expanded) && hasChildren && (
         <div className="tree-node-children">
           {children}
@@ -61,7 +71,8 @@ function TreeNode({ node, actions, titles, children }) {
   );
 }
 
-function RequirementNode({ req, ri, pi, selectedNode, onSelectNode, onRemoveRequirement, editable }) {
+function RequirementNode({ req, ri, pi, selectedNode, actions }) {
+  const { onSelectNode, onRemoveRequirement, editable } = actions;
   const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;
   const hasContent = req.text || req.description || (req.refs && req.refs.length > 0);
   const handleRemoveReq = () => {
@@ -80,7 +91,8 @@ function RequirementNode({ req, ri, pi, selectedNode, onSelectNode, onRemoveRequ
   );
 }
 
-function PrincipleNode({ principle, pi, selectedNode, onSelectNode, onAddRequirement, onRemovePrinciple, onRemoveRequirement, editable }) {
+function PrincipleNode({ principle, pi, selectedNode, actions }) {
+  const { onSelectNode, onAddRequirement, onRemovePrinciple, onRemoveRequirement, editable } = actions;
   const isPrincipleSelected = selectedNode?.type === 'principle' && selectedNode.index === pi;
   const reqCount = principle.requirements?.length || 0;
   const handleRemovePrinciple = () => {
@@ -97,7 +109,7 @@ function PrincipleNode({ principle, pi, selectedNode, onSelectNode, onAddRequire
       titles={{ addTitle: 'Add Requirement', removeTitle: 'Remove Principle' }}
     >
       {(principle.requirements || []).map((req, ri) => (
-        <RequirementNode key={ri} req={req} ri={ri} pi={pi} selectedNode={selectedNode} onSelectNode={onSelectNode} onRemoveRequirement={onRemoveRequirement} editable={editable} />
+        <RequirementNode key={ri} req={req} ri={ri} pi={pi} selectedNode={selectedNode} actions={actions} />
       ))}
     </TreeNode>
   );
@@ -107,6 +119,8 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, act
   const { onAddPrinciple, onRemovePrinciple, onAddRequirement, onRemoveRequirement } = actions || {};
   if (!standard) return null;
 
+  const treeActions = { onSelectNode, onAddRequirement, onRemovePrinciple, onRemoveRequirement, editable };
+
   return (
     <div className="standard-tree">
       <TreeNode
@@ -115,7 +129,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, act
         titles={{ addTitle: 'Add Principle' }}
       >
         {(standard.principles || []).map((principle, pi) => (
-          <PrincipleNode key={pi} principle={principle} pi={pi} selectedNode={selectedNode} onSelectNode={onSelectNode} onAddRequirement={onAddRequirement} onRemovePrinciple={onRemovePrinciple} onRemoveRequirement={onRemoveRequirement} editable={editable} />
+          <PrincipleNode key={pi} principle={principle} pi={pi} selectedNode={selectedNode} actions={treeActions} />
         ))}
       </TreeNode>
     </div>

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -91,5 +91,10 @@ export function useStandardDetail(standardId, isNew) {
 
   const editable = standard && !standard.managed;
 
-  return { standard, loading, error, dirty, editable, selectedNode, setSelectedNode, updateField, addPrinciple, removePrinciple, addRequirement, removeRequirement, save };
+  return {
+    standard, loading, error, dirty, editable,
+    selectedNode, setSelectedNode,
+    updateField, addPrinciple, removePrinciple,
+    addRequirement, removeRequirement, save,
+  };
 }

--- a/src/quodeq/ui/src/utils/planTextBuilders.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.js
@@ -1,6 +1,8 @@
 import { buildGroupPlanText } from './planBuilder.js';
 import { SEVERITY_ORDER } from './formatters.js';
 
+const addEntryTitle = (v) => ({ ...v, _entryTitle: v.principle || 'Violation' });
+
 /**
  * Build a copy-friendly plan text summarising violations for a single file.
  * @param {{ file: string, violationsBySeverity: Object }} file - File object with violation data.
@@ -8,11 +10,11 @@ import { SEVERITY_ORDER } from './formatters.js';
  */
 export function buildFilePlanText(file) {
   const allViolations = SEVERITY_ORDER.flatMap((sev) =>
-    (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }))
+    (file.violationsBySeverity?.[sev] || []).map(addEntryTitle)
   );
   const violationsBySeverity = {};
   for (const sev of SEVERITY_ORDER) {
-    violationsBySeverity[sev] = (file.violationsBySeverity?.[sev] || []).map((v) => ({ ...v, _entryTitle: v.principle || 'Violation' }));
+    violationsBySeverity[sev] = (file.violationsBySeverity?.[sev] || []).map(addEntryTitle);
   }
   return buildGroupPlanText({
     title: `\`${file.file}\``,

--- a/tests/engine/test_prompt_builder.py
+++ b/tests/engine/test_prompt_builder.py
@@ -183,13 +183,10 @@ class TestBuildAnalysisPrompt:
         )
         assert "No additional guidance" in prompt
 
-    def test_standards_written_to_file_when_work_dir_set(self, tmp_path):
-        """When work_dir is provided, standards are written to a file and the
-        prompt contains a read instruction instead of inline content."""
-        from quodeq.analysis.manifest import AnalysisTarget, SourceManifest
-
-        compiled_dir = tmp_path / "standards" / "compiled"
-        compiled_dir.mkdir(parents=True)
+    @staticmethod
+    def _create_security_compiled(compiled_dir: Path) -> None:
+        """Write a minimal compiled security standard to *compiled_dir*."""
+        compiled_dir.mkdir(parents=True, exist_ok=True)
         compiled = {
             "id": "security",
             "principles": [
@@ -205,13 +202,18 @@ class TestBuildAnalysisPrompt:
         }
         (compiled_dir / "security.json").write_text(json.dumps(compiled))
 
+    def test_standards_written_to_file_when_work_dir_set(self, tmp_path):
+        """When work_dir is provided, standards are written to a file and the
+        prompt contains a read instruction instead of inline content."""
+        from quodeq.analysis.manifest import AnalysisTarget, SourceManifest
+
+        self._create_security_compiled(tmp_path / "standards" / "compiled")
         work_dir = tmp_path / "work"
         work_dir.mkdir()
         target = AnalysisTarget(name="typescript", language="typescript", total_files=42)
         manifest = SourceManifest(targets=[target], total_files=42)
-        template = load_template()
         prompt = build_analysis_prompt(
-            template,
+            load_template(),
             PromptContext(
                 language="typescript",
                 repo_name="my-app",
@@ -224,16 +226,14 @@ class TestBuildAnalysisPrompt:
                 work_dir=work_dir,
             ),
         )
-        # Standards NOT inline — replaced by read instruction
         assert "Secrets MUST NOT be hardcoded" not in prompt
         assert "FIRST ACTION" in prompt
         assert ".quodeq_standards_security.md" in prompt
 
-        # Standards file was written (compact format: no headings, just ID: text)
         standards_file = work_dir / ".quodeq_standards_security.md"
         assert standards_file.exists()
         content = standards_file.read_text()
-        assert "### Confidentiality" not in content  # no principle headings
+        assert "### Confidentiality" not in content
         assert "S-CON-1: Secrets MUST NOT be hardcoded" in content
 
     def test_prompt_hash_present(self):


### PR DESCRIPTION
## Summary

- **10 major violations** fixed: reduce nesting depth, group excess parameters into dataclasses, reduce function fan-out, add injectable parameters for testability
- **37 minor violations** fixed: extract helpers from long functions, move inline imports to module level, extract magic numbers to constants, add docstrings to public APIs, format long single-line returns/props, extract duplicated code into shared utilities
- 38 files changed, 655 tests pass, UI builds clean

## Test plan

- [x] All 655 Python tests pass (`uv run pytest tests/ -x -q`)
- [x] UI builds cleanly (`npm run build`)
- [x] Smoke test dashboard in browser
- [x] Verify no import errors at runtime (`uv run quodeq --help`)