### PR TITLE
fix: pipeline hardening — concurrency, persistence, errors, performance

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -16,7 +16,7 @@ def check_zero_findings(
     result: dict[str, Evidence], source_file_count: int, skipped_count: int = 0,
 ) -> None:
     """Raise EvaluationError if all dimensions produced zero findings."""
-    from quodeq.analysis._pipeline import EvaluationError
+    from quodeq.analysis.errors import EvaluationError
 
     if not result or source_file_count <= 0:
         return

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -18,8 +18,7 @@ from quodeq.engine._runner_markers import emit_marker
 from quodeq.shared.logging import log_warning
 
 
-class EvaluationError(RuntimeError):
-    """Raised when an evaluation completes but produces no usable findings."""
+from quodeq.analysis.errors import EvaluationError as EvaluationError  # re-export
 
 
 def load_analysis_context(config: RunConfig) -> tuple[list[str], _AnalysisContext]:

--- a/src/quodeq/analysis/_process.py
+++ b/src/quodeq/analysis/_process.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 from quodeq.analysis._config import AnalysisConfig, _SpawnPaths
+from quodeq.analysis.errors import ProviderError
 from quodeq.analysis.stream.progress_reader import _IncrementalProgressReader
 from quodeq.shared.logging import log_warning
 from quodeq.shared.utils import sanitize_sensitive as _sanitize_stderr
@@ -15,7 +16,7 @@ from quodeq.shared.utils import sanitize_sensitive as _sanitize_stderr
 _TERMINATE_TIMEOUT_S = 10
 
 
-class AnalysisError(RuntimeError):
+class AnalysisError(ProviderError):
     """Raised when the AI CLI subprocess fails (non-zero exit, auth error, etc.)."""
 
 

--- a/src/quodeq/analysis/errors.py
+++ b/src/quodeq/analysis/errors.py
@@ -1,0 +1,26 @@
+"""Structured error types for the evaluation pipeline."""
+from __future__ import annotations
+
+
+class EvaluationError(RuntimeError):
+    """Base error for evaluation pipeline failures."""
+
+
+class RepoNotFoundError(EvaluationError):
+    """Repository path does not exist or is not accessible."""
+
+
+class RepoCloneError(EvaluationError):
+    """Failed to clone a remote repository."""
+
+
+class NoSourceFilesError(EvaluationError):
+    """No recognized source files found in the repository or scope."""
+
+
+class ProviderError(EvaluationError):
+    """AI provider failed (CLI exited with error, auth failure, etc.)."""
+
+
+class BudgetExceededError(EvaluationError):
+    """Evaluation exceeded the configured time or cost budget."""

--- a/src/quodeq/analysis/manifest_build.py
+++ b/src/quodeq/analysis/manifest_build.py
@@ -69,13 +69,25 @@ def _build_targets_from_disciplines(
 
 def _walk_and_group(
     src: Path, ext_map: dict[str, str], skip_dirs: set[str],
+    scope_path: str | None = None,
 ) -> tuple[dict[str, list[str]], Counter[str], dict[str, Counter]]:
-    """Walk *src* once, grouping files by language."""
+    """Walk *src* (or a scoped subdirectory) once, grouping files by language.
+
+    When *scope_path* is given (relative to *src*), only files under that
+    subdirectory are included.  Relative paths in the result are still
+    expressed relative to *src* so callers see the same format regardless.
+    """
+    walk_root = src
+    if scope_path:
+        candidate = src / scope_path
+        if candidate.is_dir():
+            walk_root = candidate
+
     files_by_lang: dict[str, list[str]] = {}
     ext_counts: Counter[str] = Counter()
     ext_counts_by_lang: dict[str, Counter] = {}
     all_extensions = set(ext_map.keys())
-    for dirpath, dirnames, filenames in os.walk(src):
+    for dirpath, dirnames, filenames in os.walk(walk_root):
         dirnames[:] = [d for d in dirnames if d not in skip_dirs and not d.startswith(".")]
         for fname in filenames:
             suffix = os.path.splitext(fname)[1]
@@ -92,16 +104,21 @@ def build_manifest(
     src: Path,
     detection: dict,
     disciplines_conf: Path | None = None,
+    scope_path: str | None = None,
 ) -> SourceManifest:
     """Walk a repository once and build a complete source manifest.
 
     *detection* is the parsed content of detection.json.
     *disciplines_conf* is the optional path to disciplines.conf for
     category and framework detection.
+    *scope_path*, when provided, limits the file scan to the given
+    subdirectory (relative to *src*) instead of the full repo.
     """
     ext_map: dict[str, str] = detection.get("extensions", {})
     skip_dirs = set(detection.get("skip_dirs", []))
-    files_by_lang, ext_counts, ext_counts_by_lang = _walk_and_group(src, ext_map, skip_dirs)
+    files_by_lang, ext_counts, ext_counts_by_lang = _walk_and_group(
+        src, ext_map, skip_dirs, scope_path=scope_path,
+    )
     all_source_files_count = sum(len(f) for f in files_by_lang.values())
 
     targets: list[AnalysisTarget] = []

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -4,10 +4,15 @@ Contains the core routing class and its supporting data types / protocols.
 """
 from __future__ import annotations
 
+import io
 import json
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, TextIO, runtime_checkable
+
+if sys.platform != "win32":
+    import fcntl
 
 from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
@@ -42,6 +47,28 @@ class DeduplicationStore(Protocol):
 
     def __contains__(self, key: tuple) -> bool: ...
     def add(self, key: tuple) -> None: ...
+
+
+def _locked_write(fh: TextIO, line: str) -> None:
+    """Write a line to *fh*, holding an exclusive POSIX lock when possible.
+
+    The lock protects against concurrent writes from sibling MCP server
+    processes that share the same JSONL output file.  Falls back to a plain
+    write when the file handle doesn't support ``fileno()`` (e.g. StringIO
+    in tests) or on Windows.
+    """
+    use_lock = sys.platform != "win32"
+    if use_lock:
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+        except (OSError, io.UnsupportedOperation):
+            use_lock = False
+    try:
+        fh.write(line)
+        fh.flush()
+    finally:
+        if use_lock:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
 
 def _default_read_file(path: Path) -> str:
@@ -108,7 +135,7 @@ class FindingsRouter:
         self._enrich(args, finding)
         enrich_code(finding, self._work_dir, self._read_file)
 
-        self._fh.write(json.dumps(finding) + "\n")
-        self._fh.flush()
+        line = json.dumps(finding) + "\n"
+        _locked_write(self._fh, line)
         self.counter += 1
         return f"Finding #{self.counter} recorded.", False

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -75,11 +75,16 @@ def _read_findings_from_file(jsonl_path: Path) -> FindingCounts:
 
 
 def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCounts:
-    """Count total, violation, and compliance lines in a JSONL file under a lock."""
-    if not jsonl_path.exists():
-        return FindingCounts()
+    """Count total, violation, and compliance lines in a JSONL file under a lock.
+
+    The existence check and read are both inside the lock to avoid a TOCTOU
+    race with concurrent MCP writers that may create the file between the
+    check and the open.
+    """
     try:
         with lock:
+            if not jsonl_path.exists():
+                return FindingCounts()
             return _read_findings_from_file(jsonl_path)
     except OSError:
         return FindingCounts()

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -30,11 +30,6 @@ class HeartbeatContext:
     dimension_key: str
     jsonl_path: Path
     lock: threading.Lock
-    # Optional fingerprint params — when set, fingerprint is updated each tick
-    src: Path | None = None
-    all_files: list[str] | None = None
-    evidence_dir: Path | None = None
-    standards_dir: Path | None = None
 
 
 @dataclass
@@ -90,18 +85,6 @@ def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCoun
         return FindingCounts()
 
 
-def _update_fingerprint(ctx: HeartbeatContext) -> None:
-    """Save an incremental fingerprint with all source file hashes."""
-    if not ctx.src or not ctx.all_files or not ctx.evidence_dir:
-        return
-    try:
-        from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint
-        fp = build_fingerprint(ctx.src, ctx.all_files, ctx.dimension_key, ctx.standards_dir)
-        save_fingerprint(fp, ctx.evidence_dir)
-    except (OSError, ValueError):
-        pass
-
-
 def heartbeat_loop(
     stop: threading.Event, finished: dict[str, bool],
     ctx: HeartbeatContext,
@@ -128,6 +111,5 @@ def heartbeat_loop(
                 violations=counts.violations,
                 compliances=counts.compliances,
             ))
-            _update_fingerprint(ctx)
         except (OSError, ValueError, RuntimeError) as exc:
             log_warning(f"Heartbeat error: {exc}")

--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -5,6 +5,7 @@ Internal module — use ``FileQueue`` from ``file_queue.py`` instead.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
 from contextlib import contextmanager
@@ -14,9 +15,40 @@ from quodeq.analysis.subagents._file_lock import lock_file, unlock_file
 
 _QUEUE_VERSION = 1
 
+_STALE_LOCK_THRESHOLD_SECS = 60
+
+_log = logging.getLogger(__name__)
+
 
 class FileQueueError(RuntimeError):
     """Raised on queue corruption or I/O failures."""
+
+
+def cleanup_stale_lock(lock_path: Path, threshold: float = _STALE_LOCK_THRESHOLD_SECS) -> bool:
+    """Remove a stale lock file if it exists and is older than *threshold* seconds.
+
+    Returns ``True`` if a stale lock was removed.  This is a defensive measure
+    for environments where ``flock`` may not release properly (e.g. networked
+    file-systems) or where the lock file was left behind by a hard crash.
+    """
+    try:
+        stat = lock_path.stat()
+    except FileNotFoundError:
+        return False
+
+    import time as _time
+    age = _time.time() - stat.st_mtime
+    if age > threshold:
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass  # another process already cleaned it up
+        _log.warning(
+            "Removed stale lock file %s (age=%.1fs, threshold=%.0fs)",
+            lock_path, age, threshold,
+        )
+        return True
+    return False
 
 
 @contextmanager

--- a/src/quodeq/analysis/subagents/file_queue.py
+++ b/src/quodeq/analysis/subagents/file_queue.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from quodeq.analysis.subagents._queue_state import (
     FileQueueError,  # noqa: F401 — re-export
     _QUEUE_VERSION,
+    cleanup_stale_lock,
     locked,
     read_state,
     write_state,
@@ -30,6 +31,7 @@ class FileQueue:
     ):
         self._path = Path(queue_path)
         self._lock_path = self._path.with_suffix(".lock")
+        cleanup_stale_lock(self._lock_path)
 
         if files is not None:
             state: dict = {"version": _QUEUE_VERSION, "pending": list(files), "taken": []}

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -80,15 +80,11 @@ class SubagentPool:
         self._futures[executor.submit(self._run_single, self._next_idx)] = self._next_idx
         self._next_idx += 1
 
-    def _start_heartbeat(self, src: Path | None = None,
-                          all_files: list[str] | None = None,
-                          standards_dir: Path | None = None) -> tuple[threading.Event, threading.Thread]:
+    def _start_heartbeat(self) -> tuple[threading.Event, threading.Thread]:
         stop = threading.Event()
         ctx = HeartbeatContext(
             queue_path=self._queue_path, dimension_key=self._dimension_key,
             jsonl_path=self._shared_jsonl_path(), lock=self._jsonl_lock,
-            src=src, all_files=all_files, evidence_dir=self._evidence_dir,
-            standards_dir=standards_dir,
         )
         hb = threading.Thread(
             target=heartbeat_loop, args=(stop, self._finished, ctx), daemon=True,
@@ -107,10 +103,7 @@ class SubagentPool:
         self._finished.clear()
         self._futures.clear()
         self._next_idx = 0
-        stop, hb = self._start_heartbeat(
-            src=self._paths.src, all_files=self._paths.all_files,
-            standards_dir=self._paths.standards_dir,
-        )
+        stop, hb = self._start_heartbeat()
         try:
             with ThreadPoolExecutor(max_workers=self._n) as pool:
                 ctx = LoopContext(

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -159,8 +159,15 @@ def _resolve_language(args: argparse.Namespace, src: Path, paths) -> str | None:
         return None
 
 
-def _build_manifest(args: argparse.Namespace, src: Path, paths) -> "SourceManifest | None":
-    """Build a source manifest for the repository."""
+def _build_manifest(
+    args: argparse.Namespace, src: Path, paths,
+    scope_path: str | None = None,
+) -> "SourceManifest | None":
+    """Build a source manifest for the repository.
+
+    When *scope_path* is given the file walk is restricted to the scoped
+    subdirectory, avoiding a full-repo scan for large repositories.
+    """
     if args.no_prescan:
         return None
 
@@ -173,7 +180,7 @@ def _build_manifest(args: argparse.Namespace, src: Path, paths) -> "SourceManife
 
     detection = read_json(detection_file)
     disciplines_conf = paths.disciplines_conf if paths.disciplines_conf.exists() else None
-    manifest = build_manifest(src, detection, disciplines_conf)
+    manifest = build_manifest(src, detection, disciplines_conf, scope_path=scope_path)
     if manifest.targets:
         langs = ", ".join(
             f"{t.language} ({t.total_files})"
@@ -329,9 +336,12 @@ def _resolve_evaluation_inputs(args: argparse.Namespace) -> ResolvedInputs | Non
         print(f"Invalid dimensions config: {exc}", file=sys.stderr)
         return None
 
-    manifest = _build_manifest(args, src, paths)
+    manifest = _build_manifest(args, src, paths, scope_path=scope_path)
 
-    # Scope filter: narrow manifest to files under scope_path
+    # Scope filter (fallback): ensure manifest only contains files under
+    # scope_path.  With scope-aware scanning the manifest should already be
+    # scoped, but this guard handles edge cases (e.g. disciplines.conf
+    # pulling files from outside the scope directory).
     if scope_path and manifest and manifest.targets:
         from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
         prefix = scope_path.rstrip("/") + "/"
@@ -385,6 +395,12 @@ def _run_pipeline_with_cleanup(
     """Set up directories, build config, run the pipeline, and clean up cloned repos."""
     _reports_root, evidence_dir, evaluation_dir = paths
     print(f"Report path: {evaluation_dir}", file=sys.stderr)
+    # Emit structured marker so the job manager can extract project/run IDs
+    # without fragile regex parsing of the human-readable log line above.
+    from quodeq.engine._runner_markers import emit_marker
+    run_id = evaluation_dir.parent.name
+    project_uuid = evaluation_dir.parent.parent.name
+    emit_marker("report_path", project=project_uuid, runId=run_id)
     _save_manifest(inputs.manifest, evidence_dir)
 
     config = _build_run_config(args, inputs=inputs, evidence_dir=evidence_dir)

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import threading
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -141,10 +144,146 @@ class InMemoryJobStore:
             self._jobs.pop(job_id, None)
 
 
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_PERSIST_DIR = Path.home() / ".quodeq" / "run" / "jobs"
+_STALE_JOB_AGE_S = 24 * 60 * 60  # 24 hours
+
+
+def _job_to_json(job: Job) -> dict:
+    """Serialize a Job to a JSON-safe dict (no Process objects)."""
+    return {
+        "job_id": job.job_id,
+        "status": job.status,
+        "command": job.command,
+        "started_at": job.started_at,
+        "ended_at": job.ended_at,
+        "exit_code": job.exit_code,
+        "logs": list(job.logs),
+        "output_project": job.output_project,
+        "output_run_id": job.output_run_id,
+        "phase": job.phase,
+        "current_dimension": job.current_dimension,
+        "dimensions": job.dimensions,
+    }
+
+
+def _job_from_json(data: dict) -> Job:
+    """Deserialize a Job from a JSON dict."""
+    logs: deque[str] = deque(data.get("logs", []), maxlen=_MAX_LOG_LINES)
+    return Job(
+        job_id=data["job_id"],
+        status=data["status"],
+        command=data.get("command", []),
+        started_at=data.get("started_at", ""),
+        ended_at=data.get("ended_at"),
+        exit_code=data.get("exit_code"),
+        logs=logs,
+        output_project=data.get("output_project"),
+        output_run_id=data.get("output_run_id"),
+        phase=data.get("phase"),
+        current_dimension=data.get("current_dimension"),
+        dimensions=data.get("dimensions"),
+    )
+
+
+class FileJobStore:
+    """Job store backed by per-job JSON files on disk.
+
+    Jobs are stored as ``{persist_dir}/{job_id}.json``.  All existing files
+    are loaded on init, and stale completed/failed/cancelled jobs older than
+    24 hours are cleaned up automatically.
+    """
+
+    def __init__(self, persist_dir: Path | None = None) -> None:
+        self._persist_dir = persist_dir or _DEFAULT_PERSIST_DIR
+        self._persist_dir.mkdir(parents=True, exist_ok=True)
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+        self._load_all()
+        self._cleanup_stale()
+
+    # -- JobStore protocol ---------------------------------------------------
+
+    def get(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def put(self, job: Job) -> None:
+        with self._lock:
+            self._jobs[job.job_id] = job
+            self._write(job)
+
+    def list(self) -> list[Job]:
+        with self._lock:
+            return list(self._jobs.values())
+
+    def delete(self, job_id: str) -> None:
+        with self._lock:
+            self._jobs.pop(job_id, None)
+            path = self._persist_dir / f"{job_id}.json"
+            path.unlink(missing_ok=True)
+
+    # -- persistence helpers -------------------------------------------------
+
+    def _write(self, job: Job) -> None:
+        """Write a single job to disk. Caller must hold the lock."""
+        path = self._persist_dir / f"{job.job_id}.json"
+        tmp = path.with_suffix(".tmp")
+        try:
+            tmp.write_text(json.dumps(_job_to_json(job), indent=2), encoding="utf-8")
+            tmp.replace(path)
+        except OSError:
+            _logger.warning("Failed to persist job %s", job.job_id, exc_info=True)
+            tmp.unlink(missing_ok=True)
+
+    def _load_all(self) -> None:
+        """Load every .json file in the persist dir."""
+        for path in self._persist_dir.glob("*.json"):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                job = _job_from_json(data)
+                # Jobs that were 'running' when we crashed are effectively failed.
+                if job.status == "running":
+                    job.status = "failed"
+                    job.exit_code = -1
+                    self._jobs[job.job_id] = job
+                    self._write(job)
+                else:
+                    self._jobs[job.job_id] = job
+            except (json.JSONDecodeError, KeyError, OSError):
+                _logger.warning("Skipping corrupt job file %s", path, exc_info=True)
+
+    def _cleanup_stale(self) -> None:
+        """Remove completed/failed/cancelled jobs older than 24 hours."""
+        now = time.time()
+        stale_ids: list[str] = []
+        for job in self._jobs.values():
+            if job.status == "running":
+                continue
+            if not job.ended_at:
+                continue
+            try:
+                from datetime import datetime, timezone
+
+                ended = datetime.fromisoformat(job.ended_at)
+                if ended.tzinfo is None:
+                    ended = ended.replace(tzinfo=timezone.utc)
+                age = now - ended.timestamp()
+                if age > _STALE_JOB_AGE_S:
+                    stale_ids.append(job.job_id)
+            except (ValueError, TypeError):
+                continue
+        for jid in stale_ids:
+            _logger.info("Cleaning up stale job %s", jid)
+            self._jobs.pop(jid, None)
+            (self._persist_dir / f"{jid}.json").unlink(missing_ok=True)
+
+
 def create_job_store() -> JobStore:
     """Create the default job store.
 
-    Override this factory to plug in a persistent backend for multi-worker
-    deployments.  The returned object must satisfy the ``JobStore`` protocol.
+    Returns a ``FileJobStore`` that persists jobs to ``~/.quodeq/run/jobs/``
+    so that job state survives server restarts.
     """
-    return InMemoryJobStore()
+    return FileJobStore()

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -18,6 +18,7 @@ from quodeq.services._job_model import (
     Job,
     JobStore,
     InMemoryJobStore,
+    FileJobStore,
     create_job_store,
     REPORT_PATH_RE,
     _MAX_COMPLETED_JOBS,
@@ -31,6 +32,7 @@ __all__ = [
     "Job",
     "JobStore",
     "InMemoryJobStore",
+    "FileJobStore",
     "create_job_store",
     "REPORT_PATH_RE",
     "JobManager",
@@ -154,6 +156,12 @@ class JobManager:
         elif phase in ("analyzing", "scoring"):
             job.current_dimension = marker.get("dimension")
             job.phase = phase
+        elif phase == "report_path":
+            project = marker.get("project")
+            run_id = marker.get("runId")
+            if project and run_id:
+                job.output_project = project
+                job.output_run_id = run_id
 
     def _append_log(self, job: Job, line: str) -> None:
         if not line:
@@ -162,7 +170,9 @@ class JobManager:
             self._apply_marker(job, line)
             return
         job.logs.append(_ANSI_RE.sub("", line))
-        if _REPORT_PATH_MARKER in line:
+        # Fallback: extract report path from log text if the structured
+        # marker was not received (backward compat with older pipelines).
+        if not job.output_project and _REPORT_PATH_MARKER in line:
             match = REPORT_PATH_RE.search(line)
             if match:
                 job.output_project = match.group(1)


### PR DESCRIPTION
## Summary

Hardens the evaluation pipeline for production use based on a technical analysis of the full evaluation flow.

### Concurrency fixes
- **JSONL file locking**: `fcntl.flock` around MCP router writes prevents corruption from concurrent agents
- **TOCTOU fix**: JSONL existence check moved inside lock in heartbeat thread
- **Fingerprint staleness**: removed heartbeat-based fingerprint updates — fingerprint only saved after pool completion and deduplication
- **Stale lock cleanup**: FileQueue cleans up lock files older than 60s on init (handles crashed agents)

### Persistence
- **File-based JobStore**: jobs persist to `~/.quodeq/run/jobs/{id}.json`, survive server restarts
- Running jobs marked as failed on restart (can't survive process death)
- Old completed/failed jobs cleaned up after 24h
- InMemoryJobStore preserved for testing
- **Structured report_path marker**: `{"_cc": "report_path", "project": ..., "runId": ...}` replaces regex parsing of log text (regex kept as fallback)

### Error types
- `EvaluationError` hierarchy: `ProviderError`, `RepoNotFoundError`, `RepoCloneError`, `NoSourceFilesError`, `BudgetExceededError`
- `AnalysisError` now subclasses `ProviderError`

### Performance
- **Scope-first manifest**: `build_manifest` accepts `scope_path` — scans only the scoped directory instead of full repo then filtering
- Post-scan filter preserved as fallback

## Test plan

- [x] 850 tests passing, 0 regressions
- [x] Run concurrent multi-agent evaluation — no JSONL corruption
- [x] Kill server during evaluation, restart — job shows as failed, not missing
- [x] Run scoped evaluation on large repo — faster manifest build
- [x] Crash an agent mid-queue-take, restart evaluation — stale lock cleaned up