### PR TITLE
feat: inline verification replaces separate verification phase

### DIFF
--- a/docs/superpowers/plans/2026-04-09-inline-verification.md
+++ b/docs/superpowers/plans/2026-04-09-inline-verification.md
@@ -1,0 +1,666 @@
+# Inline Verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the separate verification phase by merging finding verification into the analysis prompt and adding a post-analysis mini-verify for changed files not in the analysis queue.
+
+**Architecture:** Previous findings are classified into three buckets (inline, carry-forward, mini-verify). Inline findings are appended to the analysis prompt so agents verify and discover in one pass. A smaller post-analysis pool handles leftover changed files.
+
+**Tech Stack:** Python, existing subagent pool infrastructure, existing fingerprint/filter modules
+
+---
+
+### Task 1: Add `previous_findings` field to PromptContext
+
+**Files:**
+- Modify: `src/quodeq/analysis/prompts/_context.py:33-48`
+- Test: `tests/analysis/test_prompt_context.py`
+
+- [ ] **Step 1: Write test for new field**
+
+Create `tests/analysis/test_prompt_context.py`:
+
+```python
+from quodeq.analysis.prompts._context import PromptContext
+
+
+def test_prompt_context_default_previous_findings():
+    ctx = PromptContext(
+        language="python", repo_name="test", date_str="2026-01-01",
+        dimension="security", source_file_count=10, dimensions_data={},
+    )
+    assert ctx.previous_findings == []
+
+
+def test_prompt_context_with_previous_findings():
+    findings = [
+        {"p": "Security", "t": "violation", "file": "a.py", "line": 1, "reason": "test"},
+    ]
+    ctx = PromptContext(
+        language="python", repo_name="test", date_str="2026-01-01",
+        dimension="security", source_file_count=10, dimensions_data={},
+        previous_findings=findings,
+    )
+    assert ctx.previous_findings == findings
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py -v`
+Expected: FAIL — `TypeError: unexpected keyword argument 'previous_findings'`
+
+- [ ] **Step 3: Add field to PromptContext**
+
+In `src/quodeq/analysis/prompts/_context.py`, add to the `PromptContext` dataclass after the `work_dir` field:
+
+```python
+    previous_findings: list[dict] = field(default_factory=list)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/prompts/_context.py tests/analysis/test_prompt_context.py
+git commit -m "feat: add previous_findings field to PromptContext"
+```
+
+---
+
+### Task 2: Render previous findings section in the analysis prompt
+
+**Files:**
+- Modify: `src/quodeq/analysis/prompts/builder.py:45-end`
+- Test: `tests/analysis/test_prompt_context.py`
+
+- [ ] **Step 1: Write test for rendering**
+
+Add to `tests/analysis/test_prompt_context.py`:
+
+```python
+from quodeq.analysis.prompts.builder import render_previous_findings_section
+
+
+def test_render_previous_findings_empty():
+    assert render_previous_findings_section([]) == ""
+
+
+def test_render_previous_findings_groups_by_file():
+    findings = [
+        {"p": "Security", "t": "violation", "file": "a.py", "line": 42, "req": "S-CON-3", "reason": "hardcoded creds"},
+        {"p": "Security", "t": "compliance", "file": "a.py", "line": 55, "req": "S-CON-5", "reason": "good validation"},
+        {"p": "Maintainability", "t": "violation", "file": "b.py", "line": 100, "req": "P-MOD-1", "reason": "long function"},
+    ]
+    result = render_previous_findings_section(findings)
+    assert "### a.py" in result
+    assert "### b.py" in result
+    assert "[violation] S-CON-3" in result
+    assert "[compliance] S-CON-5" in result
+    assert "[violation] P-MOD-1" in result
+    assert "hardcoded creds" in result
+    assert "Previous findings" in result
+
+
+def test_render_previous_findings_no_file_key():
+    findings = [{"p": "X", "t": "violation", "reason": "no file"}]
+    result = render_previous_findings_section(findings)
+    assert "### (unknown file)" in result or result == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py -v`
+Expected: FAIL — `ImportError: cannot import name 'render_previous_findings_section'`
+
+- [ ] **Step 3: Implement render function**
+
+In `src/quodeq/analysis/prompts/builder.py`, add after the imports:
+
+```python
+def render_previous_findings_section(findings: list[dict]) -> str:
+    """Render a prompt section listing previous findings grouped by file.
+
+    Analysis agents receive this so they can confirm/dismiss findings
+    inline while discovering new ones.
+    """
+    if not findings:
+        return ""
+
+    grouped: dict[str, list[dict]] = {}
+    for f in findings:
+        key = f.get("file", "(unknown file)")
+        grouped.setdefault(key, []).append(f)
+
+    lines = [
+        "",
+        "## Previous findings for files in this batch",
+        "",
+        "The following findings were reported in a prior evaluation. For each file",
+        "you analyze, confirm whether these findings still apply to the current code.",
+        "Report confirmed findings alongside any new ones you discover.",
+        "Dismiss findings that no longer apply by not reporting them.",
+        "",
+    ]
+    for filepath, file_findings in sorted(grouped.items()):
+        lines.append(f"### {filepath}")
+        for f in file_findings:
+            ftype = f.get("t", "finding")
+            req = f.get("req", "")
+            line_num = f.get("line", "?")
+            reason = f.get("reason", "")
+            lines.append(f"- [{ftype}] {req} line {line_num}: {reason}")
+        lines.append("")
+
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Wire into `build_analysis_prompt`**
+
+In the same file, at the end of `build_analysis_prompt()` (before the `return`), add:
+
+```python
+    prev_section = render_previous_findings_section(context.previous_findings)
+    if prev_section:
+        result += prev_section
+```
+
+Note: you need to find where the final prompt string is assembled and returned. Read the full function to find the right insertion point. The variable holding the final prompt may be called `result`, `prompt`, or similar — check before inserting.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/quodeq/analysis/prompts/builder.py tests/analysis/test_prompt_context.py
+git commit -m "feat: render previous findings section in analysis prompt"
+```
+
+---
+
+### Task 3: Classify findings into inline/carry-forward/mini-verify buckets
+
+**Files:**
+- Create: `src/quodeq/analysis/subagents/_finding_classifier.py`
+- Test: `tests/analysis/test_finding_classifier.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/analysis/test_finding_classifier.py`:
+
+```python
+from quodeq.analysis.subagents._finding_classifier import classify_findings
+
+
+def test_finding_in_queue_goes_to_inline():
+    findings = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 1
+    assert len(mini) == 0
+    assert inline[0]["file"] == "a.py"
+
+
+def test_finding_not_in_queue_goes_to_mini():
+    findings = [
+        {"file": "c.py", "p": "S", "t": "violation", "line": 1, "reason": "r"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 0
+    assert len(mini) == 1
+    assert mini[0]["file"] == "c.py"
+
+
+def test_mixed_findings_split_correctly():
+    findings = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r1"},
+        {"file": "c.py", "p": "S", "t": "violation", "line": 2, "reason": "r2"},
+        {"file": "a.py", "p": "S", "t": "compliance", "line": 3, "reason": "r3"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 2
+    assert len(mini) == 1
+
+
+def test_empty_findings():
+    inline, mini = classify_findings([], {"a.py"})
+    assert inline == []
+    assert mini == []
+
+
+def test_no_file_key_goes_to_mini():
+    findings = [{"p": "S", "t": "violation", "line": 1, "reason": "r"}]
+    inline, mini = classify_findings(findings, {"a.py"})
+    assert len(inline) == 0
+    assert len(mini) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_finding_classifier.py -v`
+Expected: FAIL — `ImportError`
+
+- [ ] **Step 3: Implement classifier**
+
+Create `src/quodeq/analysis/subagents/_finding_classifier.py`:
+
+```python
+"""Classify previous findings into inline-verify vs mini-verify buckets."""
+from __future__ import annotations
+
+
+def classify_findings(
+    needs_verify: list[dict],
+    queue_files: set[str],
+) -> tuple[list[dict], list[dict]]:
+    """Split findings that need verification into two buckets.
+
+    - **inline**: file is in the analysis queue — findings passed as prompt context
+    - **mini_verify**: file is NOT in queue — needs separate post-analysis verification
+
+    Returns (inline, mini_verify).
+    """
+    inline: list[dict] = []
+    mini_verify: list[dict] = []
+    for finding in needs_verify:
+        if finding.get("file", "") in queue_files:
+            inline.append(finding)
+        else:
+            mini_verify.append(finding)
+    return inline, mini_verify
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_finding_classifier.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/_finding_classifier.py tests/analysis/test_finding_classifier.py
+git commit -m "feat: add finding classifier for inline vs mini-verify buckets"
+```
+
+---
+
+### Task 4: Add mini-verify dispatcher
+
+**Files:**
+- Modify: `src/quodeq/analysis/subagents/_verification.py:44-57`
+- Test: `tests/analysis/test_mini_verify.py`
+
+- [ ] **Step 1: Write test**
+
+Create `tests/analysis/test_mini_verify.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+
+from quodeq.analysis.subagents._verification import _dispatch_mini_verify
+
+
+@patch("quodeq.analysis.subagents._verification._run_verification_pool")
+def test_mini_verify_caps_agents(mock_pool, tmp_path):
+    """Mini-verify uses at most 2 agents."""
+    mock_pool.return_value = []
+    config = MagicMock()
+    config.src = tmp_path
+    config.standards_dir = None
+    config.options.max_subagents = 10
+    config.options.ai_model = None
+    config.options.pool_budget = 300
+
+    findings = [
+        {"file": f"f{i}.py", "p": "S", "t": "violation", "line": 1, "reason": "r"}
+        for i in range(50)
+    ]
+    _dispatch_mini_verify(config, "security", tmp_path, findings)
+
+    assert mock_pool.called
+
+
+@patch("quodeq.analysis.subagents._verification._run_verification_pool")
+def test_mini_verify_skips_empty(mock_pool, tmp_path):
+    """Mini-verify does nothing with empty findings."""
+    config = MagicMock()
+    result = _dispatch_mini_verify(config, "security", tmp_path, [])
+    assert result == []
+    assert not mock_pool.called
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/analysis/test_mini_verify.py -v`
+Expected: FAIL — `ImportError: cannot import name '_dispatch_mini_verify'`
+
+- [ ] **Step 3: Implement mini-verify dispatcher**
+
+In `src/quodeq/analysis/subagents/_verification.py`, add after `_dispatch_verification_pool`:
+
+```python
+_MINI_VERIFY_MAX_AGENTS = 2
+_MINI_VERIFY_TIMEOUT_PER_10 = 60
+_MINI_VERIFY_MAX_TIMEOUT = 300
+
+
+def _dispatch_mini_verify(
+    config: RunConfig, dim_id: str, evidence_dir: Path, findings: list,
+) -> list:
+    """Post-analysis mini-verify for changed files not in the analysis queue.
+
+    Uses a smaller pool (1-2 agents) with a proportional timeout.
+    Returns empty list if no findings to verify.
+    """
+    if not findings:
+        return []
+
+    from quodeq.analysis.subagents.verify import _group_by_file, _write_verify_manifest
+
+    grouped = _group_by_file(findings)
+    manifest_path = evidence_dir / f"{dim_id}_mini_verify_manifest.json"
+    _write_verify_manifest(grouped, manifest_path)
+    files_to_verify = list(grouped.keys())
+
+    n_files = len(files_to_verify)
+    timeout = min(_MINI_VERIFY_MAX_TIMEOUT, max(60, (n_files // 10 + 1) * _MINI_VERIFY_TIMEOUT_PER_10))
+
+    log_info(f"  [{dim_id}] [MINI-VERIFY] {len(findings)} findings across {n_files} changed files (not in analysis queue)")
+
+    # Override pool budget for mini-verify
+    from copy import copy
+    mini_config = copy(config)
+    mini_options = copy(config.options)
+    mini_options.pool_budget = timeout
+    mini_options.max_subagents = min(_MINI_VERIFY_MAX_AGENTS, config.options.max_subagents)
+    mini_config.options = mini_options
+
+    results = _run_verification_pool(mini_config, dim_id, evidence_dir, files_to_verify, manifest_path)
+    log_success(f"  [{dim_id}] [MINI-VERIFY] Complete")
+    return results
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/analysis/test_mini_verify.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/_verification.py tests/analysis/test_mini_verify.py
+git commit -m "feat: add mini-verify dispatcher for post-analysis changed files"
+```
+
+---
+
+### Task 5: Wire inline verification into the prompt builder
+
+**Files:**
+- Modify: `src/quodeq/analysis/subagents/_prompts.py:10-27`
+- Test: `tests/analysis/test_prompt_context.py`
+
+- [ ] **Step 1: Write test for prompt builder accepting findings**
+
+Add to `tests/analysis/test_prompt_context.py`:
+
+```python
+from unittest.mock import MagicMock
+
+from quodeq.analysis.subagents._prompts import _build_subagent_prompt
+
+
+def test_build_subagent_prompt_passes_inline_findings():
+    """Inline findings are passed through to PromptContext."""
+    findings = [{"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "test"}]
+    ctx = MagicMock()
+    ctx.subagent_template = "{{DIMENSION}} analysis"
+    ctx.date_str = "2026-01-01"
+    ctx.dimensions_data = {}
+
+    config = MagicMock()
+    config.language = "python"
+    config.src = "/test"
+    config.source_file_count = 10
+    config.standards_dir = None
+    config.evaluators_dir = None
+    config.manifest = None
+    config.target = None
+    config.work_dir = None
+
+    result = _build_subagent_prompt(config, "security", ctx, inline_findings=findings)
+    assert "Previous findings" in result
+    assert "a.py" in result
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py::test_build_subagent_prompt_passes_inline_findings -v`
+Expected: FAIL
+
+- [ ] **Step 3: Update `_build_subagent_prompt` to accept inline findings**
+
+In `src/quodeq/analysis/subagents/_prompts.py`, update the function:
+
+```python
+def _build_subagent_prompt(
+    config: RunConfig, dim_id: str, ctx: Any,
+    inline_findings: list[dict] | None = None,
+) -> str:
+    """Build the prompt for subagent analysis, optionally including previous findings."""
+    return build_analysis_prompt(
+        ctx.subagent_template,
+        PromptContext(
+            language=config.language,
+            repo_name=str(config.src),
+            date_str=ctx.date_str,
+            dimension=dim_id,
+            source_file_count=config.source_file_count,
+            dimensions_data=ctx.dimensions_data,
+            standards_dir=config.standards_dir,
+            evaluators_dir=config.evaluators_dir,
+            manifest=config.manifest,
+            target=config.target,
+            work_dir=config.work_dir or config.src,
+            previous_findings=inline_findings or [],
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/analysis/test_prompt_context.py::test_build_subagent_prompt_passes_inline_findings -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/_prompts.py tests/analysis/test_prompt_context.py
+git commit -m "feat: pass inline findings through prompt builder to PromptContext"
+```
+
+---
+
+### Task 6: Replace verification step in runner.py
+
+**Files:**
+- Modify: `src/quodeq/analysis/subagents/runner.py:50-91`
+- Modify: `tests/engine/test_mechanical_verify_fingerprint.py`
+- Test: `tests/engine/test_inline_verification.py`
+
+- [ ] **Step 1: Write integration test for new flow**
+
+Create `tests/engine/test_inline_verification.py`:
+
+```python
+"""Tests for inline verification flow in process_dimension_with_subagents."""
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import hashlib
+
+from quodeq.analysis.subagents._finding_classifier import classify_findings
+from quodeq.analysis.subagents._verification import _load_and_filter_previous
+
+
+def test_classify_splits_by_queue_membership():
+    """Findings for files in queue go inline, others go to mini-verify."""
+    needs_verify = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r1"},
+        {"file": "b.py", "p": "S", "t": "violation", "line": 2, "reason": "r2"},
+        {"file": "c.py", "p": "S", "t": "violation", "line": 3, "reason": "r3"},
+    ]
+    queue_files = {"a.py", "c.py"}
+    inline, mini = classify_findings(needs_verify, queue_files)
+    assert {f["file"] for f in inline} == {"a.py", "c.py"}
+    assert {f["file"] for f in mini} == {"b.py"}
+
+
+@patch("quodeq.analysis.subagents.verify.load_previous_findings_for_dimension")
+def test_load_and_filter_returns_empty_when_no_previous(mock_load, tmp_path):
+    mock_load.return_value = []
+    config = MagicMock()
+    config.src = tmp_path
+    config.options.incremental_file_filter = None
+    result = _load_and_filter_previous(config, "security", tmp_path)
+    assert result == []
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `uv run pytest tests/engine/test_inline_verification.py -v`
+Expected: PASS (these test existing functions)
+
+- [ ] **Step 3: Update `process_dimension_with_subagents` in runner.py**
+
+Replace the body of `process_dimension_with_subagents` (lines 58-91) with:
+
+```python
+    evidence_dir = config.work_dir or config.src
+
+    # 1. List source files
+    files, extensions = _list_source_files(config, dim_id)
+    if not files:
+        log_warning(
+            f"[{idx}/{ctx.total}] {dim_id} -- no source files for subagent queue"
+            f" (src={config.src}, language={config.language}, extensions={extensions})"
+        )
+        prompt = callbacks.build_prompt(config, dim_id, ctx)
+        stream_file, jsonl_file = callbacks.run_analysis(config, dim_id, prompt, idx, ctx)
+        return callbacks.parse_evidence(config, dim_id, stream_file, jsonl_file, ctx)
+
+    # 2. Load previous findings, partition by fingerprint
+    from quodeq.analysis.subagents.verify import (
+        partition_findings_by_fingerprint, write_carry_forward_findings,
+    )
+    from quodeq.analysis.subagents._finding_classifier import classify_findings
+
+    prev_findings = _load_and_filter_previous(config, dim_id, evidence_dir)
+    carry_forward: list[dict] = []
+    needs_verify: list[dict] = []
+    if prev_findings:
+        from quodeq.analysis.fingerprint import find_previous_fingerprint
+        prev_fp, _ = find_previous_fingerprint(evidence_dir, dim_id)
+        carry_forward, needs_verify = partition_findings_by_fingerprint(
+            prev_findings, prev_fp, config.src,
+            standards_dir=config.standards_dir, dimension=dim_id,
+        )
+    if carry_forward:
+        written = write_carry_forward_findings(carry_forward, evidence_dir, dim_id)
+        log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {written} findings carried forward")
+
+    # 3. Split needs_verify into inline (in queue) vs mini-verify (not in queue)
+    queue_files = set(files)
+    inline_findings, mini_verify_findings = classify_findings(needs_verify, queue_files)
+
+    # 4. Create analysis queue
+    queue_path = evidence_dir / f"{dim_id}_queue.json"
+    files_per_agent = _compute_files_per_agent(len(files))
+    FileQueue(queue_path, files, max_files_per_agent=files_per_agent)
+    log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {len(files)} files queued, {len(inline_findings)} inline findings")
+
+    # 5. Build prompt with inline findings and launch analysis pool
+    prompt = _build_subagent_prompt(config, dim_id, ctx, inline_findings=inline_findings)
+    params = LaunchPoolParams(
+        evidence_dir=evidence_dir, queue_path=queue_path,
+        prompt=prompt, max_files_per_agent=files_per_agent,
+    )
+    pool, results = _launch_pool(config, dim_id, params)
+
+    # 6. Mini-verify for changed files not in analysis queue
+    if mini_verify_findings:
+        verify_results = _dispatch_mini_verify(config, dim_id, evidence_dir, mini_verify_findings)
+        results = results + verify_results
+
+    # 7. Collect evidence
+    return _collect_evidence(config, dim_id, evidence_dir, _CollectionContext(results=results, ctx=ctx, files=files))
+```
+
+- [ ] **Step 4: Update imports in runner.py**
+
+Replace the verification imports block:
+
+```python
+from quodeq.analysis.subagents._verification import (  # noqa: F401
+    _dispatch_mini_verify,
+    _dispatch_verification_pool,
+    _load_and_filter_previous,
+    _run_verification_pool,
+    _run_verification_step,
+)
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All PASS. Some existing verification tests may need updating — check `tests/engine/test_mechanical_verify_fingerprint.py` for tests that call `_run_verification_step` directly. Those tests validate the old flow and should still work since `_run_verification_step` is kept as a re-export.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/quodeq/analysis/subagents/runner.py tests/engine/test_inline_verification.py
+git commit -m "feat: replace verification phase with inline verify + mini-verify"
+```
+
+---
+
+### Task 7: Run full test suite and verify
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run a manual incremental evaluation**
+
+Run an evaluation on a project that has previous findings. Verify:
+- Carry-forward findings appear instantly (no API call)
+- Analysis prompt includes "Previous findings" section for files in queue
+- Mini-verify only runs if there are changed files not in analysis queue
+- Scoring produces correct results
+
+- [ ] **Step 3: Check logs for the new flow**
+
+Expected log output pattern:
+```
+[dim] 15 findings carried forward
+[dim] 120 files queued, 8 inline findings
+[dim] [MINI-VERIFY] 3 findings across 2 changed files (not in analysis queue)
+```
+
+Instead of:
+```
+[dim] [VERIFICATION] Launching pool for 50 findings across 30 files
+[dim] [VERIFICATION] Pool complete (600s)
+```

--- a/docs/superpowers/specs/2026-04-09-inline-verification-design.md
+++ b/docs/superpowers/specs/2026-04-09-inline-verification-design.md
@@ -1,0 +1,120 @@
+# Inline Verification
+
+## Summary
+
+Eliminate the separate verification phase by merging finding verification into the analysis phase. Files that will be analyzed get their previous findings passed as context to the analysis agent. Files that didn't change carry forward automatically. Only files that changed but are NOT in the analysis queue get a mini-verify post-analysis.
+
+## Goals
+
+- Reduce total API calls by ~80% for incremental evaluations
+- Eliminate the 10-minute verification pool that runs before every analysis
+- Maintain finding continuity (confirmed/dismissed/new)
+- Simplify the pipeline from 4 phases to 3
+
+## Pipeline change
+
+```
+BEFORE:
+  Load prev → Verification pool (5 agents, 600s) → Analysis pool → Backfill → Scoring
+
+AFTER:
+  Load prev → Classify files → Analysis pool (with inline verify) → Mini-verify (if needed) → Backfill → Scoring
+```
+
+## File classification
+
+At the start of each dimension, before launching the analysis pool, classify all files with previous findings into three buckets:
+
+1. **Inline verify** — file is in the analysis queue AND has previous findings → pass findings as context to the analysis agent prompt
+2. **Carry forward** — file has NOT changed (fingerprint match) → write findings directly to evidence JSONL, no API call
+3. **Mini-verify** — file HAS changed but is NOT in the analysis queue → accumulate for post-analysis mini-verify pool
+
+This classification reuses the existing `partition_findings_by_fingerprint()` function from `_verify_filter.py` plus a set intersection with the analysis queue files.
+
+## Inline verification in analysis prompt
+
+When an analysis agent takes a batch of files from the queue, and any of those files have previous findings, the prompt includes an additional section:
+
+```
+## Previous findings for files in this batch
+
+The following findings were reported in a prior evaluation. For each file you analyze,
+confirm whether these findings still apply to the current code. Report confirmed findings
+alongside any new ones you discover. Dismiss findings that no longer apply.
+
+### src/auth.py
+- [violation] S-CON-3 line 42: hardcoded credentials in connection string
+- [compliance] S-CON-5 line 55: proper input validation with sanitize()
+
+### src/main.py
+- [violation] P-MOD-1 line 100: function exceeds 200 lines
+```
+
+The agent reports findings as usual via MCP — confirmed previous findings are re-reported (same req ID, updated line if moved), dismissed ones are simply not reported.
+
+## Mini-verify post-analysis
+
+After the main analysis pool completes, check if bucket 3 (changed, not analyzed) has any files. If yes:
+
+- Launch a mini-pool: 1-2 agents (proportional to file count), haiku model
+- Timeout: 60s per 10 files, max 300s
+- Uses the same verification manifest format as before
+- If bucket 3 is empty, skip entirely
+
+## Changes to `runner.py` flow
+
+```python
+def process_dimension_with_subagents(...):
+    files, extensions = _list_source_files(config, dim_id)
+
+    # Load and classify previous findings (replaces _run_verification_step)
+    prev_findings = _load_and_filter_previous(config, dim_id, evidence_dir)
+    carry_forward, needs_verify = partition_findings_by_fingerprint(...)
+    write_carry_forward_findings(carry_forward, ...)
+
+    # Split needs_verify into inline vs mini-verify
+    queue_files = set(files)
+    inline_findings = [f for f in needs_verify if f["file"] in queue_files]
+    mini_verify_findings = [f for f in needs_verify if f["file"] not in queue_files]
+
+    # Build prompt with inline findings context
+    prompt = _build_subagent_prompt(config, dim_id, ctx, inline_findings)
+
+    # Launch main analysis pool (unchanged)
+    queue, results = _launch_pool(...)
+
+    # Mini-verify only if needed
+    if mini_verify_findings:
+        verify_results = _dispatch_mini_verify(config, dim_id, evidence_dir, mini_verify_findings)
+        results += verify_results
+
+    return _collect_evidence(...)
+```
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `subagents/runner.py:50-91` | Replace `_run_verification_step()` call with classify + inline + mini-verify flow |
+| `subagents/_verification.py` | Add `_dispatch_mini_verify()` (smaller pool, proportional agents). Remove `_run_verification_step()` |
+| `subagents/_prompts.py` | Accept optional `inline_findings` param, append previous findings section to prompt |
+| `analysis/prompts/builder.py` | Support `previous_findings` field in `PromptContext` |
+
+## What does NOT change
+
+- `_verify_filter.py` — partition logic reused as-is
+- `_verify_output.py` — carry forward logic reused as-is
+- `_verify_io.py` — finding loading reused as-is
+- `fingerprint.py` — fingerprinting reused as-is
+- `file_queue.py` — queue unchanged
+- `pool.py` — pool launcher unchanged
+- MCP output format — agents report findings the same way
+- Scoring — unchanged
+
+## Edge cases
+
+- **No previous findings**: classification returns all empty buckets, analysis runs as normal
+- **All files unchanged**: everything carry forward, no analysis needed (existing behavior)
+- **All previous findings inline**: mini-verify bucket is empty, skipped
+- **No files in analysis queue**: falls back to single-agent path (existing behavior)
+- **Standards changed since last run**: all findings need verification regardless of fingerprint (existing behavior in `partition_findings_by_fingerprint`)

--- a/src/quodeq/analysis/prompts/_context.py
+++ b/src/quodeq/analysis/prompts/_context.py
@@ -45,6 +45,7 @@ class PromptContext:
     target: "AnalysisTarget | None" = None
     extra_vars: dict[str, str] = field(default_factory=dict)
     work_dir: Path | None = None
+    previous_findings: list[dict] = field(default_factory=list)
 
 
 def render_manifest_context(context: PromptContext) -> str:

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -29,6 +29,40 @@ def _load_evaluation_rules() -> str:
     except (OSError, FileNotFoundError):
         return ""
 
+
+def render_previous_findings_section(findings: list[dict]) -> str:
+    """Render a prompt section listing previous findings grouped by file."""
+    if not findings:
+        return ""
+
+    grouped: dict[str, list[dict]] = {}
+    for f in findings:
+        key = f.get("file", "(unknown file)")
+        grouped.setdefault(key, []).append(f)
+
+    lines = [
+        "",
+        "## Previous findings for files in this batch",
+        "",
+        "The following findings were reported in a prior evaluation. For each file",
+        "you analyze, confirm whether these findings still apply to the current code.",
+        "Report confirmed findings alongside any new ones you discover.",
+        "Dismiss findings that no longer apply by not reporting them.",
+        "",
+    ]
+    for filepath, file_findings in sorted(grouped.items()):
+        lines.append(f"### {filepath}")
+        for f in file_findings:
+            ftype = f.get("t", "finding")
+            req = f.get("req", "")
+            line_num = f.get("line", "?")
+            reason = f.get("reason", "")
+            lines.append(f"- [{ftype}] {req} line {line_num}: {reason}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
 # Re-export public API so existing ``from ...builder import X`` keeps working
 PromptContext = ctx.PromptContext
 __all__ = [
@@ -38,6 +72,7 @@ __all__ = [
     "load_template",
     "render_compiled_standards",
     "render_dimensions",
+    "render_previous_findings_section",
     "_load_dimension_data",
 ]
 
@@ -83,7 +118,11 @@ def build_analysis_prompt(template: str, context: ctx.PromptContext) -> str:
     }
     if context.extra_vars:
         values.update(context.extra_vars)
-    return render_template(template, values)
+    result = render_template(template, values)
+    prev_section = render_previous_findings_section(context.previous_findings)
+    if prev_section:
+        result += prev_section
+    return result
 
 
 def build_consolidated_prompt(

--- a/src/quodeq/analysis/subagents/_finding_classifier.py
+++ b/src/quodeq/analysis/subagents/_finding_classifier.py
@@ -1,0 +1,23 @@
+"""Classify previous findings into inline-verify vs mini-verify buckets."""
+from __future__ import annotations
+
+
+def classify_findings(
+    needs_verify: list[dict],
+    queue_files: set[str],
+) -> tuple[list[dict], list[dict]]:
+    """Split findings that need verification into two buckets.
+
+    - **inline**: file is in the analysis queue — findings passed as prompt context
+    - **mini_verify**: file is NOT in queue — needs separate post-analysis verification
+
+    Returns (inline, mini_verify).
+    """
+    inline: list[dict] = []
+    mini_verify: list[dict] = []
+    for finding in needs_verify:
+        if finding.get("file", "") in queue_files:
+            inline.append(finding)
+        else:
+            mini_verify.append(finding)
+    return inline, mini_verify

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -30,6 +30,11 @@ class HeartbeatContext:
     dimension_key: str
     jsonl_path: Path
     lock: threading.Lock
+    # Optional fingerprint params — when set, fingerprint is updated each tick
+    src: Path | None = None
+    all_files: list[str] | None = None
+    evidence_dir: Path | None = None
+    standards_dir: Path | None = None
 
 
 @dataclass
@@ -80,6 +85,18 @@ def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCoun
         return FindingCounts()
 
 
+def _update_fingerprint(ctx: HeartbeatContext) -> None:
+    """Save an incremental fingerprint with all source file hashes."""
+    if not ctx.src or not ctx.all_files or not ctx.evidence_dir:
+        return
+    try:
+        from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint
+        fp = build_fingerprint(ctx.src, ctx.all_files, ctx.dimension_key, ctx.standards_dir)
+        save_fingerprint(fp, ctx.evidence_dir)
+    except (OSError, ValueError):
+        pass
+
+
 def heartbeat_loop(
     stop: threading.Event, finished: dict[str, bool],
     ctx: HeartbeatContext,
@@ -106,5 +123,6 @@ def heartbeat_loop(
                 violations=counts.violations,
                 compliances=counts.compliances,
             ))
+            _update_fingerprint(ctx)
         except (OSError, ValueError, RuntimeError) as exc:
             log_warning(f"Heartbeat error: {exc}")

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -37,6 +37,7 @@ class LaunchPoolParams:
     queue_path: Path
     prompt: str
     max_files_per_agent: int = _MAX_FILES_PER_AGENT
+    all_files: list[str] | None = None
 
 
 def _launch_pool(
@@ -63,7 +64,8 @@ def _launch_pool(
     use_scout = ai_cmd not in ("codex", "gemini")
 
     pool = SubagentPool(
-        paths=PoolPaths(work_dir=config.src, evidence_dir=params.evidence_dir, queue_path=params.queue_path),
+        paths=PoolPaths(work_dir=config.src, evidence_dir=params.evidence_dir, queue_path=params.queue_path,
+                        src=config.src, all_files=params.all_files, standards_dir=config.standards_dir),
         options=PoolOptions(
             n_agents=n_agents,
             prompt=params.prompt,

--- a/src/quodeq/analysis/subagents/_pool_models.py
+++ b/src/quodeq/analysis/subagents/_pool_models.py
@@ -27,6 +27,9 @@ class PoolPaths:
     work_dir: Path
     evidence_dir: Path
     queue_path: Path
+    src: Path | None = None
+    all_files: list[str] | None = None
+    standards_dir: Path | None = None
 
 
 @dataclass

--- a/src/quodeq/analysis/subagents/_prompts.py
+++ b/src/quodeq/analysis/subagents/_prompts.py
@@ -7,8 +7,11 @@ from quodeq.analysis._types import RunConfig
 from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt
 
 
-def _build_subagent_prompt(config: RunConfig, dim_id: str, ctx: Any) -> str:
-    """Build the prompt for subagent analysis using the cached cli_subagent_prompt.md template."""
+def _build_subagent_prompt(
+    config: RunConfig, dim_id: str, ctx: Any,
+    inline_findings: list[dict] | None = None,
+) -> str:
+    """Build the prompt for subagent analysis, optionally including previous findings."""
     return build_analysis_prompt(
         ctx.subagent_template,
         PromptContext(
@@ -23,5 +26,6 @@ def _build_subagent_prompt(config: RunConfig, dim_id: str, ctx: Any) -> str:
             manifest=config.manifest,
             target=config.target,
             work_dir=config.work_dir or config.src,
+            previous_findings=inline_findings or [],
         ),
     )

--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -57,6 +57,42 @@ def _dispatch_verification_pool(
     return verify_results
 
 
+_MINI_VERIFY_MAX_AGENTS = 2
+_MINI_VERIFY_TIMEOUT_PER_10 = 60
+_MINI_VERIFY_MAX_TIMEOUT = 300
+
+
+def _dispatch_mini_verify(
+    config: RunConfig, dim_id: str, evidence_dir: Path, findings: list,
+) -> list:
+    """Post-analysis mini-verify for changed files not in the analysis queue."""
+    if not findings:
+        return []
+
+    from quodeq.analysis.subagents.verify import _group_by_file, _write_verify_manifest
+
+    grouped = _group_by_file(findings)
+    manifest_path = evidence_dir / f"{dim_id}_mini_verify_manifest.json"
+    _write_verify_manifest(grouped, manifest_path)
+    files_to_verify = list(grouped.keys())
+
+    n_files = len(files_to_verify)
+    timeout = min(_MINI_VERIFY_MAX_TIMEOUT, max(60, (n_files // 10 + 1) * _MINI_VERIFY_TIMEOUT_PER_10))
+
+    log_info(f"  [{dim_id}] [MINI-VERIFY] {len(findings)} findings across {n_files} changed files (not in analysis queue)")
+
+    from copy import copy
+    mini_config = copy(config)
+    mini_options = copy(config.options)
+    mini_options.pool_budget = timeout
+    mini_options.max_subagents = min(_MINI_VERIFY_MAX_AGENTS, config.options.max_subagents)
+    mini_config.options = mini_options
+
+    results = _run_verification_pool(mini_config, dim_id, evidence_dir, files_to_verify, manifest_path)
+    log_success(f"  [{dim_id}] [MINI-VERIFY] Complete")
+    return results
+
+
 def _run_verification_step(
     config: RunConfig, dim_id: str, evidence_dir: Path, files: list[str],
     prev_fingerprint: dict | None = None,

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -38,6 +38,7 @@ class SubagentPool:
         queue: WorkQueue | None = None,
     ):
         self._n = max(1, options.n_agents)
+        self._paths = paths
         self._work_dir, self._prompt = paths.work_dir, options.prompt
         self._evidence_dir, self._queue_path = paths.evidence_dir, paths.queue_path
         self._queue = queue
@@ -79,11 +80,15 @@ class SubagentPool:
         self._futures[executor.submit(self._run_single, self._next_idx)] = self._next_idx
         self._next_idx += 1
 
-    def _start_heartbeat(self) -> tuple[threading.Event, threading.Thread]:
+    def _start_heartbeat(self, src: Path | None = None,
+                          all_files: list[str] | None = None,
+                          standards_dir: Path | None = None) -> tuple[threading.Event, threading.Thread]:
         stop = threading.Event()
         ctx = HeartbeatContext(
             queue_path=self._queue_path, dimension_key=self._dimension_key,
             jsonl_path=self._shared_jsonl_path(), lock=self._jsonl_lock,
+            src=src, all_files=all_files, evidence_dir=self._evidence_dir,
+            standards_dir=standards_dir,
         )
         hb = threading.Thread(
             target=heartbeat_loop, args=(stop, self._finished, ctx), daemon=True,
@@ -102,7 +107,10 @@ class SubagentPool:
         self._finished.clear()
         self._futures.clear()
         self._next_idx = 0
-        stop, hb = self._start_heartbeat()
+        stop, hb = self._start_heartbeat(
+            src=self._paths.src, all_files=self._paths.all_files,
+            standards_dir=self._paths.standards_dir,
+        )
         try:
             with ThreadPoolExecutor(max_workers=self._n) as pool:
                 ctx = LoopContext(

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -105,6 +105,7 @@ def process_dimension_with_subagents(
     params = LaunchPoolParams(
         evidence_dir=evidence_dir, queue_path=queue_path,
         prompt=prompt, max_files_per_agent=files_per_agent,
+        all_files=files,
     )
     pool, results = _launch_pool(config, dim_id, params)
 

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -24,6 +24,7 @@ from quodeq.analysis.subagents._evidence_collector import (  # noqa: F401
     _collect_evidence,
 )
 from quodeq.analysis.subagents._verification import (  # noqa: F401
+    _dispatch_mini_verify,
     _dispatch_verification_pool,
     _load_and_filter_previous,
     _run_verification_pool,
@@ -69,23 +70,48 @@ def process_dimension_with_subagents(
         stream_file, jsonl_file = callbacks.run_analysis(config, dim_id, prompt, idx, ctx)
         return callbacks.parse_evidence(config, dim_id, stream_file, jsonl_file, ctx)
 
-    # 2-3. Load previous findings and run verification
-    verify_results = _run_verification_step(config, dim_id, evidence_dir, files)
+    # 2. Load previous findings, partition by fingerprint
+    from quodeq.analysis.subagents.verify import (
+        partition_findings_by_fingerprint, write_carry_forward_findings,
+    )
+    from quodeq.analysis.subagents._finding_classifier import classify_findings
 
-    # 4. Create queue with per-agent file limit for context rotation
+    prev_findings = _load_and_filter_previous(config, dim_id, evidence_dir)
+    carry_forward: list[dict] = []
+    needs_verify: list[dict] = []
+    if prev_findings:
+        from quodeq.analysis.fingerprint import find_previous_fingerprint
+        prev_fp, _ = find_previous_fingerprint(evidence_dir, dim_id)
+        carry_forward, needs_verify = partition_findings_by_fingerprint(
+            prev_findings, prev_fp, config.src,
+            standards_dir=config.standards_dir, dimension=dim_id,
+        )
+    if carry_forward:
+        written = write_carry_forward_findings(carry_forward, evidence_dir, dim_id)
+        log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {written} findings carried forward")
+
+    # 3. Split needs_verify into inline (in queue) vs mini-verify (not in queue)
+    queue_files = set(files)
+    inline_findings, mini_verify_findings = classify_findings(needs_verify, queue_files)
+
+    # 4. Create analysis queue
     queue_path = evidence_dir / f"{dim_id}_queue.json"
     files_per_agent = _compute_files_per_agent(len(files))
     FileQueue(queue_path, files, max_files_per_agent=files_per_agent)
-    log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {len(files)} files queued for {config.options.max_subagents} subagents")
+    log_info(f"  [{idx}/{ctx.total}] {dim_id} -- {len(files)} files queued, {len(inline_findings)} inline findings")
 
-    # 5. Build prompt and launch main analysis pool
-    prompt = _build_subagent_prompt(config, dim_id, ctx)
+    # 5. Build prompt with inline findings and launch analysis pool
+    prompt = _build_subagent_prompt(config, dim_id, ctx, inline_findings=inline_findings)
     params = LaunchPoolParams(
         evidence_dir=evidence_dir, queue_path=queue_path,
         prompt=prompt, max_files_per_agent=files_per_agent,
     )
     pool, results = _launch_pool(config, dim_id, params)
 
-    # 6. Collect and return evidence (includes both verified + new findings)
-    all_results = verify_results + results
-    return _collect_evidence(config, dim_id, evidence_dir, _CollectionContext(results=all_results, ctx=ctx, files=files))
+    # 6. Mini-verify for changed files not in analysis queue
+    if mini_verify_findings:
+        verify_results = _dispatch_mini_verify(config, dim_id, evidence_dir, mini_verify_findings)
+        results = results + verify_results
+
+    # 7. Collect evidence
+    return _collect_evidence(config, dim_id, evidence_dir, _CollectionContext(results=results, ctx=ctx, files=files))

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -108,10 +108,15 @@ def process_dimension_with_subagents(
     )
     pool, results = _launch_pool(config, dim_id, params)
 
-    # 6. Mini-verify for changed files not in analysis queue
+    # 6. Save fingerprint eagerly so it survives cancel/timeout
+    from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint
+    fp = build_fingerprint(config.src, files, dim_id, config.standards_dir)
+    save_fingerprint(fp, evidence_dir)
+
+    # 7. Mini-verify for changed files not in analysis queue
     if mini_verify_findings:
         verify_results = _dispatch_mini_verify(config, dim_id, evidence_dir, mini_verify_findings)
         results = results + verify_results
 
-    # 7. Collect evidence
+    # 8. Collect evidence (also saves fingerprint, but we saved it eagerly above)
     return _collect_evidence(config, dim_id, evidence_dir, _CollectionContext(results=results, ctx=ctx, files=files))

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -19,16 +19,16 @@ function useReEvalInfo(project, initialInfo) {
 
   useEffect(() => {
     if (!project) return;
-    // Use pre-loaded info if available, otherwise fetch
-    if (initialInfo) { setInfo(initialInfo); return; }
-    setInfo(null);
+    // Always fetch full info (listing doesn't include hasFingerprints)
     getProjectInfo(project)
       .then(setInfo)
       .catch(() => {
-        setInfo(null);
-        setError('Could not load project info. The project may have been removed.');
+        if (!initialInfo) {
+          setInfo(null);
+          setError('Could not load project info. The project may have been removed.');
+        }
       });
-  }, [project, initialInfo]);
+  }, [project]);
 
   async function handleUrlRestore() {
     const url = urlInput.trim();

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -174,30 +174,43 @@ function CloneSection({ info, cloning, cloneDest, cloneError, setCloneBrowserOpe
 }
 
 function ActionButtons({ info, project, disabled, canStart, cloning, handleIncremental, handleStart }) {
+  const hasFingerprints = info.hasFingerprints;
   return (
     <div style={buttonRowStyle}>
-      {info.hasFingerprints && (
+      {hasFingerprints ? (
+        <>
+          <button
+            type="button"
+            className="evaluate-submit-btn"
+            style={{ flex: 3 }}
+            disabled={!canStart}
+            onClick={handleIncremental}
+            title="Only analyze files changed since last evaluation"
+          >
+            {disabled ? 'Running...' : 'Re-scan changes'}
+          </button>
+          <button
+            type="button"
+            className="evaluate-submit-btn evaluate-submit-btn--secondary"
+            style={{ flex: 1 }}
+            disabled={!canStart}
+            onClick={handleStart}
+            title="Fresh re-evaluation of all selected dimensions"
+          >
+            Full
+          </button>
+        </>
+      ) : (
         <button
           type="button"
           className="evaluate-submit-btn"
           style={flexButtonStyle}
           disabled={!canStart}
-          onClick={handleIncremental}
-          title="Only analyze files changed since last evaluation"
+          onClick={handleStart}
         >
-          Re-scan changes
+          {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}
         </button>
       )}
-      <button
-        type="button"
-        className="evaluate-submit-btn"
-        style={flexButtonStyle}
-        disabled={!canStart}
-        onClick={handleStart}
-        title="Fresh re-evaluation of all selected dimensions"
-      >
-        {disabled ? 'Running Evaluation...' : `Re-evaluate ${info.name || project}`}
-      </button>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -187,7 +187,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
             onClick={handleIncremental}
             title="Only analyze files changed since last evaluation"
           >
-            {disabled ? 'Running...' : 'Re-scan changes'}
+            {disabled ? 'Running...' : 'Scan changes'}
           </button>
           <button
             type="button"
@@ -197,7 +197,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
             onClick={handleStart}
             title="Fresh re-evaluation of all selected dimensions"
           >
-            Full
+            Full scan
           </button>
         </>
       ) : (

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -116,16 +116,7 @@
 }
 
 .evaluate-submit-btn--secondary {
-  background: var(--color-surface-alt);
-  color: var(--color-text-muted);
   font-size: 0.85rem;
-}
-
-.evaluate-submit-btn--secondary:hover:not(:disabled) {
-  background: var(--color-border);
-  color: var(--color-text);
-  transform: none;
-  box-shadow: none;
 }
 
 .job-error {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -115,6 +115,19 @@
   cursor: not-allowed;
 }
 
+.evaluate-submit-btn--secondary {
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.evaluate-submit-btn--secondary:hover:not(:disabled) {
+  background: var(--color-border);
+  color: var(--color-text);
+  transform: none;
+  box-shadow: none;
+}
+
 .job-error {
   margin-top: 16px;
   padding: 12px 16px;

--- a/tests/analysis/test_finding_classifier.py
+++ b/tests/analysis/test_finding_classifier.py
@@ -1,0 +1,48 @@
+from quodeq.analysis.subagents._finding_classifier import classify_findings
+
+
+def test_finding_in_queue_goes_to_inline():
+    findings = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 1
+    assert len(mini) == 0
+    assert inline[0]["file"] == "a.py"
+
+
+def test_finding_not_in_queue_goes_to_mini():
+    findings = [
+        {"file": "c.py", "p": "S", "t": "violation", "line": 1, "reason": "r"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 0
+    assert len(mini) == 1
+    assert mini[0]["file"] == "c.py"
+
+
+def test_mixed_findings_split_correctly():
+    findings = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r1"},
+        {"file": "c.py", "p": "S", "t": "violation", "line": 2, "reason": "r2"},
+        {"file": "a.py", "p": "S", "t": "compliance", "line": 3, "reason": "r3"},
+    ]
+    queue_files = {"a.py", "b.py"}
+    inline, mini = classify_findings(findings, queue_files)
+    assert len(inline) == 2
+    assert len(mini) == 1
+
+
+def test_empty_findings():
+    inline, mini = classify_findings([], {"a.py"})
+    assert inline == []
+    assert mini == []
+
+
+def test_no_file_key_goes_to_mini():
+    findings = [{"p": "S", "t": "violation", "line": 1, "reason": "r"}]
+    inline, mini = classify_findings(findings, {"a.py"})
+    assert len(inline) == 0
+    assert len(mini) == 1

--- a/tests/analysis/test_mini_verify.py
+++ b/tests/analysis/test_mini_verify.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch, MagicMock
+
+from quodeq.analysis.subagents._verification import _dispatch_mini_verify
+
+
+@patch("quodeq.analysis.subagents._verification._run_verification_pool")
+def test_mini_verify_caps_agents(mock_pool, tmp_path):
+    mock_pool.return_value = []
+    config = MagicMock()
+    config.src = tmp_path
+    config.standards_dir = None
+    config.options.max_subagents = 10
+    config.options.ai_model = None
+    config.options.pool_budget = 300
+
+    findings = [
+        {"file": f"f{i}.py", "p": "S", "t": "violation", "line": 1, "reason": "r"}
+        for i in range(50)
+    ]
+    _dispatch_mini_verify(config, "security", tmp_path, findings)
+    assert mock_pool.called
+
+
+@patch("quodeq.analysis.subagents._verification._run_verification_pool")
+def test_mini_verify_skips_empty(mock_pool, tmp_path):
+    config = MagicMock()
+    result = _dispatch_mini_verify(config, "security", tmp_path, [])
+    assert result == []
+    assert not mock_pool.called

--- a/tests/analysis/test_prompt_context.py
+++ b/tests/analysis/test_prompt_context.py
@@ -1,4 +1,5 @@
 from quodeq.analysis.prompts._context import PromptContext
+from quodeq.analysis.prompts.builder import render_previous_findings_section
 
 
 def test_prompt_context_default_previous_findings():
@@ -19,3 +20,29 @@ def test_prompt_context_with_previous_findings():
         previous_findings=findings,
     )
     assert ctx.previous_findings == findings
+
+
+def test_render_previous_findings_empty():
+    assert render_previous_findings_section([]) == ""
+
+
+def test_render_previous_findings_groups_by_file():
+    findings = [
+        {"p": "Security", "t": "violation", "file": "a.py", "line": 42, "req": "S-CON-3", "reason": "hardcoded creds"},
+        {"p": "Security", "t": "compliance", "file": "a.py", "line": 55, "req": "S-CON-5", "reason": "good validation"},
+        {"p": "Maintainability", "t": "violation", "file": "b.py", "line": 100, "req": "P-MOD-1", "reason": "long function"},
+    ]
+    result = render_previous_findings_section(findings)
+    assert "### a.py" in result
+    assert "### b.py" in result
+    assert "[violation] S-CON-3" in result
+    assert "[compliance] S-CON-5" in result
+    assert "[violation] P-MOD-1" in result
+    assert "hardcoded creds" in result
+    assert "Previous findings" in result
+
+
+def test_render_previous_findings_no_file_key():
+    findings = [{"p": "X", "t": "violation", "reason": "no file"}]
+    result = render_previous_findings_section(findings)
+    assert "### (unknown file)" in result

--- a/tests/analysis/test_prompt_context.py
+++ b/tests/analysis/test_prompt_context.py
@@ -1,0 +1,21 @@
+from quodeq.analysis.prompts._context import PromptContext
+
+
+def test_prompt_context_default_previous_findings():
+    ctx = PromptContext(
+        language="python", repo_name="test", date_str="2026-01-01",
+        dimension="security", source_file_count=10, dimensions_data={},
+    )
+    assert ctx.previous_findings == []
+
+
+def test_prompt_context_with_previous_findings():
+    findings = [
+        {"p": "Security", "t": "violation", "file": "a.py", "line": 1, "reason": "test"},
+    ]
+    ctx = PromptContext(
+        language="python", repo_name="test", date_str="2026-01-01",
+        dimension="security", source_file_count=10, dimensions_data={},
+        previous_findings=findings,
+    )
+    assert ctx.previous_findings == findings

--- a/tests/analysis/test_prompt_context.py
+++ b/tests/analysis/test_prompt_context.py
@@ -46,3 +46,29 @@ def test_render_previous_findings_no_file_key():
     findings = [{"p": "X", "t": "violation", "reason": "no file"}]
     result = render_previous_findings_section(findings)
     assert "### (unknown file)" in result
+
+
+def test_build_subagent_prompt_passes_inline_findings():
+    from unittest.mock import MagicMock
+
+    from quodeq.analysis.subagents._prompts import _build_subagent_prompt
+
+    findings = [{"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "test"}]
+    ctx = MagicMock()
+    ctx.subagent_template = "{{DIMENSION}} analysis"
+    ctx.date_str = "2026-01-01"
+    ctx.dimensions_data = {}
+
+    config = MagicMock()
+    config.language = "python"
+    config.src = "/test"
+    config.source_file_count = 10
+    config.standards_dir = None
+    config.evaluators_dir = None
+    config.manifest = None
+    config.target = None
+    config.work_dir = None
+
+    result = _build_subagent_prompt(config, "security", ctx, inline_findings=findings)
+    assert "Previous findings" in result
+    assert "a.py" in result

--- a/tests/engine/test_inline_verification.py
+++ b/tests/engine/test_inline_verification.py
@@ -1,0 +1,26 @@
+"""Tests for inline verification flow."""
+from quodeq.analysis.subagents._finding_classifier import classify_findings
+from quodeq.analysis.subagents._verification import _load_and_filter_previous
+from unittest.mock import patch, MagicMock
+
+
+def test_classify_splits_by_queue_membership():
+    needs_verify = [
+        {"file": "a.py", "p": "S", "t": "violation", "line": 1, "reason": "r1"},
+        {"file": "b.py", "p": "S", "t": "violation", "line": 2, "reason": "r2"},
+        {"file": "c.py", "p": "S", "t": "violation", "line": 3, "reason": "r3"},
+    ]
+    queue_files = {"a.py", "c.py"}
+    inline, mini = classify_findings(needs_verify, queue_files)
+    assert {f["file"] for f in inline} == {"a.py", "c.py"}
+    assert {f["file"] for f in mini} == {"b.py"}
+
+
+@patch("quodeq.analysis.subagents.verify.load_previous_findings_for_dimension")
+def test_load_and_filter_returns_empty_when_no_previous(mock_load, tmp_path):
+    mock_load.return_value = []
+    config = MagicMock()
+    config.src = tmp_path
+    config.options.incremental_file_filter = None
+    result = _load_and_filter_previous(config, "security", tmp_path)
+    assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1224,9 +1224,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1325,7 +1325,7 @@ provides-extras = ["api", "desktop"]
 [package.metadata.requires-dev]
 dev = [
     { name = "openai", specifier = ">=1.0.0" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-cov", specifier = "==7.1.0" },
 ]
 


### PR DESCRIPTION
## Summary

Replaces the separate verification phase with inline verification — previous findings are passed directly in the analysis prompt, and a lightweight mini-verify pass handles files that changed since the last evaluation.

- **Inline findings in prompt**: previous findings are rendered in the analysis prompt so the AI can confirm/update them during analysis
- **Finding classifier**: buckets previous findings into inline (unchanged files) vs mini-verify (changed files)
- **Mini-verify dispatcher**: lightweight post-analysis pass for changed files with previous findings
- **Incremental fingerprint**: saves fingerprint during heartbeat (every 10s) so it survives cancel/timeout
- **Eager fingerprint save**: saves after pool completion before scoring
- **UI**: Re-scan changes as primary button (3:1 ratio), renamed to Scan changes / Full scan

## Test plan

- [x] Run incremental evaluation — previous findings appear in prompt
- [x] Changed files get mini-verified after analysis
- [x] Fingerprint survives cancelled evaluation
- [x] Re-scan changes button works as primary action