### PR TITLE
feat: provider settings tabs with per-provider configuration

### DIFF
--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -63,9 +63,20 @@ def create_app(
 
     @app.get("/api/health")
     def health() -> Response:
-        """Return a simple health-check response."""
+        """Return a simple health-check response with server info."""
         from quodeq import __version__
-        return jsonify({"ok": True, "version": __version__})
+        from quodeq.shared.utils import get_action_api_host, get_action_api_port
+        host = get_action_api_host()
+        port = get_action_api_port()
+        display_host = "localhost" if host in ("127.0.0.1", "0.0.0.0") else host
+        return jsonify({
+            "ok": True,
+            "version": __version__,
+            "host": host,
+            "port": port,
+            "address": f"{display_host}:{port}",
+            "pid": os.getpid(),
+        })
 
     register_all_routes(app, provider, eval_store, static_dist)
     return app

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -1,0 +1,60 @@
+"""API routes for LLM bridge — provider status, models, testing."""
+from __future__ import annotations
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.llm_bridge import (
+    get_ollama_status,
+    list_ollama_models,
+    estimate_max_agents,
+    run_concurrency_test,
+    get_known_models,
+    get_provider_configs,
+)
+from quodeq.llm_bridge._cloud import check_cloud_connection
+
+
+def register_llm_bridge_routes(app: Flask) -> None:
+    """Register all llm_bridge API routes."""
+
+    @app.get("/api/ollama/status")
+    def ollama_status() -> Response:
+        return jsonify(get_ollama_status())
+
+    @app.get("/api/ollama/models")
+    def ollama_models() -> Response:
+        return jsonify({"models": list_ollama_models()})
+
+    @app.post("/api/ollama/test-concurrency")
+    def ollama_test_concurrency() -> Response:
+        data = request.get_json() or {}
+        model = data.get("model", "")
+        if not model:
+            return jsonify({"error": "model is required"}), 400
+        result = run_concurrency_test(model)
+        return jsonify(result)
+
+    @app.post("/api/ollama/estimate-agents")
+    def ollama_estimate_agents() -> Response:
+        data = request.get_json() or {}
+        model_size = data.get("model_size", 0)
+        gpu_memory = data.get("gpu_memory", 0)
+        return jsonify(estimate_max_agents(model_size=model_size, gpu_memory=gpu_memory))
+
+    @app.post("/api/provider/test")
+    def provider_test() -> Response:
+        data = request.get_json() or {}
+        result = check_cloud_connection(
+            api_base=data.get("api_base", ""),
+            model=data.get("model", ""),
+            api_key=data.get("api_key", ""),
+        )
+        return jsonify(result)
+
+    @app.get("/api/known-models")
+    def known_models() -> Response:
+        return jsonify(get_known_models())
+
+    @app.get("/api/provider-configs")
+    def provider_configs() -> Response:
+        return jsonify(get_provider_configs())

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -15,6 +15,7 @@ from quodeq.api.routes import (
 )
 from quodeq.api.standards_routes import register_standards_routes
 from quodeq.api.routes_findings import register_findings_routes
+from quodeq.api.llm_bridge_routes import register_llm_bridge_routes
 from quodeq.api.routes_rescore import register_rescore_routes
 from quodeq.services.base import ActionProvider
 
@@ -39,4 +40,5 @@ def register_all_routes(
     register_standards_routes(app)
     register_findings_routes(app)
     register_rescore_routes(app)
+    register_llm_bridge_routes(app)
     register_static_routes(app, static_dist)

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -1,6 +1,13 @@
 {
+  "ollama": {
+    "type": "api",
+    "order": 0,
+    "model": "llama3.1",
+    "api_base": "http://localhost:11434/v1"
+  },
   "claude": {
     "type": "cli",
+    "order": 1,
     "cmd": "claude",
     "base_args": "--print --output-format stream-json --verbose",
     "mcp_permission_args": ["--permission-mode", "bypassPermissions"],
@@ -9,24 +16,31 @@
   },
   "codex": {
     "type": "cli",
+    "order": 2,
     "cmd": "codex",
     "base_args": "--print --output-format stream-json --verbose",
     "mcp_permission_args": [],
     "env_set_if_missing": {"CODEX_SANDBOX": "read-only"},
     "env_remove": []
   },
-  "ollama": {
-    "type": "api",
-    "model": "llama3.1",
-    "api_base": "http://localhost:11434/v1"
+  "copilot": {
+    "type": "cli",
+    "order": 3,
+    "cmd": "copilot",
+    "base_args": "--print --output-format stream-json --verbose",
+    "mcp_permission_args": [],
+    "env_set_if_missing": {},
+    "env_remove": []
   },
   "openrouter": {
     "type": "api",
+    "order": 4,
     "model": "anthropic/claude-sonnet-4",
     "api_key_env": "OPENROUTER_API_KEY"
   },
   "custom": {
     "type": "api",
+    "order": 99,
     "model": "${AI_MODEL}",
     "api_base": "${AI_API_BASE}",
     "api_key_env": "AI_API_KEY"

--- a/src/quodeq/data/config/known_models.json
+++ b/src/quodeq/data/config/known_models.json
@@ -1,0 +1,21 @@
+{
+  "claude": [
+    {"id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5", "tier": "fast"},
+    {"id": "claude-sonnet-4-6-20260407", "label": "Sonnet 4.6", "tier": "balanced"},
+    {"id": "claude-opus-4-6-20260407", "label": "Opus 4.6", "tier": "thorough"}
+  ],
+  "codex": [
+    {"id": "gpt-4o-mini", "label": "GPT-4o Mini", "tier": "fast"},
+    {"id": "gpt-4o", "label": "GPT-4o", "tier": "balanced"},
+    {"id": "o3", "label": "o3", "tier": "thorough"}
+  ],
+  "copilot": [
+    {"id": "gpt-4o-mini", "label": "GPT-4o Mini", "tier": "fast"},
+    {"id": "gpt-4o", "label": "GPT-4o", "tier": "balanced"},
+    {"id": "o3", "label": "o3", "tier": "thorough"}
+  ],
+  "gemini-cli": [
+    {"id": "gemini-2.5-flash", "label": "Gemini 2.5 Flash", "tier": "fast"},
+    {"id": "gemini-2.5-pro", "label": "Gemini 2.5 Pro", "tier": "thorough"}
+  ]
+}

--- a/src/quodeq/llm_bridge/__init__.py
+++ b/src/quodeq/llm_bridge/__init__.py
@@ -1,0 +1,30 @@
+"""LLM Bridge — clean interface to LLM providers.
+
+The analysis layer calls this module instead of talking to
+Ollama/OpenRouter/CLI tools directly.
+"""
+from quodeq.llm_bridge._providers import (
+    get_provider_configs,
+    get_provider_type,
+    classify_provider,
+)
+from quodeq.llm_bridge._ollama import (
+    get_ollama_status,
+    list_ollama_models,
+    estimate_max_agents,
+    run_concurrency_test,
+)
+from quodeq.llm_bridge._cloud import check_cloud_connection
+from quodeq.llm_bridge._models import get_known_models
+
+__all__ = [
+    "get_provider_configs",
+    "get_provider_type",
+    "classify_provider",
+    "get_ollama_status",
+    "list_ollama_models",
+    "estimate_max_agents",
+    "test_concurrency",
+    "check_cloud_connection",
+    "get_known_models",
+]

--- a/src/quodeq/llm_bridge/_cloud.py
+++ b/src/quodeq/llm_bridge/_cloud.py
@@ -1,0 +1,36 @@
+"""Cloud API provider testing — connection verification."""
+from __future__ import annotations
+
+import logging
+import time
+
+try:
+    import openai
+except ImportError:
+    openai = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+
+def check_cloud_connection(
+    *,
+    api_base: str,
+    model: str,
+    api_key: str,
+) -> dict:
+    """Test a cloud API provider connection with a minimal request."""
+    if openai is None:
+        return {"success": False, "error": "openai package not installed. Install with: pip install 'quodeq[api]'"}
+
+    try:
+        client = openai.OpenAI(base_url=api_base, api_key=api_key)
+        start = time.monotonic()
+        client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1,
+        )
+        latency = int((time.monotonic() - start) * 1000)
+        return {"success": True, "model": model, "latency_ms": latency}
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}

--- a/src/quodeq/llm_bridge/_models.py
+++ b/src/quodeq/llm_bridge/_models.py
@@ -1,0 +1,28 @@
+"""Known model suggestions for CLI providers."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+_KNOWN_MODELS: dict | None = None
+
+
+def _models_path() -> Path:
+    """Path to known_models.json."""
+    return Path(__file__).resolve().parent.parent / "data" / "config" / "known_models.json"
+
+
+def get_known_models() -> dict[str, list[dict]]:
+    """Load known model suggestions per CLI provider."""
+    global _KNOWN_MODELS
+    if _KNOWN_MODELS is not None:
+        return _KNOWN_MODELS
+    try:
+        _KNOWN_MODELS = json.loads(_models_path().read_text())
+        return _KNOWN_MODELS
+    except (OSError, json.JSONDecodeError) as exc:
+        _log.warning("Could not load known_models.json: %s", exc)
+        return {}

--- a/src/quodeq/llm_bridge/_ollama.py
+++ b/src/quodeq/llm_bridge/_ollama.py
@@ -1,0 +1,152 @@
+"""Ollama-specific integration: server status, model list, VRAM estimation."""
+from __future__ import annotations
+
+import json
+import logging
+import platform
+import subprocess
+import urllib.request
+import urllib.error
+
+_log = logging.getLogger(__name__)
+
+_OLLAMA_BASE = "http://localhost:11434"
+_TIMEOUT_S = 3
+
+
+def get_ollama_status(base_url: str = _OLLAMA_BASE) -> dict:
+    """Check if the Ollama server is running."""
+    try:
+        req = urllib.request.Request(f"{base_url}/api/version")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read())
+            return {
+                "running": True,
+                "version": data.get("version", "unknown"),
+                "address": base_url.replace("http://", ""),
+            }
+    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+        return {"running": False, "error": str(exc)}
+
+
+def list_ollama_models(base_url: str = _OLLAMA_BASE) -> list[dict]:
+    """List installed Ollama models."""
+    try:
+        req = urllib.request.Request(f"{base_url}/api/tags")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read())
+            models = data.get("models", [])
+            return [
+                {
+                    "name": m["name"],
+                    "size": m.get("size", 0),
+                    "quantization": m.get("details", {}).get("quantization_level", ""),
+                    "family": m.get("details", {}).get("family", ""),
+                }
+                for m in models
+            ]
+    except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
+        _log.warning("Could not list Ollama models: %s", exc)
+        return []
+
+
+def get_running_model_info(base_url: str = _OLLAMA_BASE) -> dict | None:
+    """Get info about the currently loaded model (from /api/ps)."""
+    try:
+        req = urllib.request.Request(f"{base_url}/api/ps")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read())
+            models = data.get("models", [])
+            if models:
+                m = models[0]
+                return {
+                    "name": m["name"],
+                    "size": m.get("size", 0),
+                    "size_vram": m.get("size_vram", 0),
+                }
+    except (urllib.error.URLError, ConnectionRefusedError, OSError):
+        pass
+    return None
+
+
+def estimate_max_agents(
+    model_size: float,
+    gpu_memory: float,
+    overhead_factor: float = 1.3,
+) -> dict:
+    """Estimate max parallel agents from model size and GPU memory."""
+    if model_size <= 0 or gpu_memory <= 0:
+        return {"estimate": 1, "model_size": model_size, "gpu_memory": gpu_memory}
+
+    effective_size = model_size * overhead_factor
+    max_contexts = int(gpu_memory / effective_size)
+    estimate = max(1, min(max_contexts, 5))
+
+    return {
+        "estimate": estimate,
+        "model_size": model_size,
+        "gpu_memory": gpu_memory,
+    }
+
+
+def _get_gpu_memory() -> float:
+    """Detect total GPU/unified memory in bytes. Returns 0 if unknown."""
+    system = platform.system()
+    try:
+        if system == "Darwin":
+            # macOS: unified memory — total system RAM is the GPU budget
+            out = subprocess.check_output(["sysctl", "-n", "hw.memsize"], timeout=3)
+            return float(out.strip())
+        if system == "Linux":
+            # Try nvidia-smi for discrete GPU
+            out = subprocess.check_output(
+                ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+                timeout=5,
+            )
+            # First GPU, value in MiB
+            mib = float(out.decode().strip().split("\n")[0])
+            return mib * 1024 * 1024
+    except (subprocess.SubprocessError, FileNotFoundError, ValueError, OSError):
+        pass
+    return 0
+
+
+def run_concurrency_test(
+    model: str,
+    max_agents: int = 5,
+    base_url: str = _OLLAMA_BASE,
+) -> dict:
+    """Estimate max parallel agents based on VRAM usage.
+
+    Queries the running model's VRAM footprint from Ollama /api/ps
+    and compares against available GPU memory to estimate how many
+    parallel contexts can fit.
+    """
+    # Get VRAM used by the loaded model
+    running = get_running_model_info(base_url)
+    if not running or not running.get("size_vram"):
+        # Model not loaded or no VRAM info — try model size from list
+        models = list_ollama_models(base_url)
+        match = next((m for m in models if m["name"] == model), None)
+        model_size = match["size"] if match else 0
+        vram_per_context = model_size
+    else:
+        vram_per_context = running["size_vram"]
+
+    gpu_memory = _get_gpu_memory()
+
+    if vram_per_context <= 0 or gpu_memory <= 0:
+        return {
+            "recommended": 1,
+            "vram_per_context": vram_per_context,
+            "gpu_memory": gpu_memory,
+            "reason": "Could not detect VRAM" if gpu_memory <= 0 else "Could not determine model size",
+        }
+
+    result = estimate_max_agents(model_size=vram_per_context, gpu_memory=gpu_memory)
+
+    return {
+        "recommended": result["estimate"],
+        "vram_per_context": vram_per_context,
+        "gpu_memory": gpu_memory,
+    }

--- a/src/quodeq/llm_bridge/_providers.py
+++ b/src/quodeq/llm_bridge/_providers.py
@@ -1,0 +1,36 @@
+"""Provider detection, configuration, and type classification."""
+from __future__ import annotations
+
+from quodeq.analysis._provider_cache import get_provider_configs as _get_cached_configs
+
+
+def get_provider_configs() -> dict[str, dict]:
+    """Return all provider configurations from ai_providers.json."""
+    return _get_cached_configs()
+
+
+def get_provider_type(provider_id: str) -> str:
+    """Return 'cli' or 'api' for a provider ID."""
+    configs = get_provider_configs()
+    return configs.get(provider_id, {}).get("type", "cli")
+
+
+_LOCAL_API_MARKERS = {"11434", "localhost", "127.0.0.1", "ollama"}
+
+
+def _is_local_api(provider_id: str) -> bool:
+    """Check if an API provider is local (e.g. Ollama)."""
+    configs = get_provider_configs()
+    cfg = configs.get(provider_id, {})
+    api_base = cfg.get("api_base", "")
+    return any(marker in api_base.lower() for marker in _LOCAL_API_MARKERS)
+
+
+def classify_provider(provider_id: str) -> str:
+    """Classify a provider as 'cli', 'local-api', or 'cloud-api'."""
+    ptype = get_provider_type(provider_id)
+    if ptype == "cli":
+        return "cli"
+    if _is_local_api(provider_id):
+        return "local-api"
+    return "cloud-api"

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -192,6 +192,9 @@ class FsToolingMixin:
                         "type": "api",
                     })
 
+        # Sort by 'order' field from ai_providers.json
+        clients.sort(key=lambda c: provider_configs.get(c["id"], {}).get("order", 50))
+
         return {"clients": clients}
 
     def _get_cli_models(self, client_id: str, env: dict[str, str] | None = None) -> dict[str, list[str]]:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -25,13 +25,13 @@ import { useAppState, formatDayLabel } from './hooks/useAppState.js';
  */
 function EvaluateCase({ serverHealth, evaluation, selectedProject }) {
   const { connected, setConnected } = serverHealth;
-  const { job, jobError, liveViolations, analysisPower, setAnalysisPower, persistAnalysisPower, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
+  const { job, jobError, liveViolations, analysisPower, setAnalysisPower, persistAnalysisPower, handleStartEvaluation, handleEvalDismiss, cancelEvaluation, isLocalApi } = evaluation;
   return (
     <>
       {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
-        context={{ selectedProject, analysisPower, onAnalysisPowerChange: setAnalysisPower, onPersistPower: persistAnalysisPower }}
+        context={{ selectedProject, analysisPower, onAnalysisPowerChange: setAnalysisPower, onPersistPower: persistAnalysisPower, isLocalApi }}
         actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation }}
       />
     </>
@@ -39,22 +39,13 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject }) {
 }
 
 /**
- * @param {{ settings: Object, analysisPower: string, setAnalysisPower: Function, persistAnalysisPower: Function }} props
+ * @param {{ settings: Object }} props
  * @returns {JSX.Element}
  */
-function SettingsCase({ settings, analysisPower, setAnalysisPower, persistAnalysisPower }) {
+function SettingsCase({ settings }) {
   return (
     <SettingsPage
       theme={{ mode: settings.themeMode, family: settings.themeFamily, onApplyMode: settings.applyMode, onApplyFamily: settings.applyFamily }}
-      models={{
-        aiCmd: settings.aiCmd, onApplyAiCmd: settings.applyAiCmd,
-        aiModel: settings.aiModel, onAiModelChange: settings.setAiModel,
-        fast: settings.modelFast, onFastChange: settings.setModelFast,
-        balanced: settings.modelBalanced, onBalancedChange: settings.setModelBalanced,
-        thorough: settings.modelThorough, onThoroughChange: settings.setModelThorough,
-      }}
-      analysis={{ power: analysisPower, onPowerChange: setAnalysisPower, onPersist: persistAnalysisPower }}
-      verification={{ enabled: settings.verifyFindings, onApply: settings.applyVerifyFindings }}
     />
   );
 }
@@ -201,7 +192,7 @@ const ROUTE_RENDERERS = {
   file: (params) => <FileDetailPage file={params.file} />,
   evalprinciple: renderEvalPrincipleDetail,
   'eval-principle-detail': renderEvalPrincipleDetail,
-  settings: (params, props) => <SettingsCase settings={props.settings} analysisPower={props.evaluation.analysisPower} setAnalysisPower={props.evaluation.setAnalysisPower} persistAnalysisPower={props.evaluation.persistAnalysisPower} />,
+  settings: (params, props) => <SettingsCase settings={props.settings} />,
   projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
   standards: () => <StandardsPage />,
 };

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -183,4 +183,37 @@ export function getClientModels(clientId) {
   return request(`/ai-clients/${encodeURIComponent(clientId)}/models`);
 }
 
+// ── LLM Bridge ─────────────────────────────────────────────────────────
+
+export function getOllamaStatus() {
+  return request('/ollama/status');
+}
+
+export async function getOllamaModels() {
+  const data = await request('/ollama/models');
+  return data?.models ?? [];
+}
+
+export function testOllamaConcurrency(model) {
+  return request('/ollama/test-concurrency', {
+    method: 'POST',
+    body: JSON.stringify({ model }),
+  });
+}
+
+export function testProviderConnection({ apiBase, model, apiKey }) {
+  return request('/provider/test', {
+    method: 'POST',
+    body: JSON.stringify({ api_base: apiBase, model, api_key: apiKey }),
+  });
+}
+
+export function getKnownModels() {
+  return request('/known-models');
+}
+
+export function getProviderConfigs() {
+  return request('/provider-configs');
+}
+
 // Standards and findings APIs are re-exported at the top of this file.

--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -9,6 +9,12 @@ export const POOL_BUDGET_STORAGE_KEY = 'cc-pool-budget';
 export const AI_CMD_STORAGE_KEY = 'cc-ai-cmd';
 export const PER_DIMENSION_STORAGE_KEY = 'cc-per-dimension';
 
+export const ACTIVE_PROVIDER_KEY = 'cc-active-provider';
+
+export function providerKey(providerId, setting) {
+  return `cc-${providerId}-${setting}`;
+}
+
 export const VISIBLE_STANDARDS_STORAGE_KEY = 'quodeq-visible-standards';
 export const DEFAULT_VISIBLE_STANDARDS = [
   'security', 'reliability', 'maintainability', 'performance', 'usability', 'flexibility',

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -40,7 +40,7 @@ function EvaluateHelpSection() {
   );
 }
 
-function EvaluateHeader({ isRunning, analysisPower, onAnalysisPowerChange, onPersistPower }) {
+function EvaluateHeader({ isRunning, analysisPower, onAnalysisPowerChange, onPersistPower, showPowerSelector }) {
   return (
     <header className="evaluate-header">
       <div className="evaluate-header-content">
@@ -70,19 +70,19 @@ function EvaluateHeader({ isRunning, analysisPower, onAnalysisPowerChange, onPer
           <p className="evaluate-subtitle">Run a comprehensive code quality evaluation on any repository</p>
         </div>
       </div>
-      <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} labelPosition="left" />
+      {showPowerSelector && <PowerSelector value={analysisPower} onChange={onAnalysisPowerChange} onPersist={onPersistPower} labelPosition="left" />}
     </header>
   );
 }
 
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
-  const { selectedProject, analysisPower, onAnalysisPowerChange, onPersistPower } = context;
+  const { selectedProject, analysisPower, onAnalysisPowerChange, onPersistPower, isLocalApi } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
 
   return (
     <section className="evaluate-screen">
-      <EvaluateHeader isRunning={job?.status === 'running'} analysisPower={analysisPower} onAnalysisPowerChange={onAnalysisPowerChange} onPersistPower={onPersistPower} />
+      <EvaluateHeader isRunning={job?.status === 'running'} analysisPower={analysisPower} onAnalysisPowerChange={onAnalysisPowerChange} onPersistPower={onPersistPower} showPowerSelector={!isLocalApi} />
 
       <div className="evaluate-content">
         {!job && selectedProject && (

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { startEvaluation, getEvaluation, cancelEvaluation, getDimensionEval, listEvaluations } from '../../../api/index.js';
-import { DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET, SUBAGENTS_STORAGE_KEY, POOL_BUDGET_STORAGE_KEY, PER_DIMENSION_STORAGE_KEY } from '../../../constants.js';
+import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
 
 const DIMENSION_POLL_INITIAL_MS = 2000;
 const DIMENSION_POLL_MAX_MS = 8000;
@@ -110,11 +110,23 @@ function createJobPoller(refs, setters, startDimensionPolling) {
 }
 
 function preparePayload(payload, storage = localStorage) {
-  const maxSubagents = parseInt(storage.getItem(SUBAGENTS_STORAGE_KEY) || String(DEFAULT_MAX_SUBAGENTS), 10);
-  if (maxSubagents !== DEFAULT_MAX_SUBAGENTS) payload.maxSubagents = maxSubagents;
-  const poolBudget = parseInt(storage.getItem(POOL_BUDGET_STORAGE_KEY) || String(DEFAULT_POOL_BUDGET), 10);
-  if (poolBudget !== DEFAULT_POOL_BUDGET) payload.poolBudget = poolBudget;
-  if (storage.getItem(PER_DIMENSION_STORAGE_KEY) === 'true') payload.perDimension = true;
+  const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
+  if (!activeProvider) return;
+
+  const get = (key) => storage.getItem(providerKey(activeProvider, key));
+
+  payload.aiCmd = activeProvider;
+  const model = get('model');
+  if (model) payload.aiModel = model;
+
+  const subagents = parseInt(get('subagents') || '1', 10);
+  if (subagents !== 1) payload.maxSubagents = subagents;
+
+  const poolBudget = parseInt(get('pool-budget') || '0', 10);
+  if (poolBudget !== 0) payload.poolBudget = poolBudget;
+
+  if (get('per-dimension') === 'true') payload.perDimension = true;
+  if (get('verify') === 'false') payload.verifyFindings = false;
 }
 
 function parseDimensions(payload) {

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react';
+import { getKnownModels } from '../../../api/index.js';
+import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
+import { STORAGE_KEY as POWER_KEY } from '../../evaluation/components/powerLevels.js';
+import ProviderSettings from './ProviderSettings.jsx';
+
+function ModelSuggestInput({ label, value, suggestions, placeholder, onChange }) {
+  return (
+    <div className="settings-model-field">
+      {label && <label className="settings-model-label">{label}</label>}
+      <input
+        type="text"
+        className="settings-model-input"
+        list={`models-${label}`}
+        value={value}
+        placeholder={placeholder || 'Select or type model'}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <datalist id={`models-${label}`}>
+        {suggestions.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+      </datalist>
+    </div>
+  );
+}
+
+export default function CliProviderTab({ providerId, state, update }) {
+  const [suggestions, setSuggestions] = useState([]);
+  const [power, setPower] = useState(() => {
+    try { return Number(localStorage.getItem(POWER_KEY)) || 2; } catch { return 2; }
+  });
+
+  function persistPower(level) {
+    setPower(level);
+    try { localStorage.setItem(POWER_KEY, String(level)); } catch { /* */ }
+  }
+
+  useEffect(() => {
+    getKnownModels()
+      .then((data) => setSuggestions(data[providerId] || []))
+      .catch(() => setSuggestions([]));
+  }, [providerId]);
+
+  const fast = suggestions.filter((m) => m.tier === 'fast');
+  const balanced = suggestions.filter((m) => m.tier === 'balanced');
+  const thorough = suggestions.filter((m) => m.tier === 'thorough');
+
+  return (
+    <>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Model</span>
+          <span className="settings-description">Override the default model. Leave blank to use client default.</span>
+        </div>
+        <ModelSuggestInput value={state.model} suggestions={suggestions} onChange={(v) => update('model', v)} />
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Analysis power</span>
+          <span className="settings-description">Controls which model tier is used for analysis</span>
+        </div>
+        <PowerSelector value={power} onChange={setPower} onPersist={persistPower} />
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Analysis models</span>
+          <span className="settings-description">Override models per power level</span>
+        </div>
+        <div className="settings-model-overrides">
+          <ModelSuggestInput label="Fast" value={state['model-fast']} suggestions={fast.length ? fast : suggestions} placeholder={fast[0]?.label} onChange={(v) => update('model-fast', v)} />
+          <ModelSuggestInput label="Balanced" value={state['model-balanced']} suggestions={balanced.length ? balanced : suggestions} placeholder={balanced[0]?.label} onChange={(v) => update('model-balanced', v)} />
+          <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
+        </div>
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Max parallel agents</span>
+          <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
+        </div>
+        <input
+          type="number"
+          className="settings-model-input"
+          min={1}
+          max={10}
+          value={parseInt(state.subagents || '5', 10)}
+          onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 5)))}
+          onChange={(e) => update('subagents', e.target.value)}
+        />
+      </div>
+      <ProviderSettings state={state} update={update} providerType="cli" />
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { testProviderConnection } from '../../../api/index.js';
+import ProviderSettings from './ProviderSettings.jsx';
+
+export default function CloudProviderTab({ providerId, providerConfig, state, update }) {
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
+
+  const browseUrl = providerConfig?.browse_url || '';
+
+  const runTest = async () => {
+    setTesting(true);
+    try {
+      const result = await testProviderConnection({
+        apiBase: providerConfig?.api_base || '',
+        model: state.model,
+        apiKey: '',
+      });
+      setTestResult(result);
+    } catch { setTestResult({ success: false, error: 'Connection failed' }); }
+    setTesting(false);
+  };
+
+  return (
+    <>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Model</span>
+          <span className="settings-description">
+            Enter the model identifier.
+            {browseUrl && <> <a href={browseUrl} target="_blank" rel="noopener noreferrer">Browse models</a></>}
+          </span>
+        </div>
+        <div className="settings-budget-control">
+          <input
+            type="text"
+            className="settings-model-input"
+            value={state.model}
+            placeholder="e.g. qwen/qwen3.6-plus-preview:free"
+            onChange={(e) => update('model', e.target.value)}
+          />
+          <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !state.model}>
+            {testing ? 'Testing...' : 'Test'}
+          </button>
+        </div>
+        {testResult && (
+          <span className={`settings-description ${testResult.success ? '' : 'settings-error'}`}>
+            {testResult.success ? `Connected (${testResult.latency_ms}ms)` : testResult.error}
+          </span>
+        )}
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Max parallel agents</span>
+          <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
+        </div>
+        <input
+          type="number"
+          className="settings-model-input"
+          min={1}
+          max={10}
+          value={parseInt(state.subagents || '1', 10)}
+          onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 1)))}
+          onChange={(e) => update('subagents', e.target.value)}
+        />
+      </div>
+      <ProviderSettings state={state} update={update} providerType="cloud-api" />
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+import { getOllamaModels, testOllamaConcurrency } from '../../../api/index.js';
+import ServerStatus from './ServerStatus.jsx';
+import ProviderSettings from './ProviderSettings.jsx';
+
+function ModelSelector({ label, value, models, onChange }) {
+  return (
+    <div className="settings-model-field">
+      {label && <label className="settings-model-label">{label}</label>}
+      <select className="settings-model-input" value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">Click to select</option>
+        {models.map((m) => <option key={m.name} value={m.name}>{m.name}</option>)}
+      </select>
+    </div>
+  );
+}
+
+export default function OllamaTab({ state, update }) {
+  const [models, setModels] = useState([]);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
+
+  useEffect(() => {
+    getOllamaModels().then(setModels).catch(() => setModels([]));
+  }, []);
+
+  const runTest = async () => {
+    if (!state.model) return;
+    setTesting(true);
+    try {
+      const result = await testOllamaConcurrency(state.model);
+      setTestResult(result);
+      if (result.recommended) update('subagents', String(result.recommended));
+    } catch { setTestResult(null); }
+    setTesting(false);
+  };
+
+  return (
+    <>
+      <ServerStatus />
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Orchestrator model</span>
+          <span className="settings-description">Main model used for orchestration and planning</span>
+        </div>
+        <ModelSelector value={state.model} models={models} onChange={(v) => update('model', v)} />
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Analysis model</span>
+          <span className="settings-description">Model used by subagents during evaluation. Defaults to orchestrator if not set.</span>
+        </div>
+        <ModelSelector value={state['model-analysis']} models={models} onChange={(v) => update('model-analysis', v)} />
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Max parallel agents</span>
+          <span className="settings-description">Auto-detected from VRAM. Test for accuracy.</span>
+        </div>
+        <div className="settings-budget-control">
+          <input type="number" className="settings-model-input" min={1} max={10} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
+          <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !state.model}>
+            {testing ? 'Testing...' : 'Auto-detect'}
+          </button>
+        </div>
+        {testResult && <span className="settings-description">Recommended: {testResult.recommended} agents</span>}
+      </div>
+      <ProviderSettings state={state} update={update} providerType="local-api" />
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
@@ -1,0 +1,55 @@
+export default function ProviderSettings({ state, update, providerType }) {
+  const poolBudget = parseInt(state['pool-budget'] || '0', 10);
+  const perDimension = state['per-dimension'] !== 'false';
+  const verify = state['verify'] !== 'false';
+  const unlimited = poolBudget === 0;
+
+  return (
+    <>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Analysis time limit</span>
+          <span className="settings-description">Max time per dimension. Unlimited runs until all files processed.</span>
+        </div>
+        <div className="settings-budget-control">
+          <div className="theme-toggle">
+            <button type="button" className={`theme-toggle-btn${unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '0')}>Unlimited</button>
+            <button type="button" className={`theme-toggle-btn${!unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '600')}>Limited</button>
+          </div>
+          <input
+            type="number"
+            className="settings-model-input"
+            min={1}
+            max={60}
+            value={unlimited ? '' : Math.round(poolBudget / 60)}
+            placeholder={unlimited ? '\u221E' : 'min'}
+            disabled={unlimited}
+            onChange={(e) => update('pool-budget', String(parseInt(e.target.value || '10', 10) * 60))}
+          />
+        </div>
+      </div>
+
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Analysis mode</span>
+          <span className="settings-description">Per-dimension gives deeper coverage per quality area</span>
+        </div>
+        <div className="theme-toggle">
+          <button type="button" className={`theme-toggle-btn${perDimension ? ' active' : ''}`} onClick={() => update('per-dimension', 'true')}>Per-dimension</button>
+          <button type="button" className={`theme-toggle-btn${!perDimension ? ' active' : ''}`} onClick={() => update('per-dimension', 'false')}>Grouped</button>
+        </div>
+      </div>
+
+      <div className="settings-row settings-row--last">
+        <div className="settings-row-label">
+          <span className="settings-label">Verify findings</span>
+          <span className="settings-description">Re-check findings from previous runs against current code</span>
+        </div>
+        <div className="theme-toggle">
+          <button type="button" className={`theme-toggle-btn${verify ? ' active' : ''}`} onClick={() => update('verify', 'true')}>On</button>
+          <button type="button" className={`theme-toggle-btn${!verify ? ' active' : ''}`} onClick={() => update('verify', 'false')}>Off</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from 'react';
+import { getAiClients, getOllamaStatus } from '../../../api/index.js';
+import { ACTIVE_PROVIDER_KEY } from '../../../constants.js';
+import useProviderSettings from '../hooks/useProviderSettings.js';
+import { classify_provider } from './providerUtils.js';
+import OllamaTab from './OllamaTab.jsx';
+import CliProviderTab from './CliProviderTab.jsx';
+import CloudProviderTab from './CloudProviderTab.jsx';
+
+const CLI_DEFAULTS = { 'subagents': '5' };
+
+function TabContent({ provider, providerConfig }) {
+  const classification = classify_provider(provider.id, provider.type, providerConfig);
+  const defaults = classification === 'cli' ? CLI_DEFAULTS : undefined;
+  const { state, update } = useProviderSettings(provider.id, defaults);
+
+  if (classification === 'local-api') {
+    return <OllamaTab state={state} update={update} />;
+  }
+  if (classification === 'cli') {
+    return <CliProviderTab providerId={provider.id} state={state} update={update} />;
+  }
+  return <CloudProviderTab providerId={provider.id} providerConfig={providerConfig} state={state} update={update} />;
+}
+
+export default function ProviderTabs({ providerConfigs }) {
+  const [clients, setClients] = useState([]);
+  const [activeTab, setActiveTab] = useState(() => localStorage.getItem(ACTIVE_PROVIDER_KEY) || '');
+  const [statuses, setStatuses] = useState({});
+
+  useEffect(() => {
+    getAiClients().then((data) => {
+      const raw = data.clients || [];
+      // Sort by 'order' field from provider configs (ai_providers.json)
+      const list = [...raw].sort((a, b) => {
+        const oa = providerConfigs?.[a.id]?.order ?? 50;
+        const ob = providerConfigs?.[b.id]?.order ?? 50;
+        return oa - ob;
+      });
+      setClients(list);
+      if (!activeTab && list.length > 0) {
+        setActiveTab(list[0].id);
+        localStorage.setItem(ACTIVE_PROVIDER_KEY, list[0].id);
+      }
+
+      // Migrate old global settings to active provider
+      const MIGRATION_KEY = 'cc-provider-tabs-migrated';
+      if (!localStorage.getItem(MIGRATION_KEY) && list.length > 0) {
+        const targetId = localStorage.getItem('cc-ai-cmd') || list[0].id;
+        const migrations = {
+          'cc-max-subagents': 'subagents',
+          'cc-pool-budget': 'pool-budget',
+          'cc-per-dimension': 'per-dimension',
+          'cc-ai-model': 'model',
+        };
+        for (const [oldKey, newSuffix] of Object.entries(migrations)) {
+          const oldVal = localStorage.getItem(oldKey);
+          if (oldVal !== null) {
+            localStorage.setItem(`cc-${targetId}-${newSuffix}`, oldVal);
+            localStorage.removeItem(oldKey);
+          }
+        }
+        localStorage.setItem(MIGRATION_KEY, '1');
+      }
+    }).catch(() => setClients([]));
+  }, []);
+
+  useEffect(() => {
+    const ollama = clients.find((c) => c.id === 'ollama');
+    if (ollama) {
+      getOllamaStatus()
+        .then((s) => setStatuses((prev) => ({ ...prev, ollama: s.running })))
+        .catch(() => setStatuses((prev) => ({ ...prev, ollama: false })));
+    }
+  }, [clients]);
+
+  const selectTab = (id) => {
+    setActiveTab(id);
+    localStorage.setItem(ACTIVE_PROVIDER_KEY, id);
+  };
+
+  const active = clients.find((c) => c.id === activeTab);
+
+  return (
+    <section className="panel settings-section">
+      <div className="panel-header">
+        <h2 className="settings-section-title">Analysis</h2>
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">AI Provider</span>
+          <span className="settings-description">Select the AI provider used when running evaluations</span>
+        </div>
+        <div className="provider-tab-bar">
+          {clients.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              className={`provider-tab${c.id === activeTab ? ' provider-tab--active' : ''}`}
+              onClick={() => selectTab(c.id)}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {active && (
+        <div className="provider-tab-content">
+          <TabContent key={active.id} provider={active} providerConfig={providerConfigs?.[active.id] || {}} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getAiClients, getOllamaStatus } from '../../../api/index.js';
+import { getAiClients } from '../../../api/index.js';
 import { ACTIVE_PROVIDER_KEY } from '../../../constants.js';
 import useProviderSettings from '../hooks/useProviderSettings.js';
 import { classify_provider } from './providerUtils.js';
@@ -26,8 +26,6 @@ function TabContent({ provider, providerConfig }) {
 export default function ProviderTabs({ providerConfigs }) {
   const [clients, setClients] = useState([]);
   const [activeTab, setActiveTab] = useState(() => localStorage.getItem(ACTIVE_PROVIDER_KEY) || '');
-  const [statuses, setStatuses] = useState({});
-
   useEffect(() => {
     getAiClients().then((data) => {
       const raw = data.clients || [];
@@ -64,15 +62,6 @@ export default function ProviderTabs({ providerConfigs }) {
       }
     }).catch(() => setClients([]));
   }, []);
-
-  useEffect(() => {
-    const ollama = clients.find((c) => c.id === 'ollama');
-    if (ollama) {
-      getOllamaStatus()
-        .then((s) => setStatuses((prev) => ({ ...prev, ollama: s.running })))
-        .catch(() => setStatuses((prev) => ({ ...prev, ollama: false })));
-    }
-  }, [clients]);
 
   const selectTab = (id) => {
     setActiveTab(id);

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -1,0 +1,72 @@
+import { useState, useEffect, useRef } from 'react';
+
+const POLL_MS = 10000;
+
+function ping() {
+  return fetch('/api/health?_t=' + Date.now())
+    .then((r) => r.ok ? r.json() : null)
+    .catch(() => null);
+}
+
+export default function ServerSection() {
+  const [health, setHealth] = useState(null);
+  const [status, setStatus] = useState('checking');
+  const timerRef = useRef(null);
+  const cancelledRef = useRef(false);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+
+    function tick() {
+      ping().then((d) => {
+        if (cancelledRef.current) return;
+        if (d?.ok) { setHealth(d); setStatus('online'); }
+        else { setHealth(null); setStatus('offline'); }
+        timerRef.current = setTimeout(tick, POLL_MS);
+      });
+    }
+    tick();
+
+    return () => { cancelledRef.current = true; clearTimeout(timerRef.current); };
+  }, []);
+
+  return (
+    <section className="panel settings-section">
+      <div className="panel-header">
+        <h2 className="settings-section-title">Server</h2>
+      </div>
+
+      <div className={`server-status ${status === 'online' ? 'server-status--online' : 'server-status--offline'}`}>
+        <span className={`server-dot ${status === 'online' ? 'server-dot--online' : 'server-dot--offline'}`} />
+        <span>
+          {status === 'online' && 'Running'}
+          {status === 'offline' && 'Connection lost'}
+          {status === 'checking' && 'Checking...'}
+        </span>
+        {status === 'online' && health?.address && <span className="server-address">{health.address}</span>}
+      </div>
+
+      {status === 'online' && health && (
+        <div className="settings-row settings-row--last">
+          <div className="settings-row-label">
+            <span className="settings-label">Details</span>
+            <span className="settings-description">
+              Port <strong>{health.port}</strong> &middot; PID <strong>{health.pid}</strong> &middot; v{health.version}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {status === 'offline' && (
+        <div className="settings-row settings-row--last">
+          <div className="settings-row-label">
+            <span className="settings-label">Restart</span>
+            <span className="settings-description">
+              Stop the server with <code>Ctrl+C</code> in the terminal, then run <code>quodeq dashboard</code> to restart. This page will reconnect automatically.
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/ServerStatus.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerStatus.jsx
@@ -1,15 +1,24 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { getOllamaStatus } from '../../../api/index.js';
+
+const POLL_MS = 30000;
 
 export default function ServerStatus() {
   const [status, setStatus] = useState(null);
+  const timerRef = useRef(null);
 
   useEffect(() => {
-    getOllamaStatus().then(setStatus).catch(() => setStatus({ running: false, error: 'Could not reach server' }));
-    const interval = setInterval(() => {
-      getOllamaStatus().then(setStatus).catch(() => setStatus({ running: false, error: 'Connection lost' }));
-    }, 15000);
-    return () => clearInterval(interval);
+    function tick() {
+      getOllamaStatus()
+        .then(setStatus)
+        .catch(() => setStatus({ running: false, error: 'Could not reach server' }));
+    }
+    tick();
+    timerRef.current = setTimeout(function schedule() {
+      tick();
+      timerRef.current = setTimeout(schedule, POLL_MS);
+    }, POLL_MS);
+    return () => clearTimeout(timerRef.current);
   }, []);
 
   if (!status) return null;

--- a/src/quodeq/ui/src/features/settings/components/ServerStatus.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerStatus.jsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { getOllamaStatus } from '../../../api/index.js';
+
+export default function ServerStatus() {
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    getOllamaStatus().then(setStatus).catch(() => setStatus({ running: false, error: 'Could not reach server' }));
+    const interval = setInterval(() => {
+      getOllamaStatus().then(setStatus).catch(() => setStatus({ running: false, error: 'Connection lost' }));
+    }, 15000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!status) return null;
+
+  if (status.running) {
+    return (
+      <div className="server-status server-status--online">
+        <span className="server-dot server-dot--online" />
+        <span>Server running</span>
+        <span className="server-address">{status.address}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="server-status server-status--offline">
+      <span className="server-dot server-dot--offline" />
+      <span>Server offline — Run <code>ollama serve</code> or open the Ollama app</span>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -1,20 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
-import { getHealth, getAiClients } from '../../../api/index.js';
-import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
+import { useState, useEffect } from 'react';
+import { getHealth, getProviderConfigs } from '../../../api/index.js';
 import SettingsAside from './SettingsAside.jsx';
 import AboutSection from './AboutSection.jsx';
-import ModelSection from './ModelSection.jsx';
-import { DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET, SUBAGENTS_STORAGE_KEY, POOL_BUDGET_STORAGE_KEY, AI_CMD_STORAGE_KEY, PER_DIMENSION_STORAGE_KEY } from '../../../constants.js';
-
-const MIN_SUBAGENTS = 1;
-const MAX_SUBAGENTS = 10;
-const MIN_POOL_BUDGET_MINS = 0;
-const MAX_POOL_BUDGET_MINS = 60;
-const DEFAULT_POOL_BUDGET_MINS = 10;
-
-function persistSetting(key, value) {
-  localStorage.setItem(key, String(value));
-}
+import ProviderTabs from './ProviderTabs.jsx';
+import ServerSection from './ServerSection.jsx';
 
 const MODE_OPTIONS = [
   { value: 'system',   label: 'System' },
@@ -84,164 +73,6 @@ function ThemeSection({ themeMode, themeFamily, onApplyMode, onApplyFamily }) {
   );
 }
 
-function clampSubagents(value) {
-  return Math.max(MIN_SUBAGENTS, Math.min(MAX_SUBAGENTS, parseInt(value, 10) || DEFAULT_MAX_SUBAGENTS));
-}
-
-function persistSubagents(value, setter) {
-  const v = clampSubagents(value);
-  setter(v);
-  persistSetting(SUBAGENTS_STORAGE_KEY, v);
-}
-
-function clampPoolBudget(value) {
-  const parsed = parseInt(value, 10);
-  if (isNaN(parsed)) return DEFAULT_POOL_BUDGET_MINS;
-  if (parsed === 0) return 0; // 0 = unlimited
-  return Math.max(MIN_POOL_BUDGET_MINS, Math.min(MAX_POOL_BUDGET_MINS, parsed));
-}
-
-function persistPoolBudget(value, setter) {
-  const v = clampPoolBudget(value);
-  setter(v);
-  // 0 minutes → 0 seconds (unlimited); pool interprets 0 as no limit
-  persistSetting(POOL_BUDGET_STORAGE_KEY, v * 60);
-}
-
-function SubagentsRow({ subagents }) {
-  const { max, setMax } = subagents;
-  return (
-    <div className="settings-row">
-      <div className="settings-row-label">
-        <span className="settings-label">Max parallel agents</span>
-        <span className="settings-description">
-          Maximum number of subagents to run in parallel during evaluation (1–10). Higher values speed up analysis but use more resources.
-        </span>
-      </div>
-      <input
-        type="number"
-        className="settings-model-input"
-        min={MIN_SUBAGENTS}
-        max={MAX_SUBAGENTS}
-        value={max}
-        onChange={(e) => setMax(e.target.value)}
-        onBlur={(e) => persistSubagents(e.target.value, setMax)}
-      />
-    </div>
-  );
-}
-
-function PoolBudgetRow({ subagents }) {
-  const { poolBudgetMinutes, setPoolBudgetMinutes } = subagents;
-  const unlimited = poolBudgetMinutes === 0;
-
-  return (
-    <div className="settings-row settings-row--last">
-      <div className="settings-row-label">
-        <span className="settings-label">Analysis time limit</span>
-        <span className="settings-description">
-          Maximum time allowed for the analysis pool to run. Evaluations exceeding this limit will stop early.
-        </span>
-      </div>
-      <div className="settings-budget-control">
-        <div className="theme-toggle">
-          <button
-            type="button"
-            className={`theme-toggle-btn${!unlimited ? ' active' : ''}`}
-            onClick={() => persistPoolBudget(poolBudgetMinutes || DEFAULT_POOL_BUDGET_MINS, setPoolBudgetMinutes)}
-          >Limited</button>
-          <button
-            type="button"
-            className={`theme-toggle-btn${unlimited ? ' active' : ''}`}
-            onClick={() => { setPoolBudgetMinutes(0); persistSetting(POOL_BUDGET_STORAGE_KEY, 0); }}
-          >Unlimited</button>
-        </div>
-        <input
-          type="number"
-          className="settings-model-input"
-          min={1}
-          max={MAX_POOL_BUDGET_MINS}
-          value={unlimited ? '' : poolBudgetMinutes}
-          placeholder={unlimited ? '∞' : 'min'}
-          disabled={unlimited}
-          onChange={(e) => persistPoolBudget(e.target.value, setPoolBudgetMinutes)}
-        />
-      </div>
-    </div>
-  );
-}
-
-function PerDimensionRow({ perDimension, onApply, providerType }) {
-  if (providerType === 'api') return null;
-  return (
-    <div className="settings-row">
-      <div className="settings-row-label">
-        <span className="settings-label">Per-dimension analysis</span>
-        <span className="settings-description">
-          Analyze each quality dimension separately instead of all at once. Deeper coverage per dimension but uses more tokens.
-        </span>
-      </div>
-      <div className="theme-toggle">
-        <button
-          type="button"
-          className={`theme-toggle-btn${perDimension ? ' active' : ''}`}
-          onClick={() => onApply(true)}
-        >Per-dimension</button>
-        <button
-          type="button"
-          className={`theme-toggle-btn${!perDimension ? ' active' : ''}`}
-          onClick={() => onApply(false)}
-        >Consolidated</button>
-      </div>
-    </div>
-  );
-}
-
-function AnalysisSection({ analysis, subagents, perDimension }) {
-  const { power, onChange, onPersist } = analysis;
-  return (
-    <>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">Analysis power</span>
-          <span className="settings-description">
-            Controls the AI model used for analysis. Higher power gives more thorough results but takes longer.
-          </span>
-        </div>
-        <PowerSelector value={power} onChange={onChange} onPersist={onPersist} />
-      </div>
-      <SubagentsRow subagents={subagents} />
-      <PoolBudgetRow subagents={subagents} />
-      <PerDimensionRow {...perDimension} />
-    </>
-  );
-}
-
-function VerificationSection({ verifyFindings, onApplyVerifyFindings }) {
-  return (
-    <div className="settings-row">
-      <div className="settings-row-label">
-        <span className="settings-label">Verify findings</span>
-        <span className="settings-description">
-          After analysis, verify findings from the previous evaluation against the current code. Confirms which violations persist, detects fixes, and hunts for missing compliance evidence. Improves grade consistency across runs.
-        </span>
-      </div>
-      <div className="theme-toggle">
-        <button
-          type="button"
-          className={`theme-toggle-btn${verifyFindings ? ' active' : ''}`}
-          onClick={() => onApplyVerifyFindings(true)}
-        >On</button>
-        <button
-          type="button"
-          className={`theme-toggle-btn${!verifyFindings ? ' active' : ''}`}
-          onClick={() => onApplyVerifyFindings(false)}
-        >Off</button>
-      </div>
-    </div>
-  );
-}
-
 function SettingsHeader() {
   return (
     <div className="settings-header">
@@ -266,89 +97,27 @@ function SettingsHeader() {
   );
 }
 
-function useSettingsState(aiCmd, onApplyAiCmd) {
-  const [maxSubagents, setMaxSubagents] = useState(() => parseInt(localStorage.getItem(SUBAGENTS_STORAGE_KEY) || String(DEFAULT_MAX_SUBAGENTS), 10));
-  const [poolBudgetMinutes, setPoolBudgetMinutes] = useState(() => Math.round(parseInt(localStorage.getItem(POOL_BUDGET_STORAGE_KEY) || String(DEFAULT_POOL_BUDGET), 10) / 60));
-  const [availableClients, setAvailableClients] = useState(null);
+export default function SettingsPage({ theme }) {
+  const { mode: themeMode, family: themeFamily, onApplyMode, onApplyFamily } = theme;
   const [appVersion, setAppVersion] = useState(null);
   const [settingsPhrase, setSettingsPhrase] = useState('');
-
-  // Stable reference so it can be included in the effect dep array without re-running
-  const stableApplyAiCmd = useCallback(onApplyAiCmd, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const [providerConfigs, setProviderConfigs] = useState({});
 
   useEffect(() => {
     setSettingsPhrase(_SETTINGS_PHRASES[Math.floor(Math.random() * _SETTINGS_PHRASES.length)]);
     getHealth().then((d) => setAppVersion(d.version || null)).catch((err) => console.warn('Failed to fetch app version:', err));
+    getProviderConfigs().then(setProviderConfigs).catch(() => setProviderConfigs({}));
   }, []);
-
-  useEffect(() => {
-    if (availableClients !== null) return;
-    getAiClients()
-      .then((data) => {
-        const clients = data.clients || [];
-        setAvailableClients(clients);
-        if (aiCmd && !clients.some((c) => c.id === aiCmd)) {
-          stableApplyAiCmd('');
-          localStorage.removeItem(AI_CMD_STORAGE_KEY);
-        }
-        if (!aiCmd && clients.length > 0) {
-          stableApplyAiCmd(clients[0].id);
-        }
-      })
-      .catch(() => setAvailableClients([]));
-  }, [aiCmd, stableApplyAiCmd]);
-
-  const [perDimension, setPerDimension] = useState(() => localStorage.getItem(PER_DIMENSION_STORAGE_KEY) !== 'false');
-
-  function applyPerDimension(value) {
-    setPerDimension(value);
-    persistSetting(PER_DIMENSION_STORAGE_KEY, String(value));
-  }
-
-  // Determine provider type for current aiCmd
-  const providerType = availableClients
-    ? (availableClients.find((c) => c.id === aiCmd)?.type || 'cli')
-    : 'cli';
-
-  return { maxSubagents, setMaxSubagents, poolBudgetMinutes, setPoolBudgetMinutes, availableClients, appVersion, settingsPhrase, perDimension, applyPerDimension, providerType };
-}
-
-export default function SettingsPage({ theme, models, analysis, verification }) {
-  const { mode: themeMode, family: themeFamily, onApplyMode, onApplyFamily } = theme;
-  const { aiCmd, onApplyAiCmd } = models;
-  const { power: analysisPower, onPowerChange: onAnalysisPowerChange, onPersist: onPersistPower } = analysis;
-  const { enabled: verifyFindings, onApply: onApplyVerifyFindings } = verification;
-  const { maxSubagents, setMaxSubagents, poolBudgetMinutes, setPoolBudgetMinutes, availableClients, appVersion, settingsPhrase, perDimension, applyPerDimension, providerType } = useSettingsState(aiCmd, onApplyAiCmd);
 
   return (
     <div className="settings-page">
       <SettingsHeader />
       <div className="settings-body settings-body--full">
         <div className="settings-grid">
-          <section className="panel settings-section">
-            <div className="panel-header">
-              <h2 className="settings-section-title">Analysis</h2>
-              <p className="settings-section-description">Configure the AI client used when running evaluations</p>
-            </div>
-            <ModelSection
-              aiCmd={{ value: aiCmd, onApply: onApplyAiCmd }}
-              models={{
-                aiModel: models.aiModel, onAiModelChange: models.onAiModelChange,
-                fast: models.fast, onFastChange: models.onFastChange,
-                balanced: models.balanced, onBalancedChange: models.onBalancedChange,
-                thorough: models.thorough, onThoroughChange: models.onThoroughChange,
-              }}
-              availableClients={availableClients}
-            />
-            <AnalysisSection
-              analysis={{ power: analysisPower, onChange: onAnalysisPowerChange, onPersist: onPersistPower }}
-              subagents={{ max: maxSubagents, setMax: setMaxSubagents, poolBudgetMinutes, setPoolBudgetMinutes }}
-              perDimension={{ perDimension, onApply: applyPerDimension, providerType }}
-            />
-            <VerificationSection verifyFindings={verifyFindings} onApplyVerifyFindings={onApplyVerifyFindings} />
-          </section>
+          <ProviderTabs providerConfigs={providerConfigs} />
 
           <div className="settings-grid-col">
+            <ServerSection />
             <ThemeSection themeMode={themeMode} themeFamily={themeFamily} onApplyMode={onApplyMode} onApplyFamily={onApplyFamily} />
             <AboutSection appVersion={appVersion} settingsPhrase={settingsPhrase} />
           </div>

--- a/src/quodeq/ui/src/features/settings/components/providerUtils.js
+++ b/src/quodeq/ui/src/features/settings/components/providerUtils.js
@@ -1,0 +1,8 @@
+const LOCAL_MARKERS = ['11434', 'localhost', '127.0.0.1', 'ollama'];
+
+export function classify_provider(id, type, config) {
+  if (type === 'cli' || !type) return 'cli';
+  const apiBase = (config?.api_base || '').toLowerCase();
+  if (LOCAL_MARKERS.some((m) => apiBase.includes(m))) return 'local-api';
+  return 'cloud-api';
+}

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -1,0 +1,39 @@
+import { useState, useCallback } from 'react';
+import { providerKey } from '../../../constants.js';
+
+const SETTINGS = ['model', 'model-analysis', 'model-fast', 'model-balanced', 'model-thorough', 'subagents', 'pool-budget', 'per-dimension', 'verify'];
+const DEFAULTS = {
+  'model': '',
+  'model-analysis': '',
+  'model-fast': '',
+  'model-balanced': '',
+  'model-thorough': '',
+  'subagents': '1',
+  'pool-budget': '0',
+  'per-dimension': 'true',
+  'verify': 'true',
+};
+
+function loadProviderState(providerId, overrides) {
+  const merged = { ...DEFAULTS, ...overrides };
+  const state = {};
+  for (const key of SETTINGS) {
+    state[key] = localStorage.getItem(providerKey(providerId, key)) ?? merged[key];
+  }
+  return state;
+}
+
+function saveProviderSetting(providerId, key, value) {
+  localStorage.setItem(providerKey(providerId, key), String(value));
+}
+
+export default function useProviderSettings(providerId, defaults) {
+  const [state, setState] = useState(() => loadProviderState(providerId, defaults));
+
+  const update = useCallback((key, value) => {
+    setState(prev => ({ ...prev, [key]: String(value) }));
+    saveProviderSetting(providerId, key, value);
+  }, [providerId]);
+
+  return { state, update };
+}

--- a/src/quodeq/ui/src/hooks/useAppSettings.js
+++ b/src/quodeq/ui/src/hooks/useAppSettings.js
@@ -1,13 +1,9 @@
 import { useState, useEffect } from 'react';
-import { MODEL_STORAGE_PREFIX } from '../features/evaluation/components/powerLevels.js';
 import { resolveDataTheme } from '../utils/themeResolver.js';
 
 const MODE_KEY = 'cc-theme-mode';
 const FAMILY_KEY = 'cc-theme-family';
 const OLD_THEME_KEY = 'cc-theme';
-const AI_CMD_KEY = 'cc-ai-cmd';
-const AI_MODEL_KEY = 'cc-ai-model';
-const VERIFY_FINDINGS_KEY = 'cc-verify-findings';
 
 const VALID_MODES = ['system', 'light', 'dark'];
 const VALID_FAMILIES = ['daruma', 'neo', 'galadriel', 'ifrit', 'deckard'];
@@ -64,14 +60,6 @@ export function useAppSettings() {
 
   const [themeMode, setThemeMode] = useState(safeGet(MODE_KEY, 'system'));
   const [themeFamily, setThemeFamily] = useState(safeGet(FAMILY_KEY, 'daruma'));
-  const [aiCmd, setAiCmd] = useState(safeGet(AI_CMD_KEY));
-  const [aiModel, setAiModel] = useState(safeGet(AI_MODEL_KEY));
-  const [modelFast, setModelFast] = useState(safeGet(`${MODEL_STORAGE_PREFIX}1`));
-  const [modelBalanced, setModelBalanced] = useState(safeGet(`${MODEL_STORAGE_PREFIX}2`));
-  const [modelThorough, setModelThorough] = useState(safeGet(`${MODEL_STORAGE_PREFIX}3`));
-  const [verifyFindings, setVerifyFindings] = useState(() => {
-    try { const v = localStorage.getItem(VERIFY_FINDINGS_KEY); return v === null ? true : v === 'true'; } catch { return true; }
-  });
 
   // Listen for OS color scheme changes when in system mode
   useEffect(() => {
@@ -101,28 +89,8 @@ export function useAppSettings() {
     applyDataTheme(resolveDataTheme(themeMode, value, prefersDark));
   }
 
-  function applyAiCmd(value) {
-    setAiCmd(value);
-    if (value) {
-      localStorage.setItem(AI_CMD_KEY, value);
-    } else {
-      localStorage.removeItem(AI_CMD_KEY);
-    }
-  }
-
-  function applyVerifyFindings(value) {
-    setVerifyFindings(value);
-    localStorage.setItem(VERIFY_FINDINGS_KEY, value ? 'true' : 'false');
-  }
-
   return {
     themeMode, applyMode,
     themeFamily, applyFamily,
-    aiCmd, applyAiCmd,
-    aiModel, setAiModel,
-    modelFast, setModelFast,
-    modelBalanced, setModelBalanced,
-    modelThorough, setModelThorough,
-    verifyFindings, applyVerifyFindings,
   };
 }

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 import { useEvaluation } from '../features/evaluation/hooks/useEvaluation.js';
 import { getLevels, STORAGE_KEY as POWER_KEY } from '../features/evaluation/components/powerLevels.js';
+import { ACTIVE_PROVIDER_KEY, providerKey } from '../constants.js';
+
+const LOCAL_API_PROVIDERS = ['ollama'];
 
 /**
  * Manages the full evaluation lifecycle: start, poll, dismiss, cancel.
@@ -38,9 +41,18 @@ export function useEvaluationLifecycle({ settings, navigation, projects }) {
   }, [job]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleStartEvaluation(payload) {
-    const levels = getLevels();
-    const subagentModel = levels.find(l => l.level === analysisPower)?.model;
-    startEvaluation({ ...payload, aiCmd: settings.aiCmd || undefined, aiModel: settings.aiModel || undefined, subagentModel, verifyFindings: settings.verifyFindings });
+    const activeProvider = localStorage.getItem(ACTIVE_PROVIDER_KEY) || '';
+    const get = (key) => localStorage.getItem(providerKey(activeProvider, key));
+    // Ollama uses a single analysis model; CLI providers use tier-based selection
+    const analysisModel = get('model-analysis');
+    let subagentModel;
+    if (analysisModel) {
+      subagentModel = analysisModel;
+    } else {
+      const tierNames = ['fast', 'balanced', 'thorough'];
+      subagentModel = get(`model-${tierNames[analysisPower - 1]}`) || undefined;
+    }
+    startEvaluation({ ...payload, subagentModel });
   }
 
   function handleEvalDismiss(action) {
@@ -50,9 +62,13 @@ export function useEvaluationLifecycle({ settings, navigation, projects }) {
     clearJob();
   }
 
+  const activeProvider = localStorage.getItem(ACTIVE_PROVIDER_KEY) || '';
+  const isLocalApi = LOCAL_API_PROVIDERS.includes(activeProvider);
+
   return {
     job, jobError, liveViolations,
     analysisPower, setAnalysisPower, persistAnalysisPower,
     handleStartEvaluation, handleEvalDismiss, cancelEvaluation,
+    isLocalApi,
   };
 }

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1630,3 +1630,106 @@ textarea:focus {
   from { opacity: 0; }
   to { opacity: 1; }
 }
+
+/* ── Provider Tabs ───────────────────────────────────────────────────── */
+
+.provider-tab-bar {
+  display: flex;
+  gap: 8px;
+}
+
+.provider-tab {
+  padding: 10px 14px;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  font-family: var(--font-sans);
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.provider-tab--active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: var(--weight-semibold);
+}
+
+.provider-tab:hover:not(.provider-tab--active) {
+  border-color: var(--color-text-muted);
+}
+
+.provider-tab-content {
+  padding: 0;
+}
+
+.server-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.server-dot--online { background: #4ade80; }
+.server-dot--offline { background: #f87171; }
+.server-dot--unknown { background: var(--color-text-muted); }
+
+.server-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+}
+
+.server-status--online {
+  background: color-mix(in srgb, #4ade80 10%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, #4ade80 30%, var(--color-border));
+  color: #4ade80;
+}
+
+.server-status--offline {
+  background: color-mix(in srgb, #f87171 10%, var(--color-surface));
+  border: 1px solid color-mix(in srgb, #f87171 30%, var(--color-border));
+  color: #f87171;
+}
+
+.server-address {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+.settings-error {
+  color: #f87171;
+}
+
+.settings-action-btn {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.settings-action-btn:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
+.settings-action-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -1,0 +1,61 @@
+"""Tests for llm_bridge API routes."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path):
+    from quodeq.api.app import create_app
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+class TestOllamaStatus:
+    def test_returns_status(self, client):
+        with patch("quodeq.api.llm_bridge_routes.get_ollama_status") as mock:
+            mock.return_value = {"running": True, "version": "0.20.2", "address": "localhost:11434"}
+            resp = client.get("/api/ollama/status")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["running"] is True
+
+
+class TestOllamaModels:
+    def test_returns_models(self, client):
+        with patch("quodeq.api.llm_bridge_routes.list_ollama_models") as mock:
+            mock.return_value = [{"name": "gemma4:26b", "size": 34e9, "quantization": "Q4_K_M", "family": "gemma4"}]
+            resp = client.get("/api/ollama/models")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["models"]) == 1
+
+
+class TestProviderTest:
+    def test_success(self, client):
+        with patch("quodeq.api.llm_bridge_routes.check_cloud_connection") as mock:
+            mock.return_value = {"success": True, "model": "test", "latency_ms": 200}
+            resp = client.post("/api/provider/test", json={
+                "provider": "openrouter",
+                "model": "test",
+                "api_base": "https://example.com/v1",
+                "api_key": "sk-test",
+            }, headers={"Origin": "http://localhost"})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+
+
+class TestKnownModels:
+    def test_returns_models(self, client):
+        resp = client.get("/api/known-models")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "claude" in data

--- a/tests/llm_bridge/test_cloud.py
+++ b/tests/llm_bridge/test_cloud.py
@@ -1,0 +1,52 @@
+"""Tests for cloud API provider testing."""
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.llm_bridge._cloud import check_cloud_connection
+
+
+class TestCloudConnection:
+    def test_successful_connection(self):
+        mock_client = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "hi"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch("quodeq.llm_bridge._cloud.openai") as mock_openai:
+            mock_openai.OpenAI.return_value = mock_client
+            result = check_cloud_connection(
+                api_base="https://openrouter.ai/api/v1",
+                model="test-model",
+                api_key="sk-test",
+            )
+
+        assert result["success"] is True
+        assert "latency_ms" in result
+
+    def test_auth_failure(self):
+        with patch("quodeq.llm_bridge._cloud.openai") as mock_openai:
+            mock_openai.OpenAI.return_value.chat.completions.create.side_effect = Exception("401 Unauthorized")
+            result = check_cloud_connection(
+                api_base="https://openrouter.ai/api/v1",
+                model="test-model",
+                api_key="bad-key",
+            )
+
+        assert result["success"] is False
+        assert "401" in result["error"]
+
+    def test_missing_openai_package(self):
+        with patch("quodeq.llm_bridge._cloud.openai", None):
+            result = check_cloud_connection(
+                api_base="https://example.com/v1",
+                model="test",
+                api_key="test",
+            )
+
+        assert result["success"] is False
+        assert "openai" in result["error"].lower()

--- a/tests/llm_bridge/test_models.py
+++ b/tests/llm_bridge/test_models.py
@@ -1,0 +1,32 @@
+"""Tests for known model suggestions."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.llm_bridge._models import get_known_models
+
+
+class TestGetKnownModels:
+    def test_returns_dict(self):
+        models = get_known_models()
+        assert isinstance(models, dict)
+
+    def test_claude_has_models(self):
+        models = get_known_models()
+        assert "claude" in models
+        assert len(models["claude"]) > 0
+
+    def test_model_has_required_fields(self):
+        models = get_known_models()
+        for provider, model_list in models.items():
+            for m in model_list:
+                assert "id" in m, f"Missing 'id' in {provider} model"
+                assert "label" in m, f"Missing 'label' in {provider} model"
+                assert "tier" in m, f"Missing 'tier' in {provider} model"
+
+    def test_tiers_are_valid(self):
+        valid_tiers = {"fast", "balanced", "thorough"}
+        models = get_known_models()
+        for provider, model_list in models.items():
+            for m in model_list:
+                assert m["tier"] in valid_tiers, f"Invalid tier '{m['tier']}' in {provider}"

--- a/tests/llm_bridge/test_ollama.py
+++ b/tests/llm_bridge/test_ollama.py
@@ -1,0 +1,112 @@
+"""Tests for Ollama integration in llm_bridge."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.llm_bridge._ollama import (
+    get_ollama_status,
+    list_ollama_models,
+    estimate_max_agents,
+    run_concurrency_test,
+)
+
+
+class TestGetOllamaStatus:
+    def test_running(self):
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b'{"version":"0.20.2"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
+            result = get_ollama_status()
+
+        assert result["running"] is True
+        assert result["version"] == "0.20.2"
+
+    def test_not_running(self):
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            result = get_ollama_status()
+
+        assert result["running"] is False
+        assert "error" in result
+
+
+class TestListOllamaModels:
+    def test_returns_models(self):
+        mock_data = {
+            "models": [
+                {
+                    "name": "gemma4:26b",
+                    "size": 34088653984,
+                    "details": {"quantization_level": "Q4_K_M", "family": "gemma4"},
+                }
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", return_value=mock_resp):
+            models = list_ollama_models()
+
+        assert len(models) == 1
+        assert models[0]["name"] == "gemma4:26b"
+        assert models[0]["size"] == 34088653984
+
+    def test_server_offline(self):
+        with patch("quodeq.llm_bridge._ollama.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            models = list_ollama_models()
+
+        assert models == []
+
+
+class TestEstimateMaxAgents:
+    def test_small_model_high_memory(self):
+        result = estimate_max_agents(model_size=14e9, gpu_memory=48e9)
+        assert result["estimate"] >= 2
+
+    def test_large_model_limited_memory(self):
+        result = estimate_max_agents(model_size=34e9, gpu_memory=48e9)
+        assert result["estimate"] >= 1
+
+    def test_model_exceeds_memory(self):
+        result = estimate_max_agents(model_size=80e9, gpu_memory=48e9)
+        assert result["estimate"] == 1
+
+
+class TestConcurrency:
+    def test_estimates_from_vram(self):
+        # Model using 17GB VRAM, system has 48GB
+        with patch("quodeq.llm_bridge._ollama.get_running_model_info") as mock_ps, \
+             patch("quodeq.llm_bridge._ollama._get_gpu_memory", return_value=48e9):
+            mock_ps.return_value = {"name": "gemma4:26b", "size": 34e9, "size_vram": 17e9}
+            result = run_concurrency_test("gemma4:26b")
+
+        assert "recommended" in result
+        assert result["recommended"] >= 1
+        assert result["vram_per_context"] == 17e9
+        assert result["gpu_memory"] == 48e9
+
+    def test_falls_back_to_model_list(self):
+        # No model loaded, falls back to model size from list
+        with patch("quodeq.llm_bridge._ollama.get_running_model_info", return_value=None), \
+             patch("quodeq.llm_bridge._ollama.list_ollama_models") as mock_list, \
+             patch("quodeq.llm_bridge._ollama._get_gpu_memory", return_value=48e9):
+            mock_list.return_value = [{"name": "gemma4:26b", "size": 34e9}]
+            result = run_concurrency_test("gemma4:26b")
+
+        assert result["recommended"] == 1  # 34GB model in 48GB = 1 context
+
+    def test_server_offline(self):
+        with patch("quodeq.llm_bridge._ollama.get_running_model_info", return_value=None), \
+             patch("quodeq.llm_bridge._ollama.list_ollama_models", return_value=[]), \
+             patch("quodeq.llm_bridge._ollama._get_gpu_memory", return_value=0):
+            result = run_concurrency_test("gemma4:26b")
+
+        assert result["recommended"] == 1

--- a/tests/llm_bridge/test_providers.py
+++ b/tests/llm_bridge/test_providers.py
@@ -1,0 +1,46 @@
+"""Tests for llm_bridge provider detection."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from quodeq.llm_bridge._providers import (
+    get_provider_configs,
+    get_provider_type,
+    classify_provider,
+)
+
+
+class TestGetProviderConfigs:
+    def test_returns_dict(self):
+        configs = get_provider_configs()
+        assert isinstance(configs, dict)
+
+    def test_contains_known_providers(self):
+        configs = get_provider_configs()
+        assert "claude" in configs or "ollama" in configs
+
+
+class TestGetProviderType:
+    def test_cli_provider(self):
+        assert get_provider_type("claude") == "cli"
+
+    def test_api_provider(self):
+        assert get_provider_type("ollama") == "api"
+
+    def test_unknown_defaults_to_cli(self):
+        assert get_provider_type("nonexistent-tool") == "cli"
+
+
+class TestClassifyProvider:
+    def test_ollama_is_local_api(self):
+        result = classify_provider("ollama")
+        assert result == "local-api"
+
+    def test_claude_is_cli(self):
+        result = classify_provider("claude")
+        assert result == "cli"
+
+    def test_openrouter_is_cloud_api(self):
+        result = classify_provider("openrouter")
+        assert result == "cloud-api"


### PR DESCRIPTION
## Summary

- **llm_bridge module** — new clean interface to LLM providers: detection/classification, Ollama integration (status, models, VRAM-based agent estimation), cloud API connection testing, known model suggestions
- **API routes** — endpoints for Ollama status/models, cloud connection test, known models, provider configs. Provider ordering via `order` field in `ai_providers.json`
- **Tabbed provider UI** — replaces flat Analysis settings with per-provider tabs (Ollama, Claude, Codex, Copilot, OpenRouter). Each tab has independent localStorage state with provider-specific controls
- **Server section** — dashboard server status with connection monitoring and restart instructions
- **Evaluation wiring** — reads active provider settings (model, subagents, pool budget, per-dimension, verify) from the selected tab

### Provider-specific behavior
- **Ollama**: orchestrator + analysis model selectors, VRAM-based auto-detect for max agents, server status banner
- **CLI (Claude/Codex/Copilot)**: power selector with tier model overrides (placeholders from known_models.json), default 5 agents
- **Cloud (OpenRouter)**: model input with connection test button

### Other changes
- Add Copilot CLI provider config and known models
- Tab order driven by `order` field in `ai_providers.json` (Ollama → Claude → Codex → Copilot → OpenRouter)
- Health endpoint returns host, port, PID
- localStorage migration from old global keys to per-provider keys
- Power selector hidden for Ollama in evaluate screen

## Test plan
- [x] 28 new tests (llm_bridge + API routes) all passing
- [x] Settings page shows provider tabs with correct order
- [x] Switching tabs shows independent settings per provider
- [x] Ollama tab shows server status, model dropdowns
- [x] Claude tab shows power selector, model overrides with Haiku/Sonnet/Opus placeholders
- [x] Start evaluation — uses active provider's settings
- [x] Server section shows running status, port, PID, version
- [x] Server section shows restart instructions when offline