### PR TITLE
feat: clickable severity cells with filtered navigation

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -95,6 +95,7 @@ function renderEvalPrincipleDetail(params, props) {
   return (
     <PrincipleDetailPage
       evalPrincipal={evalPrincipal}
+      severityFilter={params.severity || null}
       onDismiss={(v) => {
         dismissFinding(selectedProject, buildDismissPayload(v, evalPrincipal.dimension))
           .then(() => props.refreshDashboard?.())
@@ -129,20 +130,33 @@ const ROUTE_RENDERERS = {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
     const dims = acc?.dimensions || [];
     const nav = props.navigation.handleNavigate;
+
+    function navigateToPrinciple(principleObj, severity) {
+      const dim = dims.find(d => d.dimension === principleObj.dimension);
+      const pg = (dim?.principles || []).find(p => (p.name || p.principle) === principleObj.principle);
+      nav('evalprinciple', { evalPrincipal: buildEvalPrincipal(principleObj, pg), severity, sourceTab: 'violations' });
+    }
+
+    function navigateToDimension(row, severity) {
+      const dim = row.raw || dims.find(d => d.dimension === row.dimension);
+      if (!dim) return;
+      nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, severity, sourceTab: 'violations' });
+    }
+
     return (
       <ViolationsPage
         data={{ accumulated: acc, accumulatedDimensions: dims, selectedProject: props.navigation.selectedProject }}
         callbacks={{
           onDimensionClick: (dim) => nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, sourceTab: 'violations' }),
           onFileClick: (fileObj) => nav('file', { file: fileObj, sourceTab: 'violations' }),
-          onPrincipleClick: (principleObj) => {
-            const dim = dims.find(d => d.dimension === principleObj.dimension);
-            const pg = (dim?.principles || []).find(p => (p.name || p.principle) === principleObj.principle);
-            nav('evalprinciple', {
-              evalPrincipal: buildEvalPrincipal(principleObj, pg),
-              sourceTab: 'violations',
-            });
+          onCellClick: ({ row, severity }) => {
+            if (row.type === 'principle' && row.principleObj) {
+              navigateToPrinciple(row.principleObj, severity);
+            } else {
+              navigateToDimension(row, severity);
+            }
           },
+          onPrincipleClick: (principleObj) => navigateToPrinciple(principleObj),
           onRefresh: props.refreshDashboard,
         }}
         isDirectNav={props.navigation.navStackLength === 1}
@@ -182,7 +196,7 @@ const ROUTE_RENDERERS = {
     );
   },
   'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
-  explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} onNavigate={props.navigation.handleNavigate} refreshSignal={props.dashboardData.dashboard} />,
+  explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} severityFilter={params.severity} onNavigate={props.navigation.handleNavigate} refreshSignal={props.dashboardData.dashboard} />,
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
   file: (params) => <FileDetailPage file={params.file} />,
   evalprinciple: renderEvalPrincipleDetail,

--- a/src/quodeq/ui/src/components/HeatGridCells.jsx
+++ b/src/quodeq/ui/src/components/HeatGridCells.jsx
@@ -1,0 +1,50 @@
+import { severityCellStyle, complianceRateCellStyle } from '../features/map/utils/mapColors.js';
+
+const SEVERITY_LEVELS = ['critical', 'major', 'minor'];
+
+/**
+ * Renders the severity + violations + health cells for a heat grid row.
+ * Shared between HeatGridView (file tree) and DimensionHeatGridView (violations).
+ */
+export default function HeatGridCells({ row, onCellClick }) {
+  const total = row.violations + row.compliance;
+  const rate = total > 0 ? Math.round(row.complianceRate * 100) + '%' : '—';
+
+  return (
+    <>
+      {SEVERITY_LEVELS.map((sev) => {
+        const count = row.severity[sev];
+        const hasValue = count > 0;
+        return (
+          <td key={sev}>
+            <div
+              className={`heat-grid-cell${hasValue ? ' clickable' : ' empty'}`}
+              style={hasValue ? severityCellStyle(sev) : undefined}
+              onClick={() => hasValue && onCellClick?.({ row, severity: sev })}
+              role={hasValue ? 'button' : undefined}
+            >
+              {count || '—'}
+            </div>
+          </td>
+        );
+      })}
+      <td>
+        <div
+          className={`heat-grid-num${row.violations > 0 ? ' clickable' : ''}`}
+          onClick={() => row.violations > 0 && onCellClick?.({ row, severity: null })}
+          role={row.violations > 0 ? 'button' : undefined}
+        >
+          {row.violations}
+        </div>
+      </td>
+      <td>
+        <div
+          className={`heat-grid-cell${total > 0 ? ' health' : ' empty'}`}
+          style={total > 0 ? complianceRateCellStyle(row.complianceRate) : undefined}
+        >
+          {rate}
+        </div>
+      </td>
+    </>
+  );
+}

--- a/src/quodeq/ui/src/components/SeverityFilterPills.jsx
+++ b/src/quodeq/ui/src/components/SeverityFilterPills.jsx
@@ -1,0 +1,30 @@
+const SEVERITY_LEVELS = ['critical', 'major', 'minor'];
+const SEVERITY_LABELS = { critical: 'Critical', major: 'Major', minor: 'Minor' };
+
+/**
+ * Reusable severity filter pill group.
+ * @param {{ counts: { critical: number, major: number, minor: number }, activeFilter: string|null, onFilterChange: function }} props
+ */
+export default function SeverityFilterPills({ counts, activeFilter, onFilterChange }) {
+  const isAllActive = !activeFilter || activeFilter === 'all';
+  return (
+    <div className="map-pill-group" style={{ margin: '8px 0 4px', justifyContent: 'flex-start' }}>
+      <button type="button" className={`map-pill${isAllActive ? ' active' : ''}`} onClick={() => onFilterChange(null)}>
+        All
+      </button>
+      {SEVERITY_LEVELS.map((sev) =>
+        counts[sev] > 0 && (
+          <button
+            key={sev}
+            type="button"
+            className={`map-pill${activeFilter === sev ? ' active' : ''}`}
+            style={{ color: `var(--color-sev-${sev}-text)` }}
+            onClick={() => onFilterChange(activeFilter === sev ? null : sev)}
+          >
+            {SEVERITY_LABELS[sev]} ({counts[sev]})
+          </button>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -7,6 +7,7 @@ import { gradeColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { buildDimensionReport } from '../../../utils/reportBuilder.js';
+import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 
 const columnStyle = { display: 'flex', flexDirection: 'column', gap: 2 };
 
@@ -272,23 +273,33 @@ function useExplorerData(project, dimension, runId, refreshSignal) {
   return { evalData, loading, error, overallGrade, principleGrades, allViolations, ...stats };
 }
 
-export default function ExplorerPage({ project, dimension, runId, dateLabel, onNavigate, refreshSignal }) {
+export default function ExplorerPage({ project, dimension, runId, dateLabel, severityFilter, onNavigate, refreshSignal }) {
   const d = useExplorerData(project, dimension, runId, refreshSignal);
+  const [activeSevFilter, setActiveSevFilter] = useState(severityFilter || null);
   if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;
   const buildEvalPrincipal = buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple, project, runId);
 
+  // Apply severity filter
+  const filteredViolations = activeSevFilter
+    ? d.allViolations.filter(v => (v.severity || 'minor') === activeSevFilter)
+    : d.allViolations;
+  const filteredTopFiles = activeSevFilter
+    ? buildTopOffendingFiles(filteredViolations)
+    : d.topFiles;
+
   return (
     <>
       <DimensionOverview
-        data={{ evalData: d.evalData, runId, dateLabel, allViolations: d.allViolations }}
-        stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: d.topFiles, uniquePrinciples: d.uniquePrinciples, principleGrades: d.principleGrades }}
+        data={{ evalData: d.evalData, runId, dateLabel, allViolations: filteredViolations }}
+        stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: filteredTopFiles, uniquePrinciples: d.uniquePrinciples, principleGrades: d.principleGrades }}
         onNavigate={onNavigate}
       />
+      <SeverityFilterPills counts={d.severityCounts} activeFilter={activeSevFilter} onFilterChange={setActiveSevFilter} />
       <PrinciplesList evalData={d.evalData} principleGrades={d.principleGrades} onNavigate={onNavigate} buildEvalPrincipal={buildEvalPrincipal} />
-      <ViolationsByPrincipleSection allViolations={d.allViolations} onNavigate={onNavigate} buildEvalPrincipal={buildEvalPrincipal} />
-      <ViolationsByFileSection topFiles={d.topFiles} onNavigate={onNavigate} />
+      <ViolationsByPrincipleSection allViolations={filteredViolations} onNavigate={onNavigate} buildEvalPrincipal={buildEvalPrincipal} />
+      <ViolationsByFileSection topFiles={filteredTopFiles} onNavigate={onNavigate} />
     </>
   );
 }

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -6,6 +6,7 @@ import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { getRescore } from '../../../api/index.js';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
+import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 
 const PAGE_SIZE = 20;
 
@@ -153,12 +154,13 @@ function PrincipleContext({ principleData }) {
   );
 }
 
-const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, onDismiss }) {
+const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, severityFilter, onDismiss }) {
   const { principleData, principle, score, grade, dimension, project, runId } = evalPrincipal;
   const [showAllCompliance, setShowAllCompliance] = useState(false);
   const [dismissedSet, setDismissedSet] = useState(new Set());
   const [liveScore, setLiveScore] = useState(null);
   const [liveGrade, setLiveGrade] = useState(null);
+  const [activeSevFilter, setActiveSevFilter] = useState(severityFilter || null);
   const { violations, compliance, violationsBySeverity, sevCounts } = computeEvalPrincipleData(evalPrincipal);
   const displayedCompliance = showAllCompliance ? compliance : compliance.slice(0, PAGE_SIZE);
 
@@ -191,6 +193,16 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, o
     return { filteredBySeverity: bySev, filteredViolations: allFiltered, liveSevCounts: counts };
   }, [violationsBySeverity, dismissedSet]);
 
+  // Apply active severity filter
+  const displayedBySeverity = useMemo(() => {
+    if (!activeSevFilter || activeSevFilter === 'all') return filteredBySeverity;
+    const filtered = {};
+    for (const sev of Object.keys(filteredBySeverity)) {
+      filtered[sev] = sev === activeSevFilter ? filteredBySeverity[sev] : [];
+    }
+    return filtered;
+  }, [filteredBySeverity, activeSevFilter]);
+
   return (
     <>
       <PrincipleHeader
@@ -198,7 +210,10 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, o
         onCopyPlan={() => copyToClipboard(buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData))}
       />
       <PrincipleContext principleData={principleData} />
-      <ViolationListSection violationsBySeverity={filteredBySeverity} principle={principle} buildViolationPlanText={(v) => buildViolationPlanText(v, principle)} onDismiss={handleDismiss} />
+      {filteredViolations.length > 0 && (
+        <SeverityFilterPills counts={liveSevCounts} activeFilter={activeSevFilter} onFilterChange={setActiveSevFilter} />
+      )}
+      <ViolationListSection violationsBySeverity={displayedBySeverity} principle={principle} buildViolationPlanText={(v) => buildViolationPlanText(v, principle)} onDismiss={handleDismiss} />
       <ComplianceListSection
         data={{ compliance, displayedCompliance, principle }}
         controls={{ hasMore: compliance.length > PAGE_SIZE, showAll: showAllCompliance, setShowAll: setShowAllCompliance }}

--- a/src/quodeq/ui/src/features/map/components/HeatGridView.jsx
+++ b/src/quodeq/ui/src/features/map/components/HeatGridView.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { severityCellStyle, complianceRateCellStyle } from '../utils/mapColors.js';
+import HeatGridCells from '../../../components/HeatGridCells.jsx';
 
 const COLUMNS = [
   { id: 'name', label: 'File / Folder', align: 'left' },
@@ -27,7 +27,7 @@ function sortRows(items, sortCol, sortDir) {
   });
 }
 
-export default function HeatGridView({ node, onDrillDown, onFileClick }) {
+export default function HeatGridView({ node, onDrillDown, onFileClick, onCellClick }) {
   const [sortCol, setSortCol] = useState('violations');
   const [sortDir, setSortDir] = useState('desc');
 
@@ -65,9 +65,6 @@ export default function HeatGridView({ node, onDrillDown, onFileClick }) {
         <tbody>
           {rows.map((row) => {
             const canDrill = !row.isFile && row.children?.length > 0;
-            const total = row.violations + row.compliance;
-            const rate = total > 0 ? Math.round(row.complianceRate * 100) + '%' : '—';
-
             return (
               <tr key={row.path}>
                 <td>
@@ -82,11 +79,7 @@ export default function HeatGridView({ node, onDrillDown, onFileClick }) {
                     {row.isFile ? '' : '\uD83D\uDCC1 '}{row.name}
                   </div>
                 </td>
-                <td><div className={`heat-grid-cell${row.severity.critical > 0 ? '' : ' empty'}`} style={row.severity.critical > 0 ? severityCellStyle('critical') : undefined}>{row.severity.critical || '—'}</div></td>
-                <td><div className={`heat-grid-cell${row.severity.major > 0 ? '' : ' empty'}`} style={row.severity.major > 0 ? severityCellStyle('major') : undefined}>{row.severity.major || '—'}</div></td>
-                <td><div className={`heat-grid-cell${row.severity.minor > 0 ? '' : ' empty'}`} style={row.severity.minor > 0 ? severityCellStyle('minor') : undefined}>{row.severity.minor || '—'}</div></td>
-                <td><div className="heat-grid-num">{row.violations}</div></td>
-                <td><div className={`heat-grid-cell${total > 0 ? ' health' : ' empty'}`} style={total > 0 ? complianceRateCellStyle(row.complianceRate) : undefined}>{rate}</div></td>
+                <HeatGridCells row={row} onCellClick={onCellClick} />
               </tr>
             );
           })}

--- a/src/quodeq/ui/src/features/map/utils/fileTree.js
+++ b/src/quodeq/ui/src/features/map/utils/fileTree.js
@@ -70,10 +70,15 @@ function collapseSingleChildren(node) {
   }
 }
 
-/** Convert a leaf tree node into a file object compatible with FileDetailPage */
-export function treeNodeToFileObj(node) {
-  const violations = node.items.filter((i) => i.type === 'violation');
-  const compliance = node.items.filter((i) => i.type === 'compliance');
+/** Convert a tree node into a file object, optionally filtered by severity.
+ *  severity: null = all violations, 'critical'|'major'|'minor' = filtered, 'all' = violations + compliance */
+export function treeNodeToFileObj(node, { severity } = {}) {
+  let violations = node.items.filter((i) => i.type === 'violation');
+  let compliance = node.items.filter((i) => i.type === 'compliance');
+  if (severity && severity !== 'all') {
+    violations = violations.filter((v) => (v.severity || 'minor') === severity);
+    compliance = []; // severity filter shows only violations
+  }
   const bySev = { critical: [], major: [], minor: [], unknown: [] };
   for (const v of violations) {
     const sev = v.severity || 'minor';

--- a/src/quodeq/ui/src/features/violations/components/DimensionHeatGridView.jsx
+++ b/src/quodeq/ui/src/features/violations/components/DimensionHeatGridView.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { severityCellStyle, complianceRateCellStyle } from '../../map/utils/mapColors.js';
+import HeatGridCells from '../../../components/HeatGridCells.jsx';
 
 const COLUMNS = [
   { id: 'name', label: 'Dimension / Principle', align: 'left' },
@@ -121,7 +121,7 @@ function buildRows(dimensions, sortCol, sortDir) {
   return rows;
 }
 
-export default function DimensionHeatGridView({ dimensions, onDimensionClick, onPrincipleClick }) {
+export default function DimensionHeatGridView({ dimensions, onDimensionClick, onPrincipleClick, onCellClick }) {
   const [sortCol, setSortCol] = useState('violations');
   const [sortDir, setSortDir] = useState('desc');
 
@@ -154,10 +154,7 @@ export default function DimensionHeatGridView({ dimensions, onDimensionClick, on
         </thead>
         <tbody>
           {rows.map((row, i) => {
-            const total = row.violations + row.compliance;
-            const rate = total > 0 ? Math.round(row.complianceRate * 100) + '%' : '—';
             const isDim = row.type === 'dimension';
-
             return (
               <tr key={`${row.type}-${row.name}-${i}`} className={isDim ? 'heat-grid-dim-row' : undefined}>
                 <td>
@@ -172,11 +169,7 @@ export default function DimensionHeatGridView({ dimensions, onDimensionClick, on
                     {row.name}
                   </div>
                 </td>
-                <td><div className={`heat-grid-cell${row.severity.critical > 0 ? '' : ' empty'}`} style={row.severity.critical > 0 ? severityCellStyle('critical') : undefined}>{row.severity.critical || '—'}</div></td>
-                <td><div className={`heat-grid-cell${row.severity.major > 0 ? '' : ' empty'}`} style={row.severity.major > 0 ? severityCellStyle('major') : undefined}>{row.severity.major || '—'}</div></td>
-                <td><div className={`heat-grid-cell${row.severity.minor > 0 ? '' : ' empty'}`} style={row.severity.minor > 0 ? severityCellStyle('minor') : undefined}>{row.severity.minor || '—'}</div></td>
-                <td><div className="heat-grid-num">{row.violations}</div></td>
-                <td><div className={`heat-grid-cell${total > 0 ? ' health' : ' empty'}`} style={total > 0 ? complianceRateCellStyle(row.complianceRate) : undefined}>{rate}</div></td>
+                <HeatGridCells row={row} onCellClick={onCellClick} />
               </tr>
             );
           })}

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -78,10 +78,15 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
     if (treeNode.isFile) onFileClick?.(treeNodeToFileObj(treeNode));
   }, [onFileClick]);
 
+  const handleCellClick = useCallback(({ row, severity }) => {
+    // Navigate to file/folder detail filtered by severity
+    onFileClick?.(treeNodeToFileObj(row, { severity: severity || undefined }));
+  }, [onFileClick]);
+
   return (
     <>
       <FileBreadcrumb path={breadcrumb} onNavigate={setCurrentPath} onBack={() => setCurrentPath(findParentPath(fullTree, currentPath))} />
-      <HeatGridView node={currentNode} onDrillDown={setCurrentPath} onFileClick={handleFileClick} />
+      <HeatGridView node={currentNode} onDrillDown={setCurrentPath} onFileClick={handleFileClick} onCellClick={handleCellClick} />
     </>
   );
 }
@@ -221,7 +226,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
         <FileSubTab dimensions={visibleDimensions} onFileClick={onFileClick} currentPath={fileCurrentPath} setCurrentPath={setFileCurrentPath} />
       )}
       {activeSubTab === 'dimension' && (
-        <DimensionHeatGridView dimensions={visibleDimensions} onDimensionClick={onDimensionClick} onPrincipleClick={onPrincipleClick} />
+        <DimensionHeatGridView dimensions={visibleDimensions} onDimensionClick={onDimensionClick} onPrincipleClick={onPrincipleClick} onCellClick={callbacks.onCellClick} />
       )}
       {activeSubTab === 'dismissed' && (
         dismissed.length > 0

--- a/src/quodeq/ui/src/styles/map.css
+++ b/src/quodeq/ui/src/styles/map.css
@@ -329,6 +329,17 @@
   opacity: 0.8;
 }
 
+.heat-grid-cell.clickable,
+.heat-grid-num.clickable {
+  cursor: pointer;
+}
+
+.heat-grid-cell.clickable:hover,
+.heat-grid-num.clickable:hover {
+  opacity: 0.7;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+
 .heat-grid-cell.empty {
   background: var(--color-surface-alt);
   color: var(--color-text-muted);


### PR DESCRIPTION
## Summary
- Severity cells (Critical/Major/Minor) and Violations cells in heat grids are now clickable
- Clicking navigates to the appropriate detail page filtered by severity
- Explorer and Principle detail pages show severity filter pills for inline toggling
- Clickable cells get pointer cursor and accent-colored hover ring

## Test plan
- [x] Click Critical/Major/Minor cells in By Dimension tab → explorer opens filtered
- [x] Click severity cells on principle rows → principle detail opens filtered
- [x] Click severity cells in By File tab → file detail opens filtered
- [x] Toggle severity pills on Explorer and Principle detail pages
- [x] Verify health cells are NOT clickable