### PR TITLE
fix: refresh tabs on click, restore map on back, UI tweaks

### DIFF
--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-Corlm9gE.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D-YSjW6y.css">
+    <script type="module" crossorigin src="/assets/index-CGtTCKIe.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C2UHAto_.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -121,7 +121,7 @@ const ROUTE_RENDERERS = {
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
     const isDirectNav = props.navigation.navStackLength === 1;
-    return <MapPage data={{ accumulated: acc, dashboard: props.dashboardData.dashboard }} callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard }} isDirectNav={isDirectNav} />;
+    return <MapPage data={{ accumulated: acc, dashboard: props.dashboardData.dashboard }} callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard }} isDirectNav={isDirectNav} tabKey={params._tabKey || 0} />;
   },
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   history: (params, props) => {

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -115,6 +115,7 @@ const ROUTE_RENDERERS = {
           onRefresh: props.refreshDashboard,
         }}
         isDirectNav={props.navigation.navStackLength === 1}
+        tabKey={params._tabKey || 0}
       />
     );
   },

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -114,12 +114,14 @@ const ROUTE_RENDERERS = {
           onPrincipleClick: (principleObj) => nav('principle', { principle: principleObj, sourceTab: 'violations' }),
           onRefresh: props.refreshDashboard,
         }}
+        isDirectNav={props.navigation.navStackLength === 1}
       />
     );
   },
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
-    return <MapPage data={{ accumulated: acc, dashboard: props.dashboardData.dashboard }} callbacks={{ onNavigate: props.navigation.handleNavigate }} />;
+    const isDirectNav = props.navigation.navStackLength === 1;
+    return <MapPage data={{ accumulated: acc, dashboard: props.dashboardData.dashboard }} callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard }} isDirectNav={isDirectNav} />;
   },
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   history: (params, props) => {
@@ -213,7 +215,7 @@ export default function App() {
     navigation: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
       handleNavigate: state.handleNavigate, handleRunSelect: state.handleRunSelect,
-      handleProjectChange: state.handleProjectChange, navTab,
+      handleProjectChange: state.handleProjectChange, navTab, navStackLength: navStack.length,
       handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject,
       historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
       currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -70,7 +70,7 @@ function EvaluateHeader({ isRunning, analysisPower, onAnalysisPowerChange, onPer
           <p className="evaluate-subtitle">Run a comprehensive code quality evaluation on any repository</p>
         </div>
       </div>
-      <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} />
+      <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} labelPosition="left" />
     </header>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/PowerSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/PowerSelector.jsx
@@ -3,7 +3,7 @@ import { LEVELS, STORAGE_KEY } from './powerLevels.js';
 
 const DEFAULT_POWER_LEVEL = 2;
 
-export default function PowerSelector({ value, onChange, onPersist }) {
+export default function PowerSelector({ value, onChange, onPersist, labelPosition = 'right' }) {
   const [hover, setHover] = useState(null);
 
   const active = value ?? DEFAULT_POWER_LEVEL;
@@ -15,21 +15,25 @@ export default function PowerSelector({ value, onChange, onPersist }) {
     if (onPersist) onPersist(level);
   }
 
+  const label = <span className="power-label">{currentLevel?.label}</span>;
+  const bars = (
+    <div className="power-bars" onMouseLeave={() => setHover(null)}>
+      {LEVELS.map(({ level }) => (
+        <button
+          key={level}
+          type="button"
+          className={`power-bar power-bar--${level}${level <= display ? ' active' : ''}`}
+          onClick={() => handleClick(level)}
+          onMouseEnter={() => setHover(level)}
+          aria-label={`Power level ${level}`}
+        />
+      ))}
+    </div>
+  );
+
   return (
     <div className="power-selector" title={`Analysis power: ${currentLevel?.label}`}>
-      <div className="power-bars" onMouseLeave={() => setHover(null)}>
-        {LEVELS.map(({ level }) => (
-          <button
-            key={level}
-            type="button"
-            className={`power-bar power-bar--${level}${level <= display ? ' active' : ''}`}
-            onClick={() => handleClick(level)}
-            onMouseEnter={() => setHover(level)}
-            aria-label={`Power level ${level}`}
-          />
-        ))}
-      </div>
-      <span className="power-label">{currentLevel?.label}</span>
+      {labelPosition === 'left' ? <>{label}{bars}</> : <>{bars}{label}</>}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -3,7 +3,7 @@ import { buildFileTree, treeNodeToFileObj } from '../utils/fileTree.js';
 import { complianceRatio } from '../../../utils/formatters.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import RiskMatrixView from './RiskMatrixView.jsx';
-import ZoomablePackView from './ZoomablePackView.jsx';
+import ZoomablePackView, { resetSavedFocus } from './ZoomablePackView.jsx';
 
 let _savedMapPath = '';
 let _savedVizStyle = 'zoompack';
@@ -60,6 +60,7 @@ function DimensionFilter({ allDimensions, selectedDimensions, onToggle }) {
 function MapControls({ viewMode, setViewMode, vizStyle, setVizStyle, allDimensions, selectedDimensions, onToggleDimension }) {
   return (
     <div className="map-controls">
+      <DimensionFilter allDimensions={allDimensions} selectedDimensions={selectedDimensions} onToggle={onToggleDimension} />
       {vizStyle === 'zoompack' && (
         <div className="map-pill-group">
           {VIEW_MODES.map((m) => (
@@ -76,7 +77,6 @@ function MapControls({ viewMode, setViewMode, vizStyle, setVizStyle, allDimensio
           </button>
         ))}
       </div>
-      <DimensionFilter allDimensions={allDimensions} selectedDimensions={selectedDimensions} onToggle={onToggleDimension} />
     </div>
   );
 }
@@ -166,7 +166,15 @@ function MapVizContainer({ vizStyle, viewMode, node, onDrillDown, onFileClick, s
   );
 }
 
-export default function MapPage({ data, callbacks }) {
+function resetMapSavedState() {
+  _savedMapPath = '';
+  resetSavedFocus();
+}
+
+export default function MapPage({ data, callbacks, isDirectNav }) {
+  // Reset position state on direct tab click; keep viz style and view mode
+  if (isDirectNav) resetMapSavedState();
+
   // Lock parent to viewport height while map is active
   useEffect(() => {
     const dashboard = document.querySelector('.dashboard');
@@ -175,6 +183,11 @@ export default function MapPage({ data, callbacks }) {
       return () => dashboard.classList.remove('dashboard--fullheight');
     }
   }, []);
+
+  // Refresh data when navigating directly to the tab
+  useEffect(() => {
+    if (isDirectNav) callbacks?.onRefresh?.();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const allDimensions = data?.accumulated?.dimensions || data?.dashboard?.dimensions || [];
   const [viewMode, _setViewMode] = useState(_savedViewMode);

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -166,18 +166,18 @@ function MapVizContainer({ vizStyle, viewMode, node, onDrillDown, onFileClick, s
   );
 }
 
+let _lastTabKey = null;
+
 function resetMapSavedState() {
   _savedMapPath = '';
   resetSavedFocus();
 }
 
 export default function MapPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
-  // Reset position state on first mount from direct tab click; keep viz style and view mode
-  const initialResetDone = useRef(false);
-  if (isDirectNav && !initialResetDone.current) {
-    resetMapSavedState();
-    initialResetDone.current = true;
-  }
+  // Reset only on fresh tab click (tabKey changed), not on back from detail
+  const isFreshTabClick = _lastTabKey !== null && tabKey !== _lastTabKey;
+  _lastTabKey = tabKey;
+  if (isFreshTabClick) resetMapSavedState();
 
   // Lock parent to viewport height while map is active
   useEffect(() => {
@@ -188,10 +188,10 @@ export default function MapPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
     }
   }, []);
 
-  // Refresh data when navigating directly to the tab
+  // Refresh data on fresh tab click
   useEffect(() => {
-    if (isDirectNav) callbacks?.onRefresh?.();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (isFreshTabClick) callbacks?.onRefresh?.();
+  }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const allDimensions = data?.accumulated?.dimensions || data?.dashboard?.dimensions || [];
   const [viewMode, _setViewMode] = useState(_savedViewMode);

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -149,7 +149,7 @@ function buildBreadcrumbPath(root, path) {
   return crumbs;
 }
 
-function MapVizContainer({ vizStyle, viewMode, node, onDrillDown, onFileClick, showLabels, setShowLabels, breadcrumb, onBreadcrumbNav, onBack }) {
+function MapVizContainer({ vizStyle, viewMode, node, onDrillDown, onFileClick, showLabels, setShowLabels, breadcrumb, onBreadcrumbNav, onBack, resetKey }) {
   const hasLabels = vizStyle === 'riskmatrix' || vizStyle === 'zoompack';
   return (
     <div className="map-viz-container">
@@ -161,7 +161,7 @@ function MapVizContainer({ vizStyle, viewMode, node, onDrillDown, onFileClick, s
         </label>
       )}
       {vizStyle === 'riskmatrix' && <RiskMatrixView node={node} onDrillDown={onDrillDown} onFileClick={onFileClick} showLabels={showLabels} />}
-      {vizStyle === 'zoompack' && <ZoomablePackView node={node} viewMode={viewMode} onDrillDown={onDrillDown} onFileClick={onFileClick} showLabels={showLabels} />}
+      {vizStyle === 'zoompack' && <ZoomablePackView node={node} viewMode={viewMode} onDrillDown={onDrillDown} onFileClick={onFileClick} showLabels={showLabels} resetKey={resetKey} />}
     </div>
   );
 }
@@ -171,9 +171,13 @@ function resetMapSavedState() {
   resetSavedFocus();
 }
 
-export default function MapPage({ data, callbacks, isDirectNav }) {
-  // Reset position state on direct tab click; keep viz style and view mode
-  if (isDirectNav) resetMapSavedState();
+export default function MapPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
+  // Reset position state on first mount from direct tab click; keep viz style and view mode
+  const initialResetDone = useRef(false);
+  if (isDirectNav && !initialResetDone.current) {
+    resetMapSavedState();
+    initialResetDone.current = true;
+  }
 
   // Lock parent to viewport height while map is active
   useEffect(() => {
@@ -197,6 +201,17 @@ export default function MapPage({ data, callbacks, isDirectNav }) {
   const [showLabels, setShowLabels] = useState(false);
   const [currentPath, _setCurrentPath] = useState(_savedMapPath);
   const setCurrentPath = (p) => { _savedMapPath = p; _setCurrentPath(p); };
+
+  // Animate back to root when tab is re-clicked while already on map
+  const prevTabKey = useRef(tabKey);
+  useEffect(() => {
+    if (tabKey !== prevTabKey.current) {
+      prevTabKey.current = tabKey;
+      setCurrentPath('');
+      resetSavedFocus();
+      callbacks?.onRefresh?.();
+    }
+  }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Get visible standards and available dimension names
   const visibleIds = useMemo(() => new Set(readVisibleStandardIds()), [allDimensions]);
@@ -273,7 +288,7 @@ export default function MapPage({ data, callbacks, isDirectNav }) {
         </span>
         <MapControls viewMode={viewMode} setViewMode={setViewMode} vizStyle={vizStyle} setVizStyle={setVizStyle} allDimensions={dimensionNames} selectedDimensions={effectiveSelected} onToggleDimension={handleToggleDimension} />
       </div>
-      <MapVizContainer vizStyle={vizStyle} viewMode={viewMode} node={currentNode} onDrillDown={handleDrillDown} onFileClick={handleFileClick} showLabels={showLabels} setShowLabels={setShowLabels} breadcrumb={breadcrumb} onBreadcrumbNav={handleBreadcrumbNav} onBack={handleBack} />
+      <MapVizContainer vizStyle={vizStyle} viewMode={viewMode} node={currentNode} onDrillDown={handleDrillDown} onFileClick={handleFileClick} showLabels={showLabels} setShowLabels={setShowLabels} breadcrumb={breadcrumb} onBreadcrumbNav={handleBreadcrumbNav} onBack={handleBack} resetKey={tabKey} />
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/map/components/ZoomablePackView.jsx
+++ b/src/quodeq/ui/src/features/map/components/ZoomablePackView.jsx
@@ -8,9 +8,19 @@ let _savedFocusPath = null;
 
 export function resetSavedFocus() { _savedFocusPath = null; }
 
-export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileClick, showLabels = true, zoom = 1 }) {
+export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileClick, showLabels = true, zoom = 1, resetKey = 0 }) {
   const [focus, _setFocus] = useState(null);
   const setFocus = (n) => { _savedFocusPath = n?.data?.path || null; _setFocus(n); };
+
+  // Zoom out to root with transition when resetKey changes
+  const prevResetKey = useRef(resetKey);
+  useEffect(() => {
+    if (resetKey !== prevResetKey.current) {
+      prevResetKey.current = resetKey;
+      _savedFocusPath = null;
+      _setFocus(null);
+    }
+  }, [resetKey]);
   const [hover, setHover] = useState(null);
   const skipTransition = useRef(!!_savedFocusPath);
 

--- a/src/quodeq/ui/src/features/map/components/ZoomablePackView.jsx
+++ b/src/quodeq/ui/src/features/map/components/ZoomablePackView.jsx
@@ -6,6 +6,8 @@ import FileShape from './FileShape.jsx';
 const BASE_SIZE = 600;
 let _savedFocusPath = null;
 
+export function resetSavedFocus() { _savedFocusPath = null; }
+
 export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileClick, showLabels = true, zoom = 1 }) {
   const [focus, _setFocus] = useState(null);
   const setFocus = (n) => { _savedFocusPath = n?.data?.path || null; _setFocus(n); };
@@ -28,12 +30,14 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
     if (_savedFocusPath && circles.length > 0 && !focus) {
       const match = circles.find((c) => c.data.path === _savedFocusPath);
       if (match) _setFocus(match);
+      // Keep skipTransition true until the restored focus is rendered
+      return;
     }
-    // Allow transitions after first paint
+    // Allow transitions after focus has been restored and painted
     if (skipTransition.current) {
       requestAnimationFrame(() => { skipTransition.current = false; });
     }
-  }, [circles]);
+  }, [circles, focus]);
 
   const focusNode = focus || root;
   const viewSize = Math.round(BASE_SIZE * zoom);

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -146,9 +146,17 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh }
   };
 }
 
-export default function ViolationsPage({ data, callbacks }) {
+export default function ViolationsPage({ data, callbacks, isDirectNav }) {
+  // Reset file path on direct tab click; keep selected sub-tab
+  if (isDirectNav) _savedFilePath = '';
+
   const { accumulatedDimensions, selectedProject } = data;
   const { onDimensionClick, onFileClick, onPrincipleClick, onRefresh } = callbacks;
+
+  // Refresh data when navigating directly to the tab
+  useEffect(() => {
+    if (isDirectNav) onRefresh?.();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
     activeSubTab, setActiveSubTab, dismissed,

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -146,17 +146,20 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh }
   };
 }
 
-export default function ViolationsPage({ data, callbacks, isDirectNav }) {
-  // Reset file path on direct tab click; keep selected sub-tab
-  if (isDirectNav) _savedFilePath = '';
+let _lastViolationsTabKey = null;
+
+export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
+  const isFreshTabClick = _lastViolationsTabKey !== null && tabKey !== _lastViolationsTabKey;
+  _lastViolationsTabKey = tabKey;
+  if (isFreshTabClick) _savedFilePath = '';
 
   const { accumulatedDimensions, selectedProject } = data;
   const { onDimensionClick, onFileClick, onPrincipleClick, onRefresh } = callbacks;
 
-  // Refresh data when navigating directly to the tab
+  // Refresh data on fresh tab click
   useEffect(() => {
-    if (isDirectNav) onRefresh?.();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (isFreshTabClick) onRefresh?.();
+  }, [tabKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const {
     activeSubTab, setActiveSubTab, dismissed,

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -48,7 +48,8 @@ function createNavActions(setNavStack, navStackRef) {
     setNavStack((prev) => {
       const stepsBack = prev.length - 1;
       if (stepsBack > 0) window.history.go(-stepsBack);
-      return [{ page }];
+      const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
+      return [{ page, _tabKey: prevKey + 1 }];
     });
   }
 


### PR DESCRIPTION
## Summary
- Violations and map tabs now call `refreshDashboard()` on direct tab click, ensuring fresh `latestAccumulated` data
- Map resets to zoomed-out root on tab click; restores zoom position without animation when navigating back from file detail
- Only selected sub-tabs persist (viz style, view mode, violations sub-tab); path/zoom resets on tab click
- Dimension filter moved to left of health/violations pill group in map controls
- Power-selector label positioned left on evaluate screen, right on settings page

## Test plan
- [x] Click map tab — shows root view with fresh data, no zoom animation
- [x] Drill into map, click a file, press back — restores zoom position without animation
- [x] Click map tab again — resets to root, not previous position
- [x] Click violations tab — shows fresh data
- [x] Navigate into file from violations, come back — keeps selected sub-tab
- [x] Run evaluation, click violations/map tab — shows updated data
- [x] Verify dimension filter appears left of Health/Violations pills
- [x] Verify power-selector label is left on evaluate, right on settings