### PR TITLE
fix: refresh violations/map tabs after evaluation

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -70,7 +70,7 @@ function EvaluateHeader({ isRunning, analysisPower, onAnalysisPowerChange, onPer
           <p className="evaluate-subtitle">Run a comprehensive code quality evaluation on any repository</p>
         </div>
       </div>
-      <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} />
+      <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} labelPosition="left" />
     </header>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/PowerSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/PowerSelector.jsx
@@ -3,7 +3,7 @@ import { LEVELS, STORAGE_KEY } from './powerLevels.js';
 
 const DEFAULT_POWER_LEVEL = 2;
 
-export default function PowerSelector({ value, onChange, onPersist }) {
+export default function PowerSelector({ value, onChange, onPersist, labelPosition = 'right' }) {
   const [hover, setHover] = useState(null);
 
   const active = value ?? DEFAULT_POWER_LEVEL;
@@ -15,21 +15,25 @@ export default function PowerSelector({ value, onChange, onPersist }) {
     if (onPersist) onPersist(level);
   }
 
+  const label = <span className="power-label">{currentLevel?.label}</span>;
+  const bars = (
+    <div className="power-bars" onMouseLeave={() => setHover(null)}>
+      {LEVELS.map(({ level }) => (
+        <button
+          key={level}
+          type="button"
+          className={`power-bar power-bar--${level}${level <= display ? ' active' : ''}`}
+          onClick={() => handleClick(level)}
+          onMouseEnter={() => setHover(level)}
+          aria-label={`Power level ${level}`}
+        />
+      ))}
+    </div>
+  );
+
   return (
     <div className="power-selector" title={`Analysis power: ${currentLevel?.label}`}>
-      <div className="power-bars" onMouseLeave={() => setHover(null)}>
-        {LEVELS.map(({ level }) => (
-          <button
-            key={level}
-            type="button"
-            className={`power-bar power-bar--${level}${level <= display ? ' active' : ''}`}
-            onClick={() => handleClick(level)}
-            onMouseEnter={() => setHover(level)}
-            aria-label={`Power level ${level}`}
-          />
-        ))}
-      </div>
-      <span className="power-label">{currentLevel?.label}</span>
+      {labelPosition === 'left' ? <>{label}{bars}</> : <>{bars}{label}</>}
     </div>
   );
 }

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { buildDailyRuns } from '../utils/dailyGrouping.js';
 import { useServerHealth } from './useServerHealth.js';
@@ -90,6 +90,18 @@ export function useAppState() {
   const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
+
+  // Refresh all dashboard data (including latestAccumulated) when an evaluation finishes
+  const evalRefreshedRef = useRef(null);
+  useEffect(() => {
+    const job = evalLifecycle.job;
+    const finished = job && job.status !== 'running' && job.outputRunId;
+    if (finished && evalRefreshedRef.current !== job.outputRunId) {
+      evalRefreshedRef.current = job.outputRunId;
+      refreshDashboard();
+    }
+  }, [evalLifecycle.job, refreshDashboard]);
+
   const activeTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
     : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab
     : activePage.page === 'history-run' ? 'history'


### PR DESCRIPTION
## Summary
- Violations and map tabs were not updating after an evaluation completed — only the overview tab refreshed
- Root cause: `latestAccumulated` (used by violations/map) only re-fetched when `selectedProject` changed, not when new evaluation data arrived
- Fix: call `refreshDashboard()` from `useAppState` when the evaluation lifecycle detects a completed run, triggering a re-fetch of all dashboard data including `latestAccumulated`

## Test plan
- [x] Run an evaluation and verify violations tab shows updated data without page refresh
- [x] Run an evaluation and verify map tab shows updated data without page refresh
- [x] Verify overview tab still updates correctly
- [x] Verify changing runs in overview still works independently