### PR TITLE
feat: Circle Pack info panel, legend, and mouse-follow tooltip

### DIFF
--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
@@ -916,7 +916,7 @@ export default function GalaxyFolderView({ node, onFileClick, onNavigate, showLa
       if (sev.minor) rows.push(row('Minor', sev.minor, 'var(--color-sev-minor-text)'));
     }
     const nameCol = rgb(d.col);
-    const name = d.isFolder ? d.name + '/' : d.name;
+    const name = d.name;
     const ff = focusedFolderRef.current;
     const isFocused = h.type === 'folder' && ff && ff.starIdx === h.starIdx;
     const action = h.type === 'file' ? 'zoom in' : isFocused ? 'enter folder' : 'focus';

--- a/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
@@ -22,6 +22,8 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
     }
   }, [resetKey]);
   const [hover, setHover] = useState(null);
+  const mousePos = useRef({ x: 0, y: 0 });
+  const containerRef = useRef(null);
   const skipTransition = useRef(!!_savedFocusPath);
 
   const { root, circles } = useMemo(() => {
@@ -82,10 +84,40 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
     setFocus(focusNode?.parent || null);
   }, [focusNode]);
 
+  // Level info panel — shows current focused node stats + View Details
+  const levelInfo = useMemo(() => {
+    const fn = focusNode;
+    if (!fn || !fn.data) return null;
+    const d = fn.data;
+    const isRoot = fn === root;
+    const sev = d.severity || {};
+    const rate = (d.violations + d.compliance) > 0
+      ? Math.round((d.compliance / (d.violations + d.compliance)) * 100) + '%'
+      : '—';
+    const childFolders = (d.children || []).filter(c => !c.isFile && c.children?.length > 0).length;
+    const childFiles = (d.children || []).filter(c => c.isFile || !c.children || c.children.length === 0).length;
+    const lines = [
+      { label: 'Compliance', value: rate },
+      { label: 'Contents', value: childFolders + childFiles },
+      { label: 'Violations', value: d.violations },
+    ];
+    if (d.violations > 0) {
+      if (sev.critical > 0) lines.push({ label: 'Critical', value: sev.critical, color: 'var(--color-sev-critical-text)' });
+      if (sev.major > 0) lines.push({ label: 'Major', value: sev.major, color: 'var(--color-sev-major-text)' });
+      if (sev.minor > 0) lines.push({ label: 'Minor', value: sev.minor, color: 'var(--color-sev-minor-text)' });
+    }
+    const shortName = d.name?.includes('/') ? d.name.split('/')[0] : d.name;
+    return {
+      title: isRoot ? (d.name === '/' ? 'Project' : shortName) : shortName,
+      lines,
+      detailAction: !isRoot ? () => onFileClick?.(d) : null,
+    };
+  }, [focusNode, root, onFileClick]);
+
   if (!node || !circles.length) return null;
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+    <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }} onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) { mousePos.current = { x: e.clientX - r.left, y: e.clientY - r.top }; } }}>
       <svg
         viewBox={`-20 -20 ${viewSize + 40} ${viewSize + 40}`}
         style={{ width: '100%', height: '100%', overflow: 'hidden' }}
@@ -166,8 +198,8 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
         const hd = circles[hover].data;
         const sev = hd.severity || {};
         return (
-          <div className="map-tooltip" style={{ position: 'absolute', top: 8, right: 8, pointerEvents: 'none' }}>
-            <div className="map-tooltip-title">{hd.path || hd.name}</div>
+          <div className="map-tooltip" style={{ position: 'absolute', left: Math.min(mousePos.current.x + 16, (containerRef.current?.offsetWidth || 300) - 180), top: Math.min(mousePos.current.y + 16, (containerRef.current?.offsetHeight || 300) - 160), pointerEvents: 'none', zIndex: 10 }}>
+            <div className="map-tooltip-title">{(hd.path || hd.name || '').replace(/\/$/, '')}</div>
             <div className="map-tooltip-row">
               <span>Violations</span><span>{hd.violations}</span>
             </div>
@@ -200,6 +232,43 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
           </div>
         );
       })()}
+
+      {/* Level info panel — fixed top-right */}
+      {levelInfo && (
+        <div style={{ position: 'absolute', top: 12, right: 16, background: 'color-mix(in srgb, var(--color-surface) 88%, transparent)', border: '1px solid var(--color-border)', borderRadius: 10, padding: '12px 18px', fontSize: 12, zIndex: 2, backdropFilter: 'blur(8px)', minWidth: 160 }}>
+          <div style={{ fontWeight: 600, color: 'var(--color-text)', marginBottom: 8, fontSize: 13 }}>{levelInfo.title}</div>
+          {levelInfo.lines.map((l, i) => (
+            <div key={i} style={{ display: 'flex', justifyContent: 'space-between', gap: 16, margin: '3px 0', color: l.color || 'var(--color-text-muted)' }}>
+              <span>{l.label}</span>
+              <span style={{ color: l.color || 'var(--color-text)', fontWeight: 500 }}>{l.value}</span>
+            </div>
+          ))}
+          {levelInfo.detailAction && (
+            <button
+              type="button"
+              onClick={levelInfo.detailAction}
+              style={{ marginTop: 10, width: '100%', padding: '6px 12px', background: 'color-mix(in srgb, var(--color-accent) 20%, transparent)', border: '1px solid var(--color-border)', borderRadius: 6, color: 'var(--color-text)', fontSize: 11, cursor: 'pointer', transition: 'all 0.2s' }}
+              onMouseEnter={e => { e.target.style.background = 'color-mix(in srgb, var(--color-accent) 35%, transparent)'; }}
+              onMouseLeave={e => { e.target.style.background = 'color-mix(in srgb, var(--color-accent) 20%, transparent)'; }}
+            >View Details</button>
+          )}
+        </div>
+      )}
+
+      {/* Legend — fixed bottom-left */}
+      <div style={{ position: 'absolute', bottom: 8, left: 12, display: 'flex', gap: 14, fontSize: 11, color: 'var(--color-text-muted)', zIndex: 2 }}>
+        {[
+          { color: 'var(--color-grade-top-text)', label: 'Exemplary' },
+          { color: 'var(--color-grade-high-text)', label: 'Good' },
+          { color: 'var(--color-grade-mid-text)', label: 'Adequate' },
+          { color: 'var(--color-grade-low-text)', label: 'Poor' },
+          { color: 'var(--color-grade-bottom-text)', label: 'Critical' },
+        ].map(({ color, label }) => (
+          <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, display: 'inline-block' }} />{label}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fixed info panel (top-right) showing current level stats with severity breakdown and View Details button
- Color legend (bottom-left) with Exemplary→Critical scale
- Hover tooltip follows mouse cursor instead of fixed top-right
- Folder names no longer show trailing `/` in tooltips (Circle Pack + Galaxy Filesystem)

## Test plan
- [x] Info panel updates when zooming into folders
- [x] View Details navigates to file/folder detail page
- [x] Legend colors match theme (light/dark)
- [x] Tooltip follows mouse on hover
- [x] No trailing `/` on folder names in tooltips