### PR TITLE
fix: resolve 16 maintainability violations (round 7)

### DIFF
--- a/packaging/macos/_helpers.py
+++ b/packaging/macos/_helpers.py
@@ -9,6 +9,7 @@ import urllib.error
 import urllib.request
 
 _HEALTH_TIMEOUT = 1.0
+_CMD_DISCOVERY_TIMEOUT_S = 5
 _HOMEBREW_ARM64 = "/opt/homebrew/bin"
 _HOMEBREW_X86 = "/usr/local/bin"
 
@@ -36,7 +37,7 @@ def source_user_path() -> None:
         cmd = ('source ~/.zprofile 2>/dev/null; source ~/.zshrc 2>/dev/null; '
                'source ~/.bash_profile 2>/dev/null; echo $PATH')
         shell = os.environ.get("SHELL", "/bin/zsh")
-        result = subprocess.run([shell, "-c", cmd], capture_output=True, text=True, timeout=5)
+        result = subprocess.run([shell, "-c", cmd], capture_output=True, text=True, timeout=_CMD_DISCOVERY_TIMEOUT_S)
         if result.returncode == 0 and result.stdout.strip():
             os.environ["PATH"] = result.stdout.strip()
             return
@@ -84,7 +85,7 @@ def _find_commands_uncached(env: dict[str, str] | None) -> dict[str, str | None]
     for name in ("python3", "node", "claude", "quodeq"):
         try:
             result = subprocess.run(
-                ["which", name], capture_output=True, text=True, timeout=5,
+                ["which", name], capture_output=True, text=True, timeout=_CMD_DISCOVERY_TIMEOUT_S,
                 env=env,
             )
             cmds[name] = result.stdout.strip() if result.returncode == 0 else None

--- a/src/quodeq/analysis/subagents/_git_scoring.py
+++ b/src/quodeq/analysis/subagents/_git_scoring.py
@@ -7,6 +7,15 @@ from pathlib import Path
 
 _GIT_LOG_TIMEOUT_S = 10
 _GIT_HASH_LENGTH = 40
+_DEFAULT_CHURN_DIVISOR = 4
+_DEFAULT_CHURN_MAX = 5
+_DEFAULT_RECENCY_DAYS = 14
+_DEFAULT_RECENCY_MULTIPLIER = 1.5
+
+
+def _is_date_line(line: str) -> bool:
+    """Check if a line looks like a git date: ``YYYY-MM-DD ...``."""
+    return len(line) >= 10 and line[4:5] == "-" and line[7:8] == "-" and " " in line
 
 
 def _run_git_log(src: Path, months: int = 3) -> str | None:
@@ -50,7 +59,7 @@ def compute_git_scores(files: list[str], src: Path, config: dict | None = None) 
         if len(line) == _GIT_HASH_LENGTH and all(c in "0123456789abcdef" for c in line):
             continue
         # Date lines: "YYYY-MM-DD HH:MM:SS +ZZZZ"
-        if len(line) >= 10 and line[4:5] == "-" and line[7:8] == "-" and " " in line:
+        if _is_date_line(line):
             current_date = line[:10]
             continue
         # File path
@@ -59,10 +68,10 @@ def compute_git_scores(files: list[str], src: Path, config: dict | None = None) 
             if line not in last_date or current_date > last_date[line]:
                 last_date[line] = current_date
 
-    divisor = cfg.get("git_churn_divisor", 4)
-    max_score = cfg.get("git_churn_max", 5)
-    recency_days = cfg.get("git_recency_days", 14)
-    recency_mult = cfg.get("git_recency_multiplier", 1.5)
+    divisor = cfg.get("git_churn_divisor", _DEFAULT_CHURN_DIVISOR)
+    max_score = cfg.get("git_churn_max", _DEFAULT_CHURN_MAX)
+    recency_days = cfg.get("git_recency_days", _DEFAULT_RECENCY_DAYS)
+    recency_mult = cfg.get("git_recency_multiplier", _DEFAULT_RECENCY_MULTIPLIER)
     cutoff = (datetime.now() - timedelta(days=recency_days)).strftime("%Y-%m-%d")
 
     scores: dict[str, float] = {}

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -15,6 +15,7 @@ from quodeq.analysis.subagents._pool_models import (
 )
 from quodeq.analysis.subagents._pool_scaling import (
     EvidencePaths,
+    ScaleUpContext,
     collect_done,
     maybe_scale_up,
     should_respawn,
@@ -51,9 +52,10 @@ def scout_loop(ctx: LoopContext) -> None:
     ctx.submit_fn()
     while ctx.futures:
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
+        scale_ctx = ScaleUpContext(ctx.queue, ctx.queue_path, ctx.submit_fn)
         state.scout_done = maybe_scale_up(
             done, state, ctx.n_agents, ctx.max_files_per_agent,
-            ctx.queue, ctx.queue_path, ctx.submit_fn,
+            scale_ctx,
         )
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -19,6 +19,15 @@ from quodeq.shared.logging import log_warning
 
 
 @dataclass
+class ScaleUpContext:
+    """Grouped parameters for scale-up decisions."""
+
+    queue: WorkQueue | None
+    queue_path: Path
+    submit_fn: Callable[[], None]
+
+
+@dataclass
 class EvidencePaths:
     """Grouped paths for evidence collection."""
 
@@ -92,8 +101,7 @@ def collect_done(
 def maybe_scale_up(
     done: set, state: ScaleUpState, n_agents: int,
     max_files_per_agent: int | None,
-    queue: WorkQueue | None, queue_path: Path,
-    submit_fn: Callable[[], None],
+    ctx: ScaleUpContext,
 ) -> bool:
     """Check if scout phase is complete and scale up if needed. Returns updated scout_done."""
     if state.scout_done:
@@ -103,7 +111,7 @@ def maybe_scale_up(
     scout_timed_out = elapsed >= state.scout_timeout and n_agents > 1
     if not (scout_completed or scout_timed_out):
         return False
-    remaining = should_respawn(queue, queue_path, state.pool_start, state.max_duration)
+    remaining = should_respawn(ctx.queue, ctx.queue_path, state.pool_start, state.max_duration)
     for _ in range(compute_scale_up(remaining, n_agents, max_files_per_agent)):
-        submit_fn()
+        ctx.submit_fn()
     return True

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -10,7 +10,12 @@ from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_f
 
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
-    return Path(evaluations_dir) / project
+    base = Path(evaluations_dir).resolve()
+    resolved = (base / project).resolve()
+    if not resolved.is_relative_to(base):
+        from flask import abort
+        abort(400, description="Invalid project path")
+    return resolved
 
 
 def register_findings_routes(app: Flask) -> None:

--- a/src/quodeq/api/standards_read_routes.py
+++ b/src/quodeq/api/standards_read_routes.py
@@ -10,6 +10,8 @@ from quodeq.core.types import to_camel_dict
 
 logger = logging.getLogger(__name__)
 
+_cwe_cache: list | None = None
+
 
 def register_read_routes(app: Flask, get_service, get_library_client) -> None:
     """Register GET routes for the standards API.
@@ -22,9 +24,10 @@ def register_read_routes(app: Flask, get_service, get_library_client) -> None:
 
     @app.get("/api/standards/refs/cwe")
     def list_cwes() -> Response:
-        if not hasattr(app, "_cwe_list"):
-            app._cwe_list = get_service(app).load_cwe_list()
-        return jsonify(app._cwe_list)
+        global _cwe_cache
+        if _cwe_cache is None:
+            _cwe_cache = get_service(app).load_cwe_list()
+        return jsonify(_cwe_cache)
 
     @app.get("/api/standards")
     def list_standards() -> Response:

--- a/src/quodeq/data/fs/repo_handler.py
+++ b/src/quodeq/data/fs/repo_handler.py
@@ -3,7 +3,6 @@
 from quodeq.data.fs.repo_clone import cleanup_cloned_repo, prepare_repository
 from quodeq.data.fs.repo_validation import (
     _PRIVATE_HOST_RE,
-    _REPO_URL_RE,
     _resolves_to_private,
     is_valid_repo_url,
 )

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -111,18 +111,18 @@ class FsEvaluationMixin:
     def _build_eval_env(repo: str, options: EvaluationOptions, env: dict[str, str] | None = None) -> dict[str, str]:
         """Build the subprocess environment for an evaluation run."""
         base = env if env is not None else os.environ
-        env = {**base, "PYTHONUNBUFFERED": "1"}
-        env["AI_CMD"] = options.ai_cmd or get_ai_cmd()
+        built_env = {**base, "PYTHONUNBUFFERED": "1"}
+        built_env["AI_CMD"] = options.ai_cmd or get_ai_cmd()
         ai_model = options.ai_model or get_ai_model()
         if ai_model:
-            env["AI_MODEL"] = ai_model
+            built_env["AI_MODEL"] = ai_model
         if options.subagent_model:
-            env["SUBAGENT_MODEL"] = options.subagent_model
+            built_env["SUBAGENT_MODEL"] = options.subagent_model
         if not options.verify_findings:
-            env["QUODEQ_NO_VERIFY"] = "1"
+            built_env["QUODEQ_NO_VERIFY"] = "1"
         if options.pool_budget != _DEFAULT_POOL_BUDGET:
-            env["QUODEQ_POOL_BUDGET"] = str(options.pool_budget)
-        return env
+            built_env["QUODEQ_POOL_BUDGET"] = str(options.pool_budget)
+        return built_env
 
     def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> JobSnapshot:
         """Start an asynchronous evaluation subprocess for a repository."""

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-BAADOma6.js"></script>
+    <script type="module" crossorigin src="/assets/index-CLY0fghX.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardEditor.jsx
@@ -87,12 +87,12 @@ function EditorStatsRow({ standard }) {
 }
 
 function EditorBody({ treeProps, detailProps, treeWidth, onDividerMouseDown }) {
-  const { standard, selectedNode, setSelectedNode, actions, editable } = treeProps;
+  const { standard, selectedNode, actions, editable } = treeProps;
   const { updateField, isNew } = detailProps;
   return (
     <div className="standard-editor-body">
       <div className="standard-editor-tree-panel" style={{ width: treeWidth, minWidth: MIN_TREE_WIDTH, maxWidth: MAX_TREE_WIDTH }}>
-        <StandardTree standard={standard} selectedNode={selectedNode} onSelectNode={setSelectedNode} actions={actions} editable={editable} />
+        <StandardTree standard={standard} selectedNode={selectedNode} actions={actions} />
       </div>
       <div className="standard-editor-divider" onMouseDown={onDividerMouseDown} />
       <div className="standard-editor-detail-panel">
@@ -124,7 +124,7 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
     );
   }
 
-  const treeActions = { onAddPrinciple: addPrinciple, onRemovePrinciple: removePrinciple, onAddRequirement: addRequirement, onRemoveRequirement: removeRequirement };
+  const treeActions = { onAddPrinciple: addPrinciple, onRemovePrinciple: removePrinciple, onAddRequirement: addRequirement, onRemoveRequirement: removeRequirement, onSelectNode: setSelectedNode, editable };
 
   return (
     <div className="standard-editor">
@@ -135,7 +135,7 @@ export default function StandardEditor({ standardId, isNew, onBack, onSaved }) {
       />
       {error && <p className="inline-error" style={{ margin: '8px 16px' }}>{error}</p>}
       <EditorBody
-        treeProps={{ standard, selectedNode, setSelectedNode, actions: treeActions, editable }}
+        treeProps={{ standard, selectedNode, actions: treeActions, editable }}
         detailProps={{ updateField, isNew }}
         treeWidth={treeWidth}
         onDividerMouseDown={onDividerMouseDown}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
 
-function TreeNodeRow({ node, actions, titles, showExpand, expanded, setExpanded }) {
+function TreeNodeRow({ node, actions, titles, expand }) {
   const { label, isSelected } = node;
   const { onClick, onAdd, onRemove } = actions;
   const { addTitle, removeTitle } = titles || {};
+  const { showExpand, expanded, setExpanded } = expand || {};
 
   return (
     <div
@@ -60,7 +61,7 @@ function TreeNode({ node, actions, titles, children }) {
     <div className={`tree-node tree-node--depth-${depth}`}>
       <TreeNodeRow
         node={node} actions={actions} titles={titles}
-        showExpand={showExpand} expanded={expanded} setExpanded={setExpanded}
+        expand={{ showExpand, expanded, setExpanded }}
       />
       {(alwaysExpanded || expanded) && hasChildren && (
         <div className="tree-node-children">
@@ -73,7 +74,8 @@ function TreeNode({ node, actions, titles, children }) {
 
 const MAX_LABEL_DISPLAY_LENGTH = 40;
 
-function RequirementNode({ req, ri, pi, selectedNode, actions, confirmFn = window.confirm }) {
+function RequirementNode({ req, position, selectedNode, actions, confirmFn = window.confirm }) {
+  const { ri, pi } = position;
   const { onSelectNode, onRemoveRequirement, editable } = actions;
   const isReqSelected = selectedNode?.type === 'requirement' && selectedNode.principleIndex === pi && selectedNode.reqIndex === ri;
   const hasContent = req.text || req.description || (req.refs && req.refs.length > 0);
@@ -111,7 +113,7 @@ function PrincipleNode({ principle, pi, selectedNode, actions, confirmFn = windo
       titles={{ addTitle: 'Add Requirement', removeTitle: 'Remove Principle' }}
     >
       {(principle.requirements || []).map((req, ri) => (
-        <RequirementNode key={ri} req={req} ri={ri} pi={pi} selectedNode={selectedNode} actions={actions} confirmFn={confirmFn} />
+        <RequirementNode key={ri} req={req} position={{ ri, pi }} selectedNode={selectedNode} actions={actions} confirmFn={confirmFn} />
       ))}
     </TreeNode>
   );
@@ -123,8 +125,8 @@ function PrinciplesList({ principles, selectedNode, actions, confirmFn }) {
   ));
 }
 
-export default function StandardTree({ standard, selectedNode, onSelectNode, actions, editable, confirmFn = window.confirm }) {
-  const { onAddPrinciple, onRemovePrinciple, onAddRequirement, onRemoveRequirement } = actions || {};
+export default function StandardTree({ standard, selectedNode, actions, confirmFn = window.confirm }) {
+  const { onAddPrinciple, onRemovePrinciple, onAddRequirement, onRemoveRequirement, onSelectNode, editable } = actions || {};
   if (!standard) return null;
 
   const treeActions = { onSelectNode, onAddRequirement, onRemovePrinciple, onRemoveRequirement, editable };

--- a/src/quodeq/ui/src/features/violations/components/DismissedSubTab.jsx
+++ b/src/quodeq/ui/src/features/violations/components/DismissedSubTab.jsx
@@ -1,0 +1,69 @@
+import ContextBlock from '../../../components/ContextBlock.jsx';
+
+function dismissedLabel(d) {
+  return d.principle || d.dimension || (d.req ?? '?');
+}
+
+function DismissedCard({ d, onRestore }) {
+  return (
+    <div className="dismissed-card">
+      <div className="dismissed-card-top">
+        <span className="dismissed-tag">dismissed</span>
+        {d.severity && <span className={`severity-tag ${d.severity}`}>{d.severity}</span>}
+        <span className="dismissed-label">[{dismissedLabel(d)}]</span>
+        <span className="dismissed-file">{d.file}:{d.line}</span>
+        <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
+      </div>
+      {(d.reason || d.title) && (
+        <div className="dismissed-detail">
+          {d.title && (
+            <div className="dismissed-detail-section">
+              <div className="dismissed-detail-header">
+                <span className="dismissed-detail-label">Reason</span>
+                {(d.reqRefs || []).filter((r) => r.url && /^https?:\/\//.test(r.url)).length > 0 && (
+                  <span className="cwe-link-group">
+                    {d.reqRefs.filter((r) => r.url && /^https?:\/\//.test(r.url)).map((r, i) => (
+                      <a key={i} className="cwe-link" href={r.url} target="_blank" rel="noopener noreferrer">{r.label}</a>
+                    ))}
+                  </span>
+                )}
+              </div>
+              <p className="dismissed-detail-title">{d.title}</p>
+            </div>
+          )}
+          {d.reason && (
+            <div className="dismissed-detail-section">
+              <span className="dismissed-detail-label">Detail</span>
+              <p className="dismissed-detail-text">{d.reason}</p>
+            </div>
+          )}
+          <ContextBlock context={d.context} snippet={d.snippet} scope={d.scope} line={d.line} endLine={d.endLine} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
+  if (dismissed.length === 0) {
+    return <p className="empty-state">No dismissed findings.</p>;
+  }
+  return (
+    <>
+      <div className="section-header">
+        <h3 className="section-title">Dismissed Findings</h3>
+        <span className="section-count">{dismissed.length} findings · not included in scoring</span>
+        {dismissed.length > 1 && (
+          <button type="button" className="restore-btn" style={{ marginLeft: 'auto' }} onClick={onRestoreAll}>
+            Restore all
+          </button>
+        )}
+      </div>
+      <div className="dismissed-list-inner">
+        {dismissed.map((d) => (
+          <DismissedCard key={`${d.req}-${d.file}-${d.line}`} d={d} onRestore={onRestore} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -3,11 +3,11 @@ import DimensionViolationsRow from '../../dashboard/components/DimensionViolatio
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
-import ContextBlock from '../../../components/ContextBlock.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr, sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import { complianceRatio } from '../../../utils/formatters.js';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
+import DismissedSubTab from './DismissedSubTab.jsx';
 
 function ViolationsPillNav({ activeSubTab, onSubTabChange, dismissedCount }) {
   const tabs = [
@@ -159,71 +159,7 @@ function FileSubTab({ dimensions, onFileClick }) {
   );
 }
 
-function dismissedLabel(d) {
-  return d.principle || d.dimension || d.req || '?';
-}
-
-function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
-  if (dismissed.length === 0) {
-    return <p className="empty-state">No dismissed findings.</p>;
-  }
-  return (
-    <>
-      <div className="section-header">
-        <h3 className="section-title">Dismissed Findings</h3>
-        <span className="section-count">{dismissed.length} findings · not included in scoring</span>
-        {dismissed.length > 1 && (
-          <button type="button" className="restore-btn" style={{ marginLeft: 'auto' }} onClick={onRestoreAll}>
-            Restore all
-          </button>
-        )}
-      </div>
-      <div className="dismissed-list-inner">
-        {dismissed.map((d) => (
-          <div key={`${d.req}-${d.file}-${d.line}`} className="dismissed-card">
-            <div className="dismissed-card-top">
-              <span className="dismissed-tag">dismissed</span>
-              {d.severity && <span className={`severity-tag ${d.severity}`}>{d.severity}</span>}
-              <span className="dismissed-label">[{dismissedLabel(d)}]</span>
-              <span className="dismissed-file">{d.file}:{d.line}</span>
-              <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
-            </div>
-            {(d.reason || d.title) && (
-              <div className="dismissed-detail">
-                {d.title && (
-                  <div className="dismissed-detail-section">
-                    <div className="dismissed-detail-header">
-                      <span className="dismissed-detail-label">Reason</span>
-                      {(d.reqRefs || []).filter((r) => r.url && /^https?:\/\//.test(r.url)).length > 0 && (
-                        <span className="cwe-link-group">
-                          {d.reqRefs.filter((r) => r.url && /^https?:\/\//.test(r.url)).map((r, i) => (
-                            <a key={i} className="cwe-link" href={r.url} target="_blank" rel="noopener noreferrer">{r.label}</a>
-                          ))}
-                        </span>
-                      )}
-                    </div>
-                    <p className="dismissed-detail-title">{d.title}</p>
-                  </div>
-                )}
-                {d.reason && (
-                  <div className="dismissed-detail-section">
-                    <span className="dismissed-detail-label">Detail</span>
-                    <p className="dismissed-detail-text">{d.reason}</p>
-                  </div>
-                )}
-                <ContextBlock context={d.context} snippet={d.snippet} scope={d.scope} line={d.line} endLine={d.endLine} />
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
-    </>
-  );
-}
-
-export default function ViolationsPage({ data, callbacks }) {
-  const { accumulated, accumulatedDimensions, selectedProject } = data;
-  const { onDimensionClick, onFileClick, onPrincipleClick, onRefresh } = callbacks;
+function useViolationsData({ accumulated, accumulatedDimensions, selectedProject, onRefresh }) {
   const [activeSubTab, setActiveSubTab] = useState('dimension');
   const [dismissed, setDismissed] = useState([]);
 
@@ -285,6 +221,23 @@ export default function ViolationsPage({ data, callbacks }) {
       },
     };
   }, [accumulated, visibleDimensions]);
+
+  return {
+    activeSubTab, setActiveSubTab, dismissed,
+    handleRestore, handleRestoreAll,
+    visibleDimensions, topFilesCount, uniquePrinciples, filteredAccumulated,
+  };
+}
+
+export default function ViolationsPage({ data, callbacks }) {
+  const { accumulated, accumulatedDimensions, selectedProject } = data;
+  const { onDimensionClick, onFileClick, onPrincipleClick, onRefresh } = callbacks;
+
+  const {
+    activeSubTab, setActiveSubTab, dismissed,
+    handleRestore, handleRestoreAll,
+    visibleDimensions, topFilesCount, uniquePrinciples, filteredAccumulated,
+  } = useViolationsData({ accumulated, accumulatedDimensions, selectedProject, onRefresh });
 
   return (
     <div className="violations-page">


### PR DESCRIPTION
## Summary

- **Critical**: path traversal guard on `_project_dir` in findings API
- Extract DismissedSubTab to separate file, useViolationsData hook
- Group component props to meet max-5-params limit (StandardTree, TreeNodeRow, RequirementNode)
- Replace `app._cwe_list` with module-level cache
- Create ScaleUpContext dataclass for pool scaling params
- Extract named constants from 3 Python files

## Test plan

- [x] All 687 Python tests pass
- [x] UI builds cleanly
- [x] Smoke test dashboard