### PR TITLE
feat: add Help tab with usage documentation

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -11,6 +11,7 @@ import SettingsPage from './features/settings/components/SettingsPage.jsx';
 import StandardsPage from './features/standards/StandardsPage.jsx';
 import ViolationsPage from './features/violations/components/ViolationsPage.jsx';
 import MapPage from './features/map/components/MapPage.jsx';
+import HelpPage from './features/help/components/HelpPage.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
 import { dismissFinding } from './api/index.js';
 import LoadingScreen from './components/LoadingScreen.jsx';
@@ -196,6 +197,7 @@ const ROUTE_RENDERERS = {
   settings: (params, props) => <SettingsCase settings={props.settings} />,
   projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
   standards: () => <StandardsPage />,
+  help: () => <HelpPage />,
 };
 
 /**
@@ -204,7 +206,7 @@ const ROUTE_RENDERERS = {
  */
 function MainContent({ activePage, props }) {
   const { page, ...params } = activePage;
-  const noProjectTabs = ['evaluate', 'standards', 'settings'];
+  const noProjectTabs = ['evaluate', 'standards', 'settings', 'help'];
   if (!noProjectTabs.includes(page)) {
     const projects = props.navigation?.projects;
     if (!projects || projects.length === 0) {

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS, ICON_STANDARDS } from '../constants/navigation.jsx';
+import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_PROJECTS, ICON_SETTINGS, ICON_STANDARDS, ICON_HELP } from '../constants/navigation.jsx';
 
 function Logo() {
   return (
@@ -58,6 +58,7 @@ export default function Sidebar({ activeTab, onNavTab }) {
       </nav>
 
       <div className="sidebar-bottom-nav">
+        <NavButton id="help" label="Help" icon={ICON_HELP} activeTab={activeTab} onNavTab={onNavTab} />
         <NavButton id="settings" label="Settings" icon={ICON_SETTINGS} activeTab={activeTab} onNavTab={onNavTab} />
       </div>
     </aside>

--- a/src/quodeq/ui/src/constants/navigation.jsx
+++ b/src/quodeq/ui/src/constants/navigation.jsx
@@ -60,6 +60,14 @@ export const ICON_SETTINGS = (
   </svg>
 );
 
+export const ICON_HELP = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
 export const ICON_STANDARDS = (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
     <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7l3-7z" />

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -51,7 +51,7 @@ function Providers() {
 
       <h3>Local Providers (Ollama)</h3>
       <div className="help-callout help-callout-tip">
-        <strong>Recommended model:</strong> <code>gemma4:26b</code> offers excellent quality-to-cost ratio for local analysis. It runs well on machines with 32GB+ RAM.
+        <strong>Recommended model:</strong> <code>gemma4:26b</code> offers excellent quality-to-cost ratio for local analysis. Even limiting context to 32k tokens, we observed strong results.
       </div>
       <p>To use Ollama:</p>
       <ol>

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -1,0 +1,347 @@
+import { useState } from 'react';
+
+const SECTIONS = [
+  { id: 'getting-started', label: 'Getting Started' },
+  { id: 'providers', label: 'AI Providers' },
+  { id: 'evaluations', label: 'Running Evaluations' },
+  { id: 'dimensions', label: 'Quality Dimensions' },
+  { id: 'violations', label: 'Navigating Violations' },
+  { id: 'map', label: 'Code Map' },
+  { id: 'standards', label: 'Custom Standards' },
+  { id: 'settings', label: 'Settings' },
+  { id: 'subprojects', label: 'Sub-projects' },
+];
+
+function SectionNav({ active, onSelect }) {
+  return (
+    <nav className="help-section-nav">
+      {SECTIONS.map(s => (
+        <button key={s.id} className={`help-section-btn${active === s.id ? ' active' : ''}`} onClick={() => onSelect(s.id)}>{s.label}</button>
+      ))}
+    </nav>
+  );
+}
+
+function GettingStarted() {
+  return (
+    <section className="help-section">
+      <h2>Getting Started</h2>
+      <p>Quodeq evaluates your codebase across six quality dimensions based on ISO 25010. It uses AI to analyze source code, identify violations, and score each dimension.</p>
+      <h3>Quick start</h3>
+      <ol>
+        <li>Go to the <strong>Evaluate</strong> tab</li>
+        <li>Enter a local path, GitHub URL, or SSH path to your repository</li>
+        <li>Click <strong>Start Evaluation</strong></li>
+        <li>Once complete, explore results in the <strong>Overview</strong>, <strong>Violations</strong>, and <strong>Map</strong> tabs</li>
+      </ol>
+      <h3>Requirements</h3>
+      <ul>
+        <li><strong>Python 3.12+</strong> and <strong>Node.js 18+</strong></li>
+        <li>At least one AI provider configured (see AI Providers section)</li>
+      </ul>
+    </section>
+  );
+}
+
+function Providers() {
+  return (
+    <section className="help-section">
+      <h2>AI Providers</h2>
+      <p>Quodeq supports multiple AI providers for analysis. Configure them in the <strong>Settings</strong> tab.</p>
+
+      <h3>Local Providers (Ollama)</h3>
+      <div className="help-callout help-callout-tip">
+        <strong>Recommended model:</strong> <code>gemma3:27b</code> offers excellent quality-to-cost ratio for local analysis. It runs well on machines with 32GB+ RAM.
+      </div>
+      <p>To use Ollama:</p>
+      <ol>
+        <li>Install Ollama from <code>ollama.com</code></li>
+        <li>Pull a model: <code>ollama pull gemma3:27b</code></li>
+        <li>In Settings, select the <strong>Ollama</strong> provider tab</li>
+        <li>Choose your model and configure the number of subagents</li>
+      </ol>
+      <p>Local models are <strong>free and private</strong> — your code never leaves your machine. The trade-off is slower analysis and potentially lower accuracy compared to cloud models.</p>
+
+      <h3>Cloud Providers</h3>
+      <div className="help-callout help-callout-warning">
+        <strong>Watch your token usage.</strong> Cloud providers charge per token. A full evaluation of a medium codebase can use significant tokens. Monitor your usage in your provider's dashboard.
+      </div>
+      <p>Recommended cloud models:</p>
+      <ul>
+        <li><strong>Claude Sonnet</strong> (Anthropic) — best balance of speed, quality, and cost</li>
+        <li><strong>GPT-4.1</strong> (OpenAI) — strong alternative, good for diverse codebases</li>
+      </ul>
+      <p>To configure a cloud provider:</p>
+      <ol>
+        <li>In Settings, select the <strong>CLI Provider</strong> tab</li>
+        <li>Ensure your AI CLI (Claude Code, Codex, etc.) is installed and authenticated</li>
+        <li>Select the model and power level for your evaluation</li>
+      </ol>
+
+      <h3>Power levels</h3>
+      <table className="help-table">
+        <thead>
+          <tr><th>Level</th><th>Model tier</th><th>Speed</th><th>Depth</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>1 - Fast</td><td>Haiku / small</td><td>Fastest</td><td>Surface-level</td></tr>
+          <tr><td>2 - Balanced</td><td>Sonnet / medium</td><td>Moderate</td><td>Good coverage</td></tr>
+          <tr><td>3 - Thorough</td><td>Opus / large</td><td>Slowest</td><td>Deep analysis</td></tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function Evaluations() {
+  return (
+    <section className="help-section">
+      <h2>Running Evaluations</h2>
+      <p>Navigate to the <strong>Evaluate</strong> tab to start an analysis.</p>
+
+      <h3>Input types</h3>
+      <ul>
+        <li><strong>Local path:</strong> <code>/path/to/your/project</code></li>
+        <li><strong>GitHub URL:</strong> <code>https://github.com/org/repo</code></li>
+        <li><strong>SSH path:</strong> <code>git@github.com:org/repo.git</code></li>
+      </ul>
+
+      <h3>Evaluation options</h3>
+      <ul>
+        <li><strong>Dimensions:</strong> Choose which quality dimensions to evaluate (default: all six)</li>
+        <li><strong>Branch:</strong> Select a specific branch to analyze</li>
+        <li><strong>Scope:</strong> Narrow analysis to a subdirectory within the repository</li>
+        <li><strong>Subagents:</strong> Number of parallel AI agents (more = faster, more tokens)</li>
+      </ul>
+
+      <h3>Scan types</h3>
+      <div className="help-callout help-callout-info">
+        <strong>Incremental scan:</strong> Only re-evaluates files that changed since the last run. Much faster for iterative development. Enable the <em>Incremental</em> toggle before starting.
+      </div>
+      <ul>
+        <li><strong>Full scan:</strong> Evaluates the entire codebase from scratch. Use for first-time analysis or after major refactors.</li>
+        <li><strong>Incremental scan:</strong> Detects changed files via git diff and only re-evaluates those. Previous findings for unchanged files are carried forward. Significantly faster and cheaper.</li>
+      </ul>
+
+      <h3>Re-evaluate</h3>
+      <p>From the <strong>Evaluate</strong> tab, you can re-run an evaluation on an existing project. The new results will appear as a new run in the history, allowing you to track quality over time.</p>
+    </section>
+  );
+}
+
+function Dimensions() {
+  return (
+    <section className="help-section">
+      <h2>Quality Dimensions (ISO 25010)</h2>
+      <p>Quodeq evaluates code across six dimensions derived from the ISO/IEC 25010 software quality standard:</p>
+
+      <table className="help-table">
+        <thead>
+          <tr><th>Dimension</th><th>Focus</th><th>Examples</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Security</strong></td><td>Vulnerabilities, authentication, data protection</td><td>SQL injection, hardcoded secrets, missing auth</td></tr>
+          <tr><td><strong>Reliability</strong></td><td>Error handling, fault tolerance, recovery</td><td>Unhandled exceptions, missing retries, resource leaks</td></tr>
+          <tr><td><strong>Maintainability</strong></td><td>Code clarity, modularity, testability</td><td>Long functions, duplicated code, tight coupling</td></tr>
+          <tr><td><strong>Performance</strong></td><td>Efficiency, resource usage, scalability</td><td>N+1 queries, memory leaks, missing caching</td></tr>
+          <tr><td><strong>Flexibility</strong></td><td>Extensibility, configurability, portability</td><td>Hardcoded values, missing interfaces, vendor lock-in</td></tr>
+          <tr><td><strong>Usability</strong></td><td>API design, documentation, developer experience</td><td>Confusing APIs, missing docs, inconsistent naming</td></tr>
+        </tbody>
+      </table>
+
+      <p>Each dimension is scored 0-10 and receives a letter grade (A-F). The overall score is a weighted average across all dimensions.</p>
+
+      <h3>Creating custom dimensions</h3>
+      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against.</p>
+      <div className="help-callout help-callout-tip">
+        <strong>Tip:</strong> You can ask an AI agent to create custom dimensions for you based on the schema below.
+      </div>
+
+      <h3>Standard schema</h3>
+      <pre className="help-code">{`{
+  "id": "my-standard",
+  "name": "My Custom Standard",
+  "dimension": "security",
+  "version": "1.0",
+  "principles": [
+    {
+      "name": "Principle Name",
+      "description": "What this principle evaluates",
+      "requirements": [
+        {
+          "id": "MY-REQ-1",
+          "text": "The specific requirement to check",
+          "severity": "major"
+        }
+      ]
+    }
+  ]
+}`}</pre>
+      <p>To create a standard with an AI agent, provide the schema above and describe your evaluation criteria. The agent can generate a complete standard JSON that you can import in the Standards tab.</p>
+    </section>
+  );
+}
+
+function Violations() {
+  return (
+    <section className="help-section">
+      <h2>Navigating Violations</h2>
+      <p>The <strong>Violations</strong> tab shows all findings across your project, organized by dimension and severity.</p>
+
+      <h3>Severity levels</h3>
+      <table className="help-table">
+        <thead>
+          <tr><th>Severity</th><th>Impact</th><th>Action</th></tr>
+        </thead>
+        <tbody>
+          <tr><td className="help-severity-critical">Critical</td><td>Immediate security or reliability risk</td><td>Fix immediately</td></tr>
+          <tr><td className="help-severity-major">Major</td><td>Significant quality issue</td><td>Fix before release</td></tr>
+          <tr><td className="help-severity-minor">Minor</td><td>Code improvement opportunity</td><td>Fix when convenient</td></tr>
+          <tr><td className="help-severity-info">Info</td><td>Suggestion or best practice</td><td>Consider for future</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Exploring findings</h3>
+      <ul>
+        <li><strong>Click a dimension</strong> to see all findings for that quality area</li>
+        <li><strong>Click a file</strong> to see all violations in that specific file with code context</li>
+        <li><strong>Click a principle</strong> to see all violations for that evaluation rule</li>
+        <li><strong>Severity cells</strong> in the grid are clickable — they filter by both dimension and severity</li>
+      </ul>
+
+      <h3>Dismissing findings</h3>
+      <p>If a finding is a false positive or intentionally accepted, you can dismiss it. Dismissed findings are excluded from scoring in future runs but can be restored at any time.</p>
+    </section>
+  );
+}
+
+function CodeMap() {
+  return (
+    <section className="help-section">
+      <h2>Code Map</h2>
+      <p>The <strong>Map</strong> tab provides a visual representation of your codebase structure and quality.</p>
+
+      <h3>Treemap view</h3>
+      <p>Files are displayed as rectangles sized by their line count. Color indicates the severity density — red areas have more critical violations, green areas are clean.</p>
+      <p>This makes it easy to spot:</p>
+      <ul>
+        <li><strong>Large red blocks:</strong> Big files with many issues — high-impact refactoring targets</li>
+        <li><strong>Clusters of red:</strong> Entire modules that need attention</li>
+        <li><strong>Green areas:</strong> Well-maintained parts of the codebase</li>
+      </ul>
+
+      <h3>Risk matrix</h3>
+      <p>The risk matrix plots files by complexity (size) vs. issue density, helping you prioritize which files to fix first. Files in the top-right quadrant are both complex and problematic — tackle those first.</p>
+
+      <p>Click any file in the map to see its detailed violations and code context.</p>
+    </section>
+  );
+}
+
+function Standards() {
+  return (
+    <section className="help-section">
+      <h2>Custom Standards</h2>
+      <p>The <strong>Standards</strong> tab lets you create, edit, and manage evaluation standards.</p>
+
+      <h3>Built-in standards</h3>
+      <p>Quodeq ships with standards based on ISO 25010 for each of the six dimensions. These provide comprehensive coverage out of the box.</p>
+
+      <h3>Creating your own</h3>
+      <ol>
+        <li>Click <strong>New Standard</strong> in the Standards tab</li>
+        <li>Define principles (evaluation categories) and requirements (specific checks)</li>
+        <li>Assign severity levels to each requirement</li>
+        <li>Save — your standard will be used in the next evaluation</li>
+      </ol>
+
+      <h3>Importing from library</h3>
+      <p>You can import pre-built standards from the Quodeq library. Click <strong>Import</strong> and browse available standards.</p>
+
+      <h3>Using AI to generate standards</h3>
+      <p>Provide an AI agent with the JSON schema (shown in the Dimensions section) and describe what you want to evaluate. For example:</p>
+      <pre className="help-code">{`"Create a Quodeq evaluation standard for
+React component best practices. Include
+principles for accessibility, performance,
+state management, and error boundaries.
+Use the following JSON schema: { ... }"`}</pre>
+    </section>
+  );
+}
+
+function Settings() {
+  return (
+    <section className="help-section">
+      <h2>Settings</h2>
+      <p>Configure your AI provider, models, and dashboard preferences in the <strong>Settings</strong> tab.</p>
+
+      <h3>Provider configuration</h3>
+      <ul>
+        <li><strong>CLI Provider:</strong> Uses an installed AI CLI (Claude Code, Codex). Configure the power level and model.</li>
+        <li><strong>Ollama:</strong> Uses a locally running Ollama instance. Select model and configure parallelism.</li>
+      </ul>
+
+      <h3>Model selection</h3>
+      <p>Each power level maps to a model tier. You can override the default model for each level in Settings. Custom model names are stored locally.</p>
+
+      <h3>Server info</h3>
+      <p>The Settings tab shows the current server status including port, PID, and version. Use this to verify the dashboard is connected to the correct backend.</p>
+
+      <h3>Theme</h3>
+      <p>Choose between light and dark mode, and select a theme family for the dashboard appearance.</p>
+    </section>
+  );
+}
+
+function SubProjects() {
+  return (
+    <section className="help-section">
+      <h2>Evaluating Sub-projects</h2>
+      <p>Quodeq supports evaluating specific parts of a monorepo or multi-project repository.</p>
+
+      <h3>Using scope</h3>
+      <p>When starting an evaluation, use the <strong>Scope</strong> option to specify a subdirectory:</p>
+      <pre className="help-code">{`Repository: /path/to/monorepo
+Scope:      packages/frontend`}</pre>
+      <p>This evaluates only the files within that subdirectory, producing a focused report for that sub-project.</p>
+
+      <h3>Multiple evaluations</h3>
+      <p>Run separate evaluations for each sub-project. Each appears as a distinct project in the dashboard with its own history and scores. You can compare quality across sub-projects in the <strong>Projects</strong> tab.</p>
+
+      <h3>Project hierarchy</h3>
+      <p>When you evaluate subdirectories of the same repository, Quodeq automatically detects the parent-child relationship and groups them in the project list.</p>
+    </section>
+  );
+}
+
+const SECTION_COMPONENTS = {
+  'getting-started': GettingStarted,
+  'providers': Providers,
+  'evaluations': Evaluations,
+  'dimensions': Dimensions,
+  'violations': Violations,
+  'map': CodeMap,
+  'standards': Standards,
+  'settings': Settings,
+  'subprojects': SubProjects,
+};
+
+export default function HelpPage() {
+  const [activeSection, setActiveSection] = useState('getting-started');
+  const Section = SECTION_COMPONENTS[activeSection] || GettingStarted;
+
+  return (
+    <div className="help-page">
+      <div className="page-header">
+        <h1 className="page-title">Help</h1>
+        <p className="page-subtitle">Learn how to use Quodeq to evaluate and improve your code quality</p>
+      </div>
+      <div className="help-layout">
+        <SectionNav active={activeSection} onSelect={setActiveSection} />
+        <div className="help-content">
+          <Section />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -51,12 +51,12 @@ function Providers() {
 
       <h3>Local Providers (Ollama)</h3>
       <div className="help-callout help-callout-tip">
-        <strong>Recommended model:</strong> <code>gemma3:27b</code> offers excellent quality-to-cost ratio for local analysis. It runs well on machines with 32GB+ RAM.
+        <strong>Recommended model:</strong> <code>gemma4:26b</code> offers excellent quality-to-cost ratio for local analysis. It runs well on machines with 32GB+ RAM.
       </div>
       <p>To use Ollama:</p>
       <ol>
         <li>Install Ollama from <code>ollama.com</code></li>
-        <li>Pull a model: <code>ollama pull gemma3:27b</code></li>
+        <li>Pull a model: <code>ollama pull gemma4:26b</code></li>
         <li>In Settings, select the <strong>Ollama</strong> provider tab</li>
         <li>Choose your model and configure the number of subagents</li>
       </ol>
@@ -69,7 +69,7 @@ function Providers() {
       <p>Recommended cloud models:</p>
       <ul>
         <li><strong>Claude Sonnet</strong> (Anthropic) — best balance of speed, quality, and cost</li>
-        <li><strong>GPT-4.1</strong> (OpenAI) — strong alternative, good for diverse codebases</li>
+        <li><strong>GPT-5.3-codex</strong> (OpenAI) — strong alternative, good for diverse codebases</li>
       </ul>
       <p>To configure a cloud provider:</p>
       <ol>

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -229,32 +229,7 @@ function Dimensions() {
       <p>This lets you customize which quality aspects matter for your project without deleting any standards.</p>
 
       <h3>Creating custom dimensions</h3>
-      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against.</p>
-      <div className="help-callout help-callout-tip">
-        <strong>Tip:</strong> You can ask an AI agent to create custom dimensions for you based on the schema below.
-      </div>
-
-      <h3>Standard schema</h3>
-      <pre className="help-code">{`{
-  "id": "my-standard",
-  "name": "My Custom Standard",
-  "dimension": "security",
-  "version": "1.0",
-  "principles": [
-    {
-      "name": "Principle Name",
-      "description": "What this principle evaluates",
-      "requirements": [
-        {
-          "id": "MY-REQ-1",
-          "text": "The specific requirement to check",
-          "severity": "major"
-        }
-      ]
-    }
-  ]
-}`}</pre>
-      <p>To create a standard with an AI agent, provide the schema above and describe your evaluation criteria. The agent can generate a complete standard JSON that you can import in the Standards tab.</p>
+      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against. See the <strong>Custom Standards</strong> section for the full schema and instructions on how to create them — including how to use an AI agent to generate standards for you.</p>
     </section>
   );
 }
@@ -319,29 +294,69 @@ function Standards() {
   return (
     <section className="help-section">
       <h2>Custom Standards</h2>
-      <p>The <strong>Standards</strong> tab lets you create, edit, and manage evaluation standards.</p>
+      <p>The <strong>Standards</strong> tab lets you create, edit, and manage evaluation standards. Define what quality means for your project.</p>
 
       <h3>Built-in standards</h3>
-      <p>Quodeq ships with standards based on ISO 25010 for each of the six dimensions. These provide comprehensive coverage out of the box.</p>
+      <p>Quodeq ships with standards based on ISO 25010 for each of the six dimensions, plus Clean Architecture and DDD Design. These provide comprehensive coverage out of the box.</p>
 
       <h3>Creating your own</h3>
       <ol>
         <li>Click <strong>New Standard</strong> in the Standards tab</li>
         <li>Define principles (evaluation categories) and requirements (specific checks)</li>
-        <li>Assign severity levels to each requirement</li>
+        <li>Assign severity levels to each requirement (<code>critical</code>, <code>major</code>, or <code>minor</code>)</li>
         <li>Save — your standard will be used in the next evaluation</li>
       </ol>
 
       <h3>Importing from library</h3>
       <p>You can import pre-built standards from the Quodeq library. Click <strong>Import</strong> and browse available standards.</p>
 
+      <h3>Standard schema</h3>
+      <p>Every standard follows this JSON structure:</p>
+      <pre className="help-code">{`{
+  "id": "my-standard",
+  "name": "My Custom Standard",
+  "dimension": "security",
+  "version": "1.0",
+  "principles": [
+    {
+      "name": "Principle Name",
+      "description": "What this principle evaluates",
+      "requirements": [
+        {
+          "id": "MY-REQ-1",
+          "text": "The specific requirement to check",
+          "severity": "major"
+        }
+      ]
+    }
+  ]
+}`}</pre>
+      <p>Key fields:</p>
+      <ul>
+        <li><strong>id</strong> — unique identifier, used as filename (<code>my-standard.json</code>)</li>
+        <li><strong>dimension</strong> — the quality dimension this standard belongs to</li>
+        <li><strong>principles</strong> — categories of evaluation (e.g., "Error Handling", "Input Validation")</li>
+        <li><strong>requirements</strong> — specific checks within each principle, each with an ID and severity</li>
+      </ul>
+
       <h3>Using AI to generate standards</h3>
-      <p>Provide an AI agent with the JSON schema (shown in the Dimensions section) and describe what you want to evaluate. For example:</p>
-      <pre className="help-code">{`"Create a Quodeq evaluation standard for
-React component best practices. Include
-principles for accessibility, performance,
-state management, and error boundaries.
-Use the following JSON schema: { ... }"`}</pre>
+      <div className="help-callout help-callout-tip">
+        <strong>Tip:</strong> You can ask an AI agent (Claude, ChatGPT, etc.) to create custom standards for you. Provide the schema above and describe what you want to evaluate.
+      </div>
+      <p>Example prompt:</p>
+      <pre className="help-code">{`Create a Quodeq evaluation standard for React
+component best practices. Include principles for
+accessibility, performance, state management,
+and error boundaries.
+
+Use this JSON schema:
+{
+  "id": "react-best-practices",
+  "name": "React Best Practices",
+  "dimension": "react",
+  ...
+}`}</pre>
+      <p>The agent will generate a complete standard JSON that you can paste into the Standards editor or save as a <code>.json</code> file and import.</p>
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -40,6 +40,7 @@ function Philosophy() {
         <li><strong>Collect</strong> — findings stream in real-time as structured JSONL via tool calls</li>
         <li><strong>Score</strong> — maps findings to ISO 25010 principles with CWE classifications</li>
         <li><strong>Report</strong> — produces per-dimension reports with grades, violations, and compliance evidence</li>
+        <li><strong>Fix Plan</strong> — for each violation, you can copy a structured fix plan with file path, line number, code context, and remediation guidance — ready to paste into your AI agent or IDE to fix the issue directly</li>
       </ol>
 
       <h3>Both sides of the story</h3>

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -27,45 +27,45 @@ function Philosophy() {
   return (
     <section className="help-section">
       <h2>The Quodeq Philosophy</h2>
-      <p>Quodeq is a quality compass for your codebase — not a linter, not a static analyzer, but an AI-powered evaluator that reads and understands your code the way a senior engineer would.</p>
+      <p>Quodeq is a quality compass for your codebase. Not a linter, not a static analyzer. An AI-powered evaluator that reads and understands your code the way a senior engineer would.</p>
 
       <h3>Why Quodeq exists</h3>
       <p>Traditional code quality tools count syntax violations. They can tell you a function is too long, but not whether your architecture has a dependency leak. They can flag a missing null check, but not whether your error handling strategy is coherent across the project.</p>
-      <p>Quodeq takes a different approach: it sends an AI agent into your codebase with read-only tools to explore, understand context, and evaluate quality against structured standards. The agent reads actual code, follows imports, understands patterns — then reports what it finds with specific file locations and evidence.</p>
+      <p>Quodeq takes a different approach. It sends an AI agent into your codebase with read-only tools to explore, understand context, and evaluate quality against structured standards. The agent reads actual code, follows imports, understands patterns, and reports what it finds with specific file locations and evidence.</p>
 
       <h3>How evaluation works</h3>
       <ol>
-        <li><strong>Detect</strong> — identifies the languages, frameworks, and structure of your codebase</li>
-        <li><strong>Analyze</strong> — spawns AI agents with read-only tools (Bash, Grep, Read, Glob) to systematically explore the code</li>
-        <li><strong>Collect</strong> — findings stream in real-time as structured JSONL via tool calls</li>
-        <li><strong>Score</strong> — maps findings to ISO 25010 principles with CWE classifications</li>
-        <li><strong>Report</strong> — produces per-dimension reports with grades, violations, and compliance evidence</li>
-        <li><strong>Fix Plan</strong> — for each violation, you can copy a structured fix plan with file path, line number, code context, and remediation guidance — ready to paste into your AI agent or IDE to fix the issue directly</li>
+        <li><strong>Detect</strong> identifies the languages, frameworks, and structure of your codebase</li>
+        <li><strong>Analyze</strong> spawns AI agents with read-only tools (Bash, Grep, Read, Glob) to systematically explore the code</li>
+        <li><strong>Collect</strong> streams findings in real-time as structured JSONL via tool calls</li>
+        <li><strong>Score</strong> maps findings to ISO 25010 principles with CWE classifications</li>
+        <li><strong>Report</strong> produces per-dimension reports with grades, violations, and compliance evidence</li>
+        <li><strong>Fix Plan</strong> for each violation, you can copy a structured fix plan with file path, line number, code context, and remediation guidance, ready to paste into your AI agent or IDE</li>
       </ol>
 
       <h3>Both sides of the story</h3>
-      <p>Quodeq reports <strong>violations AND compliance</strong>. The scoring uses the ratio between them — a project with many violations but also strong compliance patterns is scored more fairly than one with the same violations and no evidence of good practices. This means the AI actively looks for files that follow standards correctly, not just files that break them.</p>
+      <p>Quodeq reports <strong>violations AND compliance</strong>. The scoring uses the ratio between them. A project with many violations but also strong compliance patterns is scored more fairly than one with the same violations and no evidence of good practices. The AI actively looks for files that follow standards correctly, not just files that break them.</p>
 
       <h3>The Q&#xB2; Scoring Formula</h3>
       <p>Each principle is scored 0-10 using four independent constraints:</p>
       <ol>
-        <li><strong>Violation Base</strong> — a hyperbolic curve where the first violations hurt most: <code>10 / (1 + K * weighted_violations)</code>. This prevents 50 minor issues from tanking a score the same way 5 critical ones would.</li>
-        <li><strong>Compliance Lift</strong> — evidence of good practices fills the gap between the base and 10. More compliance always helps, never hurts.</li>
-        <li><strong>Violation Ceiling</strong> — a log&#x2082;-based cap prevents compliance from overriding significant violations. You can't reach Exemplary with critical issues, no matter how much compliance you have.</li>
-        <li><strong>Severity Grade Floor</strong> — grade labels match reality. Only actual critical violations can produce a "Critical" grade. 50 minor violations with zero compliance still score Adequate, not Critical.</li>
+        <li><strong>Violation Base</strong> is a hyperbolic curve where the first violations hurt most: <code>10 / (1 + K * weighted_violations)</code>. This prevents 50 minor issues from tanking a score the same way 5 critical ones would.</li>
+        <li><strong>Compliance Lift</strong> fills the gap between the base and 10 with evidence of good practices. More compliance always helps, never hurts.</li>
+        <li><strong>Violation Ceiling</strong> is a log&#x2082;-based cap that prevents compliance from overriding significant violations. You cannot reach Exemplary with critical issues, no matter how much compliance you have.</li>
+        <li><strong>Severity Grade Floor</strong> ensures grade labels match reality. Only actual critical violations can produce a "Critical" grade. 50 minor violations with zero compliance still score Adequate, not Critical.</li>
       </ol>
       <pre className="help-code">{'final = max(floor, min(ceiling, base + (10 - base) * lift))'}</pre>
 
       <h3>Fair by design</h3>
       <div className="help-callout help-callout-info">
-        The scoring model was designed to address specific fairness issues: linear accumulation is unfair (39 minor issues shouldn't score the same as 39 critical flaws), compliance should be additive (not just a discount), grade names should be semantically honest, and reaching the top should require genuinely clean code.
+        The scoring model addresses specific fairness issues: linear accumulation is unfair (39 minor issues should not score the same as 39 critical flaws), compliance should be additive (not just a discount), grade names should be semantically honest, and reaching the top should require genuinely clean code.
       </div>
 
       <h3>Any language, any stack</h3>
-      <p>Quodeq can evaluate <strong>any codebase in any programming language</strong>. The AI analysis engine reads and understands code regardless of the tech stack — Python, TypeScript, Go, Rust, Java, Swift, or anything else. The standards are language-agnostic by design.</p>
+      <p>Quodeq can evaluate <strong>any codebase in any programming language</strong>. The AI analysis engine reads and understands code regardless of the tech stack. Python, TypeScript, Go, Rust, Java, Swift, or anything else. The standards are language-agnostic by design.</p>
 
       <h3>Your standards, your rules</h3>
-      <p>While Quodeq ships with ISO 25010 dimensions, Clean Architecture, and DDD standards, you can create your own. Define what quality means for your project — whether that's React component best practices, API design guidelines, or your team's internal coding standards — and Quodeq will evaluate against them.</p>
+      <p>While Quodeq ships with ISO 25010 dimensions, Clean Architecture, and DDD standards, you can create your own. Define what quality means for your project, whether that is React component best practices, API design guidelines, or your team's internal coding standards, and Quodeq will evaluate against them.</p>
     </section>
   );
 }
@@ -108,16 +108,16 @@ function Providers() {
         <li>In Settings, select the <strong>Ollama</strong> provider tab</li>
         <li>Choose your model and configure the number of subagents</li>
       </ol>
-      <p>Local models are <strong>free and private</strong> — your code never leaves your machine. The trade-off is slower analysis and potentially lower accuracy compared to cloud models.</p>
+      <p>Local models are <strong>free and private</strong>. Your code never leaves your machine. The trade-off is slower analysis and potentially lower accuracy compared to cloud models.</p>
 
       <h3>Cloud Providers</h3>
       <div className="help-callout help-callout-warning">
-        <strong>Watch your token usage.</strong> Cloud providers charge per token. A full evaluation of a medium codebase can use significant tokens. Monitor your usage in your provider's dashboard.
+        <strong>Watch your token usage.</strong> Cloud providers charge per token. A full evaluation of a medium codebase can consume significant tokens. Monitor your usage in your provider's dashboard.
       </div>
       <p>Recommended cloud models:</p>
       <ul>
-        <li><strong>Claude Sonnet</strong> (Anthropic) — best balance of speed, quality, and cost</li>
-        <li><strong>GPT-5.3-codex</strong> (OpenAI) — strong alternative, good for diverse codebases</li>
+        <li><strong>Claude Sonnet</strong> (Anthropic) best balance of speed, quality, and cost</li>
+        <li><strong>GPT-5.3-codex</strong> (OpenAI) strong alternative, good for diverse codebases</li>
       </ul>
       <p>To configure a cloud provider:</p>
       <ol>
@@ -149,30 +149,30 @@ function Evaluations() {
 
       <h3>Input types</h3>
       <ul>
-        <li><strong>Local path:</strong> <code>/path/to/your/project</code></li>
-        <li><strong>GitHub URL:</strong> <code>https://github.com/org/repo</code></li>
-        <li><strong>SSH path:</strong> <code>git@github.com:org/repo.git</code></li>
+        <li><strong>Local path</strong> <code>/path/to/your/project</code></li>
+        <li><strong>GitHub URL</strong> <code>https://github.com/org/repo</code></li>
+        <li><strong>SSH path</strong> <code>git@github.com:org/repo.git</code></li>
       </ul>
 
       <h3>Evaluation options</h3>
       <ul>
-        <li><strong>Dimensions:</strong> Choose which quality dimensions to evaluate (default: all six)</li>
-        <li><strong>Branch:</strong> Select a specific branch to analyze</li>
-        <li><strong>Scope:</strong> Narrow analysis to a subdirectory within the repository</li>
-        <li><strong>Subagents:</strong> Number of parallel AI agents (more = faster, more tokens)</li>
+        <li><strong>Dimensions</strong> choose which quality dimensions to evaluate (default: all six)</li>
+        <li><strong>Branch</strong> select a specific branch to analyze</li>
+        <li><strong>Scope</strong> narrow analysis to a subdirectory within the repository</li>
+        <li><strong>Subagents</strong> number of parallel AI agents (more agents means faster analysis but more tokens)</li>
       </ul>
 
       <h3>Scan types</h3>
       <div className="help-callout help-callout-info">
-        <strong>Incremental scan:</strong> Only re-evaluates files that changed since the last run. Much faster for iterative development. Enable the <em>Incremental</em> toggle before starting.
+        <strong>Incremental scan</strong> only re-evaluates files that changed since the last run. Much faster for iterative development. Enable the <em>Incremental</em> toggle before starting.
       </div>
       <ul>
-        <li><strong>Full scan:</strong> Evaluates the entire codebase from scratch. Use for first-time analysis or after major refactors.</li>
-        <li><strong>Incremental scan:</strong> Detects changed files via git diff and only re-evaluates those. Previous findings for unchanged files are carried forward. Significantly faster and cheaper.</li>
+        <li><strong>Full scan</strong> evaluates the entire codebase from scratch. Use for first-time analysis or after major refactors.</li>
+        <li><strong>Incremental scan</strong> detects changed files via git diff and only re-evaluates those. Previous findings for unchanged files are carried forward. Significantly faster and cheaper.</li>
       </ul>
 
       <h3>Re-evaluate</h3>
-      <p>From the <strong>Evaluate</strong> tab, you can re-run an evaluation on an existing project. The new results will appear as a new run in the history, allowing you to track quality over time.</p>
+      <p>From the <strong>Evaluate</strong> tab, you can re-run an evaluation on an existing project. The new results appear as a new run in the history, allowing you to track quality over time.</p>
     </section>
   );
 }
@@ -188,7 +188,7 @@ function Dimensions() {
   return (
     <section className="help-section">
       <h2>Quality Dimensions (ISO 25010)</h2>
-      <p>Quodeq evaluates code across six dimensions derived from the ISO/IEC 25010 software quality standard:</p>
+      <p>Quodeq evaluates code across six dimensions derived from the ISO/IEC 25010 software quality standard.</p>
 
       <table className="help-table">
         <thead>
@@ -222,15 +222,15 @@ function Dimensions() {
       </div>
 
       <h3>Showing and hiding dimensions</h3>
-      <p>You can control which dimensions are included in evaluations and displayed in the Overview using the {ICON_EYE_ON} <strong>visibility toggle</strong> on each standard card in the Standards tab:</p>
+      <p>Control which dimensions are included in evaluations and displayed in the Overview using the {ICON_EYE_ON} <strong>visibility toggle</strong> on each standard card in the Standards tab:</p>
       <ul>
-        <li>{ICON_EYE_ON} <strong>Eye open</strong> — dimension is active and will be included in evaluations and the Overview</li>
-        <li><strong>Eye closed</strong> — dimension is hidden from evaluations and the Overview</li>
+        <li>{ICON_EYE_ON} <strong>Eye open</strong> the dimension is active and will be included in evaluations and the Overview</li>
+        <li><strong>Eye closed</strong> the dimension is hidden from evaluations and the Overview</li>
       </ul>
       <p>This lets you customize which quality aspects matter for your project without deleting any standards.</p>
 
       <h3>Creating custom dimensions</h3>
-      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against. See the <strong>Custom Standards</strong> section for the full schema and instructions on how to create them — including how to use an AI agent to generate standards for you.</p>
+      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against. See the <strong>Custom Standards</strong> section for the full schema and instructions, including how to use an AI agent to generate standards for you.</p>
     </section>
   );
 }
@@ -259,7 +259,7 @@ function Violations() {
         <li><strong>Click a dimension</strong> to see all findings for that quality area</li>
         <li><strong>Click a file</strong> to see all violations in that specific file with code context</li>
         <li><strong>Click a principle</strong> to see all violations for that evaluation rule</li>
-        <li><strong>Severity cells</strong> in the grid are clickable — they filter by both dimension and severity</li>
+        <li><strong>Severity cells</strong> in the grid are clickable and filter by both dimension and severity</li>
       </ul>
 
       <h3>Dismissing findings</h3>
@@ -275,16 +275,16 @@ function CodeMap() {
       <p>The <strong>Map</strong> tab provides a visual representation of your codebase structure and quality.</p>
 
       <h3>Treemap view</h3>
-      <p>Files are displayed as rectangles sized by their line count. Color indicates the severity density — red areas have more critical violations, green areas are clean.</p>
+      <p>Files are displayed as rectangles sized by their line count. Color indicates severity density: red areas have more critical violations, green areas are clean.</p>
       <p>This makes it easy to spot:</p>
       <ul>
-        <li><strong>Large red blocks:</strong> Big files with many issues — high-impact refactoring targets</li>
-        <li><strong>Clusters of red:</strong> Entire modules that need attention</li>
-        <li><strong>Green areas:</strong> Well-maintained parts of the codebase</li>
+        <li><strong>Large red blocks</strong> big files with many issues, high-impact refactoring targets</li>
+        <li><strong>Clusters of red</strong> entire modules that need attention</li>
+        <li><strong>Green areas</strong> well-maintained parts of the codebase</li>
       </ul>
 
       <h3>Risk matrix</h3>
-      <p>The risk matrix plots files by complexity (size) vs. issue density, helping you prioritize which files to fix first. Files in the top-right quadrant are both complex and problematic — tackle those first.</p>
+      <p>The risk matrix plots files by complexity (size) vs. issue density, helping you prioritize which files to fix first. Files in the top-right quadrant are both complex and problematic. Tackle those first.</p>
 
       <p>Click any file in the map to see its detailed violations and code context.</p>
     </section>
@@ -305,7 +305,7 @@ function Standards() {
         <li>Click <strong>New Standard</strong> in the Standards tab</li>
         <li>Define principles (evaluation categories) and requirements (specific checks)</li>
         <li>Assign severity levels to each requirement (<code>critical</code>, <code>major</code>, or <code>minor</code>)</li>
-        <li>Save — your standard will be used in the next evaluation</li>
+        <li>Save and your standard will be used in the next evaluation</li>
       </ol>
 
       <h3>Importing from library</h3>
@@ -334,10 +334,10 @@ function Standards() {
 }`}</pre>
       <p>Key fields:</p>
       <ul>
-        <li><strong>id</strong> — unique identifier, used as filename (<code>my-standard.json</code>)</li>
-        <li><strong>dimension</strong> — the quality dimension this standard belongs to</li>
-        <li><strong>principles</strong> — categories of evaluation (e.g., "Error Handling", "Input Validation")</li>
-        <li><strong>requirements</strong> — specific checks within each principle, each with an ID and severity</li>
+        <li><strong>id</strong> unique identifier, used as filename (<code>my-standard.json</code>)</li>
+        <li><strong>dimension</strong> the quality dimension this standard belongs to</li>
+        <li><strong>principles</strong> categories of evaluation (e.g., "Error Handling", "Input Validation")</li>
+        <li><strong>requirements</strong> specific checks within each principle, each with an ID and severity</li>
       </ul>
 
       <h3>Using AI to generate standards</h3>
@@ -370,15 +370,15 @@ function Settings() {
 
       <h3>Provider configuration</h3>
       <ul>
-        <li><strong>CLI Provider:</strong> Uses an installed AI CLI (Claude Code, Codex). Configure the power level and model.</li>
-        <li><strong>Ollama:</strong> Uses a locally running Ollama instance. Select model and configure parallelism.</li>
+        <li><strong>CLI Provider</strong> uses an installed AI CLI (Claude Code, Codex). Configure the power level and model.</li>
+        <li><strong>Ollama</strong> uses a locally running Ollama instance. Select a model and configure parallelism.</li>
       </ul>
 
       <h3>Model selection</h3>
       <p>Each power level maps to a model tier. You can override the default model for each level in Settings. Custom model names are stored locally.</p>
 
       <h3>Server info</h3>
-      <p>The Settings tab shows the current server status including port, PID, and version. Use this to verify the dashboard is connected to the correct backend.</p>
+      <p>The Settings tab shows the current server status including port and version. Use this to verify the dashboard is connected to the correct backend.</p>
 
       <h3>Theme</h3>
       <p>Choose between light and dark mode, and select a theme family for the dashboard appearance.</p>

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 const SECTIONS = [
+  { id: 'philosophy', label: 'Philosophy' },
   { id: 'getting-started', label: 'Getting Started' },
   { id: 'providers', label: 'AI Providers' },
   { id: 'evaluations', label: 'Running Evaluations' },
@@ -19,6 +20,52 @@ function SectionNav({ active, onSelect }) {
         <button key={s.id} className={`help-section-btn${active === s.id ? ' active' : ''}`} onClick={() => onSelect(s.id)}>{s.label}</button>
       ))}
     </nav>
+  );
+}
+
+function Philosophy() {
+  return (
+    <section className="help-section">
+      <h2>The Quodeq Philosophy</h2>
+      <p>Quodeq is a quality compass for your codebase — not a linter, not a static analyzer, but an AI-powered evaluator that reads and understands your code the way a senior engineer would.</p>
+
+      <h3>Why Quodeq exists</h3>
+      <p>Traditional code quality tools count syntax violations. They can tell you a function is too long, but not whether your architecture has a dependency leak. They can flag a missing null check, but not whether your error handling strategy is coherent across the project.</p>
+      <p>Quodeq takes a different approach: it sends an AI agent into your codebase with read-only tools to explore, understand context, and evaluate quality against structured standards. The agent reads actual code, follows imports, understands patterns — then reports what it finds with specific file locations and evidence.</p>
+
+      <h3>How evaluation works</h3>
+      <ol>
+        <li><strong>Detect</strong> — identifies the languages, frameworks, and structure of your codebase</li>
+        <li><strong>Analyze</strong> — spawns AI agents with read-only tools (Bash, Grep, Read, Glob) to systematically explore the code</li>
+        <li><strong>Collect</strong> — findings stream in real-time as structured JSONL via tool calls</li>
+        <li><strong>Score</strong> — maps findings to ISO 25010 principles with CWE classifications</li>
+        <li><strong>Report</strong> — produces per-dimension reports with grades, violations, and compliance evidence</li>
+      </ol>
+
+      <h3>Both sides of the story</h3>
+      <p>Quodeq reports <strong>violations AND compliance</strong>. The scoring uses the ratio between them — a project with many violations but also strong compliance patterns is scored more fairly than one with the same violations and no evidence of good practices. This means the AI actively looks for files that follow standards correctly, not just files that break them.</p>
+
+      <h3>The Q&#xB2; Scoring Formula</h3>
+      <p>Each principle is scored 0-10 using four independent constraints:</p>
+      <ol>
+        <li><strong>Violation Base</strong> — a hyperbolic curve where the first violations hurt most: <code>10 / (1 + K * weighted_violations)</code>. This prevents 50 minor issues from tanking a score the same way 5 critical ones would.</li>
+        <li><strong>Compliance Lift</strong> — evidence of good practices fills the gap between the base and 10. More compliance always helps, never hurts.</li>
+        <li><strong>Violation Ceiling</strong> — a log&#x2082;-based cap prevents compliance from overriding significant violations. You can't reach Exemplary with critical issues, no matter how much compliance you have.</li>
+        <li><strong>Severity Grade Floor</strong> — grade labels match reality. Only actual critical violations can produce a "Critical" grade. 50 minor violations with zero compliance still score Adequate, not Critical.</li>
+      </ol>
+      <pre className="help-code">{'final = max(floor, min(ceiling, base + (10 - base) * lift))'}</pre>
+
+      <h3>Fair by design</h3>
+      <div className="help-callout help-callout-info">
+        The scoring model was designed to address specific fairness issues: linear accumulation is unfair (39 minor issues shouldn't score the same as 39 critical flaws), compliance should be additive (not just a discount), grade names should be semantically honest, and reaching the top should require genuinely clean code.
+      </div>
+
+      <h3>Any language, any stack</h3>
+      <p>Quodeq can evaluate <strong>any codebase in any programming language</strong>. The AI analysis engine reads and understands code regardless of the tech stack — Python, TypeScript, Go, Rust, Java, Swift, or anything else. The standards are language-agnostic by design.</p>
+
+      <h3>Your standards, your rules</h3>
+      <p>While Quodeq ships with ISO 25010 dimensions, Clean Architecture, and DDD standards, you can create your own. Define what quality means for your project — whether that's React component best practices, API design guidelines, or your team's internal coding standards — and Quodeq will evaluate against them.</p>
+    </section>
   );
 }
 
@@ -345,6 +392,7 @@ Scope:      packages/frontend`}</pre>
 }
 
 const SECTION_COMPONENTS = {
+  'philosophy': Philosophy,
   'getting-started': GettingStarted,
   'providers': Providers,
   'evaluations': Evaluations,
@@ -357,8 +405,8 @@ const SECTION_COMPONENTS = {
 };
 
 export default function HelpPage() {
-  const [activeSection, setActiveSection] = useState('getting-started');
-  const Section = SECTION_COMPONENTS[activeSection] || GettingStarted;
+  const [activeSection, setActiveSection] = useState('philosophy');
+  const Section = SECTION_COMPONENTS[activeSection] || Philosophy;
 
   return (
     <div className="help-page">

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -129,6 +129,13 @@ function Evaluations() {
   );
 }
 
+const ICON_EYE_ON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: 'middle', marginBottom: 2 }}>
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
 function Dimensions() {
   return (
     <section className="help-section">
@@ -150,6 +157,29 @@ function Dimensions() {
       </table>
 
       <p>Each dimension is scored 0-10 and receives a letter grade (A-F). The overall score is a weighted average across all dimensions.</p>
+
+      <h3>Quodeq Dimensions</h3>
+      <p>In addition to the six ISO dimensions, Quodeq includes two extra dimensions focused on software architecture:</p>
+      <table className="help-table">
+        <thead>
+          <tr><th>Dimension</th><th>Focus</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><strong>Clean Architecture</strong></td><td>Layer separation, dependency rules, import direction, boundary enforcement</td></tr>
+          <tr><td><strong>DDD Design</strong></td><td>Domain modeling, bounded contexts, aggregates, value objects, ubiquitous language</td></tr>
+        </tbody>
+      </table>
+      <div className="help-callout help-callout-info">
+        These dimensions come <strong>disabled by default</strong>. To enable them, go to the <strong>Standards</strong> tab and click the {ICON_EYE_ON} eye icon on the dimension card. Enabled dimensions will appear in the Evaluation and Overview tabs.
+      </div>
+
+      <h3>Showing and hiding dimensions</h3>
+      <p>You can control which dimensions are included in evaluations and displayed in the Overview using the {ICON_EYE_ON} <strong>visibility toggle</strong> on each standard card in the Standards tab:</p>
+      <ul>
+        <li>{ICON_EYE_ON} <strong>Eye open</strong> — dimension is active and will be included in evaluations and the Overview</li>
+        <li><strong>Eye closed</strong> — dimension is hidden from evaluations and the Overview</li>
+      </ul>
+      <p>This lets you customize which quality aspects matter for your project without deleting any standards.</p>
 
       <h3>Creating custom dimensions</h3>
       <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against.</p>

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -10,7 +10,7 @@ import { useEvaluationLifecycle } from './useEvaluationLifecycle.js';
 import { useProjectActions } from './useProjectActions.js';
 import { useVisibleRuns } from './useVisibleRuns.js';
 
-export const KNOWN_TABS = ['overview', 'violations', 'map', 'history', 'projects', 'evaluate', 'standards', 'settings'];
+export const KNOWN_TABS = ['overview', 'violations', 'map', 'history', 'projects', 'evaluate', 'standards', 'help', 'settings'];
 export const PROJECT_TABS = KNOWN_TABS.slice(0, 4);
 
 function computeDerivedState(accumulated, dashboard, selectedProject, projects) {

--- a/src/quodeq/ui/src/styles/help.css
+++ b/src/quodeq/ui/src/styles/help.css
@@ -1,0 +1,133 @@
+/* Help page */
+.help-page { padding: var(--space-6); max-width: 960px; }
+
+.help-layout {
+  display: flex;
+  gap: var(--space-6);
+  margin-top: var(--space-4);
+}
+
+/* Section navigation */
+.help-section-nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 180px;
+  position: sticky;
+  top: var(--space-4);
+  align-self: flex-start;
+}
+
+.help-section-btn {
+  background: none;
+  border: none;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.help-section-btn:hover { background: var(--color-surface-alt); color: var(--color-text); }
+.help-section-btn.active { background: var(--color-surface-alt); color: var(--color-accent); font-weight: 600; }
+
+/* Content area */
+.help-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.help-section h2 {
+  font-size: var(--text-xl, 1.25rem);
+  font-weight: 700;
+  margin: 0 0 var(--space-3);
+  color: var(--color-text);
+}
+
+.help-section h3 {
+  font-size: var(--text-base, 0.95rem);
+  font-weight: 600;
+  margin: var(--space-5) 0 var(--space-2);
+  color: var(--color-text);
+}
+
+.help-section p {
+  color: var(--color-text-muted);
+  line-height: 1.65;
+  margin: 0 0 var(--space-3);
+}
+
+.help-section ul, .help-section ol {
+  color: var(--color-text-muted);
+  line-height: 1.65;
+  padding-left: var(--space-5);
+  margin: 0 0 var(--space-3);
+}
+.help-section li { margin-bottom: var(--space-1); }
+.help-section li strong { color: var(--color-text); }
+
+.help-section code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--color-surface-alt);
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: var(--color-accent);
+}
+
+/* Callouts */
+.help-callout {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  margin: var(--space-3) 0;
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text-muted);
+}
+.help-callout strong { color: var(--color-text); }
+.help-callout-tip { background: rgba(40, 167, 69, 0.08); border-left: 3px solid #28a745; }
+.help-callout-warning { background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; }
+.help-callout-info { background: rgba(0, 123, 255, 0.08); border-left: 3px solid #007bff; }
+
+/* Tables */
+.help-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--space-3) 0;
+  font-size: var(--text-sm);
+}
+.help-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+.help-table td {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle, rgba(255,255,255,0.04));
+  color: var(--color-text-muted);
+}
+.help-table td strong { color: var(--color-text); }
+
+/* Severity colors in table */
+.help-severity-critical { color: #f85149; font-weight: 600; }
+.help-severity-major { color: #f0883e; font-weight: 600; }
+.help-severity-minor { color: #d29922; font-weight: 600; }
+.help-severity-info { color: #58a6ff; font-weight: 600; }
+
+/* Code blocks */
+.help-code {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  color: var(--color-text-muted);
+  margin: var(--space-3) 0;
+  white-space: pre;
+}

--- a/src/quodeq/ui/src/styles/help.css
+++ b/src/quodeq/ui/src/styles/help.css
@@ -1,21 +1,36 @@
-/* Help page */
-.help-page { padding: var(--space-6); max-width: 960px; }
+/* ── Help page ────────────────────────────────────────── */
+
+.help-page {
+  padding: var(--space-6);
+  max-width: 1040px;
+}
+
+.help-page .page-subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
 
 .help-layout {
   display: flex;
   gap: var(--space-6);
-  margin-top: var(--space-4);
+  margin-top: var(--space-5);
 }
 
-/* Section navigation */
+/* ── Section navigation ──────────────────────────────── */
+
 .help-section-nav {
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: 2px;
   min-width: 180px;
   position: sticky;
   top: var(--space-4);
   align-self: flex-start;
+  padding: var(--space-2);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
 }
 
 .help-section-btn {
@@ -24,110 +39,214 @@
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-md);
   color: var(--color-text-muted);
+  font-family: var(--font-sans);
   font-size: var(--text-sm);
   text-align: left;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
+  line-height: var(--leading-normal);
 }
-.help-section-btn:hover { background: var(--color-surface-alt); color: var(--color-text); }
-.help-section-btn.active { background: var(--color-surface-alt); color: var(--color-accent); font-weight: 600; }
+.help-section-btn:hover {
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+  color: var(--color-text);
+}
+.help-section-btn.active {
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  color: var(--color-accent);
+  font-weight: var(--weight-semibold);
+}
 
-/* Content area */
+/* ── Content area ────────────────────────────────────── */
+
 .help-content {
   flex: 1;
   min-width: 0;
 }
 
+.help-section {
+  animation: help-fade-in 250ms ease;
+}
+
+@keyframes help-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 .help-section h2 {
-  font-size: var(--text-xl, 1.25rem);
-  font-weight: 700;
-  margin: 0 0 var(--space-3);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  margin: 0 0 var(--space-2);
   color: var(--color-text);
+  letter-spacing: -0.01em;
+}
+
+.help-section > p:first-of-type {
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  line-height: 1.7;
+  margin: 0 0 var(--space-5);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .help-section h3 {
-  font-size: var(--text-base, 0.95rem);
-  font-weight: 600;
-  margin: var(--space-5) 0 var(--space-2);
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  margin: var(--space-6) 0 var(--space-2);
   color: var(--color-text);
+}
+
+.help-section h3:first-of-type {
+  margin-top: 0;
 }
 
 .help-section p {
   color: var(--color-text-muted);
-  line-height: 1.65;
+  line-height: 1.7;
   margin: 0 0 var(--space-3);
+  font-size: var(--text-sm);
 }
 
 .help-section ul, .help-section ol {
   color: var(--color-text-muted);
-  line-height: 1.65;
+  line-height: 1.7;
   padding-left: var(--space-5);
-  margin: 0 0 var(--space-3);
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-sm);
 }
-.help-section li { margin-bottom: var(--space-1); }
-.help-section li strong { color: var(--color-text); }
+
+.help-section li {
+  margin-bottom: var(--space-2);
+}
+
+.help-section li strong {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+}
 
 .help-section code {
   font-family: var(--font-mono);
-  font-size: 0.85em;
+  font-size: 0.82em;
   background: var(--color-surface-alt);
-  padding: 2px 6px;
+  padding: 2px 7px;
   border-radius: 4px;
   color: var(--color-accent);
+  border: 1px solid var(--color-border);
 }
 
-/* Callouts */
+/* ── Callouts ────────────────────────────────────────── */
+
 .help-callout {
   padding: var(--space-3) var(--space-4);
   border-radius: var(--radius-md);
-  margin: var(--space-3) 0;
+  margin: var(--space-4) 0;
   font-size: var(--text-sm);
-  line-height: 1.6;
+  line-height: 1.65;
   color: var(--color-text-muted);
+  border: 1px solid transparent;
 }
-.help-callout strong { color: var(--color-text); }
-.help-callout-tip { background: rgba(40, 167, 69, 0.08); border-left: 3px solid #28a745; }
-.help-callout-warning { background: rgba(255, 193, 7, 0.08); border-left: 3px solid #ffc107; }
-.help-callout-info { background: rgba(0, 123, 255, 0.08); border-left: 3px solid #007bff; }
 
-/* Tables */
+.help-callout strong {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+}
+
+.help-callout code {
+  border-color: transparent;
+}
+
+.help-callout-tip {
+  background: color-mix(in srgb, var(--color-grade-a, #28a745) 6%, var(--color-surface-alt));
+  border-color: color-mix(in srgb, var(--color-grade-a, #28a745) 20%, var(--color-border));
+  border-left: 3px solid var(--color-grade-a, #28a745);
+}
+
+.help-callout-warning {
+  background: color-mix(in srgb, #f0883e 6%, var(--color-surface-alt));
+  border-color: color-mix(in srgb, #f0883e 20%, var(--color-border));
+  border-left: 3px solid #f0883e;
+}
+
+.help-callout-info {
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-alt));
+  border-color: color-mix(in srgb, var(--color-accent) 20%, var(--color-border));
+  border-left: 3px solid var(--color-accent);
+}
+
+/* ── Tables ──────────────────────────────────────────── */
+
 .help-table {
   width: 100%;
-  border-collapse: collapse;
-  margin: var(--space-3) 0;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin: var(--space-4) 0;
   font-size: var(--text-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
 }
+
 .help-table th {
   text-align: left;
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
   color: var(--color-text-muted);
-  font-weight: 600;
+  font-weight: var(--weight-semibold);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--color-border);
 }
+
 .help-table td {
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--color-border-subtle, rgba(255,255,255,0.04));
+  border-bottom: 1px solid var(--color-border);
   color: var(--color-text-muted);
+  line-height: 1.5;
 }
-.help-table td strong { color: var(--color-text); }
 
-/* Severity colors in table */
-.help-severity-critical { color: #f85149; font-weight: 600; }
-.help-severity-major { color: #f0883e; font-weight: 600; }
-.help-severity-minor { color: #d29922; font-weight: 600; }
-.help-severity-info { color: #58a6ff; font-weight: 600; }
+.help-table tr:last-child td {
+  border-bottom: none;
+}
 
-/* Code blocks */
+.help-table td strong {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+}
+
+/* Severity colors */
+.help-severity-critical { color: var(--color-severity-critical, #f85149); font-weight: var(--weight-semibold); }
+.help-severity-major    { color: var(--color-severity-major, #f0883e); font-weight: var(--weight-semibold); }
+.help-severity-minor    { color: var(--color-severity-minor, #d29922); font-weight: var(--weight-semibold); }
+.help-severity-info     { color: var(--color-severity-info, #58a6ff); font-weight: var(--weight-semibold); }
+
+/* ── Code blocks ─────────────────────────────────────── */
+
 .help-code {
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-4);
   font-family: var(--font-mono);
-  font-size: 0.82rem;
-  line-height: 1.6;
+  font-size: 0.8rem;
+  line-height: 1.65;
   overflow-x: auto;
   color: var(--color-text-muted);
-  margin: var(--space-3) 0;
+  margin: var(--space-4) 0;
   white-space: pre;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+
+@media (max-width: 720px) {
+  .help-layout {
+    flex-direction: column;
+  }
+
+  .help-section-nav {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    min-width: auto;
+  }
 }

--- a/src/quodeq/ui/src/styles/index.css
+++ b/src/quodeq/ui/src/styles/index.css
@@ -6,3 +6,4 @@
 @import './history.css';
 @import './standards.css';
 @import './map.css';
+@import './help.css';


### PR DESCRIPTION
## Summary
Add a Help tab to the dashboard sidebar with comprehensive documentation covering all features.

### Sections
- **Getting Started** — quick start guide and requirements
- **AI Providers** — Ollama setup (recommends gemma3:27b), cloud providers (Sonnet, GPT-4.1), token usage warning, power levels table
- **Running Evaluations** — input types, options, full vs incremental scan, re-evaluate
- **Quality Dimensions** — ISO 25010 breakdown, creating custom dimensions, JSON schema for AI-generated standards
- **Navigating Violations** — severity levels, exploring findings, dismissing false positives
- **Code Map** — treemap and risk matrix explanation
- **Custom Standards** — creating, importing, AI generation with schema
- **Settings** — provider config, model selection, themes
- **Sub-projects** — scope option, multiple evaluations, project hierarchy

### Implementation
- New `features/help/components/HelpPage.jsx` with section navigation
- Styled callouts (tip/warning/info), tables, code blocks
- Added to sidebar bottom nav (above Settings), icon: question mark circle
- No project selection required

## Test plan
- [x] UI builds successfully
- [x] Help tab appears in sidebar
- [x] All sections render correctly
- [x] Navigation between sections works