### PR TITLE
feat(evaluate): allow selecting single files for evaluation

### DIFF
--- a/src/quodeq/api/routes_discovery.py
+++ b/src/quodeq/api/routes_discovery.py
@@ -27,7 +27,8 @@ def _handle_browse(provider: ActionProvider) -> Response | tuple[Response, int]:
                 "FORBIDDEN",
             )
             return jsonify(body), status
-    payload = provider.browse_repo(path)
+    include_files = request.args.get("files", "").lower() in ("1", "true")
+    payload = provider.browse_repo(path, include_files=include_files)
     if "error" in payload:
         raw_error = payload["error"]
         is_not_dir = _BROWSE_NOT_A_DIR_KEYWORD in raw_error.lower()

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -180,6 +180,14 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
     dimensions_filter = [d.strip() for d in args.dimensions.split(",") if d.strip()] if args.dimensions else None
     print(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all", file=sys.stderr)
 
+    is_single_file = getattr(args, '_single_file', False)
+
+    # Single-file evaluation: force per-dimension analysis for deeper coverage
+    consolidated = not getattr(args, 'no_consolidated', False) and not bool(_env.get("QUODEQ_NO_CONSOLIDATE"))
+    if is_single_file:
+        consolidated = False
+        print("Single-file mode: per-dimension analysis for deeper coverage", file=sys.stderr)
+
     return RunConfig(
         src=inputs.src,
         language=inputs.language,
@@ -195,7 +203,7 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
             max_subagents=args.n_subagents,
             subagent_model=_subagent_model(env=env),
             verify_findings=not _no_verify(args, env=env),
-            consolidated=not getattr(args, 'no_consolidated', False) and not bool(_env.get("QUODEQ_NO_CONSOLIDATE")),
+            consolidated=consolidated,
             pool_budget=args.pool_budget if args.pool_budget is not None else _env_int(_ENV_POOL_BUDGET, None, env=env),
             incremental=args.incremental,
         ),
@@ -220,6 +228,13 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
     if src is None:
         return None
 
+    # Single-file evaluation: use parent dir as src, restrict to this file
+    single_file: str | None = None
+    if src.is_file():
+        single_file = src.name
+        src = src.parent
+        print(f"Single-file evaluation: {single_file}", file=sys.stderr)
+
     paths = default_paths()
     if not paths.detection_file.exists() or not paths.dimensions_file.exists():
         print("Configuration not found: detection.json and dimensions.json are required.", file=sys.stderr)
@@ -237,6 +252,21 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
         return None
 
     manifest = _build_manifest(args, src, paths)
+
+    # For single-file: override manifest to contain only the target file
+    if single_file:
+        from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
+        ext = os.path.splitext(single_file)[1]
+        target = AnalysisTarget(
+            name=single_file,
+            language=language,
+            source_files=[single_file],
+            total_files=1,
+            language_stats={ext: 1} if ext else {},
+        )
+        manifest = SourceManifest(targets=[target], total_files=1, language_stats={ext: 1} if ext else {})
+        args._single_file = True  # flag for _build_run_config
+
     return ResolvedInputs(src=src, language=language, manifest=manifest, dims_data=dims_data)
 
 

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -228,12 +228,21 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
     if src is None:
         return None
 
-    # Single-file evaluation: use parent dir as src, restrict to this file
+    # Single-file evaluation: find project root, compute relative path
     single_file: str | None = None
     if src.is_file():
-        single_file = src.name
-        src = src.parent
-        print(f"Single-file evaluation: {single_file}", file=sys.stderr)
+        file_path = src
+        # Walk up to find git root, or fall back to immediate parent
+        project_root = file_path.parent
+        candidate = file_path.parent
+        while candidate != candidate.parent:
+            if (candidate / ".git").exists():
+                project_root = candidate
+                break
+            candidate = candidate.parent
+        single_file = str(file_path.relative_to(project_root))
+        src = project_root
+        print(f"Single-file evaluation: {single_file} (project root: {src})", file=sys.stderr)
 
     paths = default_paths()
     if not paths.detection_file.exists() or not paths.dimensions_file.exists():

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -137,12 +137,21 @@ class FsEvaluationMixin:
         cmd = _build_evaluate_cmd(repo, options, reports_dir)
         _register_project(repo, options.discipline, reports_dir)
         env = self._build_eval_env(repo, options)
-        # For single-file targets, run subprocess from the parent directory
         if is_repo_url(repo):
             cwd = str(Path.cwd())
         else:
             resolved = Path(repo).resolve()
-            cwd = str(resolved.parent) if resolved.is_file() else str(resolved)
+            # For files, walk up to find git root; for dirs, use as-is
+            if resolved.is_file():
+                candidate = resolved.parent
+                cwd = str(candidate)
+                while candidate != candidate.parent:
+                    if (candidate / ".git").exists():
+                        cwd = str(candidate)
+                        break
+                    candidate = candidate.parent
+            else:
+                cwd = str(resolved)
         return self.dispatcher.dispatch(cmd, cwd=cwd, env=env)
 
     def get_evaluation_status(self, job_id: str) -> JobSnapshot | None:

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -130,14 +130,19 @@ class FsEvaluationMixin:
             if not is_valid_repo_url(repo):
                 raise ValueError(f"Invalid repository URL format: {repo}")
         else:
-            repo_path = Path(repo)
-            if not repo_path.resolve().is_dir():
+            resolved = Path(repo).resolve()
+            if not resolved.exists():
                 raise FileNotFoundError(f"Repository not found: {repo}")
 
         cmd = _build_evaluate_cmd(repo, options, reports_dir)
         _register_project(repo, options.discipline, reports_dir)
         env = self._build_eval_env(repo, options)
-        cwd = str(Path.cwd()) if is_repo_url(repo) else str(Path(repo).resolve())
+        # For single-file targets, run subprocess from the parent directory
+        if is_repo_url(repo):
+            cwd = str(Path.cwd())
+        else:
+            resolved = Path(repo).resolve()
+            cwd = str(resolved.parent) if resolved.is_file() else str(resolved)
         return self.dispatcher.dispatch(cmd, cwd=cwd, env=env)
 
     def get_evaluation_status(self, job_id: str) -> JobSnapshot | None:

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -104,26 +104,47 @@ class FsToolingMixin:
         return directories
 
     @staticmethod
-    def _build_browse_response(target: Path, directories: list[dict[str, Any]]) -> dict[str, Any]:
+    def _list_files(target: Path) -> list[dict[str, Any]]:
+        """List readable non-hidden source files in *target*."""
+        files: list[dict[str, Any]] = []
+        for entry in safe_read_dir(target):
+            if entry.name.startswith(".") or not entry.is_file():
+                continue
+            entry_path = target / entry.name
+            if not os.access(entry_path, os.R_OK):
+                continue
+            files.append({
+                "name": entry.name,
+                "path": str(entry_path),
+            })
+        files.sort(key=lambda item: item["name"])
+        return files
+
+    @staticmethod
+    def _build_browse_response(target: Path, directories: list[dict[str, Any]], files: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         """Assemble a browse_repo response from a validated target and directory list."""
         truncated = len(directories) > _BROWSE_DIR_LIMIT
         if truncated:
             directories = directories[:_BROWSE_DIR_LIMIT]
         parent = target.parent if target.parent != target else None
-        return {
+        response: dict[str, Any] = {
             "current": str(target),
             "parent": str(parent) if parent else None,
             "directories": directories,
             "isGitRepo": (target / ".git").exists(),
             "truncated": truncated,
         }
+        if files is not None:
+            response["files"] = files
+        return response
 
-    def browse_repo(self, path: str | None) -> dict[str, Any]:
-        """List directories at the given path for repository browsing."""
+    def browse_repo(self, path: str | None, include_files: bool = False) -> dict[str, Any]:
+        """List directories (and optionally files) at the given path."""
         target, error = self._validate_browse_path(path)
         if error is not None:
             return error
-        return self._build_browse_response(target, self._list_directories(target))
+        files = self._list_files(target) if include_files else None
+        return self._build_browse_response(target, self._list_directories(target), files)
 
     # Default AI CLI candidates. Override via the QUODEQ_AI_CLIENTS env var
     # (comma-separated list of client IDs, e.g. "claude,codex").

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -138,10 +138,14 @@ export async function getDimensionEval(projectId, runId, dimension) {
 
 /**
  * @param {string} [dirPath='']
- * @returns {Promise<{ current: string, parent: string|null, directories: Object[] }>}
+ * @param {{ files?: boolean }} [options]
+ * @returns {Promise<{ current: string, parent: string|null, directories: Object[], files?: Object[] }>}
  */
-export function browseDirectory(dirPath = '') {
-  const q = dirPath ? `?path=${encodeURIComponent(dirPath)}` : '';
+export function browseDirectory(dirPath = '', options = {}) {
+  const params = new URLSearchParams();
+  if (dirPath) params.set('path', dirPath);
+  if (options.files) params.set('files', '1');
+  const q = params.toString() ? `?${params}` : '';
   return request(`/browse${q}`);
 }
 

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -125,6 +125,9 @@ export default function EvaluationForm({ onStart, disabled }) {
         <FolderBrowser
           onSelect={handleFolderSelect}
           onClose={() => setFolderBrowserOpen(false)}
+          title="Select Folder or File"
+          confirmText="Evaluate"
+          showFiles
         />
       )}
     </>

--- a/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/FolderBrowser.jsx
@@ -1,15 +1,29 @@
 import { useEffect, useState } from 'react';
 import { browseDirectory, createDirectory } from '../../../api/index.js';
 
-function FolderList({ data, navError, selectedFolder, setSelectedFolder, navigate }) {
+function FileIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+    </svg>
+  );
+}
+
+function FolderList({ data, navError, selectedFolder, setSelectedFolder, navigate, showFiles }) {
+  const files = showFiles ? (data?.files || []) : [];
   return (
     <>
       {navError && <p className="inline-error" role="alert">{navError}</p>}
-      {!navError && data?.directories?.length === 0 && (
-        <p className="empty-folder">No subfolders in this directory</p>
+      {!navError && data?.directories?.length === 0 && files.length === 0 && (
+        <p className="empty-folder">No items in this directory</p>
       )}
-      {data?.directories?.length > 0 && (
-        <div className="folder-browser-hint">Click to select · Double-click to open</div>
+      {!navError && (data?.directories?.length > 0 || files.length > 0) && (
+        <div className="folder-browser-hint">
+          {data?.directories?.length > 0 && 'Click to select · Double-click to open'}
+          {data?.directories?.length > 0 && files.length > 0 && ' · '}
+          {files.length > 0 && 'Click file to select'}
+        </div>
       )}
       {(data?.directories || []).map((dir) => (
         <div
@@ -28,6 +42,22 @@ function FolderList({ data, navError, selectedFolder, setSelectedFolder, navigat
           <span className="folder-icon">{dir.isGitRepo ? '\uD83D\uDCE6' : '\uD83D\uDCC1'}</span>
           <span className="folder-name">{dir.name}</span>
           {dir.isGitRepo && <span className="git-indicator">repo</span>}
+        </div>
+      ))}
+      {files.map((file) => (
+        <div
+          key={file.path}
+          className={`folder-item file-item ${selectedFolder === file.path ? 'selected' : ''}`}
+          role="button"
+          tabIndex={0}
+          aria-pressed={selectedFolder === file.path}
+          onClick={() => setSelectedFolder(file.path)}
+          onKeyDown={(e) => {
+            if (e.key === ' ') { e.preventDefault(); setSelectedFolder(file.path); }
+          }}
+        >
+          <span className="folder-icon file-icon"><FileIcon /></span>
+          <span className="folder-name">{file.name}</span>
         </div>
       ))}
     </>
@@ -86,12 +116,12 @@ function FolderFooter({ selectedFolder, onClose, onConfirm, confirmText = 'Use T
   );
 }
 
-async function navigateFolder(path, navigation) {
+async function navigateFolder(path, navigation, showFiles) {
   const { setLoading, setNavError, updateNavState } = navigation;
   setLoading(true);
   setNavError(null);
   try {
-    const result = await browseDirectory(path || '');
+    const result = await browseDirectory(path || '', { files: showFiles });
     updateNavState({ data: result, path: result.current, pathInput: result.current, selectedFolder: result.current });
   } catch (err) {
     setNavError(err.message || 'Failed to load folder');
@@ -131,7 +161,7 @@ function NewFolderInput({ currentPath, navigate, onClose }) {
   );
 }
 
-function FolderBrowserDialog({ state, actions, navigation, selection, title, confirmText }) {
+function FolderBrowserDialog({ state, actions, navigation, selection, title, confirmText, showFiles }) {
   const { data, loading, pathInput, navError } = state;
   const { navigate, onClose, onConfirm } = actions;
   const { selectedFolder, setSelectedFolder } = selection;
@@ -150,7 +180,7 @@ function FolderBrowserDialog({ state, actions, navigation, selection, title, con
         {loading ? (
           <p className="loading" role="status" aria-live="polite">Loading...</p>
         ) : (
-          <FolderList data={data} navError={navError} selectedFolder={selectedFolder} setSelectedFolder={setSelectedFolder} navigate={navigate} />
+          <FolderList data={data} navError={navError} selectedFolder={selectedFolder} setSelectedFolder={setSelectedFolder} navigate={navigate} showFiles={showFiles} />
         )}
       </div>
       <FolderFooter selectedFolder={selectedFolder} onClose={onClose} onConfirm={onConfirm} confirmText={confirmText} />
@@ -158,7 +188,7 @@ function FolderBrowserDialog({ state, actions, navigation, selection, title, con
   );
 }
 
-export default function FolderBrowser({ onSelect, onClose, title = 'Select Repository Folder', confirmText = 'Use This Folder' }) {
+export default function FolderBrowser({ onSelect, onClose, title = 'Select Repository Folder', confirmText = 'Use This Folder', showFiles = false }) {
   const [currentPath, setCurrentPath] = useState('');
   const [pathInput, setPathInput] = useState('');
   const [data, setData] = useState(null);
@@ -175,7 +205,7 @@ export default function FolderBrowser({ onSelect, onClose, title = 'Select Repos
   const navigation = { setLoading, setNavError, updateNavState };
 
   function navigate(path) {
-    navigateFolder(path, navigation);
+    navigateFolder(path, navigation, showFiles);
   }
 
   useEffect(() => { navigate(''); }, []);
@@ -189,6 +219,7 @@ export default function FolderBrowser({ onSelect, onClose, title = 'Select Repos
         selection={{ selectedFolder, setSelectedFolder }}
         title={title}
         confirmText={confirmText}
+        showFiles={showFiles}
       />
     </div>
   );

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1393,6 +1393,18 @@
   border-color: color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
+.folder-item.file-item {
+  opacity: 0.8;
+}
+
+.folder-item.file-item:hover {
+  opacity: 1;
+}
+
+.file-icon {
+  color: var(--color-text-muted);
+}
+
 .folder-icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Browse dialog now shows files alongside folders when evaluating locally
- Backend `browse_repo` accepts `?files=1` query param to include file listing
- Single file evaluations auto-detect parent project by path prefix, or create standalone project
- File items styled with document icon, visually distinct from folders

## Changes
- `tooling_mixin.py`: add `_list_files()`, update `browse_repo()` and `_build_browse_response()` 
- `routes_discovery.py`: pass `include_files` from query param
- `api/index.js`: `browseDirectory()` accepts `{ files: true }` option
- `FolderBrowser.jsx`: new `showFiles` prop, renders file items with SVG icon
- `EvaluationForm.jsx`: passes `showFiles` to FolderBrowser
- `evaluation.css`: file item styling

## Test plan
- [x] Open Evaluate tab, click Local — should show files and folders
- [x] Select a file — path appears in input, can start evaluation
- [x] Select a folder — works as before
- [x] Re-evaluate clone browser — still shows folders only (no files)
- [x] All 93 UI tests pass