### PR TITLE
feat: Report copy button — markdown report to clipboard

### DIFF
--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-BKoVRvoB.js"></script>
+    <script type="module" crossorigin src="/assets/index-COlP0cBz.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-CLY0fghX.js"></script>
+    <script type="module" crossorigin src="/assets/index-BKoVRvoB.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-COlP0cBz.js"></script>
+    <script type="module" crossorigin src="/assets/index-DXsd6XCf.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DcK5RMlw.css">
   </head>
   <body>

--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -20,6 +20,17 @@ export function CopyIcon() {
   );
 }
 
+export function FileTextIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="9" y1="13" x2="15" y2="13" />
+      <line x1="9" y1="17" x2="15" y2="17" />
+    </svg>
+  );
+}
+
 export default function CopyButton({ onClick, label, className, icon, 'aria-label': ariaLabel }) {
   const [copied, setCopied] = useState(false);
 

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -67,12 +67,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
     <section className="acc-eval-panel panel">
       <div className="acc-eval-top">
         <span className="acc-eval-label">Accumulated Evaluation</span>
-        <CopyButton
-          label="Report"
-          className="fix-plan-btn-header"
-          onClick={() => copyToClipboard(buildOverviewReport(accumulated, accumulatedDimensions || [], projectName))}
-        />
-        {lastDate && <span className="acc-eval-date">Last evaluated {lastDate}</span>}
+        <div style={{ marginLeft: 'auto', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4 }}>
+          <CopyButton
+            label="Report"
+            className="fix-plan-btn-header"
+            onClick={() => copyToClipboard(buildOverviewReport(accumulated, accumulatedDimensions || [], projectName))}
+          />
+          {lastDate && <span className="acc-eval-date">Last evaluated {lastDate}</span>}
+        </div>
       </div>
       <div className="acc-eval-golden">
         <div className="acc-eval-circle-col">

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -9,7 +9,7 @@ import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
-import CopyButton from '../../../components/CopyButton.jsx';
+import CopyButton, { FileTextIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildOverviewReport } from '../../../utils/reportBuilder.js';
 
@@ -71,6 +71,7 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
           <CopyButton
             label="Report"
             className="fix-plan-btn-header"
+            icon={<FileTextIcon />}
             onClick={() => copyToClipboard(buildOverviewReport(accumulated, accumulatedDimensions || [], projectName))}
           />
           {lastDate && <span className="acc-eval-date">Last evaluated {lastDate}</span>}

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -9,6 +9,9 @@ import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
+import CopyButton from '../../../components/CopyButton.jsx';
+import { copyToClipboard } from '../../../utils/clipboard.js';
+import { buildOverviewReport } from '../../../utils/reportBuilder.js';
 
 // ---------------------------------------------------------------------------
 // Accumulated overview panel helpers
@@ -58,12 +61,17 @@ function SeverityTags({ severity }) {
   );
 }
 
-function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate }) {
+function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulatedDimensions, projectName }) {
   const summary = accumulated?.summary;
   return (
     <section className="acc-eval-panel panel">
       <div className="acc-eval-top">
         <span className="acc-eval-label">Accumulated Evaluation</span>
+        <CopyButton
+          label="Report"
+          className="fix-plan-btn-header"
+          onClick={() => copyToClipboard(buildOverviewReport(accumulated, accumulatedDimensions || [], projectName))}
+        />
         {lastDate && <span className="acc-eval-date">Last evaluated {lastDate}</span>}
       </div>
       <div className="acc-eval-golden">
@@ -242,6 +250,8 @@ export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLooku
         accumulated={filteredAccumulated}
         scoreDelta={filteredStats.scoreDelta}
         lastDate={filteredStats.lastRun.date}
+        accumulatedDimensions={filteredDimensions}
+        projectName={data.selectedProject}
       />
 
       <div className="history-panels-row">

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -5,7 +5,7 @@ import RunOverviewPanel from './RunOverviewPanel.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex, selectedProject } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick } = callbacks;
   if (runMode) {
@@ -39,7 +39,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
       data={{
         accumulated: accumulated ? { ...accumulated, dimensions: accumulatedDimensions } : accumulated,
         accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
-        trend: dashboard?.trend || [], selectedRunId,
+        trend: dashboard?.trend || [], selectedRunId, selectedProject,
       }}
       callbacks={{
         onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick,
@@ -99,7 +99,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex, selectedProject }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
           callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick }}
         />

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -52,19 +52,21 @@ function DimensionOverview({ data, stats, onNavigate }) {
           <span className="explorer-dimension-title">{evalData.dimension}</span>
           {runId && <span className="acc-eval-date">{dateLabel || runId}</span>}
         </div>
-        {allViolations.length > 0 && (
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
           <CopyButton
-            label="Full fix plan"
+            label="Report"
             className="fix-plan-btn-header"
-            icon={<SparkleIcon />}
-            onClick={() => copyToClipboard(buildDimensionPlanFromViolations(evalData.dimension, allViolations))}
+            onClick={() => copyToClipboard(buildDimensionReport(evalData, principleGrades || [], allViolations, overallGrade, dateLabel, runId))}
           />
-        )}
-        <CopyButton
-          label="Report"
-          className="fix-plan-btn-header"
-          onClick={() => copyToClipboard(buildDimensionReport(evalData, principleGrades || [], allViolations, overallGrade, dateLabel, runId))}
-        />
+          {allViolations.length > 0 && (
+            <CopyButton
+              label="Full fix plan"
+              className="fix-plan-btn-header"
+              icon={<SparkleIcon />}
+              onClick={() => copyToClipboard(buildDimensionPlanFromViolations(evalData.dimension, allViolations))}
+            />
+          )}
+        </div>
       </div>
       <div className="compact-stats-row">
         <div className="compact-score-col">

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -6,6 +6,7 @@ import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { gradeColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
+import { buildDimensionReport } from '../../../utils/reportBuilder.js';
 
 const columnStyle = { display: 'flex', flexDirection: 'column', gap: 2 };
 
@@ -43,7 +44,7 @@ function computeComplianceByPrinciple(evalData) {
 
 function DimensionOverview({ data, stats, onNavigate }) {
   const { evalData, runId, dateLabel, allViolations } = data;
-  const { overallGrade, severityCounts, totalCompliant, topFiles, uniquePrinciples } = stats;
+  const { overallGrade, severityCounts, totalCompliant, topFiles, uniquePrinciples, principleGrades } = stats;
   return (
     <section className="acc-eval-panel acc-eval-panel--compact panel">
       <div className="acc-eval-top">
@@ -59,6 +60,11 @@ function DimensionOverview({ data, stats, onNavigate }) {
             onClick={() => copyToClipboard(buildDimensionPlanFromViolations(evalData.dimension, allViolations))}
           />
         )}
+        <CopyButton
+          label="Report"
+          className="fix-plan-btn-header"
+          onClick={() => copyToClipboard(buildDimensionReport(evalData, principleGrades || [], allViolations, overallGrade, dateLabel, runId))}
+        />
       </div>
       <div className="compact-stats-row">
         <div className="compact-score-col">
@@ -274,7 +280,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, onN
     <>
       <DimensionOverview
         data={{ evalData: d.evalData, runId, dateLabel, allViolations: d.allViolations }}
-        stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: d.topFiles, uniquePrinciples: d.uniquePrinciples }}
+        stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: d.topFiles, uniquePrinciples: d.uniquePrinciples, principleGrades: d.principleGrades }}
         onNavigate={onNavigate}
       />
       <PrinciplesList evalData={d.evalData} principleGrades={d.principleGrades} onNavigate={onNavigate} buildEvalPrincipal={buildEvalPrincipal} />

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -52,7 +52,7 @@ function DimensionOverview({ data, stats, onNavigate }) {
           <span className="explorer-dimension-title">{evalData.dimension}</span>
           {runId && <span className="acc-eval-date">{dateLabel || runId}</span>}
         </div>
-        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <CopyButton
             label="Report"
             className="fix-plan-btn-header"

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -8,7 +8,7 @@
 
 .acc-eval-top {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
 }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1996,7 +1996,6 @@
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
-  align-self: flex-start;
   transition: all 150ms ease;
 }
 .fix-plan-btn-header:hover {

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -1,0 +1,215 @@
+// src/quodeq/ui/src/utils/reportBuilder.js
+import { SEVERITY_ORDER } from './formatters.js';
+
+const SNIPPET_MAX_LINES = 5;
+
+function formatDate() {
+  const d = new Date();
+  const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  return `${d.getDate()} ${months[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+function capSnippet(snippet) {
+  if (!snippet) return '';
+  const lines = snippet.split('\n');
+  if (lines.length <= SNIPPET_MAX_LINES) return snippet;
+  return [...lines.slice(0, SNIPPET_MAX_LINES), `... (${lines.length - SNIPPET_MAX_LINES} more lines)`].join('\n');
+}
+
+function formatViolationEntry(v) {
+  const lines = [];
+  const principle = v.principle || '';
+  const title = v.title || v.reason || 'Violation';
+  lines.push(`#### [${principle}] ${title}`);
+  if (v.file) {
+    const fileRef = v.line != null ? `${v.file}:${v.line}` : v.file;
+    lines.push(`- **File:** \`${fileRef}\``);
+  }
+  lines.push(`- **Severity:** ${v.severity || 'minor'}`);
+  if (v.reason && v.reason !== title) lines.push(`- **Why:** ${v.reason}`);
+  const refs = (v.reqRefs || []).filter((r) => r.url);
+  if (refs.length > 0) {
+    lines.push(`- **Refs:** ${refs.map((r) => `[${r.label}](${r.url})`).join(', ')}`);
+  }
+  const snippet = capSnippet(v.snippet);
+  if (snippet) {
+    lines.push('');
+    lines.push('```');
+    lines.push(snippet);
+    lines.push('```');
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function formatPrincipleTable(principleGrades) {
+  const lines = [
+    '| Principle | Score | Grade |',
+    '|-----------|-------|-------|',
+  ];
+  for (const pg of principleGrades) {
+    lines.push(`| ${pg.principle || '—'} | ${pg.score || '—'} | ${pg.grade || '—'} |`);
+  }
+  return lines.join('\n');
+}
+
+function groupBySeverity(violations) {
+  const groups = {};
+  for (const sev of SEVERITY_ORDER) groups[sev] = [];
+  for (const v of violations) {
+    const s = (v.severity || 'minor').toLowerCase();
+    (groups[s] || (groups[s] = [])).push(v);
+  }
+  return groups;
+}
+
+export function buildDimensionReport(evalData, principleGrades, allViolations, overallGrade, dateLabel, runId) {
+  const dim = evalData?.dimension || 'Unknown';
+  const dimTitle = dim.charAt(0).toUpperCase() + dim.slice(1);
+  const score = overallGrade?.score || '—';
+  const grade = overallGrade?.grade || '—';
+  const compliance = evalData?.compliance || [];
+  const date = dateLabel || formatDate();
+  const rid = runId ? ` · **Run:** ${runId.slice(0, 8)}` : '';
+
+  const lines = [];
+  lines.push(`# ${dimTitle} Report`);
+  lines.push('');
+  lines.push(`**Date:** ${date}${rid} · **Score:** ${score} ${grade}`);
+  lines.push('');
+
+  if (principleGrades.length > 0) {
+    lines.push('## Principle Scores');
+    lines.push('');
+    lines.push(formatPrincipleTable(principleGrades));
+    lines.push('');
+  }
+
+  const bySeverity = groupBySeverity(allViolations);
+  lines.push(`## Violations (${allViolations.length})`);
+  lines.push('');
+  if (allViolations.length === 0) {
+    lines.push('No violations found.');
+    lines.push('');
+  } else {
+    for (const sev of SEVERITY_ORDER) {
+      const vs = bySeverity[sev];
+      if (!vs || vs.length === 0) continue;
+      lines.push(`### ${sev.charAt(0).toUpperCase() + sev.slice(1)} (${vs.length})`);
+      lines.push('');
+      for (const v of vs) lines.push(formatViolationEntry(v));
+    }
+  }
+
+  if (compliance.length > 0) {
+    const byPrinciple = {};
+    for (const c of compliance) {
+      const p = c.principle || 'Other';
+      byPrinciple[p] = (byPrinciple[p] || 0) + 1;
+    }
+    lines.push(`## Compliance Summary (${compliance.length})`);
+    lines.push('');
+    lines.push('| Principle | Count |');
+    lines.push('|-----------|-------|');
+    for (const [p, count] of Object.entries(byPrinciple).sort((a, b) => b[1] - a[1])) {
+      lines.push(`| ${p} | ${count} |`);
+    }
+    lines.push('');
+  }
+
+  if (evalData?.partial) {
+    lines.push('> **Note:** Evaluation in progress — results may be incomplete.');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export function buildOverviewReport(accumulated, accumulatedDimensions, projectName) {
+  const summary = accumulated?.summary || {};
+  const score = summary.numericAverage != null ? `${Math.round(summary.numericAverage * 10) / 10}/10` : '—';
+  const grade = summary.overallGrade || '—';
+  const date = formatDate();
+  const project = projectName || 'Project';
+
+  const lines = [];
+  lines.push(`# Code Quality Report — ${project}`);
+  lines.push('');
+  lines.push(`**Date:** ${date} · **Overall Score:** ${score} ${grade}`);
+  lines.push('');
+
+  if (accumulatedDimensions.length > 0) {
+    lines.push('## Dimensions');
+    lines.push('');
+    lines.push('| Dimension | Score | Grade | Violations | Compliance |');
+    lines.push('|-----------|-------|-------|------------|------------|');
+    for (const dim of accumulatedDimensions) {
+      const name = (dim.dimension || '—').charAt(0).toUpperCase() + (dim.dimension || '').slice(1);
+      const dScore = dim.overallScore || '—';
+      const dGrade = dim.overallGrade || '—';
+      const vCount = (dim.violations || []).length;
+      const cCount = (dim.compliance || []).length;
+      lines.push(`| ${name} | ${dScore} | ${dGrade} | ${vCount} | ${cCount} |`);
+    }
+    lines.push('');
+  }
+
+  const fileMap = {};
+  for (const dim of accumulatedDimensions) {
+    for (const v of (dim.violations || [])) {
+      if (!v.file) continue;
+      const f = v.file.split(':')[0];
+      if (!fileMap[f]) fileMap[f] = { count: 0, critical: 0, major: 0, minor: 0 };
+      fileMap[f].count++;
+      const s = (v.severity || 'minor').toLowerCase();
+      if (fileMap[f][s] !== undefined) fileMap[f][s]++;
+    }
+  }
+  const topFiles = Object.entries(fileMap).sort((a, b) => b[1].count - a[1].count).slice(0, 15);
+  if (topFiles.length > 0) {
+    lines.push('## Top Offending Files');
+    lines.push('');
+    lines.push('| File | Violations | Critical | Major | Minor |');
+    lines.push('|------|-----------|----------|-------|-------|');
+    for (const [file, stats] of topFiles) {
+      lines.push(`| \`${file}\` | ${stats.count} | ${stats.critical} | ${stats.major} | ${stats.minor} |`);
+    }
+    lines.push('');
+  }
+
+  const critMajor = [];
+  for (const dim of accumulatedDimensions) {
+    const vs = (dim.violations || []).filter((v) => v.severity === 'critical' || v.severity === 'major');
+    if (vs.length > 0) critMajor.push({ dimension: dim.dimension, violations: vs });
+  }
+  if (critMajor.length > 0) {
+    const total = critMajor.reduce((sum, d) => sum + d.violations.length, 0);
+    lines.push(`## Critical & Major Violations (${total})`);
+    lines.push('');
+    for (const { dimension, violations } of critMajor) {
+      const dimTitle = (dimension || '').charAt(0).toUpperCase() + (dimension || '').slice(1);
+      lines.push(`### ${dimTitle}`);
+      lines.push('');
+      for (const v of violations) lines.push(formatViolationEntry(v));
+    }
+  } else {
+    lines.push('## Critical & Major Violations');
+    lines.push('');
+    lines.push('No critical or major violations found.');
+    lines.push('');
+  }
+
+  const sev = summary.severity || {};
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- **${accumulatedDimensions.length}** dimensions evaluated`);
+  lines.push(`- **${summary.totalViolations || 0}** total violations (${sev.critical || 0} critical, ${sev.major || 0} major, ${sev.minor || 0} minor)`);
+  lines.push(`- **${summary.totalCompliance || 0}** compliance findings`);
+  const ratio = (summary.totalViolations && summary.totalCompliance)
+    ? `1:${Math.round(summary.totalCompliance / summary.totalViolations)}`
+    : '—';
+  lines.push(`- **Ratio:** ${ratio}`);
+  lines.push('');
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Add a "Report" copy button that generates a comprehensive markdown report from evaluation data and copies it to clipboard. Two entry points:

- **Overview page** — in the accumulated evaluation panel, copies all-dimensions summary with critical/major violations
- **Dimension detail page** — next to "Full fix plan", copies single-dimension report with principle scores, all violations, and compliance summary

### How it works
- Click "Report" → markdown copied to clipboard → "Copied!" feedback
- Same UX as "Fix plan" button — no new UI patterns
- Pure frontend — no backend changes, uses existing data from React state

### Report contents
- **Overview**: project name, overall score, dimensions table, top offending files, critical+major violations, summary stats
- **Dimension**: dimension score, principle scores table, all violations by severity with file/line/reason/CWE/snippet, compliance by principle

## Test plan

- [x] All 687 Python tests pass
- [x] UI builds cleanly
- [x] Overview Report button copies markdown with dimension table and top violations
- [x] Dimension Report button copies markdown with principle scores and full violation detail
- [x] Report with 0 violations shows "No violations found"