### PR TITLE
fix: resolve 16 maintainability violations (round 5)

### DIFF
--- a/src/quodeq/analysis/_incremental.py
+++ b/src/quodeq/analysis/_incremental.py
@@ -117,7 +117,6 @@ def save_dimension_fingerprint(
         log_debug(f"  [{dimension}] Fingerprint save failed: {exc}")
 
 
-
 def _parse_evidence_from_jsonl(
     config: RunConfig, dimension: str, ctx: _AnalysisContext,
     jsonl_file: Path, files_read: int,

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -54,6 +54,50 @@ def _handle_delete_project(provider: ActionProvider) -> Response | tuple[Respons
     return jsonify({"deleted": project})
 
 
+def _handle_update_project_path(provider: ActionProvider) -> Response | tuple[Response, int]:
+    """Handle PATCH /api/projects/<project>/path."""
+    project = request.view_args["project"]
+    data = request.get_json(silent=True) or {}
+    new_path = data.get("path", "").strip()
+    if not new_path:
+        body, status = error_response("Path is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    _logger.info("update_project_path: project=%s, remote_addr=%s", project, request.remote_addr)
+    ok = provider.update_project_path(_reports_dir(), project, new_path)
+    if not ok:
+        body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+        return jsonify(body), status
+    return jsonify({"updated": project, "path": new_path})
+
+
+def _handle_clone_project_local(provider: ActionProvider) -> Response | tuple[Response, int]:
+    """Handle POST /api/projects/<project>/clone-local."""
+    project = request.view_args["project"]
+    data = request.get_json(silent=True) or {}
+    destination = data.get("destination", "").strip()
+    if not destination:
+        body, status = error_response("destination is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    dest_resolved = Path(destination).resolve()
+    home = Path.home().resolve()
+    if not dest_resolved.is_relative_to(home):
+        body, status = error_response(
+            "Destination must be within the user's home directory",
+            HTTPStatus.FORBIDDEN,
+            "FORBIDDEN",
+        )
+        return jsonify(body), status
+    if not dest_resolved.is_dir():
+        body, status = error_response("Destination directory not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+        return jsonify(body), status
+    _logger.info("clone_project_local: project=%s, dest=%s, remote_addr=%s", project, destination, request.remote_addr)
+    result = provider.clone_to_local(_reports_dir(), project, str(dest_resolved))
+    if result is None:
+        body, status = error_response("Clone failed — check project exists and is an online project", HTTPStatus.BAD_REQUEST, "CLONE_FAILED")
+        return jsonify(body), status
+    return jsonify(result)
+
+
 def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
     """Register project listing, mutation, and export routes."""
 
@@ -72,17 +116,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
 
     @app.patch("/api/projects/<project>/path")
     def update_project_path(project: str) -> Response | tuple[Response, int]:
-        data = request.get_json(silent=True) or {}
-        new_path = data.get("path", "").strip()
-        if not new_path:
-            body, status = error_response("Path is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
-        _logger.info("update_project_path: project=%s, remote_addr=%s", project, request.remote_addr)
-        ok = provider.update_project_path(_reports_dir(), project, new_path)
-        if not ok:
-            body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
-            return jsonify(body), status
-        return jsonify({"updated": project, "path": new_path})
+        return _handle_update_project_path(provider)
 
     @app.get("/api/projects/<project>/export")
     def export_project(project: str) -> Response | tuple[Response, int]:
@@ -102,30 +136,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
 
     @app.post("/api/projects/<project>/clone-local")
     def clone_project_local(project: str) -> Response | tuple[Response, int]:
-        """Clone an online project's repo to a local directory."""
-        data = request.get_json(silent=True) or {}
-        destination = data.get("destination", "").strip()
-        if not destination:
-            body, status = error_response("destination is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
-        dest_resolved = Path(destination).resolve()
-        home = Path.home().resolve()
-        if not dest_resolved.is_relative_to(home):
-            body, status = error_response(
-                "Destination must be within the user's home directory",
-                HTTPStatus.FORBIDDEN,
-                "FORBIDDEN",
-            )
-            return jsonify(body), status
-        if not dest_resolved.is_dir():
-            body, status = error_response("Destination directory not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
-            return jsonify(body), status
-        _logger.info("clone_project_local: project=%s, dest=%s, remote_addr=%s", project, destination, request.remote_addr)
-        result = provider.clone_to_local(_reports_dir(), project, str(dest_resolved))
-        if result is None:
-            body, status = error_response("Clone failed — check project exists and is an online project", HTTPStatus.BAD_REQUEST, "CLONE_FAILED")
-            return jsonify(body), status
-        return jsonify(result)
+        return _handle_clone_project_local(provider)
 
 
 def register_project_data_routes(app: Flask, provider: ActionProvider) -> None:
@@ -170,6 +181,65 @@ def register_project_data_routes(app: Flask, provider: ActionProvider) -> None:
         return jsonify(to_camel_dict(payload))
 
 
+def _handle_browse(provider: ActionProvider) -> Response | tuple[Response, int]:
+    """Handle GET /api/browse."""
+    path = request.args.get("path")
+    if path:
+        resolved = Path(path).resolve()
+        home = Path.home().resolve()
+        if not resolved.is_relative_to(home):
+            body, status = error_response(
+                "Path must be within the user's home directory",
+                HTTPStatus.FORBIDDEN,
+                "FORBIDDEN",
+            )
+            return jsonify(body), status
+    payload = provider.browse_repo(path)
+    if "error" in payload:
+        raw_error = payload["error"]
+        is_not_dir = _BROWSE_NOT_A_DIR_KEYWORD in raw_error.lower()
+        browse_status = HTTPStatus.BAD_REQUEST if is_not_dir else HTTPStatus.NOT_FOUND
+        safe_msg = "Path is not a directory" if is_not_dir else "Path not found or not accessible"
+        body, status = error_response(safe_msg, browse_status, "INVALID_INPUT")
+        return jsonify(body), status
+    return jsonify(payload)
+
+
+def _handle_browse_mkdir() -> Response | tuple[Response, int]:
+    """Handle POST /api/browse/mkdir — create a new subdirectory."""
+    data = request.get_json(silent=True) or {}
+    parent = data.get("path", "").strip()
+    name = data.get("name", "").strip()
+    if not parent or not name:
+        body, status = error_response("path and name are required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    if "/" in name or "\\" in name or name in (".", ".."):
+        body, status = error_response("Invalid folder name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+        return jsonify(body), status
+    resolved = Path(parent).resolve()
+    home = Path.home().resolve()
+    if not resolved.is_relative_to(home):
+        body, status = error_response(
+            "Path must be within the user's home directory",
+            HTTPStatus.FORBIDDEN,
+            "FORBIDDEN",
+        )
+        return jsonify(body), status
+    if not resolved.is_dir():
+        body, status = error_response("Parent path not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+        return jsonify(body), status
+    target = resolved / name
+    try:
+        target.mkdir(parents=False, exist_ok=False)
+    except FileExistsError:
+        body, status = error_response("Folder already exists", HTTPStatus.CONFLICT, "CONFLICT")
+        return jsonify(body), status
+    except OSError as exc:
+        body, status = error_response(f"Could not create folder: {exc}", HTTPStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR")
+        return jsonify(body), status
+    return jsonify({"created": True, "path": str(target)})
+
+
 def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
     """Register /api/ai-clients/*, /api/plugins, /api/browse routes."""
 
@@ -188,61 +258,11 @@ def register_discovery_routes(app: Flask, provider: ActionProvider) -> None:
 
     @app.get("/api/browse")
     def browse() -> Response | tuple[Response, int]:
-        path = request.args.get("path")
-        if path:
-            resolved = Path(path).resolve()
-            home = Path.home().resolve()
-            if not resolved.is_relative_to(home):
-                body, status = error_response(
-                    "Path must be within the user's home directory",
-                    HTTPStatus.FORBIDDEN,
-                    "FORBIDDEN",
-                )
-                return jsonify(body), status
-        payload = provider.browse_repo(path)
-        if "error" in payload:
-            raw_error = payload["error"]
-            is_not_dir = _BROWSE_NOT_A_DIR_KEYWORD in raw_error.lower()
-            browse_status = HTTPStatus.BAD_REQUEST if is_not_dir else HTTPStatus.NOT_FOUND
-            safe_msg = "Path is not a directory" if is_not_dir else "Path not found or not accessible"
-            body, status = error_response(safe_msg, browse_status, "INVALID_INPUT")
-            return jsonify(body), status
-        return jsonify(payload)
+        return _handle_browse(provider)
 
     @app.post("/api/browse/mkdir")
     def browse_mkdir() -> Response | tuple[Response, int]:
-        """Create a new subdirectory inside a given parent path."""
-        data = request.get_json(silent=True) or {}
-        parent = data.get("path", "").strip()
-        name = data.get("name", "").strip()
-        if not parent or not name:
-            body, status = error_response("path and name are required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
-        if "/" in name or "\\" in name or name in (".", ".."):
-            body, status = error_response("Invalid folder name", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
-            return jsonify(body), status
-        resolved = Path(parent).resolve()
-        home = Path.home().resolve()
-        if not resolved.is_relative_to(home):
-            body, status = error_response(
-                "Path must be within the user's home directory",
-                HTTPStatus.FORBIDDEN,
-                "FORBIDDEN",
-            )
-            return jsonify(body), status
-        if not resolved.is_dir():
-            body, status = error_response("Parent path not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
-            return jsonify(body), status
-        target = resolved / name
-        try:
-            target.mkdir(parents=False, exist_ok=False)
-        except FileExistsError:
-            body, status = error_response("Folder already exists", HTTPStatus.CONFLICT, "CONFLICT")
-            return jsonify(body), status
-        except OSError as exc:
-            body, status = error_response(f"Could not create folder: {exc}", HTTPStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR")
-            return jsonify(body), status
-        return jsonify({"created": True, "path": str(target)})
+        return _handle_browse_mkdir()
 
 
 __all__ = ["register_static_routes"]  # re-exported from quodeq.api.helpers

--- a/src/quodeq/api/standards_routes.py
+++ b/src/quodeq/api/standards_routes.py
@@ -69,8 +69,8 @@ def _register_read_routes(app: Flask) -> None:
         return jsonify(to_camel_dict(detail))
 
 
-def _register_write_routes(app: Flask) -> None:
-    """Register POST/PUT/DELETE routes for the standards API."""
+def _register_import_routes(app: Flask) -> None:
+    """Register import and library routes for the standards API."""
 
     @app.post("/api/standards/library/import")
     def import_from_library() -> tuple[Response, int]:
@@ -117,6 +117,10 @@ def _register_write_routes(app: Flask) -> None:
             "detail": to_camel_dict(result["detail"]),
             "warnings": result["warnings"],
         }), 201
+
+
+def _register_standard_crud_routes(app: Flask) -> None:
+    """Register create, update, delete, and duplicate routes for standards."""
 
     @app.post("/api/standards")
     def create_standard() -> tuple[Response, int]:
@@ -171,4 +175,5 @@ def _register_write_routes(app: Flask) -> None:
 
 def register_standards_routes(app: Flask) -> None:
     _register_read_routes(app)
-    _register_write_routes(app)
+    _register_import_routes(app)
+    _register_standard_crud_routes(app)

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-CpBfAFTV.js"></script>
+    <script type="module" crossorigin src="/assets/index-DTc9zLcj.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DaBaZxOh.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,6 +1,4 @@
-import { useState, useMemo } from 'react';
-import { useDashboard } from './features/dashboard/hooks/useDashboard.js';
-import { buildDailyRuns } from './utils/dailyGrouping.js';
+import { useMemo } from 'react';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
@@ -17,14 +15,7 @@ import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.js
 import LoadingScreen from './components/LoadingScreen.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import ProjectHeader from './components/ProjectHeader.jsx';
-import { useServerHealth } from './hooks/useServerHealth.js';
-import { useNavStack } from './hooks/useNavStack.js';
-import { useRunNavigator } from './hooks/useRunNavigator.js';
-import { useProjectState } from './hooks/useProjectState.js';
-import { useAppSettings } from './hooks/useAppSettings.js';
-import { useEvaluationLifecycle } from './hooks/useEvaluationLifecycle.js';
-import { useProjectActions } from './hooks/useProjectActions.js';
-import { useVisibleRuns } from './hooks/useVisibleRuns.js';
+import { useAppState, formatDayLabel, KNOWN_TABS } from './hooks/useAppState.js';
 
 
 /**
@@ -71,8 +62,6 @@ function resolveHistorySelectedRunId(selectedRun, trend) {
   if (selectedRun && selectedRun !== 'latest' && trend.some((t) => t.runId === selectedRun)) return selectedRun;
   return trend.length > 0 ? trend[0].runId : null;
 }
-
-const KNOWN_TABS = ['overview', 'violations', 'history', 'projects', 'evaluate', 'standards', 'settings'];
 
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
@@ -148,36 +137,6 @@ function MainContent({ activePage, props }) {
   return null;
 }
 
-function computeDerivedState(accumulated, dashboard, selectedProject, projects) {
-  // Header meta
-  const accDims = accumulated?.dimensions || [];
-  let headerMeta = null;
-  if (accDims.length > 0) {
-    const discipline = accDims.find((d) => d.discipline)?.discipline ?? null;
-    const repository = accDims.find((d) => d.repository)?.repository ?? null;
-    const runDims = dashboard?.dimensions || [];
-    const totalFiles = runDims.find((d) => d.sourceFileCount)?.sourceFileCount ?? null;
-    const project = projects.find((p) => p.id === selectedProject);
-    const languageStats = project?.languageStats ?? null;
-    headerMeta = { discipline, repository, totalFiles, languageStats };
-  }
-
-  // Project display
-  let selectedDisplayName = selectedProject;
-  let selectedProjectParent = null;
-  let selectedProjectParentId = null;
-  if (selectedProject && projects.length) {
-    const data = projects.find((p) => (p.id || p.name || p) === selectedProject);
-    const parentRef = data?.parent || null;
-    const parentData = parentRef ? projects.find((p) => (p.id || p.name || p) === parentRef) : null;
-    selectedDisplayName = data?.displayName || data?.name || selectedProject;
-    selectedProjectParent = parentData?.displayName || parentData?.name || parentRef;
-    selectedProjectParentId = parentData ? (parentData.id || parentData.name || parentRef) : null;
-  }
-
-  return { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId };
-}
-
 /**
  * @param {{ sidebar: JSX.Element, header: JSX.Element|null, breadcrumb: JSX.Element|null, content: JSX.Element }} props
  * @returns {JSX.Element}
@@ -193,74 +152,6 @@ function AppShell({ sidebar, header, breadcrumb, content }) {
       </main>
     </div>
   );
-}
-
-function useProjects({ onNoProjects }) {
-  const projectState = useProjectState({ onNoProjects });
-  const projectActions = useProjectActions({
-    projects: projectState.projects,
-    selectedProject: projectState.selectedProject,
-    handleProjectChange: projectState.handleProjectChange,
-    loadProjects: projectState.loadProjects,
-  });
-  return { ...projectState, ...projectActions };
-}
-
-function useAppNavigation() {
-  const [serverConnected, setServerConnected] = useServerHealth();
-  const { navStack, activePage, navPush, navPop, navGoTo, navReset, navTab } = useNavStack();
-  const projectBundle = useProjects({ onNoProjects: () => navTab('evaluate') });
-  const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
-  const [historySelectedRun, setHistorySelectedRun] = useState('latest');
-  function handleNavigate(page, params = {}) {
-    if (page === 'run' && params.runId) setSelectedRun(params.runId);
-    if (page === 'history-run' && params.runId) setHistorySelectedRun(params.runId);
-    navPush({ page, ...params });
-  }
-  return { serverConnected, setServerConnected, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun };
-}
-
-function useAppState() {
-  const nav = useAppNavigation();
-  const { serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
-  const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
-  const settings = useAppSettings();
-  const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
-  const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun: effectiveRun });
-  const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
-    dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
-    ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
-  }), [availableRuns, dashboard, accumulated, selectedProject, projects]);
-  const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
-  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
-  const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
-  const activeTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
-    : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab
-    : activePage.page === 'history-run' ? 'history'
-    : 'overview';
-  const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
-  const showRunNav = showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
-
-  return {
-    serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
-    projects, selectedProject, selectedRun, handleProjectChange, handleNavigate,
-    handleDeleteProject, handleExportProject, handleRelocateProject,
-    dashboard, accumulated, latestAccumulated, loading, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,
-    currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
-    headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
-    historySelectedRun, setHistorySelectedRun,
-    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav,
-  };
-}
-
-function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
-  const entry = (trend || []).find((r) => r.runId === currentOverviewRun);
-  if (entry?.dateISO) {
-    try {
-      return new Date(entry.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
-    } catch { return entry.dateISO; }
-  }
-  return dailyRuns[overviewRunIndex]?.dateLabel || currentOverviewRun;
 }
 
 export default function App() {

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -53,36 +53,28 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
 // directly from App; the high prop count is intentional and not worth splitting.
 // ---------------------------------------------------------------------------
 
-function makeDashboardHandlers(onNavigate, dashboard) {
-  return {
+function useDashboardHandlers(onNavigate, dashboard) {
+  return useMemo(() => ({
     handleDimensionCardClick: (item, runId) => {
-      if (onNavigate) {
-        const dateLabel = dashboard?.selectedRun?.dateLabel || item.fromDateLabel;
-        onNavigate('explorer', { dimension: item.dimension, runId: runId || item.fromRunId, dateLabel });
-      }
+      if (!onNavigate) return;
+      const dateLabel = dashboard?.selectedRun?.dateLabel || item.fromDateLabel;
+      onNavigate('explorer', { dimension: item.dimension, runId: runId || item.fromRunId, dateLabel });
     },
     handleAccumulatedDimensionClick: (item) => {
       if (onNavigate) onNavigate('explorer', { dimension: item.dimension, runId: item.fromRunId, dateLabel: item.fromDateLabel });
     },
     handleFileClick: (fileObj) => { if (onNavigate) onNavigate('file', { file: fileObj }); },
-  };
+  }), [onNavigate, dashboard]);
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const {
-    selectedProject, selectedRun, projects = [],
-    dashboard, accumulated, loading, error,
-    availableRuns = [], dailyRuns, overviewRunIndex = 0,
-  } = data;
+  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
   const { onNavigate, onRunSelect } = callbacks;
   const [focusedDimension, setFocusedDimension] = useState(null);
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
   const accumulatedDimensions = accumulated?.dimensions || [];
-  const focusedDimensionData = useMemo(() => {
-    if (!focusedDimension) return null;
-    return (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null;
-  }, [focusedDimension, dashboard]);
-  const handlers = makeDashboardHandlers(onNavigate, dashboard);
+  const focusedDimensionData = useMemo(() => focusedDimension ? (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null : null, [focusedDimension, dashboard]);
+  const handlers = useDashboardHandlers(onNavigate, dashboard);
 
   if (!projects || projects.length === 0) {
     if (loading) return <LoadingScreen />;
@@ -96,26 +88,9 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{
-            dashboard,
-            selectedRunId,
-            accumulated,
-            accumulatedDimensions,
-            availableRuns,
-            dailyRuns,
-            overviewRunIndex,
-          }}
-          focus={{
-            dimension: focusedDimension,
-            setDimension: setFocusedDimension,
-            dimensionData: focusedDimensionData,
-          }}
-          callbacks={{
-            onRunSelect,
-            onDimensionCardClick: handlers.handleDimensionCardClick,
-            onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick,
-            onFileClick: handlers.handleFileClick,
-          }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex }}
+          focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
+          callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick }}
         />
       )}
     </div>

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -234,21 +234,19 @@ function ProjectCardGroup({ p, children: childProjects, selectedProject, onSelec
   );
 }
 
+function useRelocateDialog(onRelocate) {
+  const [relocating, setRelocating] = useState(null);
+  const [relocatePath, setRelocatePath] = useState('');
+  const startRelocate = (name, currentPath) => { setRelocating(name); setRelocatePath(currentPath || ''); };
+  const submitRelocate = (name) => { if (relocatePath.trim()) onRelocate?.(name, relocatePath.trim()); setRelocating(null); };
+  return { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate };
+}
+
 export default function ProjectsPage({ projects = [], selectedProject, actions }) {
   const { onSelect, onDelete, onExport, onRelocate } = actions;
   const { children, roots } = useMemo(() => computeProjectTree(projects), [projects]);
   const [confirming, setConfirming] = useState(null);
-  const [relocating, setRelocating] = useState(null);
-  const [relocatePath, setRelocatePath] = useState('');
-
-  function startRelocate(name, currentPath) {
-    setRelocating(name);
-    setRelocatePath(currentPath || '');
-  }
-  function submitRelocate(name) {
-    if (relocatePath.trim()) onRelocate?.(name, relocatePath.trim());
-    setRelocating(null);
-  }
+  const relocateActions = useRelocateDialog(onRelocate);
 
   return (
     <section className="projects-page">
@@ -267,20 +265,8 @@ export default function ProjectsPage({ projects = [], selectedProject, actions }
               selectedProject={selectedProject}
               onSelect={onSelect}
               dialogActions={{
-                confirmActions: {
-                  confirming,
-                  setConfirming,
-                  onDelete,
-                  onExport,
-                },
-                relocateActions: {
-                  relocating,
-                  relocatePath,
-                  setRelocatePath,
-                  submitRelocate,
-                  setRelocating,
-                  startRelocate,
-                },
+                confirmActions: { confirming, setConfirming, onDelete, onExport },
+                relocateActions,
               }}
             />
           ))}

--- a/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
@@ -100,28 +100,43 @@ async function navigateFolder(path, navigation) {
   }
 }
 
+function NewFolderInput({ currentPath, navigate, onClose }) {
+  const [name, setName] = useState('');
+  const [error, setError] = useState(null);
+
+  async function handleCreate() {
+    if (!name.trim() || !currentPath) return;
+    setError(null);
+    try {
+      await createDirectory(currentPath, name.trim());
+      onClose();
+      navigate(currentPath);
+    } catch (err) {
+      setError(err.message || 'Failed to create folder');
+    }
+  }
+
+  return (
+    <div className="new-folder-row">
+      <input
+        type="text" className="new-folder-input" value={name}
+        onChange={(e) => setName(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') handleCreate(); if (e.key === 'Escape') onClose(); }}
+        placeholder="Folder name" autoFocus
+      />
+      <button className="folder-nav-btn" onClick={handleCreate} disabled={!name.trim()}>Create</button>
+      <button className="folder-nav-btn" onClick={onClose}>✕</button>
+      {error && <span className="inline-error">{error}</span>}
+    </div>
+  );
+}
+
 function FolderBrowserDialog({ state, actions, navigation, selection, title, confirmText }) {
   const { data, loading, pathInput, navError } = state;
   const { navigate, onClose, onConfirm } = actions;
   const { selectedFolder, setSelectedFolder } = selection;
   const { setPathInput } = navigation;
-
-  const [newFolderName, setNewFolderName] = useState('');
   const [creatingFolder, setCreatingFolder] = useState(false);
-  const [newFolderError, setNewFolderError] = useState(null);
-
-  async function handleNewFolder() {
-    if (!newFolderName.trim() || !data?.current) return;
-    setNewFolderError(null);
-    try {
-      await createDirectory(data.current, newFolderName.trim());
-      setCreatingFolder(false);
-      setNewFolderName('');
-      navigate(data.current);
-    } catch (err) {
-      setNewFolderError(err.message || 'Failed to create folder');
-    }
-  }
 
   return (
     <div className="modal folder-browser-modal" role="dialog" aria-modal="true" aria-labelledby="folder-browser-title" onClick={(e) => e.stopPropagation()}>
@@ -130,22 +145,7 @@ function FolderBrowserDialog({ state, actions, navigation, selection, title, con
         <button className="modal-close" onClick={onClose} aria-label="Close">&times;</button>
       </div>
       <FolderPathBar data={data} loading={loading} pathInput={pathInput} setPathInput={setPathInput} onNavigate={navigate} onNewFolder={() => setCreatingFolder(true)} />
-      {creatingFolder && (
-        <div className="new-folder-row">
-          <input
-            type="text"
-            className="new-folder-input"
-            value={newFolderName}
-            onChange={(e) => setNewFolderName(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') handleNewFolder(); if (e.key === 'Escape') setCreatingFolder(false); }}
-            placeholder="Folder name"
-            autoFocus
-          />
-          <button className="folder-nav-btn" onClick={handleNewFolder} disabled={!newFolderName.trim()}>Create</button>
-          <button className="folder-nav-btn" onClick={() => setCreatingFolder(false)}>✕</button>
-          {newFolderError && <span className="inline-error">{newFolderError}</span>}
-        </div>
-      )}
+      {creatingFolder && <NewFolderInput currentPath={data?.current} navigate={navigate} onClose={() => setCreatingFolder(false)} />}
       <div className="folder-browser-list">
         {loading ? (
           <p className="loading" role="status" aria-live="polite">Loading...</p>

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -6,21 +6,17 @@ import FolderBrowser from './FolderBrowser.jsx';
 
 
 const BUTTON_GAP = '8px';
+const BUTTON_PADDING = '8px 16px';
+const BUTTON_FONT_SIZE = '0.85rem';
 const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: BUTTON_GAP, alignItems: 'center' };
 const flexButtonStyle = { flex: 1, marginTop: 0 };
 
-function useReEvaluateCard(project, onStart) {
+function useReEvalInfo(project) {
   const [info, setInfo] = useState(null);
   const [error, setError] = useState(null);
-  const { allDimensions } = usePluginDimensions();
-  const [selectedDims, setSelectedDims] = useState(new Set());
   const [urlInput, setUrlInput] = useState('');
   const [urlError, setUrlError] = useState(null);
   const [urlSaving, setUrlSaving] = useState(false);
-  const [cloneBrowserOpen, setCloneBrowserOpen] = useState(false);
-  const [cloning, setCloning] = useState(false);
-  const [cloneDest, setCloneDest] = useState('');
-  const [cloneError, setCloneError] = useState(null);
 
   useEffect(() => {
     if (!project) return;
@@ -32,6 +28,35 @@ function useReEvaluateCard(project, onStart) {
         setError('Could not load project info. The project may have been removed.');
       });
   }, [project]);
+
+  async function handleUrlRestore() {
+    const url = urlInput.trim();
+    if (!url) return;
+    setUrlSaving(true);
+    setUrlError(null);
+    try {
+      await relocateProject(project, url);
+      const updated = await getProjectInfo(project);
+      setInfo(updated);
+      setUrlInput('');
+    } catch (err) {
+      setUrlError(err.message || 'Failed to update URL');
+    } finally {
+      setUrlSaving(false);
+    }
+  }
+
+  return { info, setInfo, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore };
+}
+
+function useReEvaluateCard(project, onStart) {
+  const { info, setInfo, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore } = useReEvalInfo(project);
+  const { allDimensions } = usePluginDimensions();
+  const [selectedDims, setSelectedDims] = useState(new Set());
+  const [cloneBrowserOpen, setCloneBrowserOpen] = useState(false);
+  const [cloning, setCloning] = useState(false);
+  const [cloneDest, setCloneDest] = useState('');
+  const [cloneError, setCloneError] = useState(null);
 
   const toggleDim = (id) => {
     setSelectedDims((prev) => {
@@ -50,23 +75,6 @@ function useReEvaluateCard(project, onStart) {
   };
   const handleStart = () => onStart(buildPayload());
   const handleIncremental = () => onStart(buildPayload({ incremental: true }));
-
-  async function handleUrlRestore() {
-    const url = urlInput.trim();
-    if (!url) return;
-    setUrlSaving(true);
-    setUrlError(null);
-    try {
-      await relocateProject(project, url);
-      const updated = await getProjectInfo(project);
-      setInfo(updated);
-      setUrlInput('');
-    } catch (err) {
-      setUrlError(err.message || 'Failed to update URL');
-    } finally {
-      setUrlSaving(false);
-    }
-  }
 
   async function handleCloneToLocal(destination) {
     setCloneBrowserOpen(false);
@@ -89,6 +97,98 @@ function useReEvaluateCard(project, onStart) {
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
   };
+}
+
+function UrlRestoreSection({ urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore }) {
+  return (
+    <div className="re-eval-stale-warning">
+      <p>This project was evaluated from a remote repo but the original URL was not saved. Enter the URL to restore reevaluation.</p>
+      <div style={{ display: 'flex', gap: BUTTON_GAP, alignItems: 'center' }}>
+        <input
+          type="text"
+          value={urlInput}
+          onChange={(e) => setUrlInput(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleUrlRestore(); }}
+          placeholder="https://github.com/org/repo"
+          className="re-eval-url-input"
+          disabled={urlSaving}
+        />
+        <button
+          type="button"
+          className="evaluate-submit-btn"
+          style={{ padding: BUTTON_PADDING, fontSize: BUTTON_FONT_SIZE }}
+          disabled={!urlInput.trim() || urlSaving}
+          onClick={handleUrlRestore}
+        >
+          {urlSaving ? 'Saving...' : 'Restore'}
+        </button>
+      </div>
+      {urlError && <p className="inline-error">{urlError}</p>}
+    </div>
+  );
+}
+
+function DimensionSelectionSection({ allDimensions, selectedDims, cloning, toggleDim, selectAll, clearAll }) {
+  if (allDimensions.length === 0) return null;
+  return (
+    <DimensionSelector
+      allDimensions={allDimensions}
+      selectedDims={selectedDims}
+      onToggle={cloning ? undefined : toggleDim}
+      onSelectAll={cloning ? undefined : selectAll}
+      onClearAll={cloning ? undefined : clearAll}
+    />
+  );
+}
+
+function CloneSection({ info, cloning, cloneDest, cloneError, setCloneBrowserOpen }) {
+  return (
+    <>
+      {info.location === 'online' && !info.pathMissing && !cloning && (
+        <div className="re-eval-clone-row">
+          <a href="#" className="re-eval-clone-link" onClick={(e) => { e.preventDefault(); setCloneBrowserOpen(true); }}>
+            ⬇ Clone to local storage
+          </a>
+        </div>
+      )}
+      {cloneError && <p className="inline-error">{cloneError}</p>}
+      {cloning && (
+        <div className="re-eval-clone-banner">
+          <span className="re-eval-clone-spinner" />
+          <span>Cloning to <code>{cloneDest}</code>...</span>
+        </div>
+      )}
+    </>
+  );
+}
+
+function ActionButtons({ info, project, disabled, canStart, cloning, handleIncremental, handleStart }) {
+  return (
+    <div style={buttonRowStyle}>
+      {info.hasFingerprints && (
+        <button
+          type="button"
+          className="evaluate-submit-btn"
+          style={flexButtonStyle}
+          disabled={!canStart}
+          onClick={handleIncremental}
+          title="Only analyze files changed since last evaluation"
+        >
+          Re-scan changes
+        </button>
+      )}
+      <button
+        type="button"
+        className="evaluate-submit-btn"
+        style={flexButtonStyle}
+        disabled={!canStart}
+        onClick={handleStart}
+        title="Fresh re-evaluation of all selected dimensions"
+      >
+        {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}
+      </button>
+    </div>
+  );
 }
 
 function ReEvaluateCardView({ info, project, disabled, dimensions, actions }) {
@@ -114,86 +214,14 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions }) {
         </div>
 
         {info.pathMissing && (
-          <div className="re-eval-stale-warning">
-            <p>This project was evaluated from a remote repo but the original URL was not saved. Enter the URL to restore reevaluation.</p>
-            <div style={{ display: 'flex', gap: BUTTON_GAP, alignItems: 'center' }}>
-              <input
-                type="text"
-                value={urlInput}
-                onChange={(e) => setUrlInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter') handleUrlRestore(); }}
-                placeholder="https://github.com/org/repo"
-                className="re-eval-url-input"
-                disabled={urlSaving}
-              />
-              <button
-                type="button"
-                className="evaluate-submit-btn"
-                style={{ padding: '8px 16px', fontSize: '0.85rem' }}
-                disabled={!urlInput.trim() || urlSaving}
-                onClick={handleUrlRestore}
-              >
-                {urlSaving ? 'Saving...' : 'Restore'}
-              </button>
-            </div>
-            {urlError && <p className="inline-error">{urlError}</p>}
-          </div>
+          <UrlRestoreSection urlInput={urlInput} setUrlInput={setUrlInput} urlError={urlError} urlSaving={urlSaving} handleUrlRestore={handleUrlRestore} />
         )}
 
-        {info.location === 'online' && !info.pathMissing && !cloning && (
-          <div className="re-eval-clone-row">
-            <a
-              href="#"
-              className="re-eval-clone-link"
-              onClick={(e) => { e.preventDefault(); setCloneBrowserOpen(true); }}
-            >
-              ⬇ Clone to local storage
-            </a>
-          </div>
-        )}
-        {cloneError && <p className="inline-error">{cloneError}</p>}
-        {cloning && (
-          <div className="re-eval-clone-banner">
-            <span className="re-eval-clone-spinner" />
-            <span>Cloning to <code>{cloneDest}</code>...</span>
-          </div>
-        )}
+        <CloneSection info={info} cloning={cloning} cloneDest={cloneDest} cloneError={cloneError} setCloneBrowserOpen={setCloneBrowserOpen} />
 
         <div className={cloning ? 're-eval-disabled-section' : ''}>
-        {allDimensions.length > 0 && (
-          <DimensionSelector
-            allDimensions={allDimensions}
-            selectedDims={selectedDims}
-            onToggle={cloning ? undefined : toggleDim}
-            onSelectAll={cloning ? undefined : selectAll}
-            onClearAll={cloning ? undefined : clearAll}
-          />
-        )}
-
-        <div style={buttonRowStyle}>
-          {info.hasFingerprints && (
-            <button
-              type="button"
-              className="evaluate-submit-btn"
-              style={flexButtonStyle}
-              disabled={!canStart}
-              onClick={handleIncremental}
-              title="Only analyze files changed since last evaluation"
-            >
-              Re-scan changes
-            </button>
-          )}
-          <button
-            type="button"
-            className="evaluate-submit-btn"
-            style={flexButtonStyle}
-            disabled={!canStart}
-            onClick={handleStart}
-            title="Fresh re-evaluation of all selected dimensions"
-          >
-            {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}
-          </button>
-        </div>
+          <DimensionSelectionSection allDimensions={allDimensions} selectedDims={selectedDims} cloning={cloning} toggleDim={toggleDim} selectAll={selectAll} clearAll={clearAll} />
+          <ActionButtons info={info} project={project} disabled={disabled} canStart={canStart} cloning={cloning} handleIncremental={handleIncremental} handleStart={handleStart} />
         </div>
       </div>
 

--- a/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ImportModal.jsx
@@ -83,14 +83,8 @@ function ConflictStep({ parsedData, conflict, warnings, onClose, onImportAsCopy,
   );
 }
 
-function useImportModal(onImported) {
-  const [step, setStep] = useState(STEP.PICK);
-  const [error, setError] = useState(null);
-  const [warnings, setWarnings] = useState([]);
-  const [conflict, setConflict] = useState(null);
-  const [parsedData, setParsedData] = useState(null);
-  const fileRef = useRef(null);
-
+function useImportActions(onImported, state) {
+  const { setStep, setError, setWarnings, setConflict, parsedData, setParsedData } = state;
   const doImport = async (data, force) => {
     setStep(STEP.IMPORTING);
     try {
@@ -122,47 +116,33 @@ function useImportModal(onImported) {
       return;
     }
     let data;
-    try {
-      const text = await file.text();
-      data = JSON.parse(text);
-    } catch {
-      setError('Invalid file: could not parse as JSON.');
-      setStep(STEP.ERROR);
-      return;
-    }
-    if (typeof data !== 'object' || Array.isArray(data)) {
-      setError('Invalid file: expected a JSON object.');
-      setStep(STEP.ERROR);
-      return;
-    }
+    try { const text = await file.text(); data = JSON.parse(text); }
+    catch { setError('Invalid file: could not parse as JSON.'); setStep(STEP.ERROR); return; }
+    if (typeof data !== 'object' || Array.isArray(data)) { setError('Invalid file: expected a JSON object.'); setStep(STEP.ERROR); return; }
     setParsedData(data);
     await doImport(data, false);
   };
 
-  const handleForceImport = async () => {
-    await doImport(parsedData, true);
-  };
+  const handleForceImport = async () => { await doImport(parsedData, true); };
   const handleImportAsCopy = async () => {
     const copied = { ...parsedData, id: `${parsedData.id}-imported` };
     setParsedData(copied);
     await doImport(copied, false);
   };
-  const handleProceedWithWarnings = async () => {
-    await doImport(parsedData, true);
-  };
+  const handleProceedWithWarnings = async () => { await doImport(parsedData, true); };
+  return { doImport, handleFile, handleForceImport, handleImportAsCopy, handleProceedWithWarnings };
+}
 
-  return {
-    step,
-    error,
-    warnings,
-    conflict,
-    parsedData,
-    fileRef,
-    handleFile,
-    handleForceImport,
-    handleImportAsCopy,
-    handleProceedWithWarnings,
-  };
+function useImportModal(onImported) {
+  const [step, setStep] = useState(STEP.PICK);
+  const [error, setError] = useState(null);
+  const [warnings, setWarnings] = useState([]);
+  const [conflict, setConflict] = useState(null);
+  const [parsedData, setParsedData] = useState(null);
+  const fileRef = useRef(null);
+  const actions = useImportActions(onImported, { setStep, setError, setWarnings, setConflict, parsedData, setParsedData });
+
+  return { step, error, warnings, conflict, parsedData, fileRef, ...actions };
 }
 
 export default function ImportModal({ onClose, onImported }) {

--- a/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardCard.jsx
@@ -123,71 +123,58 @@ function EyeToggle({ isVisible, standardId, onToggleVisibility }) {
   );
 }
 
+async function downloadStandard(standardId) {
+  const { data, fileName } = await exportStandard(standardId);
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function StandardCardBody({ standard, isVisible, onToggleVisibility, principleCount, requirementCount }) {
+  return (
+    <>
+      <div className="standard-card-header">
+        <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
+          {TYPE_LABELS[standard.type] || standard.type}
+        </span>
+        {standard.managed && (
+          <span className="standard-managed-badge" title="Managed standard — read-only">managed</span>
+        )}
+        <EyeToggle isVisible={isVisible} standardId={standard.id} onToggleVisibility={onToggleVisibility} />
+      </div>
+      <h3 className="standard-card-name">{standard.name}</h3>
+      {standard.description && <p className="standard-card-description">{standard.description}</p>}
+      <div className="standard-card-counts">
+        <span>{principleCount} {principleCount === 1 ? 'principle' : 'principles'}</span>
+        <span className="standard-card-counts-sep">·</span>
+        <span>{requirementCount} {requirementCount === 1 ? 'requirement' : 'requirements'}</span>
+      </div>
+    </>
+  );
+}
+
 export default function StandardCard({ standard, onEdit, onDelete, onDuplicate, isVisible, onToggleVisibility }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
-
   const principleCount = standard.principleCount ?? standard.principles?.length ?? 0;
-  const requirementCount = standard.requirementCount ?? (standard.principles || []).reduce(
-    (sum, p) => sum + (p.requirements?.length ?? 0), 0
-  );
+  const requirementCount = standard.requirementCount ?? (standard.principles || []).reduce((sum, p) => sum + (p.requirements?.length ?? 0), 0);
   const isDeletable = standard.type !== STANDARD_TYPES.BUILTIN && standard.type !== STANDARD_TYPES.QUODEQ;
   const visClass = isVisible ? 'standard-card--visible' : 'standard-card--hidden';
 
   return (
     <>
       <div className={`standard-card ${visClass}`} onClick={() => onEdit(standard.id)}>
-        <div className="standard-card-header">
-          <span className={`standard-type-badge standard-type-badge--${standard.type}`}>
-            {TYPE_LABELS[standard.type] || standard.type}
-          </span>
-          {standard.managed && (
-            <span className="standard-managed-badge" title="Managed standard — read-only">managed</span>
-          )}
-          <EyeToggle isVisible={isVisible} standardId={standard.id} onToggleVisibility={onToggleVisibility} />
-        </div>
-        <h3 className="standard-card-name">{standard.name}</h3>
-        {standard.description && <p className="standard-card-description">{standard.description}</p>}
-        <div className="standard-card-counts">
-          <span>{principleCount} {principleCount === 1 ? 'principle' : 'principles'}</span>
-          <span className="standard-card-counts-sep">·</span>
-          <span>{requirementCount} {requirementCount === 1 ? 'requirement' : 'requirements'}</span>
-        </div>
-        <CardActions
-          isDeletable={isDeletable}
-          onDuplicate={() => setShowDuplicateModal(true)}
-          onDownload={async () => {
-            const { data, fileName } = await exportStandard(standard.id);
-            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = fileName;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-          }}
-          onDelete={() => setShowDeleteModal(true)}
-        />
+        <StandardCardBody standard={standard} isVisible={isVisible} onToggleVisibility={onToggleVisibility} principleCount={principleCount} requirementCount={requirementCount} />
+        <CardActions isDeletable={isDeletable} onDuplicate={() => setShowDuplicateModal(true)} onDownload={() => downloadStandard(standard.id)} onDelete={() => setShowDeleteModal(true)} />
       </div>
-
-      {showDeleteModal && (
-        <ConfirmDeleteModal
-          standardName={standard.name}
-          principleCount={principleCount}
-          requirementCount={requirementCount}
-          onConfirm={() => { setShowDeleteModal(false); onDelete(standard.id); }}
-          onCancel={() => setShowDeleteModal(false)}
-        />
-      )}
-      {showDuplicateModal && (
-        <DuplicateModal
-          standardId={standard.id}
-          onConfirm={(newId) => { setShowDuplicateModal(false); onDuplicate(standard.id, newId); }}
-          onCancel={() => setShowDuplicateModal(false)}
-        />
-      )}
+      {showDeleteModal && <ConfirmDeleteModal standardName={standard.name} principleCount={principleCount} requirementCount={requirementCount} onConfirm={() => { setShowDeleteModal(false); onDelete(standard.id); }} onCancel={() => setShowDeleteModal(false)} />}
+      {showDuplicateModal && <DuplicateModal standardId={standard.id} onConfirm={(newId) => { setShowDuplicateModal(false); onDuplicate(standard.id, newId); }} onCancel={() => setShowDuplicateModal(false)} />}
     </>
   );
 }

--- a/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js
@@ -4,20 +4,7 @@ import { generateRequirementId } from '../utils.js';
 import { deepClone } from '../../../utils/deepClone.js';
 import { STANDARD_TYPES } from './useStandards.js';
 
-function useStandardMutations(standard, setStandard, setDirty, standardId, isNew) {
-  const [selectedNode, setSelectedNode] = useState(null);
-
-  const updateField = useCallback((path, value) => {
-    setStandard((prev) => {
-      const next = deepClone(prev);
-      let target = next;
-      for (let i = 0; i < path.length - 1; i++) target = target[path[i]];
-      target[path[path.length - 1]] = value;
-      return next;
-    });
-    setDirty(true);
-  }, [setStandard, setDirty]);
-
+function useTreeMutations(setStandard, setDirty, setSelectedNode) {
   const addPrinciple = useCallback(() => {
     setStandard((prev) => {
       const next = deepClone(prev);
@@ -61,6 +48,25 @@ function useStandardMutations(standard, setStandard, setDirty, standardId, isNew
     setSelectedNode({ type: 'principle', index: principleIndex });
   }, [setStandard, setDirty]);
 
+  return { addPrinciple, removePrinciple, addRequirement, removeRequirement };
+}
+
+function useStandardMutations(standard, setStandard, setDirty, standardId, isNew) {
+  const [selectedNode, setSelectedNode] = useState(null);
+
+  const updateField = useCallback((path, value) => {
+    setStandard((prev) => {
+      const next = deepClone(prev);
+      let target = next;
+      for (let i = 0; i < path.length - 1; i++) target = target[path[i]];
+      target[path[path.length - 1]] = value;
+      return next;
+    });
+    setDirty(true);
+  }, [setStandard, setDirty]);
+
+  const tree = useTreeMutations(setStandard, setDirty, setSelectedNode);
+
   const save = useCallback(async () => {
     if (!standard) return;
     if (!standard.id) return { error: 'ID is required' };
@@ -72,7 +78,7 @@ function useStandardMutations(standard, setStandard, setDirty, standardId, isNew
     } catch (err) { return { error: err.message }; }
   }, [standard, isNew, setDirty]);
 
-  return { selectedNode, setSelectedNode, updateField, addPrinciple, removePrinciple, addRequirement, removeRequirement, save };
+  return { selectedNode, setSelectedNode, updateField, ...tree, save };
 }
 
 export function useStandardDetail(standardId, isNew) {

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -1,0 +1,109 @@
+import { useState, useMemo } from 'react';
+import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
+import { buildDailyRuns } from '../utils/dailyGrouping.js';
+import { useServerHealth } from './useServerHealth.js';
+import { useNavStack } from './useNavStack.js';
+import { useRunNavigator } from './useRunNavigator.js';
+import { useProjectState } from './useProjectState.js';
+import { useAppSettings } from './useAppSettings.js';
+import { useEvaluationLifecycle } from './useEvaluationLifecycle.js';
+import { useProjectActions } from './useProjectActions.js';
+import { useVisibleRuns } from './useVisibleRuns.js';
+
+export const KNOWN_TABS = ['overview', 'violations', 'history', 'projects', 'evaluate', 'standards', 'settings'];
+
+function computeDerivedState(accumulated, dashboard, selectedProject, projects) {
+  const accDims = accumulated?.dimensions || [];
+  let headerMeta = null;
+  if (accDims.length > 0) {
+    const discipline = accDims.find((d) => d.discipline)?.discipline ?? null;
+    const repository = accDims.find((d) => d.repository)?.repository ?? null;
+    const runDims = dashboard?.dimensions || [];
+    const totalFiles = runDims.find((d) => d.sourceFileCount)?.sourceFileCount ?? null;
+    const project = projects.find((p) => p.id === selectedProject);
+    const languageStats = project?.languageStats ?? null;
+    headerMeta = { discipline, repository, totalFiles, languageStats };
+  }
+
+  let selectedDisplayName = selectedProject;
+  let selectedProjectParent = null;
+  let selectedProjectParentId = null;
+  if (selectedProject && projects.length) {
+    const data = projects.find((p) => (p.id || p.name || p) === selectedProject);
+    const parentRef = data?.parent || null;
+    const parentData = parentRef ? projects.find((p) => (p.id || p.name || p) === parentRef) : null;
+    selectedDisplayName = data?.displayName || data?.name || selectedProject;
+    selectedProjectParent = parentData?.displayName || parentData?.name || parentRef;
+    selectedProjectParentId = parentData ? (parentData.id || parentData.name || parentRef) : null;
+  }
+
+  return { headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId };
+}
+
+function useProjects({ onNoProjects }) {
+  const projectState = useProjectState({ onNoProjects });
+  const projectActions = useProjectActions({
+    projects: projectState.projects,
+    selectedProject: projectState.selectedProject,
+    handleProjectChange: projectState.handleProjectChange,
+    loadProjects: projectState.loadProjects,
+  });
+  return { ...projectState, ...projectActions };
+}
+
+function useAppNavigation() {
+  const [serverConnected, setServerConnected] = useServerHealth();
+  const { navStack, activePage, navPush, navPop, navGoTo, navReset, navTab } = useNavStack();
+  const projectBundle = useProjects({ onNoProjects: () => navTab('evaluate') });
+  const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
+  const [historySelectedRun, setHistorySelectedRun] = useState('latest');
+  function handleNavigate(page, params = {}) {
+    if (page === 'run' && params.runId) setSelectedRun(params.runId);
+    if (page === 'history-run' && params.runId) setHistorySelectedRun(params.runId);
+    navPush({ page, ...params });
+  }
+  return { serverConnected, setServerConnected, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun };
+}
+
+export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
+  const entry = (trend || []).find((r) => r.runId === currentOverviewRun);
+  if (entry?.dateISO) {
+    try {
+      return new Date(entry.dateISO).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' });
+    } catch { return entry.dateISO; }
+  }
+  return dailyRuns[overviewRunIndex]?.dateLabel || currentOverviewRun;
+}
+
+export function useAppState() {
+  const nav = useAppNavigation();
+  const { serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
+  const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
+  const settings = useAppSettings();
+  const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
+  const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun: effectiveRun });
+  const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
+    dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
+    ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
+  }), [availableRuns, dashboard, accumulated, selectedProject, projects]);
+  const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
+  const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
+  const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
+  const activeTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
+    : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab
+    : activePage.page === 'history-run' ? 'history'
+    : 'overview';
+  const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
+  const showRunNav = showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
+
+  return {
+    serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
+    projects, selectedProject, selectedRun, handleProjectChange, handleNavigate,
+    handleDeleteProject, handleExportProject, handleRelocateProject,
+    dashboard, accumulated, latestAccumulated, loading, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,
+    currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
+    headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
+    historySelectedRun, setHistorySelectedRun,
+    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav,
+  };
+}

--- a/tests/test_project_resolver_online.py
+++ b/tests/test_project_resolver_online.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import uuid as _uuid
 from pathlib import Path
 
 from quodeq.data.fs.project_resolver import (
@@ -41,7 +42,6 @@ def test_online_project_with_temp_path_logs_warning(tmp_path: Path, capsys) -> N
 
 def _create_online_project_with_temp_path(reports_dir: Path) -> str:
     """Helper: create a project with location=online but a local temp path (simulates the bug)."""
-    import uuid as _uuid
     project_uuid = str(_uuid.uuid4())
     project_dir = reports_dir / project_uuid
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -58,7 +58,6 @@ def _create_online_project_with_temp_path(reports_dir: Path) -> str:
 
 def _create_online_project_with_url(reports_dir: Path) -> str:
     """Helper: create a project with location=online and a proper URL path."""
-    import uuid as _uuid
     project_uuid = str(_uuid.uuid4())
     project_dir = reports_dir / project_uuid
     project_dir.mkdir(parents=True, exist_ok=True)
@@ -117,7 +116,6 @@ def test_clone_to_local_updates_project(tmp_path: Path, monkeypatch) -> None:
 
 def _create_local_project(reports_dir: Path, local_path: Path) -> str:
     """Helper: create a project with location=local."""
-    import uuid as _uuid
     project_uuid = str(_uuid.uuid4())
     project_dir = reports_dir / project_uuid
     project_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Extract `useAppState` hook from `App.jsx` (314→205 lines)
- Split long route registration functions in `routes.py` and `standards_routes.py`
- Extract sub-hooks and sub-components from 7 long React functions
- Extract magic style literals to named constants
- Move inline imports to module level

## Test plan

- [x] All 670 Python tests pass
- [x] UI builds cleanly
- [x] Smoke test dashboard in browser