### PR TITLE
feat: live rescore on dismiss

### DIFF
--- a/docs/superpowers/plans/2026-04-02-live-rescore-on-dismiss.md
+++ b/docs/superpowers/plans/2026-04-02-live-rescore-on-dismiss.md
@@ -1,0 +1,702 @@
+# Live Rescore on Dismiss — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recalculate and display updated grades live when violations are dismissed or restored, using the backend as single source of truth.
+
+**Architecture:** New `GET /api/rescore` endpoint loads stored run dimensions, filters out dismissed findings, rescores at principle/dimension/run level using existing scoring primitives, and returns updated data. Frontend calls this on dashboard load and after dismiss/restore.
+
+**Tech Stack:** Python (Flask, dataclasses), JavaScript (React hooks, fetch API)
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/quodeq/services/rescore.py` | Core rescore logic: filter dismissed, recount types, rescore principles, aggregate |
+| Create | `tests/services/test_rescore.py` | Unit tests for rescore logic |
+| Create | `src/quodeq/api/routes_rescore.py` | `/api/rescore` endpoint |
+| Create | `tests/api/test_routes_rescore.py` | Integration test for the endpoint |
+| Modify | `src/quodeq/api/app.py:172` | Register rescore routes |
+| Modify | `src/quodeq/ui/src/api/index.js` | Add `getRescore()` API call |
+| Modify | `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js` | Call rescore after dashboard load |
+
+---
+
+### Task 1: Extract `rescore_dimensions` — Core Rescore Logic
+
+**Files:**
+- Create: `src/quodeq/services/rescore.py`
+- Create: `tests/services/test_rescore.py`
+
+This is the heart of the feature. It takes dimensions + dismissed keys, filters violations, recounts types, rescores each principle, and aggregates up.
+
+- [ ] **Step 1: Write failing test — rescore with no dismissals returns original scores**
+
+```python
+# tests/services/test_rescore.py
+"""Tests for the live rescore service."""
+from quodeq.core.types.finding import Finding, Totals, SeverityTally
+from quodeq.core.types.report import PrincipleGrade
+from quodeq.core.types.dimension import DimensionResult
+
+from quodeq.services.rescore import rescore_dimensions
+
+
+def _make_violation(principle="P1", severity="major", req="R1", file="a.py", line=1, reason="bug"):
+    return Finding(principle=principle, severity=severity, req=req, file=file, line=line, reason=reason)
+
+
+def _make_compliance(principle="P1", req="R1", file="a.py", line=10, reason="ok"):
+    return Finding(principle=principle, req=req, file=file, line=line, reason=reason)
+
+
+def _make_dimension(name="Reliability", violations=None, compliance=None, source_file_count=100):
+    violations = violations or []
+    compliance = compliance or []
+    return DimensionResult(
+        dimension=name,
+        violations=violations,
+        compliance=compliance,
+        overall_score="5.0/10",
+        overall_grade="Adequate",
+        principles=[PrincipleGrade(principle="P1", score="5.0/10", grade="Adequate")],
+        totals=Totals(
+            violation_count=len(violations),
+            compliance_count=len(compliance),
+            severity=SeverityTally(
+                critical=sum(1 for v in violations if v.severity == "critical"),
+                major=sum(1 for v in violations if v.severity == "major"),
+                minor=sum(1 for v in violations if v.severity == "minor"),
+            ),
+        ),
+        source_file_count=source_file_count,
+    )
+
+
+def test_rescore_no_dismissals_returns_rescored_data():
+    """With no dismissed keys, rescore should still return valid rescored dimensions."""
+    dim = _make_dimension(
+        violations=[_make_violation(severity="major")],
+        compliance=[_make_compliance()],
+    )
+    result = rescore_dimensions([dim], dismissed_keys=set())
+    assert len(result["dimensions"]) == 1
+    assert result["dimensions"][0]["overallScore"] is not None
+    assert result["dimensions"][0]["overallGrade"] is not None
+    assert result["summary"] is not None
+    assert result["summary"]["overallGrade"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/services/test_rescore.py::test_rescore_no_dismissals_returns_rescored_data -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'quodeq.services.rescore'`
+
+- [ ] **Step 3: Write minimal `rescore_dimensions` implementation**
+
+```python
+# src/quodeq/services/rescore.py
+"""Live rescore service — recalculates grades after dismissals change."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from quodeq.core.types import DimensionResult, to_camel_dict
+from quodeq.core.types.finding import Totals, SeverityTally
+from quodeq.core.types.report import PrincipleGrade
+from quodeq.core.scoring.internals import (
+    evidence_has_taxonomy,
+    tally_types_by_taxonomy,
+    tally_types_by_reason,
+    tally_compliance_types_by_taxonomy,
+    tally_compliance_types_by_reason,
+    violation_base,
+    compliance_lift,
+    violation_ceiling,
+    severity_grade_floor,
+    score_to_grade_label,
+    compliance_dampening,
+    scale_multiplier,
+)
+from quodeq.core.scoring.overall import weighted_overall, MODE_NUMERICAL
+from quodeq.core.types.scoring import PrincipleScore
+from quodeq.data.fs.report_parser.grades import summarize_dimensions
+from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
+
+
+def _compute_tallies(violations: list, compliance: list):
+    """Count violation and compliance types, auto-selecting taxonomy or reason mode."""
+    using_taxonomy = evidence_has_taxonomy(violations)
+    vt = tally_types_by_taxonomy(violations) if using_taxonomy else tally_types_by_reason(violations)
+    ct = tally_compliance_types_by_taxonomy(compliance) if using_taxonomy else tally_compliance_types_by_reason(compliance)
+    return vt, ct, using_taxonomy
+
+
+def _score_principle(violations: list, compliance: list, scale_mult: int) -> tuple[float | None, str]:
+    """Score a single principle from its filtered violations and compliance lists.
+
+    Returns (final_score, grade).
+    """
+    vt_counts, ct_counts, _ = _compute_tallies(violations, compliance)
+    if not vt_counts and not ct_counts:
+        return None, "Insufficient"
+
+    base = violation_base(vt_counts)
+    lift = compliance_lift(ct_counts, vt_counts)
+    ceil = violation_ceiling(vt_counts)
+    floor = severity_grade_floor(vt_counts)
+
+    raw = base + (10.0 - base) * lift
+    final = max(floor, min(ceil, raw))
+    final = round(final, 1)
+    grade = score_to_grade_label(final)
+    return final, grade
+
+
+def _recount_totals(violations: list, compliance_count: int) -> Totals:
+    """Recount totals from a filtered violations list."""
+    crit = sum(1 for v in violations if (v.severity or "").lower() == "critical")
+    major = sum(1 for v in violations if (v.severity or "").lower() == "major")
+    minor = sum(1 for v in violations if (v.severity or "").lower() == "minor")
+    unknown = len(violations) - crit - major - minor
+    return Totals(
+        violation_count=len(violations),
+        compliance_count=compliance_count,
+        severity=SeverityTally(critical=crit, major=major, minor=minor, unknown=unknown),
+    )
+
+
+def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> DimensionResult:
+    """Rescore a single dimension after filtering dismissed findings."""
+    # Filter violations
+    filtered_violations = [
+        v for v in dim.violations
+        if (v.req or "", v.file or "", v.line or 0) not in dismissed
+    ]
+
+    # Group violations and compliance by principle
+    principles_violations: dict[str, list] = {}
+    principles_compliance: dict[str, list] = {}
+    for v in filtered_violations:
+        principles_violations.setdefault(v.principle or "unknown", []).append(v)
+    for c in dim.compliance:
+        principles_compliance.setdefault(c.principle or "unknown", []).append(c)
+
+    # Score each principle
+    scale_mult = scale_multiplier(dim.source_file_count or 0)
+    all_principle_names = set(principles_violations) | set(principles_compliance)
+    principle_scores: dict[str, PrincipleScore] = {}
+    principle_grades: list[PrincipleGrade] = []
+
+    for name in sorted(all_principle_names):
+        p_violations = principles_violations.get(name, [])
+        p_compliance = principles_compliance.get(name, [])
+        final_score, grade = _score_principle(p_violations, p_compliance, scale_mult)
+        score_str = f"{final_score}/10" if final_score is not None else None
+
+        # Find original weight from existing principle grades
+        original_weight = "1"
+        for pg in dim.principles:
+            if pg.principle == name:
+                # Extract weight if stored; default to "1"
+                original_weight = "1"
+                break
+
+        principle_scores[name] = PrincipleScore(
+            display_name=name,
+            weight=original_weight,
+            final_score=final_score,
+            grade=grade,
+        )
+        principle_grades.append(PrincipleGrade(principle=name, score=score_str, grade=grade))
+
+    # Aggregate to dimension overall
+    overall = weighted_overall(principle_scores, MODE_NUMERICAL)
+    overall_score_str = f"{overall.weighted_score}/10" if overall.weighted_score is not None else None
+    overall_grade = overall.grade or overall.weighted_grade
+
+    # Recount totals
+    compliance_count = dim.totals.compliance_count if dim.totals else len(dim.compliance)
+    new_totals = _recount_totals(filtered_violations, compliance_count)
+
+    return replace(
+        dim,
+        violations=filtered_violations,
+        principles=principle_grades,
+        overall_score=overall_score_str,
+        overall_grade=overall_grade,
+        totals=new_totals,
+    )
+
+
+def rescore_dimensions(
+    dimensions: list[DimensionResult],
+    dismissed_keys: set[tuple],
+) -> dict[str, Any]:
+    """Rescore all dimensions after filtering dismissed findings.
+
+    Returns a dict with 'dimensions' (list of camelCase dicts) and 'summary' (camelCase dict).
+    """
+    rescored = [_rescore_dimension(dim, dismissed_keys) for dim in dimensions]
+    summary = summarize_dimensions(rescored)
+    return {
+        "dimensions": [to_camel_dict(d) for d in rescored],
+        "summary": to_camel_dict(summary),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/services/test_rescore.py::test_rescore_no_dismissals_returns_rescored_data -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/services/rescore.py tests/services/test_rescore.py
+git commit -m "feat: add rescore_dimensions service for live grade recalculation"
+```
+
+---
+
+### Task 2: Test Rescore With Dismissals
+
+**Files:**
+- Modify: `tests/services/test_rescore.py`
+
+Add tests that verify scores actually change when violations are dismissed.
+
+- [ ] **Step 1: Write test — dismissing a violation improves the score**
+
+```python
+# append to tests/services/test_rescore.py
+
+def test_rescore_dismissing_violation_changes_score():
+    """Dismissing a violation should produce a different (better) score."""
+    v1 = _make_violation(severity="critical", req="R1", file="a.py", line=1, reason="null deref")
+    v2 = _make_violation(severity="major", req="R2", file="b.py", line=5, reason="unused var")
+    dim = _make_dimension(violations=[v1, v2], compliance=[_make_compliance()])
+
+    result_all = rescore_dimensions([dim], dismissed_keys=set())
+    result_dismissed = rescore_dimensions([dim], dismissed_keys={("R1", "a.py", 1)})
+
+    score_all = result_all["dimensions"][0]["overallScore"]
+    score_dismissed = result_dismissed["dimensions"][0]["overallScore"]
+
+    # With critical removed, score should be higher
+    assert score_dismissed != score_all
+    # Parse numeric values
+    num_all = float(score_all.split("/")[0])
+    num_dismissed = float(score_dismissed.split("/")[0])
+    assert num_dismissed > num_all
+
+
+def test_rescore_dismiss_all_violations():
+    """Dismissing all violations should yield a high score."""
+    v1 = _make_violation(severity="major", req="R1", file="a.py", line=1)
+    dim = _make_dimension(violations=[v1], compliance=[_make_compliance()])
+
+    result = rescore_dimensions([dim], dismissed_keys={("R1", "a.py", 1)})
+    dim_result = result["dimensions"][0]
+
+    # No violations left — score should be high
+    assert dim_result["totals"]["violationCount"] == 0
+
+
+def test_rescore_summary_reflects_dimension_changes():
+    """Run-level summary should reflect rescored dimension scores."""
+    v1 = _make_violation(severity="critical", req="R1", file="a.py", line=1)
+    dim1 = _make_dimension(name="Reliability", violations=[v1], compliance=[_make_compliance()])
+    dim2 = _make_dimension(name="Security", violations=[], compliance=[_make_compliance()])
+
+    result = rescore_dimensions([dim1, dim2], dismissed_keys=set())
+    summary = result["summary"]
+    assert summary["dimensionsCount"] == 2
+    assert summary["overallGrade"] is not None
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `python -m pytest tests/services/test_rescore.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/test_rescore.py
+git commit -m "test: add rescore dismissal and summary tests"
+```
+
+---
+
+### Task 3: Add `/api/rescore` Endpoint
+
+**Files:**
+- Create: `src/quodeq/api/routes_rescore.py`
+- Create: `tests/api/test_routes_rescore.py`
+- Modify: `src/quodeq/api/app.py:172`
+
+- [ ] **Step 1: Write failing test for the endpoint**
+
+```python
+# tests/api/test_routes_rescore.py
+"""Tests for the /api/rescore endpoint."""
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_rescore_requires_project(client):
+    resp = client.get("/api/rescore")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "project" in data.get("error", "").lower()
+
+
+@patch("quodeq.api.routes_rescore.read_run_data")
+@patch("quodeq.api.routes_rescore.list_runs")
+@patch("quodeq.api.routes_rescore.load_dismissed_keys")
+@patch("quodeq.api.routes_rescore.rescore_dimensions")
+def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, client):
+    mock_list_runs.return_value = [MagicMock(run_id="run-1", date_iso="2026-04-02", date_label="Apr 2")]
+    mock_read_run.return_value = []
+    mock_dismissed.return_value = set()
+    mock_rescore.return_value = {"dimensions": [], "summary": {"dimensionsCount": 0, "overallGrade": None}}
+
+    resp = client.get("/api/rescore?project=test-project")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "dimensions" in data
+    assert "summary" in data
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/api/test_routes_rescore.py -v`
+Expected: FAIL — route not registered
+
+- [ ] **Step 3: Create the route module**
+
+```python
+# src/quodeq/api/routes_rescore.py
+"""API route for live rescoring after dismissals."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.data.fs.report_parser.runs import read_run_data
+from quodeq.services.ports import list_runs
+from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
+from quodeq.services.rescore import rescore_dimensions
+
+
+def _reports_dir_from_app(app: Flask) -> str:
+    return app.config.get("REPORTS_DIR") or __import__(
+        "quodeq.shared.utils", fromlist=["get_reports_dir"]
+    ).get_reports_dir()
+
+
+def _eval_dir_from_app(app: Flask) -> str:
+    return app.config.get("EVALUATIONS_DIR") or __import__(
+        "quodeq.shared.utils", fromlist=["get_evaluations_dir"]
+    ).get_evaluations_dir()
+
+
+def register_rescore_routes(app: Flask) -> None:
+    """Register /api/rescore route."""
+
+    @app.get("/api/rescore")
+    def rescore() -> Response | tuple[Response, int]:
+        project = request.args.get("project", "")
+        if not project:
+            return jsonify({"error": "project query parameter is required"}), 400
+
+        run_id = request.args.get("run", "")
+        reports_dir = _reports_dir_from_app(app)
+
+        # Resolve run ID
+        if not run_id or run_id == "latest":
+            runs = list_runs(Path(reports_dir), project, limit=1)
+            if not runs:
+                return jsonify({"error": "No runs found for project"}), 404
+            run_id = runs[0].run_id
+
+        try:
+            dimensions = read_run_data(Path(reports_dir), project, run_id)
+        except FileNotFoundError:
+            return jsonify({"error": "Run data not found"}), 404
+
+        eval_dir = _eval_dir_from_app(app)
+        project_dir = Path(eval_dir) / project
+        dismissed = load_dismissed_keys(project_dir)
+
+        result = rescore_dimensions(dimensions, dismissed)
+        return jsonify(result)
+```
+
+- [ ] **Step 4: Register the route in app.py**
+
+In `src/quodeq/api/app.py`, add the import and registration call:
+
+Add import at the top with other route imports:
+```python
+from quodeq.api.routes_rescore import register_rescore_routes
+```
+
+Add to `_register_all_routes` function (after `register_findings_routes(app)`):
+```python
+    register_rescore_routes(app)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python -m pytest tests/api/test_routes_rescore.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/quodeq/api/routes_rescore.py tests/api/test_routes_rescore.py src/quodeq/api/app.py
+git commit -m "feat: add /api/rescore endpoint for live grade recalculation"
+```
+
+---
+
+### Task 4: Add Frontend `getRescore` API Call
+
+**Files:**
+- Modify: `src/quodeq/ui/src/api/index.js`
+
+- [ ] **Step 1: Add `getRescore` function to the API module**
+
+Add after the existing `restoreFinding` function in `src/quodeq/ui/src/api/index.js`:
+
+```javascript
+/**
+ * Rescore a project run with dismissed findings filtered out.
+ * @param {string} projectId - Project identifier
+ * @param {string} [run='latest'] - Run ID (optional, defaults to latest)
+ * @returns {Promise<{dimensions: Array, summary: object}>} Rescored data
+ */
+export async function getRescore(projectId, run = 'latest') {
+  const params = new URLSearchParams({ project: projectId });
+  if (run && run !== 'latest') params.set('run', run);
+  return request(`/rescore?${params}`);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/quodeq/ui/src/api/index.js
+git commit -m "feat: add getRescore API client function"
+```
+
+---
+
+### Task 5: Integrate Rescore Into Dashboard Load
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js`
+
+The dashboard hook currently fetches dashboard data and sets it in state. We need to chain a rescore call after the dashboard loads, then patch the dashboard state with the rescored dimensions and summary.
+
+- [ ] **Step 1: Import `getRescore` and add rescore chaining**
+
+Modify `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js`:
+
+Add to imports:
+```javascript
+import { getDashboard, getAccumulated, getRescore } from '../../../api/index.js';
+```
+
+Replace the `fetchDashboardEffect` function with a version that chains rescore:
+
+```javascript
+function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError) {
+  if (!selectedProject) {
+    setDashboard(null);
+    setError(null);
+    return;
+  }
+
+  let active = true;
+  setLoading(true);
+  setError(null);
+
+  getDashboard(selectedProject, selectedRun)
+    .then((payload) => {
+      if (!active) return;
+      setDashboard(payload);
+      // Chain rescore to update grades with dismissed findings filtered
+      const runId = payload?.selectedRun?.runId || selectedRun;
+      return getRescore(selectedProject, runId).then((rescored) => {
+        if (!active) return;
+        setDashboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            dimensions: rescored.dimensions,
+            summary: { ...prev.summary, ...rescored.summary },
+          };
+        });
+      });
+    })
+    .catch((err) => {
+      console.warn('Dashboard load failed:', err);
+      if (active) setError('Failed to load dashboard data. Please try again.');
+    })
+    .finally(() => {
+      if (active) setLoading(false);
+    });
+
+  return () => { active = false; };
+}
+```
+
+- [ ] **Step 2: Verify the app loads correctly**
+
+Run: Open `http://localhost:5173/` and navigate to a project dashboard. Scores should display. If there are dismissed findings, scores should reflect the dismissals.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+git commit -m "feat: chain rescore call after dashboard load for live grades"
+```
+
+---
+
+### Task 6: Trigger Rescore After Dismiss/Restore
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js`
+
+The existing `refreshDashboard()` already triggers a full dashboard re-fetch (which now chains rescore). So dismiss/restore → `refreshDashboard()` → dashboard + rescore already works.
+
+Verify the dismiss flow triggers `refreshDashboard`. Check the existing dismiss handler in `App.jsx`.
+
+- [ ] **Step 1: Verify dismiss already triggers refresh**
+
+Read `src/quodeq/ui/src/App.jsx` lines 131-140 to confirm dismiss calls `refreshDashboard`. The pattern is:
+
+```javascript
+dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
+  .then(() => props.refreshDashboard?.())
+  .catch((e) => console.error('[Dismiss] failed:', e));
+```
+
+This already calls `refreshDashboard()` after dismiss, which re-runs `fetchDashboardEffect` (which now includes the rescore chain). No changes needed.
+
+- [ ] **Step 2: Verify restore triggers refresh in ViolationsPage**
+
+Check `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx` to confirm the restore handler also triggers a refresh. The restore flow should call the same refresh mechanism.
+
+- [ ] **Step 3: Manual test — dismiss a violation and verify grades update**
+
+1. Open a project dashboard at `http://localhost:5173/`
+2. Note the current dimension scores
+3. Navigate to a principle detail page with violations
+4. Dismiss a critical or major violation
+5. Navigate back to dashboard
+6. Verify scores have changed to reflect the dismissal
+7. Go to Violations tab → Dismissed sub-tab → Restore the finding
+8. Verify scores return to original values
+
+- [ ] **Step 4: Commit (if any changes were needed)**
+
+```bash
+git commit -m "feat: verify dismiss/restore triggers live rescore via refreshDashboard"
+```
+
+---
+
+### Task 7: Add Debounce for Rapid Dismiss Actions
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js`
+
+If a user rapidly dismisses multiple violations, we don't want to fire a rescore for each one. The existing `refreshKey` mechanism already batches — React's state batching means multiple rapid `setRefreshKey` calls within the same event loop tick only trigger one re-render. However, if dismisses happen across ticks (e.g., user clicks rapidly), we should debounce.
+
+- [ ] **Step 1: Add a debounced refresh**
+
+Modify `src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js`:
+
+Add to imports:
+```javascript
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+```
+
+Replace the `refreshDashboard` definition:
+
+```javascript
+  const refreshTimerRef = useRef(null);
+  const refreshDashboard = useCallback(() => {
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), 300);
+  }, []);
+```
+
+- [ ] **Step 2: Clean up timer on unmount**
+
+Add a cleanup effect after the existing effects:
+
+```javascript
+  useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
+```
+
+- [ ] **Step 3: Run the app and test rapid dismissals**
+
+Open the app, navigate to a principle detail page, and dismiss multiple violations quickly. Verify only one rescore fires (check Network tab in browser DevTools — only one `/api/rescore` request should appear after the last dismiss).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+git commit -m "feat: debounce dashboard refresh for rapid dismiss/restore actions"
+```
+
+---
+
+### Task 8: End-to-End Verification
+
+**Files:** None (manual testing)
+
+- [ ] **Step 1: Full flow test**
+
+1. Start the dev server: `cd src/quodeq/ui && npm run dev`
+2. Start the backend server
+3. Open a project with violations
+4. Note scores at all levels: run summary, dimension cards, principle cards
+5. Dismiss a critical violation
+6. Verify: principle score improves, dimension score improves, run summary score improves
+7. Restore the violation
+8. Verify: all scores return to original values
+9. View a historical run — verify scores also reflect dismissals
+
+- [ ] **Step 2: Run all tests**
+
+Run: `python -m pytest tests/services/test_rescore.py tests/api/test_routes_rescore.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: live rescore on dismiss — complete implementation"
+```

--- a/docs/superpowers/specs/2026-04-02-live-rescore-on-dismiss-design.md
+++ b/docs/superpowers/specs/2026-04-02-live-rescore-on-dismiss-design.md
@@ -1,0 +1,117 @@
+# Live Rescore on Dismiss
+
+**Date:** 2026-04-02
+**Status:** Approved
+
+## Problem
+
+When a user dismisses or restores a finding, the UI continues showing the original run scores. Grades only update after a full re-evaluation. Users expect scores to reflect the current state of violations immediately.
+
+## Solution
+
+Add a stateful backend `/rescore` endpoint that recalculates scores from the stored run data minus dismissed findings. The frontend calls this on dashboard load and after each dismiss/restore action. All score displays update through existing state flow.
+
+## Design Decisions
+
+- **Single source of truth:** Scoring formula lives only in the Python backend. No JS port.
+- **Stateful endpoint:** Backend loads violations and dismissed list itself. Frontend just sends `projectId` and optional `runId`.
+- **No caching:** Rescore computation is cheap (sub-50ms on localhost). Compute on every request.
+- **No report mutation:** Original run reports stay intact. Rescored data is transient, returned per-request.
+- **No "adjusted" indicator:** Deferred to future follow-up.
+
+## Architecture
+
+### Backend: `/rescore` Endpoint
+
+**Route:** `GET /api/rescore?project=<projectId>&run=<runId>`
+
+`run` is optional; defaults to latest run.
+
+**Response:** Same structure the dashboard already consumes — updated `dimensions[]` with rescored `overallScore`, `overallGrade`, `totals`, and `principles[].score/grade`, plus a `summary` object for the run level.
+
+**Flow:**
+
+1. Load the run's dimension results from the stored report
+2. Filter out dismissed findings via `filter_dismissed_from_dimensions()`
+3. For each dimension, rescore:
+   - Count violation types per severity per principle
+   - Run `_score_principle_numerical()` (or graded equivalent) with filtered counts
+   - Aggregate principle scores into dimension overall via `weighted_overall()`
+4. Aggregate dimension scores into run summary via `summarize_dimensions()`
+5. Return the full rescored structure
+
+### New Module: `core/scoring/rescore.py`
+
+**Primary function:** `rescore_dimensions(dimensions, dismissed_keys)`
+
+Takes a list of already-parsed dimension results and a set of dismissed keys. Returns the fully rescored structure.
+
+**Reuses existing functions (no changes needed):**
+
+- `violation_base()` — Stage 1: base score from weighted violations
+- `compliance_lift()` — Stage 2: lift from compliance items
+- `violation_ceiling()` — Stage 3: cap based on violation weight
+- `severity_grade_floor()` — Stage 4: floor based on worst severity
+- `weighted_overall()` — Dimension-level aggregation (weighted average of principle scores)
+- `summarize_dimensions()` — Run-level aggregation (simple average of dimension scores)
+- `score_to_grade_label()` — Numeric score to grade word
+
+**New helper to extract:** `count_violation_types(violations)`
+
+Takes a list of violation dicts `[{severity, req, reason, ...}]` and returns type counts `{critical: N, major: N, minor: N}` using the existing type-counting logic (unique types per severity, not raw counts). Currently this logic is buried in the analysis pipeline and needs to be extracted as a standalone function.
+
+### Scoring Aggregation Reference
+
+Each level uses a different calculation:
+
+| Level | Input | Method |
+|-------|-------|--------|
+| **Principle** | Violations + compliance | 4-stage formula (base, lift, ceiling, floor) |
+| **Dimension** | Principle scores | Weighted average (principles have weight multipliers: x1, x2, x3) |
+| **Run** | Dimension scores | Simple arithmetic average (all dimensions equal) |
+
+### Frontend Integration
+
+**When rescore is called:**
+
+1. **On dashboard load** — after fetching dashboard data, call `/rescore`. Replace dimension scores in state with rescored values.
+2. **After dismiss/restore** — chain rescore after the existing dashboard refresh. Debounce at 300ms for rapid-fire actions.
+
+**Flow:**
+
+```
+User dismisses finding
+  -> Card removed from UI (optimistic)
+  -> POST /findings/dismiss
+  -> GET /rescore?project=X
+  -> Response updates dashboard state
+  -> All score components re-render with new grades
+```
+
+**Components that update automatically (read from dashboard state):**
+
+- `RunOverviewPanel` — ScoreCircle (run-level summary)
+- `DimensionCard` — per-dimension score + grade chip
+- `PrincipleAccordion` — per-principle scores
+- `ExplorerPage` — dimension header scores
+- `EvalPrincipleDetailPage` — principle header score
+
+No new components or state management needed.
+
+## Edge Cases
+
+- **No dismissed findings:** Rescore returns original scores unchanged (filtering empty set is a no-op).
+- **All violations dismissed in a principle:** Formula handles naturally — zero violations yields max score, limited by compliance lift. Grade becomes "Exemplary" if compliance exists.
+- **Rescore endpoint fails:** UI keeps showing last known scores. Original dashboard data is already loaded as fallback.
+- **Rapid dismiss/restore:** Debounced at 300ms. Each rescore reads current dismissed list from disk, so always produces correct result.
+- **Scoring mode (numerical vs graded):** Backend knows each dimension's mode and calls the appropriate scoring path.
+- **Historical runs:** Endpoint accepts optional `run` parameter. Dismissed findings are project-level, so historical scores also reflect current dismissals.
+
+## Out of Scope
+
+- No frontend scoring formula (backend is single source of truth)
+- No cache layer (rescore is cheap enough per-request)
+- No mutation of stored report files
+- No "adjusted" indicator on rescored values
+- No new UI components
+- No changes to the existing analysis/evaluation pipeline

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -31,6 +31,7 @@ from quodeq.api.routes import (
 )
 from quodeq.api.standards_routes import register_standards_routes
 from quodeq.api.routes_findings import register_findings_routes
+from quodeq.api.routes_rescore import register_rescore_routes
 
 _HEALTH_PATH = "/api/health"
 _RATE_LIMITED_GET_PATHS = frozenset({"/api/browse"})
@@ -174,6 +175,7 @@ def _register_all_routes(
     register_discovery_routes(app, provider)
     register_standards_routes(app)
     register_findings_routes(app)
+    register_rescore_routes(app)
     register_static_routes(app, static_dist)
 
 

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -159,6 +159,11 @@ def register_project_data_routes(app: Flask, provider: ActionProvider) -> None:
         if payload is None:
             body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
+        # DEBUG: log reliability score from accumulated
+        for d in (payload or {}).get("dimensions", []):
+            if "reliab" in (d.get("dimension") or "").lower():
+                _logger.warning("[DEBUG-ACC] asOf=%s reliability=%s viol=%s", as_of, d.get("overallScore"), d.get("totals", {}).get("violationCount"))
+                break
         return jsonify(payload)
 
     @app.get("/api/projects/<project>/runs/<run_id>/dimensions/<dimension>/eval")

--- a/src/quodeq/api/routes.py
+++ b/src/quodeq/api/routes.py
@@ -159,11 +159,6 @@ def register_project_data_routes(app: Flask, provider: ActionProvider) -> None:
         if payload is None:
             body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        # DEBUG: log reliability score from accumulated
-        for d in (payload or {}).get("dimensions", []):
-            if "reliab" in (d.get("dimension") or "").lower():
-                _logger.warning("[DEBUG-ACC] asOf=%s reliability=%s viol=%s", as_of, d.get("overallScore"), d.get("totals", {}).get("violationCount"))
-                break
         return jsonify(payload)
 
     @app.get("/api/projects/<project>/runs/<run_id>/dimensions/<dimension>/eval")

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
 
-from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding
+from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
 
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
@@ -48,3 +48,12 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project, req, file, and line are required"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
         return jsonify({"ok": True}), 200
+
+    @app.post("/api/findings/restore-all")
+    def restore_all() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        if not project:
+            return jsonify({"error": "project is required"}), 400
+        count = restore_all_findings(_project_dir(_eval_dir(), project))
+        return jsonify({"ok": True, "restored": count}), 200

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -1,0 +1,55 @@
+"""API route for live rescoring after dismissals."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.data.fs.report_parser.runs import read_run_data
+from quodeq.services.ports import list_runs
+from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
+from quodeq.services.rescore import rescore_dimensions
+
+
+def _reports_dir_from_app(app: Flask) -> str:
+    return app.config.get("REPORTS_DIR") or __import__(
+        "quodeq.shared.utils", fromlist=["get_reports_dir"]
+    ).get_reports_dir()
+
+
+def _eval_dir_from_app(app: Flask) -> str:
+    return app.config.get("EVALUATIONS_DIR") or __import__(
+        "quodeq.shared.utils", fromlist=["get_evaluations_dir"]
+    ).get_evaluations_dir()
+
+
+def register_rescore_routes(app: Flask) -> None:
+    """Register /api/rescore route."""
+
+    @app.get("/api/rescore")
+    def rescore() -> Response | tuple[Response, int]:
+        project = request.args.get("project", "")
+        if not project:
+            return jsonify({"error": "project query parameter is required"}), 400
+
+        run_id = request.args.get("run", "")
+        reports_dir = _reports_dir_from_app(app)
+
+        # Resolve run ID
+        if not run_id or run_id == "latest":
+            runs = list_runs(Path(reports_dir), project, limit=1)
+            if not runs:
+                return jsonify({"error": "No runs found for project"}), 404
+            run_id = runs[0].run_id
+
+        try:
+            dimensions = read_run_data(Path(reports_dir), project, run_id)
+        except FileNotFoundError:
+            return jsonify({"error": "Run data not found"}), 404
+
+        eval_dir = _eval_dir_from_app(app)
+        project_dir = Path(eval_dir) / project
+        dismissed = load_dismissed_keys(project_dir)
+
+        result = rescore_dimensions(dimensions, dismissed)
+        return jsonify(result)

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -11,12 +11,6 @@ from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 
 
-def _reports_dir_from_app(app: Flask) -> str:
-    return app.config.get("REPORTS_DIR") or __import__(
-        "quodeq.shared.utils", fromlist=["get_reports_dir"]
-    ).get_reports_dir()
-
-
 def _eval_dir_from_app(app: Flask) -> str:
     return app.config.get("EVALUATIONS_DIR") or __import__(
         "quodeq.shared.utils", fromlist=["get_evaluations_dir"]
@@ -33,21 +27,20 @@ def register_rescore_routes(app: Flask) -> None:
             return jsonify({"error": "project query parameter is required"}), 400
 
         run_id = request.args.get("run", "")
-        reports_dir = _reports_dir_from_app(app)
+        eval_dir = _eval_dir_from_app(app)
 
         # Resolve run ID
         if not run_id or run_id == "latest":
-            runs = list_runs(Path(reports_dir), project, limit=1)
+            runs = list_runs(Path(eval_dir), project, limit=1)
             if not runs:
                 return jsonify({"error": "No runs found for project"}), 404
             run_id = runs[0].run_id
 
         try:
-            dimensions = read_run_data(Path(reports_dir), project, run_id)
+            dimensions = read_run_data(Path(eval_dir), project, run_id)
         except FileNotFoundError:
             return jsonify({"error": "Run data not found"}), 404
 
-        eval_dir = _eval_dir_from_app(app)
         project_dir = Path(eval_dir) / project
         dismissed = load_dismissed_keys(project_dir)
 

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -72,6 +72,18 @@ def restore_finding(project_dir: Path, finding: dict) -> None:
         path.unlink()
 
 
+def restore_all_findings(project_dir: Path) -> int:
+    """Remove all dismissed findings. Returns the count of restored items."""
+    entries = load_dismissed(project_dir)
+    count = len(entries)
+    if count == 0:
+        return 0
+    path = _dismissed_path(project_dir)
+    if path.exists():
+        path.unlink()
+    return count
+
+
 def dismissed_keys(project_dir: Path) -> set[tuple]:
     """Return a set of (req, file, line) tuples for all dismissed findings."""
     return {_key(e) for e in load_dismissed(project_dir)}

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -18,7 +18,6 @@ from quodeq.core.scoring.internals import (
     violation_ceiling,
     severity_grade_floor,
     score_to_grade_label,
-    scale_multiplier,
 )
 from quodeq.core.scoring.overall import weighted_overall, MODE_NUMERICAL
 from quodeq.core.types.scoring import PrincipleScore

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -1,0 +1,151 @@
+"""Live rescore service -- recalculates grades after dismissals change."""
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from quodeq.core.types import DimensionResult, to_camel_dict
+from quodeq.core.types.finding import Finding, Totals, SeverityTally
+from quodeq.core.types.report import PrincipleGrade
+from quodeq.core.scoring.internals import (
+    evidence_has_taxonomy,
+    tally_types_by_taxonomy,
+    tally_types_by_reason,
+    tally_compliance_types_by_taxonomy,
+    tally_compliance_types_by_reason,
+    violation_base,
+    compliance_lift,
+    violation_ceiling,
+    severity_grade_floor,
+    score_to_grade_label,
+    scale_multiplier,
+)
+from quodeq.core.scoring.overall import weighted_overall, MODE_NUMERICAL
+from quodeq.core.types.scoring import PrincipleScore
+from quodeq.data.fs.report_parser.grades import summarize_dimensions
+
+
+def _finding_to_dict(f: Finding) -> dict[str, Any]:
+    """Convert a Finding dataclass to the dict format scoring internals expect.
+
+    The tally functions use 'vt' for violation_type and dict.get() for access.
+    """
+    return {
+        "severity": f.severity or "minor",
+        "reason": f.reason or "",
+        "vt": f.violation_type or "",
+    }
+
+
+def _compute_tallies(violations: list[Finding], compliance: list[Finding]):
+    """Count violation and compliance types, auto-selecting taxonomy or reason mode."""
+    v_dicts = [_finding_to_dict(v) for v in violations]
+    c_dicts = [_finding_to_dict(c) for c in compliance]
+    using_taxonomy = evidence_has_taxonomy(v_dicts)
+    vt = tally_types_by_taxonomy(v_dicts) if using_taxonomy else tally_types_by_reason(v_dicts)
+    ct = tally_compliance_types_by_taxonomy(c_dicts) if using_taxonomy else tally_compliance_types_by_reason(c_dicts)
+    return vt, ct
+
+
+def _score_principle(violations: list[Finding], compliance: list[Finding]) -> tuple[float | None, str]:
+    """Score a single principle from its filtered violations and compliance lists.
+
+    Returns (final_score, grade).
+    """
+    vt_counts, ct_counts = _compute_tallies(violations, compliance)
+    if not vt_counts and not ct_counts:
+        return None, "Insufficient"
+
+    base = violation_base(vt_counts)
+    lift = compliance_lift(ct_counts, vt_counts)
+    ceil = violation_ceiling(vt_counts)
+    floor = severity_grade_floor(vt_counts)
+
+    raw = base + (10.0 - base) * lift
+    final = max(floor, min(ceil, raw))
+    final = round(final, 1)
+    grade = score_to_grade_label(final)
+    return final, grade
+
+
+def _recount_totals(violations: list[Finding], compliance_count: int) -> Totals:
+    """Recount totals from a filtered violations list."""
+    crit = sum(1 for v in violations if (v.severity or "").lower() == "critical")
+    major = sum(1 for v in violations if (v.severity or "").lower() == "major")
+    minor = sum(1 for v in violations if (v.severity or "").lower() == "minor")
+    unknown = len(violations) - crit - major - minor
+    return Totals(
+        violation_count=len(violations),
+        compliance_count=compliance_count,
+        severity=SeverityTally(critical=crit, major=major, minor=minor, unknown=unknown),
+    )
+
+
+def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> DimensionResult:
+    """Rescore a single dimension after filtering dismissed findings."""
+    # Filter violations -- dismissed key is (req, file, line)
+    filtered_violations = [
+        v for v in dim.violations
+        if (v.req or "", v.file or "", v.line or 0) not in dismissed
+    ]
+
+    # Group violations and compliance by principle
+    principles_violations: dict[str, list[Finding]] = {}
+    principles_compliance: dict[str, list[Finding]] = {}
+    for v in filtered_violations:
+        principles_violations.setdefault(v.principle or "unknown", []).append(v)
+    for c in dim.compliance:
+        principles_compliance.setdefault(c.principle or "unknown", []).append(c)
+
+    # Score each principle
+    all_principle_names = set(principles_violations) | set(principles_compliance)
+    principle_scores: dict[str, PrincipleScore] = {}
+    principle_grades: list[PrincipleGrade] = []
+
+    for name in sorted(all_principle_names):
+        p_violations = principles_violations.get(name, [])
+        p_compliance = principles_compliance.get(name, [])
+        final_score, grade = _score_principle(p_violations, p_compliance)
+        score_str = f"{final_score}/10" if final_score is not None else None
+
+        principle_scores[name] = PrincipleScore(
+            display_name=name,
+            weight="1",
+            final_score=final_score,
+            grade=grade,
+        )
+        principle_grades.append(PrincipleGrade(principle=name, score=score_str, grade=grade))
+
+    # Aggregate to dimension overall
+    overall = weighted_overall(principle_scores, MODE_NUMERICAL)
+    overall_score_str = f"{overall.weighted_score}/10" if overall.weighted_score is not None else None
+    overall_grade = overall.grade or overall.weighted_grade
+
+    # Recount totals
+    compliance_count = dim.totals.compliance_count if dim.totals else len(dim.compliance)
+    new_totals = _recount_totals(filtered_violations, compliance_count)
+
+    return replace(
+        dim,
+        violations=filtered_violations,
+        principles=principle_grades,
+        overall_score=overall_score_str,
+        overall_grade=overall_grade,
+        totals=new_totals,
+    )
+
+
+def rescore_dimensions(
+    dimensions: list[DimensionResult],
+    dismissed_keys: set[tuple],
+) -> dict[str, Any]:
+    """Rescore all dimensions after filtering dismissed findings.
+
+    Returns a dict with 'dimensions' (list of camelCase dicts) and 'summary' (camelCase dict).
+    """
+    rescored = [_rescore_dimension(dim, dismissed_keys) for dim in dimensions]
+    summary = summarize_dimensions(rescored)
+    return {
+        "dimensions": [to_camel_dict(d) for d in rescored],
+        "summary": to_camel_dict(summary),
+    }

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-BcoZ7b1Q.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-N1AJiR7P.css">
+    <script type="module" crossorigin src="/assets/index-rJeqbnDp.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -130,7 +130,7 @@ const ROUTE_RENDERERS = {
     );
   },
   'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
-  explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} onNavigate={props.navigation.handleNavigate} />,
+  explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} onNavigate={props.navigation.handleNavigate} refreshSignal={props.dashboardData.dashboard} />,
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
   file: (params) => <FileDetailPage file={params.file} />,
   principle: (params) => <PrincipleDetailPage principle={params.principle} />,

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -197,7 +197,7 @@ export default function App() {
   const contentProps = {
     dashboardData: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
-      dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, error: state.error,
+      dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, rescoreLookup: state.rescoreLookup, loading: state.loading, error: state.error,
       availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
     },
     navigation: {

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -316,3 +316,15 @@ export async function restoreFinding(projectId, finding) {
     body: JSON.stringify({ project: projectId, ...finding }),
   });
 }
+
+/**
+ * Rescore a project run with dismissed findings filtered out.
+ * @param {string} projectId - Project identifier
+ * @param {string} [run='latest'] - Run ID (optional, defaults to latest)
+ * @returns {Promise<{dimensions: Array, summary: object}>} Rescored data
+ */
+export async function getRescore(projectId, run = 'latest') {
+  const params = new URLSearchParams({ project: projectId });
+  if (run && run !== 'latest') params.set('run', run);
+  return request(`/rescore?${params}`);
+}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -318,6 +318,18 @@ export async function restoreFinding(projectId, finding) {
 }
 
 /**
+ * Restore all dismissed findings for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<{ok: boolean, restored: number}>} Server response
+ */
+export async function restoreAllFindings(projectId) {
+  return request('/findings/restore-all', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId }),
+  });
+}
+
+/**
  * Rescore a project run with dismissed findings filtered out.
  * @param {string} projectId - Project identifier
  * @param {string} [run='latest'] - Run ID (optional, defaults to latest)

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -101,14 +101,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate }) {
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDimNames }) {
+function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDimNames, rescoreLookup }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} rescoreLookup={rescoreLookup} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -231,7 +231,7 @@ function useAccumulatedComputations(data) {
   return { currentOverviewRun, referenceRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats };
 }
 
-export default function AccumulatedOverviewPanel({ data, callbacks }) {
+export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLookup }) {
   const { onRunClick, onDimensionClick } = callbacks;
   const { currentOverviewRun, referenceRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats } = useAccumulatedComputations(data);
 
@@ -254,6 +254,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={filteredStats.dimsWithViolations}
         selectedDayDimNames={selectedDayDimNames}
+        rescoreLookup={rescoreLookup}
       />
     </>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -37,7 +37,8 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
   return (
     <AccumulatedOverviewPanel
       data={{
-        accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
+        accumulated: accumulated ? { ...accumulated, dimensions: accumulatedDimensions } : accumulated,
+        accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
         trend: dashboard?.trend || [], selectedRunId,
       }}
       callbacks={{

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -5,7 +5,7 @@ import RunOverviewPanel from './RunOverviewPanel.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick } = callbacks;
   if (runMode) {
@@ -99,7 +99,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
           callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick }}
         />

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -44,6 +44,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
       callbacks={{
         onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick,
       }}
+      rescoreLookup={rescoreLookup}
     />
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -68,11 +68,20 @@ function useDashboardHandlers(onNavigate, dashboard) {
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
+  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, rescoreLookup = {}, loading, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
   const { onNavigate, onRunSelect } = callbacks;
   const [focusedDimension, setFocusedDimension] = useState(null);
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
-  const accumulatedDimensions = accumulated?.dimensions || [];
+  // Merge rescored grades into accumulated dimensions so all cards reflect live scores
+  const accumulatedDimensions = useMemo(() => {
+    const dims = accumulated?.dimensions || [];
+    if (Object.keys(rescoreLookup).length === 0) return dims;
+    return dims.map((dim) => {
+      const match = rescoreLookup[(dim.dimension || '').toLowerCase()];
+      if (!match) return dim;
+      return { ...dim, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? dim.totals };
+    });
+  }, [accumulated, rescoreLookup]);
   const focusedDimensionData = useMemo(() => focusedDimension ? (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null : null, [focusedDimension, dashboard]);
   const handlers = useDashboardHandlers(onNavigate, dashboard);
 

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -2,17 +2,19 @@ import { useMemo } from 'react';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import { formatRunId, scoreColorClass, splitScore, complianceRatio } from '../../../utils/formatters.js';
 
-function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
-  const currScore = parseFloat(item.overallScore);
-  const prevScore = parseFloat(item.previousScore);
+function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true, rescoreLookup }) {
+  const match = rescoreLookup?.[(item.dimension || '').toLowerCase()];
+  const effectiveItem = match ? { ...item, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? item.totals } : item;
+  const currScore = parseFloat(effectiveItem.overallScore);
+  const prevScore = parseFloat(effectiveItem.previousScore);
   const delta = !isNaN(currScore) && !isNaN(prevScore) ? currScore - prevScore : null;
-  const score = splitScore(item.overallScore);
+  const score = splitScore(effectiveItem.overallScore);
   const gradeClass = scoreColorClass(currScore);
   const staleClass = evaluatedToday ? 'qd-card--active' : 'qd-card-stale qd-card--carried';
   return (
     <article
       className={`qd-card ${staleClass} ${gradeClass}`}
-      onClick={() => onDimensionClick(item)}
+      onClick={() => onDimensionClick(effectiveItem)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDimensionClick(item); } }}
@@ -31,12 +33,12 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
         <div className="qd-card-col-divider" />
         <div className="qd-card-col">
           <span className="qd-card-col-label">Viol</span>
-          <span className="qd-card-col-value">{item.totals?.violationCount ?? 0}</span>
+          <span className="qd-card-col-value">{effectiveItem.totals?.violationCount ?? 0}</span>
         </div>
         <div className="qd-card-col-divider" />
         <div className="qd-card-col">
           <span className="qd-card-col-label">Ratio</span>
-          <span className="qd-card-col-value">{complianceRatio(item.totals?.violationCount ?? 0, item.totals?.complianceCount ?? 0)}</span>
+          <span className="qd-card-col-value">{complianceRatio(effectiveItem.totals?.violationCount ?? 0, effectiveItem.totals?.complianceCount ?? 0)}</span>
         </div>
       </div>
       <div className="qd-card-footer">
@@ -48,7 +50,7 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDimNames }) {
+export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDimNames, rescoreLookup }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
   const sorted = useMemo(() => [...sortedDimensions].sort((a, b) => {
     if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);
@@ -68,6 +70,7 @@ export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onD
             item={item}
             onDimensionClick={onDimensionClick}
             evaluatedToday={isActive}
+            rescoreLookup={rescoreLookup}
           />
         );
       })}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -14,7 +14,22 @@ import { createDimension } from '../../../models/dimension.js';
  *   availableRuns: Array<{ runId: string, dateLabel: string }>,
  * }}
  */
-function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError) {
+function patchAccumulatedWithRescore(setAcc, rescored) {
+  const rescoredDims = rescored.dimensions || [];
+  if (rescoredDims.length === 0) return;
+  const lookup = Object.fromEntries(rescoredDims.map((d) => [(d.dimension || '').toLowerCase(), d]));
+  setAcc((prev) => {
+    if (!prev?.dimensions) return prev;
+    const patched = prev.dimensions.map((dim) => {
+      const match = lookup[(dim.dimension || '').toLowerCase()];
+      if (!match) return dim;
+      return { ...dim, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? dim.totals };
+    });
+    return { ...prev, dimensions: patched };
+  });
+}
+
+function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAccumulated, setLatestAccumulated, setLoading, setError) {
   if (!selectedProject) {
     setDashboard(null);
     setError(null);
@@ -42,6 +57,8 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
             summary: { ...prev.summary, ...rescored.summary },
           };
         });
+        patchAccumulatedWithRescore(setAccumulated, rescored);
+        patchAccumulatedWithRescore(setLatestAccumulated, rescored);
       }).catch((err) => console.warn('Rescore failed (non-fatal):', err));
     })
     .catch((err) => {
@@ -103,7 +120,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
     setError(null);
   }
 
-  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
+  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAccumulated, setLatestAccumulated, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject, refreshKey]);
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getDashboard, getAccumulated, getRescore } from '../../../api/index.js';
+import { createDimension } from '../../../models/dimension.js';
 
 /**
  * Fetches and manages dashboard data for a given project and run.
@@ -36,7 +37,7 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
           if (!prev) return prev;
           return {
             ...prev,
-            dimensions: rescored.dimensions,
+            dimensions: (rescored.dimensions || []).map(createDimension),
             summary: { ...prev.summary, ...rescored.summary },
           };
         });

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getDashboard, getAccumulated, getRescore } from '../../../api/index.js';
 
 /**
@@ -106,7 +106,13 @@ export function useDashboard({ selectedProject, selectedRun }) {
   useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject, refreshKey]);
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
 
-  const refreshDashboard = () => setRefreshKey((k) => k + 1);
+  const refreshTimerRef = useRef(null);
+  const refreshDashboard = useCallback(() => {
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), 300);
+  }, []);
+
+  useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
 
   return { dashboard, accumulated, latestAccumulated, loading, error, availableRuns, refreshDashboard };
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -14,10 +14,8 @@ import { createDimension } from '../../../models/dimension.js';
  *   availableRuns: Array<{ runId: string, dateLabel: string }>,
  * }}
  */
-function patchAccumulatedWithRescore(setAcc, rescored) {
-  const rescoredDims = rescored.dimensions || [];
-  if (rescoredDims.length === 0) return;
-  const lookup = Object.fromEntries(rescoredDims.map((d) => [(d.dimension || '').toLowerCase(), d]));
+function patchAccumulatedWithLookup(setAcc, lookup) {
+  if (Object.keys(lookup).length === 0) return;
   setAcc((prev) => {
     if (!prev?.dimensions) return prev;
     const patched = prev.dimensions.map((dim) => {
@@ -29,6 +27,30 @@ function patchAccumulatedWithRescore(setAcc, rescored) {
   });
 }
 
+function rescoreAccumulatedDimensions(project, setAcc, setLatestAcc, active) {
+  // Collect unique run IDs from accumulated dimensions, rescore each, merge results
+  setAcc((prev) => {
+    if (!prev?.dimensions) return prev;
+    const runIds = [...new Set(prev.dimensions.map((d) => d.fromRunId).filter(Boolean))];
+    if (runIds.length === 0) return prev;
+    // Fire rescores outside setState (side-effect), return prev unchanged
+    Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
+      .then((results) => {
+        if (!active.current) return;
+        const lookup = {};
+        for (const r of results) {
+          if (!r) continue;
+          for (const d of (r.dimensions || [])) {
+            lookup[(d.dimension || '').toLowerCase()] = d;
+          }
+        }
+        patchAccumulatedWithLookup(setAcc, lookup);
+        patchAccumulatedWithLookup(setLatestAcc, lookup);
+      });
+    return prev;
+  });
+}
+
 function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAccumulated, setLatestAccumulated, setLoading, setError) {
   if (!selectedProject) {
     setDashboard(null);
@@ -36,19 +58,18 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAcc
     return;
   }
 
-  let active = true;
+  const activeRef = { current: true };
   setLoading(true);
   setError(null);
 
   getDashboard(selectedProject, selectedRun)
     .then((payload) => {
-      if (!active) return;
+      if (!activeRef.current) return;
       setDashboard(payload);
-      // Chain rescore to update grades with dismissed findings filtered
-      // Errors are caught separately so the dashboard still shows original data
+      // Rescore dashboard dimensions for the selected run
       const runId = payload?.selectedRun?.runId || selectedRun;
       getRescore(selectedProject, runId).then((rescored) => {
-        if (!active) return;
+        if (!activeRef.current) return;
         setDashboard((prev) => {
           if (!prev) return prev;
           return {
@@ -57,19 +78,19 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAcc
             summary: { ...prev.summary, ...rescored.summary },
           };
         });
-        patchAccumulatedWithRescore(setAccumulated, rescored);
-        patchAccumulatedWithRescore(setLatestAccumulated, rescored);
       }).catch((err) => console.warn('Rescore failed (non-fatal):', err));
+      // Rescore accumulated dimensions — each may come from a different run
+      rescoreAccumulatedDimensions(selectedProject, setAccumulated, setLatestAccumulated, activeRef);
     })
     .catch((err) => {
       console.warn('Dashboard load failed:', err);
-      if (active) setError('Failed to load dashboard data. Please try again.');
+      if (activeRef.current) setError('Failed to load dashboard data. Please try again.');
     })
     .finally(() => {
-      if (active) setLoading(false);
+      if (activeRef.current) setLoading(false);
     });
 
-  return () => { active = false; };
+  return () => { activeRef.current = false; };
 }
 
 function fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError) {

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -27,31 +27,28 @@ function patchAccumulatedWithLookup(setAcc, lookup) {
   });
 }
 
-function rescoreAccumulatedDimensions(project, setAcc, setLatestAcc, active) {
-  // Collect unique run IDs from accumulated dimensions, rescore each, merge results
-  setAcc((prev) => {
-    if (!prev?.dimensions) return prev;
-    const runIds = [...new Set(prev.dimensions.map((d) => d.fromRunId).filter(Boolean))];
-    if (runIds.length === 0) return prev;
-    // Fire rescores outside setState (side-effect), return prev unchanged
-    Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
-      .then((results) => {
-        if (!active.current) return;
-        const lookup = {};
-        for (const r of results) {
-          if (!r) continue;
-          for (const d of (r.dimensions || [])) {
-            lookup[(d.dimension || '').toLowerCase()] = d;
-          }
+function rescoreAccumulatedEffect(project, accumulated, setAcc) {
+  if (!project || !accumulated?.dimensions) return;
+  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId).filter(Boolean))];
+  if (runIds.length === 0) return;
+
+  let active = true;
+  Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
+    .then((results) => {
+      if (!active) return;
+      const lookup = {};
+      for (const r of results) {
+        if (!r) continue;
+        for (const d of (r.dimensions || [])) {
+          lookup[(d.dimension || '').toLowerCase()] = d;
         }
-        patchAccumulatedWithLookup(setAcc, lookup);
-        patchAccumulatedWithLookup(setLatestAcc, lookup);
-      });
-    return prev;
-  });
+      }
+      patchAccumulatedWithLookup(setAcc, lookup);
+    });
+  return () => { active = false; };
 }
 
-function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAccumulated, setLatestAccumulated, setLoading, setError) {
+function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError) {
   if (!selectedProject) {
     setDashboard(null);
     setError(null);
@@ -79,8 +76,6 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAcc
           };
         });
       }).catch((err) => console.warn('Rescore failed (non-fatal):', err));
-      // Rescore accumulated dimensions — each may come from a different run
-      rescoreAccumulatedDimensions(selectedProject, setAccumulated, setLatestAccumulated, activeRef);
     })
     .catch((err) => {
       console.warn('Dashboard load failed:', err);
@@ -141,9 +136,23 @@ export function useDashboard({ selectedProject, selectedRun }) {
     setError(null);
   }
 
-  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setAccumulated, setLatestAccumulated, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
+  useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject, refreshKey]);
+  // Rescore accumulated dimensions — runs after accumulated loads/refreshes
+  // Uses a ref to track whether accumulated has been rescored for the current refreshKey
+  const accRescoredRef = useRef(-1);
+  useEffect(() => {
+    if (!accumulated || accRescoredRef.current === refreshKey) return;
+    accRescoredRef.current = refreshKey;
+    return rescoreAccumulatedEffect(selectedProject, accumulated, setAccumulated);
+  }, [accumulated, refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const latestAccRescoredRef = useRef(-1);
+  useEffect(() => {
+    if (!latestAccumulated || latestAccRescoredRef.current === refreshKey) return;
+    latestAccRescoredRef.current = refreshKey;
+    return rescoreAccumulatedEffect(selectedProject, latestAccumulated, setLatestAccumulated);
+  }, [latestAccumulated, refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
 
   const refreshTimerRef = useRef(null);

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -4,49 +4,7 @@ import { createDimension } from '../../../models/dimension.js';
 
 /**
  * Fetches and manages dashboard data for a given project and run.
- *
- * @param {{ selectedProject: string, selectedRun: string }} params
- * @returns {{
- *   dashboard: object|null,
- *   accumulated: object|null,
- *   loading: boolean,
- *   error: string|null,
- *   availableRuns: Array<{ runId: string, dateLabel: string }>,
- * }}
  */
-function patchAccumulatedWithLookup(setAcc, lookup) {
-  if (Object.keys(lookup).length === 0) return;
-  setAcc((prev) => {
-    if (!prev?.dimensions) return prev;
-    const patched = prev.dimensions.map((dim) => {
-      const match = lookup[(dim.dimension || '').toLowerCase()];
-      if (!match) return dim;
-      return { ...dim, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? dim.totals };
-    });
-    return { ...prev, dimensions: patched };
-  });
-}
-
-function rescoreAccumulatedEffect(project, accumulated, setAcc) {
-  if (!project || !accumulated?.dimensions) return;
-  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId || d.runId).filter(Boolean))];
-  if (runIds.length === 0) return;
-
-  let active = true;
-  Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
-    .then((results) => {
-      if (!active) return;
-      const lookup = {};
-      for (const r of results) {
-        if (!r) continue;
-        for (const d of (r.dimensions || [])) {
-          lookup[(d.dimension || '').toLowerCase()] = d;
-        }
-      }
-      patchAccumulatedWithLookup(setAcc, lookup);
-    });
-  return () => { active = false; };
-}
 
 function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError) {
   if (!selectedProject) {
@@ -55,18 +13,18 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
     return;
   }
 
-  const activeRef = { current: true };
+  let active = true;
   setLoading(true);
   setError(null);
 
   getDashboard(selectedProject, selectedRun)
     .then((payload) => {
-      if (!activeRef.current) return;
+      if (!active) return;
       setDashboard(payload);
       // Rescore dashboard dimensions for the selected run
       const runId = payload?.selectedRun?.runId || selectedRun;
       getRescore(selectedProject, runId).then((rescored) => {
-        if (!activeRef.current) return;
+        if (!active) return;
         setDashboard((prev) => {
           if (!prev) return prev;
           return {
@@ -79,13 +37,13 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
     })
     .catch((err) => {
       console.warn('Dashboard load failed:', err);
-      if (activeRef.current) setError('Failed to load dashboard data. Please try again.');
+      if (active) setError('Failed to load dashboard data. Please try again.');
     })
     .finally(() => {
-      if (activeRef.current) setLoading(false);
+      if (active) setLoading(false);
     });
 
-  return () => { activeRef.current = false; };
+  return () => { active = false; };
 }
 
 function fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError) {
@@ -109,6 +67,32 @@ function fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, se
   return () => { active = false; };
 }
 
+/**
+ * Rescore all unique runs from accumulated dimensions and build a lookup
+ * of dimension name → rescored data. Stored as separate state so patching
+ * accumulated doesn't cause re-render loops.
+ */
+function rescoreAllRunsEffect(project, accumulated, setRescoreLookup) {
+  if (!project || !accumulated?.dimensions) return;
+  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId || d.runId).filter(Boolean))];
+  if (runIds.length === 0) return;
+
+  let active = true;
+  Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
+    .then((results) => {
+      if (!active) return;
+      const lookup = {};
+      for (const r of results) {
+        if (!r) continue;
+        for (const d of (r.dimensions || [])) {
+          lookup[(d.dimension || '').toLowerCase()] = d;
+        }
+      }
+      setRescoreLookup(lookup);
+    });
+  return () => { active = false; };
+}
+
 function buildAvailableRuns(dashboard) {
   const trendRows = dashboard?.trend || [];
   if (trendRows.length === 0) return [];
@@ -125,6 +109,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [rescoreLookup, setRescoreLookup] = useState({});
 
   // Clear stale data immediately when project changes to prevent rendering old data for a new project
   const prevProjectRef = useRef(selectedProject);
@@ -133,26 +118,15 @@ export function useDashboard({ selectedProject, selectedRun }) {
     setDashboard(null);
     setAccumulated(null);
     setLatestAccumulated(null);
+    setRescoreLookup({});
     setError(null);
   }
 
   useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError), [selectedProject, refreshKey]);
-  // Rescore accumulated dimensions — runs after accumulated loads/refreshes
-  // Uses a ref to track whether accumulated has been rescored for the current refreshKey
-  const accRescoredRef = useRef(-1);
-  useEffect(() => {
-    if (!accumulated || accRescoredRef.current === refreshKey) return;
-    accRescoredRef.current = refreshKey;
-    return rescoreAccumulatedEffect(selectedProject, accumulated, setAccumulated);
-  }, [accumulated, refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
-  const latestAccRescoredRef = useRef(-1);
-  useEffect(() => {
-    if (!latestAccumulated || latestAccRescoredRef.current === refreshKey) return;
-    latestAccRescoredRef.current = refreshKey;
-    return rescoreAccumulatedEffect(selectedProject, latestAccumulated, setLatestAccumulated);
-  }, [latestAccumulated, refreshKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Rescore all runs that contribute to accumulated — stored as lookup, not patched into accumulated
+  useEffect(() => rescoreAllRunsEffect(selectedProject, accumulated, setRescoreLookup), [selectedProject, accumulated]);
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
 
   const refreshTimerRef = useRef(null);
@@ -163,5 +137,5 @@ export function useDashboard({ selectedProject, selectedRun }) {
 
   useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
 
-  return { dashboard, accumulated, latestAccumulated, loading, error, availableRuns, refreshDashboard };
+  return { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, error, availableRuns, refreshDashboard };
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -74,18 +74,29 @@ function fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, se
  */
 function rescoreAllRunsEffect(project, accumulated, setRescoreLookup) {
   if (!project || !accumulated?.dimensions) return;
-  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId || d.runId).filter(Boolean))];
+  // Map each dimension to its authoritative run (the run the accumulated view selected)
+  const dimToRun = {};
+  for (const d of accumulated.dimensions) {
+    const key = (d.dimension || '').toLowerCase();
+    const rid = d.fromRunId || d.runId;
+    if (key && rid) dimToRun[key] = rid;
+  }
+  const runIds = [...new Set(Object.values(dimToRun))];
   if (runIds.length === 0) return;
 
   let active = true;
-  Promise.all(runIds.map((rid) => getRescore(project, rid).catch(() => null)))
+  Promise.all(runIds.map((rid) => getRescore(project, rid).then((r) => ({ rid, data: r })).catch(() => null)))
     .then((results) => {
       if (!active) return;
       const lookup = {};
       for (const r of results) {
-        if (!r) continue;
-        for (const d of (r.dimensions || [])) {
-          lookup[(d.dimension || '').toLowerCase()] = d;
+        if (!r?.data) continue;
+        for (const d of (r.data.dimensions || [])) {
+          const key = (d.dimension || '').toLowerCase();
+          // Only use this dimension if it came from its authoritative run
+          if (dimToRun[key] === r.rid) {
+            lookup[key] = d;
+          }
         }
       }
       setRescoreLookup(lookup);

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -29,7 +29,7 @@ function patchAccumulatedWithLookup(setAcc, lookup) {
 
 function rescoreAccumulatedEffect(project, accumulated, setAcc) {
   if (!project || !accumulated?.dimensions) return;
-  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId).filter(Boolean))];
+  const runIds = [...new Set(accumulated.dimensions.map((d) => d.fromRunId || d.runId).filter(Boolean))];
   if (runIds.length === 0) return;
 
   let active = true;

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { getDashboard, getAccumulated } from '../../../api/index.js';
+import { getDashboard, getAccumulated, getRescore } from '../../../api/index.js';
 
 /**
  * Fetches and manages dashboard data for a given project and run.
@@ -26,7 +26,21 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
 
   getDashboard(selectedProject, selectedRun)
     .then((payload) => {
-      if (active) setDashboard(payload);
+      if (!active) return;
+      setDashboard(payload);
+      // Chain rescore to update grades with dismissed findings filtered
+      const runId = payload?.selectedRun?.runId || selectedRun;
+      return getRescore(selectedProject, runId).then((rescored) => {
+        if (!active) return;
+        setDashboard((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            dimensions: rescored.dimensions,
+            summary: { ...prev.summary, ...rescored.summary },
+          };
+        });
+      });
     })
     .catch((err) => {
       console.warn('Dashboard load failed:', err);

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -30,8 +30,9 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
       if (!active) return;
       setDashboard(payload);
       // Chain rescore to update grades with dismissed findings filtered
+      // Errors are caught separately so the dashboard still shows original data
       const runId = payload?.selectedRun?.runId || selectedRun;
-      return getRescore(selectedProject, runId).then((rescored) => {
+      getRescore(selectedProject, runId).then((rescored) => {
         if (!active) return;
         setDashboard((prev) => {
           if (!prev) return prev;
@@ -41,7 +42,7 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
             summary: { ...prev.summary, ...rescored.summary },
           };
         });
-      });
+      }).catch((err) => console.warn('Rescore failed (non-fatal):', err));
     })
     .catch((err) => {
       console.warn('Dashboard load failed:', err);

--- a/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -177,21 +177,19 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
     }
   }, [onDismiss, project, runId, dimension, principle]);
 
-  // Filter dismissed violations from each severity group
-  const filteredBySeverity = {};
-  for (const sev of Object.keys(violationsBySeverity)) {
-    filteredBySeverity[sev] = (violationsBySeverity[sev] || []).filter(
-      (v) => !dismissedSet.has(`${v.file}:${v.line}`)
-    );
-  }
-
-  // Recompute counts from filtered violations
-  const filteredViolations = useMemo(() => Object.values(filteredBySeverity).flat(), [dismissedSet]); // eslint-disable-line react-hooks/exhaustive-deps
-  const liveSevCounts = useMemo(() => {
+  // Filter dismissed violations and recompute derived stats
+  const { filteredBySeverity, filteredViolations, liveSevCounts } = useMemo(() => {
+    const bySev = {};
+    for (const sev of Object.keys(violationsBySeverity)) {
+      bySev[sev] = (violationsBySeverity[sev] || []).filter(
+        (v) => !dismissedSet.has(`${v.file}:${v.line}`)
+      );
+    }
+    const allFiltered = Object.values(bySev).flat();
     const counts = { critical: 0, major: 0, minor: 0 };
-    filteredViolations.forEach((v) => { const s = (v.severity || 'minor').toLowerCase(); if (counts[s] !== undefined) counts[s]++; });
-    return counts;
-  }, [filteredViolations]);
+    allFiltered.forEach((v) => { const s = (v.severity || 'minor').toLowerCase(); if (counts[s] !== undefined) counts[s]++; });
+    return { filteredBySeverity: bySev, filteredViolations: allFiltered, liveSevCounts: counts };
+  }, [violationsBySeverity, dismissedSet]);
 
   return (
     <>

--- a/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalPrincipleDetailPage.jsx
@@ -1,9 +1,10 @@
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, useMemo } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
 import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
+import { getRescore } from '../../../api/index.js';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 
 const PAGE_SIZE = 20;
@@ -153,9 +154,11 @@ function PrincipleContext({ principleData }) {
 }
 
 const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrincipal, onDismiss }) {
-  const { principleData, principle, score, grade } = evalPrincipal;
+  const { principleData, principle, score, grade, dimension, project, runId } = evalPrincipal;
   const [showAllCompliance, setShowAllCompliance] = useState(false);
   const [dismissedSet, setDismissedSet] = useState(new Set());
+  const [liveScore, setLiveScore] = useState(null);
+  const [liveGrade, setLiveGrade] = useState(null);
   const { violations, compliance, violationsBySeverity, sevCounts } = computeEvalPrincipleData(evalPrincipal);
   const displayedCompliance = showAllCompliance ? compliance : compliance.slice(0, PAGE_SIZE);
 
@@ -163,7 +166,16 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
     if (!onDismiss) return;
     onDismiss(v);
     setDismissedSet((prev) => new Set(prev).add(`${v.file}:${v.line}`));
-  }, [onDismiss]);
+    // Fire rescore to update principle score/grade
+    if (project && runId) {
+      getRescore(project, runId).then((rescored) => {
+        const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
+        if (!dimData) return;
+        const pg = (dimData.principles || []).find((p) => p.principle === principle);
+        if (pg) { setLiveScore(pg.score); setLiveGrade(pg.grade); }
+      }).catch(() => {});
+    }
+  }, [onDismiss, project, runId, dimension, principle]);
 
   // Filter dismissed violations from each severity group
   const filteredBySeverity = {};
@@ -173,10 +185,18 @@ const EvalPrincipleDetailPage = memo(function EvalPrincipleDetailPage({ evalPrin
     );
   }
 
+  // Recompute counts from filtered violations
+  const filteredViolations = useMemo(() => Object.values(filteredBySeverity).flat(), [dismissedSet]); // eslint-disable-line react-hooks/exhaustive-deps
+  const liveSevCounts = useMemo(() => {
+    const counts = { critical: 0, major: 0, minor: 0 };
+    filteredViolations.forEach((v) => { const s = (v.severity || 'minor').toLowerCase(); if (counts[s] !== undefined) counts[s]++; });
+    return counts;
+  }, [filteredViolations]);
+
   return (
     <>
       <PrincipleHeader
-        data={{ principle, score, grade, violations, compliance, sevCounts }}
+        data={{ principle, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts }}
         onCopyPlan={() => copyToClipboard(buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData))}
       />
       <PrincipleContext principleData={principleData} />

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -224,6 +224,10 @@ function useExplorerData(project, dimension, runId) {
             // Merge rescored principle grades and overall score
             const rescPrinciples = dimData.principles || [];
             const updatedGrades = (prev.principleGrades || []).map((pg) => {
+              // Update the overall row with dimension-level rescored values
+              if (pg.isOverall || pg.principle?.includes('Overall')) {
+                return { ...pg, score: dimData.overallScore ?? pg.score, grade: dimData.overallGrade ?? pg.grade };
+              }
               const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
               return match ? { ...pg, score: match.score, grade: match.grade } : pg;
             });

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { getDimensionEval } from '../../../api/index.js';
+import { getDimensionEval, getRescore } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
@@ -211,7 +211,30 @@ function useExplorerData(project, dimension, runId) {
   useEffect(() => {
     setLoading(true);
     getDimensionEval(project, runId, dimension)
-      .then((data) => { setEvalData(data); setLoading(false); })
+      .then((data) => {
+        setEvalData(data);
+        setLoading(false);
+        // Chain rescore to patch principle grades with dismissed-filtered scores
+        return getRescore(project, runId).then((rescored) => {
+          const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
+          if (!dimData) return;
+          setEvalData((prev) => {
+            if (!prev) return prev;
+            // Merge rescored principle grades and overall score
+            const rescPrinciples = dimData.principles || [];
+            const updatedGrades = (prev.principleGrades || []).map((pg) => {
+              const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
+              return match ? { ...pg, score: match.score, grade: match.grade } : pg;
+            });
+            return {
+              ...prev,
+              principleGrades: updatedGrades,
+              overallScore: dimData.overallScore ?? prev.overallScore,
+              overallGrade: dimData.overallGrade ?? prev.overallGrade,
+            };
+          });
+        }).catch(() => { /* rescore failure is non-fatal */ });
+      })
       .catch((err) => { setError(err.message); setLoading(false); });
   }, [project, dimension, runId]);
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -182,13 +182,14 @@ function ViolationsByFileSection({ topFiles, onNavigate }) {
   );
 }
 
-function buildEvalPrincipalFn(evalData, complianceByPrinciple) {
+function buildEvalPrincipalFn(evalData, complianceByPrinciple, project, runId) {
   return function buildEvalPrincipal(principleId) {
     const principleData = (evalData.principles || []).find((p) => p.name === principleId);
     const pg = (evalData.principleGrades || []).find((p) => p.principle === principleId);
     return {
       principle: principleId, score: pg?.score || null, grade: pg?.grade || null,
       dimension: evalData.dimension || '',
+      project: project || '', runId: runId || '',
       principleData, dimViolations: principleData?.violations || [],
       dimCompliance: complianceByPrinciple.get(principleId) || [],
     };
@@ -249,7 +250,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
   if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;
-  const buildEvalPrincipal = buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple);
+  const buildEvalPrincipal = buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple, project, runId);
 
   return (
     <>

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { getDimensionEval, getRescore } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
@@ -205,17 +205,17 @@ function useDerivedExplorerStats(evalData, allViolations) {
   return { topFiles, severityCounts, uniquePrinciples, totalCompliant, complianceByPrinciple };
 }
 
-function useExplorerData(project, dimension, runId) {
+function useExplorerData(project, dimension, runId, refreshSignal) {
   const [evalData, setEvalData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  // Fetch eval data when params change
   useEffect(() => {
     setLoading(true);
     getDimensionEval(project, runId, dimension)
       .then((data) => {
         setEvalData(data);
         setLoading(false);
-        // Chain rescore to patch principle grades with dismissed-filtered scores
         return getRescore(project, runId).then((rescored) => {
           const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
           if (!dimData) return;
@@ -242,6 +242,28 @@ function useExplorerData(project, dimension, runId) {
       })
       .catch((err) => { setError(err.message); setLoading(false); });
   }, [project, dimension, runId]);
+  // Re-run rescore when refreshSignal changes (e.g. after a dismiss on another page)
+  const initialRef = useRef(refreshSignal);
+  useEffect(() => {
+    if (refreshSignal === initialRef.current) return; // skip initial mount
+    if (!evalData || !project || !runId) return;
+    getRescore(project, runId).then((rescored) => {
+      const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
+      if (!dimData) return;
+      setEvalData((prev) => {
+        if (!prev) return prev;
+        const rescPrinciples = dimData.principles || [];
+        const updatedGrades = (prev.principleGrades || []).map((pg) => {
+          if (pg.isOverall || pg.principle?.includes('Overall')) {
+            return { ...pg, score: dimData.overallScore ?? pg.score, grade: dimData.overallGrade ?? pg.grade };
+          }
+          const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
+          return match ? { ...pg, score: match.score, grade: match.grade } : pg;
+        });
+        return { ...prev, principleGrades: updatedGrades, overallScore: dimData.overallScore, overallGrade: dimData.overallGrade };
+      });
+    }).catch(() => {});
+  }, [refreshSignal]); // eslint-disable-line react-hooks/exhaustive-deps
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);
@@ -249,8 +271,8 @@ function useExplorerData(project, dimension, runId) {
   return { evalData, loading, error, overallGrade, principleGrades, allViolations, ...stats };
 }
 
-export default function ExplorerPage({ project, dimension, runId, dateLabel, onNavigate }) {
-  const d = useExplorerData(project, dimension, runId);
+export default function ExplorerPage({ project, dimension, runId, dateLabel, onNavigate, refreshSignal }) {
+  const d = useExplorerData(project, dimension, runId, refreshSignal);
   if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import DimensionViolationsRow from '../../dashboard/components/DimensionViolationsRow.jsx';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
-import { listDismissedFindings, restoreFinding } from '../../../api/index.js';
+import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
@@ -159,7 +159,7 @@ function FileSubTab({ dimensions, onFileClick }) {
   );
 }
 
-function DismissedSubTab({ dismissed, onRestore }) {
+function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
   if (dismissed.length === 0) {
     return <p className="empty-state">No dismissed findings.</p>;
   }
@@ -168,6 +168,11 @@ function DismissedSubTab({ dismissed, onRestore }) {
       <div className="section-header">
         <h3 className="section-title">Dismissed Findings</h3>
         <span className="section-count">{dismissed.length} findings · not included in scoring</span>
+        {dismissed.length > 1 && (
+          <button type="button" className="restore-btn" style={{ marginLeft: 'auto' }} onClick={onRestoreAll}>
+            Restore all
+          </button>
+        )}
       </div>
       <div className="dismissed-list-inner">
         {dismissed.map((d) => (
@@ -233,6 +238,16 @@ export default function ViolationsPage({ data, callbacks }) {
     }
   }, [selectedProject, onRefresh]);
 
+  const handleRestoreAll = useCallback(async () => {
+    try {
+      await restoreAllFindings(selectedProject);
+      setDismissed([]);
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to restore all findings:', err);
+    }
+  }, [selectedProject, onRefresh]);
+
   const visibleDimensions = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
     return accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
@@ -278,7 +293,7 @@ export default function ViolationsPage({ data, callbacks }) {
         <FileSubTab dimensions={visibleDimensions} onFileClick={onFileClick} />
       )}
       {activeSubTab === 'dismissed' && (
-        <DismissedSubTab dismissed={dismissed} onRestore={handleRestore} />
+        <DismissedSubTab dismissed={dismissed} onRestore={handleRestore} onRestoreAll={handleRestoreAll} />
       )}
     </div>
   );

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -81,7 +81,7 @@ export function useAppState() {
   const { projects, setProjects, selectedProject, selectedRun, setSelectedRun, loadProjects, handleProjectChange, selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject } = projectBundle;
   const settings = useAppSettings();
   const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
-  const { dashboard, accumulated, latestAccumulated, loading, error, availableRuns, refreshDashboard } = useDashboard({ selectedProject, selectedRun: effectiveRun });
+  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, error, availableRuns, refreshDashboard } = useDashboard({ selectedProject, selectedRun: effectiveRun });
   const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
     dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
     ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
@@ -100,7 +100,7 @@ export function useAppState() {
     serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
     projects, selectedProject, selectedRun, handleProjectChange, handleNavigate,
     handleDeleteProject, handleExportProject, handleRelocateProject,
-    dashboard, accumulated, latestAccumulated, loading, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,
+    dashboard, accumulated, latestAccumulated, rescoreLookup, loading, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,
     currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect,
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,

--- a/tests/api/test_routes_rescore.py
+++ b/tests/api/test_routes_rescore.py
@@ -1,0 +1,40 @@
+"""Tests for the /api/rescore endpoint."""
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_rescore_requires_project(client):
+    resp = client.get("/api/rescore")
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "project" in data.get("error", "").lower()
+
+
+@patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value="/tmp/eval")
+@patch("quodeq.api.routes_rescore._reports_dir_from_app", return_value="/tmp/reports")
+@patch("quodeq.api.routes_rescore.read_run_data")
+@patch("quodeq.api.routes_rescore.list_runs")
+@patch("quodeq.api.routes_rescore.load_dismissed_keys")
+@patch("quodeq.api.routes_rescore.rescore_dimensions")
+def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, _mock_reports, _mock_eval, client):
+    mock_list_runs.return_value = [MagicMock(run_id="run-1", date_iso="2026-04-02", date_label="Apr 2")]
+    mock_read_run.return_value = []
+    mock_dismissed.return_value = set()
+    mock_rescore.return_value = {"dimensions": [], "summary": {"dimensionsCount": 0, "overallGrade": None}}
+
+    resp = client.get("/api/rescore?project=test-project")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "dimensions" in data
+    assert "summary" in data

--- a/tests/api/test_routes_rescore.py
+++ b/tests/api/test_routes_rescore.py
@@ -22,12 +22,11 @@ def test_rescore_requires_project(client):
 
 
 @patch("quodeq.api.routes_rescore._eval_dir_from_app", return_value="/tmp/eval")
-@patch("quodeq.api.routes_rescore._reports_dir_from_app", return_value="/tmp/reports")
 @patch("quodeq.api.routes_rescore.read_run_data")
 @patch("quodeq.api.routes_rescore.list_runs")
 @patch("quodeq.api.routes_rescore.load_dismissed_keys")
 @patch("quodeq.api.routes_rescore.rescore_dimensions")
-def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, _mock_reports, _mock_eval, client):
+def test_rescore_returns_rescored_data(mock_rescore, mock_dismissed, mock_list_runs, mock_read_run, _mock_eval, client):
     mock_list_runs.return_value = [MagicMock(run_id="run-1", date_iso="2026-04-02", date_label="Apr 2")]
     mock_read_run.return_value = []
     mock_dismissed.return_value = set()

--- a/tests/services/test_rescore.py
+++ b/tests/services/test_rescore.py
@@ -1,0 +1,51 @@
+"""Tests for the live rescore service."""
+from quodeq.core.types.finding import Finding, Totals, SeverityTally
+from quodeq.core.types.report import PrincipleGrade
+from quodeq.core.types.dimension import DimensionResult
+
+from quodeq.services.rescore import rescore_dimensions
+
+
+def _make_violation(principle="P1", severity="major", req="R1", file="a.py", line=1, reason="bug"):
+    return Finding(principle=principle, severity=severity, req=req, file=file, line=line, reason=reason)
+
+
+def _make_compliance(principle="P1", req="R1", file="a.py", line=10, reason="ok"):
+    return Finding(principle=principle, req=req, file=file, line=line, reason=reason)
+
+
+def _make_dimension(name="Reliability", violations=None, compliance=None, source_file_count=100):
+    violations = violations or []
+    compliance = compliance or []
+    return DimensionResult(
+        dimension=name,
+        violations=violations,
+        compliance=compliance,
+        overall_score="5.0/10",
+        overall_grade="Adequate",
+        principles=[PrincipleGrade(principle="P1", score="5.0/10", grade="Adequate")],
+        totals=Totals(
+            violation_count=len(violations),
+            compliance_count=len(compliance),
+            severity=SeverityTally(
+                critical=sum(1 for v in violations if v.severity == "critical"),
+                major=sum(1 for v in violations if v.severity == "major"),
+                minor=sum(1 for v in violations if v.severity == "minor"),
+            ),
+        ),
+        source_file_count=source_file_count,
+    )
+
+
+def test_rescore_no_dismissals_returns_rescored_data():
+    """With no dismissed keys, rescore should still return valid rescored dimensions."""
+    dim = _make_dimension(
+        violations=[_make_violation(severity="major")],
+        compliance=[_make_compliance()],
+    )
+    result = rescore_dimensions([dim], dismissed_keys=set())
+    assert len(result["dimensions"]) == 1
+    assert result["dimensions"][0]["overallScore"] is not None
+    assert result["dimensions"][0]["overallGrade"] is not None
+    assert result["summary"] is not None
+    assert result["summary"]["overallGrade"] is not None

--- a/tests/services/test_rescore.py
+++ b/tests/services/test_rescore.py
@@ -49,3 +49,47 @@ def test_rescore_no_dismissals_returns_rescored_data():
     assert result["dimensions"][0]["overallGrade"] is not None
     assert result["summary"] is not None
     assert result["summary"]["overallGrade"] is not None
+
+
+def test_rescore_dismissing_violation_changes_score():
+    """Dismissing a violation should produce a different (better) score."""
+    v1 = _make_violation(severity="critical", req="R1", file="a.py", line=1, reason="null deref")
+    v2 = _make_violation(severity="major", req="R2", file="b.py", line=5, reason="unused var")
+    dim = _make_dimension(violations=[v1, v2], compliance=[_make_compliance()])
+
+    result_all = rescore_dimensions([dim], dismissed_keys=set())
+    result_dismissed = rescore_dimensions([dim], dismissed_keys={("R1", "a.py", 1)})
+
+    score_all = result_all["dimensions"][0]["overallScore"]
+    score_dismissed = result_dismissed["dimensions"][0]["overallScore"]
+
+    # With critical removed, score should be higher
+    assert score_dismissed != score_all
+    # Parse numeric values
+    num_all = float(score_all.split("/")[0])
+    num_dismissed = float(score_dismissed.split("/")[0])
+    assert num_dismissed > num_all
+
+
+def test_rescore_dismiss_all_violations():
+    """Dismissing all violations should yield a high score."""
+    v1 = _make_violation(severity="major", req="R1", file="a.py", line=1)
+    dim = _make_dimension(violations=[v1], compliance=[_make_compliance()])
+
+    result = rescore_dimensions([dim], dismissed_keys={("R1", "a.py", 1)})
+    dim_result = result["dimensions"][0]
+
+    # No violations left — score should be high
+    assert dim_result["totals"]["violationCount"] == 0
+
+
+def test_rescore_summary_reflects_dimension_changes():
+    """Run-level summary should reflect rescored dimension scores."""
+    v1 = _make_violation(severity="critical", req="R1", file="a.py", line=1)
+    dim1 = _make_dimension(name="Reliability", violations=[v1], compliance=[_make_compliance()])
+    dim2 = _make_dimension(name="Security", violations=[], compliance=[_make_compliance()])
+
+    result = rescore_dimensions([dim1, dim2], dismissed_keys=set())
+    summary = result["summary"]
+    assert summary["dimensionsCount"] == 2
+    assert summary["overallGrade"] is not None


### PR DESCRIPTION
## Summary
- New `GET /api/rescore?project=X&run=Y` endpoint that recalculates grades from stored run data minus dismissed findings
- Backend `rescore_dimensions()` service reuses existing scoring primitives (4-stage formula, weighted aggregation, run summary)
- Frontend chains rescore after dashboard load and after dismiss/restore actions
- All score displays update live: dashboard cards, dimension overview, explorer principle grades, principle detail header
- 300ms debounce for rapid dismiss/restore actions
- Each accumulated dimension uses rescore data only from its authoritative run (fromRunId)

## Test plan
- [x] Dismiss a violation on a principle detail page — header score, severity tags, and violation count update immediately
- [x] Navigate to dashboard overview — all dimension cards show rescored grades
- [x] Restore a dismissed finding — scores revert
- [x] Rapid-fire dismiss multiple violations — only one rescore fires (check Network tab)
- [x] View a historical run — scores reflect current dismissals
- [x] 687 backend tests pass, 0 regressions