### PR TITLE
feat: desktop distribution — standalone app packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,7 @@ Click any dimension, file, or principle to explore the details.
 
 A native menu bar companion app to manage the dashboard — start/stop the server, see evaluation status at a glance, and open the dashboard in one click.
 
-> **Early preview:** You can try it now by downloading the DMG from [Releases](https://github.com/quodeq/quodeq/releases/latest). Since it's not yet signed, allow it with:
-> ```bash
-> xattr -cr /Applications/QuodeqBar.app
-> ```
+> **Early preview:** You can try it now by downloading the DMG from [Releases](https://github.com/quodeq/quodeq/releases/latest). Since it's not yet signed, on first launch right-click the app → **Open**, then click **Open** in the dialog.
 
 ### CLI usage
 

--- a/packaging/macos/build-dashboard-dmg.sh
+++ b/packaging/macos/build-dashboard-dmg.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build Quodeq.dmg for macOS — standalone dashboard app
+# Usage: ./packaging/macos/build-dashboard-dmg.sh
+# Prerequisites: brew install create-dmg (optional, for styled DMG)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD_DIR="$REPO_ROOT/dist/dashboard-build"
+DMG_DIR="$REPO_ROOT/dist"
+
+# DMG layout settings
+DMG_WINDOW_X=200
+DMG_WINDOW_Y=120
+DMG_WINDOW_WIDTH=540
+DMG_WINDOW_HEIGHT=380
+DMG_ICON_SIZE=100
+DMG_TEXT_SIZE=13
+DMG_APP_ICON_X=150
+DMG_APP_ICON_Y=180
+DMG_DROP_LINK_X=390
+DMG_DROP_LINK_Y=180
+
+VERSION=$(python3 -c "
+import re
+text = open('$REPO_ROOT/pyproject.toml').read()
+print(re.search(r'version = \"(.+?)\"', text).group(1))
+")
+echo "Building Quodeq v$VERSION..."
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR" "$DMG_DIR"
+
+# Step 1: Build web UI (always fresh to avoid stale asset hashes)
+# Vite outputs directly to src/quodeq/static/ via its config
+STATIC_DIR="$REPO_ROOT/src/quodeq/static"
+rm -rf "$STATIC_DIR"
+echo "==> Building web UI..."
+cd "$REPO_ROOT/src/quodeq/ui" && npm ci && npm run build
+cd "$REPO_ROOT"
+
+# Step 2: Bundle with PyInstaller
+echo "==> Building app bundle..."
+export QUODEQ_REPO_ROOT="$REPO_ROOT"
+export QUODEQ_VERSION="$VERSION"
+uv run --with pyinstaller --with pywebview --with flask --with jsonschema pyinstaller \
+    "$SCRIPT_DIR/quodeq_dashboard.spec" \
+    --distpath "$BUILD_DIR/dist" \
+    --workpath "$BUILD_DIR/work"
+
+APP="$BUILD_DIR/dist/Quodeq.app"
+
+if [ ! -d "$APP" ]; then
+    echo "ERROR: Quodeq.app was not created."
+    exit 1
+fi
+
+echo "  Created $APP"
+
+# Step 3: Strip quarantine attribute so users don't need xattr -cr
+xattr -cr "$APP"
+
+# Step 4: Create DMG
+echo "==> Creating DMG..."
+DMG_PATH="$DMG_DIR/Quodeq-${VERSION}-macOS.dmg"
+rm -f "$DMG_PATH"
+
+if command -v create-dmg &>/dev/null; then
+    DMGOPTS=(
+        --volname "Quodeq"
+        --volicon "$SCRIPT_DIR/volicon.icns"
+        --background "$SCRIPT_DIR/dmg-background.png"
+        --window-pos "$DMG_WINDOW_X" "$DMG_WINDOW_Y"
+        --window-size "$DMG_WINDOW_WIDTH" "$DMG_WINDOW_HEIGHT"
+        --icon-size "$DMG_ICON_SIZE"
+        --text-size "$DMG_TEXT_SIZE"
+        --icon "Quodeq.app" "$DMG_APP_ICON_X" "$DMG_APP_ICON_Y"
+        --hide-extension "Quodeq.app"
+        --app-drop-link "$DMG_DROP_LINK_X" "$DMG_DROP_LINK_Y"
+        --no-internet-enable
+    )
+    create-dmg "${DMGOPTS[@]}" "$DMG_PATH" "$APP" || true
+else
+    hdiutil create -volname "Quodeq $VERSION" \
+        -srcfolder "$APP" \
+        -ov -format UDZO \
+        "$DMG_PATH"
+fi
+
+if [ -f "$DMG_PATH" ]; then
+    SIZE=$(du -h "$DMG_PATH" | cut -f1)
+    echo ""
+    echo "==> Done: $DMG_PATH ($SIZE)"
+else
+    echo "ERROR: DMG was not created."
+    exit 1
+fi

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -73,6 +73,9 @@ cp "$SCRIPT_DIR/icon.icns" "$APP/Contents/Resources/icon.icns"
 
 echo "  Created $APP"
 
+# Strip quarantine attribute so users don't need xattr -cr
+xattr -cr "$APP"
+
 # Step 2: Create DMG
 echo "==> Creating DMG..."
 DMG_PATH="$DMG_DIR/QuodeqBar-${VERSION}-macOS.dmg"

--- a/packaging/macos/dashboard_entry.py
+++ b/packaging/macos/dashboard_entry.py
@@ -1,0 +1,50 @@
+"""PyInstaller entry point for the Quodeq Dashboard.
+
+Dispatches internal subprocess flags before falling through to the
+normal dashboard CLI.  Flags use a leading underscore to signal they
+are private / not user-facing.
+"""
+import os
+import sys
+
+
+def _setup_frozen_env() -> None:
+    """Set environment variables for frozen mode."""
+    base = sys._MEIPASS  # type: ignore[attr-defined]
+    os.environ.setdefault("QUODEQ_STATIC_DIST", os.path.join(base, "quodeq", "static"))
+
+
+def main() -> int:
+    if getattr(sys, "frozen", False):
+        _setup_frozen_env()
+
+    # Internal subprocess dispatch — checked before heavy imports.
+    if len(sys.argv) > 1:
+        flag = sys.argv[1]
+
+        if flag == "--_api":
+            from quodeq.api.app import main as api_main
+            api_main()
+            return 0
+
+        if flag == "--_webview":
+            # Rewrite argv so _webview_window.main() sees [prog, url, sock, pid]
+            sys.argv = [sys.argv[0]] + sys.argv[2:]
+            from quodeq.dashboard._webview_window import main as webview_main
+            webview_main()
+            return 0
+
+    # Normal dashboard launch — force --no-build in frozen mode
+    argv = None
+    if getattr(sys, "frozen", False):
+        raw = sys.argv[1:]
+        if "--no-build" not in raw:
+            raw.append("--no-build")
+        argv = raw
+
+    from quodeq.dashboard.cli import main as dashboard_main
+    return dashboard_main(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/macos/quodeq_dashboard.spec
+++ b/packaging/macos/quodeq_dashboard.spec
@@ -1,0 +1,105 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for Quodeq Dashboard macOS .app bundle."""
+
+import os
+import sys
+from pathlib import Path
+
+repo_root = Path(os.environ["QUODEQ_REPO_ROOT"])
+src_dir = repo_root / "src"
+pkg_dir = repo_root / "packaging" / "macos"
+
+# ── Data files ──
+datas = []
+
+data_dir = src_dir / "quodeq" / "data"
+if data_dir.exists():
+    datas.append((str(data_dir), "quodeq/data"))
+
+static_dir = src_dir / "quodeq" / "static"
+if static_dir.exists():
+    datas.append((str(static_dir), "quodeq/static"))
+
+defaults_json = src_dir / "quodeq" / "shared" / "defaults.json"
+if defaults_json.exists():
+    datas.append((str(defaults_json), "quodeq/shared"))
+
+# Bundle icons so _icon_path() finds them in frozen mode
+icon_icns = pkg_dir / "icon.icns"
+if icon_icns.exists():
+    datas.append((str(icon_icns), "packaging/macos"))
+
+icon_ico = repo_root / "packaging" / "windows" / "icon.ico"
+if icon_ico.exists():
+    datas.append((str(icon_ico), "packaging/windows"))
+
+# ── Analysis ──
+a = Analysis(
+    [str(pkg_dir / "dashboard_entry.py")],
+    pathex=[str(src_dir)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        # quodeq modules
+        "quodeq.cli",
+        "quodeq.dashboard.cli",
+        "quodeq.dashboard._webview_window",
+        "quodeq.dashboard._instance",
+        "quodeq.dashboard._frozen",
+        "quodeq.api.app",
+        "quodeq.api.routes",
+        "quodeq.services.filesystem",
+        "quodeq.services.jobs",
+        "quodeq.services.accumulated",
+        "quodeq.services.dashboard",
+        "quodeq.analysis.runner",
+        "quodeq.analysis.subprocess",
+        "quodeq.core.scoring.engine",
+        "quodeq.core.scoring.report",
+        # dependencies
+        "flask",
+        "jsonschema",
+        "webview",
+        "webview.platforms.cocoa",
+    ],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Quodeq",
+    debug=False,
+    strip=True,
+    upx=False,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=True,
+    upx=False,
+    name="Quodeq",
+)
+
+app = BUNDLE(
+    coll,
+    name="Quodeq.app",
+    icon=str(icon_icns) if icon_icns.exists() else None,
+    bundle_identifier="com.quodeq.app",
+    info_plist={
+        "CFBundleShortVersionString": os.environ.get("QUODEQ_VERSION", "0.10.0"),
+        "CFBundleVersion": os.environ.get("QUODEQ_VERSION", "0.10.0"),
+        "CFBundleDisplayName": "Quodeq",
+        "CFBundleName": "Quodeq",
+        "NSHighResolutionCapable": True,
+        "NSRequiresAquaSystemAppearance": False,
+        "LSBackgroundOnly": False,
+    },
+)

--- a/packaging/windows/build-exe.ps1
+++ b/packaging/windows/build-exe.ps1
@@ -1,0 +1,59 @@
+# Build Quodeq.exe for Windows
+# Usage: .\packaging\windows\build-exe.ps1
+# Prerequisites: Python 3.12+, Node.js, uv
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path "$ScriptDir\..\..").Path
+$BuildDir = "$RepoRoot\dist\dashboard-build"
+$DistDir = "$RepoRoot\dist"
+
+# Extract version
+$Version = python3 -c "import re; print(re.search(r'version = \`"(.+?)\`"', open('$RepoRoot\pyproject.toml').read()).group(1))"
+Write-Host "Building Quodeq v$Version..."
+
+# Clean build dir
+if (Test-Path $BuildDir) { Remove-Item -Recurse -Force $BuildDir }
+New-Item -ItemType Directory -Force -Path $BuildDir | Out-Null
+New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+
+# Step 1: Build web UI (always fresh)
+$StaticDir = "$RepoRoot\src\quodeq\static"
+if (Test-Path $StaticDir) { Remove-Item -Recurse -Force $StaticDir }
+Write-Host "==> Building web UI..."
+Push-Location "$RepoRoot\src\quodeq\ui"
+npm ci
+npm run build
+Pop-Location
+
+if (-not (Test-Path "$StaticDir\index.html")) {
+    Write-Error "ERROR: UI build failed — no index.html"
+    exit 1
+}
+
+# Step 2: Bundle with PyInstaller
+Write-Host "==> Building exe..."
+$env:QUODEQ_REPO_ROOT = $RepoRoot
+$env:QUODEQ_VERSION = $Version
+uv run --with pyinstaller --with pywebview --with flask --with jsonschema pyinstaller `
+    "$ScriptDir\quodeq_dashboard.spec" `
+    --distpath "$BuildDir\dist" `
+    --workpath "$BuildDir\work"
+
+$ExeDir = "$BuildDir\dist\Quodeq"
+if (-not (Test-Path "$ExeDir\Quodeq.exe")) {
+    Write-Error "ERROR: Quodeq.exe was not created."
+    exit 1
+}
+
+Write-Host "  Created $ExeDir\Quodeq.exe"
+
+# Step 3: Copy to dist
+$ZipPath = "$DistDir\Quodeq-$Version-Windows.zip"
+if (Test-Path $ZipPath) { Remove-Item $ZipPath }
+Compress-Archive -Path "$ExeDir\*" -DestinationPath $ZipPath
+
+$Size = (Get-Item $ZipPath).Length / 1MB
+Write-Host ""
+Write-Host "==> Done: $ZipPath ($([math]::Round($Size, 1)) MB)"

--- a/packaging/windows/quodeq_dashboard.spec
+++ b/packaging/windows/quodeq_dashboard.spec
@@ -1,0 +1,91 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for Quodeq Dashboard Windows .exe bundle."""
+
+import os
+import sys
+from pathlib import Path
+
+repo_root = Path(os.environ["QUODEQ_REPO_ROOT"])
+src_dir = repo_root / "src"
+pkg_mac = repo_root / "packaging" / "macos"
+pkg_win = repo_root / "packaging" / "windows"
+
+# ── Data files ──
+datas = []
+
+data_dir = src_dir / "quodeq" / "data"
+if data_dir.exists():
+    datas.append((str(data_dir), "quodeq/data"))
+
+static_dir = src_dir / "quodeq" / "static"
+if static_dir.exists():
+    datas.append((str(static_dir), "quodeq/static"))
+
+defaults_json = src_dir / "quodeq" / "shared" / "defaults.json"
+if defaults_json.exists():
+    datas.append((str(defaults_json), "quodeq/shared"))
+
+# Bundle icons so _icon_path() finds them in frozen mode
+icon_ico = pkg_win / "icon.ico"
+if icon_ico.exists():
+    datas.append((str(icon_ico), "packaging/windows"))
+
+icon_icns = pkg_mac / "icon.icns"
+if icon_icns.exists():
+    datas.append((str(icon_icns), "packaging/macos"))
+
+# ── Analysis ──
+a = Analysis(
+    [str(pkg_mac / "dashboard_entry.py")],
+    pathex=[str(src_dir)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[
+        # quodeq modules
+        "quodeq.cli",
+        "quodeq.dashboard.cli",
+        "quodeq.dashboard._webview_window",
+        "quodeq.dashboard._instance",
+        "quodeq.dashboard._frozen",
+        "quodeq.api.app",
+        "quodeq.api.routes",
+        "quodeq.services.filesystem",
+        "quodeq.services.jobs",
+        "quodeq.services.accumulated",
+        "quodeq.services.dashboard",
+        "quodeq.analysis.runner",
+        "quodeq.analysis.subprocess",
+        "quodeq.core.scoring.engine",
+        "quodeq.core.scoring.report",
+        # dependencies
+        "flask",
+        "jsonschema",
+        "webview",
+        "webview.platforms.edgechromium",
+    ],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="Quodeq",
+    debug=False,
+    strip=False,
+    upx=False,
+    console=False,
+    icon=str(icon_ico) if icon_ico.exists() else None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=False,
+    name="Quodeq",
+)

--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.shared.logging import log_warning
-from quodeq.shared.utils import ACTION_API_MODULE, IS_WIN32 as _IS_WIN32, get_evaluations_dir
+from quodeq.shared.utils import IS_WIN32 as _IS_WIN32, get_evaluations_dir
 
 from quodeq.dashboard._api_health_check import wait_for_action_api
+from quodeq.dashboard._frozen import subprocess_cmd
 
 _ENV_ACTION_API_PORT = "QUODEQ_ACTION_API_PORT"
 _ENV_ACTION_API_HOST = "QUODEQ_ACTION_API_HOST"
@@ -51,7 +52,7 @@ def spawn_action_api(
     env[_ENV_EVALUATIONS_DIR] = cfg.evaluations_dir or get_evaluations_dir()
     verbose = env.get("QUODEQ_VERBOSE") == "1"
     proc = subprocess.Popen(
-        [sys.executable, "-m", ACTION_API_MODULE],
+        subprocess_cmd("api"),
         env=env,
         stdout=None if verbose else subprocess.DEVNULL,
         stderr=None if verbose else subprocess.DEVNULL,

--- a/src/quodeq/dashboard/_frozen.py
+++ b/src/quodeq/dashboard/_frozen.py
@@ -1,0 +1,26 @@
+"""Frozen-app subprocess command helpers for PyInstaller bundles."""
+from __future__ import annotations
+
+import sys
+
+_MODULE_MAP = {
+    "api": "quodeq.api.app",
+    "webview": "quodeq.dashboard._webview_window",
+}
+
+
+def is_frozen() -> bool:
+    """Return True when running inside a PyInstaller bundle."""
+    return getattr(sys, "frozen", False)
+
+
+def subprocess_cmd(mode: str, args: list[str] | None = None) -> list[str]:
+    """Return the subprocess command for *mode*.
+
+    Frozen:   [sys.executable, "--_<mode>", ...args]
+    Unfrozen: [sys.executable, "-m", "<module>", ...args]
+    """
+    extra = args or []
+    if is_frozen():
+        return [sys.executable, f"--_{mode}"] + extra
+    return [sys.executable, "-m", _MODULE_MAP[mode]] + extra

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -18,6 +18,7 @@ from quodeq.dashboard._networking import (
     _is_port_open,
     _local_hosts,
 )
+from quodeq.dashboard._frozen import subprocess_cmd
 from quodeq.dashboard._process import (
     _PROCESS_WAIT_TIMEOUT_S,
     _spawn_and_wait_local,
@@ -139,8 +140,7 @@ def _serve_native(
     api_pid = str(action_api_process.pid) if action_api_process else ""
 
     subprocess.Popen(
-        [sys.executable, "-m", "quodeq.dashboard._webview_window",
-         action_api_url, str(instance._sock_path), api_pid],
+        subprocess_cmd("webview", [action_api_url, str(instance._sock_path), api_pid]),
         start_new_session=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -235,11 +235,14 @@ def _kill_api(pid: int) -> None:
 
 def _icon_path(ext: str) -> str | None:
     """Resolve the quodeq icon path for the given extension (.icns or .ico)."""
-    p = Path(__file__).resolve().parent.parent.parent.parent / "packaging"
+    if getattr(sys, "frozen", False):
+        base = Path(sys._MEIPASS) / "packaging"  # type: ignore[attr-defined]
+    else:
+        base = Path(__file__).resolve().parent.parent.parent.parent / "packaging"
     if ext == ".icns":
-        p = p / "macos" / "icon.icns"
+        p = base / "macos" / "icon.icns"
     elif ext == ".ico":
-        p = p / "windows" / "icon.ico"
+        p = base / "windows" / "icon.ico"
     else:
         return None
     return str(p) if p.exists() else None


### PR DESCRIPTION
## Summary
- Add PyInstaller packaging to bundle the dashboard as a standalone desktop app (Quodeq.app on macOS, Quodeq.exe on Windows)
- Frozen-aware subprocess dispatch (`_frozen.py`) so the bundled app correctly spawns Flask API and PyWebView window subprocesses
- Build scripts: `build-dashboard-dmg.sh` (macOS) and `build-exe.ps1` (Windows) with fresh UI build, xattr quarantine stripping, and DMG/zip creation
- Update README to recommend right-click → Open instead of `xattr -cr`

## Test plan
- [x] All 850 existing tests pass
- [x] macOS: `./packaging/macos/build-dashboard-dmg.sh` produces working `Quodeq.app` inside `.dmg`
- [x] Dashboard loads correctly in the pywebview window (Flask API + static assets)
- [x] Windows: `.\packaging\windows\build-exe.ps1` (needs Windows runner)