### PR TITLE
feat: kill evaluations on shutdown + close dialog with eval info

### DIFF
--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -43,6 +43,7 @@ def create_app(
     if test_config is not None:
         app.config.update(test_config)
     provider = provider or _default_provider()
+    app.config["_provider"] = provider
     store = rate_limit_store or create_rate_limit_store()
     eval_store = InMemoryRateLimitStore(
         window=_EVALUATION_RATE_LIMIT_WINDOW, max_requests=_EVALUATION_RATE_LIMIT_MAX,
@@ -105,7 +106,16 @@ def main(env: dict[str, str] | None = None) -> None:
     # consider a secrets manager or platform keychain instead.
     app = create_app(static_dist=get_static_dist(), api_key=_env.get("QUODEQ_API_KEY"))
 
+    # Kill running evaluation subprocesses on shutdown
+    import atexit
+    def _cleanup_jobs():
+        provider = app.config.get("_provider")
+        if provider and hasattr(provider, "_jobs"):
+            provider._jobs.shutdown()
+    atexit.register(_cleanup_jobs)
+
     def _handle_shutdown(signum: int, frame: object) -> None:
+        _cleanup_jobs()
         raise SystemExit(0)
 
     if hasattr(signal, "SIGTERM"):

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -135,11 +135,78 @@ class _WindowApi:
         self._instance = instance
 
     def close(self) -> None:
+        job = self._get_running_evaluation() if self._window else None
+        if job:
+            try:
+                choice = self._window.evaluate_js(self._build_close_dialog_js(job))
+                if choice == 'back':
+                    return
+                if choice == 'keep':
+                    os._exit(0)
+            except Exception:
+                pass
         if self._api_pid:
             _kill_api(self._api_pid)
         if self._instance:
             self._instance.shutdown()
         os._exit(0)
+
+    def _get_running_evaluation(self) -> dict | None:
+        """Return the first running evaluation job, or None."""
+        try:
+            import urllib.request
+            import json as _json
+            url = self._window.get_current_url().split("#")[0].rstrip("/")
+            base = url.rsplit("/", 1)[0] if "/" in url.lstrip("http") else url
+            req = urllib.request.Request(f"{base}/api/evaluations")
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                jobs = _json.loads(resp.read())
+                for j in (jobs if isinstance(jobs, list) else []):
+                    if j.get("status") == "running":
+                        return j
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
+    def _build_close_dialog_js(job: dict) -> str:
+        """Build JS for the close confirmation dialog with job info."""
+        phase = job.get("phase", "analyzing")
+        dim = job.get("currentDimension", "")
+        repo = job.get("repo", "")
+        # Build info line
+        info_parts = []
+        if repo:
+            name = repo.rsplit("/", 1)[-1] if "/" in repo else repo
+            info_parts.append(f"Project: <b>{name}</b>")
+        if dim:
+            info_parts.append(f"Dimension: <b>{dim}</b>")
+        if phase:
+            info_parts.append(f"Phase: <b>{phase}</b>")
+        info_html = "<br>".join(info_parts) if info_parts else "Running..."
+
+        return """
+            (function() {
+                var d = document.createElement('div');
+                d.id = '_qd_close_dialog';
+                d.style.cssText = 'position:fixed;inset:0;z-index:999999;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center';
+                d.innerHTML = '<div style="background:var(--color-surface,#1c2128);border:1px solid var(--color-border,#333);border-radius:12px;padding:24px 28px;max-width:420px;color:var(--color-text,#e6edf3);font-family:inherit">'
+                    + '<h3 style="margin:0 0 12px;font-size:1rem">Evaluation in progress</h3>'
+                    + '<div style="margin:0 0 16px;padding:10px 14px;background:var(--color-surface-alt,#161b22);border-radius:6px;font-size:0.82rem;line-height:1.6;color:var(--color-text-muted,#8b949e)">""" + info_html + """</div>'
+                    + '<div style="display:flex;flex-direction:column;gap:8px">'
+                    + '<button id="_qd_close_keep" style="padding:10px 16px;border:1px solid var(--color-border,#333);border-radius:6px;background:var(--color-surface-alt,#161b22);color:var(--color-text,#e6edf3);cursor:pointer;font-size:0.85rem">Close window (evaluation continues in background)</button>'
+                    + '<button id="_qd_close_cancel" style="padding:10px 16px;border:1px solid #da3633;border-radius:6px;background:transparent;color:#f85149;cursor:pointer;font-size:0.85rem">Cancel evaluation and close</button>'
+                    + '<button id="_qd_close_back" style="padding:10px 16px;border:none;border-radius:6px;background:transparent;color:var(--color-text-muted,#8b949e);cursor:pointer;font-size:0.85rem">Go back</button>'
+                    + '</div></div>';
+                document.body.appendChild(d);
+                return new Promise(function(resolve) {
+                    document.getElementById('_qd_close_keep').onclick = function() { d.remove(); resolve('keep'); };
+                    document.getElementById('_qd_close_cancel').onclick = function() { d.remove(); resolve('cancel'); };
+                    document.getElementById('_qd_close_back').onclick = function() { d.remove(); resolve('back'); };
+                    d.onclick = function(e) { if (e.target === d) { d.remove(); resolve('back'); } };
+                });
+            })()
+        """
 
     def minimize(self) -> None:
         if self._window:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -129,6 +129,17 @@ class JobManager:
             _kill_tree(process.pid)
         return True
 
+    def shutdown(self) -> None:
+        """Kill all running job subprocesses. Called on server shutdown."""
+        with self._lock:
+            for job_id, process in list(self._processes.items()):
+                try:
+                    from quodeq.analysis._process import _kill_tree
+                    _kill_tree(process.pid)
+                except (ProcessLookupError, OSError):
+                    pass
+            self._processes.clear()
+
     def get_job(self, job_id: str) -> JobSnapshot | None:
         """Return the current state of a job, or None if not found."""
         with self._lock:


### PR DESCRIPTION
## Summary

- **Kill running evaluations on server shutdown**: `JobManager.shutdown()` kills all running subprocesses via `_kill_tree`. Called on SIGTERM/SIGINT and via `atexit`.
- **Close dialog**: when user clicks close button with a running evaluation, shows a 3-option modal:
  - Close window (evaluation continues in background)
  - Cancel evaluation and close
  - Go back
- Dialog shows live evaluation info: project name, current dimension, phase

## Test plan

- [x] Close window during evaluation — dialog appears with eval info
- [x] "Keep running" — window closes, evaluation continues
- [x] "Cancel and close" — evaluation killed, window closes
- [x] "Go back" — dialog dismissed, nothing happens
- [x] Close window with no evaluation — closes immediately