### PR TITLE
feat: finding dismissal and false-positive prevention

### DIFF
--- a/docs/superpowers/plans/2026-04-01-finding-dismissal.md
+++ b/docs/superpowers/plans/2026-04-01-finding-dismissal.md
@@ -1,0 +1,849 @@
+# Finding Dismissal & False-Positive Prevention — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users permanently dismiss false-positive findings from scoring, and reduce false positives at the AI verification level with a counter-argument prompt clause.
+
+**Architecture:** Two features: (A) prompt-level false-positive check in verification and analysis prompts — zero code changes, just text; (B) full dismissal pipeline — storage service, API routes, verification/scoring integration, and UI (dismiss button on cards, dismissed section in violations tab).
+
+**Tech Stack:** Python/Flask backend, React frontend, JSON file storage.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/quodeq/services/dismissed.py` | Create | Read/write/remove dismissed findings from `dismissed.json` |
+| `src/quodeq/api/routes_findings.py` | Create | 3 REST endpoints: list, dismiss, restore |
+| `src/quodeq/api/app.py` | Modify | Register findings routes |
+| `src/quodeq/analysis/subagents/_verify_pool.py` | Modify | Add false-positive clause to verification prompt |
+| `src/quodeq/data/prompts/subagent.md` | Modify | Add false-positive note in Rules section |
+| `src/quodeq/analysis/subagents/_verification.py` | Modify | Filter dismissed findings before verification |
+| `src/quodeq/services/violations_parsing.py` | Modify | Accept and apply dismissed_keys filter |
+| `src/quodeq/services/violations.py` | Modify | Load dismissed set and pass through chain |
+| `src/quodeq/ui/src/api/index.js` | Modify | Add 3 API client functions |
+| `src/quodeq/ui/src/features/explorer/components/EvalCards.jsx` | Modify | Add dismiss button to EvalViolationCard |
+| `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx` | Modify | Add dismissed section |
+| `src/quodeq/ui/src/styles/evaluation.css` | Modify | Dismissed card styles |
+| `tests/services/test_dismissed.py` | Create | Unit tests for dismissed service |
+| `tests/api/test_routes_findings.py` | Create | API endpoint tests |
+
+---
+
+### Task 1: Dismissed Findings Storage Service
+
+**Files:**
+- Create: `src/quodeq/services/dismissed.py`
+- Test: `tests/services/test_dismissed.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/services/test_dismissed.py
+"""Tests for the dismissed findings storage service."""
+import json
+from pathlib import Path
+
+from quodeq.services.dismissed import (
+    load_dismissed,
+    dismiss_finding,
+    restore_finding,
+    dismissed_keys,
+)
+
+
+class TestDismissedStorage:
+    def test_load_empty_when_no_file(self, tmp_path):
+        result = load_dismissed(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_dismiss_creates_file_and_appends(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
+        dismiss_finding(project_dir, finding)
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+        assert result[0]["req"] == "M-MOD-4"
+        assert result[0]["file"] == "foo.js"
+        assert result[0]["line"] == 4
+        assert "dismissed_at" in result[0]
+
+    def test_dismiss_deduplicates(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
+        dismiss_finding(project_dir, finding)
+        dismiss_finding(project_dir, finding)
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+
+    def test_restore_removes_finding(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
+        dismiss_finding(project_dir, {"req": "S-CON-1", "file": "bar.py", "line": 10, "dimension": "security", "severity": "major"})
+        restore_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4})
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+        assert result[0]["req"] == "S-CON-1"
+
+    def test_restore_nonexistent_is_noop(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        restore_finding(project_dir, {"req": "X-X-1", "file": "x.py", "line": 1})
+        assert load_dismissed(project_dir) == []
+
+    def test_dismissed_keys_returns_set_of_tuples(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
+        keys = dismissed_keys(project_dir)
+        assert keys == {("M-MOD-4", "foo.js", 4)}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/victor/GitHub/quodeq && export PATH="$HOME/.local/bin:$PATH" && uv run pytest tests/services/test_dismissed.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'quodeq.services.dismissed'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/quodeq/services/dismissed.py
+"""Persistent storage for dismissed findings — per-project JSON file."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+_FILENAME = "dismissed.json"
+
+
+def _dismissed_path(project_dir: Path) -> Path:
+    return project_dir / _FILENAME
+
+
+def _key(entry: dict) -> tuple:
+    return (entry.get("req", ""), entry.get("file", ""), entry.get("line", 0))
+
+
+def load_dismissed(project_dir: Path) -> list[dict]:
+    """Load dismissed findings for a project. Returns empty list if none."""
+    path = _dismissed_path(project_dir)
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def dismiss_finding(project_dir: Path, finding: dict) -> None:
+    """Add a finding to the dismissed list. Deduplicates by (req, file, line)."""
+    entries = load_dismissed(project_dir)
+    new_key = _key(finding)
+    if any(_key(e) == new_key for e in entries):
+        return
+    entry = {
+        "req": finding.get("req", ""),
+        "file": finding.get("file", ""),
+        "line": finding.get("line", 0),
+        "dimension": finding.get("dimension", ""),
+        "severity": finding.get("severity", ""),
+        "reason": finding.get("reason", ""),
+        "dismissed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    entries.append(entry)
+    _dismissed_path(project_dir).write_text(
+        json.dumps(entries, indent=2), encoding="utf-8",
+    )
+
+
+def restore_finding(project_dir: Path, finding: dict) -> None:
+    """Remove a finding from the dismissed list by (req, file, line)."""
+    entries = load_dismissed(project_dir)
+    target = _key(finding)
+    updated = [e for e in entries if _key(e) != target]
+    if len(updated) == len(entries):
+        return
+    path = _dismissed_path(project_dir)
+    if updated:
+        path.write_text(json.dumps(updated, indent=2), encoding="utf-8")
+    elif path.exists():
+        path.unlink()
+
+
+def dismissed_keys(project_dir: Path) -> set[tuple]:
+    """Return a set of (req, file, line) tuples for all dismissed findings."""
+    return {_key(e) for e in load_dismissed(project_dir)}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/services/test_dismissed.py -v`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/services/dismissed.py tests/services/test_dismissed.py
+git commit -m "feat(dismissed): add persistent storage service for dismissed findings"
+```
+
+---
+
+### Task 2: API Endpoints for Dismiss/Restore
+
+**Files:**
+- Create: `src/quodeq/api/routes_findings.py`
+- Modify: `src/quodeq/api/app.py:174` — add `register_findings_routes(app)` call
+- Test: `tests/api/test_routes_findings.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/api/test_routes_findings.py
+"""Tests for the findings dismiss/restore API endpoints."""
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from quodeq.api.routes_findings import register_findings_routes
+
+
+@pytest.fixture()
+def app(tmp_path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_findings_routes(app)
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+class TestDismissEndpoint:
+    def test_dismiss_creates_entry(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+            "reason": "False positive",
+        })
+        assert resp.status_code == 200
+        data = json.loads((project_dir / "dismissed.json").read_text())
+        assert len(data) == 1
+        assert data[0]["req"] == "M-MOD-4"
+
+    def test_dismiss_missing_fields_returns_400(self, client):
+        resp = client.post("/api/findings/dismiss", json={"project": "x"})
+        assert resp.status_code == 400
+
+
+class TestRestoreEndpoint:
+    def test_restore_removes_entry(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        resp = client.post("/api/findings/restore", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+        })
+        assert resp.status_code == 200
+        assert not (project_dir / "dismissed.json").exists()
+
+
+class TestListDismissedEndpoint:
+    def test_list_returns_dismissed(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        resp = client.get("/api/findings/dismissed?project=my-project")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data) == 1
+
+    def test_list_empty_project(self, client):
+        resp = client.get("/api/findings/dismissed?project=nonexistent")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/api/test_routes_findings.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'quodeq.api.routes_findings'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# src/quodeq/api/routes_findings.py
+"""API routes for dismissing and restoring individual findings."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding
+from quodeq.shared.utils import get_evaluations_dir
+
+
+def _project_dir(project: str) -> Path:
+    return Path(get_evaluations_dir()) / project
+
+
+def register_findings_routes(app: Flask) -> None:
+    """Register /api/findings/* routes."""
+
+    @app.get("/api/findings/dismissed")
+    def list_dismissed() -> Response:
+        project = request.args.get("project", "")
+        if not project:
+            return jsonify([])
+        return jsonify(load_dismissed(_project_dir(project)))
+
+    @app.post("/api/findings/dismiss")
+    def dismiss() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        req = body.get("req", "")
+        file = body.get("file", "")
+        line = body.get("line")
+        if not project or not req or not file or line is None:
+            return jsonify({"error": "project, req, file, and line are required"}), 400
+        dismiss_finding(_project_dir(project), body)
+        return jsonify({"ok": True}), 200
+
+    @app.post("/api/findings/restore")
+    def restore() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        req = body.get("req", "")
+        file = body.get("file", "")
+        line = body.get("line")
+        if not project or not req or not file or line is None:
+            return jsonify({"error": "project, req, file, and line are required"}), 400
+        restore_finding(_project_dir(project), body)
+        return jsonify({"ok": True}), 200
+```
+
+- [ ] **Step 4: Register routes in app factory**
+
+In `src/quodeq/api/app.py`, add import and call:
+
+```python
+# Add to imports (around line 31)
+from quodeq.api.routes_findings import register_findings_routes
+
+# Add to _register_all_routes (around line 174, after register_standards_routes)
+    register_findings_routes(app)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/api/test_routes_findings.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All tests pass (no regressions)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/quodeq/api/routes_findings.py src/quodeq/api/app.py tests/api/test_routes_findings.py
+git commit -m "feat(dismissed): add API endpoints for dismiss/restore/list findings"
+```
+
+---
+
+### Task 3: Verification & Scoring Integration
+
+**Files:**
+- Modify: `src/quodeq/analysis/subagents/_verification.py:20-32` — filter dismissed findings
+- Modify: `src/quodeq/services/violations_parsing.py:87-116` — accept dismissed_keys param
+- Modify: `src/quodeq/services/violations.py:63-72` — load and pass dismissed set
+
+- [ ] **Step 1: Filter dismissed findings in verification**
+
+In `src/quodeq/analysis/subagents/_verification.py`, modify `_load_and_filter_previous` to filter dismissed findings after loading:
+
+```python
+def _load_and_filter_previous(
+    config: RunConfig, dim_id: str, evidence_dir: Path,
+) -> list[dict]:
+    """Load previous findings and apply incremental file filter if active."""
+    from quodeq.analysis.subagents.verify import load_previous_findings_for_dimension  # deferred to avoid circular import
+
+    prev_findings = load_previous_findings_for_dimension(config, dim_id, evidence_dir)
+    if not prev_findings:
+        return []
+    if config.options.incremental_file_filter is not None:
+        filter_set = config.options.incremental_file_filter
+        prev_findings = [f for f in prev_findings if f.get("file") in filter_set]
+
+    # Filter out dismissed findings
+    from quodeq.services.dismissed import dismissed_keys  # deferred to avoid import at module level
+    project_dir = evidence_dir.parent
+    dkeys = dismissed_keys(project_dir)
+    if dkeys:
+        prev_findings = [
+            f for f in prev_findings
+            if (f.get("p", ""), f.get("file", ""), f.get("line", 0)) not in dkeys
+        ]
+
+    return prev_findings
+```
+
+- [ ] **Step 2: Add dismissed_keys param to violations parsing**
+
+In `src/quodeq/services/violations_parsing.py`, modify `_parse_jsonl_findings` signature and add filter:
+
+```python
+def _parse_jsonl_findings(
+    lines: Iterable[str], dimension: str, req_refs_lookup: dict[str, list[dict]] | None = None,
+    req_to_principle: dict[str, str] | None = None,
+    dismissed_keys: set[tuple] | None = None,
+) -> tuple[list[Finding], list[Finding]]:
+    """Parse raw JSONL lines into deduplicated violation and compliance lists."""
+    violations: list[Finding] = []
+    compliance: list[Finding] = []
+    seen: set[tuple] = set()
+    for raw_line in lines:
+        raw = raw_line.strip()
+        if not raw:
+            continue
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        principle = obj.get("p") or obj.get("req")
+        if not principle or obj.get("t") not in _FINDING_TYPES:
+            continue
+        # Skip dismissed findings
+        if dismissed_keys and obj.get("t") == _TYPE_VIOLATION:
+            key = (principle, obj.get("file", ""), obj.get("line", 0))
+            if key in dismissed_keys:
+                continue
+        obj["p"] = req_to_principle.get(principle, principle) if req_to_principle else principle
+        dedup_key = (principle, obj.get("t"), obj.get("file"), obj.get("line"))
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+        entry = _build_finding_entry(obj, dimension, req_refs_lookup)
+        if obj["t"] == _TYPE_VIOLATION:
+            violations.append(entry)
+        else:
+            compliance.append(entry)
+    return violations, compliance
+```
+
+- [ ] **Step 3: Thread dismissed set through the violations chain**
+
+Read `parse_violations_from_jsonl` in `violations_parsing.py` to find where it calls `_parse_jsonl_findings`, and add the `dismissed_keys` parameter through. Then in `violations.py`, load the dismissed set before calling into parsing.
+
+In `src/quodeq/services/violations.py`, modify `resolve_dimension_eval` to load and pass dismissed keys:
+
+```python
+def resolve_dimension_eval(
+    base: Path, project: str, run_id: str, dimension: str,
+    options: _ResolveOptions | None = None,
+) -> ViolationResponse | dict[str, Any] | None:
+    # ... existing code up to the jsonl_path block ...
+
+    jsonl_path = base / "evidence" / f"{dimension}_evidence.jsonl"
+    stream_path = base / "evidence" / f"{dimension}_live.stream"
+    if _exists(jsonl_path) and _stat(jsonl_path).st_size > 0:
+        # Load dismissed findings for this project
+        from quodeq.services.dismissed import dismissed_keys as _dismissed_keys
+        project_dir = base  # base is already the project run dir's parent
+        # The evaluations structure is: evaluations/<project>/<run_id>/evidence/
+        # base = evaluations/<project>/<run_id>, so project_dir = base.parent
+        dkeys = _dismissed_keys(base.parent)
+        return parse_violations_from_jsonl(
+            jsonl_path, stream_path, ctx, compiled_dir=compiled_dir,
+            dismissed_keys=dkeys,
+        )
+    # ... rest unchanged ...
+```
+
+Then thread `dismissed_keys` through `parse_violations_from_jsonl` to `_parse_jsonl_findings`. Read `parse_violations_from_jsonl` to see its signature and update it.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest tests/ -x -q`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/_verification.py src/quodeq/services/violations_parsing.py src/quodeq/services/violations.py
+git commit -m "feat(dismissed): filter dismissed findings from verification and scoring"
+```
+
+---
+
+### Task 4: False-Positive Counter-Argument in Prompts
+
+**Files:**
+- Modify: `src/quodeq/analysis/subagents/_verify_pool.py:25-51`
+- Modify: `src/quodeq/data/prompts/subagent.md:28-35`
+
+- [ ] **Step 1: Update verification prompt**
+
+In `src/quodeq/analysis/subagents/_verify_pool.py`, modify `_VERIFY_PROMPT_TEMPLATE` to add a false-positive check after step 3:
+
+```python
+_VERIFY_PROMPT_TEMPLATE = """\
+You are re-verifying previous evaluation findings against the current codebase.
+This is a quick verification pass — be fast and decisive.
+
+## Task
+
+For each file in the verification manifest at `{manifest_path}`:
+1. Read the file from the queue
+2. Look up its findings in the manifest
+3. For each finding, check if the violation/compliance condition **still applies**
+   to the current code — not just whether the line exists, but whether the
+   underlying issue is still present. Each finding may include a `context` field
+   with ~10 lines of surrounding code that can help assess whether the violation
+   still applies
+4. Before confirming, check for false positives:
+   - A string/number literal inside a constant, enum, or config definition is
+     NOT a "magic literal" violation — the definition IS the extraction
+   - A long function that only registers routes/handlers with no extractable
+     logic may not be meaningfully splittable
+   - Duplicated code in test fixtures may be intentional for test clarity
+   - If the finding targets the fix itself (the code IS the remediation), skip it
+5. If the finding still applies after the false-positive check, report it using
+   the `report_finding` tool with the same fields
+6. If the issue has been fixed, no longer applies, or is a false positive, skip
+   it silently
+
+## Important
+
+- Do NOT discover new findings — only verify existing ones
+- Do NOT modify any files
+- Read each file, check the findings, report confirmed ones, move on
+- Be fast — this should take seconds per file
+
+Dimension: {dimension}
+"""
+```
+
+- [ ] **Step 2: Update analysis prompt**
+
+In `src/quodeq/data/prompts/subagent.md`, add after the existing Rules section (after line 35 "Skip generated, vendored, and dependency directories"):
+
+```markdown
+- **Avoid false positives** — a string/number literal inside a constant definition or enum is NOT a magic literal; a long function that only registers routes with no extractable logic is not always splittable; duplicated test setup code may be intentional. If the code IS the remediation for the issue, it is not a violation.
+```
+
+- [ ] **Step 3: Verify prompts render correctly**
+
+Run: `uv run pytest tests/engine/test_prompt_builder.py -v`
+Expected: All prompt builder tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/_verify_pool.py src/quodeq/data/prompts/subagent.md
+git commit -m "feat(dismissed): add false-positive counter-argument to verification and analysis prompts"
+```
+
+---
+
+### Task 5: UI — API Client Functions
+
+**Files:**
+- Modify: `src/quodeq/ui/src/api/index.js`
+
+- [ ] **Step 1: Add three API client functions**
+
+Add to the end of `src/quodeq/ui/src/api/index.js` (before any default export if present):
+
+```javascript
+/**
+ * List dismissed findings for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Array>} Dismissed findings array
+ */
+export async function listDismissedFindings(projectId) {
+  const res = await fetch(`/api/findings/dismissed?project=${encodeURIComponent(projectId)}`);
+  if (!res.ok) throw new Error(`Failed to list dismissed findings: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Dismiss a finding (exclude from scoring).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding data: { req, file, line, dimension, severity, reason }
+ * @returns {Promise<object>} Server response
+ */
+export async function dismissFinding(projectId, finding) {
+  const res = await fetch('/api/findings/dismiss', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+  if (!res.ok) throw new Error(`Failed to dismiss finding: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Restore a dismissed finding (include in scoring again).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding key: { req, file, line }
+ * @returns {Promise<object>} Server response
+ */
+export async function restoreFinding(projectId, finding) {
+  const res = await fetch('/api/findings/restore', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+  if (!res.ok) throw new Error(`Failed to restore finding: ${res.status}`);
+  return res.json();
+}
+```
+
+- [ ] **Step 2: Verify UI builds**
+
+Run: `cd src/quodeq/ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/quodeq/ui/src/api/index.js
+git commit -m "feat(dismissed): add API client functions for dismiss/restore/list"
+```
+
+---
+
+### Task 6: UI — Dismiss Button on Violation Cards
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/explorer/components/EvalCards.jsx`
+- Modify: `src/quodeq/ui/src/styles/evaluation.css`
+
+- [ ] **Step 1: Add dismiss button to EvalViolationCard**
+
+In `src/quodeq/ui/src/features/explorer/components/EvalCards.jsx`, modify `EvalViolationCard` to accept an `onDismiss` prop and render a dismiss button:
+
+```jsx
+export function EvalViolationCard({ v, principle, buildViolationPlanText, index, onDismiss }) {
+  const { filename, ref, display } = useFileInfo(v.file, v.line, v.endLine);
+  return (
+    <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
+      <div className="vdetail-row-main">
+        <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
+        <span className="vrow-label">[{v.principle || principle}]</span>
+        {filename && <FileCopyBtn display={display} copyText={ref} />}
+        <CopyButton label="Fix plan" onClick={() => copyToClipboard(buildViolationPlanText(v))} />
+        {onDismiss && (
+          <button
+            type="button"
+            className="dismiss-btn"
+            onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
+            title="Dismiss this finding (exclude from scoring)"
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+      <ViolationDetail item={v} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add CSS for dismiss button**
+
+In `src/quodeq/ui/src/styles/evaluation.css`, add after the `.vdetail-row-main .detail-copy-btn` block:
+
+```css
+/* Dismiss button on violation cards */
+.dismiss-btn {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 150ms ease;
+}
+.dismiss-btn:hover {
+  color: #f0883e;
+  border-color: #f0883e;
+}
+```
+
+- [ ] **Step 3: Thread onDismiss through callers**
+
+The `EvalViolationCard` is used in `EvalPrincipleDetailPage.jsx` via `ViolationListSection`. Thread the `onDismiss` callback from the page level down. The caller will need to know the project ID to call the API. Read the page component to see how `project` is available and pass `onDismiss` through.
+
+The `onDismiss` handler at the page level should:
+1. Call `dismissFinding(projectId, finding)` 
+2. Remove the finding from the local violations state (optimistic update)
+
+- [ ] **Step 4: Verify UI builds**
+
+Run: `cd src/quodeq/ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/ui/src/features/explorer/components/EvalCards.jsx src/quodeq/ui/src/styles/evaluation.css
+git commit -m "feat(dismissed): add dismiss button to violation cards"
+```
+
+---
+
+### Task 7: UI — Dismissed Section in Violations Tab
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx`
+- Modify: `src/quodeq/ui/src/styles/evaluation.css`
+
+- [ ] **Step 1: Add DismissedSection component**
+
+Create a `DismissedSection` component inside `ViolationsPage.jsx` (or a new file if the page gets too long):
+
+```jsx
+function DismissedSection({ dismissed, onRestore }) {
+  const [open, setOpen] = useState(false);
+  if (dismissed.length === 0) return null;
+  return (
+    <>
+      <div className="dismissed-bar" onClick={() => setOpen((v) => !v)} role="button" tabIndex={0}>
+        <span className={`dismissed-bar-icon${open ? ' open' : ''}`}>›</span>
+        <span className="dismissed-bar-label">Dismissed findings</span>
+        <span className="dismissed-bar-count">{dismissed.length}</span>
+        <span className="dismissed-bar-note">Not included in scoring</span>
+      </div>
+      {open && (
+        <div className="dismissed-list-inner">
+          {dismissed.map((d, i) => (
+            <div key={`${d.req}-${d.file}-${d.line}`} className="dismissed-card">
+              <div className="dismissed-card-body">
+                <div className="dismissed-card-top">
+                  <span className="dismissed-tag">dismissed</span>
+                  <span className="dismissed-label">[{d.dimension}]</span>
+                  <span className="dismissed-file">{d.file}:{d.line}</span>
+                </div>
+                {d.reason && <div className="dismissed-reason">{d.reason}</div>}
+              </div>
+              <button type="button" className="restore-btn" onClick={() => onRestore(d)}>
+                Restore
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Load dismissed findings in ViolationsPage**
+
+In the `ViolationsPage` default export, add state and effect to load dismissed findings:
+
+```jsx
+// At the top of ViolationsPage component:
+const [dismissed, setDismissed] = useState([]);
+
+useEffect(() => {
+  // data.accumulated should contain the project name
+  const project = data.accumulated?.project;
+  if (project) {
+    listDismissedFindings(project).then(setDismissed).catch(() => setDismissed([]));
+  }
+}, [data.accumulated?.project]);
+
+const handleRestore = useCallback(async (finding) => {
+  const project = data.accumulated?.project;
+  if (!project) return;
+  await restoreFinding(project, finding);
+  setDismissed((prev) => prev.filter((d) => !(d.req === finding.req && d.file === finding.file && d.line === finding.line)));
+}, [data.accumulated?.project]);
+```
+
+Add `<DismissedSection dismissed={dismissed} onRestore={handleRestore} />` at the bottom of the return JSX.
+
+- [ ] **Step 3: Add CSS for dismissed section**
+
+In `src/quodeq/ui/src/styles/evaluation.css`, add the dismissed section styles (dismissed-bar, dismissed-card, dismissed-tag, restore-btn, etc.) matching the mockup. Use the CSS from the mockup HTML as reference.
+
+- [ ] **Step 4: Verify UI builds**
+
+Run: `cd src/quodeq/ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx src/quodeq/ui/src/styles/evaluation.css
+git commit -m "feat(dismissed): add dismissed findings section to violations tab"
+```
+
+---
+
+### Task 8: Integration Test & Smoke Test
+
+**Files:**
+- No new files — run existing tests and manual verification
+
+- [ ] **Step 1: Run full Python test suite**
+
+Run: `cd /Users/victor/GitHub/quodeq && export PATH="$HOME/.local/bin:$PATH" && uv run pytest tests/ -x -q`
+Expected: All tests pass
+
+- [ ] **Step 2: Build UI**
+
+Run: `cd src/quodeq/ui && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Smoke test in browser**
+
+Run: `cd /Users/victor/GitHub/quodeq && export PATH="$HOME/.local/bin:$PATH" && uv run quodeq dashboard`
+
+Verify:
+1. Open a project with violations
+2. Navigate to a dimension → principle → see violation cards with "Dismiss" button
+3. Click Dismiss — card disappears
+4. Go to Violations tab — see "Dismissed findings (1)" at the bottom
+5. Expand it — see the dismissed card with "Restore" button
+6. Click Restore — card disappears from dismissed, reappears on next page load
+
+- [ ] **Step 4: Final commit (if any fixes needed)**
+
+```bash
+git add -u
+git commit -m "fix(dismissed): integration fixes from smoke test"
+```

--- a/docs/superpowers/specs/2026-04-01-finding-dismissal-design.md
+++ b/docs/superpowers/specs/2026-04-01-finding-dismissal-design.md
@@ -1,0 +1,162 @@
+# Finding Dismissal & False-Positive Prevention
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Problem
+
+The AI evaluation pipeline produces false positives — findings that are technically correct pattern matches but don't represent real issues (e.g., "magic strings" that exist only inside a named constant definition). These inflate violation counts and drag grades down unfairly. Users have no way to exclude them.
+
+## Solution
+
+Two complementary features:
+
+1. **Counter-argument step in verification** — Prompt-level change that asks the AI to check for common false-positive patterns before confirming a finding
+2. **Finding dismissal mechanism** — Lets users permanently dismiss individual findings, excluding them from scoring, with a UI to view and restore dismissed findings
+
+## Feature A: Counter-Argument in Verification Prompt
+
+### What changes
+
+Add a false-positive check clause to `_VERIFY_PROMPT_TEMPLATE` in `src/quodeq/analysis/subagents/_verify_pool.py`.
+
+After step 3 ("check if the violation/compliance condition still applies"), insert:
+
+> 4. Before confirming, check for false positives. Common patterns:
+>    - String/number literal inside a constant, enum, or config definition is NOT a "magic literal" violation — the definition IS the fix
+>    - A long function that only registers routes/handlers with no extractable logic is not always splittable
+>    - Duplicated code in test fixtures may be intentional for test clarity
+>    - If the finding targets the fix itself, skip it
+
+### Scope
+
+- One file changed: `_verify_pool.py`
+- No code changes beyond the prompt string
+- Also applies during initial analysis via the subagent prompt (`subagent.md`) — add a similar note in the Rules section
+
+## Feature B: Finding Dismissal
+
+### Storage
+
+Dismissed findings stored at:
+```
+~/.quodeq/evaluations/<project>/dismissed.json
+```
+
+Project-level file (not per-run, not per-dimension) so dismissals persist across evaluations.
+
+Schema:
+```json
+[
+  {
+    "req": "M-MOD-4",
+    "file": "useStandards.js",
+    "line": 4,
+    "dimension": "maintainability",
+    "severity": "minor",
+    "reason": "String literals inside STANDARD_TYPES constant definition",
+    "dismissed_at": "2026-04-01T12:00:00Z"
+  }
+]
+```
+
+**Finding identity:** A dismissed finding matches by `(req, file, line)` tuple. If the same requirement is violated at the same file and line, it's considered the same finding.
+
+### Backend API
+
+Three endpoints on the existing Flask app:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/findings/dismissed?project=<id>` | List dismissed findings for a project |
+| `POST` | `/api/findings/dismiss` | Dismiss a finding (body: `{ project, req, file, line, dimension, severity, reason }`) |
+| `POST` | `/api/findings/restore` | Restore a finding (body: `{ project, req, file, line }`) |
+
+Implementation:
+- New file: `src/quodeq/api/routes_findings.py` — registers the three routes
+- Storage helper: `src/quodeq/services/dismissed.py` — read/write/remove from `dismissed.json`
+- Register routes in the existing app factory
+
+### Verification Integration
+
+In `src/quodeq/analysis/subagents/verify.py`, `load_previous_findings_for_dimension`:
+- After loading previous findings, load the project's `dismissed.json`
+- Filter out any finding whose `(req, file, line)` matches a dismissed entry
+- Dismissed findings are not sent to verification subagents and not carried forward
+
+### Scoring Integration
+
+In `src/quodeq/services/violations_parsing.py`, `_parse_jsonl_findings`:
+- Accept an optional `dismissed_keys: set[tuple] | None` parameter
+- Skip any parsed finding whose `(req, file, line)` is in the dismissed set
+- The caller (`resolve_dimension_eval` or its chain) loads dismissed findings and passes the set
+
+### UI: Dismiss Button on Violation Cards
+
+In `src/quodeq/ui/src/features/explorer/components/EvalCards.jsx`:
+- Add a "Dismiss" button to `EvalViolationCard`, next to "Fix plan"
+- Small, unobtrusive — same style as "Fix plan" button
+- On click: calls `POST /api/findings/dismiss` with the finding's data
+- Card animates out (fade + slide left, 300ms)
+- Parent component removes it from the active violations list
+
+### UI: Dismissed Section in Violations Tab
+
+In `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx`:
+- At the bottom of the page, add a collapsible "Dismissed findings (N)" bar
+- Collapsed by default — shows count badge and "Not included in scoring" note
+- When expanded, shows dismissed cards in a compact format:
+  - Greyed out (opacity 0.55, 0.8 on hover)
+  - Each card shows: dismissed tag, principle label, file ref, reason
+  - "Restore" button on each card
+- On restore: calls `POST /api/findings/restore`, removes from dismissed list, finding reappears in next evaluation or page refresh
+
+### UI: API Client
+
+In `src/quodeq/ui/src/api/index.js`, add:
+- `dismissFinding(project, finding)` — POST to dismiss endpoint
+- `restoreFinding(project, finding)` — POST to restore endpoint
+- `listDismissedFindings(project)` — GET dismissed for project
+
+### Data Flow
+
+```
+User clicks Dismiss on violation card
+  → POST /api/findings/dismiss
+  → Server appends to dismissed.json
+  → Card removed from UI
+
+Next evaluation runs
+  → Verification loads dismissed.json
+  → Skips matching findings
+  → Scoring excludes dismissed findings
+  → Grade reflects only active findings
+
+User opens Violations tab
+  → Page loads dismissed list
+  → Shows in collapsed section at bottom
+  → User can Restore → POST /api/findings/restore → removed from dismissed.json
+```
+
+## Files Changed
+
+### Feature A (prompt)
+- `src/quodeq/analysis/subagents/_verify_pool.py` — add false-positive clause to verification prompt
+- `src/quodeq/data/prompts/subagent.md` — add false-positive note in Rules section
+
+### Feature B (dismissal)
+- `src/quodeq/api/routes_findings.py` — new file, 3 routes
+- `src/quodeq/services/dismissed.py` — new file, read/write/remove helpers
+- `src/quodeq/api/routes.py` — register new routes in app factory (or wherever routes are registered)
+- `src/quodeq/analysis/subagents/verify.py` — filter dismissed in `load_previous_findings_for_dimension`
+- `src/quodeq/services/violations_parsing.py` — accept dismissed_keys param in `_parse_jsonl_findings`
+- `src/quodeq/services/violations.py` — pass dismissed set through the chain
+- `src/quodeq/ui/src/api/index.js` — add 3 API functions
+- `src/quodeq/ui/src/features/explorer/components/EvalCards.jsx` — dismiss button on violation card
+- `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx` — dismissed section
+- `src/quodeq/ui/src/styles/evaluation.css` — dismissed card styles
+
+### Tests
+- `tests/services/test_dismissed.py` — new, test read/write/remove
+- `tests/api/test_routes_findings.py` — new, test 3 endpoints
+- `tests/engine/test_verification_dismissed.py` — test filtering in verify.py

--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -29,6 +29,15 @@ def _load_and_filter_previous(
     if config.options.incremental_file_filter is not None:
         filter_set = config.options.incremental_file_filter
         prev_findings = [f for f in prev_findings if f.get("file") in filter_set]
+    # Filter out dismissed findings
+    from quodeq.services.dismissed import dismissed_keys  # deferred to avoid import at module level
+    project_dir = evidence_dir.parent
+    dkeys = dismissed_keys(project_dir)
+    if dkeys:
+        prev_findings = [
+            f for f in prev_findings
+            if (f.get("p", ""), f.get("file", ""), f.get("line", 0)) not in dkeys
+        ]
     return prev_findings
 
 

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -36,9 +36,17 @@ For each file in the verification manifest at `{manifest_path}`:
    underlying issue is still present. Each finding may include a `context` field
    with ~10 lines of surrounding code that can help assess whether the violation
    still applies
-4. If the finding still applies, report it using the `report_finding` tool
-   with the same fields (principle, type, severity, file, line, reason, snippet)
-5. If the issue has been fixed or no longer applies, skip it silently
+4. Before confirming, check for false positives:
+   - A string/number literal inside a constant, enum, or config definition is
+     NOT a "magic literal" violation — the definition IS the extraction
+   - A long function that only registers routes/handlers with no extractable
+     logic may not be meaningfully splittable
+   - Duplicated code in test fixtures may be intentional for test clarity
+   - If the finding targets the fix itself (the code IS the remediation), skip it
+5. If the finding still applies after the false-positive check, report it using
+   the `report_finding` tool with the same fields
+6. If the issue has been fixed, no longer applies, or is a false positive, skip
+   it silently
 
 ## Important
 

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -30,6 +30,7 @@ from quodeq.api.routes import (
     register_static_routes,
 )
 from quodeq.api.standards_routes import register_standards_routes
+from quodeq.api.routes_findings import register_findings_routes
 
 _HEALTH_PATH = "/api/health"
 _RATE_LIMITED_GET_PATHS = frozenset({"/api/browse"})
@@ -172,6 +173,7 @@ def _register_all_routes(
     register_evaluation_item_routes(app, provider)
     register_discovery_routes(app, provider)
     register_standards_routes(app)
+    register_findings_routes(app)
     register_static_routes(app, static_dist)
 
 

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -1,0 +1,50 @@
+"""API routes for dismissing and restoring individual findings."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding
+
+
+def _project_dir(evaluations_dir: str, project: str) -> Path:
+    return Path(evaluations_dir) / project
+
+
+def register_findings_routes(app: Flask) -> None:
+    """Register /api/findings/* routes."""
+
+    def _eval_dir() -> str:
+        return app.config.get("EVALUATIONS_DIR") or __import__("quodeq.shared.utils", fromlist=["get_evaluations_dir"]).get_evaluations_dir()
+
+    @app.get("/api/findings/dismissed")
+    def list_dismissed() -> Response:
+        project = request.args.get("project", "")
+        if not project:
+            return jsonify([])
+        return jsonify(load_dismissed(_project_dir(_eval_dir(), project)))
+
+    @app.post("/api/findings/dismiss")
+    def dismiss() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        req = body.get("req", "")
+        file = body.get("file", "")
+        line = body.get("line")
+        if not project or not req or not file or line is None:
+            return jsonify({"error": "project, req, file, and line are required"}), 400
+        dismiss_finding(_project_dir(_eval_dir(), project), body)
+        return jsonify({"ok": True}), 200
+
+    @app.post("/api/findings/restore")
+    def restore() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        req = body.get("req", "")
+        file = body.get("file", "")
+        line = body.get("line")
+        if not project or not req or not file or line is None:
+            return jsonify({"error": "project, req, file, and line are required"}), 400
+        restore_finding(_project_dir(_eval_dir(), project), body)
+        return jsonify({"ok": True}), 200

--- a/src/quodeq/data/prompts/subagent.md
+++ b/src/quodeq/data/prompts/subagent.md
@@ -32,6 +32,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 - Every finding must have a specific file and line
 - Do not fabricate findings — only report what you can see in the code
 - Skip generated, vendored, and dependency directories — use the project type to infer what to skip
+- **Avoid false positives** — a string/number literal inside a constant definition or enum is NOT a magic literal; a long function that only registers routes with no extractable logic is not always splittable; duplicated test setup code may be intentional. If the code IS the remediation for the issue, it is not a violation.
 
 ## Severity (applies to BOTH violations AND compliance)
 

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -18,6 +18,7 @@ from quodeq.services.ports import (
 from quodeq.core.types import DimensionResult, to_camel_dict
 from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.shared.utils import _env_int
 
 _DEFAULT_ACC_CACHE_MAX = 256
@@ -220,6 +221,11 @@ def _compute_result(
         reports_root, project, all_run_infos, runs, get_run_data
     )
     all_dimensions = list(latest_by_dimension.values())
+    all_dimensions = filter_dismissed_from_dimensions(
+        all_dimensions, reports_root / project,
+    )
+    # Rebuild lookup so downstream trend computation uses filtered data
+    latest_by_dimension = {d.dimension: d for d in all_dimensions if d.dimension}
     dimensions_with_trend = _compute_accumulated_trends(all_dimensions, prev_occurrence)
     severity = _aggregate_severity_counts(all_dimensions)
     avg_score, prev_avg_score = _compute_accumulated_scores(all_dimensions, prev_run_latest)

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -1,0 +1,120 @@
+"""Persistent storage for dismissed findings — per-project JSON file."""
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from quodeq.core.types.finding import Finding, SeverityTally, Totals
+
+_FILENAME = "dismissed.json"
+
+
+def _dismissed_path(project_dir: Path) -> Path:
+    return project_dir / _FILENAME
+
+
+def _key(entry: dict) -> tuple:
+    return (entry.get("req", ""), entry.get("file", ""), entry.get("line", 0))
+
+
+def load_dismissed(project_dir: Path) -> list[dict]:
+    """Load dismissed findings for a project. Returns empty list if none."""
+    path = _dismissed_path(project_dir)
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def dismiss_finding(project_dir: Path, finding: dict) -> None:
+    """Add a finding to the dismissed list. Deduplicates by (req, file, line)."""
+    entries = load_dismissed(project_dir)
+    new_key = _key(finding)
+    if any(_key(e) == new_key for e in entries):
+        return
+    entry = {
+        "req": finding.get("req", ""),
+        "file": finding.get("file", ""),
+        "line": finding.get("line", 0),
+        "dimension": finding.get("dimension", ""),
+        "principle": finding.get("principle", ""),
+        "severity": finding.get("severity", ""),
+        "reason": finding.get("reason", ""),
+        "dismissed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    entries.append(entry)
+    _dismissed_path(project_dir).write_text(
+        json.dumps(entries, indent=2), encoding="utf-8",
+    )
+
+
+def restore_finding(project_dir: Path, finding: dict) -> None:
+    """Remove a finding from the dismissed list by (req, file, line)."""
+    entries = load_dismissed(project_dir)
+    target = _key(finding)
+    updated = [e for e in entries if _key(e) != target]
+    if len(updated) == len(entries):
+        return
+    path = _dismissed_path(project_dir)
+    if updated:
+        path.write_text(json.dumps(updated, indent=2), encoding="utf-8")
+    elif path.exists():
+        path.unlink()
+
+
+def dismissed_keys(project_dir: Path) -> set[tuple]:
+    """Return a set of (req, file, line) tuples for all dismissed findings."""
+    return {_key(e) for e in load_dismissed(project_dir)}
+
+
+def _finding_key(f: Finding) -> tuple:
+    return (f.req or "", f.file or "", f.line or 0)
+
+
+def _recount_totals(violations: list[Finding], old_totals: Totals | None) -> Totals:
+    """Recompute totals from a filtered violations list, preserving compliance count."""
+    critical = major = minor = unknown = 0
+    for v in violations:
+        sev = (v.severity or "").lower()
+        if sev == "critical":
+            critical += 1
+        elif sev == "major":
+            major += 1
+        elif sev == "minor":
+            minor += 1
+        else:
+            unknown += 1
+    return Totals(
+        violation_count=len(violations),
+        compliance_count=old_totals.compliance_count if old_totals else 0,
+        severity=SeverityTally(critical=critical, major=major, minor=minor, unknown=unknown),
+    )
+
+
+def filter_dismissed_from_dimensions(
+    dimensions: list, project_dir: Path,
+) -> list:
+    """Return a new list of DimensionResult with dismissed findings removed.
+
+    Recalculates totals for any dimension whose violations were filtered.
+    Leaves compliance, principles, overall_score, overall_grade unchanged.
+    """
+    keys = dismissed_keys(project_dir)
+    if not keys:
+        return dimensions
+    result = []
+    for dim in dimensions:
+        filtered = [v for v in dim.violations if _finding_key(v) not in keys]
+        if len(filtered) == len(dim.violations):
+            result.append(dim)
+        else:
+            result.append(replace(
+                dim,
+                violations=filtered,
+                totals=_recount_totals(filtered, dim.totals),
+            ))
+    return result

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -34,6 +34,50 @@ class _ResolveOptions:
     compiled_dir: Path | None = None
 
 
+def _dismissed_key_for_violation(v: dict) -> tuple:
+    """Build a (req, file, line) key from a violation dict.
+
+    Handles two formats:
+    - Separated: file="path/to/file.py", line=42
+    - Combined: file="path/to/file.py:42", line=None
+    """
+    req = v.get("req", "")
+    raw_file = v.get("file", "")
+    line = v.get("line")
+    if line is not None:
+        return (req, raw_file, line)
+    # Parse line from "file:line" format
+    if ":" in raw_file:
+        parts = raw_file.rsplit(":", 1)
+        try:
+            return (req, parts[0], int(parts[1]))
+        except (ValueError, IndexError):
+            pass
+    return (req, raw_file, 0)
+
+
+def _filter_dismissed_from_result(
+    result: "ViolationResponse | dict[str, Any] | None",
+    dkeys: "set[tuple]",
+) -> "ViolationResponse | dict[str, Any] | None":
+    """Remove dismissed violations from any result format."""
+    if not result or not dkeys:
+        return result
+    if isinstance(result, dict):
+        if "violations" in result:
+            result["violations"] = [
+                v for v in result["violations"]
+                if _dismissed_key_for_violation(v) not in dkeys
+            ]
+        for p in result.get("principles", []):
+            if "violations" in p:
+                p["violations"] = [
+                    v for v in p["violations"]
+                    if _dismissed_key_for_violation(v) not in dkeys
+                ]
+    return result
+
+
 def resolve_dimension_eval(
     base: Path, project: str, run_id: str, dimension: str,
     options: _ResolveOptions | None = None,
@@ -43,14 +87,19 @@ def resolve_dimension_eval(
     *options* bundles injectable filesystem callbacks and the compiled
     standards directory for testing without a real FS.
     """
+    from quodeq.services.dismissed import dismissed_keys as _dismissed_keys
+
     opts = options or _ResolveOptions()
     _exists = opts.exists_fn
     _stat = opts.stat_fn
     compiled_dir = opts.compiled_dir
+    dkeys = _dismissed_keys(base.parent)
 
     eval_path = base / "evaluation" / f"{dimension}.json"
     if _exists(eval_path):
-        return parse_eval_from_json(eval_path, project, run_id, dimension)
+        return _filter_dismissed_from_result(
+            parse_eval_from_json(eval_path, project, run_id, dimension), dkeys,
+        )
 
     markdown_path = base / "evaluation" / f"{dimension}_eval.md"
     if _exists(markdown_path):
@@ -58,18 +107,25 @@ def resolve_dimension_eval(
             content = read_text(markdown_path)
         except OSError:
             return None
-        return parse_eval_markdown(content, project, run_id, dimension)
+        return _filter_dismissed_from_result(
+            parse_eval_markdown(content, project, run_id, dimension), dkeys,
+        )
 
     ctx = ViolationContext(project=project, run_id=run_id, dimension=dimension)
 
     evidence_path = base / "evidence" / f"{dimension}_evidence.json"
     if _exists(evidence_path):
-        return parse_violations_from_evidence(evidence_path, ctx)
+        return _filter_dismissed_from_result(
+            parse_violations_from_evidence(evidence_path, ctx), dkeys,
+        )
 
     jsonl_path = base / "evidence" / f"{dimension}_evidence.jsonl"
     stream_path = base / "evidence" / f"{dimension}_live.stream"
     if _exists(jsonl_path) and _stat(jsonl_path).st_size > 0:
-        return parse_violations_from_jsonl(jsonl_path, stream_path, ctx, compiled_dir=compiled_dir)
+        return parse_violations_from_jsonl(
+            jsonl_path, stream_path, ctx, compiled_dir=compiled_dir,
+            dismissed_keys=dkeys,
+        )
 
     if _exists(stream_path):
         return parse_violations_from_stream(stream_path, ctx)

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -87,6 +87,7 @@ def _build_finding_entry(obj: dict, dimension: str, req_refs_lookup: dict[str, l
 def _parse_jsonl_findings(
     lines: Iterable[str], dimension: str, req_refs_lookup: dict[str, list[dict]] | None = None,
     req_to_principle: dict[str, str] | None = None,
+    dismissed_keys: "set[tuple] | None" = None,
 ) -> tuple[list[Finding], list[Finding]]:
     """Parse raw JSONL lines into deduplicated violation and compliance lists."""
     violations: list[Finding] = []
@@ -103,6 +104,12 @@ def _parse_jsonl_findings(
         principle = obj.get("p") or obj.get("req")
         if not principle or obj.get("t") not in _FINDING_TYPES:
             continue
+        # Skip dismissed findings — match by req ID (e.g. "M-MOD-3"), not principle name
+        if dismissed_keys and obj.get("t") == _TYPE_VIOLATION:
+            req_id = obj.get("req") or principle
+            dismissed_key = (req_id, obj.get("file", ""), obj.get("line", 0))
+            if dismissed_key in dismissed_keys:
+                continue
         obj["p"] = req_to_principle.get(principle, principle) if req_to_principle else principle
         dedup_key = (principle, obj.get("t"), obj.get("file"), obj.get("line"))
         if dedup_key in seen:
@@ -149,13 +156,16 @@ def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None)
 def parse_violations_from_jsonl(
     jsonl_path: Path, stream_path: Path | None, ctx: ViolationContext,
     compiled_dir: Path | None = None,
+    dismissed_keys: "set[tuple] | None" = None,
 ) -> ViolationResponse | None:
     """Parse live JSONL findings written by the MCP server."""
     req_refs_lookup = build_req_refs_lookup(compiled_dir, ctx.dimension) if compiled_dir else None
     req_to_principle = _load_req_to_principle(ctx.dimension)
     try:
         with open_text(jsonl_path) as _f:
-            violations, compliance = _parse_jsonl_findings(_f, ctx.dimension, req_refs_lookup, req_to_principle)
+            violations, compliance = _parse_jsonl_findings(
+                _f, ctx.dimension, req_refs_lookup, req_to_principle, dismissed_keys=dismissed_keys,
+            )
     except OSError as exc:
         _logger.warning("Failed to read findings file: %s", exc)
         return None

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-DTc9zLcj.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DaBaZxOh.css">
+    <script type="module" crossorigin src="/assets/index-BcoZ7b1Q.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-N1AJiR7P.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -12,6 +12,7 @@ import SettingsPage from './features/settings/components/SettingsPage.jsx';
 import StandardsPage from './features/standards/StandardsPage.jsx';
 import ViolationsPage from './features/violations/components/ViolationsPage.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
+import { dismissFinding } from './api/index.js';
 import LoadingScreen from './components/LoadingScreen.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import ProjectHeader from './components/ProjectHeader.jsx';
@@ -63,6 +64,21 @@ function resolveHistorySelectedRunId(selectedRun, trend) {
   return trend.length > 0 ? trend[0].runId : null;
 }
 
+function buildDismissPayload(v, fallbackDimension) {
+  const fileParts = (v.file || '').split(':');
+  const file = fileParts[0];
+  const line = v.line ?? (fileParts[1] ? parseInt(fileParts[1], 10) : 0);
+  return {
+    req: v.req || v.principle,
+    file,
+    line,
+    dimension: v.dimension || fallbackDimension || '',
+    severity: v.severity,
+    reason: v.reason,
+    principle: v.principle || '',
+  };
+}
+
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
   violations: (params, props) => {
@@ -71,11 +87,12 @@ const ROUTE_RENDERERS = {
     const nav = props.navigation.handleNavigate;
     return (
       <ViolationsPage
-        data={{ accumulated: acc, accumulatedDimensions: dims }}
+        data={{ accumulated: acc, accumulatedDimensions: dims, selectedProject: props.navigation.selectedProject }}
         callbacks={{
           onDimensionClick: (dim) => nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, sourceTab: 'violations' }),
           onFileClick: (fileObj) => nav('file', { file: fileObj, sourceTab: 'violations' }),
           onPrincipleClick: (principleObj) => nav('principle', { principle: principleObj, sourceTab: 'violations' }),
+          onRefresh: props.refreshDashboard,
         }}
       />
     );
@@ -111,8 +128,16 @@ const ROUTE_RENDERERS = {
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
   file: (params) => <FileDetailPage file={params.file} />,
   principle: (params) => <PrincipleDetailPage principle={params.principle} />,
-  evalprinciple: (params) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} />,
-  'eval-principle-detail': (params) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} />,
+  evalprinciple: (params, props) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} onDismiss={(v) => {
+    dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
+      .then(() => props.refreshDashboard?.())
+      .catch((e) => console.error('[Dismiss] failed:', e));
+  }} />,
+  'eval-principle-detail': (params, props) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} onDismiss={(v) => {
+    dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
+      .then(() => props.refreshDashboard?.())
+      .catch((e) => console.error('[Dismiss] failed:', e));
+  }} />,
   settings: (params, props) => <SettingsCase settings={props.settings} analysisPower={props.evaluation.analysisPower} setAnalysisPower={props.evaluation.setAnalysisPower} persistAnalysisPower={props.evaluation.persistAnalysisPower} />,
   projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
   standards: () => <StandardsPage />,
@@ -180,6 +205,7 @@ export default function App() {
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },
     settings: state.settings,
+    refreshDashboard: state.refreshDashboard,
   };
 
   return (

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -279,3 +279,40 @@ export async function exportStandard(standardId) {
   const { managed, type, origin, originHash, principleCount, requirementCount, ...portable } = detail;
   return { id: standardId, data: portable, fileName: `${standardId}.quodeq` };
 }
+
+// ── Dismissed Findings ─────────────────────────────────────────────────
+
+/**
+ * List dismissed findings for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Array>} Dismissed findings array
+ */
+export async function listDismissedFindings(projectId) {
+  return request(`/findings/dismissed?project=${encodeURIComponent(projectId)}`);
+}
+
+/**
+ * Dismiss a finding (exclude from scoring).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding data: { req, file, line, dimension, severity, reason }
+ * @returns {Promise<object>} Server response
+ */
+export async function dismissFinding(projectId, finding) {
+  return request('/findings/dismiss', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+}
+
+/**
+ * Restore a dismissed finding (include in scoring again).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding key: { req, file, line }
+ * @returns {Promise<object>} Server response
+ */
+export async function restoreFinding(projectId, finding) {
+  return request('/findings/restore', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -75,6 +75,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
   const [latestAccumulated, setLatestAccumulated] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   // Clear stale data immediately when project changes to prevent rendering old data for a new project
   const prevProjectRef = useRef(selectedProject);
@@ -86,10 +87,12 @@ export function useDashboard({ selectedProject, selectedRun }) {
     setError(null);
   }
 
-  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun]);
-  useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun]);
-  useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject]);
+  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
+  useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun, refreshKey]);
+  useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject, refreshKey]);
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
 
-  return { dashboard, accumulated, latestAccumulated, loading, error, availableRuns };
+  const refreshDashboard = () => setRefreshKey((k) => k + 1);
+
+  return { dashboard, accumulated, latestAccumulated, loading, error, availableRuns, refreshDashboard };
 }

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -51,7 +51,7 @@ function ViolationDetail({ item }) {
   );
 }
 
-export function EvalViolationCard({ v, principle, buildViolationPlanText, index }) {
+export function EvalViolationCard({ v, principle, buildViolationPlanText, index, onDismiss }) {
   const { filename, ref, display } = useFileInfo(v.file, v.line, v.endLine);
   return (
     <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
@@ -60,6 +60,16 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index 
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
         <CopyButton label="Fix plan" onClick={() => copyToClipboard(buildViolationPlanText(v))} />
+        {onDismiss && (
+          <button
+            type="button"
+            className="dismiss-btn"
+            onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
+            title="Dismiss this finding (exclude from scoring)"
+          >
+            Dismiss
+          </button>
+        )}
       </div>
       <ViolationDetail item={v} />
     </div>

--- a/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useState, useCallback } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
@@ -8,7 +8,7 @@ import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 
 const PAGE_SIZE = 20;
 
-function ViolationListSection({ violationsBySeverity, principle, buildViolationPlanText }) {
+function ViolationListSection({ violationsBySeverity, principle, buildViolationPlanText, onDismiss }) {
   return EVAL_SEVERITY_ORDER.map((sev) => {
     const vs = violationsBySeverity[sev];
     if (!vs || vs.length === 0) return null;
@@ -20,7 +20,7 @@ function ViolationListSection({ violationsBySeverity, principle, buildViolationP
         </div>
         <div className="vlive-violations-group">
           {vs.map((v, idx) => (
-            <EvalViolationCard key={idx} v={v} principle={principle} buildViolationPlanText={buildViolationPlanText} index={idx} />
+            <EvalViolationCard key={idx} v={v} principle={principle} buildViolationPlanText={buildViolationPlanText} index={idx} onDismiss={onDismiss} />
           ))}
         </div>
       </div>
@@ -147,11 +147,26 @@ function PrincipleContext({ principleData }) {
   );
 }
 
-const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrincipal }) {
+const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrincipal, onDismiss }) {
   const { principleData, principle, score, grade } = evalPrincipal;
   const [showAllCompliance, setShowAllCompliance] = useState(false);
+  const [dismissedSet, setDismissedSet] = useState(new Set());
   const { violations, compliance, violationsBySeverity, sevCounts } = computeEvalPrincipleData(evalPrincipal);
   const displayedCompliance = showAllCompliance ? compliance : compliance.slice(0, PAGE_SIZE);
+
+  const handleDismiss = useCallback((v) => {
+    if (!onDismiss) return;
+    onDismiss(v);
+    setDismissedSet((prev) => new Set(prev).add(`${v.file}:${v.line}`));
+  }, [onDismiss]);
+
+  // Filter dismissed violations from each severity group
+  const filteredBySeverity = {};
+  for (const sev of Object.keys(violationsBySeverity)) {
+    filteredBySeverity[sev] = (violationsBySeverity[sev] || []).filter(
+      (v) => !dismissedSet.has(`${v.file}:${v.line}`)
+    );
+  }
 
   return (
     <>
@@ -160,7 +175,7 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
         onCopyPlan={() => copyToClipboard(buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData))}
       />
       <PrincipleContext principleData={principleData} />
-      <ViolationListSection violationsBySeverity={violationsBySeverity} principle={principle} buildViolationPlanText={(v) => buildViolationPlanText(v, principle)} />
+      <ViolationListSection violationsBySeverity={filteredBySeverity} principle={principle} buildViolationPlanText={(v) => buildViolationPlanText(v, principle)} onDismiss={handleDismiss} />
       <ComplianceListSection
         data={{ compliance, displayedCompliance, principle }}
         controls={{ hasMore: compliance.length > PAGE_SIZE, showAll: showAllCompliance, setShowAll: setShowAllCompliance }}

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -186,6 +186,7 @@ function buildEvalPrincipalFn(evalData, complianceByPrinciple) {
     const pg = (evalData.principleGrades || []).find((p) => p.principle === principleId);
     return {
       principle: principleId, score: pg?.score || null, grade: pg?.grade || null,
+      dimension: evalData.dimension || '',
       principleData, dimViolations: principleData?.violations || [],
       dimCompliance: complianceByPrinciple.get(principleId) || [],
     };

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -1,25 +1,28 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import DimensionViolationsRow from '../../dashboard/components/DimensionViolationsRow.jsx';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
+import { listDismissedFindings, restoreFinding } from '../../../api/index.js';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import { complianceRatio } from '../../../utils/formatters.js';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
 
-const SUB_TABS = [
-  { id: 'dimension', label: 'By Dimension' },
-  { id: 'file', label: 'By File' },
-];
-
-function ViolationsPillNav({ activeSubTab, onSubTabChange }) {
+function ViolationsPillNav({ activeSubTab, onSubTabChange, dismissedCount }) {
+  const tabs = [
+    { id: 'dimension', label: 'By Dimension' },
+    { id: 'file', label: 'By File' },
+  ];
+  if (dismissedCount > 0) {
+    tabs.push({ id: 'dismissed', label: `Dismissed (${dismissedCount})` });
+  }
   return (
     <div className="violations-pill-nav">
-      {SUB_TABS.map((tab) => (
+      {tabs.map((tab) => (
         <button
           key={tab.id}
           type="button"
-          className={`pill-btn${activeSubTab === tab.id ? ' active' : ''}`}
+          className={`pill-btn${activeSubTab === tab.id ? ' active' : ''}${tab.id === 'dismissed' ? ' pill-btn--dismissed' : ''}`}
           onClick={() => onSubTabChange(tab.id)}
         >
           {tab.label}
@@ -155,10 +158,55 @@ function FileSubTab({ dimensions, onFileClick }) {
   );
 }
 
+function DismissedSubTab({ dismissed, onRestore }) {
+  if (dismissed.length === 0) {
+    return <p className="empty-state">No dismissed findings.</p>;
+  }
+  return (
+    <>
+      <div className="section-header">
+        <h3 className="section-title">Dismissed Findings</h3>
+        <span className="section-count">{dismissed.length} findings · not included in scoring</span>
+      </div>
+      <div className="dismissed-list-inner">
+        {dismissed.map((d) => (
+          <div key={`${d.req}-${d.file}-${d.line}`} className="dismissed-card">
+            <div className="dismissed-card-body">
+              <div className="dismissed-card-top">
+                <span className="dismissed-tag">dismissed</span>
+                <span className="dismissed-label">[{d.principle || d.dimension || d.req || '?'}]</span>
+                <span className="dismissed-file">{d.file}:{d.line}</span>
+              </div>
+              {d.reason && <div className="dismissed-reason">{d.reason}</div>}
+            </div>
+            <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
 export default function ViolationsPage({ data, callbacks }) {
-  const { accumulated, accumulatedDimensions } = data;
-  const { onDimensionClick, onFileClick, onPrincipleClick } = callbacks;
+  const { accumulated, accumulatedDimensions, selectedProject } = data;
+  const { onDimensionClick, onFileClick, onPrincipleClick, onRefresh } = callbacks;
   const [activeSubTab, setActiveSubTab] = useState('dimension');
+  const [dismissed, setDismissed] = useState([]);
+
+  useEffect(() => {
+    if (!selectedProject) return;
+    listDismissedFindings(selectedProject).then(setDismissed).catch(() => setDismissed([]));
+  }, [selectedProject]);
+
+  const handleRestore = useCallback(async (d) => {
+    try {
+      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
+      setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to restore finding:', err);
+    }
+  }, [selectedProject, onRefresh]);
 
   const visibleDimensions = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
@@ -197,12 +245,15 @@ export default function ViolationsPage({ data, callbacks }) {
   return (
     <div className="violations-page">
       <ViolationsHeader accumulated={filteredAccumulated} topFilesCount={topFilesCount} uniquePrinciples={uniquePrinciples} />
-      <ViolationsPillNav activeSubTab={activeSubTab} onSubTabChange={setActiveSubTab} />
+      <ViolationsPillNav activeSubTab={activeSubTab} onSubTabChange={setActiveSubTab} dismissedCount={dismissed.length} />
       {activeSubTab === 'dimension' && (
         <DimensionSubTab dimensions={visibleDimensions} onDimensionClick={onDimensionClick} onPrincipleClick={onPrincipleClick} />
       )}
       {activeSubTab === 'file' && (
         <FileSubTab dimensions={visibleDimensions} onFileClick={onFileClick} />
+      )}
+      {activeSubTab === 'dismissed' && (
+        <DismissedSubTab dismissed={dismissed} onRestore={handleRestore} />
       )}
     </div>
   );

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -81,7 +81,7 @@ export function useAppState() {
   const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
   const settings = useAppSettings();
   const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
-  const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns } = useDashboard({ selectedProject, selectedRun: effectiveRun });
+  const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns, refreshDashboard } = useDashboard({ selectedProject, selectedRun: effectiveRun });
   const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
     dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
     ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
@@ -104,6 +104,6 @@ export function useAppState() {
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,
-    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav,
+    evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard,
   };
 }

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2265,6 +2265,15 @@
   font-weight: var(--weight-semibold);
 }
 
+.pill-btn--dismissed {
+  color: var(--color-text-muted);
+  opacity: 0.7;
+}
+.pill-btn--dismissed.active {
+  background: color-mix(in srgb, var(--color-text-muted) 10%, transparent);
+  opacity: 1;
+}
+
 /* Severity-specific pill active colors */
 .severity-pill.critical.active {
   background: color-mix(in srgb, var(--color-sev-critical-text) 12%, transparent);

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1953,6 +1953,23 @@
   margin-left: auto;
 }
 
+/* Dismiss button on violation cards */
+.dismiss-btn {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 150ms ease;
+}
+.dismiss-btn:hover {
+  color: #f0883e;
+  border-color: #f0883e;
+}
+
 /* Dimension label inline in the row (file detail page) */
 .vlive-dimension-inline {
   font-family: var(--font-data);
@@ -2086,4 +2103,102 @@
 .folder-new-btn {
   font-size: 1.1rem;
   font-weight: bold;
+}
+
+/* ── Dismissed findings section ─────────────────────── */
+.dismissed-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 24px;
+  padding: 10px 14px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background 150ms ease;
+  user-select: none;
+}
+.dismissed-bar:hover { background: var(--color-surface-alt); }
+.dismissed-bar-icon {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  transition: transform 200ms ease;
+  display: inline-block;
+  width: 12px;
+}
+.dismissed-bar-icon.open { transform: rotate(90deg); }
+.dismissed-bar-label { font-size: 0.82rem; color: var(--color-text-muted); }
+.dismissed-bar-count {
+  font-size: 0.68rem;
+  background: rgba(139, 148, 158, 0.15);
+  color: var(--color-text-muted);
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+.dismissed-bar-note {
+  margin-left: auto;
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+.dismissed-list-inner { padding-top: 12px; }
+.dismissed-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  opacity: 0.55;
+  transition: opacity 200ms ease;
+}
+.dismissed-card:hover { opacity: 0.8; }
+.dismissed-card-body { flex: 1; min-width: 0; }
+.dismissed-card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.dismissed-tag {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 3px;
+  background: rgba(139, 148, 158, 0.12);
+  color: var(--color-text-muted);
+}
+.dismissed-label { font-size: 0.78rem; color: var(--color-text-muted); }
+.dismissed-file {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--color-text-muted);
+}
+.dismissed-reason {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  margin-top: 2px;
+}
+.restore-btn {
+  font-size: 0.7rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-accent);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 150ms ease;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+.restore-btn:hover {
+  border-color: var(--color-accent);
+  background: rgba(88, 166, 255, 0.08);
 }

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -1,0 +1,79 @@
+"""Tests for the findings dismiss/restore API endpoints."""
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from quodeq.api.routes_findings import register_findings_routes
+
+
+@pytest.fixture()
+def app(tmp_path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_findings_routes(app)
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+class TestDismissEndpoint:
+    def test_dismiss_creates_entry(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+            "reason": "False positive",
+        })
+        assert resp.status_code == 200
+        data = json.loads((project_dir / "dismissed.json").read_text())
+        assert len(data) == 1
+        assert data[0]["req"] == "M-MOD-4"
+
+    def test_dismiss_missing_fields_returns_400(self, client):
+        resp = client.post("/api/findings/dismiss", json={"project": "x"})
+        assert resp.status_code == 400
+
+
+class TestRestoreEndpoint:
+    def test_restore_removes_entry(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        resp = client.post("/api/findings/restore", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+        })
+        assert resp.status_code == 200
+        assert not (project_dir / "dismissed.json").exists()
+
+
+class TestListDismissedEndpoint:
+    def test_list_returns_dismissed(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        resp = client.get("/api/findings/dismissed?project=my-project")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data) == 1
+
+    def test_list_empty_project(self, client):
+        resp = client.get("/api/findings/dismissed?project=nonexistent")
+        assert resp.status_code == 200
+        assert resp.get_json() == []

--- a/tests/services/test_dismissed.py
+++ b/tests/services/test_dismissed.py
@@ -1,0 +1,60 @@
+"""Tests for the dismissed findings storage service."""
+import json
+from pathlib import Path
+
+from quodeq.services.dismissed import (
+    load_dismissed,
+    dismiss_finding,
+    restore_finding,
+    dismissed_keys,
+)
+
+
+class TestDismissedStorage:
+    def test_load_empty_when_no_file(self, tmp_path):
+        result = load_dismissed(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_dismiss_creates_file_and_appends(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
+        dismiss_finding(project_dir, finding)
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+        assert result[0]["req"] == "M-MOD-4"
+        assert result[0]["file"] == "foo.js"
+        assert result[0]["line"] == 4
+        assert "dismissed_at" in result[0]
+
+    def test_dismiss_deduplicates(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
+        dismiss_finding(project_dir, finding)
+        dismiss_finding(project_dir, finding)
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+
+    def test_restore_removes_finding(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
+        dismiss_finding(project_dir, {"req": "S-CON-1", "file": "bar.py", "line": 10, "dimension": "security", "severity": "major"})
+        restore_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4})
+        result = load_dismissed(project_dir)
+        assert len(result) == 1
+        assert result[0]["req"] == "S-CON-1"
+
+    def test_restore_nonexistent_is_noop(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        restore_finding(project_dir, {"req": "X-X-1", "file": "x.py", "line": 1})
+        assert load_dismissed(project_dir) == []
+
+    def test_dismissed_keys_returns_set_of_tuples(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
+        keys = dismissed_keys(project_dir)
+        assert keys == {("M-MOD-4", "foo.js", 4)}


### PR DESCRIPTION
## Summary

Users can now dismiss individual false-positive violations from the dashboard. Dismissed findings are excluded from violation counts and scoring, with a dedicated UI to view and restore them.

### Backend
- **Storage**: per-project `dismissed.json` with dismiss/restore/list operations
- **API**: `POST /api/findings/dismiss`, `POST /api/findings/restore`, `GET /api/findings/dismissed`
- **Filtering**: dismissed findings filtered from all data pipelines — detail page (JSON/markdown/JSONL formats), accumulated dashboard view, and verification step
- **Prompts**: false-positive counter-argument clause added to verification and analysis prompts to reduce false positives at evaluation time

### UI
- **Dismiss button** on each violation card (next to "Fix plan")
- **"Dismissed (N)" pill tab** in Violations page showing dismissed findings with Restore button
- **Auto-refresh**: dashboard data refreshes automatically after dismiss/restore

### Known Limitation
- Grades/scores are not recalculated after dismissal — they reflect the original evaluation. Scores will self-correct on the next evaluation run.

## Test plan

- [x] All 681 Python tests pass
- [x] UI builds cleanly
- [x] Dismiss finding → card disappears, violation count updates
- [x] Dismissed tab shows findings with Restore button
- [x] Restore → finding reappears in next refresh
- [x] Run new evaluation → dismissed findings not re-verified