### PR TITLE
feat: PyWebView desktop mode + server logs console

### DIFF
--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -152,7 +152,18 @@ class QuodeqApp(rumps.App):
         with self._state_lock:
             port = self._port
         port = port or self._find_running_port()
-        if port:
+        if not port:
+            return
+        quodeq_cmd = self._cached_cmds.get("quodeq")
+        if quodeq_cmd:
+            # Launches PyWebView window (or brings existing one to front via socket IPC)
+            subprocess.Popen(
+                [quodeq_cmd, "dashboard", "--no-build", "--port", str(port)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        else:
             webbrowser.open(f"http://127.0.0.1:{port}")
 
     def _on_start(self, _):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 api = [
     "instructor>=1.15.0",
 ]
+desktop = [
+    "pywebview>=5.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/quodeq/quodeq"

--- a/src/quodeq/api/_log_buffer.py
+++ b/src/quodeq/api/_log_buffer.py
@@ -1,0 +1,77 @@
+"""Thread-safe ring buffer for capturing log lines."""
+from __future__ import annotations
+
+import logging
+import threading
+from collections import deque
+from datetime import datetime, timezone
+
+_DEFAULT_MAX_LINES = 500
+
+
+class LogBuffer:
+    """Fixed-size ring buffer that stores log lines with monotonic indices.
+
+    Usage::
+
+        buf = LogBuffer(max_lines=500)
+        logging.getLogger("werkzeug").addHandler(buf.handler)
+        # later
+        result = buf.get_lines(since=last_index)
+    """
+
+    def __init__(self, max_lines: int = _DEFAULT_MAX_LINES) -> None:
+        self._max = max_lines
+        self._entries: deque[dict] = deque(maxlen=max_lines)
+        self._index = 0
+        self._lock = threading.Lock()
+        self._handler = _BufferHandler(self)
+        self._handler.setFormatter(logging.Formatter("%(message)s"))
+
+    @property
+    def handler(self) -> logging.Handler:
+        """Return a logging.Handler that feeds into this buffer."""
+        return self._handler
+
+    def append(self, line: str) -> None:
+        """Add a log line to the buffer."""
+        with self._lock:
+            self._entries.append({
+                "index": self._index,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "line": line,
+            })
+            self._index += 1
+
+    def get_lines(self, since: int | None = None) -> dict:
+        """Return buffered lines, optionally filtered by index.
+
+        Args:
+            since: If provided, return only entries with index > since.
+
+        Returns:
+            ``{"lines": [...], "total": int}``
+        """
+        with self._lock:
+            if since is not None:
+                lines = [e for e in self._entries if e["index"] > since]
+            else:
+                lines = list(self._entries)
+            return {"lines": lines, "total": self._index}
+
+    def clear(self) -> None:
+        """Remove all buffered entries and reset the index."""
+        with self._lock:
+            self._entries.clear()
+            self._index = 0
+
+
+class _BufferHandler(logging.Handler):
+    """Logging handler that writes formatted records into a LogBuffer."""
+
+    def __init__(self, buffer: LogBuffer) -> None:
+        super().__init__()
+        self._buffer = buffer
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self._buffer.append(self.format(record))

--- a/src/quodeq/api/_log_routes.py
+++ b/src/quodeq/api/_log_routes.py
@@ -1,0 +1,74 @@
+"""Log streaming routes — exposes buffered server logs via REST."""
+from __future__ import annotations
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.api._log_buffer import LogBuffer
+
+
+def register_log_routes(app: Flask, log_buffer: LogBuffer) -> None:
+    """Register the /api/logs endpoint."""
+
+    @app.get("/api/logs")
+    def get_logs() -> Response:
+        since = request.args.get("since", type=int)
+        return jsonify(log_buffer.get_lines(since=since))
+
+    @app.get("/logs")
+    def logs_page() -> Response:
+        html = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Quodeq — Server Logs</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0d1117; color: #c9d1d9;
+    font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    font-size: 13px; line-height: 1.7;
+    padding: 16px;
+  }
+  h1 {
+    font-size: 14px; font-weight: 500;
+    color: #8b949e; margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #21262d;
+  }
+  #logs { white-space: pre-wrap; word-break: break-word; }
+  .ts { color: #484f58; }
+</style>
+</head>
+<body>
+<h1>Quodeq Server Logs</h1>
+<div id="logs"></div>
+<script>
+let since = -1;
+const el = document.getElementById('logs');
+async function poll() {
+  try {
+    const url = '/api/logs' + (since >= 0 ? '?since=' + since : '');
+    const r = await fetch(url);
+    if (!r.ok) return;
+    const data = await r.json();
+    if (data.lines.length) {
+      const frag = document.createDocumentFragment();
+      data.lines.forEach(e => {
+        const line = document.createElement('div');
+        const ts = e.timestamp ? e.timestamp.slice(11, 19) : '';
+        line.innerHTML = '<span class="ts">[' + ts + ']</span> ' +
+          e.line.replace(/</g, '&lt;');
+        frag.appendChild(line);
+        since = e.index;
+      });
+      el.appendChild(frag);
+      window.scrollTo(0, document.body.scrollHeight);
+    }
+  } catch {}
+}
+poll();
+setInterval(poll, 2000);
+</script>
+</body>
+</html>"""
+        return Response(html, content_type="text/html")

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -8,6 +8,7 @@ import sys
 
 from flask import Flask, Response, jsonify
 
+from quodeq.api._log_buffer import LogBuffer
 from quodeq.api._rate_limit import (
     InMemoryRateLimitStore,
     RateLimitStore,
@@ -61,6 +62,19 @@ def create_app(
 
     configure_security(app, store, api_key)
 
+    log_buffer = LogBuffer()
+    app.extensions["log_buffer"] = log_buffer
+
+    # Capture request logs in the ring buffer for the UI console.
+    # Terminal output is suppressed unless QUODEQ_VERBOSE=1 (set by --verbose).
+    verbose = os.environ.get("QUODEQ_VERBOSE") == "1"
+    for name in ("werkzeug", "quodeq.api"):
+        lgr = logging.getLogger(name)
+        lgr.handlers = [log_buffer.handler]
+        if verbose:
+            lgr.handlers.append(logging.StreamHandler())
+        lgr.propagate = False
+
     @app.get("/api/health")
     def health() -> Response:
         """Return a simple health-check response with server info."""
@@ -78,7 +92,7 @@ def create_app(
             "pid": os.getpid(),
         })
 
-    register_all_routes(app, provider, eval_store, static_dist)
+    register_all_routes(app, provider, eval_store, static_dist, log_buffer)
     return app
 
 

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from flask import Flask
 
+from quodeq.api._log_buffer import LogBuffer
+from quodeq.api._log_routes import register_log_routes
 from quodeq.api._rate_limit import RateLimitStore
 from quodeq.api.routes import (
     register_project_list_routes,
@@ -23,6 +25,7 @@ from quodeq.services.base import ActionProvider
 def register_all_routes(
     app: Flask, provider: ActionProvider,
     eval_store: RateLimitStore, static_dist: str | None,
+    log_buffer: LogBuffer | None = None,
 ) -> None:
     """Register all API route groups on the app.
 
@@ -41,4 +44,6 @@ def register_all_routes(
     register_findings_routes(app)
     register_rescore_routes(app)
     register_llm_bridge_routes(app)
+    if log_buffer:
+        register_log_routes(app, log_buffer)
     register_static_routes(app, static_dist)

--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -49,9 +49,12 @@ def spawn_action_api(
     if cfg.static_dist:
         env[_ENV_STATIC_DIST] = str(cfg.static_dist)
     env[_ENV_EVALUATIONS_DIR] = cfg.evaluations_dir or get_evaluations_dir()
+    verbose = env.get("QUODEQ_VERBOSE") == "1"
     proc = subprocess.Popen(
         [sys.executable, "-m", ACTION_API_MODULE],
         env=env,
+        stdout=None if verbose else subprocess.DEVNULL,
+        stderr=None if verbose else subprocess.DEVNULL,
         **_popen_platform_kwargs(),
     )
     try:

--- a/src/quodeq/dashboard/_config.py
+++ b/src/quodeq/dashboard/_config.py
@@ -21,6 +21,8 @@ class BuildConfig:
     no_build: bool
     reinstall: bool
     dev: bool = False
+    use_native: bool = True
+    verbose: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/quodeq/dashboard/_instance.py
+++ b/src/quodeq/dashboard/_instance.py
@@ -1,0 +1,122 @@
+"""Single-instance controller using unix domain sockets."""
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+from pathlib import Path
+from typing import Callable
+
+_logger = logging.getLogger(__name__)
+_SOCK_TIMEOUT = 1.0
+_RELOAD_PREFIX = "reload:"
+
+
+def _default_sock_path() -> Path:
+    run_dir = Path(os.environ.get("QUODEQ_RUN_DIR", Path.home() / ".quodeq" / "run"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir / "dashboard.sock"
+
+
+class InstanceController:
+    """Manage single-instance lifecycle via a unix domain socket.
+
+    First instance: ``try_acquire()`` returns True, call ``start_listening()``.
+    Second instance: ``try_acquire()`` returns False, call ``send_reload(url)``.
+    """
+
+    def __init__(self, sock_path: Path | None = None) -> None:
+        self._sock_path = sock_path or _default_sock_path()
+        self._server_sock: socket.socket | None = None
+        self._listen_thread: threading.Thread | None = None
+        self._shutdown_event = threading.Event()
+
+    def _connect_to_sock(self, sock: socket.socket) -> None:
+        """Connect *sock* to self._sock_path, handling long-path macOS limit."""
+        path_str = str(self._sock_path)
+        if len(path_str) <= 100:
+            sock.connect(path_str)
+            return
+        orig_cwd = os.getcwd()
+        try:
+            os.chdir(str(self._sock_path.parent))
+            sock.connect(self._sock_path.name)
+        finally:
+            os.chdir(orig_cwd)
+
+    def try_acquire(self) -> bool:
+        """Try to become the primary instance. Return True if acquired."""
+        if self._sock_path.exists():
+            try:
+                probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                probe.settimeout(_SOCK_TIMEOUT)
+                self._connect_to_sock(probe)
+                probe.close()
+                return False
+            except (ConnectionRefusedError, OSError):
+                _logger.debug("Removing stale socket %s", self._sock_path)
+                self._sock_path.unlink(missing_ok=True)
+
+        self._server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._bind_server_sock()
+        self._server_sock.listen(1)
+        self._server_sock.settimeout(_SOCK_TIMEOUT)
+        return True
+
+    def _bind_server_sock(self) -> None:
+        """Bind the server socket, working around macOS's 104-char AF_UNIX limit."""
+        path_str = str(self._sock_path)
+        if len(path_str) <= 100:
+            self._server_sock.bind(path_str)
+            return
+        # Path too long for AF_UNIX on macOS — bind using a relative name by
+        # temporarily switching to the socket's parent directory.
+        orig_cwd = os.getcwd()
+        try:
+            os.chdir(str(self._sock_path.parent))
+            self._server_sock.bind(self._sock_path.name)
+        finally:
+            os.chdir(orig_cwd)
+
+    def start_listening(self, on_reload: Callable[[str], None]) -> None:
+        """Start a background thread that listens for reload commands."""
+        def _listen() -> None:
+            while not self._shutdown_event.is_set():
+                try:
+                    conn, _ = self._server_sock.accept()
+                    data = conn.recv(4096).decode("utf-8", errors="replace")
+                    conn.close()
+                    if data.startswith(_RELOAD_PREFIX):
+                        url = data[len(_RELOAD_PREFIX):]
+                        _logger.info("Received reload request: %s", url)
+                        on_reload(url)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    if not self._shutdown_event.is_set():
+                        _logger.debug("Listener socket error", exc_info=True)
+                    break
+
+        self._listen_thread = threading.Thread(target=_listen, daemon=True)
+        self._listen_thread.start()
+
+    def send_reload(self, url: str) -> None:
+        """Send a reload command to the running instance."""
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(_SOCK_TIMEOUT)
+        self._connect_to_sock(sock)
+        sock.sendall(f"{_RELOAD_PREFIX}{url}".encode("utf-8"))
+        sock.close()
+
+    def shutdown(self) -> None:
+        """Stop listening and clean up the socket file."""
+        self._shutdown_event.set()
+        if self._server_sock:
+            try:
+                self._server_sock.close()
+            except OSError:
+                pass
+        if self._listen_thread:
+            self._listen_thread.join(timeout=2.0)
+        self._sock_path.unlink(missing_ok=True)

--- a/src/quodeq/dashboard/_instance.py
+++ b/src/quodeq/dashboard/_instance.py
@@ -1,9 +1,10 @@
-"""Single-instance controller using unix domain sockets."""
+"""Single-instance controller — unix socket on macOS/Linux, TCP localhost on Windows."""
 from __future__ import annotations
 
 import logging
 import os
 import socket
+import sys
 import threading
 from pathlib import Path
 from typing import Callable
@@ -11,6 +12,8 @@ from typing import Callable
 _logger = logging.getLogger(__name__)
 _SOCK_TIMEOUT = 1.0
 _RELOAD_PREFIX = "reload:"
+_IS_WIN32 = sys.platform == "win32"
+_WIN_PORT_FILE = "dashboard.port"
 
 
 def _default_sock_path() -> Path:
@@ -19,21 +22,35 @@ def _default_sock_path() -> Path:
     return run_dir / "dashboard.sock"
 
 
+def _default_port_file() -> Path:
+    run_dir = Path(os.environ.get("QUODEQ_RUN_DIR", Path.home() / ".quodeq" / "run"))
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir / _WIN_PORT_FILE
+
+
 class InstanceController:
-    """Manage single-instance lifecycle via a unix domain socket.
+    """Manage single-instance lifecycle.
+
+    Uses unix domain sockets on macOS/Linux, TCP localhost on Windows.
 
     First instance: ``try_acquire()`` returns True, call ``start_listening()``.
     Second instance: ``try_acquire()`` returns False, call ``send_reload(url)``.
     """
 
     def __init__(self, sock_path: Path | None = None) -> None:
-        self._sock_path = sock_path or _default_sock_path()
+        if _IS_WIN32:
+            self._port_file = sock_path or _default_port_file()
+            self._sock_path = self._port_file  # for compatibility with _server.py
+            self._tcp_port: int | None = None
+        else:
+            self._sock_path = sock_path or _default_sock_path()
         self._server_sock: socket.socket | None = None
         self._listen_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
 
+    # ── Unix socket helpers (macOS/Linux) ──
+
     def _connect_to_sock(self, sock: socket.socket) -> None:
-        """Connect *sock* to self._sock_path, handling long-path macOS limit."""
         path_str = str(self._sock_path)
         if len(path_str) <= 100:
             sock.connect(path_str)
@@ -45,8 +62,27 @@ class InstanceController:
         finally:
             os.chdir(orig_cwd)
 
+    def _bind_server_sock(self) -> None:
+        path_str = str(self._sock_path)
+        if len(path_str) <= 100:
+            self._server_sock.bind(path_str)
+            return
+        orig_cwd = os.getcwd()
+        try:
+            os.chdir(str(self._sock_path.parent))
+            self._server_sock.bind(self._sock_path.name)
+        finally:
+            os.chdir(orig_cwd)
+
+    # ── Public API ──
+
     def try_acquire(self) -> bool:
         """Try to become the primary instance. Return True if acquired."""
+        if _IS_WIN32:
+            return self._try_acquire_tcp()
+        return self._try_acquire_unix()
+
+    def _try_acquire_unix(self) -> bool:
         if self._sock_path.exists():
             try:
                 probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -64,20 +100,28 @@ class InstanceController:
         self._server_sock.settimeout(_SOCK_TIMEOUT)
         return True
 
-    def _bind_server_sock(self) -> None:
-        """Bind the server socket, working around macOS's 104-char AF_UNIX limit."""
-        path_str = str(self._sock_path)
-        if len(path_str) <= 100:
-            self._server_sock.bind(path_str)
-            return
-        # Path too long for AF_UNIX on macOS — bind using a relative name by
-        # temporarily switching to the socket's parent directory.
-        orig_cwd = os.getcwd()
-        try:
-            os.chdir(str(self._sock_path.parent))
-            self._server_sock.bind(self._sock_path.name)
-        finally:
-            os.chdir(orig_cwd)
+    def _try_acquire_tcp(self) -> bool:
+        """Windows: use TCP localhost with port stored in a file."""
+        if self._port_file.exists():
+            try:
+                port = int(self._port_file.read_text().strip())
+                probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                probe.settimeout(_SOCK_TIMEOUT)
+                probe.connect(("127.0.0.1", port))
+                probe.close()
+                self._tcp_port = port
+                return False
+            except (ConnectionRefusedError, OSError, ValueError):
+                _logger.debug("Removing stale port file %s", self._port_file)
+                self._port_file.unlink(missing_ok=True)
+
+        self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_sock.bind(("127.0.0.1", 0))
+        self._tcp_port = self._server_sock.getsockname()[1]
+        self._server_sock.listen(1)
+        self._server_sock.settimeout(_SOCK_TIMEOUT)
+        self._port_file.write_text(str(self._tcp_port))
+        return True
 
     def start_listening(self, on_reload: Callable[[str], None]) -> None:
         """Start a background thread that listens for reload commands."""
@@ -103,14 +147,19 @@ class InstanceController:
 
     def send_reload(self, url: str) -> None:
         """Send a reload command to the running instance."""
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(_SOCK_TIMEOUT)
-        self._connect_to_sock(sock)
+        if _IS_WIN32:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(_SOCK_TIMEOUT)
+            sock.connect(("127.0.0.1", self._tcp_port))
+        else:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(_SOCK_TIMEOUT)
+            self._connect_to_sock(sock)
         sock.sendall(f"{_RELOAD_PREFIX}{url}".encode("utf-8"))
         sock.close()
 
     def shutdown(self) -> None:
-        """Stop listening and clean up the socket file."""
+        """Stop listening and clean up."""
         self._shutdown_event.set()
         if self._server_sock:
             try:
@@ -119,4 +168,7 @@ class InstanceController:
                 pass
         if self._listen_thread:
             self._listen_thread.join(timeout=2.0)
-        self._sock_path.unlink(missing_ok=True)
+        if _IS_WIN32:
+            self._port_file.unlink(missing_ok=True)
+        else:
+            self._sock_path.unlink(missing_ok=True)

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -6,6 +6,7 @@ import signal
 import subprocess
 import sys
 import threading
+import typing
 import webbrowser
 from pathlib import Path
 
@@ -75,11 +76,8 @@ def _serve_and_wait(
     action_api_process: subprocess.Popen | None,
     config: DashboardConfig,
 ) -> None:
-    """Open browser, register signal handlers, and block until exit."""
+    """Open window or browser, register signal handlers, and block until exit."""
     log_success(f"Dashboard running at {action_api_url}")
-
-    if config.build.open_browser:
-        webbrowser.open(action_api_url)
 
     def _stop_children() -> None:
         if action_api_process and action_api_process.poll() is None:
@@ -96,6 +94,64 @@ def _serve_and_wait(
     if hasattr(signal, "SIGTSTP"):
         signal.signal(signal.SIGTSTP, _handle_tstp)
 
+    if config.build.use_native and config.build.open_browser:
+        _serve_native(action_api_url, action_api_process, _stop_children)
+    elif config.build.open_browser:
+        webbrowser.open(action_api_url)
+        _serve_blocking(action_api_process, _stop_children)
+    else:
+        _serve_blocking(action_api_process, _stop_children)
+
+
+def _serve_native(
+    action_api_url: str,
+    action_api_process: subprocess.Popen | None,
+    stop_children: typing.Callable,
+) -> None:
+    """Open a PyWebView native window with single-instance support."""
+    try:
+        import webview  # noqa: F401
+    except ImportError:
+        raise RuntimeError(
+            "pywebview is not installed. "
+            "Install it with 'pip install quodeq[desktop]' or use --browser."
+        )
+
+    from quodeq.dashboard._instance import InstanceController
+
+    instance = InstanceController()
+
+    if not instance.try_acquire():
+        try:
+            instance.send_reload(action_api_url)
+        except (ConnectionRefusedError, OSError):
+            logging.getLogger(__name__).warning("Could not reach existing instance — opening new window")
+            instance.shutdown()
+            instance = InstanceController()
+            if not instance.try_acquire():
+                stop_children()
+                return
+        else:
+            stop_children()
+            return
+
+    # Pass Flask PID so the webview process can kill it on window close.
+    api_pid = str(action_api_process.pid) if action_api_process else ""
+
+    subprocess.Popen(
+        [sys.executable, "-m", "quodeq.dashboard._webview_window",
+         action_api_url, str(instance._sock_path), api_pid],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _serve_blocking(
+    action_api_process: subprocess.Popen | None,
+    stop_children: typing.Callable,
+) -> None:
+    """Block until process exits or keyboard interrupt (browser mode)."""
     try:
         if action_api_process:
             _wait_for_process(action_api_process)
@@ -106,4 +162,4 @@ def _serve_and_wait(
     except KeyboardInterrupt:
         pass
     finally:
-        _stop_children()
+        stop_children()

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -1,0 +1,172 @@
+"""PyWebView window process — launched as a subprocess by _server.py."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+
+import webview
+
+from quodeq.dashboard._build_npm import _quodeq_dir
+from quodeq.dashboard._instance import InstanceController
+
+_CONTROLS_HTML = """\
+<style>
+  .qd-traffic {
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: flex;
+    gap: 6px;
+    z-index: 99999;
+    padding: 6px 11px;
+    pointer-events: auto;
+  }
+  /* Invisible hover bridge so sidebar stays expanded when moving to dots */
+  .qd-traffic::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 64px;
+    height: 100%;
+    z-index: -1;
+  }
+  .qd-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s;
+    padding: 0;
+    background: var(--color-text-muted, #484f58);
+    opacity: 0.4;
+  }
+  .qd-traffic:hover .qd-dot,
+  body:has(.sidebar:hover) .qd-dot { opacity: 1; }
+  .qd-traffic:hover .qd-dot--close,
+  body:has(.sidebar:hover) .qd-dot--close { background: #ff5f57; }
+  .qd-traffic:hover .qd-dot--minimize,
+  body:has(.sidebar:hover) .qd-dot--minimize { background: #febc2e; }
+  .qd-traffic:hover .qd-dot--maximize,
+  body:has(.sidebar:hover) .qd-dot--maximize { background: #28c840; }
+
+  .sidebar { padding-top: 18px !important; }
+  /* Keep sidebar expanded when hovering the traffic dots */
+  body:has(.qd-traffic:hover) .app-shell {
+    grid-template-columns: var(--sidebar-expanded-width) 1fr;
+  }
+  body:has(.qd-traffic:hover) .sidebar {
+    width: var(--sidebar-expanded-width);
+  }
+  body:has(.qd-traffic:hover) .sidebar-brand-text {
+    opacity: 1;
+  }
+  body:has(.qd-traffic:hover) .sidebar-nav-label {
+    opacity: 1;
+  }
+</style>
+<div class="qd-traffic">
+  <button class="qd-dot qd-dot--close" title="Close" onclick="pywebview.api.close()"></button>
+  <button class="qd-dot qd-dot--minimize" title="Minimize" onclick="pywebview.api.minimize()"></button>
+  <button class="qd-dot qd-dot--maximize" title="Fullscreen" onclick="pywebview.api.maximize()"></button>
+</div>
+"""
+
+_CONTROLS_JS = """\
+(function() {
+  if (document.querySelector('.qd-traffic')) return;
+  var d = document.createElement('div');
+  d.innerHTML = %s;
+  while (d.firstChild) document.body.insertBefore(d.firstChild, document.body.firstChild);
+
+  document.addEventListener('keydown', function(e) {
+    if (e.metaKey && e.key === '[') { e.preventDefault(); history.back(); }
+    if (e.metaKey && e.key === ']') { e.preventDefault(); history.forward(); }
+  });
+})();
+"""
+
+_INJECT_JS = _CONTROLS_JS % json.dumps(_CONTROLS_HTML)
+
+
+class _WindowApi:
+    """Python API exposed to JavaScript for window controls."""
+
+    def __init__(self) -> None:
+        self._window: webview.Window | None = None
+        self._api_pid = 0
+        self._instance: InstanceController | None = None
+
+    def bind(self, window: webview.Window, api_pid: int = 0,
+             instance: InstanceController | None = None) -> None:
+        self._window = window
+        self._api_pid = api_pid
+        self._instance = instance
+
+    def close(self) -> None:
+        if self._api_pid:
+            _kill_api(self._api_pid)
+        if self._instance:
+            self._instance.shutdown()
+        os._exit(0)
+
+    def minimize(self) -> None:
+        if self._window:
+            self._window.minimize()
+
+    def maximize(self) -> None:
+        if self._window:
+            self._window.toggle_fullscreen()
+
+
+def _kill_api(pid: int) -> None:
+    """Terminate the Flask API process."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        pass
+
+
+def main() -> None:
+    url = sys.argv[1]
+    sock_path = Path(sys.argv[2])
+    api_pid = int(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else 0
+
+    instance = InstanceController(sock_path)
+    api = _WindowApi()
+
+    window = webview.create_window("quodeq", url, width=1280, height=800,
+                                    frameless=True, easy_drag=True,
+                                    background_color='#0d1117', hidden=True,
+                                    js_api=api)
+    api.bind(window, api_pid=api_pid, instance=instance)
+
+    def _on_reload(new_url: str) -> None:
+        window.load_url(new_url)
+        window.on_top = True
+        window.on_top = False
+
+    def _on_loaded() -> None:
+        window.show()
+        window.evaluate_js(_INJECT_JS)
+
+    window.events.loaded += _on_loaded
+
+    instance.start_listening(on_reload=_on_reload)
+
+    storage_dir = str(_quodeq_dir() / "webview")
+
+    try:
+        webview.start(private_mode=False, storage_path=storage_dir)
+    finally:
+        instance.shutdown()
+        if api_pid:
+            _kill_api(api_pid)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -12,7 +12,7 @@ import webview
 from quodeq.dashboard._build_npm import _quodeq_dir
 from quodeq.dashboard._instance import InstanceController
 
-_CONTROLS_HTML = """\
+_CONTROLS_MAC = """\
 <style>
   .qd-traffic {
     position: fixed;
@@ -24,19 +24,15 @@ _CONTROLS_HTML = """\
     padding: 6px 11px;
     pointer-events: auto;
   }
-  /* Invisible hover bridge so sidebar stays expanded when moving to dots */
   .qd-traffic::after {
     content: "";
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 64px;
-    height: 100%;
+    top: 0; left: 0;
+    width: 64px; height: 100%;
     z-index: -1;
   }
   .qd-dot {
-    width: 10px;
-    height: 10px;
+    width: 10px; height: 10px;
     border-radius: 50%;
     border: none;
     cursor: pointer;
@@ -53,9 +49,7 @@ _CONTROLS_HTML = """\
   body:has(.sidebar:hover) .qd-dot--minimize { background: #febc2e; }
   .qd-traffic:hover .qd-dot--maximize,
   body:has(.sidebar:hover) .qd-dot--maximize { background: #28c840; }
-
   .sidebar { padding-top: 18px !important; }
-  /* Keep sidebar expanded when hovering the traffic dots */
   body:has(.qd-traffic:hover) .app-shell {
     grid-template-columns: var(--sidebar-expanded-width) 1fr;
   }
@@ -73,8 +67,40 @@ _CONTROLS_HTML = """\
   <button class="qd-dot qd-dot--close" title="Close" onclick="pywebview.api.close()"></button>
   <button class="qd-dot qd-dot--minimize" title="Minimize" onclick="pywebview.api.minimize()"></button>
   <button class="qd-dot qd-dot--maximize" title="Fullscreen" onclick="pywebview.api.maximize()"></button>
-</div>
-"""
+</div>"""
+
+_CONTROLS_WIN = """\
+<style>
+  .qd-winbtns {
+    position: fixed;
+    top: 0;
+    right: 0;
+    display: flex;
+    z-index: 99999;
+  }
+  .qd-winbtn {
+    width: 46px; height: 32px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted, #888);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    transition: background 0.1s;
+  }
+  .qd-winbtn:hover { background: var(--color-surface-alt, rgba(255,255,255,0.1)); }
+  .qd-winbtn--close:hover { background: #e81123; color: #fff; }
+  body { padding-top: 32px !important; }
+</style>
+<div class="qd-winbtns">
+  <button class="qd-winbtn" title="Minimize" onclick="pywebview.api.minimize()">&#x2013;</button>
+  <button class="qd-winbtn" title="Maximize" onclick="pywebview.api.maximize()">&#x2610;</button>
+  <button class="qd-winbtn qd-winbtn--close" title="Close" onclick="pywebview.api.close()">&#x2715;</button>
+</div>"""
+
+_CONTROLS_HTML = _CONTROLS_WIN if sys.platform == "win32" else _CONTROLS_MAC
 
 _CONTROLS_JS = """\
 (function() {
@@ -84,8 +110,9 @@ _CONTROLS_JS = """\
   while (d.firstChild) document.body.insertBefore(d.firstChild, document.body.firstChild);
 
   document.addEventListener('keydown', function(e) {
-    if (e.metaKey && e.key === '[') { e.preventDefault(); history.back(); }
-    if (e.metaKey && e.key === ']') { e.preventDefault(); history.forward(); }
+    var mod = navigator.platform.indexOf('Mac') >= 0 ? e.metaKey : e.ctrlKey;
+    if (mod && e.key === '[') { e.preventDefault(); history.back(); }
+    if (mod && e.key === ']') { e.preventDefault(); history.forward(); }
   });
 })();
 """
@@ -119,14 +146,22 @@ class _WindowApi:
             self._window.minimize()
 
     def maximize(self) -> None:
-        if self._window:
+        if not self._window:
+            return
+        if sys.platform == "win32":
+            if self._window.maximized:
+                self._window.restore()
+            else:
+                self._window.maximize()
+        else:
             self._window.toggle_fullscreen()
 
 
 def _kill_api(pid: int) -> None:
     """Terminate the Flask API process."""
     try:
-        os.kill(pid, signal.SIGTERM)
+        sig = signal.SIGTERM if sys.platform != "win32" else signal.CTRL_BREAK_EVENT
+        os.kill(pid, sig)
     except (OSError, ProcessLookupError):
         pass
 

--- a/src/quodeq/dashboard/cli.py
+++ b/src/quodeq/dashboard/cli.py
@@ -42,6 +42,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help=argparse.SUPPRESS)
     parser.add_argument("--open", action=argparse.BooleanOptionalAction, default=True,
                         help="Open the dashboard in a browser after starting (default: %(default)s)")
+    parser.add_argument("--browser", action="store_true", default=False,
+                        help="Open in browser instead of native window")
+    parser.add_argument("--verbose", action="store_true", default=False,
+                        help="Show API request logs in console")
     return parser
 
 
@@ -64,6 +68,8 @@ def parse_args(argv: list[str] | None = None) -> DashboardConfig:
             no_build=args.no_build,
             reinstall=args.reinstall,
             dev=args.dev,
+            use_native=not args.browser,
+            verbose=args.verbose,
         ),
         reports_dir=Path(args.evaluations),
         static_dist=Path(args.static_dist),

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -7,15 +7,18 @@ Sub-modules:
 """
 from __future__ import annotations
 
+import logging
+import os
+
 from quodeq.dashboard._api_health import ApiConfig
 from quodeq.dashboard._build import maybe_build_ui
 from quodeq.dashboard._config import BuildConfig, DashboardConfig, ServerConfig
 from quodeq.dashboard._networking import _choose_ui_port, _is_port_open
 from quodeq.dashboard._process import _kill_stale_action_api
+from quodeq.dashboard import _server as _server_mod
 from quodeq.dashboard._server import (
     _ensure_action_api,
     _ensure_action_api_forced,
-    _serve_and_wait,
 )
 from quodeq.shared.config_loader import get_default_host as _get_default_host
 from quodeq.shared.logging import log_info, log_warning
@@ -111,6 +114,9 @@ def run_dashboard(config: DashboardConfig, env: dict[str, str] | None = None) ->
     config = _resolve_paths_and_build(config)
     validate_paths(config)
 
+    if config.build.verbose:
+        os.environ["QUODEQ_VERBOSE"] = "1"
+
     log_info("Starting dashboard...")
     log_info(f"Reports: {config.reports_dir}")
     log_info(f"Static:  {config.static_dist}")
@@ -121,5 +127,5 @@ def run_dashboard(config: DashboardConfig, env: dict[str, str] | None = None) ->
     api_config = ApiConfig(static_dist=config.static_dist, evaluations_dir=str(config.reports_dir))
     action_api_url, action_api_process = _start_action_api(config, action_api_host, action_api_port, api_config)
 
-    _serve_and_wait(action_api_url, action_api_process, config)
+    _server_mod._serve_and_wait(action_api_url, action_api_process, config)
     return 0

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 
-const POLL_MS = 10000;
+const HEALTH_POLL_MS = 10000;
+const LOG_POLL_MS = 2000;
 
 function ping() {
   return fetch('/api/health?_t=' + Date.now())
@@ -8,12 +9,29 @@ function ping() {
     .catch(() => null);
 }
 
+function ConsoleIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none"
+      stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="1" y="2" width="14" height="12" rx="2" />
+      <polyline points="4.5,6.5 7,9 4.5,11.5" />
+      <line x1="9" y1="11" x2="12" y2="11" />
+    </svg>
+  );
+}
+
 export default function ServerSection() {
   const [health, setHealth] = useState(null);
   const [status, setStatus] = useState('checking');
-  const timerRef = useRef(null);
+  const [consoleOpen, setConsoleOpen] = useState(false);
+  const [logLines, setLogLines] = useState([]);
+  const sinceRef = useRef(-1);
+  const logRef = useRef(null);
+  const healthTimerRef = useRef(null);
+  const logTimerRef = useRef(null);
   const cancelledRef = useRef(false);
 
+  // Health polling
   useEffect(() => {
     cancelledRef.current = false;
 
@@ -22,13 +40,61 @@ export default function ServerSection() {
         if (cancelledRef.current) return;
         if (d?.ok) { setHealth(d); setStatus('online'); }
         else { setHealth(null); setStatus('offline'); }
-        timerRef.current = setTimeout(tick, POLL_MS);
+        healthTimerRef.current = setTimeout(tick, HEALTH_POLL_MS);
       });
     }
     tick();
 
-    return () => { cancelledRef.current = true; clearTimeout(timerRef.current); };
+    return () => { cancelledRef.current = true; clearTimeout(healthTimerRef.current); };
   }, []);
+
+  // Log polling — only when console is open
+  useEffect(() => {
+    if (!consoleOpen || status !== 'online') {
+      clearTimeout(logTimerRef.current);
+      return;
+    }
+
+    let active = true;
+
+    function pollLogs() {
+      const url = '/api/logs' + (sinceRef.current >= 0 ? '?since=' + sinceRef.current : '');
+      fetch(url)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data) => {
+          if (!active || !data) return;
+          if (data.lines.length) {
+            setLogLines((prev) => {
+              const next = [...prev, ...data.lines];
+              return next.length > 500 ? next.slice(-500) : next;
+            });
+            sinceRef.current = data.lines[data.lines.length - 1].index;
+          }
+          logTimerRef.current = setTimeout(pollLogs, LOG_POLL_MS);
+        })
+        .catch(() => {
+          if (active) logTimerRef.current = setTimeout(pollLogs, LOG_POLL_MS);
+        });
+    }
+    pollLogs();
+
+    return () => { active = false; clearTimeout(logTimerRef.current); };
+  }, [consoleOpen, status]);
+
+  // Auto-scroll
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [logLines]);
+
+  function handlePopOut() {
+    window.open('/logs', '_blank', 'width=800,height=500');
+  }
+
+  function handleClear() {
+    setLogLines([]);
+  }
 
   return (
     <section className="panel settings-section">
@@ -47,7 +113,7 @@ export default function ServerSection() {
       </div>
 
       {status === 'online' && health && (
-        <div className="settings-row settings-row--last">
+        <div className="settings-row">
           <div className="settings-row-label">
             <span className="settings-label">Details</span>
             <span className="settings-description">
@@ -55,6 +121,42 @@ export default function ServerSection() {
             </span>
           </div>
         </div>
+      )}
+
+      {status === 'online' && (
+        <>
+          <div
+            className="server-console-toggle"
+            role="button"
+            tabIndex={0}
+            onClick={() => setConsoleOpen((o) => !o)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setConsoleOpen((o) => !o); } }}
+            aria-label={consoleOpen ? 'Hide console' : 'Show console'}
+          >
+            <ConsoleIcon />
+            <span>Console</span>
+            <span className="console-chevron">{consoleOpen ? '\u25BE' : '\u25B8'}</span>
+          </div>
+
+          {consoleOpen && (
+            <div className="server-console-wrap">
+              <div className="console-output" ref={logRef}>
+                <pre>
+                  {logLines.length
+                    ? logLines.map((e) => {
+                        const ts = e.timestamp ? e.timestamp.slice(11, 19) : '';
+                        return `[${ts}] ${e.line}`;
+                      }).join('\n')
+                    : 'No logs yet\u2026'}
+                </pre>
+              </div>
+              <div className="server-console-actions">
+                <button onClick={handlePopOut}>Pop out</button>
+                <button onClick={handleClear}>Clear</button>
+              </div>
+            </div>
+          )}
+        </>
       )}
 
       {status === 'offline' && (

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1738,3 +1738,62 @@ textarea:focus {
   cursor: not-allowed;
 }
 
+/* Server console */
+.server-console-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: var(--space-3) var(--space-4);
+  margin: 0 var(--space-4);
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  border-top: 1px solid var(--color-border);
+  user-select: none;
+}
+
+.server-console-toggle:hover {
+  color: var(--color-text);
+}
+
+.server-console-toggle .console-chevron {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.server-console-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-console-bg);
+  border-top: 1px solid color-mix(in srgb, var(--color-console-text) 12%, var(--color-console-bg));
+}
+
+.server-console-actions button {
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--color-console-text) 25%, var(--color-console-bg));
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  padding: 2px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.server-console-actions button:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
+.server-console-wrap {
+  margin: 0 var(--space-4) var(--space-4);
+}
+
+.server-console-wrap .console-output {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  max-height: 240px;
+}
+

--- a/tests/api/test_log_buffer.py
+++ b/tests/api/test_log_buffer.py
@@ -1,0 +1,73 @@
+import logging
+
+from quodeq.api._log_buffer import LogBuffer
+
+
+def test_append_and_get_lines():
+    buf = LogBuffer(max_lines=10)
+    buf.append("line one")
+    buf.append("line two")
+    result = buf.get_lines()
+    assert len(result["lines"]) == 2
+    assert result["lines"][0]["line"] == "line one"
+    assert result["lines"][1]["line"] == "line two"
+    assert result["total"] == 2
+
+
+def test_ring_buffer_overflow():
+    buf = LogBuffer(max_lines=3)
+    for i in range(5):
+        buf.append(f"line {i}")
+    result = buf.get_lines()
+    assert len(result["lines"]) == 3
+    assert result["lines"][0]["line"] == "line 2"
+    assert result["lines"][2]["line"] == "line 4"
+
+
+def test_since_returns_delta():
+    buf = LogBuffer(max_lines=10)
+    buf.append("old")
+    buf.append("new")
+    result = buf.get_lines(since=0)
+    assert len(result["lines"]) == 1
+    assert result["lines"][0]["line"] == "new"
+    assert result["lines"][0]["index"] == 1
+
+
+def test_since_out_of_range_returns_all():
+    buf = LogBuffer(max_lines=10)
+    buf.append("a")
+    buf.append("b")
+    result = buf.get_lines(since=99)
+    assert len(result["lines"]) == 0
+
+
+def test_monotonic_index():
+    buf = LogBuffer(max_lines=3)
+    for i in range(5):
+        buf.append(f"line {i}")
+    result = buf.get_lines()
+    indices = [e["index"] for e in result["lines"]]
+    assert indices == [2, 3, 4]
+
+
+def test_handler_captures_log_records():
+    buf = LogBuffer(max_lines=10)
+    logger = logging.getLogger("test_handler_capture")
+    logger.addHandler(buf.handler)
+    logger.setLevel(logging.INFO)
+    logger.info("hello from logger")
+    result = buf.get_lines()
+    assert len(result["lines"]) == 1
+    assert "hello from logger" in result["lines"][0]["line"]
+    logger.removeHandler(buf.handler)
+
+
+def test_clear():
+    buf = LogBuffer(max_lines=10)
+    buf.append("a")
+    buf.append("b")
+    buf.clear()
+    result = buf.get_lines()
+    assert len(result["lines"]) == 0
+    assert result["total"] == 0

--- a/tests/api/test_log_routes.py
+++ b/tests/api/test_log_routes.py
@@ -1,0 +1,54 @@
+import logging
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+def test_logs_endpoint_returns_empty():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/api/logs")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["lines"] == [] or isinstance(data["lines"], list)
+    assert "total" in data
+
+
+def test_logs_endpoint_since_param():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/api/logs?since=0")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data["lines"], list)
+
+
+def test_logs_endpoint_captures_requests():
+    app = create_app()
+    client = app.test_client()
+    # Make a request that generates a log
+    client.get("/api/health")
+    resp = client.get("/api/logs")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] >= 0
+
+
+def test_logs_page_returns_html():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/logs")
+    assert resp.status_code == 200
+    assert b"<!DOCTYPE html>" in resp.data
+    assert b"Quodeq" in resp.data
+    assert b"/api/logs" in resp.data
+
+
+@pytest.mark.parametrize("logger_name", ["werkzeug", "quodeq.api"])
+def test_logs_suppressed_by_default(logger_name):
+    """Request logs go to buffer only, not stderr."""
+    create_app()
+    lgr = logging.getLogger(logger_name)
+    assert len(lgr.handlers) == 1
+    assert lgr.propagate is False

--- a/tests/dashboard/test_dashboard_cli.py
+++ b/tests/dashboard/test_dashboard_cli.py
@@ -1,0 +1,23 @@
+from quodeq.dashboard.cli import parse_args
+
+
+def test_default_uses_native():
+    config = parse_args([])
+    assert config.build.use_native is True
+    assert config.build.verbose is False
+
+
+def test_browser_flag_disables_native():
+    config = parse_args(["--browser"])
+    assert config.build.use_native is False
+
+
+def test_verbose_flag():
+    config = parse_args(["--verbose"])
+    assert config.build.verbose is True
+
+
+def test_browser_and_verbose():
+    config = parse_args(["--browser", "--verbose"])
+    assert config.build.use_native is False
+    assert config.build.verbose is True

--- a/tests/dashboard/test_dashboard_runner.py
+++ b/tests/dashboard/test_dashboard_runner.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+import logging
 
 import pytest
 
@@ -115,3 +117,105 @@ def test_validate_paths_missing_reports_custom_message(tmp_path: Path):
     assert "Reports directory not found" in message
     assert "mkdir -p" in message
     assert "omit --evaluations" in message
+
+
+def test_build_config_native_defaults():
+    cfg = BuildConfig(open_browser=True, no_build=True, reinstall=False)
+    assert cfg.use_native is True
+    assert cfg.verbose is False
+
+
+def test_build_config_browser_mode():
+    cfg = BuildConfig(open_browser=True, no_build=True, reinstall=False, use_native=False)
+    assert cfg.use_native is False
+
+
+def test_run_dashboard_native_window(tmp_path: Path, monkeypatch):
+    """When use_native=True, _serve_and_wait uses webview instead of webbrowser."""
+    (tmp_path / "reports").mkdir()
+    static_dist = tmp_path / "ui/web/dist"
+    static_dist.mkdir(parents=True)
+    (static_dist / "index.html").write_text("ok")
+
+    webview_calls = []
+
+    monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        runner, "_ensure_action_api",
+        lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
+    )
+    monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
+    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+
+    from quodeq.dashboard import _server
+
+    def fake_serve(url, proc, config):
+        webview_calls.append(config.build.use_native)
+
+    monkeypatch.setattr(_server, "_serve_and_wait", fake_serve)
+
+    config = _make_config(
+        tmp_path,
+        static_dist=static_dist,
+        build=BuildConfig(open_browser=True, no_build=True, reinstall=False, use_native=True),
+    )
+    run_dashboard(config)
+    assert webview_calls == [True]
+
+
+def test_run_dashboard_browser_fallback(tmp_path: Path, monkeypatch):
+    """When use_native=False, _serve_and_wait opens browser."""
+    (tmp_path / "reports").mkdir()
+    static_dist = tmp_path / "ui/web/dist"
+    static_dist.mkdir(parents=True)
+    (static_dist / "index.html").write_text("ok")
+
+    from quodeq.dashboard import _server
+    browser_calls = []
+
+    monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        runner, "_ensure_action_api",
+        lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
+    )
+    monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
+    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+
+    def fake_serve(url, proc, config):
+        browser_calls.append(config.build.use_native)
+
+    monkeypatch.setattr(_server, "_serve_and_wait", fake_serve)
+
+    config = _make_config(
+        tmp_path,
+        static_dist=static_dist,
+        build=BuildConfig(open_browser=True, no_build=True, reinstall=False, use_native=False),
+    )
+    run_dashboard(config)
+    assert browser_calls == [False]
+
+
+def test_run_dashboard_verbose_sets_env(tmp_path: Path, monkeypatch):
+    """When verbose=True, QUODEQ_VERBOSE env var is set."""
+    (tmp_path / "reports").mkdir()
+    static_dist = tmp_path / "ui/web/dist"
+    static_dist.mkdir(parents=True)
+    (static_dist / "index.html").write_text("ok")
+
+    monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        runner, "_ensure_action_api",
+        lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
+    )
+    monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
+    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.delenv("QUODEQ_VERBOSE", raising=False)
+
+    config = _make_config(
+        tmp_path,
+        static_dist=static_dist,
+        build=BuildConfig(open_browser=False, no_build=True, reinstall=False, verbose=True),
+    )
+    run_dashboard(config)
+
+    assert os.environ.get("QUODEQ_VERBOSE") == "1"

--- a/tests/dashboard/test_instance.py
+++ b/tests/dashboard/test_instance.py
@@ -1,0 +1,49 @@
+import threading
+import time
+from pathlib import Path
+
+from quodeq.dashboard._instance import InstanceController
+
+
+def test_first_instance_acquires_lock(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    ctrl = InstanceController(sock_path)
+    assert ctrl.try_acquire() is True
+    ctrl.shutdown()
+
+
+def test_second_instance_sends_reload(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    received = []
+
+    ctrl1 = InstanceController(sock_path)
+    assert ctrl1.try_acquire() is True
+    ctrl1.start_listening(on_reload=lambda url: received.append(url))
+
+    ctrl2 = InstanceController(sock_path)
+    assert ctrl2.try_acquire() is False
+    ctrl2.send_reload("http://localhost:8001")
+
+    # Give the listener thread time to process
+    time.sleep(0.2)
+    ctrl1.shutdown()
+
+    assert received == ["http://localhost:8001"]
+
+
+def test_stale_socket_is_cleaned_up(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    # Create a stale socket file (not a real socket)
+    sock_path.touch()
+
+    ctrl = InstanceController(sock_path)
+    assert ctrl.try_acquire() is True
+    ctrl.shutdown()
+
+
+def test_shutdown_removes_socket(tmp_path: Path):
+    sock_path = tmp_path / "test.sock"
+    ctrl = InstanceController(sock_path)
+    ctrl.try_acquire()
+    ctrl.shutdown()
+    assert not sock_path.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -159,12 +159,44 @@ wheels = [
 ]
 
 [[package]]
+name = "bottle"
+version = "0.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/71/cca6167c06d00c81375fd668719df245864076d284f7cb46a694cbeb5454/bottle-0.13.4.tar.gz", hash = "sha256:787e78327e12b227938de02248333d788cfe45987edca735f8f88e03472c3f47", size = 98717, upload-time = "2025-06-15T10:08:59.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/f6/b55ec74cfe68c6584163faa311503c20b0da4c09883a41e8e00d6726c954/bottle-0.13.4-py2.py3-none-any.whl", hash = "sha256:045684fbd2764eac9cdeb824861d1551d113e8b683d8d26e296898d3dd99a12e", size = 103807, upload-time = "2025-06-15T10:08:57.691Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -250,6 +282,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "clr-loader"
+version = "0.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/24/c12faf3f61614b3131b5c98d3bf0d376b49c7feaa73edca559aeb2aee080/clr_loader-0.2.10.tar.gz", hash = "sha256:81f114afbc5005bafc5efe5af1341d400e22137e275b042a8979f3feb9fc9446", size = 83605, upload-time = "2026-01-03T23:13:06.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/61/cf819f8e8bb4d4c74661acf2498ba8d4a296714be3478d21eaabf64f5b9b/clr_loader-0.2.10-py3-none-any.whl", hash = "sha256:ebbbf9d511a7fe95fa28a95a4e04cd195b097881dfe66158dc2c281d3536f282", size = 56483, upload-time = "2026-01-03T23:13:05.439Z" },
 ]
 
 [[package]]
@@ -967,6 +1011,21 @@ wheels = [
 ]
 
 [[package]]
+name = "proxy-tools"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/cf/77d3e19b7fabd03895caca7857ef51e4c409e0ca6b37ee6e9f7daa50b642/proxy_tools-0.1.0.tar.gz", hash = "sha256:ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010", size = 2978, upload-time = "2014-05-05T21:02:24.606Z" }
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1062,6 +1121,99 @@ wheels = [
 ]
 
 [[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d2/29e5e536adc07bc3d33dd09f3f7cf844bf7b4981820dc2a91dd810f3c782/pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a", size = 677370, upload-time = "2025-11-14T09:33:05.273Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/f0/4b4ed8924cd04e425f2a07269943018d43949afad1c348c3ed4d9d032787/pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc", size = 719586, upload-time = "2025-11-14T09:33:53.302Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/9f4ed07162de69603144ff480be35cd021808faa7f730d082b92f7ebf2b5/pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43", size = 670164, upload-time = "2025-11-14T09:34:37.458Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/dc076965c96c7f0de25c0a32b7f8aa98133ed244deaeeacfc758783f1f30/pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882", size = 712204, upload-time = "2025-11-14T09:35:24.148Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/31/0c2e734165abb46215797bd830c4bdcb780b699854b15f2b6240515edcc6/pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118", size = 384689, upload-time = "2025-11-14T09:41:41.478Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/b9f61be7b9f9b4e0a6db18b3c35c4c4d589f2d04e963e2174d38c6555a92/pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44", size = 388843, upload-time = "2025-11-14T09:42:05.719Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/f777cc9e775fc7dae77b569254570fe46eb842516b3e4fe383ab49eab598/pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a", size = 384932, upload-time = "2025-11-14T09:42:29.771Z" },
+    { url = "https://files.pythonhosted.org/packages/58/27/b457b7b37089cad692c8aada90119162dfb4c4a16f513b79a8b2b022b33b/pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc", size = 388970, upload-time = "2025-11-14T09:42:53.964Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7730cdce46c7e985535b5a42c31381af4aa6556e5642dc55b5e6597595e57a16", size = 218798, upload-time = "2025-11-14T10:00:01.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/e8f495328101898c16c32ac10e7b14b08ff2c443a756a76fd1271915f097/pyobjc_framework_quartz-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:629b7971b1b43a11617f1460cd218bd308dfea247cd4ee3842eb40ca6f588860", size = 219206, upload-time = "2025-11-14T10:00:15.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/43/b1f0ad3b842ab150a7e6b7d97f6257eab6af241b4c7d14cb8e7fde9214b8/pyobjc_framework_quartz-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:53b84e880c358ba1ddcd7e8d5ea0407d760eca58b96f0d344829162cda5f37b3", size = 224317, upload-time = "2025-11-14T10:00:30.703Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/00/96249c5c7e5aaca5f688ca18b8d8ad05cd7886ebd639b3c71a6a4cadbe75/pyobjc_framework_quartz-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:42d306b07f05ae7d155984503e0fb1b701fecd31dcc5c79fe8ab9790ff7e0de0", size = 219558, upload-time = "2025-11-14T10:00:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a6/708a55f3ff7a18c403b30a29a11dccfed0410485a7548c60a4b6d4cc0676/pyobjc_framework_quartz-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0cc08fddb339b2760df60dea1057453557588908e42bdc62184b6396ce2d6e9a", size = 224580, upload-time = "2025-11-14T10:01:00.091Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/aa/796e09a3e3d5cee32ebeebb7dcf421b48ea86e28c387924608a05e3f668b/pyobjc_framework_security-12.1.tar.gz", hash = "sha256:7fecb982bd2f7c4354513faf90ba4c53c190b7e88167984c2d0da99741de6da9", size = 168044, upload-time = "2025-11-14T10:22:06.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/66/5160c0f938fc0515fe8d9af146aac1b093f7ef285ce797fedae161b6c0e8/pyobjc_framework_security-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab42e55f5b782332be5442750fcd9637ee33247d57c7b1d5801bc0e24ee13278", size = 41280, upload-time = "2025-11-14T10:02:58.097Z" },
+    { url = "https://files.pythonhosted.org/packages/32/48/b294ed75247c5cfa00d51925a10237337d24f54961d49a179b20a4307642/pyobjc_framework_security-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:afc36661cc6eb98cd794bed1d6668791e96557d6f72d9ac70aa49022d26af1d4", size = 41284, upload-time = "2025-11-14T10:03:01.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/57/0d3ef78779cf5c3bba878b2f824137e50978ad4a21dabe65d8b5ae0fc0d1/pyobjc_framework_security-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9510c98ab56921d1d416437372605cc1c1f6c1ad8d3061ee56b17bf423dd5427", size = 42162, upload-time = "2025-11-14T10:03:05.337Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4d/63c15f9449c191e7448a05ff8af4a82c39a51bb627bc96dc9697586c0f79/pyobjc_framework_security-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6319a34508fd87ab6ca3cda6f54e707196197a65b792b292705af967e225438a", size = 41348, upload-time = "2025-11-14T10:03:08.926Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d8/5aaa2a8124ed04a9d6ca7053dc0fa64e42be51497ed8263a24b744a95598/pyobjc_framework_security-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:03d166371cefdef24908825148eb848f99ee2c0b865870a09dcbb94334dd3e0a", size = 42908, upload-time = "2025-11-14T10:03:13.01Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/b8/dd9d2a94509a6c16d965a7b0155e78edf520056313a80f0cd352413f0d0b/pyobjc_framework_uniformtypeidentifiers-12.1.tar.gz", hash = "sha256:64510a6df78336579e9c39b873cfcd03371c4b4be2cec8af75a8a3d07dff607d", size = 17030, upload-time = "2025-11-14T10:23:02.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/5f/1f10f5275b06d213c9897850f1fca9c881c741c1f9190cea6db982b71824/pyobjc_framework_uniformtypeidentifiers-12.1-py2.py3-none-any.whl", hash = "sha256:ec5411e39152304d2a7e0e426c3058fa37a00860af64e164794e0bcffee813f2", size = 4901, upload-time = "2025-11-14T10:05:51.532Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/10/110a50e8e6670765d25190ca7f7bfeecc47ec4a8c018cb928f4f82c56e04/pyobjc_framework_webkit-12.1.tar.gz", hash = "sha256:97a54dd05ab5266bd4f614e41add517ae62cdd5a30328eabb06792474b37d82a", size = 284531, upload-time = "2025-11-14T10:23:40.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/67/64920c8d201a7fc27962f467c636c4e763b43845baba2e091a50a97a5d52/pyobjc_framework_webkit-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:af2c7197447638b92aafbe4847c063b6dd5e1ed83b44d3ce7e71e4c9b042ab5a", size = 50084, upload-time = "2025-11-14T10:07:05.868Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/3d/80d36280164c69220ce99372f7736a028617c207e42cb587716009eecb88/pyobjc_framework_webkit-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1da0c428c9d9891c93e0de51c9f272bfeb96d34356cdf3136cb4ad56ce32ec2d", size = 50096, upload-time = "2025-11-14T10:07:10.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/7a/03c29c46866e266b0c705811c55c22625c349b0a80f5cf4776454b13dc4c/pyobjc_framework_webkit-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1a29e334d5a7dd4a4f0b5647481b6ccf8a107b92e67b2b3c6b368c899f571965", size = 50572, upload-time = "2025-11-14T10:07:14.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ac/924878f239c167ffe3bfc643aee4d6dd5b357e25f6b28db227e40e9e6df3/pyobjc_framework_webkit-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:99d0d28542a266a95ee2585f51765c0331794bca461aaf4d1f5091489d475179", size = 50210, upload-time = "2025-11-14T10:07:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/86/637cda4983dc0936b73a385f3906256953ac434537b812814cb0b6d231a2/pyobjc_framework_webkit-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1aaa3bf12c7b68e1a36c0b294d2728e06f2cc220775e6dc4541d5046290e4dc8", size = 50680, upload-time = "2025-11-14T10:07:23.331Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1244,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pythonnet"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "clr-loader" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d6/1afd75edd932306ae9bd2c2d961d603dc2b52fcec51b04afea464f1f6646/pythonnet-3.0.5.tar.gz", hash = "sha256:48e43ca463941b3608b32b4e236db92d8d40db4c58a75ace902985f76dac21cf", size = 239212, upload-time = "2024-12-13T08:30:44.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/f1/bfb6811df4745f92f14c47a29e50e89a36b1533130fcc56452d4660bd2d6/pythonnet-3.0.5-py3-none-any.whl", hash = "sha256:f6702d694d5d5b163c9f3f5cc34e0bed8d6857150237fae411fefb883a656d20", size = 297506, upload-time = "2024-12-13T08:30:40.661Z" },
+]
+
+[[package]]
+name = "pywebview"
+version = "6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bottle" },
+    { name = "proxy-tools" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-security", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-webkit", marker = "sys_platform == 'darwin'" },
+    { name = "pythonnet", marker = "sys_platform == 'win32'" },
+    { name = "qtpy", marker = "sys_platform == 'openbsd6'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/09/75cf92c4db19350ddb084d841e352ce30e89668815d0494d1dd595c85469/pywebview-6.1.tar.gz", hash = "sha256:f0b95047860caf3d921581f9e16b4edb1a125b23e2ce691c4da2968f8b160ff2", size = 496270, upload-time = "2025-10-21T18:02:44.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/12/ce9006cdcc1834378826b5c0d4b554d899cd25ac9c665569d060f220b0e1/pywebview-6.1-py3-none-any.whl", hash = "sha256:2b552a340557e76a740b045a25937f72dae751e0985d5f5d9556f697ba622ec5", size = 511255, upload-time = "2025-10-21T18:02:42.377Z" },
+]
+
+[[package]]
+name = "qtpy"
+version = "2.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
+]
+
+[[package]]
 name = "quodeq"
 version = "0.10.0"
 source = { editable = "." }
@@ -1103,6 +1301,9 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "instructor" },
+]
+desktop = [
+    { name = "pywebview" },
 ]
 
 [package.dev-dependencies]
@@ -1117,8 +1318,9 @@ requires-dist = [
     { name = "flask", specifier = "==3.1.3" },
     { name = "instructor", marker = "extra == 'api'", specifier = ">=1.15.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
+    { name = "pywebview", marker = "extra == 'desktop'", specifier = ">=5.0" },
 ]
-provides-extras = ["api"]
+provides-extras = ["api", "desktop"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- **PyWebView desktop mode**: native frameless window with custom traffic light controls, single-instance support via unix socket IPC, localStorage persistence, terminal released immediately
- **Server logs console**: ring buffer capturing Flask logs, `/api/logs` endpoint with delta polling, collapsible console panel in Settings > Server, pop-out `/logs` page
- **QuodeqBar integration**: "Open Dashboard" launches PyWebView window instead of browser
- `--browser` flag for browser fallback, `--verbose` for terminal log output
- `pip install quodeq[desktop]` to enable native window mode

## New files
- `_log_buffer.py` — thread-safe ring buffer (500 lines)
- `_log_routes.py` — `/api/logs` endpoint + `/logs` standalone page
- `_instance.py` — single-instance controller via unix domain socket
- `_webview_window.py` — PyWebView subprocess with frameless window controls

## Test plan
- [x] 811 tests passing, 0 regressions
- [x] `uv run quodeq dashboard` opens native window, terminal freed
- [x] `uv run quodeq dashboard --browser` opens in browser
- [x] Second `quodeq dashboard` brings existing window to front
- [x] Closing window kills Flask
- [x] Settings > Server console shows live logs
- [x] Pop out opens `/logs` in new window
- [x] `--verbose` shows logs in terminal
- [x] localStorage persists between sessions (theme, project, settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)