### PR TITLE
feat: online project reevaluation and clone-to-local

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ warn_unused_configs = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 
 [tool.coverage.run]
 source = ["quodeq"]

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -104,6 +104,33 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             return jsonify(body), status
         return jsonify(info)
 
+    @app.post("/api/projects/<project>/clone-local")
+    def clone_project_local(project: str) -> Response | tuple[Response, int]:
+        """Clone an online project's repo to a local directory."""
+        data = request.get_json(silent=True) or {}
+        destination = data.get("destination", "").strip()
+        if not destination:
+            body, status = error_response("destination is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        dest_resolved = Path(destination).resolve()
+        home = Path.home().resolve()
+        if not dest_resolved.is_relative_to(home):
+            body, status = error_response(
+                "Destination must be within the user's home directory",
+                HTTPStatus.FORBIDDEN,
+                "FORBIDDEN",
+            )
+            return jsonify(body), status
+        if not dest_resolved.is_dir():
+            body, status = error_response("Destination directory not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        _logger.info("clone_project_local: project=%s, dest=%s, remote_addr=%s", project, destination, request.remote_addr)
+        result = provider.clone_to_local(_reports_dir(), project, str(dest_resolved))
+        if result is None:
+            body, status = error_response("Clone failed — check project exists and is an online project", HTTPStatus.BAD_REQUEST, "CLONE_FAILED")
+            return jsonify(body), status
+        return jsonify(result)
+
 
 def register_project_data_routes(app: Flask, provider: ActionProvider) -> None:
     """Register project dashboard, accumulated, evaluation, and violation routes."""

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -291,5 +291,40 @@ def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
             return jsonify(body), status
         return jsonify(payload)
 
+    @app.post("/api/browse/mkdir")
+    def browse_mkdir() -> Response | tuple[Response, int]:
+        """Create a new subdirectory inside a given parent path."""
+        data = request.get_json(silent=True) or {}
+        parent = data.get("path", "").strip()
+        name = data.get("name", "").strip()
+        if not parent or not name:
+            body, status = error_response("path and name are required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        if "/" in name or "\\" in name or name in (".", ".."):
+            body, status = error_response("Invalid folder name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        resolved = Path(parent).resolve()
+        home = Path.home().resolve()
+        if not resolved.is_relative_to(home):
+            body, status = error_response(
+                "Path must be within the user's home directory",
+                HTTPStatus.FORBIDDEN,
+                "FORBIDDEN",
+            )
+            return jsonify(body), status
+        if not resolved.is_dir():
+            body, status = error_response("Parent path not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        target = resolved / name
+        try:
+            target.mkdir(parents=False, exist_ok=False)
+        except FileExistsError:
+            body, status = error_response("Folder already exists", HTTPStatus.CONFLICT, "CONFLICT")
+            return jsonify(body), status
+        except OSError as exc:
+            body, status = error_response(f"Could not create folder: {exc}", HTTPStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR")
+            return jsonify(body), status
+        return jsonify({"created": True, "path": str(target)})
+
 
 __all__ = ["register_static_routes"]  # re-exported from quodeq.api.helpers

--- a/src/quodeq/data/fs/project_resolver.py
+++ b/src/quodeq/data/fs/project_resolver.py
@@ -183,6 +183,12 @@ def _create_project(
     save_fn: Callable[[Path, dict[str, str]], None] = _save_index,
 ) -> str:
     """Create a new UUID project directory, write repository_info.json, and index it."""
+    if identity.location == "online" and not identity.repo_path.startswith(("https://", "git@")):
+        logging.getLogger(__name__).warning(
+            "Online project '%s' has a non-URL path '%s'; expected a remote URL.",
+            identity.project_name,
+            identity.repo_path,
+        )
     project_uuid = str(uuid.uuid4())
     project_dir = reports_dir / project_uuid
     project_dir.mkdir(parents=True, exist_ok=True)

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -42,6 +42,10 @@ class ProjectActions(Protocol):
         """Update the local filesystem path for a project. Return True on success."""
         ...
 
+    def clone_to_local(self, reports_dir: str, project: str, destination: str) -> dict | None:
+        """Clone an online project's repo to a local directory. Return updated info or None."""
+        ...
+
     def delete_project(self, reports_dir: str, project: str) -> bool:
         """Remove a project and all its report data. Return True on success."""
         ...

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -97,10 +97,13 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         return result
 
     def update_project_path(self, reports_dir: str, project: str, new_path: str) -> bool:
-        """Update the local filesystem path stored in a project's metadata."""
-        resolved_path = Path(new_path).resolve()
-        if not resolved_path.is_absolute() or not resolved_path.is_dir():
-            return False
+        """Update the path stored in a project's metadata.
+
+        Accepts both local directory paths and remote repository URLs.
+        """
+        from quodeq.shared.utils import is_repo_url
+        from quodeq.shared.repo_handler import is_valid_repo_url
+
         reports_root = Path(reports_dir).resolve()
         info_path = (reports_root / project).resolve()
         if not info_path.is_relative_to(reports_root):
@@ -108,10 +111,28 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         info_path = info_path / "repository_info.json"
         if not info_path.exists():
             return False
+
+        try:
+            is_url = is_repo_url(new_path)
+        except ValueError:
+            return False
+
+        if is_url:
+            if not is_valid_repo_url(new_path):
+                return False
+            resolved_path = new_path
+            location = "online"
+        else:
+            resolved = Path(new_path).resolve()
+            if not resolved.is_absolute() or not resolved.is_dir():
+                return False
+            resolved_path = str(resolved)
+            location = "local"
+
         try:
             info = json.loads(info_path.read_text())
-            info["path"] = str(resolved_path)
-            info["location"] = "local"
+            info["path"] = resolved_path
+            info["location"] = location
             info_path.write_text(json.dumps(info, indent=2))
             return True
         except (json.JSONDecodeError, OSError):

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -137,6 +138,53 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             return True
         except (json.JSONDecodeError, OSError):
             return False
+
+    def clone_to_local(self, reports_dir: str, project: str, destination: str) -> dict[str, Any] | None:
+        """Clone an online project's repo to a local path and update its metadata."""
+        import subprocess as _subprocess
+
+        from quodeq.shared.repo_handler import is_valid_repo_url
+
+        reports_root = Path(reports_dir).resolve()
+        info_path = (reports_root / project / "repository_info.json").resolve()
+        if not info_path.is_relative_to(reports_root) or not info_path.exists():
+            return None
+        try:
+            info = json.loads(info_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+        url = info.get("path", "")
+        if info.get("location") != "online" or not is_valid_repo_url(url):
+            return None
+
+        dest_dir = Path(destination).resolve()
+        if not dest_dir.is_dir():
+            return None
+
+        project_name = info.get("name", url.split("/")[-1].replace(".git", ""))
+        clone_dest = dest_dir / project_name
+
+        env = {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"}
+        try:
+            _subprocess.run(
+                ["git", "clone", "--progress", url, str(clone_dest)],
+                check=True,
+                env=env,
+                timeout=300,
+            )
+        except (_subprocess.CalledProcessError, _subprocess.TimeoutExpired, OSError):
+            return None
+
+        resolved_clone = str(clone_dest.resolve())
+        info["path"] = resolved_clone
+        info["location"] = "local"
+        try:
+            info_path.write_text(json.dumps(info, indent=2))
+        except OSError:
+            return None
+
+        return self.get_project_info(reports_dir, project)
 
     def delete_project(self, reports_dir: str, project: str) -> bool:
         """Remove a project directory and all its report data."""

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -162,8 +162,21 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         if not dest_dir.is_dir():
             return None
 
+        from quodeq.data.fs.repo_handler import _PRIVATE_HOST_RE, _resolves_to_private
+
+        if _PRIVATE_HOST_RE.match(url):
+            return None
+        if url.startswith("http"):
+            import urllib.parse
+            hostname = urllib.parse.urlparse(url).hostname or ""
+            if hostname and _resolves_to_private(hostname):
+                return None
+
         project_name = info.get("name", url.split("/")[-1].replace(".git", ""))
         clone_dest = dest_dir / project_name
+
+        if clone_dest.exists():
+            return None
 
         env = {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"}
         try:

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -146,7 +146,18 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         discipline = info.get("discipline") or _infer_discipline(Path(reports_dir), project)
         available_dimensions = _list_available_dimensions_for_discipline() if discipline else []
         has_fingerprints = _has_fingerprints(Path(reports_dir), project)
-        return {**info, "discipline": discipline, "availableDimensions": available_dimensions, "hasFingerprints": has_fingerprints}
+        # Detect stale path: online project with a local path instead of a URL
+        path_missing = (
+            info.get("location") == "online"
+            and not (info.get("path", "").startswith(("https://", "git@")))
+        )
+        return {
+            **info,
+            "discipline": discipline,
+            "availableDimensions": available_dimensions,
+            "hasFingerprints": has_fingerprints,
+            "pathMissing": path_missing,
+        }
 
     def get_dashboard(self, reports_dir: str, project: str, run: str) -> dict[str, Any]:
         """Return the dashboard payload for a specific project run."""

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-DxiwchJi.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BfapjkfH.css">
+    <script type="module" crossorigin src="/assets/index-DiW3bZDF.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DaBaZxOh.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -74,6 +74,13 @@ export function relocateProject(projectId, newPath) {
   });
 }
 
+export function cloneToLocal(projectId, destination) {
+  return request(`/projects/${encodeURIComponent(projectId)}/clone-local`, {
+    method: 'POST',
+    body: JSON.stringify({ destination }),
+  });
+}
+
 // ── Dashboard ───────────────────────────────────────────────────────────
 
 /** @returns {Promise<import('../models/dashboard.js').Dashboard>} */
@@ -131,6 +138,13 @@ export async function getDimensionEval(projectId, runId, dimension) {
 export function browseDirectory(dirPath = '') {
   const q = dirPath ? `?path=${encodeURIComponent(dirPath)}` : '';
   return request(`/browse${q}`);
+}
+
+export function createDirectory(path, name) {
+  return request('/browse/mkdir', {
+    method: 'POST',
+    body: JSON.stringify({ path, name }),
+  });
 }
 
 export function listPlugins() {

--- a/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
@@ -34,7 +34,7 @@ function FolderList({ data, navError, selectedFolder, setSelectedFolder, navigat
   );
 }
 
-function FolderPathBar({ data, loading, pathInput, setPathInput, onNavigate }) {
+function FolderPathBar({ data, loading, pathInput, setPathInput, onNavigate, onNewFolder }) {
   return (
     <div className="folder-browser-path">
       <button
@@ -45,6 +45,17 @@ function FolderPathBar({ data, loading, pathInput, setPathInput, onNavigate }) {
       >
         ↑
       </button>
+      {onNewFolder && (
+        <button
+          className="folder-nav-btn folder-new-btn"
+          disabled={loading}
+          onClick={onNewFolder}
+          aria-label="Create new folder"
+          title="New folder"
+        >
+          +
+        </button>
+      )}
       <input
         type="text"
         className="folder-path-input"
@@ -58,7 +69,7 @@ function FolderPathBar({ data, loading, pathInput, setPathInput, onNavigate }) {
   );
 }
 
-function FolderFooter({ selectedFolder, onClose, onConfirm }) {
+function FolderFooter({ selectedFolder, onClose, onConfirm, confirmText = 'Use This Folder' }) {
   return (
     <div className="folder-browser-footer">
       <div className={`selected-path ${selectedFolder ? 'visible' : ''}`}>
@@ -68,7 +79,7 @@ function FolderFooter({ selectedFolder, onClose, onConfirm }) {
       <div className="folder-browser-actions">
         <button className="btn-cancel" onClick={onClose}>Cancel</button>
         <button className="btn-confirm" onClick={onConfirm} disabled={!selectedFolder}>
-          Use This Folder
+          {confirmText}
         </button>
       </div>
     </div>
@@ -92,18 +103,53 @@ async function navigateFolder(path, navigation) {
   }
 }
 
-function FolderBrowserDialog({ state, actions, navigation, selection }) {
+function FolderBrowserDialog({ state, actions, navigation, selection, title, confirmText }) {
   const { data, loading, pathInput, navError } = state;
   const { navigate, onClose, onConfirm } = actions;
   const { selectedFolder, setSelectedFolder } = selection;
   const { setPathInput } = navigation;
+
+  const [newFolderName, setNewFolderName] = useState('');
+  const [creatingFolder, setCreatingFolder] = useState(false);
+  const [newFolderError, setNewFolderError] = useState(null);
+
+  async function handleNewFolder() {
+    if (!newFolderName.trim() || !data?.current) return;
+    setNewFolderError(null);
+    try {
+      const { createDirectory } = await import('../../../api/index.js');
+      await createDirectory(data.current, newFolderName.trim());
+      setCreatingFolder(false);
+      setNewFolderName('');
+      navigate(data.current);
+    } catch (err) {
+      setNewFolderError(err.message || 'Failed to create folder');
+    }
+  }
+
   return (
     <div className="modal folder-browser-modal" role="dialog" aria-modal="true" aria-labelledby="folder-browser-title" onClick={(e) => e.stopPropagation()}>
       <div className="modal-header">
-        <h2 id="folder-browser-title">Select Repository Folder</h2>
+        <h2 id="folder-browser-title">{title}</h2>
         <button className="modal-close" onClick={onClose} aria-label="Close">&times;</button>
       </div>
-      <FolderPathBar data={data} loading={loading} pathInput={pathInput} setPathInput={setPathInput} onNavigate={navigate} />
+      <FolderPathBar data={data} loading={loading} pathInput={pathInput} setPathInput={setPathInput} onNavigate={navigate} onNewFolder={() => setCreatingFolder(true)} />
+      {creatingFolder && (
+        <div className="new-folder-row">
+          <input
+            type="text"
+            className="new-folder-input"
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleNewFolder(); if (e.key === 'Escape') setCreatingFolder(false); }}
+            placeholder="Folder name"
+            autoFocus
+          />
+          <button className="folder-nav-btn" onClick={handleNewFolder} disabled={!newFolderName.trim()}>Create</button>
+          <button className="folder-nav-btn" onClick={() => setCreatingFolder(false)}>✕</button>
+          {newFolderError && <span className="inline-error">{newFolderError}</span>}
+        </div>
+      )}
       <div className="folder-browser-list">
         {loading ? (
           <p className="loading" role="status" aria-live="polite">Loading...</p>
@@ -111,12 +157,12 @@ function FolderBrowserDialog({ state, actions, navigation, selection }) {
           <FolderList data={data} navError={navError} selectedFolder={selectedFolder} setSelectedFolder={setSelectedFolder} navigate={navigate} />
         )}
       </div>
-      <FolderFooter selectedFolder={selectedFolder} onClose={onClose} onConfirm={onConfirm} />
+      <FolderFooter selectedFolder={selectedFolder} onClose={onClose} onConfirm={onConfirm} confirmText={confirmText} />
     </div>
   );
 }
 
-export default function FolderBrowser({ onSelect, onClose }) {
+export default function FolderBrowser({ onSelect, onClose, title = 'Select Repository Folder', confirmText = 'Use This Folder' }) {
   const [currentPath, setCurrentPath] = useState('');
   const [pathInput, setPathInput] = useState('');
   const [data, setData] = useState(null);
@@ -139,6 +185,8 @@ export default function FolderBrowser({ onSelect, onClose }) {
         actions={{ navigate, onClose, onConfirm: () => { if (selectedFolder) onSelect(selectedFolder); } }}
         navigation={{ setPathInput }}
         selection={{ selectedFolder, setSelectedFolder }}
+        title={title}
+        confirmText={confirmText}
       />
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { browseDirectory } from '../../../api/index.js';
+import { browseDirectory, createDirectory } from '../../../api/index.js';
 
 function FolderList({ data, navError, selectedFolder, setSelectedFolder, navigate }) {
   return (
@@ -117,7 +117,6 @@ function FolderBrowserDialog({ state, actions, navigation, selection, title, con
     if (!newFolderName.trim() || !data?.current) return;
     setNewFolderError(null);
     try {
-      const { createDirectory } = await import('../../../api/index.js');
       await createDirectory(data.current, newFolderName.trim());
       setCreatingFolder(false);
       setNewFolderName('');

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { getProjectInfo } from '../../../api/index.js';
+import { getProjectInfo, relocateProject, cloneToLocal } from '../../../api/index.js';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import DimensionSelector from './DimensionSelector.jsx';
+import FolderBrowser from './FolderBrowser.jsx';
 
 
 const BUTTON_GAP = '8px';
@@ -13,6 +14,13 @@ function useReEvaluateCard(project, onStart) {
   const [error, setError] = useState(null);
   const { allDimensions } = usePluginDimensions();
   const [selectedDims, setSelectedDims] = useState(new Set());
+  const [urlInput, setUrlInput] = useState('');
+  const [urlError, setUrlError] = useState(null);
+  const [urlSaving, setUrlSaving] = useState(false);
+  const [cloneBrowserOpen, setCloneBrowserOpen] = useState(false);
+  const [cloning, setCloning] = useState(false);
+  const [cloneDest, setCloneDest] = useState('');
+  const [cloneError, setCloneError] = useState(null);
 
   useEffect(() => {
     if (!project) return;
@@ -43,12 +51,54 @@ function useReEvaluateCard(project, onStart) {
   const handleStart = () => onStart(buildPayload());
   const handleIncremental = () => onStart(buildPayload({ incremental: true }));
 
-  return { info, error, allDimensions, selectedDims, toggleDim, selectAll, clearAll, handleStart, handleIncremental };
+  async function handleUrlRestore() {
+    const url = urlInput.trim();
+    if (!url) return;
+    setUrlSaving(true);
+    setUrlError(null);
+    try {
+      await relocateProject(project, url);
+      const updated = await getProjectInfo(project);
+      setInfo(updated);
+      setUrlInput('');
+    } catch (err) {
+      setUrlError(err.message || 'Failed to update URL');
+    } finally {
+      setUrlSaving(false);
+    }
+  }
+
+  async function handleCloneToLocal(destination) {
+    setCloneBrowserOpen(false);
+    setCloning(true);
+    setCloneDest(destination);
+    setCloneError(null);
+    try {
+      const updated = await cloneToLocal(project, destination);
+      setInfo(updated);
+    } catch (err) {
+      setCloneError(err.message || 'Clone failed');
+    } finally {
+      setCloning(false);
+    }
+  }
+
+  return {
+    info, error, allDimensions, selectedDims,
+    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
+    cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
+  };
 }
 
 function ReEvaluateCardView({ info, project, disabled, allDimensions, selectedDims, actions }) {
-  const { toggleDim, selectAll, clearAll, handleStart, handleIncremental } = actions;
-  const canStart = !disabled && selectedDims.size > 0;
+  const {
+    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
+    cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
+  } = actions;
+
+  const canStart = !disabled && !cloning && selectedDims.size > 0 && !info.pathMissing;
 
   return (
     <div className="panel evaluate-panel">
@@ -62,13 +112,60 @@ function ReEvaluateCardView({ info, project, disabled, allDimensions, selectedDi
           <code>{info.path}</code>
         </div>
 
+        {info.pathMissing && (
+          <div className="re-eval-stale-warning">
+            <p>This project was evaluated from a remote repo but the original URL was not saved. Enter the URL to restore reevaluation.</p>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+              <input
+                type="text"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleUrlRestore(); }}
+                placeholder="https://github.com/org/repo"
+                className="re-eval-url-input"
+                disabled={urlSaving}
+              />
+              <button
+                type="button"
+                className="evaluate-submit-btn"
+                style={{ padding: '8px 16px', fontSize: '0.85rem' }}
+                disabled={!urlInput.trim() || urlSaving}
+                onClick={handleUrlRestore}
+              >
+                {urlSaving ? 'Saving...' : 'Restore'}
+              </button>
+            </div>
+            {urlError && <p className="inline-error">{urlError}</p>}
+          </div>
+        )}
+
+        {info.location === 'online' && !info.pathMissing && !cloning && (
+          <div className="re-eval-clone-row">
+            <a
+              href="#"
+              className="re-eval-clone-link"
+              onClick={(e) => { e.preventDefault(); setCloneBrowserOpen(true); }}
+            >
+              ⬇ Clone to local storage
+            </a>
+          </div>
+        )}
+        {cloneError && <p className="inline-error">{cloneError}</p>}
+        {cloning && (
+          <div className="re-eval-clone-banner">
+            <span className="re-eval-clone-spinner" />
+            <span>Cloning to <code>{cloneDest}</code>...</span>
+          </div>
+        )}
+
+        <div className={cloning ? 're-eval-disabled-section' : ''}>
         {allDimensions.length > 0 && (
           <DimensionSelector
             allDimensions={allDimensions}
             selectedDims={selectedDims}
-            onToggle={toggleDim}
-            onSelectAll={selectAll}
-            onClearAll={clearAll}
+            onToggle={cloning ? undefined : toggleDim}
+            onSelectAll={cloning ? undefined : selectAll}
+            onClearAll={cloning ? undefined : clearAll}
           />
         )}
 
@@ -96,7 +193,17 @@ function ReEvaluateCardView({ info, project, disabled, allDimensions, selectedDi
             {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}
           </button>
         </div>
+        </div>
       </div>
+
+      {cloneBrowserOpen && (
+        <FolderBrowser
+          onSelect={handleCloneToLocal}
+          onClose={() => setCloneBrowserOpen(false)}
+          title="Select Clone Destination"
+          confirmText="Clone Here"
+        />
+      )}
     </div>
   );
 }
@@ -105,6 +212,8 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
   const {
     info, error, allDimensions, selectedDims,
     toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
+    cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
   } = useReEvaluateCard(project, onStart);
 
   if (error || !info) return null;
@@ -116,7 +225,11 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
       disabled={disabled}
       allDimensions={allDimensions}
       selectedDims={selectedDims}
-      actions={{ toggleDim, selectAll, clearAll, handleStart, handleIncremental }}
+      actions={{
+        toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+        urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
+        cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
+      }}
     />
   );
 }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2016,3 +2016,29 @@
   background: color-mix(in srgb, var(--primitive-green-400, #4ade80) 15%, transparent);
   color: var(--primitive-green-700, #4ade80);
 }
+
+/* New folder inline row */
+.new-folder-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.new-folder-input {
+  flex: 1;
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-family: var(--font-data);
+}
+
+.folder-new-btn {
+  font-size: 1.1rem;
+  font-weight: bold;
+}

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -878,6 +878,51 @@
   min-width: 0;
 }
 
+/* Stale path warning */
+.re-eval-stale-warning {
+  padding: var(--space-3);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 10%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, var(--color-warning, #f59e0b) 30%, var(--color-border));
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-3);
+}
+
+.re-eval-stale-warning p {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.re-eval-url-input {
+  flex: 1;
+  padding: var(--space-2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-family: var(--font-data);
+}
+
+/* Clone to local link */
+.re-eval-clone-link {
+  display: inline-block;
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  text-decoration: none;
+  margin-bottom: var(--space-3);
+}
+
+.re-eval-clone-link:hover {
+  text-decoration: underline;
+}
+
+.re-eval-clone-status {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: var(--space-1) 0;
+}
+
 /* Dimension label row: label left, actions right */
 .dimension-label-row {
   display: flex;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,6 @@
 """Shared test fixtures and helpers."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-# Ensure tests always load the worktree's source, not the installed package.
-_WORKTREE_SRC = str(Path(__file__).parent.parent / "src")
-if _WORKTREE_SRC not in sys.path:
-    sys.path.insert(0, _WORKTREE_SRC)
-
 import pytest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 """Shared test fixtures and helpers."""
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Ensure tests always load the worktree's source, not the installed package.
+_WORKTREE_SRC = str(Path(__file__).parent.parent / "src")
+if _WORKTREE_SRC not in sys.path:
+    sys.path.insert(0, _WORKTREE_SRC)
+
 import pytest
 
 

--- a/tests/test_browse_mkdir.py
+++ b/tests/test_browse_mkdir.py
@@ -1,0 +1,74 @@
+"""Tests for POST /api/browse/mkdir endpoint."""
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+from quodeq.api.app import create_app
+
+_ORIGIN = {"Origin": "http://localhost"}
+
+
+@pytest.fixture()
+def app_client(tmp_path):
+    app = create_app(test_config={"TESTING": True})
+    home = tmp_path.resolve()
+    with app.test_client() as c:
+        yield c, home
+
+
+def _patch_home(home: Path):
+    """Return a context manager that patches Path.home() to return *home*."""
+    return patch("pathlib.Path.home", new=classmethod(lambda cls: home))
+
+
+def test_mkdir_creates_directory(app_client):
+    c, home = app_client
+    parent = home / "projects"
+    parent.mkdir()
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(parent), "name": "new_folder"}, headers=_ORIGIN)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["created"] is True
+    assert (parent / "new_folder").is_dir()
+
+
+def test_mkdir_outside_home_returns_403(app_client):
+    c, home = app_client
+    outside = Path("/tmp")
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(outside), "name": "evil_dir"}, headers=_ORIGIN)
+    assert resp.status_code == 403
+
+
+def test_mkdir_path_traversal_in_name_returns_400(app_client):
+    c, home = app_client
+    parent = home / "projects"
+    parent.mkdir()
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(parent), "name": "../escape"}, headers=_ORIGIN)
+    assert resp.status_code == 400
+
+
+def test_mkdir_missing_fields_returns_400(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(home)}, headers=_ORIGIN)
+    assert resp.status_code == 400
+
+
+def test_mkdir_conflict_returns_409(app_client):
+    c, home = app_client
+    parent = home / "projects"
+    parent.mkdir()
+    existing = parent / "already_there"
+    existing.mkdir()
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(parent), "name": "already_there"}, headers=_ORIGIN)
+    assert resp.status_code == 409
+
+
+def test_mkdir_parent_not_found_returns_404(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post("/api/browse/mkdir", json={"path": str(home / "nonexistent"), "name": "child"}, headers=_ORIGIN)
+    assert resp.status_code == 404

--- a/tests/test_clone_local_endpoint.py
+++ b/tests/test_clone_local_endpoint.py
@@ -1,0 +1,40 @@
+"""Tests for POST /api/projects/<id>/clone-local endpoint."""
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+from quodeq.api.app import create_app
+
+_ORIGIN = {"Origin": "http://localhost"}
+
+
+@pytest.fixture()
+def app_client(tmp_path):
+    app = create_app(test_config={"TESTING": True})
+    home = tmp_path.resolve()
+    with app.test_client() as c:
+        yield c, home
+
+
+def _patch_home(home: Path):
+    """Return a context manager that patches Path.home() to return *home*."""
+    return patch("pathlib.Path.home", new=classmethod(lambda cls: home))
+
+
+def test_clone_local_no_body_returns_400(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post("/api/projects/fake-uuid/clone-local", json={}, headers=_ORIGIN)
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "destination" in data.get("error", "").lower()
+
+
+def test_clone_local_outside_home_returns_403(app_client):
+    c, home = app_client
+    with _patch_home(home):
+        resp = c.post(
+            "/api/projects/fake-uuid/clone-local",
+            json={"destination": "/etc"},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 403

--- a/tests/test_project_resolver_online.py
+++ b/tests/test_project_resolver_online.py
@@ -88,3 +88,16 @@ def test_get_project_info_valid_online_not_missing(tmp_path: Path) -> None:
     info = provider.get_project_info(str(tmp_path), project_uuid)
     assert info is not None
     assert info["pathMissing"] is False
+
+
+def test_update_project_path_accepts_url(tmp_path: Path) -> None:
+    """update_project_path should accept a URL for online projects."""
+    project_uuid = _create_online_project_with_temp_path(tmp_path)
+    provider = FilesystemActionProvider()
+    ok = provider.update_project_path(
+        str(tmp_path), project_uuid, "https://github.com/shaka-project/shaka-player"
+    )
+    assert ok is True
+    info = json.loads((tmp_path / project_uuid / "repository_info.json").read_text())
+    assert info["path"] == "https://github.com/shaka-project/shaka-player"
+    assert info["location"] == "online"

--- a/tests/test_project_resolver_online.py
+++ b/tests/test_project_resolver_online.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from quodeq.data.fs.project_resolver import (
+    ProjectIdentity,
+    resolve_project_uuid,
+    clear_index_cache,
+)
+
+
+def test_online_project_stores_url(tmp_path: Path) -> None:
+    """An online project must store the original URL as its path."""
+    clear_index_cache()
+    identity = ProjectIdentity(
+        project_name="shaka-player",
+        repo_path="https://github.com/shaka-project/shaka-player",
+        discipline=None,
+        location="online",
+    )
+    project_uuid = resolve_project_uuid(tmp_path, identity)
+    info = json.loads((tmp_path / project_uuid / "repository_info.json").read_text())
+    assert info["path"] == "https://github.com/shaka-project/shaka-player"
+    assert info["location"] == "online"
+
+
+def test_online_project_with_temp_path_logs_warning(tmp_path: Path, capsys) -> None:
+    """Creating an online project with a local path should log a warning."""
+    clear_index_cache()
+    identity = ProjectIdentity(
+        project_name="shaka-player",
+        repo_path="/private/var/folders/t2/xyz/shaka-player",
+        discipline=None,
+        location="online",
+    )
+    resolve_project_uuid(tmp_path, identity)
+    captured = capsys.readouterr()
+    assert "online project" in captured.err.lower()

--- a/tests/test_project_resolver_online.py
+++ b/tests/test_project_resolver_online.py
@@ -90,6 +90,60 @@ def test_get_project_info_valid_online_not_missing(tmp_path: Path) -> None:
     assert info["pathMissing"] is False
 
 
+import subprocess
+
+
+def test_clone_to_local_updates_project(tmp_path: Path, monkeypatch) -> None:
+    """clone_to_local should clone the repo and update repository_info.json."""
+    project_uuid = _create_online_project_with_url(tmp_path)
+    dest = tmp_path / "local_repos"
+    dest.mkdir()
+
+    def fake_run(cmd, check, **kwargs):
+        clone_dest = Path(cmd[-1])
+        clone_dest.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    provider = FilesystemActionProvider()
+    result = provider.clone_to_local(str(tmp_path), project_uuid, str(dest))
+    assert result is not None
+    assert result["location"] == "local"
+    assert "shaka-player" in result["path"]
+    assert Path(result["path"]).is_dir()
+
+    info = json.loads((tmp_path / project_uuid / "repository_info.json").read_text())
+    assert info["location"] == "local"
+    assert info["path"] == result["path"]
+
+
+def _create_local_project(reports_dir: Path, local_path: Path) -> str:
+    """Helper: create a project with location=local."""
+    import uuid as _uuid
+    project_uuid = str(_uuid.uuid4())
+    project_dir = reports_dir / project_uuid
+    project_dir.mkdir(parents=True, exist_ok=True)
+    info = {
+        "uuid": project_uuid,
+        "name": "my-project",
+        "discipline": None,
+        "location": "local",
+        "path": str(local_path),
+    }
+    (project_dir / "repository_info.json").write_text(json.dumps(info))
+    return project_uuid
+
+
+def test_clone_to_local_rejects_local_project(tmp_path: Path) -> None:
+    """clone_to_local should return None for projects already local."""
+    local_path = tmp_path / "existing"
+    local_path.mkdir()
+    project_uuid = _create_local_project(tmp_path, local_path)
+    provider = FilesystemActionProvider()
+    result = provider.clone_to_local(str(tmp_path), project_uuid, str(tmp_path / "dest"))
+    assert result is None
+
+
 def test_update_project_path_accepts_url(tmp_path: Path) -> None:
     """update_project_path should accept a URL for online projects."""
     project_uuid = _create_online_project_with_temp_path(tmp_path)

--- a/tests/test_project_resolver_online.py
+++ b/tests/test_project_resolver_online.py
@@ -6,6 +6,7 @@ from quodeq.data.fs.project_resolver import (
     resolve_project_uuid,
     clear_index_cache,
 )
+from quodeq.services.filesystem import FilesystemActionProvider
 
 
 def test_online_project_stores_url(tmp_path: Path) -> None:
@@ -35,3 +36,55 @@ def test_online_project_with_temp_path_logs_warning(tmp_path: Path, capsys) -> N
     resolve_project_uuid(tmp_path, identity)
     captured = capsys.readouterr()
     assert "online project" in captured.err.lower()
+
+
+def _create_online_project_with_temp_path(reports_dir: Path) -> str:
+    """Helper: create a project with location=online but a local temp path (simulates the bug)."""
+    import uuid as _uuid
+    project_uuid = str(_uuid.uuid4())
+    project_dir = reports_dir / project_uuid
+    project_dir.mkdir(parents=True, exist_ok=True)
+    info = {
+        "uuid": project_uuid,
+        "name": "shaka-player",
+        "discipline": None,
+        "location": "online",
+        "path": "/private/var/folders/t2/xyz/shaka-player",
+    }
+    (project_dir / "repository_info.json").write_text(json.dumps(info))
+    return project_uuid
+
+
+def _create_online_project_with_url(reports_dir: Path) -> str:
+    """Helper: create a project with location=online and a proper URL path."""
+    import uuid as _uuid
+    project_uuid = str(_uuid.uuid4())
+    project_dir = reports_dir / project_uuid
+    project_dir.mkdir(parents=True, exist_ok=True)
+    info = {
+        "uuid": project_uuid,
+        "name": "shaka-player",
+        "discipline": None,
+        "location": "online",
+        "path": "https://github.com/shaka-project/shaka-player",
+    }
+    (project_dir / "repository_info.json").write_text(json.dumps(info))
+    return project_uuid
+
+
+def test_get_project_info_detects_stale_online_path(tmp_path: Path) -> None:
+    """get_project_info should flag online projects with non-URL paths."""
+    project_uuid = _create_online_project_with_temp_path(tmp_path)
+    provider = FilesystemActionProvider()
+    info = provider.get_project_info(str(tmp_path), project_uuid)
+    assert info is not None
+    assert info["pathMissing"] is True
+
+
+def test_get_project_info_valid_online_not_missing(tmp_path: Path) -> None:
+    """Online project with a proper URL should have pathMissing=False."""
+    project_uuid = _create_online_project_with_url(tmp_path)
+    provider = FilesystemActionProvider()
+    info = provider.get_project_info(str(tmp_path), project_uuid)
+    assert info is not None
+    assert info["pathMissing"] is False


### PR DESCRIPTION
## Summary

- **Bug fix**: Online projects now correctly store the original URL (not the temp clone path) for reevaluation. Stale paths are detected and users can restore the URL via the UI.
- **Clone to local**: Online projects can be cloned to a permanent local directory via a new "Clone to local storage" action in the Re-evaluate card, using the existing FolderBrowser with a new "New Folder" capability.
- **UI polish**: Clone link is right-aligned near the path. During cloning, an inline progress banner shows the destination while dimensions and buttons are disabled.

## Changes

### Backend
- Defensive guard in `_create_project` warns when online projects get non-URL paths
- `get_project_info` returns `pathMissing` flag for stale online project paths
- `update_project_path` extended to accept URLs for online projects
- New `POST /api/browse/mkdir` endpoint for creating directories
- New `clone_to_local()` method with SSRF protection (private host + DNS rebinding checks)
- New `POST /api/projects/<id>/clone-local` endpoint

### Frontend
- `ReEvaluateCard`: stale path warning with URL restore input, clone-to-local link with inline progress banner, disabled controls during cloning
- `FolderBrowser`: configurable title/confirmText props, "New Folder" button
- New `cloneToLocal()` and `createDirectory()` API functions

## Test plan

- [x] 15 new tests added (670 total, all passing)
- [x] Manual: evaluate an online project, verify URL is stored correctly
- [x] Manual: select online project, click "Clone to local storage", verify FolderBrowser opens with "Clone Here" button
- [x] Manual: create new folder via "+" button in FolderBrowser
- [x] Manual: clone completes, project switches to "Local" with correct path
- [x] Manual: verify dimensions and buttons are disabled during cloning