### PR TITLE
fix: always send maxSubagents and poolBudget in payload

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -125,10 +125,10 @@ function preparePayload(payload, storage = localStorage) {
   payload.aiModel = model;
 
   const subagents = parseInt(get('subagents') || '1', 10);
-  if (subagents !== 1) payload.maxSubagents = subagents;
+  payload.maxSubagents = subagents;
 
   const poolBudget = parseInt(get('pool-budget') || '0', 10);
-  if (poolBudget !== 0) payload.poolBudget = poolBudget;
+  payload.poolBudget = poolBudget;
 
   if (get('per-dimension') === 'true') payload.perDimension = true;
   if (get('verify') === 'false') payload.verifyFindings = false;


### PR DESCRIPTION
## Summary
- UI was conditionally skipping `maxSubagents` (when 1) and `poolBudget` (when 0) from the evaluation payload
- Backend defaults differ: 5 agents and 600s budget — so user settings were silently ignored
- This caused Ollama to get overwhelmed with 5 concurrent requests (despite max set to 1) and evaluations stopping at 55% coverage (despite "unlimited" selected)

## Test plan
- [x] Set Ollama max agents to 1, run evaluation — verify only 1 agent launches
- [x] Set pool budget to unlimited, run evaluation — verify it runs until all files are processed
- [x] Set pool budget to limited (e.g. 5 min) — verify it respects the limit