### PR TITLE
fix: verification pool respects max_subagents setting

### DIFF
--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -93,6 +93,7 @@ def run_verification_pool(
 
     n_agents = min(
         _VERIFY_N_AGENTS,
+        config.options.max_subagents,
         (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
     )
     pool = SubagentPool(


### PR DESCRIPTION
## Summary
- The verification pool had a hardcoded cap of 5 agents (`_VERIFY_N_AGENTS`) but did not consider `config.options.max_subagents`, causing it to spawn more concurrent agents than the provider supports (e.g. Ollama with max 1)
- Added `config.options.max_subagents` to the `min()` calculation so the verification pool respects the user's configured concurrency limit

## Test plan
- [x] Run evaluation with Ollama (max_subagents=1) and confirm verification pool stays at 1 active agent
- [x] Run with default settings and confirm verification pool still scales up normally