### PR TITLE
fix: multi-provider polish, process cleanup, scope & UI

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -130,8 +130,13 @@ def _mcp_server_name(config: AnalysisConfig) -> str:
 def _build_mcp_server_args(
     config: AnalysisConfig,
     work_dir: Path | None = None,
+    skip_agent_id: bool = False,
 ) -> list[str]:
-    """Build the MCP findings server command-line args."""
+    """Build the MCP findings server command-line args.
+
+    *skip_agent_id*: set True for cli-register MCP where all agents share
+    one server — the per-agent file cap doesn't apply.
+    """
     mcp_script = str(Path(__file__).resolve().parent / "mcp" / "findings_server.py")
     mcp_args = [sys.executable, mcp_script, str(config.jsonl_file.resolve())]
     if config.compiled_dir and config.dimension:
@@ -141,7 +146,7 @@ def _build_mcp_server_args(
         ])
     if config.queue_path:
         mcp_args.extend(["--queue", str(config.queue_path.resolve())])
-    if config.agent_id:
+    if config.agent_id and not skip_agent_id:
         mcp_args.extend(["--agent-id", config.agent_id])
     wd = config.work_dir or work_dir
     if wd:
@@ -162,7 +167,9 @@ def _register_cli_mcp(cmd: str, config: AnalysisConfig, work_dir: Path | None = 
         if key in _cli_mcp_registered:
             return name
         _unregister_cli_mcp(cmd, name)
-        mcp_args = _build_mcp_server_args(config, work_dir)
+        # Skip agent-id: all agents share one MCP server, so per-agent
+        # file caps don't apply — the queue distributes freely.
+        mcp_args = _build_mcp_server_args(config, work_dir, skip_agent_id=True)
         provider_cfg = _get_provider_configs().get(cmd, {})
         # Codex/Copilot use "-- cmd args", Gemini uses "cmd args" (no separator)
         use_separator = provider_cfg.get("mcp_add_separator", True)

--- a/src/quodeq/analysis/_process.py
+++ b/src/quodeq/analysis/_process.py
@@ -1,7 +1,10 @@
 """Subprocess spawning, heartbeat monitoring, and error handling."""
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
+import sys
 from pathlib import Path
 
 from quodeq.analysis._config import AnalysisConfig, _SpawnPaths
@@ -16,13 +19,35 @@ class AnalysisError(RuntimeError):
     """Raised when the AI CLI subprocess fails (non-zero exit, auth error, etc.)."""
 
 
+def _kill_tree(pid: int, sig: int = signal.SIGTERM) -> None:
+    """Kill a process and all its children, cross-platform."""
+    if sys.platform == "win32":
+        # taskkill /T kills the entire process tree
+        subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(pid)],
+            capture_output=True, timeout=10,
+        )
+    else:
+        try:
+            os.killpg(os.getpgid(pid), sig)
+        except (ProcessLookupError, OSError):
+            try:
+                os.kill(pid, sig)
+            except (ProcessLookupError, OSError):
+                pass
+
+
 def _terminate_process(process: subprocess.Popen) -> None:
-    """Send SIGTERM and escalate to SIGKILL if the process doesn't exit."""
-    process.terminate()
+    """Kill the process and its entire process tree to prevent orphans."""
+    _kill_tree(process.pid, signal.SIGTERM)
     try:
         process.wait(timeout=_TERMINATE_TIMEOUT_S)
     except subprocess.TimeoutExpired:
-        process.kill()
+        _kill_tree(process.pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
 
 
 def _run_with_heartbeat(
@@ -77,9 +102,12 @@ def _spawn_and_monitor(
 ) -> tuple[subprocess.Popen, bool]:
     """Spawn the AI CLI process, monitor with heartbeat, return (process, timed_out)."""
     with open(paths.stream_file, "w") as out, open(paths.stream_err, "w") as err:
+        # start_new_session creates a new process group so we can kill the
+        # entire tree (including child processes) when the agent is cancelled.
         process = subprocess.Popen(
             args, cwd=str(work_dir), env=env,
             stdout=out, stderr=err, stdin=subprocess.DEVNULL,
+            start_new_session=True,
         )
         timed_out = _run_with_heartbeat(process, cfg, paths.stream_file)
     return process, timed_out

--- a/src/quodeq/analysis/stream/progress_reader.py
+++ b/src/quodeq/analysis/stream/progress_reader.py
@@ -17,12 +17,19 @@ class _IncrementalProgressReader:
         self._jsonl_offset = 0
         self._seen_files: set[str] = set()
         self._jsonl_count = 0
+        self._violations = 0
+        self._compliances = 0
 
     def read_progress(self) -> dict:
         """Return incremental progress since the last call."""
         self._read_stream()
         self._read_jsonl()
-        return {"files_read": len(self._seen_files), "evidence": self._jsonl_count}
+        return {
+            "files_read": len(self._seen_files),
+            "evidence": self._jsonl_count,
+            "violations": self._violations,
+            "compliances": self._compliances,
+        }
 
     def _read_stream(self) -> None:
         try:
@@ -41,13 +48,23 @@ class _IncrementalProgressReader:
         if self._jsonl_file is None or not self._jsonl_file.exists():
             return
         try:
+            import json as _json
             with open(self._jsonl_file, "rb") as jf:
                 jf.seek(self._jsonl_offset)
                 new_bytes = jf.read()
                 self._jsonl_offset += len(new_bytes)
-            self._jsonl_count += sum(
-                1 for line in new_bytes.decode("utf-8", errors="replace").splitlines()
-                if line.strip()
-            )
+            for line in new_bytes.decode("utf-8", errors="replace").splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                self._jsonl_count += 1
+                try:
+                    t = _json.loads(stripped).get("t", "")
+                except (ValueError, AttributeError):
+                    t = ""
+                if t == "violation":
+                    self._violations += 1
+                elif t == "compliance":
+                    self._compliances += 1
         except OSError as exc:
             log_debug(f"Failed to read JSONL {self._jsonl_file}: {exc}")

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -68,10 +68,23 @@ def scout_loop(ctx: LoopContext) -> None:
 
 def immediate_loop(ctx: LoopContext) -> None:
     """Launch all agents immediately, respawning as they complete."""
+    from quodeq.shared.logging import log_warning as _log_warn
+
     ev_paths = EvidencePaths(ctx.shared_jsonl_path, ctx.evidence_dir, ctx.dimension_key)
     for _ in range(ctx.n_agents):
         ctx.submit_fn()
     while ctx.futures:
+        # Check pool budget — cancel all running agents if exceeded
+        if ctx.max_duration > 0:
+            elapsed = time.monotonic() - ctx.pool_start
+            if elapsed >= ctx.max_duration:
+                _log_warn(
+                    f"  Pool budget ({ctx.max_duration:.0f}s) exceeded "
+                    f"-- cancelling {len(ctx.futures)} remaining agents"
+                )
+                for future in list(ctx.futures):
+                    future.cancel()
+                break
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -33,11 +33,15 @@ def build_agent_config(
     jsonl_file = wctx.evidence_dir / f"{wctx.dimension_key}_evidence.jsonl"
     stream_file = wctx.evidence_dir / f"{wctx.dimension_key}_{agent_id}.stream"
     bc = base_config
+    # Cap per-agent duration to pool budget so agents can't outlive the pool
+    agent_dur = bc.max_duration or _DEFAULT_MAX_DURATION_S
+    if bc.pool_budget and bc.pool_budget > 0:
+        agent_dur = min(agent_dur, bc.pool_budget)
     ac = AnalysisConfig(
         jsonl_file=jsonl_file, analysis_budget=bc.analysis_budget,
         heartbeat_interval=bc.heartbeat_interval, heartbeat_callback=bc.heartbeat_callback,
         ai_cmd=bc.ai_cmd, ai_model=bc.ai_model, max_turns=bc.max_turns,
-        max_duration=bc.max_duration or _DEFAULT_MAX_DURATION_S,
+        max_duration=agent_dur,
         compiled_dir=bc.compiled_dir, dimension=wctx.dimension,
         queue_path=wctx.queue_path, agent_id=agent_id,
         max_files_per_agent=bc.max_files_per_agent,

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -159,3 +159,22 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
 
         import dataclasses
         return jsonify(dataclasses.asdict(result))
+
+    @app.post("/api/scan")
+    def scan_path() -> Response | tuple[Response, int]:
+        """Scan a local path directly (no project required)."""
+        data = request.get_json(silent=True) or {}
+        target = data.get("path", "").strip()
+        if not target:
+            body, status = error_response("path is required", HTTPStatus.BAD_REQUEST, "MISSING_PATH")
+            return jsonify(body), status
+
+        target_path = Path(target).resolve()
+        if not target_path.is_dir():
+            body, status = error_response("Path is not a directory", HTTPStatus.BAD_REQUEST, "NOT_DIR")
+            return jsonify(body), status
+
+        from quodeq.services._fs_scan import scan_project
+        import dataclasses
+        result = scan_project(target_path)
+        return jsonify(dataclasses.asdict(result))

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -280,18 +280,21 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
     if src is None:
         return None
 
-    # --scope: narrow analysis to a subdirectory
+    # --scope: narrow analysis to a subdirectory or single file
+    # Language detection runs on the full repo; scope only filters analyzed files.
     scope = getattr(args, "scope", None)
+    scope_path = None
     if scope and src.is_dir():
         scoped = (src / scope).resolve()
-        if not scoped.is_dir():
-            print(f"Scope directory does not exist: {scoped}", file=sys.stderr)
+        if not scoped.exists():
+            print(f"Scope path does not exist: {scoped}", file=sys.stderr)
             return None
         if not str(scoped).startswith(str(src)):
             print(f"Scope must be within the repository: {scope}", file=sys.stderr)
             return None
-        src = scoped
-        print(f"Scoped evaluation: {scope} (repo root: {src.parent})", file=sys.stderr)
+        scope_path = scope
+        kind = "file" if scoped.is_file() else "folder"
+        print(f"Scoped evaluation: {scope} ({kind}, repo root: {src})", file=sys.stderr)
 
     # Single-file evaluation: find project root, compute relative path
     single_file: str | None = None
@@ -326,6 +329,35 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
         return None
 
     manifest = _build_manifest(args, src, paths)
+
+    # Scope filter: narrow manifest to files under scope_path
+    if scope_path and manifest and manifest.targets:
+        from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
+        prefix = scope_path.rstrip("/") + "/"
+        scoped_targets = []
+        total = 0
+        all_stats: dict[str, int] = {}
+        for t in manifest.targets:
+            scoped_files = [f for f in t.source_files if f.startswith(prefix) or f == scope_path]
+            if scoped_files:
+                stats = {}
+                for f in scoped_files:
+                    ext = os.path.splitext(f)[1]
+                    if ext:
+                        stats[ext] = stats.get(ext, 0) + 1
+                scoped_targets.append(AnalysisTarget(
+                    name=t.name, language=t.language,
+                    source_files=scoped_files, total_files=len(scoped_files),
+                    language_stats=stats, category=t.category,
+                ))
+                total += len(scoped_files)
+                for k, v in stats.items():
+                    all_stats[k] = all_stats.get(k, 0) + v
+        if scoped_targets:
+            manifest = SourceManifest(targets=scoped_targets, total_files=total, language_stats=all_stats)
+            print(f"Scope filter: {total} files under '{scope_path}'", file=sys.stderr)
+        else:
+            print(f"No source files found under scope '{scope_path}'", file=sys.stderr)
 
     # For single-file: override manifest to contain only the target file
     if single_file:

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -21,7 +21,7 @@ _CONTROLS_MAC = """\
     display: flex;
     gap: 6px;
     z-index: 99999;
-    padding: 6px 11px;
+    padding: 12px 11px;
     pointer-events: auto;
   }
   .qd-traffic::after {
@@ -49,7 +49,7 @@ _CONTROLS_MAC = """\
   body:has(.sidebar:hover) .qd-dot--minimize { background: #febc2e; }
   .qd-traffic:hover .qd-dot--maximize,
   body:has(.sidebar:hover) .qd-dot--maximize { background: #28c840; }
-  .sidebar { padding-top: 18px !important; }
+  .sidebar { padding-top: 26px !important; }
   body:has(.qd-traffic:hover) .app-shell {
     grid-template-columns: var(--sidebar-expanded-width) 1fr;
   }

--- a/src/quodeq/data/config/known_models.json
+++ b/src/quodeq/data/config/known_models.json
@@ -1,8 +1,8 @@
 {
   "claude": [
-    {"id": "claude-haiku-4-5-20251001", "label": "Haiku 4.5", "tier": "fast"},
-    {"id": "claude-sonnet-4-6-20260407", "label": "Sonnet 4.6", "tier": "balanced"},
-    {"id": "claude-opus-4-6-20260407", "label": "Opus 4.6", "tier": "thorough"}
+    {"id": "claude-haiku-4-5", "label": "Haiku 4.5", "tier": "fast"},
+    {"id": "claude-sonnet-4-6", "label": "Sonnet 4.6", "tier": "balanced"},
+    {"id": "claude-opus-4-6", "label": "Opus 4.6", "tier": "thorough"}
   ],
   "codex": [
     {"id": "gpt-5.4-mini", "label": "GPT-5.4 Mini", "tier": "fast"},

--- a/src/quodeq/engine/_runner_markers.py
+++ b/src/quodeq/engine/_runner_markers.py
@@ -36,5 +36,10 @@ def make_heartbeat(dim_name: str, idx: int, total: int) -> Callable[[int, dict],
         secs = elapsed % _SECONDS_PER_MINUTE
         mins = elapsed // _SECONDS_PER_MINUTE
         evidence = progress.get("evidence", 0)
-        log_info(f"  [{idx}/{total}] {dim_name} | {mins}m{secs:02d}s | {evidence} findings")
+        violations = progress.get("violations", 0)
+        compliances = progress.get("compliances", 0)
+        log_info(
+            f"  [{idx}/{total}] {dim_name} | {mins}m{secs:02d}s | "
+            f"{evidence} findings | {violations} violations \u00b7 {compliances} compliance"
+        )
     return _cb

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -90,6 +90,7 @@ class JobManager:
                 text=True,
                 cwd=cwd,
                 env=env,
+                start_new_session=True,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             _logger.error("Failed to start job subprocess: %s", exc)
@@ -122,7 +123,8 @@ class JobManager:
             job.ended_at = datetime.now(timezone.utc).isoformat()
             self._store.put(job)
         if process:
-            process.terminate()
+            from quodeq.analysis._process import _kill_tree
+            _kill_tree(process.pid)
         return True
 
     def get_job(self, job_id: str) -> JobSnapshot | None:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -23,15 +23,16 @@ import { useAppState, formatDayLabel } from './hooks/useAppState.js';
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
  * @returns {JSX.Element}
  */
-function EvaluateCase({ serverHealth, evaluation, selectedProject }) {
+function EvaluateCase({ serverHealth, evaluation, selectedProject, projects }) {
   const { connected, setConnected } = serverHealth;
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
+  const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
   return (
     <>
       {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
-        context={{ selectedProject }}
+        context={{ selectedProject, projectInfo }}
         actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation }}
       />
     </>
@@ -188,7 +189,7 @@ const ROUTE_RENDERERS = {
   },
   'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   explorer: (params, props) => <ExplorerPage project={props.navigation.selectedProject} dimension={params.dimension} runId={params.runId} dateLabel={params.dateLabel} severityFilter={params.severity} onNavigate={props.navigation.handleNavigate} refreshSignal={props.dashboardData.dashboard} />,
-  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} />,
+  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} />,
   file: (params) => <FileDetailPage file={params.file} />,
   evalprinciple: renderEvalPrincipleDetail,
   'eval-principle-detail': renderEvalPrincipleDetail,

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -216,4 +216,8 @@ export function getProviderConfigs() {
   return request('/provider-configs');
 }
 
+export function scanPath(dirPath) {
+  return request('/scan', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ path: dirPath }) });
+}
+
 // Standards and findings APIs are re-exported at the top of this file.

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -195,7 +195,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
   // Dashboard (dimensions/summary): loads per run
   useEffect(() => { setLoading(true); return fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError); }, [selectedProject, selectedRun, refreshKey]);
   useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError, true), [selectedProject, selectedRun, refreshKey]);
-  useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError, true), [selectedProject, refreshKey]);
+  useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError, true), [selectedProject, selectedRun, refreshKey]);
   useEffect(() => rescoreAllRunsEffect(selectedProject, accumulated, setRescoreLookup), [selectedProject, accumulated]);
   const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
 

--- a/src/quodeq/ui/src/features/evaluation/components/BranchScopeSelector.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/BranchScopeSelector.jsx
@@ -2,50 +2,49 @@ import { useState } from 'react';
 import FolderBrowser from './FolderBrowser.jsx';
 
 /**
- * Branch dropdown + Scope button for local project evaluations.
- * Only rendered when scan data with branches is available.
+ * Scope toggle for local project evaluations.
+ * Default: "Entire project". Toggle to "Custom scope" to pick a subfolder.
+ * Branch is display-only (detected from scan data).
  */
 export default function BranchScopeSelector({
   branches,
   currentBranch,
   projectPath,
-  onBranchChange,
   onScopeChange,
   scopePath,
 }) {
   const [scopeBrowserOpen, setScopeBrowserOpen] = useState(false);
-
-  if (!branches || branches.length === 0) return null;
+  const customScope = !!scopePath;
 
   return (
-    <div className="form-group">
-      <label htmlFor="eval-branch">Branch</label>
-      <div className="branch-scope-row">
-        <select
-          id="eval-branch"
-          className="branch-select"
-          value={currentBranch || ''}
-          onChange={(e) => onBranchChange(e.target.value || null)}
-        >
-          {branches.map((b) => (
-            <option key={b} value={b}>{b}</option>
-          ))}
-        </select>
+    <div className="scope-toggle-group">
+      <div className="scope-toggle-row">
         <button
           type="button"
-          className="browse-btn"
-          onClick={() => setScopeBrowserOpen(true)}
-          title="Narrow evaluation to a subfolder"
+          className={`scope-toggle-btn${!customScope ? ' active' : ''}`}
+          onClick={() => { onScopeChange(null); }}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
-          </svg>
-          Scope
+          Entire project
+        </button>
+        <button
+          type="button"
+          className={`scope-toggle-btn${customScope ? ' active' : ''}`}
+          onClick={() => setScopeBrowserOpen(true)}
+        >
+          Custom scope
         </button>
       </div>
-      {scopePath ? (
+
+      {customScope && (
         <div className="scope-display">
-          <span className="scope-path">{scopePath}</span>
+          <code className="scope-path">{scopePath}</code>
+          <button
+            type="button"
+            className="scope-change-btn"
+            onClick={() => setScopeBrowserOpen(true)}
+          >
+            Change
+          </button>
           <button
             type="button"
             className="input-clear-btn"
@@ -57,20 +56,26 @@ export default function BranchScopeSelector({
             </svg>
           </button>
         </div>
-      ) : (
-        <span className="form-hint">Entire project · Click Scope to narrow to a subfolder</span>
+      )}
+
+      {currentBranch && (
+        <div className="scope-branch-display">
+          <span className="scope-branch-label">Branch</span>
+          <code className="scope-branch-value">{currentBranch}</code>
+        </div>
       )}
 
       {scopeBrowserOpen && (
         <FolderBrowser
           onSelect={(path) => {
             const rel = projectPath ? path.replace(projectPath, '').replace(/^\//, '') : path;
-            onScopeChange(rel);
+            onScopeChange(rel || null);
             setScopeBrowserOpen(false);
           }}
           onClose={() => setScopeBrowserOpen(false)}
-          title="Select Subfolder"
-          confirmText="Use This Folder"
+          title="Select scope"
+          confirmText="Select"
+          showFiles={true}
           rootPath={projectPath}
         />
       )}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -75,7 +75,7 @@ function EvaluateHeader({ isRunning }) {
 
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
-  const { selectedProject } = context;
+  const { selectedProject, projectInfo } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
 
   return (
@@ -84,7 +84,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
       <div className="evaluate-content">
         {!job && selectedProject && (
-          <ReEvaluateCard project={selectedProject} onStart={onStartEvaluation} disabled={false} />
+          <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={onStartEvaluation} disabled={false} />
         )}
 
         {!job && (
@@ -92,7 +92,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
             <div className="panel-header">
               <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
             </div>
-            <EvaluationForm onStart={onStartEvaluation} disabled={false} selectedProject={selectedProject} />
+            <EvaluationForm onStart={onStartEvaluation} disabled={false} selectedProject={projectInfo} />
           </div>
         )}
 

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import FolderBrowser from './FolderBrowser.jsx';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import DimensionSelector from './DimensionSelector.jsx';
@@ -56,6 +56,9 @@ function useEvaluationForm(onStart) {
   const [branch, setBranch] = useState(null);
   const [scopePath, setScopePath] = useState(null);
 
+  // Reset scope when repo changes
+  useEffect(() => { setScopePath(null); setBranch(null); }, [repo]);
+
   const toggleDim = (id) => setSelectedDims((prev) => {
     const next = new Set(prev);
     if (next.has(id)) next.delete(id); else next.add(id);
@@ -106,8 +109,8 @@ export default function EvaluationForm({ onStart, disabled, selectedProject }) {
     branch, setBranch, scopePath, setScopePath,
   } = useEvaluationForm(onStart);
 
-  const isLocal = selectedProject?.location === 'local';
-  const { scanData } = useScanData(isLocal ? selectedProject?.id : null);
+  const isLocalRepo = !!repo && !repo.startsWith('http') && !repo.startsWith('git@') && !repo.includes('github.com');
+  const { scanData } = useScanData(null, isLocalRepo ? repo : null);
 
   const canSubmit = !disabled && !!repo && (allDimensions.length === 0 || selectedDims.size > 0);
 
@@ -121,12 +124,11 @@ export default function EvaluationForm({ onStart, disabled, selectedProject }) {
           onBrowse={() => setFolderBrowserOpen(true)}
         />
 
-        {isLocal && scanData && (
+        {isLocalRepo && (
           <BranchScopeSelector
-            branches={scanData.branches}
-            currentBranch={branch}
-            projectPath={selectedProject?.path}
-            onBranchChange={setBranch}
+            branches={scanData?.branches}
+            currentBranch={scanData?.currentBranch || branch}
+            projectPath={repo}
             onScopeChange={setScopePath}
             scopePath={scopePath}
           />

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -1,18 +1,17 @@
 import { useState, useEffect } from 'react';
 import { getProjectInfo, relocateProject, cloneToLocal } from '../../../api/index.js';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
+import { useScanData } from '../hooks/useScanData.js';
+import BranchScopeSelector from './BranchScopeSelector.jsx';
 import DimensionSelector from './DimensionSelector.jsx';
 import FolderBrowser from './FolderBrowser.jsx';
 
 
-const BUTTON_GAP = '8px';
-const BUTTON_PADDING = '8px 16px';
-const BUTTON_FONT_SIZE = '0.85rem';
-const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: BUTTON_GAP, alignItems: 'center' };
-const flexButtonStyle = { flex: 1, marginTop: 0 };
+const buttonRowStyle = { display: 'flex', flexDirection: 'row', gap: '8px', alignItems: 'center' };
+const flexButtonStyle = { flex: 1 };
 
-function useReEvalInfo(project) {
-  const [info, setInfo] = useState(null);
+function useReEvalInfo(project, initialInfo) {
+  const [info, setInfo] = useState(initialInfo || null);
   const [error, setError] = useState(null);
   const [urlInput, setUrlInput] = useState('');
   const [urlError, setUrlError] = useState(null);
@@ -20,6 +19,8 @@ function useReEvalInfo(project) {
 
   useEffect(() => {
     if (!project) return;
+    // Use pre-loaded info if available, otherwise fetch
+    if (initialInfo) { setInfo(initialInfo); return; }
     setInfo(null);
     getProjectInfo(project)
       .then(setInfo)
@@ -27,7 +28,7 @@ function useReEvalInfo(project) {
         setInfo(null);
         setError('Could not load project info. The project may have been removed.');
       });
-  }, [project]);
+  }, [project, initialInfo]);
 
   async function handleUrlRestore() {
     const url = urlInput.trim();
@@ -49,14 +50,22 @@ function useReEvalInfo(project) {
   return { info, setInfo, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore };
 }
 
-function useReEvaluateCard(project, onStart) {
-  const { info, setInfo, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore } = useReEvalInfo(project);
+function useReEvaluateCard(project, onStart, projectInfo) {
+  const { info, setInfo, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore } = useReEvalInfo(project, projectInfo);
   const { allDimensions } = usePluginDimensions();
   const [selectedDims, setSelectedDims] = useState(new Set());
+  const [branch, setBranch] = useState(null);
+  const [scopePath, setScopePath] = useState(null);
+
+  // Reset scope when project changes
+  useEffect(() => { setScopePath(null); setBranch(null); }, [project]);
   const [cloneBrowserOpen, setCloneBrowserOpen] = useState(false);
   const [cloning, setCloning] = useState(false);
   const [cloneDest, setCloneDest] = useState('');
   const [cloneError, setCloneError] = useState(null);
+
+  const isLocal = info?.location === 'local';
+  const { scanData } = useScanData(isLocal ? project : null);
 
   const toggleDim = (id) => {
     setSelectedDims((prev) => {
@@ -71,6 +80,8 @@ function useReEvaluateCard(project, onStart) {
   const buildPayload = (extra) => {
     const payload = { repo: info.path, ...extra };
     if (selectedDims.size > 0) payload.dimensions = [...selectedDims];
+    if (branch) payload.branch = branch;
+    if (scopePath) payload.scopePath = scopePath;
     return payload;
   };
   const handleStart = () => onStart(buildPayload());
@@ -96,6 +107,7 @@ function useReEvaluateCard(project, onStart) {
     toggleDim, selectAll, clearAll, handleStart, handleIncremental,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
+    isLocal, scanData, branch, setBranch, scopePath, setScopePath,
   };
 }
 
@@ -103,7 +115,7 @@ function UrlRestoreSection({ urlInput, setUrlInput, urlError, urlSaving, handleU
   return (
     <div className="re-eval-stale-warning">
       <p>This project was evaluated from a remote repo but the original URL was not saved. Enter the URL to restore reevaluation.</p>
-      <div style={{ display: 'flex', gap: BUTTON_GAP, alignItems: 'center' }}>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
         <input
           type="text"
           value={urlInput}
@@ -116,7 +128,6 @@ function UrlRestoreSection({ urlInput, setUrlInput, urlError, urlSaving, handleU
         <button
           type="button"
           className="evaluate-submit-btn"
-          style={{ padding: BUTTON_PADDING, fontSize: BUTTON_FONT_SIZE }}
           disabled={!urlInput.trim() || urlSaving}
           onClick={handleUrlRestore}
         >
@@ -191,7 +202,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
   );
 }
 
-function ReEvaluateCardView({ info, project, disabled, dimensions, actions }) {
+function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scope }) {
   const { all: allDimensions, selected: selectedDims } = dimensions;
   const {
     toggleDim, selectAll, clearAll, handleStart, handleIncremental,
@@ -219,6 +230,16 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions }) {
 
         <CloneSection info={info} cloning={cloning} cloneDest={cloneDest} cloneError={cloneError} setCloneBrowserOpen={setCloneBrowserOpen} />
 
+        {scope.isLocal && (
+          <BranchScopeSelector
+            branches={scope.scanData?.branches}
+            currentBranch={scope.scanData?.currentBranch || scope.branch}
+            projectPath={info.path}
+            onScopeChange={scope.setScopePath}
+            scopePath={scope.scopePath}
+          />
+        )}
+
         <div className={cloning ? 're-eval-disabled-section' : ''}>
           <DimensionSelectionSection allDimensions={allDimensions} selectedDims={selectedDims} cloning={cloning} toggleDim={toggleDim} selectAll={selectAll} clearAll={clearAll} />
           <ActionButtons info={info} project={project} disabled={disabled} canStart={canStart} cloning={cloning} handleIncremental={handleIncremental} handleStart={handleStart} />
@@ -237,15 +258,21 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions }) {
   );
 }
 
-export default function ReEvaluateCard({ project, onStart, disabled }) {
+export default function ReEvaluateCard({ project, projectInfo, onStart, disabled }) {
   const {
     info, error, allDimensions, selectedDims,
     toggleDim, selectAll, clearAll, handleStart, handleIncremental,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
-  } = useReEvaluateCard(project, onStart);
+    isLocal, scanData, branch, setBranch, scopePath, setScopePath,
+  } = useReEvaluateCard(project, onStart, projectInfo);
 
-  if (error || !info) return null;
+  if (error) return null;
+  if (!info) return (
+    <div className="panel evaluate-panel">
+      <div className="panel-header"><h3>Loading project...</h3></div>
+    </div>
+  );
 
   return (
     <ReEvaluateCardView
@@ -258,6 +285,7 @@ export default function ReEvaluateCard({ project, onStart, disabled }) {
         urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
         cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
       }}
+      scope={{ isLocal, scanData, branch, setBranch, scopePath, setScopePath }}
     />
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -240,7 +240,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
           />
         )}
 
-        <div className={cloning ? 're-eval-disabled-section' : ''}>
+        <div className={`re-eval-actions-group${cloning ? ' re-eval-disabled-section' : ''}`}>
           <DimensionSelectionSection allDimensions={allDimensions} selectedDims={selectedDims} cloning={cloning} toggleDim={toggleDim} selectAll={selectAll} clearAll={clearAll} />
           <ActionButtons info={info} project={project} disabled={disabled} canStart={canStart} cloning={cloning} handleIncremental={handleIncremental} handleStart={handleStart} />
         </div>

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -128,7 +128,8 @@ function preparePayload(payload, storage = localStorage) {
   const subagents = parseInt(get('subagents') || defaultSubagents, 10);
   payload.maxSubagents = subagents;
 
-  const poolBudget = parseInt(get('pool-budget') || '0', 10);
+  const defaultBudget = ['ollama'].includes(activeProvider) ? '0' : '600';
+  const poolBudget = parseInt(get('pool-budget') || defaultBudget, 10);
   payload.poolBudget = poolBudget;
 
   if (get('per-dimension') === 'true') payload.perDimension = true;

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
@@ -1,16 +1,19 @@
 import { useState, useEffect } from 'react';
+import { scanPath } from '../../../api/index.js';
 
 /**
- * Fetch scan data (branches, modules) for a project.
+ * Fetch scan data for a project ID or a raw local path.
+ * Pass projectId for existing projects, or localPath for new evaluations.
  * Returns { scanData, loading, error }.
  */
-export function useScanData(projectId) {
+export function useScanData(projectId, localPath) {
   const [scanData, setScanData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (!projectId) {
+    const target = projectId || localPath;
+    if (!target) {
       setScanData(null);
       return;
     }
@@ -19,11 +22,14 @@ export function useScanData(projectId) {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
-        return res.json();
-      })
+    const fetchPromise = projectId
+      ? fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`).then((res) => {
+          if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
+          return res.json();
+        })
+      : scanPath(localPath);
+
+    fetchPromise
       .then((data) => {
         if (!cancelled) {
           setScanData(data);
@@ -38,7 +44,7 @@ export function useScanData(projectId) {
       });
 
     return () => { cancelled = true; };
-  }, [projectId]);
+  }, [projectId, localPath]);
 
   return { scanData, loading, error };
 }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -825,7 +825,7 @@
 .evaluate-form-large {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
 }
 
 .evaluate-form-large .form-group label {
@@ -1060,7 +1060,6 @@
   flex-wrap: wrap;
   gap: 8px;
   padding: 12px;
-  margin-bottom: 12px;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -1107,7 +1106,6 @@
 
 /* Improve submit button */
 .evaluate-submit-btn {
-  margin-top: 4px;
   padding: 12px 24px;
   font-size: 0.9rem;
   font-weight: 600;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1011,6 +1011,17 @@
   margin: var(--space-1) 0;
 }
 
+.re-eval-actions-group {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.re-eval-disabled-section {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 /* Dimension label row: label left, actions right */
 .dimension-label-row {
   display: flex;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -772,7 +772,6 @@
   background: var(--color-danger-bg);
   color: var(--color-danger-text);
   opacity: 1;
-  transform: translateY(-50%) scale(1.1);
 }
 
 .input-clear-btn svg {
@@ -837,33 +836,86 @@
   color: var(--color-text);
 }
 
-.branch-scope-row {
+.scope-toggle-group {
+  margin-bottom: 12px;
   display: flex;
-  gap: var(--space-2);
+  flex-direction: column;
+  align-items: flex-end;
 }
 
-.branch-select {
-  flex: 1;
-  padding: 10px 14px;
-  background: var(--color-surface-alt);
+.scope-toggle-row {
+  display: inline-flex;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  color: var(--color-text);
-  font-size: inherit;
-  appearance: auto;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.scope-toggle-btn {
+  padding: 3px 10px;
+  background: var(--color-surface-alt);
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.scope-toggle-btn:not(:last-child) {
+  border-right: 1px solid var(--color-border);
+}
+
+.scope-toggle-btn.active {
+  background: var(--color-accent);
+  color: var(--color-on-accent, #fff);
 }
 
 .scope-display {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-top: var(--space-1);
-  font-size: 0.85rem;
+  margin-top: var(--space-2);
+  font-size: 0.8rem;
+  align-self: flex-end;
+  white-space: nowrap;
 }
 
 .scope-path {
   color: var(--color-accent);
   font-family: monospace;
+}
+
+.scope-change-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.scope-change-btn:hover {
+  color: var(--color-text);
+}
+
+.scope-branch-display {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  align-self: flex-end;
+}
+
+.scope-branch-label {
+  font-weight: var(--weight-medium);
+}
+
+.scope-branch-value {
+  color: var(--color-text);
+  font-family: monospace;
+  font-size: 0.75rem;
 }
 
 .form-hint {
@@ -1008,6 +1060,7 @@
   flex-wrap: wrap;
   gap: 8px;
   padding: 12px;
+  margin-bottom: 12px;
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -1054,9 +1107,9 @@
 
 /* Improve submit button */
 .evaluate-submit-btn {
-  margin-top: 8px;
-  padding: 18px 36px;
-  font-size: 1.05rem;
+  margin-top: 4px;
+  padding: 12px 24px;
+  font-size: 0.9rem;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary

- **Process cleanup**: `start_new_session` + `kill_tree` prevents orphaned subagent processes on cancel/close (cross-platform: POSIX killpg / Windows taskkill /T)
- **Pool budget enforcement**: per-agent duration capped to pool budget; immediate_loop cancels agents when budget exceeded
- **MCP fix**: skip agent-id for cli-register providers so shared queue distributes files correctly
- **Scope selector**: "Entire project / Custom scope" toggle for local projects (both evaluate and re-evaluate)
- **Scan API**: `POST /api/scan` for path-based scanning without existing project
- **UI consistency**: unified button padding/font between evaluate and re-evaluate panels; dimension grid spacing; traffic light margin; clear button hover fix
- **Heartbeat**: single-agent mode now shows violations/compliance breakdown
- **Claude model IDs**: fixed to `claude-sonnet-4-6` (no dated suffix)
- **Dashboard refresh**: latestAccumulated re-fetches on run change
- **ReEvaluateCard**: uses pre-loaded project info (instant render, no loading delay)
- **Default settings**: CLI providers default to 5 agents + 600s pool budget

## Test plan

- [x] Cancel evaluation mid-run — verify all claude/codex processes die
- [x] Run Codex evaluation — 5 agents, respects 10min budget
- [x] Scope toggle visible only for local projects
- [x] Custom scope opens file browser rooted at project/repo path
- [x] Re-evaluate card renders instantly (no loading flash)
- [x] Button styling consistent between evaluate and re-evaluate panels