### PR TITLE
fix: resolve remaining maintainability violations (round 3)

### DIFF
--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -194,7 +194,17 @@ def build_analysis_prompt(template: str, context: PromptContext) -> str:
 
 
 def _render_all_standards(standards_dir: Path, dimensions: list[str], evaluators_dir: Path | None = None) -> str:
-    """Render compact standards for all dimensions, separated by headers."""
+    """Render compact standards for all dimensions, separated by headers.
+
+    Args:
+        standards_dir: Root standards directory containing a ``compiled/`` subdirectory.
+        dimensions: Dimension IDs to include (e.g. ``["security", "reliability"]``).
+        evaluators_dir: Optional path to custom evaluator JSON files.
+
+    Returns:
+        Markdown string with per-dimension sections, or a fallback message
+        when no standards are available.
+    """
     compiled_dir = standards_dir / "compiled"
     _eval_dir = evaluators_dir
     if not compiled_dir.exists() and not (_eval_dir and _eval_dir.is_dir()):

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -54,19 +54,27 @@ def _classify_jsonl_line(line: str, counts: FindingCounts) -> None:
         pass
 
 
+def _read_findings_from_file(jsonl_path: Path) -> FindingCounts:
+    """Open *jsonl_path* and classify every non-empty line into finding counts.
+
+    Caller is responsible for holding any required lock before invoking this.
+    """
+    counts = FindingCounts()
+    with open_text(jsonl_path) as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                _classify_jsonl_line(stripped, counts)
+    return counts
+
+
 def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCounts:
     """Count total, violation, and compliance lines in a JSONL file under a lock."""
     try:
         if not jsonl_path.exists():
             return FindingCounts()
-        counts = FindingCounts()
         with lock:
-            with open_text(jsonl_path) as f:
-                for line in f:
-                    stripped = line.strip()
-                    if stripped:
-                        _classify_jsonl_line(stripped, counts)
-        return counts
+            return _read_findings_from_file(jsonl_path)
     except OSError:
         return FindingCounts()
 

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -174,13 +174,17 @@ class FsToolingMixin:
         fetcher = self._model_fetchers.get(client_id, self._get_cli_models)
         return fetcher(client_id)
 
-    def _get_claude_models(self, _client_id: str = "claude", api_key: str | None = None) -> dict[str, list[str]]:
+    def _get_claude_models(
+        self, _client_id: str = "claude", api_key: str | None = None,
+        key_fn: Callable[[], str | None] | None = None,
+    ) -> dict[str, list[str]]:
         """Fetch Claude model list from the Anthropic API, with fallback.
 
-        Pass *api_key* to override the global ``get_anthropic_api_key()``
-        accessor, e.g. for testing or per-request credential injection.
+        Pass *api_key* to supply a concrete key directly, or *key_fn* to
+        override the global ``get_anthropic_api_key()`` accessor (e.g. for
+        testing or per-request credential injection).
         """
-        key = api_key or get_anthropic_api_key()
+        key = api_key or (key_fn or get_anthropic_api_key)()
         if key:
             models = _fetch_anthropic_models(key)
             if models:

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-DiW3bZDF.js"></script>
+    <script type="module" crossorigin src="/assets/index-BNKx2qkB.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DaBaZxOh.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -96,8 +96,20 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex }}
-          focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
+          data={{
+            dashboard,
+            selectedRunId,
+            accumulated,
+            accumulatedDimensions,
+            availableRuns,
+            dailyRuns,
+            overviewRunIndex,
+          }}
+          focus={{
+            dimension: focusedDimension,
+            setDimension: setFocusedDimension,
+            dimensionData: focusedDimensionData,
+          }}
           callbacks={{
             onRunSelect,
             onDimensionCardClick: handlers.handleDimensionCardClick,

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -267,8 +267,20 @@ export default function ProjectsPage({ projects = [], selectedProject, actions }
               selectedProject={selectedProject}
               onSelect={onSelect}
               dialogActions={{
-                confirmActions: { confirming, setConfirming, onDelete, onExport },
-                relocateActions: { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate },
+                confirmActions: {
+                  confirming,
+                  setConfirming,
+                  onDelete,
+                  onExport,
+                },
+                relocateActions: {
+                  relocating,
+                  relocatePath,
+                  setRelocatePath,
+                  submitRelocate,
+                  setRelocating,
+                  startRelocate,
+                },
               }}
             />
           ))}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -71,10 +71,18 @@ function useEvaluationForm(onStart) {
   const handleRepoClear = () => { setRepo(''); setSelectedDims(new Set()); };
 
   return {
-    repo, setRepo, allDimensions, selectedDims,
-    folderBrowserOpen, setFolderBrowserOpen,
-    toggleDim, selectAll, clearAll,
-    handleSubmit, handleFolderSelect, handleRepoClear,
+    repo,
+    setRepo,
+    allDimensions,
+    selectedDims,
+    folderBrowserOpen,
+    setFolderBrowserOpen,
+    toggleDim,
+    selectAll,
+    clearAll,
+    handleSubmit,
+    handleFolderSelect,
+    handleRepoClear,
     dimLoadError,
   };
 }

--- a/src/quodeq/ui/src/features/standards/StandardsPage.jsx
+++ b/src/quodeq/ui/src/features/standards/StandardsPage.jsx
@@ -41,7 +41,18 @@ function StandardsListView({ grouped, loading, error, actions }) {
 export default function StandardsPage() {
   const { grouped, loading, error, refresh, handleDelete, handleDuplicate } = useStandards();
   const { isVisible, toggle, add: addVisible, remove: removeVisible } = useVisibleStandards();
-  const { view, showLibrary, setShowLibrary, showImport, setShowImport, handleEdit, handleNewStandard, handleEditorBack, handleSaved, handleDeleteWithCleanup } = useStandardsPageActions(refresh, handleDelete, addVisible, removeVisible);
+  const {
+    view,
+    showLibrary,
+    setShowLibrary,
+    showImport,
+    setShowImport,
+    handleEdit,
+    handleNewStandard,
+    handleEditorBack,
+    handleSaved,
+    handleDeleteWithCleanup,
+  } = useStandardsPageActions(refresh, handleDelete, addVisible, removeVisible);
 
   if (view.mode === 'edit' || view.mode === 'new') {
     return <StandardEditor standardId={view.standardId} isNew={view.mode === 'new'} onBack={handleEditorBack} onSaved={handleSaved} />;

--- a/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
@@ -139,15 +139,38 @@ function useImportModal(onImported) {
     await doImport(data, false);
   };
 
-  const handleForceImport = async () => { await doImport(parsedData, true); };
-  const handleImportAsCopy = async () => { const copied = { ...parsedData, id: `${parsedData.id}-imported` }; setParsedData(copied); await doImport(copied, false); };
-  const handleProceedWithWarnings = async () => { await doImport(parsedData, true); };
+  const handleForceImport = async () => {
+    await doImport(parsedData, true);
+  };
+  const handleImportAsCopy = async () => {
+    const copied = { ...parsedData, id: `${parsedData.id}-imported` };
+    setParsedData(copied);
+    await doImport(copied, false);
+  };
+  const handleProceedWithWarnings = async () => {
+    await doImport(parsedData, true);
+  };
 
-  return { step, error, warnings, conflict, parsedData, fileRef, handleFile, handleForceImport, handleImportAsCopy, handleProceedWithWarnings };
+  return {
+    step,
+    error,
+    warnings,
+    conflict,
+    parsedData,
+    fileRef,
+    handleFile,
+    handleForceImport,
+    handleImportAsCopy,
+    handleProceedWithWarnings,
+  };
 }
 
 export default function ImportModal({ onClose, onImported }) {
-  const { step, error, warnings, conflict, parsedData, fileRef, handleFile, handleForceImport, handleImportAsCopy, handleProceedWithWarnings } = useImportModal(onImported);
+  const {
+    step, error, warnings, conflict, parsedData,
+    fileRef, handleFile, handleForceImport,
+    handleImportAsCopy, handleProceedWithWarnings,
+  } = useImportModal(onImported);
 
   return (
     <div className="modal-overlay" onClick={onClose}>

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -115,6 +115,12 @@ function PrincipleNode({ principle, pi, selectedNode, actions }) {
   );
 }
 
+function PrinciplesList({ principles, selectedNode, actions }) {
+  return (principles || []).map((principle, pi) => (
+    <PrincipleNode key={pi} principle={principle} pi={pi} selectedNode={selectedNode} actions={actions} />
+  ));
+}
+
 export default function StandardTree({ standard, selectedNode, onSelectNode, actions, editable }) {
   const { onAddPrinciple, onRemovePrinciple, onAddRequirement, onRemoveRequirement } = actions || {};
   if (!standard) return null;
@@ -128,9 +134,7 @@ export default function StandardTree({ standard, selectedNode, onSelectNode, act
         actions={{ onClick: () => onSelectNode({ type: 'root' }), onAdd: editable ? onAddPrinciple : undefined }}
         titles={{ addTitle: 'Add Principle' }}
       >
-        {(standard.principles || []).map((principle, pi) => (
-          <PrincipleNode key={pi} principle={principle} pi={pi} selectedNode={selectedNode} actions={treeActions} />
-        ))}
+        <PrinciplesList principles={standard.principles} selectedNode={selectedNode} actions={treeActions} />
       </TreeNode>
     </div>
   );

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -92,9 +92,18 @@ export function useStandardDetail(standardId, isNew) {
   const editable = standard && !standard.managed;
 
   return {
-    standard, loading, error, dirty, editable,
-    selectedNode, setSelectedNode,
-    updateField, addPrinciple, removePrinciple,
-    addRequirement, removeRequirement, save,
+    standard,
+    loading,
+    error,
+    dirty,
+    editable,
+    selectedNode,
+    setSelectedNode,
+    updateField,
+    addPrinciple,
+    removePrinciple,
+    addRequirement,
+    removeRequirement,
+    save,
   };
 }

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

- Reduce nesting depth in `_count_jsonl_findings` by extracting file reader helper
- Add `key_fn` injectable parameter to `_get_claude_models` for testability
- Add Args/Returns docstring to `_render_all_standards`
- Extract `PrinciplesList` sub-component from `StandardTree`
- Expand compressed single-line returns/props onto multiple lines for readability across 6 UI files

Most of the 47 listed violations were already resolved by rounds 1–2 (#161, #162). This PR addresses the remaining ones.

## Test plan

- [x] All 670 Python tests pass
- [x] UI builds cleanly
- [x] Smoke test dashboard in browser
