### PR TITLE
fix: require orchestrator model before starting evaluation

### DIFF
--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -31,7 +31,7 @@ def _build_consolidated_config(
     # Deferred import: breaks circular dependency between _consolidated and runner.
     from quodeq.analysis.subagents.runner import _default_subagent_model
 
-    subagent_model = config.options.subagent_model or _default_subagent_model()
+    subagent_model = config.options.subagent_model or _default_subagent_model() or config.options.ai_model
     pool_budget_val = config.options.pool_budget
     return AnalysisConfig(
         analysis_budget=config.options.analysis_budget,

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -84,18 +84,18 @@ def run_verification_pool(
         is_local = True
 
     if is_local:
-        n_agents = min(config.options.max_subagents, len(files_to_verify))
-        files_per_agent = (len(files_to_verify) + n_agents - 1) // n_agents if n_agents else 0
+        # Local: use all configured agents, no file-count-based cap
+        n_agents = config.options.max_subagents
     else:
-        files_per_agent = _VERIFY_MAX_FILES_PER_AGENT
+        # Cloud/CLI: cap agents based on file count and max pool size
         n_agents = min(
             _VERIFY_N_AGENTS,
             config.options.max_subagents,
-            (len(files_to_verify) + files_per_agent - 1) // files_per_agent,
+            (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
         )
 
     queue_path = evidence_dir / f"{dim_id}_verify_queue.json"
-    FileQueue(queue_path, files_to_verify, max_files_per_agent=files_per_agent)
+    FileQueue(queue_path, files_to_verify, max_files_per_agent=_VERIFY_MAX_FILES_PER_AGENT)
 
     ac = AnalysisConfig(
         compiled_dir=compiled_dir,

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -73,18 +73,29 @@ def run_verification_pool(
     Uses the fast model (haiku by default) with a smaller pool.
     Confirmed findings are written to JSONL via MCP -> appear on dashboard.
     """
-    queue_path = evidence_dir / f"{dim_id}_verify_queue.json"
-    FileQueue(queue_path, files_to_verify, max_files_per_agent=_VERIFY_MAX_FILES_PER_AGENT)
-
     prompt = build_verify_prompt(manifest_path, dim_id)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
     fast = _fast_model()
-    # For non-CLI providers (e.g. Ollama), use the same model and agent count
-    # as analysis — no cost benefit to a cheaper model, and swapping wastes VRAM.
+    # For non-CLI providers (e.g. Ollama), treat verification the same as
+    # analysis — no caps on agents or files-per-agent, no model swapping.
     is_local = False
     if config.options.ai_model and fast == _DEFAULT_FAST_MODEL:
         fast = config.options.ai_model
         is_local = True
+
+    if is_local:
+        n_agents = min(config.options.max_subagents, len(files_to_verify))
+        files_per_agent = (len(files_to_verify) + n_agents - 1) // n_agents if n_agents else 0
+    else:
+        files_per_agent = _VERIFY_MAX_FILES_PER_AGENT
+        n_agents = min(
+            _VERIFY_N_AGENTS,
+            config.options.max_subagents,
+            (len(files_to_verify) + files_per_agent - 1) // files_per_agent,
+        )
+
+    queue_path = evidence_dir / f"{dim_id}_verify_queue.json"
+    FileQueue(queue_path, files_to_verify, max_files_per_agent=files_per_agent)
 
     ac = AnalysisConfig(
         compiled_dir=compiled_dir,
@@ -93,17 +104,6 @@ def run_verification_pool(
         ai_model=fast,
         dimension=dim_id,
     )
-
-    if is_local:
-        # Local providers: use all configured agents, distribute files evenly
-        n_agents = min(config.options.max_subagents, len(files_to_verify))
-    else:
-        # CLI providers: cap at _VERIFY_N_AGENTS, batch by _VERIFY_MAX_FILES_PER_AGENT
-        n_agents = min(
-            _VERIFY_N_AGENTS,
-            config.options.max_subagents,
-            (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
-        )
     pool = SubagentPool(
         paths=PoolPaths(work_dir=config.src, evidence_dir=evidence_dir, queue_path=queue_path),
         options=PoolOptions(

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -94,12 +94,16 @@ def run_verification_pool(
         dimension=dim_id,
     )
 
-    max_verify_agents = config.options.max_subagents if is_local else _VERIFY_N_AGENTS
-    n_agents = min(
-        max_verify_agents,
-        config.options.max_subagents,
-        (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
-    )
+    if is_local:
+        # Local providers: use all configured agents, distribute files evenly
+        n_agents = min(config.options.max_subagents, len(files_to_verify))
+    else:
+        # CLI providers: cap at _VERIFY_N_AGENTS, batch by _VERIFY_MAX_FILES_PER_AGENT
+        n_agents = min(
+            _VERIFY_N_AGENTS,
+            config.options.max_subagents,
+            (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
+        )
     pool = SubagentPool(
         paths=PoolPaths(work_dir=config.src, evidence_dir=evidence_dir, queue_path=queue_path),
         options=PoolOptions(

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -79,9 +79,12 @@ def run_verification_pool(
     prompt = build_verify_prompt(manifest_path, dim_id)
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
     fast = _fast_model()
-    # For non-Claude providers, use the configured model instead of 'haiku'
+    # For non-CLI providers (e.g. Ollama), use the same model and agent count
+    # as analysis — no cost benefit to a cheaper model, and swapping wastes VRAM.
+    is_local = False
     if config.options.ai_model and fast == _DEFAULT_FAST_MODEL:
         fast = config.options.ai_model
+        is_local = True
 
     ac = AnalysisConfig(
         compiled_dir=compiled_dir,
@@ -91,8 +94,9 @@ def run_verification_pool(
         dimension=dim_id,
     )
 
+    max_verify_agents = config.options.max_subagents if is_local else _VERIFY_N_AGENTS
     n_agents = min(
-        _VERIFY_N_AGENTS,
+        max_verify_agents,
         config.options.max_subagents,
         (len(files_to_verify) + _VERIFY_MAX_FILES_PER_AGENT - 1) // _VERIFY_MAX_FILES_PER_AGENT,
     )

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -48,13 +48,15 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
     max_subagents = max(_MIN_SUBAGENTS, min(_MAX_SUBAGENTS, int(max_subagents_raw)))
     pool_budget_raw = int(payload.get("poolBudget", _DEFAULT_POOL_BUDGET))
     pool_budget = 0 if pool_budget_raw == 0 else max(_MIN_POOL_BUDGET, min(_MAX_POOL_BUDGET, pool_budget_raw))
+    ai_model = payload.get("aiModel") or None
+    subagent_model = payload.get("subagentModel") or ai_model  # default to orchestrator
     return EvaluationOptions(
         discipline=payload.get("discipline"),
         dimensions=payload.get("dimensions") or "",
         numerical=bool(payload.get("numerical")),
         ai_cmd=payload.get("aiCmd") or None,
-        ai_model=payload.get("aiModel") or None,
-        subagent_model=payload.get("subagentModel") or None,
+        ai_model=ai_model,
+        subagent_model=subagent_model,
         verify_findings=bool(payload.get("verifyFindings", True)),
         max_subagents=max_subagents,
         pool_budget=pool_budget,

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -41,6 +41,16 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
         ai_cmd_error = _validate_ai_cmd(ai_cmd)
         if ai_cmd_error is not None:
             return ai_cmd_error
+        # Require an explicit model for API-type providers (e.g. Ollama)
+        if ai_cmd:
+            from quodeq.analysis._provider_cache import get_provider_configs
+            ptype = get_provider_configs().get(ai_cmd, {}).get("type")
+            if ptype == "api" and not payload.get("aiModel"):
+                body, status = error_response(
+                    "No model selected. Go to Settings and select an orchestrator model.",
+                    HTTPStatus.BAD_REQUEST, "MODEL_REQUIRED",
+                )
+                return jsonify(body), status
         repo = payload.get("repo")
         _logger.info("start_evaluation: repo=%s, remote_addr=%s", _sanitize_url(repo), request.remote_addr)
         try:

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -2,7 +2,7 @@
   "ollama": {
     "type": "api",
     "order": 0,
-    "model": "gemma4:27b",
+    "model": "gemma4:26b",
     "api_base": "http://localhost:11434/v1"
   },
   "claude": {

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -2,7 +2,7 @@
   "ollama": {
     "type": "api",
     "order": 0,
-    "model": "llama3.1",
+    "model": "gemma4:27b",
     "api_base": "http://localhost:11434/v1"
   },
   "claude": {

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -118,10 +118,13 @@ class FsEvaluationMixin:
         built_env = {**base, "PYTHONUNBUFFERED": "1"}
         built_env["AI_CMD"] = options.ai_cmd or get_ai_cmd()
         ai_model = options.ai_model or get_ai_model()
+        subagent_model = options.subagent_model or ai_model
+        # Ensure both env vars are set consistently — prevents model swapping
+        # between verification (reads AI_MODEL) and analysis (reads SUBAGENT_MODEL)
         if ai_model:
             built_env["AI_MODEL"] = ai_model
-        if options.subagent_model:
-            built_env["SUBAGENT_MODEL"] = options.subagent_model
+        if subagent_model:
+            built_env["SUBAGENT_MODEL"] = subagent_model
         if not options.verify_findings:
             built_env["QUODEQ_NO_VERIFY"] = "1"
         if options.pool_budget != _DEFAULT_POOL_BUDGET:

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -98,7 +98,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
           </div>
         )}
 
-        {jobError && <div className="job-error-banner">Evaluation failed. Please check your inputs and try again.</div>}
+        {jobError && <div className="job-error-banner">{jobError}</div>}
         <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} />
 
         {!job && <EvaluateHelpSection />}

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -109,15 +109,20 @@ function createJobPoller(refs, setters, startDimensionPolling) {
   };
 }
 
+/**
+ * Build the evaluation payload from provider settings.
+ * Throws if the orchestrator model is not configured.
+ */
 function preparePayload(payload, storage = localStorage) {
   const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  if (!activeProvider) return;
+  if (!activeProvider) throw new Error('No AI provider selected. Go to Settings to configure one.');
 
   const get = (key) => storage.getItem(providerKey(activeProvider, key));
 
   payload.aiCmd = activeProvider;
   const model = get('model');
-  if (model) payload.aiModel = model;
+  if (!model) throw new Error('No orchestrator model selected. Go to Settings and select a model for the active provider.');
+  payload.aiModel = model;
 
   const subagents = parseInt(get('subagents') || '1', 10);
   if (subagents !== 1) payload.maxSubagents = subagents;
@@ -177,8 +182,8 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
     refs.liveViolationsRef.current = {};
     refs.partialDimensionsRef.current = new Set();
     setLiveViolations({});
-    preparePayload(payload);
     try {
+      preparePayload(payload);
       const created = await startEvaluation(payload);
       setJob({ ...created, repo: payload.repo });
       startPolling(created.jobId);

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -43,14 +43,15 @@ export function useEvaluationLifecycle({ settings, navigation, projects }) {
   function handleStartEvaluation(payload) {
     const activeProvider = localStorage.getItem(ACTIVE_PROVIDER_KEY) || '';
     const get = (key) => localStorage.getItem(providerKey(activeProvider, key));
-    // Ollama uses a single analysis model; CLI providers use tier-based selection
+    // Ollama uses a single analysis model; CLI providers use tier-based selection.
+    // Falls back to the orchestrator model if no analysis-specific model is set.
     const analysisModel = get('model-analysis');
     let subagentModel;
     if (analysisModel) {
       subagentModel = analysisModel;
     } else {
       const tierNames = ['fast', 'balanced', 'thorough'];
-      subagentModel = get(`model-${tierNames[analysisPower - 1]}`) || undefined;
+      subagentModel = get(`model-${tierNames[analysisPower - 1]}`) || get('model') || undefined;
     }
     startEvaluation({ ...payload, subagentModel });
   }


### PR DESCRIPTION
## Summary

- Evaluation now **throws a clear error** if no AI provider or orchestrator model is selected in settings
- Subagent model **falls back to the orchestrator model** when no analysis-specific model is configured (instead of falling back to the hardcoded default in `ai_providers.json`)
- Error is shown in the evaluation status panel, preventing silent fallback to wrong models

## Root cause

Previously, if no orchestrator model was selected in settings, `preparePayload` would skip setting `aiModel` in the payload. The backend would then fall back to the hardcoded default in `ai_providers.json` (e.g., `llama3.1`), which could resolve to a completely different model (e.g., qwen) depending on what Ollama had loaded.

## Test plan
- [x] Open Evaluate without selecting an orchestrator model → error shown
- [x] Select orchestrator model, no analysis model → subagents use orchestrator model
- [x] Select both orchestrator and analysis model → subagents use analysis model

🤖 Generated with [Claude Code](https://claude.com/claude-code)