### PR TITLE
feat(ui): fade transitions and fix stale data on run switch

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -236,7 +236,7 @@ export default function App() {
         />
       ) : null}
       breadcrumb={navStack.length > 1 ? <NavBreadcrumb stack={navStack} onBack={navPop} onGoTo={navGoTo} /> : null}
-      content={<MainContent activePage={activePage} props={contentProps} />}
+      content={<div className="tab-fade" key={activeTab}><MainContent activePage={activePage} props={contentProps} /></div>}
     />
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import DimensionCard from './DimensionCard.jsx';
 import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
@@ -74,6 +74,12 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const { onNavigate, onRunSelect } = callbacks;
   const [focusedDimension, setFocusedDimension] = useState(null);
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
+  // Clear focused dimension when the active run changes to avoid showing stale data
+  const prevRunRef = useRef(selectedRunId);
+  if (prevRunRef.current !== selectedRunId) {
+    prevRunRef.current = selectedRunId;
+    if (focusedDimension) setFocusedDimension(null);
+  }
   // Merge rescored grades into accumulated dimensions so all cards reflect live scores
   const accumulatedDimensions = useMemo(() => {
     const dims = accumulated?.dimensions || [];
@@ -92,10 +98,12 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     return <section className="empty-state"><h2>No analyzed projects yet</h2><p>Run an evaluation to get started.</p></section>;
   }
 
+  const isLoading = loading && !dashboard;
+
   return (
-    <div className="dashboard-page">
+    <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}`}>
       {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
-      {loading && !dashboard && <LoadingScreen />}
+      {isLoading && <LoadingScreen />}
       {dashboard && (
         <DashboardContent
           runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import DimensionViolationsRow from './DimensionViolationsRow.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
@@ -207,19 +208,25 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, onDimension
     return new Set(violations.map((v) => v.principle).filter(Boolean)).size;
   }, [dashboard]);
 
-  if (!dashboard) return <p className="empty-state">Loading run data...</p>;
+  const isLoading = !dashboard || !dashboard.dimensions;
 
   return (
-    <>
-      <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} stats={{ runSummary, runScoreDelta, runTopFiles, runUniquePrinciples }} />
-      <div className="dimensions-header">
-        <h3 className="dimensions-title">Dimensions Analyzed</h3>
-      </div>
-      <div className="dimensions-panel">
-        <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} />
-      </div>
-      <ViolationsByDimension dimensionsWithViolations={dimensionsWithViolations} onDimensionClick={onDimensionClick} selectedRunId={selectedRunId} />
-      <RunFileViolations runTopFiles={runTopFiles} onFileClick={onFileClick} />
-    </>
+    <div className={`run-overview-fade ${isLoading ? 'run-overview-loading' : 'run-overview-ready'}`}>
+      {isLoading ? (
+        <div className="run-overview-spinner"><LoadingScreen /></div>
+      ) : (
+        <>
+          <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} stats={{ runSummary, runScoreDelta, runTopFiles, runUniquePrinciples }} />
+          <div className="dimensions-header">
+            <h3 className="dimensions-title">Dimensions Analyzed</h3>
+          </div>
+          <div className="dimensions-panel">
+            <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} />
+          </div>
+          <ViolationsByDimension dimensionsWithViolations={dimensionsWithViolations} onDimensionClick={onDimensionClick} selectedRunId={selectedRunId} />
+          <RunFileViolations runTopFiles={runTopFiles} onFileClick={onFileClick} />
+        </>
+      )}
+    </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -124,15 +124,21 @@ export function useDashboard({ selectedProject, selectedRun }) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [rescoreLookup, setRescoreLookup] = useState({});
 
-  // Clear stale data immediately when project changes to prevent rendering old data for a new project
+  // Clear stale data immediately when project or run changes to prevent rendering old data
   const prevProjectRef = useRef(selectedProject);
+  const prevRunRef = useRef(selectedRun);
   if (prevProjectRef.current !== selectedProject) {
     prevProjectRef.current = selectedProject;
+    prevRunRef.current = selectedRun;
     setDashboard(null);
     setAccumulated(null);
     setLatestAccumulated(null);
     setRescoreLookup({});
     setError(null);
+  } else if (prevRunRef.current !== selectedRun) {
+    prevRunRef.current = selectedRun;
+    // Clear run-specific data but preserve trend so history page doesn't flash empty
+    setDashboard((prev) => prev ? { trend: prev.trend } : null);
   }
 
   useEffect(() => fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError), [selectedProject, selectedRun, refreshKey]);

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -11,6 +11,7 @@ import { useProjectActions } from './useProjectActions.js';
 import { useVisibleRuns } from './useVisibleRuns.js';
 
 export const KNOWN_TABS = ['overview', 'violations', 'history', 'projects', 'evaluate', 'standards', 'settings'];
+export const PROJECT_TABS = KNOWN_TABS.slice(0, 3);
 
 function computeDerivedState(accumulated, dashboard, selectedProject, projects) {
   const accDims = accumulated?.dimensions || [];
@@ -93,8 +94,8 @@ export function useAppState() {
     : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab
     : activePage.page === 'history-run' ? 'history'
     : 'overview';
-  const showProjectHeader = ['overview'].includes(activeTab) && projects.length > 0 && !!selectedProject;
-  const showRunNav = showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
+  const showProjectHeader = PROJECT_TABS.includes(activeTab) && projects.length > 0 && !!selectedProject;
+  const showRunNav = activeTab === 'overview' && showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
 
   return {
     serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1585,7 +1585,7 @@ textarea:focus {
   justify-content: center;
   z-index: 50;
   pointer-events: none;
-  animation: loading-fadein 300ms ease;
+  animation: loading-fadein 500ms ease;
 }
 
 .loading-logo {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -1,3 +1,67 @@
+/* ── Tab fade transition ─────────────────────────────── */
+
+.tab-fade {
+  animation: tab-fadein 300ms ease;
+}
+
+@keyframes tab-fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── Dashboard fade transitions ──────────────────────── */
+
+.dashboard-fade {
+  transition: opacity 250ms ease;
+}
+
+.dashboard-loading {
+  opacity: 0.4;
+}
+
+.dashboard-ready {
+  animation: dashboard-fadein 400ms ease;
+}
+
+@keyframes dashboard-fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── Run overview transitions ─────────────────────────── */
+
+.run-overview-fade {
+  transition: opacity 250ms ease;
+}
+
+.run-overview-loading {
+  opacity: 0.4;
+}
+
+.run-overview-ready {
+  animation: run-overview-fadein 300ms ease;
+}
+
+.run-overview-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
+.run-overview-spinner .loading-screen {
+  position: static;
+  inset: auto;
+  z-index: auto;
+  width: auto;
+  height: auto;
+}
+
+@keyframes run-overview-fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 /* ── Stat cards ───────────────────────────────────────── */
 
 .acc-eval-panel {


### PR DESCRIPTION
## Summary
- Add smooth fade-in/out transitions when switching between tabs
- Add fade transition from loading screen to dashboard content on initial load
- Add fade transition when switching runs in history (prevents stale number flash)
- Fix stale data briefly rendering when clicking history rows by clearing run-specific dashboard state while preserving trend data
- Show project header (title + metadata) on Violations and History tabs

## Test plan
- [x] Switch between tabs — each should fade in smoothly
- [x] Start app with `uv run quodeq dashboard --dev` — loading logo fades, then content fades in
- [x] Click a history row — should show loading spinner, then fade in the run data (no stale numbers)
- [x] Navigate back from history-run to history — no "No evaluations yet" flash
- [x] Violations and History tabs show project title header