### PR TITLE
feat: redesign dismissed findings cards

### DIFF
--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -43,7 +43,13 @@ def dismiss_finding(project_dir: Path, finding: dict) -> None:
         "dimension": finding.get("dimension", ""),
         "principle": finding.get("principle", ""),
         "severity": finding.get("severity", ""),
+        "title": finding.get("title", ""),
         "reason": finding.get("reason", ""),
+        "reqRefs": finding.get("reqRefs", []),
+        "context": finding.get("context", ""),
+        "snippet": finding.get("snippet", ""),
+        "scope": finding.get("scope", ""),
+        "endLine": finding.get("endLine", 0),
         "dismissed_at": datetime.now(timezone.utc).isoformat(),
     }
     entries.append(entry)

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -74,7 +74,13 @@ function buildDismissPayload(v, fallbackDimension) {
     line,
     dimension: v.dimension || fallbackDimension || '',
     severity: v.severity,
+    title: v.title || '',
     reason: v.reason,
+    reqRefs: v.reqRefs || [],
+    context: v.context || '',
+    snippet: v.snippet || '',
+    scope: v.scope || '',
+    endLine: v.endLine || 0,
     principle: v.principle || '',
   };
 }

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -3,6 +3,7 @@ import DimensionViolationsRow from '../../dashboard/components/DimensionViolatio
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import { listDismissedFindings, restoreFinding } from '../../../api/index.js';
+import ContextBlock from '../../../components/ContextBlock.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import { complianceRatio } from '../../../utils/formatters.js';
@@ -171,15 +172,39 @@ function DismissedSubTab({ dismissed, onRestore }) {
       <div className="dismissed-list-inner">
         {dismissed.map((d) => (
           <div key={`${d.req}-${d.file}-${d.line}`} className="dismissed-card">
-            <div className="dismissed-card-body">
-              <div className="dismissed-card-top">
-                <span className="dismissed-tag">dismissed</span>
-                <span className="dismissed-label">[{d.principle || d.dimension || d.req || '?'}]</span>
-                <span className="dismissed-file">{d.file}:{d.line}</span>
-              </div>
-              {d.reason && <div className="dismissed-reason">{d.reason}</div>}
+            <div className="dismissed-card-top">
+              <span className="dismissed-tag">dismissed</span>
+              {d.severity && <span className={`severity-tag ${d.severity}`}>{d.severity}</span>}
+              <span className="dismissed-label">[{d.principle || d.dimension || d.req || '?'}]</span>
+              <span className="dismissed-file">{d.file}:{d.line}</span>
+              <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
             </div>
-            <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
+            {(d.reason || d.title) && (
+              <div className="dismissed-detail">
+                {d.title && (
+                  <div className="dismissed-detail-section">
+                    <div className="dismissed-detail-header">
+                      <span className="dismissed-detail-label">Reason</span>
+                      {(d.reqRefs || []).filter((r) => r.url && /^https?:\/\//.test(r.url)).length > 0 && (
+                        <span className="cwe-link-group">
+                          {d.reqRefs.filter((r) => r.url && /^https?:\/\//.test(r.url)).map((r, i) => (
+                            <a key={i} className="cwe-link" href={r.url} target="_blank" rel="noopener noreferrer">{r.label}</a>
+                          ))}
+                        </span>
+                      )}
+                    </div>
+                    <p className="dismissed-detail-title">{d.title}</p>
+                  </div>
+                )}
+                {d.reason && (
+                  <div className="dismissed-detail-section">
+                    <span className="dismissed-detail-label">Detail</span>
+                    <p className="dismissed-detail-text">{d.reason}</p>
+                  </div>
+                )}
+                <ContextBlock context={d.context} snippet={d.snippet} scope={d.scope} line={d.line} endLine={d.endLine} />
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2144,46 +2144,75 @@
 }
 .dismissed-list-inner { padding-top: 12px; }
 .dismissed-card {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 10px 12px;
-  margin-bottom: 8px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-surface);
-  opacity: 0.55;
-  transition: opacity 200ms ease;
+  border-left: 3px solid var(--color-text-muted);
+  margin-bottom: var(--space-3);
 }
-.dismissed-card:hover { opacity: 0.8; }
-.dismissed-card-body { flex: 1; min-width: 0; }
 .dismissed-card-top {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: 10px;
+  padding: 10px 0 10px 10px;
 }
 .dismissed-tag {
-  font-size: 0.6rem;
+  font-size: 0.58rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   padding: 2px 7px;
   border-radius: 3px;
-  background: rgba(139, 148, 158, 0.12);
+  background: rgba(139, 148, 158, 0.15);
   color: var(--color-text-muted);
 }
-.dismissed-label { font-size: 0.78rem; color: var(--color-text-muted); }
+.dismissed-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-data);
+}
 .dismissed-file {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-family: var(--font-data);
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
 }
-.dismissed-reason {
-  font-size: 0.78rem;
-  color: var(--color-text-muted);
+.dismissed-card-top .restore-btn {
+  margin-left: auto;
+}
+.dismissed-detail {
+  padding: 12px 14px 12px 10px;
+  background: var(--color-surface);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.dismissed-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.dismissed-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.dismissed-detail-label {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.dismissed-detail-title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text);
   line-height: 1.4;
-  margin-top: 2px;
+}
+.dismissed-detail-text {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  line-height: 1.5;
 }
 .restore-btn {
   font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- Restyle dismissed cards: left gray border, fully visible (no opacity dimming), restore button top-right
- Show full violation info matching active cards: severity tag, Reason (with CWE/CISQ ref links), Detail text, and expandable code widget (ContextBlock)
- Backend now persists `title`, `reqRefs`, `context`, `snippet`, `scope`, and `endLine` on dismiss for complete card rendering

## Test plan
- [x] Dismiss a finding and verify the dismissed card shows severity tag, reason title, CWE links, detail text, and code widget
- [x] Verify Restore button is top-right aligned
- [x] Verify cards are fully visible (no dimming/opacity)
- [x] Verify existing dismissed findings (without new fields) still render gracefully with available data
- [x] Verify restoring a dismissed finding works correctly