### PR TITLE
fix: resolve 42 maintainability violations (round 6)

### DIFF
--- a/src/quodeq/analysis/_incr_change_detection.py
+++ b/src/quodeq/analysis/_incr_change_detection.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from quodeq.analysis.fingerprint import _hash_file, _hash_standards
 
+_GIT_DIFF_TIMEOUT_S = 10
+
 
 @dataclass
 class ChangeDetectionResult:
@@ -21,7 +23,7 @@ def _detect_via_git(src: Path, prev_commit: str) -> set[str] | None:
     try:
         result = subprocess.run(
             ["git", "diff", "--name-only", f"{prev_commit}..HEAD"],
-            cwd=str(src), capture_output=True, text=True, timeout=10,
+            cwd=str(src), capture_output=True, text=True, timeout=_GIT_DIFF_TIMEOUT_S,
         )
         if result.returncode == 0:
             return {f.strip() for f in result.stdout.splitlines() if f.strip()}

--- a/src/quodeq/analysis/_incremental_phases.py
+++ b/src/quodeq/analysis/_incremental_phases.py
@@ -64,12 +64,23 @@ def _finalize_incremental(
     return ev
 
 
+def _can_carry_forward(
+    prev_fp: dict | None, prev_evidence_dir: Path | None, classification: object,
+) -> bool:
+    """Return True when previous findings exist and can be reused."""
+    return bool(
+        prev_fp and prev_evidence_dir
+        and not classification.full_reanalysis
+        and classification.unchanged
+    )
+
+
 def _maybe_carry_forward(
     prev_fp: dict | None, prev_evidence_dir: Path | None,
     classification: object, dimension: str, evidence_dir: Path,
 ) -> None:
     """Carry forward findings for unchanged files if conditions are met."""
-    if not (prev_fp and prev_evidence_dir and not classification.full_reanalysis and classification.unchanged):
+    if not _can_carry_forward(prev_fp, prev_evidence_dir, classification):
         return
     prev_jsonl = prev_evidence_dir / f"{dimension}_evidence.jsonl"
     output_jsonl = evidence_dir / f"{dimension}_evidence.jsonl"

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -16,7 +16,7 @@ def check_zero_findings(
     result: dict[str, Evidence], source_file_count: int, skipped_count: int = 0,
 ) -> None:
     """Raise EvaluationError if all dimensions produced zero findings."""
-    from quodeq.analysis.runner import EvaluationError
+    from quodeq.analysis._pipeline import EvaluationError
 
     if not result or source_file_count <= 0:
         return
@@ -35,14 +35,22 @@ def check_zero_findings(
 
 def run_incremental_loop(
     config: RunConfig, dimensions: list[str], ctx: _AnalysisContext,
-    *, process_fn: Callable[..., Evidence | None] | None = None,
+    *, process_fn: Callable[..., Evidence | None],
+    log_result_fn: Callable[..., None],
 ) -> dict[str, Evidence]:
-    """Run incremental per-dimension analysis."""
+    """Run incremental per-dimension analysis.
+
+    Args:
+        config: Run configuration for this evaluation.
+        dimensions: Dimension identifiers to analyze.
+        ctx: Shared analysis context (total count, etc.).
+        process_fn: Callback to process a single dimension (signature:
+            ``(config, dimension, idx, ctx) -> Evidence | None``).
+        log_result_fn: Callback to log a completed dimension result.
+    """
     from quodeq.analysis._incremental import run_dimension_incremental
-    from quodeq.analysis.runner import _process_single_dimension, _log_dimension_result
     from quodeq.engine._runner_markers import emit_marker
 
-    _process = process_fn or _process_single_dimension
     result: dict[str, Evidence] = {}
     for idx, dimension in enumerate(dimensions, 1):
         emit_marker("analyzing", dimension=dimension)
@@ -54,9 +62,9 @@ def run_incremental_loop(
             fallback_options = copy(config.options)
             fallback_options.incremental_file_filter = None
             fallback_config = replace(config, options=fallback_options)
-            ev = _process(fallback_config, dimension, idx, ctx)
+            ev = process_fn(fallback_config, dimension, idx, ctx)
         if ev:
-            _log_dimension_result(ev, dimension, idx, ctx.total)
+            log_result_fn(ev, dimension, idx, ctx.total)
             result[dimension] = ev
     check_zero_findings(result, config.source_file_count)
     return result
@@ -64,17 +72,22 @@ def run_incremental_loop(
 
 def run_per_dimension_loop(
     config: RunConfig, dimensions: list[str], ctx: _AnalysisContext,
-    *, process_fn: Callable[..., Evidence | None] | None = None,
+    *, process_fn: Callable[..., Evidence | None],
 ) -> dict[str, Evidence]:
-    """Per-dimension loop (fallback or single-dimension)."""
-    from quodeq.analysis.runner import _process_single_dimension
+    """Per-dimension loop (fallback or single-dimension).
 
-    _process = process_fn or _process_single_dimension
+    Args:
+        config: Run configuration for this evaluation.
+        dimensions: Dimension identifiers to analyze.
+        ctx: Shared analysis context (total count, etc.).
+        process_fn: Callback to process a single dimension (signature:
+            ``(config, dimension, idx, ctx) -> Evidence | None``).
+    """
     result: dict[str, Evidence] = {}
     skipped_count = 0
     for idx, dimension in enumerate(dimensions, 1):
         try:
-            ev = _process(config, dimension, idx, ctx)
+            ev = process_fn(config, dimension, idx, ctx)
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 failed: {exc}")
             skipped_count += 1

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -36,7 +36,11 @@ def _run_dimensions(config: RunConfig) -> dict[str, Evidence]:
 
     if config.options.incremental:
         emit_marker("setup", dimensions=dimensions)
-        return run_incremental_loop(config, dimensions, ctx)
+        return run_incremental_loop(
+            config, dimensions, ctx,
+            process_fn=_process_single_dimension,
+            log_result_fn=_log_dimension_result,
+        )
 
     emit_marker("setup", dimensions=dimensions)
 
@@ -56,7 +60,10 @@ def _run_dimensions(config: RunConfig) -> dict[str, Evidence]:
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
             log_warning(f"Consolidated mode failed: {exc}, falling back to per-dimension")
 
-    return run_per_dimension_loop(config, dimensions, ctx)
+    return run_per_dimension_loop(
+        config, dimensions, ctx,
+        process_fn=_process_single_dimension,
+    )
 
 
 def run(config: RunConfig) -> Evidence:

--- a/src/quodeq/analysis/_report_assembly.py
+++ b/src/quodeq/analysis/_report_assembly.py
@@ -1,6 +1,8 @@
 """Report assembly -- builds complete JSON report dicts from evidence and scores."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from quodeq.core.types import ScoringResult
 from quodeq.core.evidence.model import Evidence
 
@@ -17,40 +19,51 @@ from quodeq.analysis._report_scoring import (
 from quodeq.analysis._report_findings import build_principle_rows
 
 
-def _assemble_report_dict(
-    dimension: str, evidence: dict, top_score: str | None, top_grade: str | None,
-    principle_rows: list, flat_violations: list, flat_compliance: list, sev_tally: dict,
-) -> dict:
+@dataclass
+class _ReportData:
+    """Grouped components for assembling a report dict."""
+
+    dimension: str
+    evidence: dict
+    top_score: str | None
+    top_grade: str | None
+    principle_rows: list
+    flat_violations: list
+    flat_compliance: list
+    sev_tally: dict
+
+
+def _assemble_report_dict(data: _ReportData) -> dict:
     """Assemble the final report dict from pre-computed components."""
-    raw_meta = evidence.get("meta", {})
+    raw_meta = data.evidence.get("meta", {})
     report: dict = {
         "schema_version": _REPORT_SCHEMA_VERSION,
-        "dimension": dimension,
-        "project": evidence.get("repository", ""),
+        "dimension": data.dimension,
+        "project": data.evidence.get("repository", ""),
         "runId": "",
-        "discipline": evidence.get("discipline", ""),
-        "date": evidence.get("date", ""),
-        "sourceFileCount": evidence.get("source_file_count"),
-        "filesRead": evidence.get("files_read", 0),
-        "coveragePct": evidence.get("coverage_pct", 0.0),
+        "discipline": data.evidence.get("discipline", ""),
+        "date": data.evidence.get("date", ""),
+        "sourceFileCount": data.evidence.get("source_file_count"),
+        "filesRead": data.evidence.get("files_read", 0),
+        "coveragePct": data.evidence.get("coverage_pct", 0.0),
         "meta": {
             "analysis_prompt_version": raw_meta.get("analysis_prompt_version"),
             "scoring_prompt_version": raw_meta.get("scoring_prompt_version"),
             "mapping_file_hash": raw_meta.get("mapping_file_hash"),
             "quodeq_version": raw_meta.get("quodeq_version"),
         },
-        "overallScore": top_score,
-        "overallGrade": top_grade,
-        "principles": principle_rows,
-        "violations": flat_violations,
-        "compliance": flat_compliance,
+        "overallScore": data.top_score,
+        "overallGrade": data.top_grade,
+        "principles": data.principle_rows,
+        "violations": data.flat_violations,
+        "compliance": data.flat_compliance,
         "totals": {
-            "violationCount": len(flat_violations),
-            "complianceCount": len(flat_compliance),
-            "severity": sev_tally,
+            "violationCount": len(data.flat_violations),
+            "complianceCount": len(data.flat_compliance),
+            "severity": data.sev_tally,
         },
     }
-    module = evidence.get("module")
+    module = data.evidence.get("module")
     if module:
         report["module"] = module
     return report
@@ -74,10 +87,12 @@ def build_report_json(
         top_score = None
         top_grade = None
 
-    return _assemble_report_dict(
-        dimension, evidence, top_score, top_grade,
-        principle_rows, flat_violations, flat_compliance, sev_tally,
-    )
+    return _assemble_report_dict(_ReportData(
+        dimension=dimension, evidence=evidence, top_score=top_score,
+        top_grade=top_grade, principle_rows=principle_rows,
+        flat_violations=flat_violations, flat_compliance=flat_compliance,
+        sev_tally=sev_tally,
+    ))
 
 
 def build_full_report(evidence: Evidence, scores: ScoringResult | dict) -> dict:

--- a/src/quodeq/analysis/manifest_models.py
+++ b/src/quodeq/analysis/manifest_models.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 
 from quodeq.analysis.manifest_render import render_target_prompt_context
 
+_MAX_EXTENSION_DISPLAY = 8
+
 
 @dataclass
 class AnalysisTarget:
@@ -120,7 +122,7 @@ class SourceManifest:
             if self.language_stats:
                 breakdown = ", ".join(
                     f"{ext}: {count}" for ext, count in
-                    sorted(self.language_stats.items(), key=lambda x: -x[1])[:8]
+                    sorted(self.language_stats.items(), key=lambda x: -x[1])[:_MAX_EXTENSION_DISPLAY]
                 )
                 lines.append(f"**Extension breakdown:** {breakdown}")
             return "\n".join(lines)
@@ -138,7 +140,7 @@ class SourceManifest:
         if self.language_stats:
             breakdown = ", ".join(
                 f"{ext}: {count}" for ext, count in
-                sorted(self.language_stats.items(), key=lambda x: -x[1])[:8]
+                sorted(self.language_stats.items(), key=lambda x: -x[1])[:_MAX_EXTENSION_DISPLAY]
             )
             lines.append(f"**Extension breakdown:** {breakdown}")
         return "\n".join(lines)

--- a/src/quodeq/analysis/mcp/enrichment.py
+++ b/src/quodeq/analysis/mcp/enrichment.py
@@ -10,6 +10,31 @@ from typing import Callable
 CONTEXT_LINES = 5
 
 
+def _enrich_line_level(
+    finding: dict, source_lines: list[str], line: int,
+) -> None:
+    """Fill snippet and context for a line-level finding."""
+    end_line = finding.get("end_line") or line
+    if end_line < line:
+        line, end_line = end_line, line
+    # Clamp to file boundaries (1-indexed)
+    line = max(1, min(line, len(source_lines)))
+    end_line = max(line, min(end_line, len(source_lines)))
+
+    # Build snippet (the offending lines)
+    snippet_lines = source_lines[line - 1:end_line]
+    finding["snippet"] = "\n".join(snippet_lines)
+
+    # Build context with >>> markers
+    ctx_start = max(0, line - 1 - CONTEXT_LINES)
+    ctx_end = min(len(source_lines), end_line + CONTEXT_LINES)
+    context_parts = []
+    for i in range(ctx_start, ctx_end):
+        prefix = ">>> " if line - 1 <= i < end_line else ""
+        context_parts.append(f"{prefix}{source_lines[i]}")
+    finding["context"] = "\n".join(context_parts)
+
+
 def enrich_code(
     finding: dict,
     work_dir: Path | None,
@@ -44,23 +69,4 @@ def enrich_code(
         finding["context"] = None
         return
 
-    # Normal line-level enrichment
-    end_line = finding.get("end_line") or line
-    if end_line < line:
-        line, end_line = end_line, line
-    # Clamp to file boundaries (1-indexed)
-    line = max(1, min(line, len(source_lines)))
-    end_line = max(line, min(end_line, len(source_lines)))
-
-    # Build snippet (the offending lines)
-    snippet_lines = source_lines[line - 1:end_line]
-    finding["snippet"] = "\n".join(snippet_lines)
-
-    # Build context with >>> markers
-    ctx_start = max(0, line - 1 - CONTEXT_LINES)
-    ctx_end = min(len(source_lines), end_line + CONTEXT_LINES)
-    context_parts = []
-    for i in range(ctx_start, ctx_end):
-        prefix = ">>> " if line - 1 <= i < end_line else ""
-        context_parts.append(f"{prefix}{source_lines[i]}")
-    finding["context"] = "\n".join(context_parts)
+    _enrich_line_level(finding, source_lines, line)

--- a/src/quodeq/analysis/prompts/_template.py
+++ b/src/quodeq/analysis/prompts/_template.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from quodeq.config.paths import default_paths
 
 _TEMPLATE_HASH_CACHE_SIZE = 128
+_HASH_PREFIX_LEN = 12
 
 
 def load_template(
@@ -41,4 +42,4 @@ def load_template(
 @lru_cache(maxsize=_TEMPLATE_HASH_CACHE_SIZE)
 def template_hash(template: str) -> str:
     """Return a short hash of the template string, computed once per unique template."""
-    return hashlib.sha256(template.encode()).hexdigest()[:12]
+    return hashlib.sha256(template.encode()).hexdigest()[:_HASH_PREFIX_LEN]

--- a/src/quodeq/analysis/subagents/_git_scoring.py
+++ b/src/quodeq/analysis/subagents/_git_scoring.py
@@ -5,6 +5,9 @@ import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
+_GIT_LOG_TIMEOUT_S = 10
+_GIT_HASH_LENGTH = 40
+
 
 def _run_git_log(src: Path, months: int = 3) -> str | None:
     """Run git log and return raw output, or None if git unavailable."""
@@ -20,7 +23,7 @@ def _run_git_log(src: Path, months: int = 3) -> str | None:
     try:
         result = subprocess.run(
             ["git", "log", f"--since={months} months ago", "--name-only", "--format=%H%n%ai"],
-            cwd=str(src), capture_output=True, text=True, timeout=10,
+            cwd=str(src), capture_output=True, text=True, timeout=_GIT_LOG_TIMEOUT_S,
         )
         return result.stdout if result.returncode == 0 else None
     except (OSError, subprocess.TimeoutExpired):
@@ -44,7 +47,7 @@ def compute_git_scores(files: list[str], src: Path, config: dict | None = None) 
         if not line:
             continue
         # 40-char hex = commit hash, skip
-        if len(line) == 40 and all(c in "0123456789abcdef" for c in line):
+        if len(line) == _GIT_HASH_LENGTH and all(c in "0123456789abcdef" for c in line):
             continue
         # Date lines: "YYYY-MM-DD HH:MM:SS +ZZZZ"
         if len(line) >= 10 and line[4:5] == "-" and line[7:8] == "-" and " " in line:

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
@@ -13,6 +14,7 @@ from quodeq.analysis.subagents._pool_models import (
     _SCOUT_TIMEOUT_S,
 )
 from quodeq.analysis.subagents._pool_scaling import (
+    EvidencePaths,
     collect_done,
     maybe_scale_up,
     should_respawn,
@@ -20,67 +22,58 @@ from quodeq.analysis.subagents._pool_scaling import (
 from quodeq.analysis.subagents.file_queue import WorkQueue
 
 
-def scout_loop(
-    futures: dict[Future[SubagentResult], int],
-    finished: dict[str, bool],
-    results: list[SubagentResult],
-    max_duration: float,
-    pool_start: float,
-    n_agents: int,
-    max_files_per_agent: int | None,
-    queue: WorkQueue | None,
-    queue_path: Path,
-    shared_jsonl_path: Path,
-    evidence_dir: Path,
-    dimension_key: str,
-    submit_fn: Callable[[], None],
-) -> None:
+@dataclass
+class LoopContext:
+    """Grouped parameters shared by scout_loop and immediate_loop."""
+
+    futures: dict[Future[SubagentResult], int]
+    finished: dict[str, bool]
+    results: list[SubagentResult]
+    max_duration: float
+    pool_start: float
+    n_agents: int
+    queue: WorkQueue | None
+    queue_path: Path
+    shared_jsonl_path: Path
+    evidence_dir: Path
+    dimension_key: str
+    submit_fn: Callable[[], None]
+    max_files_per_agent: int | None = None
+
+
+def scout_loop(ctx: LoopContext) -> None:
     """Run scout-then-scale loop: launch one agent, scale up when it finishes."""
-    scout_timeout = min(_SCOUT_TIMEOUT_S, max_duration / max(n_agents, 1) * 0.5)
+    scout_timeout = min(_SCOUT_TIMEOUT_S, ctx.max_duration / max(ctx.n_agents, 1) * 0.5)
     state = ScaleUpState(
-        pool_start=pool_start, max_duration=max_duration, scout_timeout=scout_timeout,
+        pool_start=ctx.pool_start, max_duration=ctx.max_duration, scout_timeout=scout_timeout,
     )
-    submit_fn()
-    while futures:
-        done = collect_done(
-            futures, finished, results, shared_jsonl_path, evidence_dir, dimension_key,
-        )
+    ev_paths = EvidencePaths(ctx.shared_jsonl_path, ctx.evidence_dir, ctx.dimension_key)
+    ctx.submit_fn()
+    while ctx.futures:
+        done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
         state.scout_done = maybe_scale_up(
-            done, state, n_agents, max_files_per_agent, queue, queue_path, submit_fn,
+            done, state, ctx.n_agents, ctx.max_files_per_agent,
+            ctx.queue, ctx.queue_path, ctx.submit_fn,
         )
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)
             continue
         if state.scout_done:
             for _ in done:
-                if should_respawn(queue, queue_path, pool_start, max_duration):
-                    submit_fn()
+                if should_respawn(ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration):
+                    ctx.submit_fn()
 
 
-def immediate_loop(
-    futures: dict[Future[SubagentResult], int],
-    finished: dict[str, bool],
-    results: list[SubagentResult],
-    max_duration: float,
-    pool_start: float,
-    n_agents: int,
-    queue: WorkQueue | None,
-    queue_path: Path,
-    shared_jsonl_path: Path,
-    evidence_dir: Path,
-    dimension_key: str,
-    submit_fn: Callable[[], None],
-) -> None:
+def immediate_loop(ctx: LoopContext) -> None:
     """Launch all agents immediately, respawning as they complete."""
-    for _ in range(n_agents):
-        submit_fn()
-    while futures:
-        done = collect_done(
-            futures, finished, results, shared_jsonl_path, evidence_dir, dimension_key,
-        )
+    ev_paths = EvidencePaths(ctx.shared_jsonl_path, ctx.evidence_dir, ctx.dimension_key)
+    for _ in range(ctx.n_agents):
+        ctx.submit_fn()
+    while ctx.futures:
+        done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)
             continue
         for _ in done:
-            if should_respawn(queue, queue_path, pool_start, max_duration):
-                submit_fn()
+            if should_respawn(ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration):
+                ctx.submit_fn()

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from math import ceil
 from pathlib import Path
+from typing import Callable
 
 from quodeq.analysis.subagents._pool_models import (
     ScaleUpState,
@@ -14,6 +16,15 @@ from quodeq.analysis.subagents._pool_models import (
 )
 from quodeq.analysis.subagents.file_queue import FileQueue, WorkQueue
 from quodeq.shared.logging import log_warning
+
+
+@dataclass
+class EvidencePaths:
+    """Grouped paths for evidence collection."""
+
+    shared_jsonl_path: Path
+    evidence_dir: Path
+    dimension_key: str
 
 
 def get_queue(queue: WorkQueue | None, queue_path: Path) -> WorkQueue:
@@ -54,9 +65,7 @@ def collect_done(
     futures: dict[Future[SubagentResult], int],
     finished: dict[str, bool],
     results: list[SubagentResult],
-    shared_jsonl_path: Path,
-    evidence_dir: Path,
-    dimension_key: str,
+    paths: EvidencePaths,
 ) -> set[Future[SubagentResult]]:
     """Collect completed futures, updating results and finished map."""
     done_futures = {f for f in futures if f.done()}
@@ -69,8 +78,8 @@ def collect_done(
             log_warning(f"  {agent_id} raised {type(exc).__name__}: {exc}")
             result = SubagentResult(
                 agent_id=agent_id,
-                jsonl_file=shared_jsonl_path,
-                stream_file=evidence_dir / f"{dimension_key}_{agent_id}.stream",
+                jsonl_file=paths.shared_jsonl_path,
+                stream_file=paths.evidence_dir / f"{paths.dimension_key}_{agent_id}.stream",
                 success=False,
                 error=str(exc),
             )
@@ -84,7 +93,7 @@ def maybe_scale_up(
     done: set, state: ScaleUpState, n_agents: int,
     max_files_per_agent: int | None,
     queue: WorkQueue | None, queue_path: Path,
-    submit_fn: callable,
+    submit_fn: Callable[[], None],
 ) -> bool:
     """Check if scout phase is complete and scale up if needed. Returns updated scout_done."""
     if state.scout_done:

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -1,6 +1,7 @@
 """Worker logic: building agent configs and running single subagents."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.analysis.subagents._pool_models import (
@@ -12,26 +13,33 @@ from quodeq.analysis.subprocess import AnalysisConfig, AnalysisError, run_analys
 from quodeq.shared.logging import log_warning
 
 
+@dataclass
+class WorkerContext:
+    """Grouped dimension and path context for a pool worker."""
+
+    dimension: str
+    dimension_key: str
+    evidence_dir: Path
+    queue_path: Path
+
+
 def build_agent_config(
     idx: int,
     base_config: AnalysisConfig,
-    dimension: str,
-    dimension_key: str,
-    evidence_dir: Path,
-    queue_path: Path,
+    wctx: WorkerContext,
 ) -> tuple[AnalysisConfig, Path, Path]:
     """Build per-agent AnalysisConfig, JSONL path, and stream path."""
     agent_id = f"{_AGENT_ID_PREFIX}-{idx}"
-    jsonl_file = evidence_dir / f"{dimension_key}_evidence.jsonl"
-    stream_file = evidence_dir / f"{dimension_key}_{agent_id}.stream"
+    jsonl_file = wctx.evidence_dir / f"{wctx.dimension_key}_evidence.jsonl"
+    stream_file = wctx.evidence_dir / f"{wctx.dimension_key}_{agent_id}.stream"
     bc = base_config
     ac = AnalysisConfig(
         jsonl_file=jsonl_file, analysis_budget=bc.analysis_budget,
         heartbeat_interval=bc.heartbeat_interval, heartbeat_callback=bc.heartbeat_callback,
         ai_cmd=bc.ai_cmd, ai_model=bc.ai_model, max_turns=bc.max_turns,
         max_duration=bc.max_duration or _DEFAULT_MAX_DURATION_S,
-        compiled_dir=bc.compiled_dir, dimension=dimension,
-        queue_path=queue_path, agent_id=agent_id,
+        compiled_dir=bc.compiled_dir, dimension=wctx.dimension,
+        queue_path=wctx.queue_path, agent_id=agent_id,
         max_files_per_agent=bc.max_files_per_agent,
     )
     return ac, jsonl_file, stream_file
@@ -42,16 +50,11 @@ def run_single_agent(
     work_dir: Path,
     prompt: str,
     base_config: AnalysisConfig,
-    dimension: str,
-    dimension_key: str,
-    evidence_dir: Path,
-    queue_path: Path,
+    wctx: WorkerContext,
 ) -> SubagentResult:
     """Run a single subagent. Returns SubagentResult."""
     agent_id = f"{_AGENT_ID_PREFIX}-{idx}"
-    ac, jsonl_file, stream_file = build_agent_config(
-        idx, base_config, dimension, dimension_key, evidence_dir, queue_path,
-    )
+    ac, jsonl_file, stream_file = build_agent_config(idx, base_config, wctx)
     try:
         run_analysis(
             work_dir=work_dir,

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -7,7 +7,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 
 from quodeq.analysis.subagents._heartbeat import HeartbeatContext, heartbeat_loop
-from quodeq.analysis.subagents._pool_loops import immediate_loop, scout_loop
+from quodeq.analysis.subagents._pool_loops import LoopContext, immediate_loop, scout_loop
 from quodeq.analysis.subagents._pool_models import (
     PoolOptions,
     PoolPaths,
@@ -16,7 +16,7 @@ from quodeq.analysis.subagents._pool_models import (
     _HEARTBEAT_JOIN_TIMEOUT_S,
 )
 from quodeq.analysis.subagents._pool_scaling import compute_scale_up
-from quodeq.analysis.subagents._pool_worker import build_agent_config, run_single_agent
+from quodeq.analysis.subagents._pool_worker import WorkerContext, build_agent_config, run_single_agent
 from quodeq.analysis.subagents.file_queue import WorkQueue
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl, merge_jsonl
 from quodeq.analysis.subprocess import AnalysisConfig
@@ -49,6 +49,10 @@ class SubagentPool:
             self._dimensions = [dimension] if dimension else []
             self._dimension, self._dimension_key = dimension, dimension
         self._base_config = config or AnalysisConfig()
+        self._worker_ctx = WorkerContext(
+            dimension=self._dimension, dimension_key=self._dimension_key,
+            evidence_dir=self._evidence_dir, queue_path=self._queue_path,
+        )
         self._scout_first, self._jsonl_lock = options.scout_first, threading.Lock()
         self._futures: dict[Future[SubagentResult], int] = {}
         self._finished: dict[str, bool] = {}
@@ -58,10 +62,7 @@ class SubagentPool:
         return self._evidence_dir / f"{self._dimension_key}_evidence.jsonl"
 
     def _build_agent_config(self, idx: int) -> tuple[AnalysisConfig, Path, Path]:
-        return build_agent_config(
-            idx, self._base_config, self._dimension, self._dimension_key,
-            self._evidence_dir, self._queue_path,
-        )
+        return build_agent_config(idx, self._base_config, self._worker_ctx)
 
     def _compute_scale_up(self, remaining: int) -> int:
         return compute_scale_up(remaining, self._n, self._base_config.max_files_per_agent)
@@ -69,8 +70,7 @@ class SubagentPool:
     def _run_single(self, idx: int) -> SubagentResult:
         return run_single_agent(
             idx, self._work_dir, self._prompt, self._base_config,
-            self._dimension, self._dimension_key, self._evidence_dir,
-            self._queue_path,
+            self._worker_ctx,
         )
 
     def _submit_agent(self, executor: ThreadPoolExecutor) -> None:
@@ -104,20 +104,20 @@ class SubagentPool:
         stop, hb = self._start_heartbeat()
         try:
             with ThreadPoolExecutor(max_workers=self._n) as pool:
-                loop_args = dict(
+                ctx = LoopContext(
                     futures=self._futures, finished=self._finished, results=results,
                     max_duration=max_dur, pool_start=time.monotonic(),
+                    n_agents=self._n,
                     queue=self._queue, queue_path=self._queue_path,
                     shared_jsonl_path=self._shared_jsonl_path(),
                     evidence_dir=self._evidence_dir, dimension_key=self._dimension_key,
                     submit_fn=lambda: self._submit_agent(pool),
+                    max_files_per_agent=self._base_config.max_files_per_agent,
                 )
                 if self._scout_first:
-                    scout_loop(n_agents=self._n,
-                               max_files_per_agent=self._base_config.max_files_per_agent,
-                               **loop_args)
+                    scout_loop(ctx)
                 else:
-                    immediate_loop(n_agents=self._n, **loop_args)
+                    immediate_loop(ctx)
         finally:
             stop.set()
             hb.join(timeout=_HEARTBEAT_JOIN_TIMEOUT_S)

--- a/src/quodeq/analysis/subagents/priority_scoring.py
+++ b/src/quodeq/analysis/subagents/priority_scoring.py
@@ -19,9 +19,11 @@ __all__ = [
 ]
 
 
-def compute_base_score(filepath: str, category: str | None = None) -> int:
+def compute_base_score(
+    filepath: str, category: str | None = None, config: dict | None = None,
+) -> int:
     """Layer 1: base score from path patterns, entry points, and category."""
-    config = load_priority_config()
+    config = config or load_priority_config()
     score = config["default_path_score"]
 
     filepath_lower = filepath.lower().replace("\\", "/")
@@ -50,9 +52,10 @@ def compute_dimension_boost(
     filepath: str,
     dimension: str | list[str],
     file_size: int = 0,
+    config: dict | None = None,
 ) -> int:
     """Layer 2: dimension-specific keyword boost or file-size boost."""
-    config = load_priority_config()
+    config = config or load_priority_config()
     dims = dimension if isinstance(dimension, list) else [dimension]
     filepath_lower = filepath.lower().replace("\\", "/")
 

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -1,6 +1,7 @@
 """API routes for dismissing and restoring individual findings."""
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, request
@@ -16,7 +17,7 @@ def register_findings_routes(app: Flask) -> None:
     """Register /api/findings/* routes."""
 
     def _eval_dir() -> str:
-        return app.config.get("EVALUATIONS_DIR") or __import__("quodeq.shared.utils", fromlist=["get_evaluations_dir"]).get_evaluations_dir()
+        return app.config.get("EVALUATIONS_DIR") or importlib.import_module("quodeq.shared.utils").get_evaluations_dir()
 
     @app.get("/api/findings/dismissed")
     def list_dismissed() -> Response:

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -23,7 +23,14 @@ def register_all_routes(
     app: Flask, provider: ActionProvider,
     eval_store: RateLimitStore, static_dist: str | None,
 ) -> None:
-    """Register all API route groups on the app."""
+    """Register all API route groups on the app.
+
+    Args:
+        app: The Flask application instance.
+        provider: Action provider for evaluation and project operations.
+        eval_store: Rate-limit store for evaluation requests.
+        static_dist: Optional path to the static assets directory.
+    """
     register_project_list_routes(app, provider)
     register_project_data_routes(app, provider)
     register_evaluation_list_routes(app, provider, eval_store)

--- a/src/quodeq/api/standards_read_routes.py
+++ b/src/quodeq/api/standards_read_routes.py
@@ -12,7 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 def register_read_routes(app: Flask, get_service, get_library_client) -> None:
-    """Register GET routes for the standards API."""
+    """Register GET routes for the standards API.
+
+    Args:
+        app: The Flask application instance.
+        get_service: Factory callable returning the standards service.
+        get_library_client: Factory callable returning the library client (or None).
+    """
 
     @app.get("/api/standards/refs/cwe")
     def list_cwes() -> Response:

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -3,21 +3,31 @@ from __future__ import annotations
 
 import math
 
-from quodeq.core.scoring._constants import *  # noqa: F401,F403
-from quodeq.core.scoring._constants import (
+from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
+    GRADE_LADDER,
+    SCALE_TIER_NAMES,
     _BASE_K,
     _CEIL_SCALE,
     _GRADE_THRESHOLDS,
     _LIFT_COMPRESS,
     _MAX_PENALTY_MULTIPLIER,
     _RATIO_DAMPENING_TABLE,
+    _SCALE_TIERS,
     _SEVERITY_GRADE_FLOOR,
+    _SEVERITY_WEIGHT,
     _WEIGHT_DOUBLE,
     _WEIGHT_TRIPLE,
-    GRADE_LADDER,
+    scale_multiplier,
 )
-from quodeq.core.scoring._tallies import *  # noqa: F401,F403
-from quodeq.core.scoring._tallies import _weighted_sum
+from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
+    _tally_types,
+    _weighted_sum,
+    evidence_has_taxonomy,
+    tally_compliance_types_by_reason,
+    tally_compliance_types_by_taxonomy,
+    tally_types_by_reason,
+    tally_types_by_taxonomy,
+)
 from quodeq.core.scoring.confidence import confidence_interval_for  # noqa: F401 — re-export
 from quodeq.core.scoring.numerical import (  # noqa: F401 — re-export
     build_deductions,

--- a/src/quodeq/dashboard/_api_health_check.py
+++ b/src/quodeq/dashboard/_api_health_check.py
@@ -14,6 +14,9 @@ _HEALTH_POLL_INTERVAL_S = 0.2
 _DEFAULT_WAIT_TIMEOUT_S = 10
 _MAX_HEALTH_POLL_ATTEMPTS = 200
 _MAX_JITTER_DELAY_S = 2.0
+_LOG_CADENCE = 10
+_JITTER_RATIO = 0.2
+_BACKOFF_MULTIPLIER = 1.5
 
 
 def action_api_healthy(base_url: str) -> bool:
@@ -40,10 +43,10 @@ def wait_for_action_api(base_url: str, timeout_s: float = _DEFAULT_WAIT_TIMEOUT_
         if action_api_healthy(base_url):
             return None
         attempts += 1
-        if attempts % 10 == 0:
+        if attempts % _LOG_CADENCE == 0:
             elapsed = round(time.monotonic() - start, 1)
             log_info(f"Still waiting for Action API ({elapsed:.0f}s elapsed)...")
-        jitter = random.uniform(0, delay * 0.2)
+        jitter = random.uniform(0, delay * _JITTER_RATIO)
         time.sleep(delay + jitter)
-        delay = min(delay * 1.5, max_delay)
+        delay = min(delay * _BACKOFF_MULTIPLIER, max_delay)
     raise TimeoutError(f"Action API did not become ready within {timeout_s} seconds.")

--- a/src/quodeq/dashboard/_networking.py
+++ b/src/quodeq/dashboard/_networking.py
@@ -33,9 +33,11 @@ def _is_port_open(host: str, port: int) -> bool:
 def _choose_ui_port(start: int, host: str | None = None) -> int:
     host = host if host is not None else _get_default_host()
     port = start
+    tries = 0
     while _is_port_open(host, port):
         port += 1
-        if port > _MAX_PORT:
+        tries += 1
+        if tries >= _MAX_PORT_SCAN_TRIES or port > _MAX_PORT:
             raise RuntimeError("No free port available.")
     return port
 

--- a/src/quodeq/data/fs/repo_handler.py
+++ b/src/quodeq/data/fs/repo_handler.py
@@ -9,9 +9,6 @@ from quodeq.data.fs.repo_validation import (
 )
 
 __all__ = [
-    "_PRIVATE_HOST_RE",
-    "_REPO_URL_RE",
-    "_resolves_to_private",
     "cleanup_cloned_repo",
     "is_valid_repo_url",
     "prepare_repository",

--- a/src/quodeq/data/web/http_client.py
+++ b/src/quodeq/data/web/http_client.py
@@ -25,14 +25,4 @@ __all__ = [
     "HttpClientConfig",
     "HttpResponse",
     "check_response_status",
-    # Semi-private helpers re-exported for backward compatibility
-    "_allow_private_urls",
-    "_circuit_breaker_reset_s",
-    "_circuit_breaker_threshold",
-    "_http_timeout_s",
-    "_max_retries",
-    "_retry_base_delay_s",
-    "_retry_jitter_s",
-    "_safe_float",
-    "_safe_int",
 ]

--- a/src/quodeq/services/_standards_crud.py
+++ b/src/quodeq/services/_standards_crud.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.core.types.standard import StandardDetail
@@ -13,12 +14,20 @@ from quodeq.services.import_validator import validate_import, scan_injection
 _CUSTOM_DEFAULTS = {"type": _TYPE_CUSTOM, "managed": False, "origin": None, "origin_hash": None}
 
 
+@dataclass
+class JsonIO:
+    """Grouped JSON read/write callables."""
+
+    read: Callable
+    write: Callable
+
+
 def _validate_id(standard_id: str) -> None:
     if not standard_id or "/" in standard_id or "\\" in standard_id or ".." in standard_id:
         raise ValueError(f"Invalid standard ID: {standard_id}")
 
 
-def create(data: dict, evaluators_dir: Path, read_json: Callable, write_json: Callable) -> StandardDetail:
+def create(data: dict, evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Create a new custom standard and persist it to disk."""
     standard_id = data["id"]
     _validate_id(standard_id)
@@ -26,37 +35,36 @@ def create(data: dict, evaluators_dir: Path, read_json: Callable, write_json: Ca
     if path.exists():
         raise ValueError(f"Standard '{standard_id}' already exists")
     evaluators_dir.mkdir(parents=True, exist_ok=True)
-    write_json(path, {**data, **_CUSTOM_DEFAULTS})
-    return build_detail(read_json(path))
+    io.write(path, {**data, **_CUSTOM_DEFAULTS})
+    return build_detail(io.read(path))
 
 
-def update(standard_id: str, data: dict, evaluators_dir: Path,
-           read_json: Callable, write_json: Callable) -> StandardDetail:
+def update(standard_id: str, data: dict, evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Update an existing custom standard with new *data*."""
     path = evaluators_dir / f"{standard_id}.json"
     if not path.is_file():
         raise FileNotFoundError(f"Standard not found: {standard_id}")
-    if read_json(path).get("managed", False):
+    if io.read(path).get("managed", False):
         raise PermissionError(f"Cannot edit managed standard '{standard_id}'")
-    write_json(path, {**data, "id": standard_id, "type": _TYPE_CUSTOM, "managed": False})
-    return build_detail(read_json(path))
+    io.write(path, {**data, "id": standard_id, "type": _TYPE_CUSTOM, "managed": False})
+    return build_detail(io.read(path))
 
 
 def delete(standard_id: str, evaluators_dir: Path, compiled_dir: Path,
-           read_json: Callable, is_builtin: Callable[[str], bool]) -> None:
+           io: JsonIO, is_builtin: Callable[[str], bool]) -> None:
     """Delete a custom standard. Raises for built-in or managed standards."""
     path = evaluators_dir / f"{standard_id}.json"
     if not path.is_file():
         if (compiled_dir / f"{standard_id}.json").is_file() or is_builtin(standard_id):
             raise PermissionError(f"Cannot delete built-in standard '{standard_id}'")
         raise FileNotFoundError(f"Standard not found: {standard_id}")
-    if read_json(path).get("managed", False):
+    if io.read(path).get("managed", False):
         raise PermissionError(f"Cannot delete managed standard '{standard_id}'")
     path.unlink()
 
 
 def duplicate(standard_id: str, new_id: str, source_detail: StandardDetail,
-              evaluators_dir: Path, read_json: Callable, write_json: Callable) -> StandardDetail:
+              evaluators_dir: Path, io: JsonIO) -> StandardDetail:
     """Duplicate an existing standard under *new_id* as a custom copy."""
     _validate_id(new_id)
     new_path = evaluators_dir / f"{new_id}.json"
@@ -67,12 +75,11 @@ def duplicate(standard_id: str, new_id: str, source_detail: StandardDetail,
     payload = {"id": new_id, "name": s.name, "description": s.description,
                "weight": s.weight, "source": s.source, "principles": s.principles,
                **_CUSTOM_DEFAULTS}
-    write_json(new_path, payload)
-    return build_detail(read_json(new_path))
+    io.write(new_path, payload)
+    return build_detail(io.read(new_path))
 
 
-def import_from_file(data: dict, force: bool, evaluators_dir: Path,
-                     read_json: Callable, write_json: Callable) -> dict:
+def import_from_file(data: dict, force: bool, evaluators_dir: Path, io: JsonIO) -> dict:
     """Import an evaluator from parsed file data."""
     validation = validate_import(data)
     if not validation["valid"]:
@@ -82,13 +89,13 @@ def import_from_file(data: dict, force: bool, evaluators_dir: Path,
     standard_id = cleaned["id"]
     path = evaluators_dir / f"{standard_id}.json"
     if path.is_file() and not force:
-        existing = read_json(path)
+        existing = io.read(path)
         p, r = count_principles_and_requirements(existing)
         return {"status": "conflict", "detail": None,
                 "existing": build_custom_meta(existing, p, r), "warnings": warnings}
-    if path.is_file() and force and read_json(path).get("managed", False):
+    if path.is_file() and force and io.read(path).get("managed", False):
         raise PermissionError(f"Cannot overwrite managed standard '{standard_id}'")
     evaluators_dir.mkdir(parents=True, exist_ok=True)
-    write_json(path, {**cleaned, **_CUSTOM_DEFAULTS})
-    return {"status": "imported", "detail": build_detail(read_json(path)),
+    io.write(path, {**cleaned, **_CUSTOM_DEFAULTS})
+    return {"status": "imported", "detail": build_detail(io.read(path)),
             "existing": None, "warnings": warnings}

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -56,6 +56,16 @@ def _score_principle(violations: list[Finding], compliance: list[Finding]) -> tu
     return final, grade
 
 
+def _group_by_principle(
+    findings: list[Finding],
+) -> dict[str, list[Finding]]:
+    """Group a list of findings by their principle name."""
+    groups: dict[str, list[Finding]] = {}
+    for f in findings:
+        groups.setdefault(f.principle or "unknown", []).append(f)
+    return groups
+
+
 def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> DimensionResult:
     """Rescore a single dimension after filtering dismissed findings."""
     # Filter violations -- dismissed key is (req, file, line)
@@ -65,12 +75,8 @@ def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> Dimension
     ]
 
     # Group violations and compliance by principle
-    principles_violations: dict[str, list[Finding]] = {}
-    principles_compliance: dict[str, list[Finding]] = {}
-    for v in filtered_violations:
-        principles_violations.setdefault(v.principle or "unknown", []).append(v)
-    for c in dim.compliance:
-        principles_compliance.setdefault(c.principle or "unknown", []).append(c)
+    principles_violations = _group_by_principle(filtered_violations)
+    principles_compliance = _group_by_principle(dim.compliance)
 
     # Score each principle
     all_principle_names = set(principles_violations) | set(principles_compliance)

--- a/src/quodeq/services/standards.py
+++ b/src/quodeq/services/standards.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from quodeq.core.types.standard import StandardDetail, StandardMeta
 from quodeq.services._standards_crud import (
-    create, delete, duplicate, import_from_file, update,
+    JsonIO, create, delete, duplicate, import_from_file, update,
 )
 from quodeq.services._standards_io import default_read_json, default_write_json
 from quodeq.services._standards_queries import (
@@ -23,6 +23,7 @@ class StandardsService:
         self._dimensions_file = dimensions_file
         self._read_json = read_json or default_read_json
         self._write_json = write_json or default_write_json
+        self._io = JsonIO(read=self._read_json, write=self._write_json)
 
     def list_standards(self) -> list[StandardMeta]:
         return (list_builtin(self._dimensions_file, self._compiled_dir, self._read_json)
@@ -33,25 +34,24 @@ class StandardsService:
                             self._dimensions_file, self._read_json)
 
     def create_standard(self, data: dict) -> StandardDetail:
-        return create(data, self._evaluators_dir, self._read_json, self._write_json)
+        return create(data, self._evaluators_dir, self._io)
 
     def update_standard(self, standard_id: str, data: dict) -> StandardDetail:
-        return update(standard_id, data, self._evaluators_dir, self._read_json, self._write_json)
+        return update(standard_id, data, self._evaluators_dir, self._io)
 
     def delete_standard(self, standard_id: str) -> None:
         delete(standard_id, self._evaluators_dir, self._compiled_dir,
-               self._read_json,
+               self._io,
                lambda sid: check_builtin_id(sid, self._dimensions_file, self._read_json))
 
     def duplicate_standard(self, standard_id: str, new_id: str) -> StandardDetail:
         return duplicate(new_id=new_id, standard_id=standard_id,
                          source_detail=self.get_standard(standard_id),
                          evaluators_dir=self._evaluators_dir,
-                         read_json=self._read_json, write_json=self._write_json)
+                         io=self._io)
 
     def import_from_file(self, data: dict, force: bool = False) -> dict:
-        return import_from_file(data, force, self._evaluators_dir,
-                                self._read_json, self._write_json)
+        return import_from_file(data, force, self._evaluators_dir, self._io)
 
     def load_cwe_list(self) -> list[dict]:
         return load_cwe_list(self._compiled_dir, self._read_json)

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -9,6 +9,9 @@ from typing import Any, Protocol
 # NOTE: logging in inner layer — tracked for middleware extraction
 logger = logging.getLogger(__name__)
 
+_HTTP_TIMEOUT_S = 30
+_HASH_PREFIX_LEN = 16
+
 class HttpClient(Protocol):
     def get_json(self, url: str, headers: dict[str, str] | None = None) -> Any: ...
 
@@ -16,7 +19,7 @@ class UrllibJsonClient:
     def get_json(self, url: str, headers: dict[str, str] | None = None) -> Any:
         import urllib.request
         req = urllib.request.Request(url, headers=headers or {})
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_S) as resp:
             return json.loads(resp.read())
 
 class StandardsLibraryClient:
@@ -48,7 +51,7 @@ class StandardsLibraryClient:
             raise ValueError(f"Invalid library file path: {file_path}")
         data = self.fetch_standard(file_path)
         self._validate_id(data.get("id", ""))
-        content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:16]
+        content_hash = hashlib.sha256(json.dumps(data, sort_keys=True).encode()).hexdigest()[:_HASH_PREFIX_LEN]
         evaluators_dir.mkdir(parents=True, exist_ok=True)
         dest = evaluators_dir / f"{data['id']}.json"
         # Check for collision with existing standard

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-rJeqbnDp.js"></script>
+    <script type="module" crossorigin src="/assets/index-BAADOma6.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -85,6 +85,19 @@ function buildDismissPayload(v, fallbackDimension) {
   };
 }
 
+function renderEvalPrincipleDetail(params, props) {
+  return (
+    <EvalPrincipleDetailPage
+      evalPrincipal={params.evalPrincipal}
+      onDismiss={(v) => {
+        dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
+          .then(() => props.refreshDashboard?.())
+          .catch((e) => console.error('[Dismiss] failed:', e));
+      }}
+    />
+  );
+}
+
 const ROUTE_RENDERERS = {
   overview: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate, onRunSelect: props.navigation.handleRunSelect }} runMode={false} />,
   violations: (params, props) => {
@@ -134,16 +147,8 @@ const ROUTE_RENDERERS = {
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
   file: (params) => <FileDetailPage file={params.file} />,
   principle: (params) => <PrincipleDetailPage principle={params.principle} />,
-  evalprinciple: (params, props) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} onDismiss={(v) => {
-    dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
-      .then(() => props.refreshDashboard?.())
-      .catch((e) => console.error('[Dismiss] failed:', e));
-  }} />,
-  'eval-principle-detail': (params, props) => <EvalPrincipleDetailPage evalPrincipal={params.evalPrincipal} onDismiss={(v) => {
-    dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.evalPrincipal?.dimension))
-      .then(() => props.refreshDashboard?.())
-      .catch((e) => console.error('[Dismiss] failed:', e));
-  }} />,
+  evalprinciple: renderEvalPrincipleDetail,
+  'eval-principle-detail': renderEvalPrincipleDetail,
   settings: (params, props) => <SettingsCase settings={props.settings} analysisPower={props.evaluation.analysisPower} setAnalysisPower={props.evaluation.setAnalysisPower} persistAnalysisPower={props.evaluation.persistAnalysisPower} />,
   projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
   standards: () => <StandardsPage />,

--- a/src/quodeq/ui/src/api/findings.js
+++ b/src/quodeq/ui/src/api/findings.js
@@ -1,0 +1,64 @@
+/**
+ * Findings API — dismissed findings management.
+ */
+
+import { request } from './request.js';
+
+/**
+ * List dismissed findings for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Array>} Dismissed findings array
+ */
+export async function listDismissedFindings(projectId) {
+  return request(`/findings/dismissed?project=${encodeURIComponent(projectId)}`);
+}
+
+/**
+ * Dismiss a finding (exclude from scoring).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding data: { req, file, line, dimension, severity, reason }
+ * @returns {Promise<object>} Server response
+ */
+export async function dismissFinding(projectId, finding) {
+  return request('/findings/dismiss', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+}
+
+/**
+ * Restore a dismissed finding (include in scoring again).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding key: { req, file, line }
+ * @returns {Promise<object>} Server response
+ */
+export async function restoreFinding(projectId, finding) {
+  return request('/findings/restore', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+}
+
+/**
+ * Restore all dismissed findings for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<{ok: boolean, restored: number}>} Server response
+ */
+export async function restoreAllFindings(projectId) {
+  return request('/findings/restore-all', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId }),
+  });
+}
+
+/**
+ * Rescore a project run with dismissed findings filtered out.
+ * @param {string} projectId - Project identifier
+ * @param {string} [run='latest'] - Run ID (optional, defaults to latest)
+ * @returns {Promise<{dimensions: Array, summary: object}>} Rescored data
+ */
+export async function getRescore(projectId, run = 'latest') {
+  const params = new URLSearchParams({ project: projectId });
+  if (run && run !== 'latest') params.set('run', run);
+  return request(`/rescore?${params}`);
+}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -3,40 +3,19 @@
  *
  * Every public function maps a raw JSON response to a typed model object
  * (see ../models/) so components never see raw API shapes.
+ *
+ * Standards and findings APIs are in separate modules; re-exported here
+ * for backward compatibility.
  */
 
 import { createDashboard } from '../models/dashboard.js';
 import { createDimensionEval } from '../models/dimension.js';
 import { createJob } from '../models/job.js';
 import { createProject } from '../models/project.js';
+import { request, BASE } from './request.js';
 
-const BASE = import.meta.env.VITE_API_BASE || '/api';
-const API_TIMEOUT_MS = 30000;
-
-async function request(path, options = {}) {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
-  try {
-    const res = await fetch(`${BASE}${path}`, {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(options.headers || {}),
-      },
-      ...options,
-      signal: controller.signal,
-    });
-
-    const payload = await res.json().catch(() => ({}));
-
-    if (!res.ok) {
-      throw new Error(payload.error || `Request failed: ${res.status}`);
-    }
-
-    return payload;
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
+export { listDismissedFindings, dismissFinding, restoreFinding, restoreAllFindings, getRescore } from './findings.js';
+export { listStandards, getStandard, createStandard, updateStandard, deleteStandard, duplicateStandard, listLibrary, listCwes, importFromLibrary, importStandard, exportStandard } from './standards.js';
 
 // ── Health ──────────────────────────────────────────────────────────────
 
@@ -196,147 +175,4 @@ export function getClientModels(clientId) {
   return request(`/ai-clients/${encodeURIComponent(clientId)}/models`);
 }
 
-// ── Standards ──────────────────────────────────────────────
-/** @returns {Promise<Object[]>} */
-export async function listStandards() {
-  return request('/standards');
-}
-/**
- * @param {string} standardId
- * @returns {Promise<Object>}
- */
-export async function getStandard(standardId) {
-  return request(`/standards/${encodeURIComponent(standardId)}`);
-}
-/**
- * @param {Object} data - Standard definition
- * @returns {Promise<Object>}
- */
-export async function createStandard(data) {
-  return request('/standards', { method: 'POST', body: JSON.stringify(data) });
-}
-/**
- * @param {string} standardId
- * @param {Object} data - Updated standard definition
- * @returns {Promise<Object>}
- */
-export async function updateStandard(standardId, data) {
-  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'PUT', body: JSON.stringify(data) });
-}
-/**
- * @param {string} standardId
- * @returns {Promise<Object>}
- */
-export async function deleteStandard(standardId) {
-  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'DELETE' });
-}
-/**
- * @param {string} standardId
- * @param {string} newId
- * @returns {Promise<Object>}
- */
-export async function duplicateStandard(standardId, newId) {
-  return request(`/standards/${encodeURIComponent(standardId)}/duplicate`, { method: 'POST', body: JSON.stringify({ newId }) });
-}
-/** @returns {Promise<Object[]>} */
-export async function listLibrary() {
-  return request('/standards/library');
-}
-/** @returns {Promise<Object[]>} */
-export async function listCwes() {
-  return request('/standards/refs/cwe');
-}
-/**
- * @param {string} file - Library file identifier
- * @returns {Promise<Object>}
- */
-export async function importFromLibrary(file) {
-  return request('/standards/library/import', { method: 'POST', body: JSON.stringify({ file }) });
-}
-/**
- * @param {Object} data - Standard data to import
- * @param {boolean} [force=false] - Overwrite existing standard if true
- * @returns {Promise<Object>} Result with optional `_conflict` flag
- */
-export async function importStandard(data, force = false) {
-  const res = await fetch(`${BASE}/standards/import`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ data, force }),
-  });
-  const body = await res.json().catch(() => ({}));
-  if (res.status === 409) return { ...body, _conflict: true };
-  if (!res.ok) throw new Error(body.error || `Import failed: ${res.status}`);
-  return body;
-}
-/**
- * Fetch a standard and return a portable (non-managed) representation.
- * @param {string} standardId
- * @returns {Promise<{ id: string, data: Object, fileName: string }>}
- */
-export async function exportStandard(standardId) {
-  const detail = await getStandard(standardId);
-  const { managed, type, origin, originHash, principleCount, requirementCount, ...portable } = detail;
-  return { id: standardId, data: portable, fileName: `${standardId}.quodeq` };
-}
-
-// ── Dismissed Findings ─────────────────────────────────────────────────
-
-/**
- * List dismissed findings for a project.
- * @param {string} projectId - Project identifier
- * @returns {Promise<Array>} Dismissed findings array
- */
-export async function listDismissedFindings(projectId) {
-  return request(`/findings/dismissed?project=${encodeURIComponent(projectId)}`);
-}
-
-/**
- * Dismiss a finding (exclude from scoring).
- * @param {string} projectId - Project identifier
- * @param {object} finding - Finding data: { req, file, line, dimension, severity, reason }
- * @returns {Promise<object>} Server response
- */
-export async function dismissFinding(projectId, finding) {
-  return request('/findings/dismiss', {
-    method: 'POST',
-    body: JSON.stringify({ project: projectId, ...finding }),
-  });
-}
-
-/**
- * Restore a dismissed finding (include in scoring again).
- * @param {string} projectId - Project identifier
- * @param {object} finding - Finding key: { req, file, line }
- * @returns {Promise<object>} Server response
- */
-export async function restoreFinding(projectId, finding) {
-  return request('/findings/restore', {
-    method: 'POST',
-    body: JSON.stringify({ project: projectId, ...finding }),
-  });
-}
-
-/**
- * Restore all dismissed findings for a project.
- * @param {string} projectId - Project identifier
- * @returns {Promise<{ok: boolean, restored: number}>} Server response
- */
-export async function restoreAllFindings(projectId) {
-  return request('/findings/restore-all', {
-    method: 'POST',
-    body: JSON.stringify({ project: projectId }),
-  });
-}
-
-/**
- * Rescore a project run with dismissed findings filtered out.
- * @param {string} projectId - Project identifier
- * @param {string} [run='latest'] - Run ID (optional, defaults to latest)
- * @returns {Promise<{dimensions: Array, summary: object}>} Rescored data
- */
-export async function getRescore(projectId, run = 'latest') {
-  const params = new URLSearchParams({ project: projectId });
-  if (run && run !== 'latest') params.set('run', run);
-  return request(`/rescore?${params}`);
-}
+// Standards and findings APIs are re-exported at the top of this file.

--- a/src/quodeq/ui/src/api/request.js
+++ b/src/quodeq/ui/src/api/request.js
@@ -1,0 +1,31 @@
+/**
+ * Shared HTTP request helper for the API layer.
+ */
+
+export const BASE = import.meta.env.VITE_API_BASE || '/api';
+const API_TIMEOUT_MS = 30000;
+
+export async function request(path, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${BASE}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options.headers || {}),
+      },
+      ...options,
+      signal: controller.signal,
+    });
+
+    const payload = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      throw new Error(payload.error || `Request failed: ${res.status}`);
+    }
+
+    return payload;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/quodeq/ui/src/api/standards.js
+++ b/src/quodeq/ui/src/api/standards.js
@@ -1,0 +1,98 @@
+/**
+ * Standards API — standard CRUD and library operations.
+ */
+
+import { request, BASE } from './request.js';
+
+/** @returns {Promise<Object[]>} */
+export async function listStandards() {
+  return request('/standards');
+}
+
+/**
+ * @param {string} standardId
+ * @returns {Promise<Object>}
+ */
+export async function getStandard(standardId) {
+  return request(`/standards/${encodeURIComponent(standardId)}`);
+}
+
+/**
+ * @param {Object} data - Standard definition
+ * @returns {Promise<Object>}
+ */
+export async function createStandard(data) {
+  return request('/standards', { method: 'POST', body: JSON.stringify(data) });
+}
+
+/**
+ * @param {string} standardId
+ * @param {Object} data - Updated standard definition
+ * @returns {Promise<Object>}
+ */
+export async function updateStandard(standardId, data) {
+  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'PUT', body: JSON.stringify(data) });
+}
+
+/**
+ * @param {string} standardId
+ * @returns {Promise<Object>}
+ */
+export async function deleteStandard(standardId) {
+  return request(`/standards/${encodeURIComponent(standardId)}`, { method: 'DELETE' });
+}
+
+/**
+ * @param {string} standardId
+ * @param {string} newId
+ * @returns {Promise<Object>}
+ */
+export async function duplicateStandard(standardId, newId) {
+  return request(`/standards/${encodeURIComponent(standardId)}/duplicate`, { method: 'POST', body: JSON.stringify({ newId }) });
+}
+
+/** @returns {Promise<Object[]>} */
+export async function listLibrary() {
+  return request('/standards/library');
+}
+
+/** @returns {Promise<Object[]>} */
+export async function listCwes() {
+  return request('/standards/refs/cwe');
+}
+
+/**
+ * @param {string} file - Library file identifier
+ * @returns {Promise<Object>}
+ */
+export async function importFromLibrary(file) {
+  return request('/standards/library/import', { method: 'POST', body: JSON.stringify({ file }) });
+}
+
+/**
+ * @param {Object} data - Standard data to import
+ * @param {boolean} [force=false] - Overwrite existing standard if true
+ * @returns {Promise<Object>} Result with optional `_conflict` flag
+ */
+export async function importStandard(data, force = false) {
+  const res = await fetch(`${BASE}/standards/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data, force }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (res.status === 409) return { ...body, _conflict: true };
+  if (!res.ok) throw new Error(body.error || `Import failed: ${res.status}`);
+  return body;
+}
+
+/**
+ * Fetch a standard and return a portable (non-managed) representation.
+ * @param {string} standardId
+ * @returns {Promise<{ id: string, data: Object, fileName: string }>}
+ */
+export async function exportStandard(standardId) {
+  const detail = await getStandard(standardId);
+  const { managed, type, origin, originHash, principleCount, requirementCount, ...portable } = detail;
+  return { id: standardId, data: portable, fileName: `${standardId}.quodeq` };
+}

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -101,14 +101,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate }) {
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimensionClick, dimensionsWithViolations, selectedDayDimNames, rescoreLookup }) {
+function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, dimensionsWithViolations, selectedDayDimNames, rescoreLookup }) {
   return (
     <>
       <div className="dimensions-header">
         <h3 className="dimensions-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} referenceRun={referenceRun} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} rescoreLookup={rescoreLookup} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} rescoreLookup={rescoreLookup} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -140,6 +140,8 @@ function AccumulatedDimensionsSection({ sortedDimensions, referenceRun, onDimens
 // Pure computation helpers extracted from the component
 // ---------------------------------------------------------------------------
 
+const roundOneDecimal = (n) => Math.round(n * 10) / 10;
+
 function buildFilteredTrend(trend, dailyTrend, visibleSet) {
   const accByDim = {};
   const accByDate = new Map(); // date string → accAvg
@@ -156,7 +158,7 @@ function buildFilteredTrend(trend, dailyTrend, visibleSet) {
     }
     if (hasVisible) {
       const accScores = Object.values(accByDim).filter((s) => s != null);
-      const accAvg = accScores.length > 0 ? Math.round((accScores.reduce((a, b) => a + b, 0) / accScores.length) * 10) / 10 : null;
+      const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
       const datePart = (entry.dateISO || '').slice(0, 10);
       accByDate.set(datePart, accAvg);
       visibleDates.add(datePart);
@@ -170,7 +172,7 @@ function buildFilteredTrend(trend, dailyTrend, visibleSet) {
       const accAvg = accByDate.get(datePart) ?? null;
       const details = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
       const runScores = details.map((d) => d.score).filter((s) => s != null);
-      const runAvg = runScores.length > 0 ? Math.round((runScores.reduce((a, b) => a + b, 0) / runScores.length) * 10) / 10 : null;
+      const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;
       const dims = (entry.dimensions || []).filter((d) => visibleSet.has(d.toLowerCase()));
       return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: details, dimensions: dims, dimensionsCount: dims.length };
     });
@@ -180,7 +182,7 @@ function buildFilteredAccumulated(accumulated, filteredDimensions, filteredDaily
   if (!accumulated) return accumulated;
   const scores = filteredDimensions.map((d) => parseFloat(d.overallScore)).filter((s) => !isNaN(s));
   const numericAverage = scores.length > 0
-    ? Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 10) / 10
+    ? roundOneDecimal(scores.reduce((a, b) => a + b, 0) / scores.length)
     : null;
   const selectedIdx = currentOverviewRun ? filteredDailyTrend.findIndex((t) => t.runId === currentOverviewRun) : 0;
   const prevIdx = (selectedIdx >= 0 ? selectedIdx : 0) + 1;
@@ -215,7 +217,6 @@ function useAccumulatedComputations(data) {
   }, [selectedRunId, trend, dailyTrend]);
 
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
-  const referenceRun = overviewRunIndex === 0 ? dayRuns[0]?.runId : currentOverviewRun;
   const selectedDayDimNames = useMemo(
     () => collectDayDimensions(trend, currentOverviewRun) || collectDayDimensions(trend, selectedRunId),
     [trend, currentOverviewRun, selectedRunId]
@@ -228,12 +229,12 @@ function useAccumulatedComputations(data) {
   const filteredAccumulated = useMemo(() => buildFilteredAccumulated(accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun), [accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
   const filteredStats = useMemo(() => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun), [filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
 
-  return { currentOverviewRun, referenceRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats };
+  return { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats };
 }
 
 export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLookup }) {
   const { onRunClick, onDimensionClick } = callbacks;
-  const { currentOverviewRun, referenceRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats } = useAccumulatedComputations(data);
+  const { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats } = useAccumulatedComputations(data);
 
   return (
     <>
@@ -250,7 +251,6 @@ export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLooku
 
       <AccumulatedDimensionsSection
         sortedDimensions={filteredStats.sorted}
-        referenceRun={referenceRun}
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={filteredStats.dimsWithViolations}
         selectedDayDimNames={selectedDayDimNames}

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -50,7 +50,7 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true, resco
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, referenceRun, onDimensionClick, selectedDayDimNames, rescoreLookup }) {
+export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames, rescoreLookup }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
   const sorted = useMemo(() => [...sortedDimensions].sort((a, b) => {
     if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -6,6 +6,8 @@ import { createDimension } from '../../../models/dimension.js';
  * Fetches and manages dashboard data for a given project and run.
  */
 
+const REFRESH_DEBOUNCE_MS = 300;
+
 function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError) {
   if (!selectedProject) {
     setDashboard(null);
@@ -143,7 +145,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
   const refreshTimerRef = useRef(null);
   const refreshDashboard = useCallback(() => {
     if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), 300);
+    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), REFRESH_DEBOUNCE_MS);
   }, []);
 
   useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -205,65 +205,57 @@ function useDerivedExplorerStats(evalData, allViolations) {
   return { topFiles, severityCounts, uniquePrinciples, totalCompliant, complianceByPrinciple };
 }
 
+function mergeRescoreIntoEval(prev, dimData) {
+  if (!prev || !dimData) return prev;
+  const rescPrinciples = dimData.principles || [];
+  const updatedGrades = (prev.principleGrades || []).map((pg) => {
+    if (pg.isOverall || pg.principle?.includes('Overall')) {
+      return { ...pg, score: dimData.overallScore ?? pg.score, grade: dimData.overallGrade ?? pg.grade };
+    }
+    const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
+    return match ? { ...pg, score: match.score, grade: match.grade } : pg;
+  });
+  return {
+    ...prev,
+    principleGrades: updatedGrades,
+    overallScore: dimData.overallScore ?? prev.overallScore,
+    overallGrade: dimData.overallGrade ?? prev.overallGrade,
+  };
+}
+
+async function fetchAndRescore(project, runId, dimension) {
+  const data = await getDimensionEval(project, runId, dimension);
+  try {
+    const rescored = await getRescore(project, runId);
+    const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
+    return dimData ? mergeRescoreIntoEval(data, dimData) : data;
+  } catch {
+    return data; // rescore failure is non-fatal
+  }
+}
+
 function useExplorerData(project, dimension, runId, refreshSignal) {
   const [evalData, setEvalData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  // Fetch eval data when params change
+
   useEffect(() => {
     setLoading(true);
-    getDimensionEval(project, runId, dimension)
-      .then((data) => {
-        setEvalData(data);
-        setLoading(false);
-        return getRescore(project, runId).then((rescored) => {
-          const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
-          if (!dimData) return;
-          setEvalData((prev) => {
-            if (!prev) return prev;
-            // Merge rescored principle grades and overall score
-            const rescPrinciples = dimData.principles || [];
-            const updatedGrades = (prev.principleGrades || []).map((pg) => {
-              // Update the overall row with dimension-level rescored values
-              if (pg.isOverall || pg.principle?.includes('Overall')) {
-                return { ...pg, score: dimData.overallScore ?? pg.score, grade: dimData.overallGrade ?? pg.grade };
-              }
-              const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
-              return match ? { ...pg, score: match.score, grade: match.grade } : pg;
-            });
-            return {
-              ...prev,
-              principleGrades: updatedGrades,
-              overallScore: dimData.overallScore ?? prev.overallScore,
-              overallGrade: dimData.overallGrade ?? prev.overallGrade,
-            };
-          });
-        }).catch(() => { /* rescore failure is non-fatal */ });
-      })
+    fetchAndRescore(project, runId, dimension)
+      .then((data) => { setEvalData(data); setLoading(false); })
       .catch((err) => { setError(err.message); setLoading(false); });
   }, [project, dimension, runId]);
-  // Re-run rescore when refreshSignal changes (e.g. after a dismiss on another page)
+
   const initialRef = useRef(refreshSignal);
   useEffect(() => {
-    if (refreshSignal === initialRef.current) return; // skip initial mount
+    if (refreshSignal === initialRef.current) return;
     if (!evalData || !project || !runId) return;
     getRescore(project, runId).then((rescored) => {
       const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
-      if (!dimData) return;
-      setEvalData((prev) => {
-        if (!prev) return prev;
-        const rescPrinciples = dimData.principles || [];
-        const updatedGrades = (prev.principleGrades || []).map((pg) => {
-          if (pg.isOverall || pg.principle?.includes('Overall')) {
-            return { ...pg, score: dimData.overallScore ?? pg.score, grade: dimData.overallGrade ?? pg.grade };
-          }
-          const match = rescPrinciples.find((rp) => rp.principle === pg.principle);
-          return match ? { ...pg, score: match.score, grade: match.grade } : pg;
-        });
-        return { ...prev, principleGrades: updatedGrades, overallScore: dimData.overallScore, overallGrade: dimData.overallGrade };
-      });
+      if (dimData) setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
     }).catch(() => {});
   }, [refreshSignal]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -71,13 +71,15 @@ function TreeNode({ node, actions, titles, children }) {
   );
 }
 
+const MAX_LABEL_DISPLAY_LENGTH = 40;
+
 function RequirementNode({ req, ri, pi, selectedNode, actions, confirmFn = window.confirm }) {
   const { onSelectNode, onRemoveRequirement, editable } = actions;
   const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;
   const hasContent = req.text || req.description || (req.refs && req.refs.length > 0);
   const handleRemoveReq = () => {
     if (hasContent) {
-      if (!confirmFn(`Delete requirement "${req.text ? (req.text.length > 40 ? req.text.slice(0, 40) + '...' : req.text) : 'Untitled'}"?`)) return;
+      if (!confirmFn(`Delete requirement "${req.text ? (req.text.length > MAX_LABEL_DISPLAY_LENGTH ? req.text.slice(0, MAX_LABEL_DISPLAY_LENGTH) + '...' : req.text) : 'Untitled'}"?`)) return;
     }
     onRemoveRequirement(pi, ri);
   };

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -159,6 +159,10 @@ function FileSubTab({ dimensions, onFileClick }) {
   );
 }
 
+function dismissedLabel(d) {
+  return d.principle || d.dimension || d.req || '?';
+}
+
 function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
   if (dismissed.length === 0) {
     return <p className="empty-state">No dismissed findings.</p>;
@@ -180,7 +184,7 @@ function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
             <div className="dismissed-card-top">
               <span className="dismissed-tag">dismissed</span>
               {d.severity && <span className={`severity-tag ${d.severity}`}>{d.severity}</span>}
-              <span className="dismissed-label">[{d.principle || d.dimension || d.req || '?'}]</span>
+              <span className="dismissed-label">[{dismissedLabel(d)}]</span>
               <span className="dismissed-file">{d.file}:{d.line}</span>
               <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
             </div>

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -8,21 +8,39 @@ const LS_THEME = 'cc-theme';
 const LS_THEME_MODE = 'cc-theme-mode';
 const LS_THEME_FAMILY = 'cc-theme-family';
 
+const THEME_MODES = { SYSTEM: 'system', LIGHT: 'light', DARK: 'dark' };
+const THEME_FAMILIES = { DARUMA: 'daruma', FLYNN: 'flynn', GALADRIEL: 'galadriel', IFRIT: 'ifrit', DECKARD: 'deckard' };
+
+const LEGACY_THEME_MAP = {
+  system: [THEME_MODES.SYSTEM, THEME_FAMILIES.DARUMA],
+  light: [THEME_MODES.LIGHT, THEME_FAMILIES.DARUMA],
+  dark: [THEME_MODES.DARK, THEME_FAMILIES.DARUMA],
+  ember: [THEME_MODES.DARK, THEME_FAMILIES.IFRIT],
+  forest: [THEME_MODES.LIGHT, THEME_FAMILIES.GALADRIEL],
+  midnight: [THEME_MODES.DARK, THEME_FAMILIES.FLYNN],
+  slate: [THEME_MODES.LIGHT, THEME_FAMILIES.DARUMA],
+  horizon: [THEME_MODES.LIGHT, THEME_FAMILIES.FLYNN],
+};
+
+const LEGACY_FAMILY_MAP = {
+  default: THEME_FAMILIES.DARUMA,
+  midnight: THEME_FAMILIES.FLYNN,
+  forest: THEME_FAMILIES.GALADRIEL,
+  ember: THEME_FAMILIES.IFRIT,
+  cyber: THEME_FAMILIES.DECKARD,
+};
+
 function applyInitialTheme() {
   const oldTheme = localStorage.getItem(LS_THEME);
   if (oldTheme !== null) {
-    const map = { system: ['system','daruma'], light: ['light','daruma'], dark: ['dark','daruma'],
-      ember: ['dark','ifrit'], forest: ['light','galadriel'], midnight: ['dark','flynn'],
-      slate: ['light','daruma'], horizon: ['light','flynn'] };
-    const [m, f] = map[oldTheme] || ['system','daruma'];
+    const [m, f] = LEGACY_THEME_MAP[oldTheme] || [THEME_MODES.SYSTEM, THEME_FAMILIES.DARUMA];
     localStorage.setItem(LS_THEME_MODE, m);
     localStorage.setItem(LS_THEME_FAMILY, f);
     localStorage.removeItem(LS_THEME);
   }
   const oldFamily = localStorage.getItem(LS_THEME_FAMILY);
-  const familyMap = { 'default': 'daruma', 'midnight': 'flynn', 'forest': 'galadriel', 'ember': 'ifrit', 'cyber': 'deckard' };
-  if (oldFamily && familyMap[oldFamily]) {
-    localStorage.setItem(LS_THEME_FAMILY, familyMap[oldFamily]);
+  if (oldFamily && LEGACY_FAMILY_MAP[oldFamily]) {
+    localStorage.setItem(LS_THEME_FAMILY, LEGACY_FAMILY_MAP[oldFamily]);
   }
   const mode = localStorage.getItem(LS_THEME_MODE) || 'system';
   const family = localStorage.getItem(LS_THEME_FAMILY) || 'daruma';


### PR DESCRIPTION
## Summary

- Break circular dependency `_loops.py → runner.py` using callback injection
- Replace wildcard imports with explicit imports in `scoring/internals.py`
- Create 5 dataclasses to reduce parameter counts (LoopContext, WorkerContext, EvidencePaths, JsonIO, _ReportData)
- Extract `fetchAndRescore` from ExplorerPage (65→28 lines, eliminates 5-level nesting)
- Split `api/index.js` (343→178 lines) into `request.js`, `findings.js`, `standards.js`
- Extract 12 magic numbers to named constants across 8 files
- Remove private names from `__all__`, add injectable config params, add docstrings

## Test plan

- [x] All 687 Python tests pass
- [x] UI builds cleanly
- [x] Smoke test dashboard