### PR TITLE
experimental: multi-provider support (local models + API)

### DIFF
--- a/docs/superpowers/plans/2026-04-03-multi-provider-support.md
+++ b/docs/superpowers/plans/2026-04-03-multi-provider-support.md
@@ -1,0 +1,1531 @@
+# Multi-Provider Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Quodeq model-agnostic with dual-mode execution — CLI tools and direct API via OpenAI SDK.
+
+**Architecture:** Extend the existing subprocess runner with a `type` field in provider config. Add a new API runner using the OpenAI Python SDK that produces the same JSONL evidence. Add model tier resolution (orchestrator/light/medium/high) with backward-compatible defaults.
+
+**Tech Stack:** Python, OpenAI SDK (`openai>=1.0.0`), existing Flask API, React dashboard
+
+**Spec:** `docs/superpowers/specs/2026-04-03-multi-provider-support-design.md`
+
+---
+
+### Task 1: Add `openai` dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add openai to dependencies**
+
+In `pyproject.toml`, add `openai` as an optional dependency so it's only required for API mode:
+
+```toml
+[project.optional-dependencies]
+api = [
+    "openai>=1.0.0",
+]
+```
+
+Also add it to the dev group so tests can use it:
+
+```toml
+[dependency-groups]
+dev = [
+    "pytest==9.0.2",
+    "pytest-cov==7.1.0",
+    "openai>=1.0.0",
+]
+```
+
+- [ ] **Step 2: Install the new dependency**
+
+Run: `uv sync --group dev`
+Expected: openai installed successfully
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build: add openai SDK as optional dependency for API mode"
+```
+
+---
+
+### Task 2: Extend provider config with `type` field
+
+**Files:**
+- Modify: `src/quodeq/data/config/ai_providers.json`
+- Modify: `src/quodeq/analysis/_provider_cache.py`
+- Test: `tests/analysis/test_provider_cache.py`
+
+- [ ] **Step 1: Write test for provider type parsing**
+
+```python
+# tests/analysis/test_provider_cache.py
+"""Tests for provider configuration cache and type field."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._provider_cache import _ProviderConfigCache, get_provider_configs
+
+
+class TestProviderConfigType:
+    """Provider configs must include a 'type' field (cli or api)."""
+
+    def test_builtin_providers_have_type(self):
+        configs = get_provider_configs()
+        for name, cfg in configs.items():
+            assert "type" in cfg, f"Provider '{name}' missing 'type' field"
+            assert cfg["type"] in ("cli", "api"), f"Provider '{name}' has invalid type: {cfg['type']}"
+
+    def test_claude_is_cli_type(self):
+        configs = get_provider_configs()
+        assert configs["claude"]["type"] == "cli"
+
+    def test_ollama_is_api_type(self):
+        configs = get_provider_configs()
+        assert configs["ollama"]["type"] == "api"
+        assert configs["ollama"]["api_base"] == "http://localhost:11434/v1"
+
+    def test_openrouter_is_api_type(self):
+        configs = get_provider_configs()
+        assert configs["openrouter"]["type"] == "api"
+        assert configs["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+
+    def test_custom_provider_has_env_interpolation_fields(self):
+        configs = get_provider_configs()
+        assert configs["custom"]["type"] == "api"
+        assert "${AI_MODEL}" in configs["custom"]["model"]
+
+    def test_cache_loads_from_file(self, tmp_path):
+        cfg_file = tmp_path / "providers.json"
+        cfg_file.write_text(json.dumps({
+            "test-cli": {"type": "cli", "cmd": "test", "base_args": "--print"},
+            "test-api": {"type": "api", "model": "gpt-4o", "api_base": "http://localhost:8000/v1"},
+        }))
+        cache = _ProviderConfigCache()
+        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", cfg_file):
+            result = cache.get()
+        assert result["test-cli"]["type"] == "cli"
+        assert result["test-api"]["type"] == "api"
+
+    def test_fallback_configs_have_type(self):
+        """Fallback configs used when JSON is unreadable must also have type."""
+        cache = _ProviderConfigCache()
+        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", Path("/nonexistent")):
+            result = cache.get()
+        for name, cfg in result.items():
+            assert "type" in cfg, f"Fallback provider '{name}' missing 'type'"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/analysis/test_provider_cache.py -v`
+Expected: FAIL — providers missing `type` field
+
+- [ ] **Step 3: Update ai_providers.json**
+
+Replace `src/quodeq/data/config/ai_providers.json` with:
+
+```json
+{
+  "claude": {
+    "type": "cli",
+    "cmd": "claude",
+    "base_args": "--print --output-format stream-json --verbose",
+    "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
+    "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
+    "env_remove": ["CLAUDECODE"]
+  },
+  "codex": {
+    "type": "cli",
+    "cmd": "codex",
+    "base_args": "--print --output-format stream-json --verbose",
+    "mcp_permission_args": [],
+    "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
+    "env_remove": []
+  },
+  "ollama": {
+    "type": "api",
+    "model": "llama3.1",
+    "api_base": "http://localhost:11434/v1"
+  },
+  "openrouter": {
+    "type": "api",
+    "model": "anthropic/claude-sonnet-4",
+    "api_key_env": "OPENROUTER_API_KEY"
+  },
+  "custom": {
+    "type": "api",
+    "model": "${AI_MODEL}",
+    "api_base": "${AI_API_BASE}",
+    "api_key_env": "AI_API_KEY"
+  }
+}
+```
+
+- [ ] **Step 4: Update fallback configs in _provider_cache.py**
+
+In `src/quodeq/analysis/_provider_cache.py`, update `_PROVIDER_CONFIGS_FALLBACK` to include the `type` field:
+
+```python
+_PROVIDER_CONFIGS_FALLBACK: dict[str, dict] = {
+    "claude": {
+        "type": "cli",
+        "cmd": "claude",
+        "base_args": "--print --output-format stream-json --verbose",
+        "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
+        "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
+        "env_remove": ["CLAUDECODE"],
+    },
+    "codex": {
+        "type": "cli",
+        "cmd": "codex",
+        "base_args": "--print --output-format stream-json --verbose",
+        "mcp_permission_args": [],
+        "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
+        "env_remove": [],
+    },
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_provider_cache.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/quodeq/data/config/ai_providers.json src/quodeq/analysis/_provider_cache.py tests/analysis/test_provider_cache.py
+git commit -m "feat: add provider type field and API provider entries (ollama, openrouter, custom)"
+```
+
+---
+
+### Task 3: Add model tier resolution
+
+**Files:**
+- Create: `src/quodeq/config/ai_models.py`
+- Test: `tests/config/test_ai_models.py`
+
+- [ ] **Step 1: Write tests for model tier resolution**
+
+```python
+# tests/config/test_ai_models.py
+"""Tests for model tier resolution."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.config.ai_models import get_model_for_tier, ModelTier
+
+
+class TestModelTier:
+    """Model tier enum values."""
+
+    def test_tier_values(self):
+        assert ModelTier.ORCHESTRATOR == "orchestrator"
+        assert ModelTier.LIGHT == "light"
+        assert ModelTier.MEDIUM == "medium"
+        assert ModelTier.HIGH == "high"
+
+
+class TestGetModelForTier:
+    """get_model_for_tier resolves model name from env vars with fallbacks."""
+
+    def test_ai_model_overrides_all_tiers(self):
+        env = {"AI_MODEL": "my-model"}
+        assert get_model_for_tier(ModelTier.LIGHT, env=env) == "my-model"
+        assert get_model_for_tier(ModelTier.HIGH, env=env) == "my-model"
+
+    def test_tier_specific_env_var(self):
+        env = {"QUODEQ_MODEL_MEDIUM": "sonnet", "AI_MODEL": "fallback"}
+        assert get_model_for_tier(ModelTier.MEDIUM, env=env) == "sonnet"
+
+    def test_tier_env_takes_precedence_over_ai_model(self):
+        env = {"QUODEQ_MODEL_HIGH": "opus", "AI_MODEL": "default"}
+        assert get_model_for_tier(ModelTier.HIGH, env=env) == "opus"
+
+    def test_falls_back_to_ai_model(self):
+        env = {"AI_MODEL": "my-model"}
+        assert get_model_for_tier(ModelTier.ORCHESTRATOR, env=env) == "my-model"
+
+    def test_returns_none_when_nothing_set(self):
+        assert get_model_for_tier(ModelTier.MEDIUM, env={}) is None
+
+    def test_empty_tier_var_falls_through(self):
+        env = {"QUODEQ_MODEL_LIGHT": "", "AI_MODEL": "fallback"}
+        assert get_model_for_tier(ModelTier.LIGHT, env=env) == "fallback"
+
+    def test_provider_default_used_as_last_resort(self):
+        env = {}
+        result = get_model_for_tier(ModelTier.MEDIUM, env=env, provider_default="llama3.1")
+        assert result == "llama3.1"
+
+    def test_ai_model_overrides_provider_default(self):
+        env = {"AI_MODEL": "custom-model"}
+        result = get_model_for_tier(ModelTier.MEDIUM, env=env, provider_default="llama3.1")
+        assert result == "custom-model"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/config/test_ai_models.py -v`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement model tier resolution**
+
+```python
+# src/quodeq/config/ai_models.py
+"""Model tier resolution -- maps tier names to concrete model IDs."""
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+
+
+class ModelTier(StrEnum):
+    """Analysis model tiers, from lightest to heaviest."""
+
+    ORCHESTRATOR = "orchestrator"
+    LIGHT = "light"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+_TIER_ENV_VARS: dict[ModelTier, str] = {
+    ModelTier.ORCHESTRATOR: "QUODEQ_MODEL_ORCHESTRATOR",
+    ModelTier.LIGHT: "QUODEQ_MODEL_LIGHT",
+    ModelTier.MEDIUM: "QUODEQ_MODEL_MEDIUM",
+    ModelTier.HIGH: "QUODEQ_MODEL_HIGH",
+}
+
+
+def get_model_for_tier(
+    tier: ModelTier,
+    *,
+    env: dict[str, str] | None = None,
+    provider_default: str | None = None,
+) -> str | None:
+    """Resolve the model name for a given tier.
+
+    Priority: QUODEQ_MODEL_<TIER> > AI_MODEL > provider_default > None
+    """
+    environ = env if env is not None else os.environ
+    tier_var = _TIER_ENV_VARS[tier]
+    tier_value = environ.get(tier_var, "").strip()
+    if tier_value:
+        return tier_value
+    ai_model = environ.get("AI_MODEL", "").strip()
+    if ai_model:
+        return ai_model
+    return provider_default
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/config/test_ai_models.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/config/ai_models.py tests/config/test_ai_models.py
+git commit -m "feat: add model tier resolution (orchestrator/light/medium/high)"
+```
+
+---
+
+### Task 4: Implement the API prompt assembler
+
+**Files:**
+- Create: `src/quodeq/analysis/_api_prompt.py`
+- Test: `tests/analysis/test_api_prompt.py`
+
+- [ ] **Step 1: Write tests for prompt assembly**
+
+```python
+# tests/analysis/test_api_prompt.py
+"""Tests for API runner prompt assembly."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._api_prompt import assemble_api_prompt
+
+
+@pytest.fixture()
+def src_dir(tmp_path):
+    """Create a minimal source directory with two files."""
+    (tmp_path / "main.py").write_text("def hello():\n    print('hi')\n")
+    (tmp_path / "utils.py").write_text("def add(a, b):\n    return a + b\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def standards_text():
+    return "M-MOD-1: Modules should have a single responsibility.\nS-CON-3: No hardcoded secrets."
+
+
+class TestAssembleApiPrompt:
+    """assemble_api_prompt bundles code + standards into a structured prompt."""
+
+    def test_includes_source_files(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py", src_dir / "utils.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert "main.py" in prompt
+        assert "def hello():" in prompt
+        assert "utils.py" in prompt
+        assert "def add(a, b):" in prompt
+
+    def test_includes_standards(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert "M-MOD-1" in prompt
+        assert "S-CON-3" in prompt
+
+    def test_includes_dimension(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert "security" in prompt.lower()
+
+    def test_includes_json_schema(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert '"req"' in prompt
+        assert '"severity"' in prompt
+        assert '"violation"' in prompt
+
+    def test_handles_unreadable_file_gracefully(self, src_dir, standards_text):
+        missing = src_dir / "gone.py"
+        prompt = assemble_api_prompt(
+            source_files=[missing, src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert "def hello():" in prompt
+
+    def test_returns_string(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_api_prompt.py -v`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement the prompt assembler**
+
+```python
+# src/quodeq/analysis/_api_prompt.py
+"""Prompt assembly for the direct API runner.
+
+Bundles source files, standards, and evaluation instructions into a single
+prompt that requests structured JSON output matching the JSONL evidence schema.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+_FINDING_SCHEMA = """\
+Each finding must be a JSON object with these fields:
+  Required:
+    "req": string - requirement ID (e.g. "M-MOD-1", "S-CON-3")
+    "t": string - "violation" or "compliance"
+    "file": string - file path relative to repo root
+    "line": integer - line number
+    "severity": string - "critical", "major", or "minor"
+    "w": string - short title of the finding
+    "reason": string - why this is a violation or compliance
+  Optional:
+    "end_line": integer - last line if multi-line
+    "snippet": string - code snippet
+    "scope": string - "file", "class", or "module"
+"""
+
+_SYSTEM_TEMPLATE = """\
+You are a code quality evaluator. Analyze the provided source code against \
+the given standards for the "{dimension}" dimension.
+
+Repository: {repo_name}
+
+## Standards
+
+{standards_text}
+
+## Output Format
+
+Return a JSON object with a single key "findings" containing an array of finding objects.
+
+{schema}
+
+Example:
+{{"findings": [{{"req": "M-MOD-1", "t": "violation", "file": "src/app.py", "line": 10, \
+"severity": "major", "w": "Multiple responsibilities", "reason": "Module handles both IO and logic"}}]}}
+
+If no findings, return: {{"findings": []}}
+
+## Source Files
+
+{files_block}
+
+Analyze these files for the "{dimension}" dimension only. \
+Report violations and notable compliance. Be precise with line numbers.
+"""
+
+
+def _read_file_safe(path: Path) -> str | None:
+    """Read a file, returning None on failure."""
+    try:
+        return path.read_text()
+    except (OSError, UnicodeDecodeError):
+        _log.warning("Could not read file: %s", path)
+        return None
+
+
+def _build_files_block(source_files: list[Path]) -> str:
+    """Build the source files block for the prompt."""
+    parts: list[str] = []
+    for path in source_files:
+        content = _read_file_safe(path)
+        if content is None:
+            continue
+        parts.append(f"### {path.name}\n```\n{content}\n```")
+    return "\n\n".join(parts)
+
+
+def assemble_api_prompt(
+    *,
+    source_files: list[Path],
+    standards_text: str,
+    dimension: str,
+    repo_name: str,
+) -> str:
+    """Assemble a complete evaluation prompt for the API runner."""
+    files_block = _build_files_block(source_files)
+    return _SYSTEM_TEMPLATE.format(
+        dimension=dimension,
+        repo_name=repo_name,
+        standards_text=standards_text,
+        schema=_FINDING_SCHEMA,
+        files_block=files_block,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_api_prompt.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/_api_prompt.py tests/analysis/test_api_prompt.py
+git commit -m "feat: add API prompt assembler for direct LLM evaluation"
+```
+
+---
+
+### Task 5: Implement the API runner
+
+**Files:**
+- Create: `src/quodeq/analysis/_api_runner.py`
+- Test: `tests/analysis/test_api_runner.py`
+
+- [ ] **Step 1: Write tests for the API runner**
+
+```python
+# tests/analysis/test_api_runner.py
+"""Tests for the OpenAI SDK-based API runner."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis._api_runner import run_api_analysis, ApiRunnerConfig
+
+
+@pytest.fixture()
+def mock_openai_response():
+    """Create a mock OpenAI chat completion response."""
+    mock_choice = MagicMock()
+    mock_choice.message.content = json.dumps({
+        "findings": [
+            {
+                "req": "M-MOD-1",
+                "t": "violation",
+                "file": "main.py",
+                "line": 5,
+                "severity": "major",
+                "w": "Multiple responsibilities",
+                "reason": "Module mixes IO and business logic",
+            },
+            {
+                "req": "S-CON-3",
+                "t": "compliance",
+                "file": "utils.py",
+                "line": 1,
+                "severity": "minor",
+                "w": "No hardcoded secrets",
+                "reason": "No secrets found in file",
+            },
+        ]
+    })
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.fixture()
+def api_config():
+    """Create a minimal ApiRunnerConfig."""
+    return ApiRunnerConfig(
+        model="test-model",
+        api_base="http://localhost:11434/v1",
+        api_key="test-key",
+    )
+
+
+class TestRunApiAnalysis:
+    """run_api_analysis calls OpenAI SDK and writes JSONL evidence."""
+
+    def test_writes_jsonl_findings(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        (tmp_path / "main.py").write_text("x = 1\n")
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+        assert jsonl_file.exists()
+        lines = jsonl_file.read_text().strip().split("\n")
+        assert len(lines) == 2
+        finding = json.loads(lines[0])
+        assert finding["req"] == "M-MOD-1"
+        assert finding["t"] == "violation"
+
+    def test_passes_model_and_base_url(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+            mock_openai.OpenAI.assert_called_once_with(
+                base_url="http://localhost:11434/v1",
+                api_key="test-key",
+            )
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["model"] == "test-model"
+
+    def test_handles_empty_findings(self, tmp_path, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        mock_choice = MagicMock()
+        mock_choice.message.content = json.dumps({"findings": []})
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+        assert jsonl_file.exists()
+        assert jsonl_file.read_text().strip() == ""
+
+    def test_handles_malformed_json_response(self, tmp_path, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        mock_choice = MagicMock()
+        mock_choice.message.content = "This is not JSON at all"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            with pytest.raises(ValueError, match="parse"):
+                run_api_analysis(
+                    prompt="test prompt",
+                    jsonl_file=jsonl_file,
+                    config=api_config,
+                )
+
+    def test_requests_json_response_format(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+class TestApiRunnerConfig:
+    """ApiRunnerConfig dataclass."""
+
+    def test_defaults(self):
+        cfg = ApiRunnerConfig(model="test", api_base="http://localhost/v1")
+        assert cfg.api_key == ""
+        assert cfg.temperature == 0.1
+        assert cfg.max_tokens is None
+
+    def test_custom_values(self):
+        cfg = ApiRunnerConfig(
+            model="gpt-4o",
+            api_base="https://api.openai.com/v1",
+            api_key="sk-...",
+            temperature=0.0,
+            max_tokens=4096,
+        )
+        assert cfg.temperature == 0.0
+        assert cfg.max_tokens == 4096
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_api_runner.py -v`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement the API runner**
+
+```python
+# src/quodeq/analysis/_api_runner.py
+"""OpenAI SDK-based API runner for direct LLM evaluation.
+
+Calls any OpenAI-compatible API (Ollama, OpenRouter, LM Studio, etc.)
+and writes findings as JSONL evidence -- the same format the CLI runner
+produces via MCP.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import openai
+except ImportError:
+    openai = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApiRunnerConfig:
+    """Configuration for a single API runner invocation."""
+
+    model: str
+    api_base: str
+    api_key: str = ""
+    temperature: float = 0.1
+    max_tokens: int | None = None
+
+
+def _parse_findings(raw: str) -> list[dict]:
+    """Parse the LLM response into a list of finding dicts.
+
+    Raises ValueError if the response is not valid JSON with a 'findings' key.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Could not parse LLM response as JSON: {exc}") from exc
+
+    if isinstance(data, dict) and "findings" in data:
+        findings = data["findings"]
+        if isinstance(findings, list):
+            return findings
+
+    raise ValueError(
+        "LLM response missing 'findings' array. "
+        f"Got keys: {list(data.keys()) if isinstance(data, dict) else type(data).__name__}"
+    )
+
+
+def run_api_analysis(
+    *,
+    prompt: str,
+    jsonl_file: Path,
+    config: ApiRunnerConfig,
+) -> None:
+    """Call an OpenAI-compatible API and write findings to JSONL.
+
+    Raises ImportError if the openai package is not installed.
+    Raises ValueError if the LLM response cannot be parsed.
+    """
+    if openai is None:
+        raise ImportError(
+            "The 'openai' package is required for API mode. "
+            "Install it with: pip install 'quodeq[api]'"
+        )
+
+    client = openai.OpenAI(
+        base_url=config.api_base,
+        api_key=config.api_key,
+    )
+
+    create_kwargs: dict = dict(
+        model=config.model,
+        messages=[{"role": "user", "content": prompt}],
+        response_format={"type": "json_object"},
+        temperature=config.temperature,
+    )
+    if config.max_tokens is not None:
+        create_kwargs["max_tokens"] = config.max_tokens
+
+    _log.info("Calling %s model=%s", config.api_base, config.model)
+    response = client.chat.completions.create(**create_kwargs)
+
+    raw_content = response.choices[0].message.content
+    findings = _parse_findings(raw_content)
+
+    _log.info("Received %d findings from API", len(findings))
+
+    with open(jsonl_file, "w") as fh:
+        for finding in findings:
+            fh.write(json.dumps(finding) + "\n")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_api_runner.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/_api_runner.py tests/analysis/test_api_runner.py
+git commit -m "feat: add OpenAI SDK-based API runner for direct LLM evaluation"
+```
+
+---
+
+### Task 6: Add provider type routing in the analysis dispatcher
+
+**Files:**
+- Modify: `src/quodeq/analysis/subprocess.py`
+- Test: `tests/analysis/test_runner_dispatch.py`
+
+- [ ] **Step 1: Write tests for provider type routing**
+
+```python
+# tests/analysis/test_runner_dispatch.py
+"""Tests for runner dispatch based on provider type."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis.subprocess import run_analysis
+from quodeq.analysis._config import AnalysisConfig
+
+
+class TestRunnerDispatch:
+    """run_analysis routes to CLI or API runner based on provider config type."""
+
+    def test_cli_type_uses_subprocess(self, tmp_path):
+        """Provider with type=cli should call the subprocess runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        cfg = AnalysisConfig(ai_cmd="claude")
+
+        with patch("quodeq.analysis.subprocess._run_cli_analysis") as mock_cli:
+            mock_cli.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_cli.assert_called_once()
+
+    def test_api_type_uses_api_runner(self, tmp_path):
+        """Provider with type=api should call the API runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        jsonl_file = tmp_path / "evidence.jsonl"
+        cfg = AnalysisConfig(ai_cmd="ollama", jsonl_file=jsonl_file)
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs") as mock_cfg, \
+             patch("quodeq.analysis.subprocess._run_api_analysis_bridge") as mock_api:
+            mock_cfg.return_value = {
+                "ollama": {
+                    "type": "api",
+                    "model": "llama3.1",
+                    "api_base": "http://localhost:11434/v1",
+                }
+            }
+            mock_api.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_api.assert_called_once()
+
+    def test_unknown_provider_defaults_to_cli(self, tmp_path):
+        """Unknown providers should fall back to CLI runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        cfg = AnalysisConfig(ai_cmd="unknown-tool")
+
+        with patch("quodeq.analysis.subprocess._run_cli_analysis") as mock_cli:
+            mock_cli.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_cli.assert_called_once()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_runner_dispatch.py -v`
+Expected: FAIL — `_run_cli_analysis` not found
+
+- [ ] **Step 3: Refactor subprocess.py to support dual dispatch**
+
+Replace `src/quodeq/analysis/subprocess.py` with:
+
+```python
+"""AI analysis runner -- dispatches to CLI subprocess or API runner.
+
+This module is the public entry point. Implementation is split across:
+- _config.py:      AnalysisConfig, HeartbeatCallback, dataclasses
+- _mcp_config.py:  MCP config file creation
+- _command.py:     CLI argument and environment construction
+- _process.py:     Process spawning, heartbeat, error handling
+- _api_runner.py:  OpenAI SDK-based direct API runner
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from quodeq.analysis._command import _build_ai_cmd, _build_analysis_env
+from quodeq.analysis._config import AnalysisConfig, HeartbeatCallback, _SpawnPaths
+from quodeq.analysis._process import AnalysisError, _check_process_result, _spawn_and_monitor
+from quodeq.analysis._provider_cache import get_provider_configs
+from quodeq.analysis.stream.counters import count_files_in_stream
+from quodeq.shared.utils import get_ai_cmd
+
+_log = logging.getLogger(__name__)
+
+# Re-export public API so existing imports keep working
+__all__ = [
+    "AnalysisConfig",
+    "AnalysisError",
+    "HeartbeatCallback",
+    "count_files_from_stream",
+    "run_analysis",
+    "_build_ai_cmd",
+]
+
+
+def count_files_from_stream(stream_file: Path) -> int:
+    """Public: count unique files read by the AI from the stream file."""
+    return len(count_files_in_stream(stream_file))
+
+
+def _get_provider_type(ai_cmd: str) -> str:
+    """Determine the provider type (cli or api) from the provider config."""
+    configs = get_provider_configs()
+    provider_cfg = configs.get(ai_cmd, {})
+    return provider_cfg.get("type", "cli")
+
+
+def _run_cli_analysis(
+    work_dir: Path, prompt: str, stream_file: Path, cfg: AnalysisConfig,
+) -> None:
+    """Run analysis via CLI subprocess (existing behavior)."""
+    args, mcp_config_path = _build_ai_cmd(prompt, cfg, work_dir=work_dir)
+    env = _build_analysis_env(cfg.ai_cmd or get_ai_cmd())
+    stream_err = Path(str(stream_file) + ".err")
+
+    try:
+        process, timed_out = _spawn_and_monitor(
+            args, work_dir, env, _SpawnPaths(stream_file, stream_err), cfg,
+        )
+    finally:
+        if mcp_config_path is not None:
+            mcp_config_path.unlink(missing_ok=True)
+
+    if not timed_out:
+        _check_process_result(process, stream_err)
+
+
+def _run_api_analysis_bridge(
+    work_dir: Path, prompt: str, stream_file: Path, cfg: AnalysisConfig,
+) -> None:
+    """Run analysis via direct API call (new behavior)."""
+    from quodeq.analysis._api_runner import run_api_analysis, ApiRunnerConfig
+
+    ai_cmd = cfg.ai_cmd or get_ai_cmd()
+    configs = get_provider_configs()
+    provider_cfg = configs.get(ai_cmd, {})
+
+    model = cfg.ai_model or provider_cfg.get("model", "")
+    api_base = provider_cfg.get("api_base", "")
+    api_key_env = provider_cfg.get("api_key_env", "")
+    api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+
+    if not model:
+        raise AnalysisError(f"No model configured for API provider '{ai_cmd}'")
+    if not api_base:
+        raise AnalysisError(f"No api_base configured for API provider '{ai_cmd}'")
+
+    jsonl_file = cfg.jsonl_file
+    if jsonl_file is None:
+        jsonl_file = Path(str(stream_file).replace(".stream", "_evidence.jsonl"))
+
+    run_api_analysis(
+        prompt=prompt,
+        jsonl_file=jsonl_file,
+        config=ApiRunnerConfig(
+            model=model,
+            api_base=api_base,
+            api_key=api_key,
+        ),
+    )
+
+    # Write a minimal stream file so downstream checks (is_stream_valid) pass
+    stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
+    _log.info("API analysis complete, evidence written to %s", jsonl_file)
+
+
+def run_analysis(
+    work_dir: Path, prompt: str, stream_file: Path,
+    config: AnalysisConfig | None = None,
+) -> None:
+    """Run AI analysis, dispatching to CLI or API runner based on provider type."""
+    cfg = config or AnalysisConfig()
+    ai_cmd = cfg.ai_cmd or get_ai_cmd()
+    provider_type = _get_provider_type(ai_cmd)
+
+    if provider_type == "api":
+        _run_api_analysis_bridge(work_dir, prompt, stream_file, cfg)
+    else:
+        _run_cli_analysis(work_dir, prompt, stream_file, cfg)
+```
+
+- [ ] **Step 4: Run dispatch tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_runner_dispatch.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run existing analysis tests to verify no regressions**
+
+Run: `uv run pytest tests/analysis/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/quodeq/analysis/subprocess.py tests/analysis/test_runner_dispatch.py
+git commit -m "feat: add dual dispatch — route to CLI or API runner based on provider type"
+```
+
+---
+
+### Task 7: Expand provider configuration (ai_provider.py)
+
+**Files:**
+- Modify: `src/quodeq/config/ai_provider.py`
+- Modify: `tests/config/test_config_ai_provider.py`
+
+- [ ] **Step 1: Write tests for expanded providers**
+
+Add the following test class to `tests/config/test_config_ai_provider.py`:
+
+```python
+class TestExpandedProviders:
+    """PROVIDERS dict should include API-mode providers."""
+
+    def test_ollama_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "ollama" in PROVIDERS
+
+    def test_openrouter_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "openrouter" in PROVIDERS
+
+    def test_custom_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "custom" in PROVIDERS
+
+    def test_ollama_no_api_key_required(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        api_key_var, cmd = PROVIDERS["ollama"]
+        assert api_key_var == ""
+
+    def test_openrouter_api_key_env(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        api_key_var, cmd = PROVIDERS["openrouter"]
+        assert api_key_var == "OPENROUTER_API_KEY"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/config/test_config_ai_provider.py::TestExpandedProviders -v`
+Expected: FAIL — "ollama" not in PROVIDERS
+
+- [ ] **Step 3: Expand the PROVIDERS dict**
+
+In `src/quodeq/config/ai_provider.py`, update:
+
+```python
+PROVIDERS = {
+    "claude": ("ANTHROPIC_API_KEY", "claude"),
+    "copilot": ("GITHUB_TOKEN", "copilot"),
+    "codex": ("CODEX_API_KEY", "codex"),
+    "ollama": ("", "ollama"),
+    "openrouter": ("OPENROUTER_API_KEY", "openrouter"),
+    "custom": ("AI_API_KEY", "custom"),
+}
+```
+
+Also update the error message in `configure_provider_noninteractive`:
+
+```python
+    if provider not in PROVIDERS:
+        valid = ", ".join(sorted(PROVIDERS.keys()))
+        log_error(f"Invalid provider: {provider}. Expected one of: {valid}")
+        return 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/config/test_config_ai_provider.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/config/ai_provider.py tests/config/test_config_ai_provider.py
+git commit -m "feat: expand PROVIDERS with ollama, openrouter, and custom API entries"
+```
+
+---
+
+### Task 8: Update dashboard client discovery for API providers
+
+**Files:**
+- Modify: `src/quodeq/services/tooling_mixin.py`
+- Test: `tests/services/test_tooling_api_clients.py`
+
+- [ ] **Step 1: Write tests for API provider discovery**
+
+```python
+# tests/services/test_tooling_api_clients.py
+"""Tests for API provider discovery in tooling mixin."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.services.tooling_mixin import FsToolingMixin
+
+
+class TestGetAiClientsIncludesApiProviders:
+    """get_ai_clients should include API providers alongside CLI tools."""
+
+    def test_includes_api_providers_from_config(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"},
+                "openrouter": {"type": "api", "model": "claude-sonnet-4", "api_key_env": "OPENROUTER_API_KEY"},
+                "claude": {"type": "cli", "cmd": "claude"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "ollama" in client_ids
+        assert "openrouter" in client_ids
+
+    def test_api_providers_have_type_label(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        ollama = [c for c in result["clients"] if c["id"] == "ollama"][0]
+        assert ollama["type"] == "api"
+
+    def test_cli_providers_still_require_which(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "claude": {"type": "cli", "cmd": "claude"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "claude" not in client_ids
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/services/test_tooling_api_clients.py -v`
+Expected: FAIL — `get_provider_configs` not imported in tooling_mixin
+
+- [ ] **Step 3: Update get_ai_clients to include API providers**
+
+In `src/quodeq/services/tooling_mixin.py`, add this import near the top:
+
+```python
+from quodeq.analysis._provider_cache import get_provider_configs
+```
+
+Then replace the `get_ai_clients` method:
+
+```python
+    def get_ai_clients(self, env: dict[str, str] | None = None) -> dict[str, list[dict[str, str]]]:
+        """Return available AI clients (CLI tools that are installed + API providers).
+
+        *env* overrides ``os.environ`` when provided, making the method
+        testable without environment mutation.
+        """
+        environ = env if env is not None else os.environ
+        clients: list[dict[str, str]] = []
+
+        # CLI tools: only include if installed
+        if "QUODEQ_AI_CLIENTS" in environ:
+            ids = [c.strip() for c in environ["QUODEQ_AI_CLIENTS"].split(",") if c.strip()]
+            candidates = [{"id": c, "label": c.capitalize()} for c in ids]
+        else:
+            candidates = self._CLI_CANDIDATES
+
+        for c in candidates:
+            if shutil.which(c["id"]):
+                clients.append({**c, "type": "cli"})
+
+        # API providers: always available (no CLI binary needed)
+        provider_configs = get_provider_configs()
+        for provider_id, cfg in provider_configs.items():
+            if cfg.get("type") == "api" and provider_id != "custom":
+                if not any(c["id"] == provider_id for c in clients):
+                    clients.append({
+                        "id": provider_id,
+                        "label": provider_id.capitalize(),
+                        "type": "api",
+                    })
+
+        return {"clients": clients}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/services/test_tooling_api_clients.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/services/tooling_mixin.py tests/services/test_tooling_api_clients.py
+git commit -m "feat: include API providers in client discovery for dashboard"
+```
+
+---
+
+### Task 9: Update dashboard UI for provider types
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/settings/components/ModelSection.jsx`
+
+- [ ] **Step 1: Update ClientSelector to show both CLI and API providers**
+
+In `src/quodeq/ui/src/features/settings/components/ModelSection.jsx`, replace the `ClientSelector` function:
+
+```jsx
+function ClientSelector({ aiCmd, availableClients }) {
+  const { value, onApply } = aiCmd;
+  if (availableClients === null) {
+    return (
+      <div className="settings-row settings-row--last">
+        <div className="settings-row-label">
+          <span className="settings-label">Client</span>
+          <span className="settings-description">Detecting...</span>
+        </div>
+      </div>
+    );
+  }
+
+  const cliClients = availableClients.filter((c) => c.type === 'cli' || !c.type);
+  const apiClients = availableClients.filter((c) => c.type === 'api');
+
+  return (
+    <>
+      <div className={`settings-row${!value && apiClients.length === 0 ? ' settings-row--last' : ''}`}>
+        <div className="settings-row-label">
+          <span className="settings-label">Client</span>
+          <span className="settings-description">CLI tool or API provider for analysis</span>
+        </div>
+        <div className="theme-toggle">
+          {cliClients.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={`theme-toggle-btn${value === id ? ' active' : ''}`}
+              onClick={() => onApply(id)}
+            >
+              {label}
+            </button>
+          ))}
+          {apiClients.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={`theme-toggle-btn${value === id ? ' active' : ''}`}
+              onClick={() => onApply(id)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {cliClients.length === 0 && apiClients.length === 0 && (
+        <div className="settings-row settings-row--last settings-install-guide">
+          <div className="settings-row-label">
+            <span className="settings-label">No providers detected</span>
+            <span className="settings-description">
+              Install a CLI tool or configure an API provider.
+            </span>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Build the UI**
+
+Run: `cd ui/web && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Copy built assets to static directory**
+
+Run: `cp -r ui/web/dist/* src/quodeq/static/`
+Expected: Static files updated
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/quodeq/ui/src/features/settings/components/ModelSection.jsx src/quodeq/static/
+git commit -m "feat(ui): update settings to show CLI and API providers"
+```
+
+---
+
+### Task 10: Integration test — end-to-end API runner flow
+
+**Files:**
+- Create: `tests/analysis/test_api_integration.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+# tests/analysis/test_api_integration.py
+"""Integration test: full API runner flow from provider config to JSONL evidence."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis.subprocess import run_analysis
+from quodeq.analysis._config import AnalysisConfig
+
+
+@pytest.fixture()
+def source_repo(tmp_path):
+    """Create a minimal source repo for evaluation."""
+    src = tmp_path / "repo"
+    src.mkdir()
+    (src / "main.py").write_text(
+        "import os\n"
+        "password = 'hunter2'\n"
+        "def run():\n"
+        "    os.system(password)\n"
+    )
+    return src
+
+
+class TestApiIntegration:
+    """End-to-end: run_analysis with API provider produces JSONL evidence."""
+
+    def test_full_flow(self, source_repo, tmp_path):
+        stream_file = tmp_path / "stream.json"
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        mock_findings = {
+            "findings": [
+                {
+                    "req": "S-CON-3",
+                    "t": "violation",
+                    "file": "main.py",
+                    "line": 2,
+                    "severity": "critical",
+                    "w": "Hardcoded password",
+                    "reason": "Password stored as plaintext string literal",
+                },
+            ]
+        }
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = json.dumps(mock_findings)
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs") as mock_cfg, \
+             patch("quodeq.analysis._api_runner.openai") as mock_openai:
+
+            mock_cfg.return_value = {
+                "ollama": {
+                    "type": "api",
+                    "model": "llama3.1",
+                    "api_base": "http://localhost:11434/v1",
+                }
+            }
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            cfg = AnalysisConfig(ai_cmd="ollama", jsonl_file=jsonl_file)
+            run_analysis(
+                work_dir=source_repo,
+                prompt="Evaluate this code for security issues.",
+                stream_file=stream_file,
+                config=cfg,
+            )
+
+        # Verify JSONL evidence was produced
+        assert jsonl_file.exists()
+        lines = jsonl_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+        finding = json.loads(lines[0])
+        assert finding["req"] == "S-CON-3"
+        assert finding["t"] == "violation"
+        assert finding["severity"] == "critical"
+
+        # Verify stream file was created (for downstream checks)
+        assert stream_file.exists()
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `uv run pytest tests/analysis/test_api_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest tests/ -v --timeout=60`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/analysis/test_api_integration.py
+git commit -m "test: add end-to-end integration test for API runner flow"
+```
+
+---
+
+### Task 11: Final verification and cleanup
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+Run: `uv run pytest tests/ -v --cov=quodeq --cov-report=term-missing --timeout=60`
+Expected: All PASS, coverage at or above 60%
+
+- [ ] **Step 2: Verify backward compatibility**
+
+Run: `uv run python -c "from quodeq.analysis.subprocess import run_analysis; print('Import OK')"`
+Expected: `Import OK`
+
+- [ ] **Step 3: Verify openai import is lazy**
+
+Run: `uv run python -c "from quodeq.analysis.subprocess import run_analysis; print('No openai import at module level')"`
+Expected: Works even if openai is not installed (import is lazy in `_api_runner.py`)
+
+- [ ] **Step 4: Commit any final adjustments**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup for multi-provider support (Phase 1)"
+```

--- a/docs/superpowers/specs/2026-04-03-multi-provider-support-design.md
+++ b/docs/superpowers/specs/2026-04-03-multi-provider-support-design.md
@@ -1,0 +1,280 @@
+# Multi-Provider Support Design
+
+**Date:** 2026-04-03
+**Status:** Draft
+**Goal:** Make Quodeq model-agnostic — support any CLI tool and any LLM API with minimal code changes.
+
+## Motivation
+
+Quodeq's mission is to preserve human coding standards regardless of who — or what — writes the code. To fulfill that mission, the tool cannot be locked to a single LLM provider. It must be accessible to everyone: beginners using local models, companies with existing contracts, researchers evaluating synthetic code across providers.
+
+The current architecture delegates all LLM work to a CLI tool (Claude Code, Codex) via subprocess. This design extends that approach with a second execution path for direct API access, keeping the existing pipeline intact.
+
+## Architecture: Dual-Mode Execution
+
+Two runner types share a single output contract (JSONL evidence):
+
+```
+quodeq evaluate
+  → build prompt
+  → provider type?
+      ├── CLI runner (existing) → subprocess: claude/codex/gemini/aider → stream-json + MCP
+      └── API runner (new)      → OpenAI SDK → structured JSON output
+  → both produce JSONL evidence
+  → scoring → report (unchanged)
+```
+
+### CLI Runner (existing, extended)
+
+Spawns an external CLI tool as a subprocess. The CLI tool acts as a full agent with multi-turn reasoning, file exploration, and MCP tool use. This is the "full power" path.
+
+**Currently supported:** Claude Code, Codex CLI
+**To add:** Gemini CLI, Aider, OpenCode, GitHub Copilot CLI, Pi
+
+Each CLI tool is configured in `ai_providers.json` with `"type": "cli"` and its specific args/env.
+
+### API Runner (new)
+
+Calls any OpenAI-compatible API directly using the OpenAI Python SDK. Quodeq pre-loads the source files into the prompt context and requests structured JSON output. This is the "universal" path for providers that don't have a CLI tool, including local models.
+
+**Supported via OpenAI-compatible API:** Ollama, OpenRouter, LM Studio, vLLM, Together, Groq, Mistral, DeepSeek, any OpenAI-compatible endpoint.
+
+**Why OpenAI SDK (not LiteLLM):** The OpenAI-compatible API has become the de facto standard — nearly every provider implements it. Using the OpenAI SDK directly means one small, well-maintained dependency instead of a large transitive dependency tree. LiteLLM was considered but rejected due to a recent supply chain attack (March 2026) and the principle of minimizing the trust surface.
+
+### Output Contract
+
+Both runners produce JSONL files with identical schema. Each line is a finding:
+
+**Required fields:**
+- `req` (string): Requirement ID (e.g., `"M-MOD-1"`)
+- `t` (string): `"violation"` or `"compliance"`
+- `file` (string): File path relative to repo root
+- `line` (integer): Line number
+- `severity` (string): `"critical"`, `"major"`, or `"minor"`
+- `w` (string): Short description/title
+- `reason` (string): Why this is a violation or compliance
+
+**Optional fields:** `p`, `d`, `end_line`, `scope`, `snippet`, `vt`, `context`, `refs`
+
+Both runners pass output through the existing `FindingsRouter` for enrichment (adding `schema_version`, `req_refs`, resolving dimensions). No duplication of enrichment logic.
+
+## Provider Configuration
+
+### ai_providers.json
+
+Each provider declares its `type` (`"cli"` or `"api"`) which determines the runner:
+
+```json
+{
+  "claude": {
+    "type": "cli",
+    "cmd": "claude",
+    "base_args": "--print --output-format stream-json --verbose",
+    "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
+    "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
+    "env_remove": ["CLAUDECODE"]
+  },
+  "codex": {
+    "type": "cli",
+    "cmd": "codex",
+    "base_args": "--print --output-format stream-json --verbose",
+    "mcp_permission_args": [],
+    "env_set_if_missing": {"CODEX_SANDBOX": "read-only"}
+  },
+  "gemini": {
+    "type": "cli",
+    "cmd": "gemini",
+    "base_args": "--to-be-determined",
+    "mcp_permission_args": []
+  },
+  "aider": {
+    "type": "cli",
+    "cmd": "aider",
+    "base_args": "--to-be-determined",
+    "mcp_permission_args": []
+  },
+  "ollama": {
+    "type": "api",
+    "model": "llama3.1",
+    "api_base": "http://localhost:11434/v1"
+  },
+  "openrouter": {
+    "type": "api",
+    "model": "anthropic/claude-sonnet-4",
+    "api_key_env": "OPENROUTER_API_KEY"
+  },
+  "custom": {
+    "type": "api",
+    "model": "${AI_MODEL}",
+    "api_base": "${AI_API_BASE}",
+    "api_key_env": "AI_API_KEY"
+  }
+}
+```
+
+Notes:
+- CLI providers with `"base_args": "--to-be-determined"` will be filled in as each CLI tool is integrated.
+- The `"custom"` entry is the escape hatch for power users — `${VAR}` placeholders are resolved at runtime from environment variables (same as `.quodeq.env` sourcing).
+- `api_key_env` names the environment variable holding the API key (never stored in JSON).
+
+### .quodeq.env
+
+Persistent user config, written by `quodeq configure`:
+
+```bash
+# Provider
+export AI_PROVIDER=openrouter
+export OPENROUTER_API_KEY=sk-or-...
+
+# Model tiers (optional — omit to use AI_MODEL for everything)
+export QUODEQ_MODEL_ORCHESTRATOR=claude-haiku
+export QUODEQ_MODEL_LIGHT=claude-haiku
+export QUODEQ_MODEL_MEDIUM=claude-sonnet-4
+export QUODEQ_MODEL_HIGH=claude-opus-4
+
+# Single model override (overrides all tiers)
+# export AI_MODEL=my-model
+```
+
+## Model Tiers
+
+Four roles allow cost optimization and capability matching:
+
+| Tier | Purpose | Needs |
+|------|---------|-------|
+| **Orchestrator** | Routes tasks, plans analysis | Reasoning, low cost |
+| **Light** | Quick scans, syntax checks, simple patterns | Speed, low cost |
+| **Medium** | Standard evaluation — most dimensions | Good reasoning, decent context |
+| **High** | Deep analysis — security audits, architecture | Best reasoning, large context |
+
+**Defaults and backward compatibility:**
+- If only `AI_MODEL` is set, it's used for all tiers. Zero friction.
+- Tiers are opt-in. Setting `QUODEQ_MODEL_MEDIUM` overrides only the medium tier.
+- If no tiers are configured, the provider's default model is used for everything.
+- `AI_MODEL` overrides all tiers when set (escape hatch for single-model setups).
+
+**Configuration surfaces:**
+- `quodeq configure --models` — interactive CLI wizard
+- Dashboard Settings panel — dropdown per tier
+- Environment variables — direct control for CI/CD
+
+## Configuration UX
+
+### Tier 1: Easy Mode — `quodeq configure --ai-cli`
+
+Interactive wizard for beginners:
+
+1. Show available providers grouped by type (CLI Tools / API Providers)
+2. For CLI tools: show install instructions, verify the command is available
+3. For API providers: ask for model name, endpoint URL, API key (if needed)
+4. Write to `.quodeq.env`
+
+### Tier 2: Power Mode — env vars + JSON
+
+For companies, CI/CD, researchers:
+- Set `AI_PROVIDER`, `AI_MODEL`, `AI_API_BASE` etc. as environment variables
+- Add custom providers to `ai_providers.json`
+- Override per-run: `quodeq evaluate --model my-model ./src`
+
+### Dashboard Settings
+
+The web UI Settings panel exposes:
+- Provider selection (dropdown)
+- Model tier configuration (dropdown per tier, populated from provider's available models)
+- API base URL and key fields (for API providers)
+- Save/reset buttons
+- Changes write to `.quodeq.env` via the existing API
+
+## Files Changed
+
+### Modified (small changes)
+- `ai_providers.json` — add `type` field, new provider entries
+- `ai_provider.py` — expand `PROVIDERS` dict, support new providers
+- `_provider_cache.py` — parse `type` field, updated fallbacks
+- `_command.py` — route to correct runner based on provider type
+- `subprocess.py` or `runner.py` — dispatch: CLI → existing path, API → new runner
+- `shared/defaults.json` — add model tier defaults
+- `shared/utils.py` — add model tier env var accessors
+- `services/tooling_mixin.py` — extend model fetching for non-Anthropic providers
+- Dashboard Settings component — add provider/tier dropdowns
+
+### New files
+- `analysis/_api_runner.py` — OpenAI SDK-based runner. Pre-loads code context, calls API, parses structured JSON response, writes JSONL evidence, passes through `FindingsRouter`.
+- `analysis/_api_prompt.py` — Prompt assembly for direct API mode. Bundles source files + standards + evaluation instructions into a single prompt with structured output instructions.
+- `config/ai_models.py` — Model tier resolution logic. Reads `QUODEQ_MODEL_*` env vars, falls back to `AI_MODEL`, falls back to provider default.
+
+### Unchanged
+- Scoring engine (`engine/`)
+- Report generation
+- Evidence model and parser (`core/evidence/`)
+- Standards and evaluators (`data/`)
+- MCP findings server (still used by CLI runners)
+- Dashboard (except Settings panel)
+
+## API Runner Detail
+
+### Prompt Assembly (`_api_prompt.py`)
+
+The API runner cannot explore files interactively like a CLI agent. Instead, Quodeq pre-loads the context:
+
+1. Read the source files targeted for evaluation (already known from the manifest/queue)
+2. Load the compiled standards for the dimension being evaluated
+3. Assemble into a single prompt: system instructions + standards + code + output format
+4. Request `response_format: {"type": "json_object"}` for structured output
+
+The prompt includes the JSONL schema so the model knows exactly what fields to produce.
+
+### Execution Flow (`_api_runner.py`)
+
+```python
+# Pseudocode
+client = openai.OpenAI(base_url=provider.api_base, api_key=api_key)
+response = client.chat.completions.create(
+    model=provider.model,
+    messages=[{"role": "user", "content": assembled_prompt}],
+    response_format={"type": "json_object"},
+    temperature=0.1,
+)
+findings = parse_findings(response.choices[0].message.content)
+write_jsonl(findings, jsonl_file)
+enrich_via_findings_router(jsonl_file)
+```
+
+### Limitations vs CLI Runner
+
+The API runner is inherently less capable than CLI agents:
+- No multi-turn file exploration — Quodeq must pre-load all relevant files
+- Limited by context window — very large codebases may need chunking
+- No MCP tool use — findings come from structured output, not tool calls
+- Model quality varies — smaller local models may produce lower-quality findings
+
+These are acceptable trade-offs for universality. The CLI tools remain the recommended path for comprehensive analysis.
+
+## Phasing
+
+### Phase 1: Foundation
+- Add `type` field to provider config
+- Implement API runner with OpenAI SDK
+- Add Ollama and OpenRouter as built-in API providers
+- Model tier env vars and resolution logic
+- `quodeq configure --models` wizard
+
+### Phase 2: CLI Expansion
+- Add Gemini CLI adapter (args, output parsing)
+- Add Aider adapter
+- Add OpenCode adapter
+- Normalize output format differences between CLI tools
+
+### Phase 3: Dashboard & Polish
+- Settings panel for provider + model tier selection
+- Model discovery (list available models from provider)
+- Per-evaluation model override in dashboard
+- Documentation and guides
+
+## Success Criteria
+
+- A user with only Ollama installed can run `quodeq configure`, pick Ollama, and evaluate code
+- A user with OpenRouter can evaluate with any model available on the platform
+- CLI tools (Claude Code, Codex) continue working exactly as before
+- The scoring engine produces identical report structure regardless of provider
+- `AI_MODEL` single-model setups continue working with no config changes (backward compatible)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ dependencies = [
     "flask==3.1.3",
 ]
 
+[project.optional-dependencies]
+api = [
+    "openai>=1.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/quodeq/quodeq"
 Repository = "https://github.com/quodeq/quodeq"
@@ -34,6 +39,7 @@ Issues = "https://github.com/quodeq/quodeq/issues"
 dev = [
     "pytest==9.0.2",
     "pytest-cov==7.1.0",
+    "openai>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/quodeq/analysis/_api_prompt.py
+++ b/src/quodeq/analysis/_api_prompt.py
@@ -1,0 +1,95 @@
+"""Prompt assembly for the direct API runner.
+
+Bundles source files, standards, and evaluation instructions into a single
+prompt that requests structured JSON output matching the JSONL evidence schema.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+_FINDING_SCHEMA = """\
+Each finding must be a JSON object with these fields:
+  Required:
+    "req": string - requirement ID (e.g. "M-MOD-1", "S-CON-3")
+    "t": string - "violation" or "compliance"
+    "file": string - file path relative to repo root
+    "line": integer - line number
+    "severity": string - "critical", "major", or "minor"
+    "w": string - short title of the finding
+    "reason": string - why this is a violation or compliance
+  Optional:
+    "end_line": integer - last line if multi-line
+    "snippet": string - code snippet
+    "scope": string - "file", "class", or "module"
+"""
+
+_SYSTEM_TEMPLATE = """\
+You are a code quality evaluator. Analyze the provided source code against \
+the given standards for the "{dimension}" dimension.
+
+Repository: {repo_name}
+
+## Standards
+
+{standards_text}
+
+## Output Format
+
+Return a JSON object with a single key "findings" containing an array of finding objects.
+
+{schema}
+
+Example:
+{{"findings": [{{"req": "M-MOD-1", "t": "violation", "file": "src/app.py", "line": 10, \
+"severity": "major", "w": "Multiple responsibilities", "reason": "Module handles both IO and logic"}}]}}
+
+If no findings, return: {{"findings": []}}
+
+## Source Files
+
+{files_block}
+
+Analyze these files for the "{dimension}" dimension only. \
+Report violations and notable compliance. Be precise with line numbers.
+"""
+
+
+def _read_file_safe(path: Path) -> str | None:
+    """Read a file, returning None on failure."""
+    try:
+        return path.read_text()
+    except (OSError, UnicodeDecodeError):
+        _log.warning("Could not read file: %s", path)
+        return None
+
+
+def _build_files_block(source_files: list[Path]) -> str:
+    """Build the source files block for the prompt."""
+    parts: list[str] = []
+    for path in source_files:
+        content = _read_file_safe(path)
+        if content is None:
+            continue
+        parts.append(f"### {path.name}\n```\n{content}\n```")
+    return "\n\n".join(parts)
+
+
+def assemble_api_prompt(
+    *,
+    source_files: list[Path],
+    standards_text: str,
+    dimension: str,
+    repo_name: str,
+) -> str:
+    """Assemble a complete evaluation prompt for the API runner."""
+    files_block = _build_files_block(source_files)
+    return _SYSTEM_TEMPLATE.format(
+        dimension=dimension,
+        repo_name=repo_name,
+        standards_text=standards_text,
+        schema=_FINDING_SCHEMA,
+        files_block=files_block,
+    )

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -1,0 +1,95 @@
+"""OpenAI SDK-based API runner for direct LLM evaluation.
+
+Calls any OpenAI-compatible API (Ollama, OpenRouter, LM Studio, etc.)
+and writes findings as JSONL evidence -- the same format the CLI runner
+produces via MCP.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import openai
+except ImportError:
+    openai = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApiRunnerConfig:
+    """Configuration for a single API runner invocation."""
+
+    model: str
+    api_base: str
+    api_key: str = ""
+    temperature: float = 0.1
+    max_tokens: int | None = None
+
+
+def _parse_findings(raw: str) -> list[dict]:
+    """Parse the LLM response into a list of finding dicts.
+
+    Raises ValueError if the response is not valid JSON with a 'findings' key.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Could not parse LLM response as JSON: {exc}") from exc
+
+    if isinstance(data, dict) and "findings" in data:
+        findings = data["findings"]
+        if isinstance(findings, list):
+            return findings
+
+    raise ValueError(
+        "LLM response missing 'findings' array. "
+        f"Got keys: {list(data.keys()) if isinstance(data, dict) else type(data).__name__}"
+    )
+
+
+def run_api_analysis(
+    *,
+    prompt: str,
+    jsonl_file: Path,
+    config: ApiRunnerConfig,
+) -> None:
+    """Call an OpenAI-compatible API and write findings to JSONL.
+
+    Raises ImportError if the openai package is not installed.
+    Raises ValueError if the LLM response cannot be parsed.
+    """
+    if openai is None:
+        raise ImportError(
+            "The 'openai' package is required for API mode. "
+            "Install it with: pip install 'quodeq[api]'"
+        )
+
+    client = openai.OpenAI(
+        base_url=config.api_base,
+        api_key=config.api_key,
+    )
+
+    create_kwargs: dict = dict(
+        model=config.model,
+        messages=[{"role": "user", "content": prompt}],
+        response_format={"type": "json_object"},
+        temperature=config.temperature,
+    )
+    if config.max_tokens is not None:
+        create_kwargs["max_tokens"] = config.max_tokens
+
+    _log.info("Calling %s model=%s", config.api_base, config.model)
+    response = client.chat.completions.create(**create_kwargs)
+
+    raw_content = response.choices[0].message.content
+    findings = _parse_findings(raw_content)
+
+    _log.info("Received %d findings from API", len(findings))
+
+    with open(jsonl_file, "w") as fh:
+        for finding in findings:
+            fh.write(json.dumps(finding) + "\n")

--- a/src/quodeq/analysis/_provider_cache.py
+++ b/src/quodeq/analysis/_provider_cache.py
@@ -11,11 +11,17 @@ _AI_PROVIDERS_PATH = Path(__file__).resolve().parent.parent / "data" / "config" 
 # (data/config/ai_providers.json) cannot be loaded.
 _PROVIDER_CONFIGS_FALLBACK: dict[str, dict] = {
     "claude": {
+        "type": "cli",
+        "cmd": "claude",
+        "base_args": "--print --output-format stream-json --verbose",
         "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
         "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
         "env_remove": ["CLAUDECODE"],
     },
     "codex": {
+        "type": "cli",
+        "cmd": "codex",
+        "base_args": "--print --output-format stream-json --verbose",
         "mcp_permission_args": [],
         "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
         "env_remove": [],

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -1,20 +1,26 @@
-"""AI CLI subprocess runner -- spawns the AI CLI, captures stream-json.
+"""AI analysis runner -- dispatches to CLI subprocess or API runner.
 
 This module is the public entry point. Implementation is split across:
-- _config.py:     AnalysisConfig, HeartbeatCallback, dataclasses
-- _mcp_config.py: MCP config file creation
-- _command.py:    CLI argument and environment construction
-- _process.py:    Process spawning, heartbeat, error handling
+- _config.py:      AnalysisConfig, HeartbeatCallback, dataclasses
+- _mcp_config.py:  MCP config file creation
+- _command.py:     CLI argument and environment construction
+- _process.py:     Process spawning, heartbeat, error handling
+- _api_runner.py:  OpenAI SDK-based direct API runner
 """
 from __future__ import annotations
 
+import logging
+import os
 from pathlib import Path
 
 from quodeq.analysis._command import _build_ai_cmd, _build_analysis_env
 from quodeq.analysis._config import AnalysisConfig, HeartbeatCallback, _SpawnPaths
 from quodeq.analysis._process import AnalysisError, _check_process_result, _spawn_and_monitor
+from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.shared.utils import get_ai_cmd
+
+_log = logging.getLogger(__name__)
 
 # Re-export public API so existing imports keep working
 __all__ = [
@@ -32,21 +38,82 @@ def count_files_from_stream(stream_file: Path) -> int:
     return len(count_files_in_stream(stream_file))
 
 
-def run_analysis(
-    work_dir: Path, prompt: str, stream_file: Path,
-    config: AnalysisConfig | None = None,
+def _get_provider_type(ai_cmd: str) -> str:
+    """Determine the provider type (cli or api) from the provider config."""
+    configs = get_provider_configs()
+    provider_cfg = configs.get(ai_cmd, {})
+    return provider_cfg.get("type", "cli")
+
+
+def _run_cli_analysis(
+    work_dir: Path, prompt: str, stream_file: Path, cfg: AnalysisConfig,
 ) -> None:
-    """Spawn AI CLI subprocess, capturing stream-json to *stream_file*."""
-    cfg = config or AnalysisConfig()
+    """Run analysis via CLI subprocess (existing behavior)."""
     args, mcp_config_path = _build_ai_cmd(prompt, cfg, work_dir=work_dir)
     env = _build_analysis_env(cfg.ai_cmd or get_ai_cmd())
     stream_err = Path(str(stream_file) + ".err")
 
     try:
-        process, timed_out = _spawn_and_monitor(args, work_dir, env, _SpawnPaths(stream_file, stream_err), cfg)
+        process, timed_out = _spawn_and_monitor(
+            args, work_dir, env, _SpawnPaths(stream_file, stream_err), cfg,
+        )
     finally:
         if mcp_config_path is not None:
             mcp_config_path.unlink(missing_ok=True)
 
     if not timed_out:
         _check_process_result(process, stream_err)
+
+
+def _run_api_analysis_bridge(
+    work_dir: Path, prompt: str, stream_file: Path, cfg: AnalysisConfig,
+) -> None:
+    """Run analysis via direct API call (new behavior)."""
+    from quodeq.analysis._api_runner import run_api_analysis, ApiRunnerConfig
+
+    ai_cmd = cfg.ai_cmd or get_ai_cmd()
+    configs = get_provider_configs()
+    provider_cfg = configs.get(ai_cmd, {})
+
+    model = cfg.ai_model or provider_cfg.get("model", "")
+    api_base = provider_cfg.get("api_base", "")
+    api_key_env = provider_cfg.get("api_key_env", "")
+    api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+
+    if not model:
+        raise AnalysisError(f"No model configured for API provider '{ai_cmd}'")
+    if not api_base:
+        raise AnalysisError(f"No api_base configured for API provider '{ai_cmd}'")
+
+    jsonl_file = cfg.jsonl_file
+    if jsonl_file is None:
+        jsonl_file = Path(str(stream_file).replace(".stream", "_evidence.jsonl"))
+
+    run_api_analysis(
+        prompt=prompt,
+        jsonl_file=jsonl_file,
+        config=ApiRunnerConfig(
+            model=model,
+            api_base=api_base,
+            api_key=api_key,
+        ),
+    )
+
+    # Write a minimal stream file so downstream checks (is_stream_valid) pass
+    stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
+    _log.info("API analysis complete, evidence written to %s", jsonl_file)
+
+
+def run_analysis(
+    work_dir: Path, prompt: str, stream_file: Path,
+    config: AnalysisConfig | None = None,
+) -> None:
+    """Run AI analysis, dispatching to CLI or API runner based on provider type."""
+    cfg = config or AnalysisConfig()
+    ai_cmd = cfg.ai_cmd or get_ai_cmd()
+    provider_type = _get_provider_type(ai_cmd)
+
+    if provider_type == "api":
+        _run_api_analysis_bridge(work_dir, prompt, stream_file, cfg)
+    else:
+        _run_cli_analysis(work_dir, prompt, stream_file, cfg)

--- a/src/quodeq/config/ai_models.py
+++ b/src/quodeq/config/ai_models.py
@@ -1,0 +1,43 @@
+"""Model tier resolution -- maps tier names to concrete model IDs."""
+from __future__ import annotations
+
+import os
+from enum import StrEnum
+
+
+class ModelTier(StrEnum):
+    """Analysis model tiers, from lightest to heaviest."""
+
+    ORCHESTRATOR = "orchestrator"
+    LIGHT = "light"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+_TIER_ENV_VARS: dict[ModelTier, str] = {
+    ModelTier.ORCHESTRATOR: "QUODEQ_MODEL_ORCHESTRATOR",
+    ModelTier.LIGHT: "QUODEQ_MODEL_LIGHT",
+    ModelTier.MEDIUM: "QUODEQ_MODEL_MEDIUM",
+    ModelTier.HIGH: "QUODEQ_MODEL_HIGH",
+}
+
+
+def get_model_for_tier(
+    tier: ModelTier,
+    *,
+    env: dict[str, str] | None = None,
+    provider_default: str | None = None,
+) -> str | None:
+    """Resolve the model name for a given tier.
+
+    Priority: QUODEQ_MODEL_<TIER> > AI_MODEL > provider_default > None
+    """
+    environ = env if env is not None else os.environ
+    tier_var = _TIER_ENV_VARS[tier]
+    tier_value = environ.get(tier_var, "").strip()
+    if tier_value:
+        return tier_value
+    ai_model = environ.get("AI_MODEL", "").strip()
+    if ai_model:
+        return ai_model
+    return provider_default

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -16,6 +16,9 @@ PROVIDERS = {
     "claude": ("ANTHROPIC_API_KEY", "claude"),
     "copilot": ("GITHUB_TOKEN", "copilot"),
     "codex": ("CODEX_API_KEY", "codex"),
+    "ollama": ("", "ollama"),
+    "openrouter": ("OPENROUTER_API_KEY", "openrouter"),
+    "custom": ("AI_API_KEY", "custom"),
 }
 
 
@@ -91,7 +94,8 @@ def _ensure_gitignore(paths: ConfigPaths) -> None:
 def configure_provider_noninteractive(provider: str, paths: ConfigPaths) -> int:
     """Write the chosen AI provider to the env file without interactive prompts."""
     if provider not in PROVIDERS:
-        log_error(f"Invalid provider: {provider}. Expected: claude, copilot, or codex.")
+        valid = ", ".join(sorted(PROVIDERS.keys()))
+        log_error(f"Invalid provider: {provider}. Expected one of: {valid}")
         return 1
     api_key_var, _ = PROVIDERS[provider]
     api_key_value = ""

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -1,12 +1,34 @@
 {
   "claude": {
+    "type": "cli",
+    "cmd": "claude",
+    "base_args": "--print --output-format stream-json --verbose",
     "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
     "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
     "env_remove": ["CLAUDECODE"]
   },
   "codex": {
+    "type": "cli",
+    "cmd": "codex",
+    "base_args": "--print --output-format stream-json --verbose",
     "mcp_permission_args": [],
     "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
     "env_remove": []
+  },
+  "ollama": {
+    "type": "api",
+    "model": "llama3.1",
+    "api_base": "http://localhost:11434/v1"
+  },
+  "openrouter": {
+    "type": "api",
+    "model": "anthropic/claude-sonnet-4",
+    "api_key_env": "OPENROUTER_API_KEY"
+  },
+  "custom": {
+    "type": "api",
+    "model": "${AI_MODEL}",
+    "api_base": "${AI_API_BASE}",
+    "api_key_env": "AI_API_KEY"
   }
 }

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from typing import Any, Callable
 
+from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.data.fs.report_parser import safe_read_dir
 from quodeq.shared.config_loader import get_anthropic_api_url, get_anthropic_api_version
 from quodeq.shared.utils import get_anthropic_api_key, read_json
@@ -155,18 +156,37 @@ class FsToolingMixin:
     ]
 
     def get_ai_clients(self, env: dict[str, str] | None = None) -> dict[str, list[dict[str, str]]]:
-        """Return AI CLI clients that are installed on the system.
+        """Return available AI clients (CLI tools that are installed + API providers).
 
         *env* overrides ``os.environ`` when provided, making the method
         testable without environment mutation.
         """
         environ = env if env is not None else os.environ
+        clients: list[dict[str, str]] = []
+
+        # CLI tools: only include if installed
         if "QUODEQ_AI_CLIENTS" in environ:
             ids = [c.strip() for c in environ["QUODEQ_AI_CLIENTS"].split(",") if c.strip()]
             candidates = [{"id": c, "label": c.capitalize()} for c in ids]
         else:
             candidates = self._CLI_CANDIDATES
-        return {"clients": [c for c in candidates if shutil.which(c["id"])]}
+
+        for c in candidates:
+            if shutil.which(c["id"]):
+                clients.append({**c, "type": "cli"})
+
+        # API providers: always available (no CLI binary needed)
+        provider_configs = get_provider_configs()
+        for provider_id, cfg in provider_configs.items():
+            if cfg.get("type") == "api" and provider_id != "custom":
+                if not any(c["id"] == provider_id for c in clients):
+                    clients.append({
+                        "id": provider_id,
+                        "label": provider_id.capitalize(),
+                        "type": "api",
+                    })
+
+        return {"clients": clients}
 
     def _get_cli_models(self, client_id: str, env: dict[str, str] | None = None) -> dict[str, list[str]]:
         if client_id not in get_allowed_client_ids(env=env):

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
@@ -11,43 +11,57 @@ export { AI_MODEL_STORAGE_KEY, AI_CMD_STORAGE_KEY };
 
 function ClientSelector({ aiCmd, availableClients }) {
   const { value, onApply } = aiCmd;
-  return (
-    <>
-      <div className={`settings-row${!value ? ' settings-row--last' : ''}`}>
+  if (availableClients === null) {
+    return (
+      <div className="settings-row settings-row--last">
         <div className="settings-row-label">
           <span className="settings-label">Client</span>
-          <span className="settings-description">CLI tool used to run the analysis</span>
+          <span className="settings-description">Detecting...</span>
         </div>
-        {availableClients === null ? (
-          <span className="settings-description">Detecting…</span>
-        ) : availableClients.filter((c) => c.id === 'claude').length > 0 ? (
-          <div className="theme-toggle">
-            {availableClients.filter((c) => c.id === 'claude').map(({ id, label }) => (
-              <button
-                key={id}
-                type="button"
-                className={`theme-toggle-btn${value === id ? ' active' : ''}`}
-                onClick={() => onApply(id)}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        ) : null}
       </div>
-      {availableClients !== null && !availableClients.some((c) => c.id === 'claude') && (
+    );
+  }
+
+  const cliClients = availableClients.filter((c) => c.type === 'cli' || !c.type);
+  const apiClients = availableClients.filter((c) => c.type === 'api');
+
+  return (
+    <>
+      <div className={`settings-row${!value && apiClients.length === 0 ? ' settings-row--last' : ''}`}>
+        <div className="settings-row-label">
+          <span className="settings-label">Client</span>
+          <span className="settings-description">CLI tool or API provider for analysis</span>
+        </div>
+        <div className="theme-toggle">
+          {cliClients.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={`theme-toggle-btn${value === id ? ' active' : ''}`}
+              onClick={() => onApply(id)}
+            >
+              {label}
+            </button>
+          ))}
+          {apiClients.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              className={`theme-toggle-btn${value === id ? ' active' : ''}`}
+              onClick={() => onApply(id)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {cliClients.length === 0 && apiClients.length === 0 && (
         <div className="settings-row settings-row--last settings-install-guide">
           <div className="settings-row-label">
-            <span className="settings-label">Claude not detected</span>
+            <span className="settings-label">No providers detected</span>
             <span className="settings-description">
-              Install Claude Code and restart Quodeq.
+              Install a CLI tool or configure an API provider.
             </span>
-          </div>
-          <div className="settings-install-options">
-            <div className="settings-install-item">
-              <span className="settings-install-name">Claude</span>
-              <code className="settings-install-cmd">npm i -g @anthropic-ai/claude-code</code>
-            </div>
           </div>
         </div>
       )}

--- a/tests/analysis/test_api_integration.py
+++ b/tests/analysis/test_api_integration.py
@@ -1,0 +1,87 @@
+"""Integration test: full API runner flow from provider config to JSONL evidence."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis.subprocess import run_analysis
+from quodeq.analysis._config import AnalysisConfig
+
+
+@pytest.fixture()
+def source_repo(tmp_path):
+    """Create a minimal source repo for evaluation."""
+    src = tmp_path / "repo"
+    src.mkdir()
+    (src / "main.py").write_text(
+        "import os\n"
+        "password = 'hunter2'\n"
+        "def run():\n"
+        "    os.system(password)\n"
+    )
+    return src
+
+
+class TestApiIntegration:
+    """End-to-end: run_analysis with API provider produces JSONL evidence."""
+
+    def test_full_flow(self, source_repo, tmp_path):
+        stream_file = tmp_path / "stream.json"
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        mock_findings = {
+            "findings": [
+                {
+                    "req": "S-CON-3",
+                    "t": "violation",
+                    "file": "main.py",
+                    "line": 2,
+                    "severity": "critical",
+                    "w": "Hardcoded password",
+                    "reason": "Password stored as plaintext string literal",
+                },
+            ]
+        }
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = json.dumps(mock_findings)
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs") as mock_cfg, \
+             patch("quodeq.analysis._api_runner.openai") as mock_openai:
+
+            mock_cfg.return_value = {
+                "ollama": {
+                    "type": "api",
+                    "model": "llama3.1",
+                    "api_base": "http://localhost:11434/v1",
+                }
+            }
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            cfg = AnalysisConfig(ai_cmd="ollama", jsonl_file=jsonl_file)
+            run_analysis(
+                work_dir=source_repo,
+                prompt="Evaluate this code for security issues.",
+                stream_file=stream_file,
+                config=cfg,
+            )
+
+        # Verify JSONL evidence was produced
+        assert jsonl_file.exists()
+        lines = jsonl_file.read_text().strip().split("\n")
+        assert len(lines) == 1
+        finding = json.loads(lines[0])
+        assert finding["req"] == "S-CON-3"
+        assert finding["t"] == "violation"
+        assert finding["severity"] == "critical"
+
+        # Verify stream file was created (for downstream checks)
+        assert stream_file.exists()

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -1,0 +1,87 @@
+"""Tests for API runner prompt assembly."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._api_prompt import assemble_api_prompt
+
+
+@pytest.fixture()
+def src_dir(tmp_path):
+    """Create a minimal source directory with two files."""
+    (tmp_path / "main.py").write_text("def hello():\n    print('hi')\n")
+    (tmp_path / "utils.py").write_text("def add(a, b):\n    return a + b\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def standards_text():
+    return "M-MOD-1: Modules should have a single responsibility.\nS-CON-3: No hardcoded secrets."
+
+
+class TestAssembleApiPrompt:
+    """assemble_api_prompt bundles code + standards into a structured prompt."""
+
+    def test_includes_source_files(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py", src_dir / "utils.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert "main.py" in prompt
+        assert "def hello():" in prompt
+        assert "utils.py" in prompt
+        assert "def add(a, b):" in prompt
+
+    def test_includes_standards(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert "M-MOD-1" in prompt
+        assert "S-CON-3" in prompt
+
+    def test_includes_dimension(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert "security" in prompt.lower()
+
+    def test_includes_json_schema(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert '"req"' in prompt
+        assert '"severity"' in prompt
+        assert '"violation"' in prompt
+
+    def test_handles_unreadable_file_gracefully(self, src_dir, standards_text):
+        missing = src_dir / "gone.py"
+        prompt = assemble_api_prompt(
+            source_files=[missing, src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert "def hello():" in prompt
+
+    def test_returns_string(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+        )
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -1,0 +1,176 @@
+"""Tests for the OpenAI SDK-based API runner."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis._api_runner import run_api_analysis, ApiRunnerConfig
+
+
+@pytest.fixture()
+def mock_openai_response():
+    """Create a mock OpenAI chat completion response."""
+    mock_choice = MagicMock()
+    mock_choice.message.content = json.dumps({
+        "findings": [
+            {
+                "req": "M-MOD-1",
+                "t": "violation",
+                "file": "main.py",
+                "line": 5,
+                "severity": "major",
+                "w": "Multiple responsibilities",
+                "reason": "Module mixes IO and business logic",
+            },
+            {
+                "req": "S-CON-3",
+                "t": "compliance",
+                "file": "utils.py",
+                "line": 1,
+                "severity": "minor",
+                "w": "No hardcoded secrets",
+                "reason": "No secrets found in file",
+            },
+        ]
+    })
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.fixture()
+def api_config():
+    """Create a minimal ApiRunnerConfig."""
+    return ApiRunnerConfig(
+        model="test-model",
+        api_base="http://localhost:11434/v1",
+        api_key="test-key",
+    )
+
+
+class TestRunApiAnalysis:
+    """run_api_analysis calls OpenAI SDK and writes JSONL evidence."""
+
+    def test_writes_jsonl_findings(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        (tmp_path / "main.py").write_text("x = 1\n")
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+        assert jsonl_file.exists()
+        lines = jsonl_file.read_text().strip().split("\n")
+        assert len(lines) == 2
+        finding = json.loads(lines[0])
+        assert finding["req"] == "M-MOD-1"
+        assert finding["t"] == "violation"
+
+    def test_passes_model_and_base_url(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+            mock_openai.OpenAI.assert_called_once_with(
+                base_url="http://localhost:11434/v1",
+                api_key="test-key",
+            )
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["model"] == "test-model"
+
+    def test_handles_empty_findings(self, tmp_path, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        mock_choice = MagicMock()
+        mock_choice.message.content = json.dumps({"findings": []})
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+        assert jsonl_file.exists()
+        assert jsonl_file.read_text().strip() == ""
+
+    def test_handles_malformed_json_response(self, tmp_path, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        mock_choice = MagicMock()
+        mock_choice.message.content = "This is not JSON at all"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            with pytest.raises(ValueError, match="parse"):
+                run_api_analysis(
+                    prompt="test prompt",
+                    jsonl_file=jsonl_file,
+                    config=api_config,
+                )
+
+    def test_requests_json_response_format(self, tmp_path, mock_openai_response, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        with patch("quodeq.analysis._api_runner.openai") as mock_openai:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_openai_response
+            mock_openai.OpenAI.return_value = mock_client
+
+            run_api_analysis(
+                prompt="test prompt",
+                jsonl_file=jsonl_file,
+                config=api_config,
+            )
+
+            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+            assert call_kwargs["response_format"] == {"type": "json_object"}
+
+
+class TestApiRunnerConfig:
+    """ApiRunnerConfig dataclass."""
+
+    def test_defaults(self):
+        cfg = ApiRunnerConfig(model="test", api_base="http://localhost/v1")
+        assert cfg.api_key == ""
+        assert cfg.temperature == 0.1
+        assert cfg.max_tokens is None
+
+    def test_custom_values(self):
+        cfg = ApiRunnerConfig(
+            model="gpt-4o",
+            api_base="https://api.openai.com/v1",
+            api_key="sk-...",
+            temperature=0.0,
+            max_tokens=4096,
+        )
+        assert cfg.temperature == 0.0
+        assert cfg.max_tokens == 4096

--- a/tests/analysis/test_provider_cache.py
+++ b/tests/analysis/test_provider_cache.py
@@ -1,0 +1,59 @@
+"""Tests for provider configuration cache and type field."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._provider_cache import _ProviderConfigCache, get_provider_configs
+
+
+class TestProviderConfigType:
+    """Provider configs must include a 'type' field (cli or api)."""
+
+    def test_builtin_providers_have_type(self):
+        configs = get_provider_configs()
+        for name, cfg in configs.items():
+            assert "type" in cfg, f"Provider '{name}' missing 'type' field"
+            assert cfg["type"] in ("cli", "api"), f"Provider '{name}' has invalid type: {cfg['type']}"
+
+    def test_claude_is_cli_type(self):
+        configs = get_provider_configs()
+        assert configs["claude"]["type"] == "cli"
+
+    def test_ollama_is_api_type(self):
+        configs = get_provider_configs()
+        assert configs["ollama"]["type"] == "api"
+        assert configs["ollama"]["api_base"] == "http://localhost:11434/v1"
+
+    def test_openrouter_is_api_type(self):
+        configs = get_provider_configs()
+        assert configs["openrouter"]["type"] == "api"
+        assert configs["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+
+    def test_custom_provider_has_env_interpolation_fields(self):
+        configs = get_provider_configs()
+        assert configs["custom"]["type"] == "api"
+        assert "${AI_MODEL}" in configs["custom"]["model"]
+
+    def test_cache_loads_from_file(self, tmp_path):
+        cfg_file = tmp_path / "providers.json"
+        cfg_file.write_text(json.dumps({
+            "test-cli": {"type": "cli", "cmd": "test", "base_args": "--print"},
+            "test-api": {"type": "api", "model": "gpt-4o", "api_base": "http://localhost:8000/v1"},
+        }))
+        cache = _ProviderConfigCache()
+        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", cfg_file):
+            result = cache.get()
+        assert result["test-cli"]["type"] == "cli"
+        assert result["test-api"]["type"] == "api"
+
+    def test_fallback_configs_have_type(self):
+        """Fallback configs used when JSON is unreadable must also have type."""
+        cache = _ProviderConfigCache()
+        with patch("quodeq.analysis._provider_cache._AI_PROVIDERS_PATH", Path("/nonexistent")):
+            result = cache.get()
+        for name, cfg in result.items():
+            assert "type" in cfg, f"Fallback provider '{name}' missing 'type'"

--- a/tests/analysis/test_runner_dispatch.py
+++ b/tests/analysis/test_runner_dispatch.py
@@ -1,0 +1,62 @@
+"""Tests for runner dispatch based on provider type."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis.subprocess import run_analysis
+from quodeq.analysis._config import AnalysisConfig
+
+
+class TestRunnerDispatch:
+    """run_analysis routes to CLI or API runner based on provider config type."""
+
+    def test_cli_type_uses_subprocess(self, tmp_path):
+        """Provider with type=cli should call the subprocess runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        cfg = AnalysisConfig(ai_cmd="claude")
+
+        with patch("quodeq.analysis.subprocess._run_cli_analysis") as mock_cli:
+            mock_cli.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_cli.assert_called_once()
+
+    def test_api_type_uses_api_runner(self, tmp_path):
+        """Provider with type=api should call the API runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        jsonl_file = tmp_path / "evidence.jsonl"
+        cfg = AnalysisConfig(ai_cmd="ollama", jsonl_file=jsonl_file)
+
+        with patch("quodeq.analysis.subprocess.get_provider_configs") as mock_cfg, \
+             patch("quodeq.analysis.subprocess._run_api_analysis_bridge") as mock_api:
+            mock_cfg.return_value = {
+                "ollama": {
+                    "type": "api",
+                    "model": "llama3.1",
+                    "api_base": "http://localhost:11434/v1",
+                }
+            }
+            mock_api.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_api.assert_called_once()
+
+    def test_unknown_provider_defaults_to_cli(self, tmp_path):
+        """Unknown providers should fall back to CLI runner."""
+        stream_file = tmp_path / "stream.json"
+        stream_file.touch()
+        cfg = AnalysisConfig(ai_cmd="unknown-tool")
+
+        with patch("quodeq.analysis.subprocess._run_cli_analysis") as mock_cli:
+            mock_cli.return_value = None
+            run_analysis(
+                work_dir=tmp_path, prompt="test", stream_file=stream_file, config=cfg,
+            )
+            mock_cli.assert_called_once()

--- a/tests/config/test_ai_models.py
+++ b/tests/config/test_ai_models.py
@@ -1,0 +1,54 @@
+"""Tests for model tier resolution."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.config.ai_models import get_model_for_tier, ModelTier
+
+
+class TestModelTier:
+    """Model tier enum values."""
+
+    def test_tier_values(self):
+        assert ModelTier.ORCHESTRATOR == "orchestrator"
+        assert ModelTier.LIGHT == "light"
+        assert ModelTier.MEDIUM == "medium"
+        assert ModelTier.HIGH == "high"
+
+
+class TestGetModelForTier:
+    """get_model_for_tier resolves model name from env vars with fallbacks."""
+
+    def test_ai_model_overrides_all_tiers(self):
+        env = {"AI_MODEL": "my-model"}
+        assert get_model_for_tier(ModelTier.LIGHT, env=env) == "my-model"
+        assert get_model_for_tier(ModelTier.HIGH, env=env) == "my-model"
+
+    def test_tier_specific_env_var(self):
+        env = {"QUODEQ_MODEL_MEDIUM": "sonnet", "AI_MODEL": "fallback"}
+        assert get_model_for_tier(ModelTier.MEDIUM, env=env) == "sonnet"
+
+    def test_tier_env_takes_precedence_over_ai_model(self):
+        env = {"QUODEQ_MODEL_HIGH": "opus", "AI_MODEL": "default"}
+        assert get_model_for_tier(ModelTier.HIGH, env=env) == "opus"
+
+    def test_falls_back_to_ai_model(self):
+        env = {"AI_MODEL": "my-model"}
+        assert get_model_for_tier(ModelTier.ORCHESTRATOR, env=env) == "my-model"
+
+    def test_returns_none_when_nothing_set(self):
+        assert get_model_for_tier(ModelTier.MEDIUM, env={}) is None
+
+    def test_empty_tier_var_falls_through(self):
+        env = {"QUODEQ_MODEL_LIGHT": "", "AI_MODEL": "fallback"}
+        assert get_model_for_tier(ModelTier.LIGHT, env=env) == "fallback"
+
+    def test_provider_default_used_as_last_resort(self):
+        env = {}
+        result = get_model_for_tier(ModelTier.MEDIUM, env=env, provider_default="llama3.1")
+        assert result == "llama3.1"
+
+    def test_ai_model_overrides_provider_default(self):
+        env = {"AI_MODEL": "custom-model"}
+        result = get_model_for_tier(ModelTier.MEDIUM, env=env, provider_default="llama3.1")
+        assert result == "custom-model"

--- a/tests/config/test_config_ai_provider.py
+++ b/tests/config/test_config_ai_provider.py
@@ -30,3 +30,29 @@ def test_configure_unknown_provider(tmp_path):
     paths = ConfigPaths.from_root(tmp_path)
     exit_code = configure_provider_noninteractive("nonexistent_provider", paths)
     assert exit_code != 0
+
+
+class TestExpandedProviders:
+    """PROVIDERS dict should include API-mode providers."""
+
+    def test_ollama_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "ollama" in PROVIDERS
+
+    def test_openrouter_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "openrouter" in PROVIDERS
+
+    def test_custom_in_providers(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        assert "custom" in PROVIDERS
+
+    def test_ollama_no_api_key_required(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        api_key_var, cmd = PROVIDERS["ollama"]
+        assert api_key_var == ""
+
+    def test_openrouter_api_key_env(self):
+        from quodeq.config.ai_provider import PROVIDERS
+        api_key_var, cmd = PROVIDERS["openrouter"]
+        assert api_key_var == "OPENROUTER_API_KEY"

--- a/tests/services/test_tooling_api_clients.py
+++ b/tests/services/test_tooling_api_clients.py
@@ -1,0 +1,48 @@
+"""Tests for API provider discovery in tooling mixin."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.services.tooling_mixin import FsToolingMixin
+
+
+class TestGetAiClientsIncludesApiProviders:
+    """get_ai_clients should include API providers alongside CLI tools."""
+
+    def test_includes_api_providers_from_config(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"},
+                "openrouter": {"type": "api", "model": "claude-sonnet-4", "api_key_env": "OPENROUTER_API_KEY"},
+                "claude": {"type": "cli", "cmd": "claude"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "ollama" in client_ids
+        assert "openrouter" in client_ids
+
+    def test_api_providers_have_type_label(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "ollama": {"type": "api", "model": "llama3.1", "api_base": "http://localhost:11434/v1"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        ollama = [c for c in result["clients"] if c["id"] == "ollama"][0]
+        assert ollama["type"] == "api"
+
+    def test_cli_providers_still_require_which(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "claude": {"type": "cli", "cmd": "claude"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "claude" not in client_ids

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,28 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -18,6 +40,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -126,6 +157,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -140,6 +180,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
 ]
 
 [[package]]
@@ -170,6 +256,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -263,6 +417,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -278,6 +451,92 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
 ]
 
 [[package]]
@@ -321,15 +580,21 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },
     { name = "jsonschema" },
 ]
 
+[package.optional-dependencies]
+api = [
+    { name = "openai" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "openai" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
@@ -338,10 +603,13 @@ dev = [
 requires-dist = [
     { name = "flask", specifier = "==3.1.3" },
     { name = "jsonschema", specifier = "==4.26.0" },
+    { name = "openai", marker = "extra == 'api'", specifier = ">=1.0.0" },
 ]
+provides-extras = ["api"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "pytest", specifier = "==9.0.2" },
     { name = "pytest-cov", specifier = "==7.1.0" },
 ]
@@ -442,12 +710,45 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add dual-mode execution: CLI tools (existing) + direct API via OpenAI SDK (new)
- Support Ollama, OpenRouter, and any OpenAI-compatible endpoint as API providers
- Add model tier resolution (orchestrator/light/medium/high) with backward-compatible defaults
- Update dashboard to show both CLI tools and API providers in settings
- OpenAI SDK is an optional dependency (`pip install quodeq[api]`)

**Fully backward compatible** — existing `AI_PROVIDER=claude` and `AI_MODEL` workflows are unchanged. 728 tests passing, zero regressions.

## What's included

| Area | Change |
|------|--------|
| Provider config | `type` field in `ai_providers.json` (cli vs api), new entries for ollama, openrouter, custom |
| API runner | `_api_runner.py` using OpenAI SDK, `_api_prompt.py` for prompt assembly |
| Dispatch | `subprocess.py` routes to CLI or API runner based on provider type |
| Model tiers | `ai_models.py` with `QUODEQ_MODEL_ORCHESTRATOR/LIGHT/MEDIUM/HIGH` env vars |
| Dashboard | Settings shows both CLI and API providers |
| Tests | 40+ new tests including end-to-end integration |

## What's NOT included (Phase 2)

- Tier routing into evaluation pipeline (which dimension uses which model)
- CLI adapters for Gemini, Aider, OpenCode
- `quodeq configure --models` CLI wizard
- Dashboard model discovery for non-Anthropic providers

## Test plan

- [x] 728 tests passing (full suite)
- [x] Backward compatibility verified (default claude path unchanged)
- [x] Lazy openai import (works without openai installed)
- [x] End-to-end integration test (mocked API → JSONL evidence)
- [x] Manual test with Ollama local model

**Spec:** `docs/superpowers/specs/2026-04-03-multi-provider-support-design.md`
**Plan:** `docs/superpowers/plans/2026-04-03-multi-provider-support.md`