### PR TITLE
feat: redesign fix plan and dismiss buttons

### DIFF
--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -2,6 +2,15 @@ import { useState } from 'react';
 
 export const COPY_FEEDBACK_MS = 1500;
 
+export function SparkleIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5z" />
+      <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1z" />
+    </svg>
+  );
+}
+
 export function CopyIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -11,7 +20,7 @@ export function CopyIcon() {
   );
 }
 
-export default function CopyButton({ onClick, label, 'aria-label': ariaLabel }) {
+export default function CopyButton({ onClick, label, className, icon, 'aria-label': ariaLabel }) {
   const [copied, setCopied] = useState(false);
 
   const handleClick = () => {
@@ -21,9 +30,10 @@ export default function CopyButton({ onClick, label, 'aria-label': ariaLabel }) 
   };
 
   return (
-    <button className="detail-copy-btn" onClick={handleClick} aria-label={ariaLabel}>
+    <button className={className || 'detail-copy-btn'} onClick={handleClick} aria-label={ariaLabel}>
+      {icon}
       {copied ? 'Copied!' : label}
-      <CopyIcon />
+      {!icon && <CopyIcon />}
     </button>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCard.jsx
@@ -10,7 +10,7 @@
 import { useState, useMemo } from 'react';
 import PrincipleAccordion from './PrincipleAccordion.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { splitScore, gradeColorClass, gradeLetter } from '../../../utils/formatters.js';
 import { buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
@@ -105,7 +105,9 @@ function DimViolationsList({ filteredViolations, activeFilterCount, totalCount, 
             : ` (${filteredViolations.length})`}
         </h4>
         <CopyButton
-          label="Fix plan"
+          label="Full fix plan"
+          className="fix-plan-btn-header"
+          icon={<SparkleIcon />}
           onClick={() => copyToClipboard(buildFixPlan())}
         />
       </div>

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import DimensionViolationsRow from './DimensionViolationsRow.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
@@ -153,7 +153,9 @@ function RunHeroSection({ dashboard, selectedRunId, stats }) {
         <span className="acc-eval-date">{dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId)}</span>
         {(dashboard?.dimensions || []).some((d) => (d.violations?.length || 0) > 0) && (
           <CopyButton
-            label="Fix plan"
+            label="Full fix plan"
+            className="fix-plan-btn-header"
+            icon={<SparkleIcon />}
             onClick={() => {
               const allViolations = (dashboard.dimensions || []).flatMap(
                 (d) => (d.violations || []).map((v) => ({ ...v, dimension: d.dimension }))

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -1,5 +1,5 @@
 import { parseFileRef } from '../../../utils/formatters.js';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
@@ -59,7 +59,12 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index,
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
-        <CopyButton label="Fix plan" onClick={() => copyToClipboard(buildViolationPlanText(v))} />
+        <CopyButton
+          label="Fix plan"
+          className="fix-plan-btn"
+          icon={<SparkleIcon />}
+          onClick={() => copyToClipboard(buildViolationPlanText(v))}
+        />
         {onDismiss && (
           <button
             type="button"
@@ -67,7 +72,7 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index,
             onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
             title="Dismiss this finding (exclude from scoring)"
           >
-            Dismiss
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
           </button>
         )}
       </div>

--- a/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -2,7 +2,7 @@ import { memo, useState, useCallback } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 
@@ -109,7 +109,12 @@ function PrincipleHeader({ data, onCopyPlan }) {
           )}
         </div>
         {violations.length > 0 && (
-          <CopyButton label="Principle fix plan" onClick={onCopyPlan} />
+          <CopyButton
+            label="Full fix plan"
+            className="fix-plan-btn-header"
+            icon={<SparkleIcon />}
+            onClick={onCopyPlan}
+          />
         )}
       </div>
       <div className="file-detail-stats" style={{ marginTop: 6 }}>

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { getDimensionEval } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { gradeColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
@@ -53,7 +53,9 @@ function DimensionOverview({ data, stats, onNavigate }) {
         </div>
         {allViolations.length > 0 && (
           <CopyButton
-            label="Fix plan"
+            label="Full fix plan"
+            className="fix-plan-btn-header"
+            icon={<SparkleIcon />}
             onClick={() => copyToClipboard(buildDimensionPlanFromViolations(evalData.dimension, allViolations))}
           />
         )}

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
@@ -33,6 +33,8 @@ function ViolationCard({ v, index }) {
         )}
         <CopyButton
           label="Fix plan"
+          className="fix-plan-btn"
+          icon={<SparkleIcon />}
           onClick={() => copyToClipboard(buildViolationPlanText(v))}
         />
       </div>
@@ -112,7 +114,9 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
         <div className="file-detail-stats-row">
           <FileSeverityStats file={file} totalViolations={totalViolations} dimensionsCount={dimensionsCount} />
           <CopyButton
-            label="File fix plan"
+            label="Full fix plan"
+            className="fix-plan-btn-header"
+            icon={<SparkleIcon />}
             onClick={() => copyToClipboard(buildFilePlanText(file))}
           />
         </div>

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
@@ -35,6 +35,8 @@ function ViolationCard({ v, principleName, index }) {
         )}
         <CopyButton
           label="Fix plan"
+          className="fix-plan-btn"
+          icon={<SparkleIcon />}
           onClick={() => copyToClipboard(buildViolationPlanText(v, principleName))}
         />
       </div>
@@ -98,7 +100,9 @@ function ComplianceStatsRow({ principle, totalViolations, totalCompliance }) {
           )}
         </div>
         <CopyButton
-          label="Principle fix plan"
+          label="Full fix plan"
+          className="fix-plan-btn-header"
+          icon={<SparkleIcon />}
           onClick={() => copyToClipboard(buildPrinciplePlanText(principle))}
         />
       </div>

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1949,25 +1949,82 @@
 
 
 
-.vdetail-row-main .detail-copy-btn {
+.vdetail-row-main .detail-copy-btn,
+.vdetail-row-main .fix-plan-btn {
   margin-left: auto;
 }
 
-/* Dismiss button on violation cards */
+/* Fix plan button — outlined with left accent bar */
+.fix-plan-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 8px 3px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  border-left: 2px solid var(--color-accent);
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: all 150ms ease;
+}
+.fix-plan-btn:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+/* Header-level fix plan button (principle & dimension) */
+.fix-plan-btn-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px 5px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  border-left: 2px solid var(--color-accent);
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  align-self: flex-start;
+  transition: all 150ms ease;
+}
+.fix-plan-btn-header:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+/* Dismiss button on violation cards — icon-only trash can */
 .dismiss-btn {
-  font-size: 0.7rem;
-  padding: 2px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   border-radius: 4px;
   border: 1px solid var(--color-border);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  white-space: nowrap;
+  flex-shrink: 0;
   transition: all 150ms ease;
 }
 .dismiss-btn:hover {
   color: #f0883e;
   border-color: #f0883e;
+  background: rgba(240, 136, 62, 0.08);
 }
 
 /* Dimension label inline in the row (file detail page) */


### PR DESCRIPTION
## Summary
- Restyle all fix plan buttons with left accent bar + sparkle icon (Option C style)
- Per-violation buttons use compact `fix-plan-btn` style with "Fix plan" label
- Header-level buttons (principle, dimension, file, run) use larger `fix-plan-btn-header` style labeled "Full fix plan"
- Dismiss button replaced with icon-only trash can (no text)
- Added `SparkleIcon` and `className`/`icon` props to `CopyButton` component for reuse

## Test plan
- [x] Verify per-violation "Fix plan" buttons show left accent bar + sparkle icon on EvalCards, PrincipleDetailPage, FileDetailPage
- [x] Verify header-level "Full fix plan" buttons appear on principle, dimension, file, and run overview headers
- [x] Verify dismiss button shows trash can icon, no text, with orange hover
- [x] Confirm "Copied!" feedback still works on all fix plan buttons
- [x] Check alignment: header buttons should be top-aligned (`align-self: flex-start`)
- [x] Test hover states on all new button styles