### PR TITLE
fix: provider errors, settings UX, toast notifications, console pop-out

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug Report
+description: Report something that is not working correctly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `quodeq evaluate /path/to/project`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Quodeq version
+      description: Output of `quodeq --version`
+      placeholder: "1.0.3"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.4 / Ubuntu 24.04 / Windows 11"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: AI provider
+      description: Which provider were you using?
+      placeholder: "Ollama / Claude Code / Codex CLI / Gemini CLI"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error output
+      description: Paste any error messages or logs here.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the problem or limitation you are experiencing.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to happen?
+      description: Describe your proposed solution or feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Any other approaches you thought about.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that helps explain the request.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What does this PR do?
+
+<!-- A brief description of the change. -->
+
+## Why?
+
+<!-- What problem does this solve or what feature does it add? Link to an issue if applicable. -->
+
+## How to test
+
+<!-- Steps to verify the change works correctly. -->
+
+## Checklist
+
+- [ ] Tests pass (`uv run pytest`)
+- [ ] PR targets `develop`, not `main`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at security@quodeq.ai. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Quodeq
+
+Thanks for your interest in contributing. Quodeq is open source and we welcome contributions of all kinds: bug reports, feature requests, documentation improvements, and code.
+
+## Getting Started
+
+```bash
+git clone https://github.com/quodeq/quodeq.git && cd quodeq
+uv sync
+uv run pytest
+```
+
+## How to Contribute
+
+### Reporting Bugs
+
+Open an issue using the **Bug Report** template. Include:
+
+- What you expected to happen
+- What actually happened
+- Steps to reproduce
+- Your OS, Python version, and Quodeq version (`quodeq --version`)
+
+### Suggesting Features
+
+Open an issue using the **Feature Request** template. Describe the problem you are trying to solve, not just the solution you have in mind.
+
+### Submitting Code
+
+1. Fork the repo and create a branch from `develop`
+2. Make your changes
+3. Run the tests: `uv run pytest`
+4. Open a pull request targeting `develop`
+
+Keep pull requests focused on a single change. If you are fixing a bug and also want to refactor something, open two PRs.
+
+### Code Style
+
+- Follow the existing patterns in the codebase
+- No need to add docstrings or type annotations to code you did not change
+- Tests go in `tests/` mirroring the `src/` structure
+
+## Branch Model
+
+- `main` is for releases only
+- `develop` is the active development branch
+- Feature branches go `feature/your-branch` -> `develop` via PR
+
+## Security
+
+If you find a security vulnerability, do not open a public issue. Email security@quodeq.ai instead. See [SECURITY.md](SECURITY.md) for details.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
 <p align="center"><strong>v1.0.3</strong></p>
+<p align="center">
+  <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
+  <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>
+  <a href="https://pypi.org/project/quodeq/"><img src="https://img.shields.io/pypi/v/quodeq.svg" alt="PyPI" /></a>
+</p>
 
 <p align="center">
   <a href="https://www.youtube.com/watch?v=C9feqpR5BMI&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R">Watch the 2-min demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center"><strong>v1.0.3</strong></p>
 
 <p align="center">
-  <a href="https://www.youtube.com/watch?v=YUq9cr__2CI">Watch the 2-min demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
+  <a href="https://www.youtube.com/watch?v=C9feqpR5BMI&list=PLJjpl8sE7W-U1HMePWdGis7w834NPYD3R">Watch the 2-min demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Quodeq exists to change that.
 
 **Open source. MIT license. Runs locally. No telemetry. No account. No servers.**
 
-Scans any codebase with AI across six quality dimensions from [ISO 25010](https://www.iso.org/standard/35733.html): **Security**, **Reliability**, **Maintainability**, **Performance**, **Flexibility**, and **Usability**. Every finding maps to a [CWE](https://cwe.mitre.org/) identifier. You get grades, violations with line numbers, and a fix plan.
+Scans any codebase with AI across six quality dimensions from [ISO 25010](https://www.iso.org/standard/35733.html):
+**Security**, **Reliability**, **Maintainability**, **Performance**, **Flexibility**, and **Usability**.
 
-Cloud providers (Claude, Gemini, Codex) for speed. Local models via [Ollama](https://ollama.com) for privacy.
+Every finding maps to a [CWE](https://cwe.mitre.org/) identifier. You get grades, violations with line numbers, and a fix plan. Cloud providers (Claude, Gemini, Codex) for speed. Local models via [Ollama](https://ollama.com) for privacy.
 
 ---
 
@@ -69,6 +70,7 @@ Running `quodeq` opens the dashboard, where you can point to any project and run
     <img src="res/dashboard.png" alt="Quodeq Dashboard" width="900" />
   </picture>
 </p>
+<br>
 
 - **Grades and scores** per dimension with A-F letter grades, numeric scores, and trends across runs
 - **Violations explorer** to drill into findings by file, principle, or CWE classification
@@ -91,12 +93,12 @@ quodeq evaluate /path/to/project -d security        # Single dimension
 
 Choose what fits your workflow. Configure in **Settings** from the dashboard.
 
-| | Provider | Type | Getting started |
-|---|---|---|---|
-| | [Ollama](https://ollama.com/download) | Local | Free, private, code never leaves your machine |
-| | [Claude Code](https://code.claude.com/docs/en/quickstart) | Cloud | Best balance of speed, quality, and cost |
-| | [Codex CLI](https://developers.openai.com/codex/quickstart) | Cloud | OpenAI models |
-| | [Gemini CLI](https://geminicli.com/docs/get-started/installation/) | Cloud | Google models |
+| Provider | Type | Getting started |
+|---|---|---|
+| [Ollama](https://ollama.com/download) | Local | Free, private, code never leaves your machine |
+| [Claude Code](https://code.claude.com/docs/en/quickstart) | Cloud | Best balance of speed, quality, and cost |
+| [Codex CLI](https://developers.openai.com/codex/quickstart) | Cloud | OpenAI models |
+| [Gemini CLI](https://geminicli.com/docs/get-started/installation/) | Cloud | Google models |
 
 > For local analysis we recommend [Gemma 4](https://deepmind.google/models/gemma/gemma-4/) ([`gemma4:26b`](https://ollama.com/library/gemma4:26b)). Reducing the context window to 32k still gives good results and allows running multiple subagents in parallel.
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,44 @@
 <p align="center"><strong>v1.0.3</strong></p>
 
 <p align="center">
-  Quodeq scans any codebase with AI and scores it across six quality dimensions:
-  <strong>Security</strong>, <strong>Reliability</strong>, <strong>Maintainability</strong>,
-  <strong>Performance</strong>, <strong>Flexibility</strong>, and <strong>Usability</strong>,
-  based on ISO 25010. Get grades, find violations, fix what matters.
-</p>
-
-<p align="center">
-  <a href="https://www.youtube.com/watch?v=YUq9cr__2CI">Watch the demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
+  <a href="https://www.youtube.com/watch?v=YUq9cr__2CI">Watch the 2-min demo</a> · <a href="https://quodeq.ai">Website</a> · <a href="https://quodeq.ai/blog/">Blog</a> · <a href="https://github.com/quodeq/quodeq/releases/latest">Releases</a>
 </p>
 
 ---
 
-> **Why now?** AI models can now autonomously find and exploit zero-day vulnerabilities across operating systems, browsers, and web applications. Thousands of previously unknown flaws have been uncovered in weeks, not years. The code you ship today will be read by models that can spot what humans miss. If your codebase carries security debt, reliability gaps, or maintenance shortcuts, the window to fix them is shrinking fast. Quodeq helps you prepare your software: find vulnerabilities, enforce quality standards, and harden your code before the next generation of models is used against it.
+### Why
+
+AI models can now autonomously find and exploit zero-day vulnerabilities across operating systems, browsers, and web applications. Thousands of previously unknown flaws have been uncovered in weeks, not years. The code you ship today will be read by models that can spot what humans miss.
+
+But the tools to prepare for this are locked behind enterprise contracts and partner programs. Quodeq exists to change that.
+
+**Open source. MIT license. Runs locally. No telemetry. No account. No servers.**
+
+Quodeq scans any codebase with AI and scores it across six quality dimensions based on [ISO 25010](https://www.iso.org/standard/35733.html): **Security**, **Reliability**, **Maintainability**, **Performance**, **Flexibility**, and **Usability**. Every finding maps to a [CWE](https://cwe.mitre.org/) identifier. You get grades, violations with line numbers, and a fix plan.
+
+You choose how it runs. Cloud providers (Claude, Gemini, Codex) for speed. Local models via [Ollama](https://ollama.com) for privacy. Your code, your choice.
+
+---
+
+## What It Finds
+
+Quodeq evaluates real code and returns structured findings with severity, CWE classification, and file location:
+
+```
+CRITICAL  src/db.py:15        SQL Injection via string concatenation     CWE-89
+          query = f"SELECT * FROM users WHERE id = {user_id}"
+
+HIGH      src/auth.py:42      Hardcoded credentials in source code       CWE-798
+          credentials = {"user": "admin", "pass": "secret123"}
+
+MEDIUM    src/api.py:88       Missing rate limiting on login endpoint     CWE-307
+          @app.route("/login", methods=["POST"])
+
+MINOR     src/utils.py:23     Bare except clause hides errors             CWE-396
+          except: pass
+```
+
+Each finding includes a reason, the offending snippet, and a fix plan. Results are stored as JSON on your machine and viewable in the dashboard or as raw files.
 
 ---
 
@@ -30,10 +55,10 @@
 
 ```bash
 pipx install quodeq    # Install quodeq
-quodeq dashboard       # Launch the dashboard
+quodeq                 # Launch the dashboard
 ```
 
-That's it. The dashboard lets you point to any project and run evaluations from the UI.
+That's it. Running `quodeq` with no arguments opens the dashboard, where you can point to any project and run evaluations from the UI.
 
 > Also available via `pip install quodeq`.
 
@@ -75,7 +100,8 @@ After installing a provider, go to **Settings** in the dashboard and select it.
 The Quodeq Dashboard is the main way to use Quodeq. Launch evaluations, browse results, and track quality over time.
 
 ```bash
-quodeq dashboard
+quodeq                 # Launch the dashboard (default command)
+quodeq dashboard       # Same as above, explicit form
 ```
 
 <p align="center">
@@ -107,7 +133,7 @@ quodeq evaluate /path/to/project --scope src/api    # Scoped to a subdirectory
 quodeq evaluate /path/to/project -d security        # Single dimension
 ```
 
-Run `quodeq evaluate --help` and `quodeq dashboard --help` for all available options.
+Run `quodeq evaluate --help` and `quodeq --help` for all available options.
 
 ---
 
@@ -138,18 +164,9 @@ Quodeq can evaluate **any codebase in any language**. The AI analysis engine rea
 
 ---
 
-## The Q² Scoring Formula
+## Scoring
 
-Quodeq scores each principle on a 0 to 10 scale using four independent constraints:
-
-1. **Violation Base** is a hyperbolic curve where the first violations hurt most (`10 / (1 + K * weighted_violations)`)
-2. **Compliance Lift** is evidence of good practices that fills the gap between the base and 10
-3. **Violation Ceiling** is a log-based cap that prevents compliance from overriding significant violations
-4. **Severity Grade Floor** ensures grade labels match reality (only critical violations can produce a "Critical" grade)
-
-The final score: `max(floor, min(ceiling, base + (10 - base) * lift))`
-
-Full details in [src/quodeq/core/scoring/README.md](src/quodeq/core/scoring/README.md).
+Quodeq scores each principle on a 0 to 10 scale using four independent constraints: violation base, compliance lift, violation ceiling, and severity grade floor. Full details in [the scoring formula documentation](src/quodeq/core/scoring/README.md).
 
 ## Development
 
@@ -159,12 +176,10 @@ uv sync
 uv run pytest
 ```
 
-Development powered by [Claude Code](https://claude.ai/code) from [Anthropic](https://anthropic.com).
-
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## License
 
-See [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Running `quodeq` opens the dashboard, where you can point to any project and run
 
 Click any dimension, file, or principle to explore the details. Dismiss false positives directly from the UI.
 
+Running `quodeq` is equivalent to `quodeq dashboard`. Both open the same UI.
+
 ### CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
   </picture>
 </p>
 
-<h2 align="center">The quality code compass</h2>
-<p align="center"><em>Your guide to drive any codebase to excellence.</em></p>
+<h2 align="center">AI-powered code quality and security scanner</h2>
 <p align="center"><strong>v1.0.3</strong></p>
 
 <p align="center">
@@ -15,23 +14,21 @@
 
 ---
 
-### Why
+AI models can now autonomously find and exploit zero-day vulnerabilities across operating systems, browsers, and web applications. Thousands of previously unknown flaws uncovered in weeks, not years.
 
-AI models can now autonomously find and exploit zero-day vulnerabilities across operating systems, browsers, and web applications. Thousands of previously unknown flaws have been uncovered in weeks, not years. The code you ship today will be read by models that can spot what humans miss.
+The code you ship today will be read by models that can spot what humans miss. But the tools to prepare for this are locked behind enterprise contracts and partner programs.
 
-But the tools to prepare for this are locked behind enterprise contracts and partner programs. Quodeq exists to change that.
+Quodeq exists to change that.
 
 **Open source. MIT license. Runs locally. No telemetry. No account. No servers.**
 
-Quodeq scans any codebase with AI and scores it across six quality dimensions based on [ISO 25010](https://www.iso.org/standard/35733.html): **Security**, **Reliability**, **Maintainability**, **Performance**, **Flexibility**, and **Usability**. Every finding maps to a [CWE](https://cwe.mitre.org/) identifier. You get grades, violations with line numbers, and a fix plan.
+Scans any codebase with AI across six quality dimensions from [ISO 25010](https://www.iso.org/standard/35733.html): **Security**, **Reliability**, **Maintainability**, **Performance**, **Flexibility**, and **Usability**. Every finding maps to a [CWE](https://cwe.mitre.org/) identifier. You get grades, violations with line numbers, and a fix plan.
 
-You choose how it runs. Cloud providers (Claude, Gemini, Codex) for speed. Local models via [Ollama](https://ollama.com) for privacy. Your code, your choice.
+Cloud providers (Claude, Gemini, Codex) for speed. Local models via [Ollama](https://ollama.com) for privacy.
 
 ---
 
 ## What It Finds
-
-Quodeq evaluates real code and returns structured findings with severity, CWE classification, and file location:
 
 ```
 CRITICAL  src/db.py:15        SQL Injection via string concatenation     CWE-89
@@ -47,7 +44,7 @@ MINOR     src/utils.py:23     Bare except clause hides errors             CWE-39
           except: pass
 ```
 
-Each finding includes a reason, the offending snippet, and a fix plan. Results are stored as JSON on your machine and viewable in the dashboard or as raw files.
+Each finding includes a reason, the offending code, and a fix plan. Results are stored as JSON on your machine.
 
 ---
 
@@ -58,51 +55,13 @@ pipx install quodeq    # Install quodeq
 quodeq                 # Launch the dashboard
 ```
 
-That's it. Running `quodeq` with no arguments opens the dashboard, where you can point to any project and run evaluations from the UI.
+Running `quodeq` opens the dashboard, where you can point to any project and run evaluations from the UI. Also available via `pip install quodeq`.
 
-> Also available via `pip install quodeq`.
-
-### Requirements
-
-| Dependency | Version | |
-|---|---|---|
-| [Python](https://www.python.org/downloads/) | 3.12+ | Runtime (`brew install python` or [download](https://www.python.org/downloads/)) |
-| [Node.js](https://nodejs.org/) | 18+ | Dashboard UI (`brew install node` or [download](https://nodejs.org/)) |
-
-### AI Providers
-
-Quodeq works with **local models** and **cloud AI CLIs**. Choose what fits your workflow.
-
-#### Local models (free, private, your code never leaves your machine)
-
-| Provider | Getting started |
-|---|---|
-| Ollama | [Installation guide](https://ollama.com/download) |
-
-> We recommend [Gemma 4](https://deepmind.google/models/gemma/gemma-4/), specifically [`gemma4:26b`](https://ollama.com/library/gemma4:26b), for an excellent quality-to-cost ratio in local analysis. Reducing the context window to 32k still gives good results and allows running multiple subagents in parallel.
-
-#### Cloud CLI providers (faster, deeper analysis)
-
-| Provider | Getting started |
-|---|---|
-| Claude Code | [Installation guide](https://code.claude.com/docs/en/quickstart) |
-| Codex CLI | [Installation guide](https://developers.openai.com/codex/quickstart) |
-| Gemini CLI | [Installation guide](https://geminicli.com/docs/get-started/installation/) |
-
-After installing a provider, go to **Settings** in the dashboard and select it.
-
-> For cloud, Claude Sonnet gives the best balance of speed, quality, and cost.
+**Requirements:** [Python 3.12+](https://www.python.org/downloads/) and [Node.js 18+](https://nodejs.org/) (for the dashboard UI).
 
 ---
 
 ## Dashboard
-
-The Quodeq Dashboard is the main way to use Quodeq. Launch evaluations, browse results, and track quality over time.
-
-```bash
-quodeq                 # Launch the dashboard (default command)
-quodeq dashboard       # Same as above, explicit form
-```
 
 <p align="center">
   <picture>
@@ -111,21 +70,14 @@ quodeq dashboard       # Same as above, explicit form
   </picture>
 </p>
 
-Opens at `http://localhost:4173` with:
-
-- **Overall grade and score** with A-F letter grade, numeric score /10, and trend across runs
-- **Dimension breakdown** with individual scores per quality dimension and severity counts
+- **Grades and scores** per dimension with A-F letter grades, numeric scores, and trends across runs
 - **Violations explorer** to drill into findings by file, principle, or CWE classification
-- **Code map** showing a visual heatmap of your codebase and where issues concentrate
-- **Top offending files** ranked by impact for focused remediation
-- **Run history** to track how your codebase evolves over time
+- **Code map** showing a visual heatmap of where issues concentrate in your codebase
 - **Custom standards** to create your own evaluation dimensions or import from the library
 
-Click any dimension, file, or principle to explore the details. Dismiss false positives directly from the UI. Dismissed findings are excluded from future evaluations.
+Click any dimension, file, or principle to explore the details. Dismiss false positives directly from the UI.
 
-### CLI usage
-
-You can also run evaluations directly from the terminal:
+### CLI
 
 ```bash
 quodeq evaluate /path/to/project
@@ -133,40 +85,40 @@ quodeq evaluate /path/to/project --scope src/api    # Scoped to a subdirectory
 quodeq evaluate /path/to/project -d security        # Single dimension
 ```
 
-Run `quodeq evaluate --help` and `quodeq --help` for all available options.
+---
+
+## AI Providers
+
+Choose what fits your workflow. Configure in **Settings** from the dashboard.
+
+| | Provider | Type | Getting started |
+|---|---|---|---|
+| | [Ollama](https://ollama.com/download) | Local | Free, private, code never leaves your machine |
+| | [Claude Code](https://code.claude.com/docs/en/quickstart) | Cloud | Best balance of speed, quality, and cost |
+| | [Codex CLI](https://developers.openai.com/codex/quickstart) | Cloud | OpenAI models |
+| | [Gemini CLI](https://geminicli.com/docs/get-started/installation/) | Cloud | Google models |
+
+> For local analysis we recommend [Gemma 4](https://deepmind.google/models/gemma/gemma-4/) ([`gemma4:26b`](https://ollama.com/library/gemma4:26b)). Reducing the context window to 32k still gives good results and allows running multiple subagents in parallel.
 
 ---
 
 ## How It Works
 
-1. **Detect** identifies the languages and structure of the codebase
-2. **Analyze** sends an AI agent with read-only tools to explore the code
-3. **Collect** findings stream as structured JSONL via tool calls
-4. **Score** maps findings to ISO 25010 principles with CWE classifications
-5. **Report** produces per-dimension reports with grades, violations, and compliance
+1. **Detect** languages, frameworks, and project structure
+2. **Analyze** with AI agents that read the code using read-only tools
+3. **Collect** findings as structured JSONL via tool calls
+4. **Score** against [ISO 25010](https://www.iso.org/standard/35733.html) principles with [CWE](https://cwe.mitre.org/) classifications
+5. **Report** per-dimension grades, violations, compliance, and fix plans
 
-Results are stored in `~/.quodeq/evaluations/` and persist across sessions.
+Results are stored in `~/.quodeq/evaluations/` and persist across sessions. Works with any language. The AI analysis engine reads and understands code regardless of the tech stack.
 
-## Standards
+Quodeq scores each principle on a 0 to 10 scale using four independent constraints. Full details in [the scoring formula documentation](src/quodeq/core/scoring/README.md).
 
-By default, Quodeq evaluates six quality dimensions based on **ISO 25010**: Security, Reliability, Maintainability, Performance, Flexibility, and Usability.
+### Standards
 
-It also ships with additional built-in standards:
-
-- **Clean Architecture** for layer separation, dependency rules, and boundary enforcement
-- **Domain-Driven Design** for bounded contexts, aggregates, and ubiquitous language
-
-You can **create your own standards** from the dashboard, or ask any AI to generate one as a `.json` file and import it. See the Help tab in the dashboard for the full schema.
-
-## Supported Languages
-
-Quodeq can evaluate **any codebase in any language**. The AI analysis engine reads and understands code regardless of the tech stack.
+By default, Quodeq evaluates the six ISO 25010 dimensions. It also ships with **Clean Architecture** and **Domain-Driven Design** standards. You can create your own from the dashboard, or ask any AI to generate one as a `.json` file and import it.
 
 ---
-
-## Scoring
-
-Quodeq scores each principle on a 0 to 10 scale using four independent constraints: violation base, compliance lift, violation ceiling, and severity grade floor. Full details in [the scoring formula documentation](src/quodeq/core/scoring/README.md).
 
 ## Development
 

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -237,9 +237,15 @@ def _run_api_analysis_bridge(
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""
 
     if not model:
-        raise AnalysisError(f"No model configured for API provider '{ai_cmd}'")
+        raise AnalysisError(
+            f"No model configured for provider '{ai_cmd}'. "
+            f"Go to Settings in the dashboard to select a model, or set AI_MODEL in your environment."
+        )
     if not api_base:
-        raise AnalysisError(f"No api_base configured for API provider '{ai_cmd}'")
+        raise AnalysisError(
+            f"No API base URL configured for provider '{ai_cmd}'. "
+            f"Go to Settings in the dashboard to configure it, or set the URL in ai_providers.json."
+        )
 
     jsonl_file = cfg.jsonl_file
     if jsonl_file is None:

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -47,7 +47,7 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
             ptype = get_provider_configs().get(ai_cmd, {}).get("type")
             if ptype == "api" and not payload.get("aiModel"):
                 body, status = error_response(
-                    "No model selected. Go to Settings and select an orchestrator model.",
+                    "No model selected. Go to Settings and select one.",
                     HTTPStatus.BAD_REQUEST, "MODEL_REQUIRED",
                 )
                 return jsonify(body), status

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -450,9 +450,13 @@ def main(argv: list[str] | None = None) -> int:
     load_env_file(default_paths())
     parser = build_parser()
     args, remaining = parser.parse_known_args(argv)
-    if args.handler_command == "evaluate":
+    command = getattr(args, "handler_command", None) or args.command
+    # Default to dashboard when no subcommand is given
+    if command is None:
+        return dashboard_main(argv[1:] if argv is not None else sys.argv[1:])
+    if command == "evaluate":
         return run_evaluate(args)
-    handler = _COMMAND_HANDLERS.get(args.handler_command)
+    handler = _COMMAND_HANDLERS.get(command)
     if handler:
         return handler(argv)
     return 1

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -81,7 +81,7 @@ def _add_evaluate_args(parser: argparse.ArgumentParser) -> None:
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with all subcommands."""
     parser = argparse.ArgumentParser(prog="quodeq")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     dashboard_parser = subparsers.add_parser("dashboard", help="Run the dashboard")
     dashboard_parser.set_defaults(handler_command="dashboard")

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -234,6 +234,14 @@ class _WindowApi:
             })()
         """
 
+    def open_browser(self, path: str = '/') -> None:
+        """Open a URL in the system default browser."""
+        import webbrowser
+        if self._window:
+            base = self._window.get_current_url().split('#')[0].rstrip('/')
+            base = base.rsplit('/', 1)[0] if '/' in base.lstrip('http') else base
+            webbrowser.open(base + path)
+
     def minimize(self) -> None:
         if self._window:
             self._window.minimize()

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -128,12 +128,15 @@ class _WindowApi:
         self._window: webview.Window | None = None
         self._api_pid = 0
         self._instance: InstanceController | None = None
+        self._base_url: str = ''
 
     def bind(self, window: webview.Window, api_pid: int = 0,
-             instance: InstanceController | None = None) -> None:
+             instance: InstanceController | None = None,
+             base_url: str = '') -> None:
         self._window = window
         self._api_pid = api_pid
         self._instance = instance
+        self._base_url = base_url.rstrip('/')
 
     _CLOSING_OVERLAY_JS = """
         (function() {
@@ -237,10 +240,8 @@ class _WindowApi:
     def open_browser(self, path: str = '/') -> None:
         """Open a URL in the system default browser."""
         import webbrowser
-        if self._window:
-            base = self._window.get_current_url().split('#')[0].rstrip('/')
-            base = base.rsplit('/', 1)[0] if '/' in base.lstrip('http') else base
-            webbrowser.open(base + path)
+        url = self._base_url + path if self._base_url else path
+        webbrowser.open(url)
 
     def minimize(self) -> None:
         if self._window:
@@ -324,7 +325,7 @@ def main() -> None:
                                     frameless=True, easy_drag=True,
                                     background_color='#0d1117', hidden=True,
                                     js_api=api)
-    api.bind(window, api_pid=api_pid, instance=instance)
+    api.bind(window, api_pid=api_pid, instance=instance, base_url=url)
 
     def _on_reload(new_url: str) -> None:
         window.load_url(new_url)

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -1,6 +1,7 @@
 """Prerequisite checks for external tool dependencies."""
 from __future__ import annotations
 
+import os
 import subprocess
 
 from quodeq.shared.utils import IS_WIN32 as _IS_WIN32
@@ -11,11 +12,28 @@ _INSTALL_HINT_NODE = (
     "  apt install nodejs       # Ubuntu/Debian"
 )
 
-_INSTALL_HINT_CLAUDE = (
-    "Install it from https://docs.anthropic.com/en/docs/claude-code/overview\n"
-    "  npm install -g @anthropic-ai/claude-code"
-)
+_CLI_INSTALL_HINTS: dict[str, str] = {
+    "claude": (
+        "Install Claude Code:\n"
+        "  npm install -g @anthropic-ai/claude-code\n"
+        "  https://docs.anthropic.com/en/docs/claude-code/overview"
+    ),
+    "codex": (
+        "Install Codex CLI:\n"
+        "  npm install -g @openai/codex\n"
+        "  https://developers.openai.com/codex/quickstart"
+    ),
+    "gemini": (
+        "Install Gemini CLI:\n"
+        "  npm install -g @anthropic-ai/gemini-cli\n"
+        "  https://geminicli.com/docs/get-started/installation/"
+    ),
+}
 
+_SETTINGS_HINT = (
+    "Open the dashboard and go to Settings to select your AI provider:\n"
+    "  quodeq"
+)
 
 _VERSION_CMD_TIMEOUT_S = 30
 
@@ -72,14 +90,39 @@ def check_npm(min_major: int = 9) -> None:
     _check_tool_version(["npm", "--version"], "npm", min_major, _INSTALL_HINT_NODE)
 
 
-def check_claude_code() -> None:
-    """Raise RuntimeError if Claude Code CLI is not available."""
+def _is_provider_explicitly_configured() -> bool:
+    """Return True if the user has explicitly set a provider via env or config."""
+    return "AI_PROVIDER" in os.environ or "AI_CMD" in os.environ
+
+
+def _check_cli_provider(provider: str) -> None:
+    """Check that a CLI provider binary is available on PATH."""
     try:
-        _run_version_cmd(["claude", "--version"])
+        _run_version_cmd([provider, "--version"])
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        hint = _CLI_INSTALL_HINTS.get(provider, f"Install {provider} and make sure it is on your PATH.")
         raise RuntimeError(
-            f"Claude Code is required but not found.\n{_INSTALL_HINT_CLAUDE}"
+            f"'{provider}' is configured as your AI provider but was not found.\n\n"
+            f"{hint}\n\n"
+            f"Or choose a different provider in the dashboard Settings:\n"
+            f"  quodeq"
         ) from exc
+
+
+def _check_api_provider(provider: str) -> None:
+    """Check that an API provider has basic connectivity (Ollama: server running)."""
+    if provider == "ollama":
+        import urllib.request
+        import urllib.error
+        try:
+            urllib.request.urlopen("http://localhost:11434/api/tags", timeout=5)
+        except (urllib.error.URLError, OSError) as exc:
+            raise RuntimeError(
+                "Ollama is configured as your AI provider but the server is not running.\n\n"
+                "Start it with:\n"
+                "  ollama serve\n\n"
+                "Or install Ollama from https://ollama.com/download"
+            ) from exc
 
 
 def check_dashboard_prereqs() -> None:
@@ -89,5 +132,29 @@ def check_dashboard_prereqs() -> None:
 
 
 def check_evaluate_prereqs() -> None:
-    """Check all prerequisites for the evaluate command."""
-    check_claude_code()
+    """Check all prerequisites for the evaluate command.
+
+    Checks the configured AI provider instead of always assuming Claude.
+    If no provider is configured, tells the user to select one.
+    """
+    from quodeq.shared.utils import get_ai_cmd
+    from quodeq.analysis._provider_cache import get_provider_configs
+
+    if not _is_provider_explicitly_configured():
+        raise RuntimeError(
+            "No AI provider configured.\n\n"
+            "Quodeq needs an AI provider to evaluate your code. You can use:\n\n"
+            "  Local (free, private):  Ollama with Gemma 4\n"
+            "  Cloud (faster):         Claude Code, Codex CLI, or Gemini CLI\n\n"
+            f"{_SETTINGS_HINT}"
+        )
+
+    provider = get_ai_cmd()
+    configs = get_provider_configs()
+    provider_cfg = configs.get(provider, {})
+    provider_type = provider_cfg.get("type", "cli")
+
+    if provider_type == "cli":
+        _check_cli_provider(provider)
+    elif provider_type == "api":
+        _check_api_provider(provider)

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -108,20 +108,16 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
   const { selectedProject, projectInfo } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
+  const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
-  const errorCount = useRef(0);
-  const prevError = useRef('');
 
   useEffect(() => {
-    if (jobError) {
-      errorCount.current += 1;
-      setToastVisible(true);
-    }
-    prevError.current = jobError || '';
-  }, [jobError]);
+    if (jobError) setToastVisible(true);
+  }, [jobError, toastKey]);
 
   const wrappedOnStart = (payload) => {
     setToastVisible(false);
+    setToastKey(k => k + 1);
     onStartEvaluation(payload);
   };
 
@@ -149,7 +145,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
       </div>
 
       {jobError && toastVisible && (
-        <ErrorToast key={errorCount.current} message={jobError} onDismiss={() => setToastVisible(false)} />
+        <ErrorToast key={toastKey} message={jobError} onDismiss={() => setToastVisible(false)} />
       )}
     </section>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -109,10 +109,11 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
               <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
             </div>
             <EvaluationForm onStart={onStartEvaluation} disabled={false} selectedProject={projectInfo} />
+            {jobError && <div className="job-error-banner" ref={el => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })}>{typeof jobError === 'string' ? jobError.slice(0, 200) : 'An error occurred'}</div>}
           </div>
         )}
 
-        {jobError && <div className="job-error-banner">{typeof jobError === 'string' ? jobError.slice(0, 200) : 'An error occurred'}</div>}
+        {job && jobError && <div className="job-error-banner">{typeof jobError === 'string' ? jobError.slice(0, 200) : 'An error occurred'}</div>}
         <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} />
 
         {!job && <EvaluateHelpSection />}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -89,7 +89,7 @@ function EvaluateHeader({ isRunning }) {
   );
 }
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 function ErrorToast({ message, onDismiss }) {
   useEffect(() => {
@@ -108,21 +108,30 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
   const { selectedProject, projectInfo } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
-  const [toastDismissed, setToastDismissed] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+  const errorCount = useRef(0);
+  const prevError = useRef('');
 
-  useEffect(() => { setToastDismissed(false); }, [jobError]);
+  useEffect(() => {
+    if (jobError) {
+      errorCount.current += 1;
+      setToastVisible(true);
+    }
+    prevError.current = jobError || '';
+  }, [jobError]);
+
+  const wrappedOnStart = (payload) => {
+    setToastVisible(false);
+    onStartEvaluation(payload);
+  };
 
   return (
     <section className="evaluate-screen">
-      {jobError && !toastDismissed && (
-        <ErrorToast message={jobError} onDismiss={() => setToastDismissed(true)} />
-      )}
-
       <EvaluateHeader isRunning={job?.status === 'running'} />
 
       <div className="evaluate-content">
         {!job && selectedProject && (
-          <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={onStartEvaluation} disabled={false} />
+          <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={wrappedOnStart} disabled={false} />
         )}
 
         {!job && (
@@ -130,7 +139,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
             <div className="panel-header">
               <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
             </div>
-            <EvaluationForm onStart={onStartEvaluation} disabled={false} selectedProject={projectInfo} />
+            <EvaluationForm onStart={wrappedOnStart} disabled={false} selectedProject={projectInfo} />
           </div>
         )}
 
@@ -138,6 +147,10 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
         {!job && <EvaluateHelpSection />}
       </div>
+
+      {jobError && toastVisible && (
+        <ErrorToast key={errorCount.current} message={jobError} onDismiss={() => setToastVisible(false)} />
+      )}
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -89,13 +89,35 @@ function EvaluateHeader({ isRunning }) {
   );
 }
 
+import { useState, useEffect } from 'react';
+
+function ErrorToast({ message, onDismiss }) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 8000);
+    return () => clearTimeout(timer);
+  }, [message, onDismiss]);
+
+  return (
+    <div className="job-error-toast" onClick={onDismiss}>
+      {typeof message === 'string' ? message.slice(0, 200) : 'An error occurred'}
+    </div>
+  );
+}
+
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
   const { selectedProject, projectInfo } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
+  const [toastDismissed, setToastDismissed] = useState(false);
+
+  useEffect(() => { setToastDismissed(false); }, [jobError]);
 
   return (
     <section className="evaluate-screen">
+      {jobError && !toastDismissed && (
+        <ErrorToast message={jobError} onDismiss={() => setToastDismissed(true)} />
+      )}
+
       <EvaluateHeader isRunning={job?.status === 'running'} />
 
       <div className="evaluate-content">
@@ -109,11 +131,9 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
               <h3>{selectedProject ? 'Evaluate a new repository' : 'Evaluate a Repository'}</h3>
             </div>
             <EvaluationForm onStart={onStartEvaluation} disabled={false} selectedProject={projectInfo} />
-            {jobError && <div className="job-error-banner" ref={el => el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })}>{typeof jobError === 'string' ? jobError.slice(0, 200) : 'An error occurred'}</div>}
           </div>
         )}
 
-        {job && jobError && <div className="job-error-banner">{typeof jobError === 'string' ? jobError.slice(0, 200) : 'An error occurred'}</div>}
         <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} />
 
         {!job && <EvaluateHelpSection />}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -93,7 +93,7 @@ import { useState, useEffect } from 'react';
 
 function ErrorToast({ message, onDismiss }) {
   useEffect(() => {
-    const timer = setTimeout(onDismiss, 8000);
+    const timer = setTimeout(onDismiss, 5000);
     return () => clearTimeout(timer);
   }, [message, onDismiss]);
 

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -184,7 +184,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
         onClick={handleIncremental}
         title="Only analyze files changed since last evaluation"
       >
-        {disabled ? 'Running...' : 'Scan changes'}
+        {disabled ? 'Running...' : 'Scan incremental'}
       </button>
       <button
         type="button"
@@ -194,7 +194,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
         onClick={handleStart}
         title="Fresh re-evaluation of all selected dimensions"
       >
-        Full scan
+        Clean scan
       </button>
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -79,7 +79,7 @@ function useReEvaluateCard(project, onStart, projectInfo) {
   const clearAll = () => setSelectedDims(new Set());
   const buildPayload = (extra) => {
     const payload = { repo: info.path, ...extra };
-    if (selectedDims.size > 0) payload.dimensions = [...selectedDims];
+    payload.dimensions = [...selectedDims];
     if (branch) payload.branch = branch;
     if (scopePath) payload.scopePath = scopePath;
     return payload;
@@ -208,7 +208,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
   } = actions;
 
-  const canStart = !disabled && !cloning && selectedDims.size > 0 && !info.pathMissing;
+  const canStart = !disabled && !cloning && !info.pathMissing;
 
   return (
     <div className="panel evaluate-panel">

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -121,13 +121,13 @@ function createJobPoller(refs, setters, startDimensionPolling) {
  */
 function preparePayload(payload, storage = localStorage) {
   const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  if (!activeProvider) throw new Error('No AI provider selected. Go to Settings to configure one.');
+  if (!activeProvider) throw new Error('No provider selected. Go to Settings to configure one.');
 
   const get = (key) => storage.getItem(providerKey(activeProvider, key));
 
   payload.aiCmd = activeProvider;
   const model = get('model');
-  if (!model) throw new Error('No orchestrator model selected. Go to Settings and select a model for the active provider.');
+  if (!model) throw new Error('No model selected. Go to Settings and select one.');
   payload.aiModel = model;
 
   const defaultSubagents = ['ollama'].includes(activeProvider) ? '1' : '5';

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -191,6 +191,9 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
     refs.partialDimensionsRef.current = new Set();
     setLiveViolations({});
     try {
+      if (Array.isArray(payload.dimensions) && payload.dimensions.length === 0) {
+        throw new Error('Select at least one dimension.');
+      }
       preparePayload(payload);
       const created = await startEvaluation(payload);
       setJob({ ...created, repo: payload.repo });

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { getKnownModels } from '../../../api/index.js';
 import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
 import { STORAGE_KEY as POWER_KEY } from '../../evaluation/components/powerLevels.js';
-import ProviderSettings from './ProviderSettings.jsx';
+import { TimeLimitSetting, AdvancedAnalysisSettings } from './ProviderSettings.jsx';
 
 function ModelSuggestInput({ label, value, suggestions, placeholder, onChange, required }) {
   return (
@@ -77,7 +77,7 @@ export default function CliProviderTab({ providerId, state, update }) {
           onChange={(e) => update('subagents', e.target.value)}
         />
       </div>
-      <ProviderSettings state={state} update={update} providerType="cli" />
+      <TimeLimitSetting state={state} update={update} />
       <details className="settings-advanced">
         <summary className="settings-advanced-toggle">Advanced</summary>
         <div className="settings-advanced-content">
@@ -99,6 +99,7 @@ export default function CliProviderTab({ providerId, state, update }) {
               <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
             </div>
           </div>
+          <AdvancedAnalysisSettings state={state} update={update} />
         </div>
       </details>
     </>

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -59,40 +59,43 @@ export default function CliProviderTab({ providerId, state, update }) {
         </div>
         <ModelSuggestInput value={state.model} suggestions={suggestions} onChange={(v) => update('model', v)} />
       </div>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">Analysis power</span>
-          <span className="settings-description">Controls which model tier is used for analysis</span>
+      <details className="settings-advanced">
+        <summary className="settings-advanced-toggle">Advanced</summary>
+        <div className="settings-row">
+          <div className="settings-row-label">
+            <span className="settings-label">Analysis power</span>
+            <span className="settings-description">Controls which model tier is used for analysis</span>
+          </div>
+          <PowerSelector value={power} onChange={setPower} onPersist={persistPower} />
         </div>
-        <PowerSelector value={power} onChange={setPower} onPersist={persistPower} />
-      </div>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">Analysis models</span>
-          <span className="settings-description">Override models per power level</span>
+        <div className="settings-row">
+          <div className="settings-row-label">
+            <span className="settings-label">Analysis models</span>
+            <span className="settings-description">Override models per power level</span>
+          </div>
+          <div className="settings-model-overrides">
+            <ModelSuggestInput label="Fast" value={state['model-fast']} suggestions={fast.length ? fast : suggestions} placeholder={fast[0]?.label} onChange={(v) => update('model-fast', v)} />
+            <ModelSuggestInput label="Balanced" value={state['model-balanced']} suggestions={balanced.length ? balanced : suggestions} placeholder={balanced[0]?.label} onChange={(v) => update('model-balanced', v)} />
+            <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
+          </div>
         </div>
-        <div className="settings-model-overrides">
-          <ModelSuggestInput label="Fast" value={state['model-fast']} suggestions={fast.length ? fast : suggestions} placeholder={fast[0]?.label} onChange={(v) => update('model-fast', v)} />
-          <ModelSuggestInput label="Balanced" value={state['model-balanced']} suggestions={balanced.length ? balanced : suggestions} placeholder={balanced[0]?.label} onChange={(v) => update('model-balanced', v)} />
-          <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
+        <div className="settings-row">
+          <div className="settings-row-label">
+            <span className="settings-label">Max parallel agents</span>
+            <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
+          </div>
+          <input
+            type="number"
+            className="settings-model-input"
+            min={1}
+            max={10}
+            value={parseInt(state.subagents || '5', 10)}
+            onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 5)))}
+            onChange={(e) => update('subagents', e.target.value)}
+          />
         </div>
-      </div>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">Max parallel agents</span>
-          <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
-        </div>
-        <input
-          type="number"
-          className="settings-model-input"
-          min={1}
-          max={10}
-          value={parseInt(state.subagents || '5', 10)}
-          onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 5)))}
-          onChange={(e) => update('subagents', e.target.value)}
-        />
-      </div>
-      <ProviderSettings state={state} update={update} providerType="cli" />
+        <ProviderSettings state={state} update={update} providerType="cli" />
+      </details>
     </>
   );
 }

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -4,13 +4,13 @@ import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
 import { STORAGE_KEY as POWER_KEY } from '../../evaluation/components/powerLevels.js';
 import ProviderSettings from './ProviderSettings.jsx';
 
-function ModelSuggestInput({ label, value, suggestions, placeholder, onChange }) {
+function ModelSuggestInput({ label, value, suggestions, placeholder, onChange, required }) {
   return (
     <div className="settings-model-field">
       {label && <label className="settings-model-label">{label}</label>}
       <input
         type="text"
-        className="settings-model-input"
+        className={`settings-model-input${required && !value ? ' settings-model-input--required' : ''}`}
         list={`models-${label}`}
         value={value}
         placeholder={placeholder || 'Select or type model'}
@@ -55,9 +55,12 @@ export default function CliProviderTab({ providerId, state, update }) {
       <div className="settings-row">
         <div className="settings-row-label">
           <span className="settings-label">Model</span>
-          <span className="settings-description">Override the default model. Leave blank to use client default.</span>
+          <span className="settings-description">Select the model to use for evaluation</span>
         </div>
-        <ModelSuggestInput value={state.model} suggestions={suggestions} onChange={(v) => update('model', v)} />
+        <div className="settings-model-field">
+          <ModelSuggestInput value={state.model} suggestions={suggestions} onChange={(v) => update('model', v)} required />
+          {!state.model && <span className="settings-model-hint">Select a model to get started</span>}
+        </div>
       </div>
       <details className="settings-advanced">
         <summary className="settings-advanced-toggle">Advanced</summary>

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -62,42 +62,44 @@ export default function CliProviderTab({ providerId, state, update }) {
           {!state.model && <span className="settings-model-hint">Select a model to get started</span>}
         </div>
       </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Max parallel agents</span>
+          <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
+        </div>
+        <input
+          type="number"
+          className="settings-model-input"
+          min={1}
+          max={10}
+          value={parseInt(state.subagents || '5', 10)}
+          onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 5)))}
+          onChange={(e) => update('subagents', e.target.value)}
+        />
+      </div>
+      <ProviderSettings state={state} update={update} providerType="cli" />
       <details className="settings-advanced">
         <summary className="settings-advanced-toggle">Advanced</summary>
-        <div className="settings-row">
-          <div className="settings-row-label">
-            <span className="settings-label">Analysis power</span>
-            <span className="settings-description">Controls which model tier is used for analysis</span>
+        <div className="settings-advanced-content">
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label">Analysis power</span>
+              <span className="settings-description">Controls which model tier is used for analysis</span>
+            </div>
+            <PowerSelector value={power} onChange={setPower} onPersist={persistPower} />
           </div>
-          <PowerSelector value={power} onChange={setPower} onPersist={persistPower} />
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label">Analysis models</span>
+              <span className="settings-description">Override models per power level</span>
+            </div>
+            <div className="settings-model-overrides">
+              <ModelSuggestInput label="Fast" value={state['model-fast']} suggestions={fast.length ? fast : suggestions} placeholder={fast[0]?.label} onChange={(v) => update('model-fast', v)} />
+              <ModelSuggestInput label="Balanced" value={state['model-balanced']} suggestions={balanced.length ? balanced : suggestions} placeholder={balanced[0]?.label} onChange={(v) => update('model-balanced', v)} />
+              <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
+            </div>
+          </div>
         </div>
-        <div className="settings-row">
-          <div className="settings-row-label">
-            <span className="settings-label">Analysis models</span>
-            <span className="settings-description">Override models per power level</span>
-          </div>
-          <div className="settings-model-overrides">
-            <ModelSuggestInput label="Fast" value={state['model-fast']} suggestions={fast.length ? fast : suggestions} placeholder={fast[0]?.label} onChange={(v) => update('model-fast', v)} />
-            <ModelSuggestInput label="Balanced" value={state['model-balanced']} suggestions={balanced.length ? balanced : suggestions} placeholder={balanced[0]?.label} onChange={(v) => update('model-balanced', v)} />
-            <ModelSuggestInput label="Thorough" value={state['model-thorough']} suggestions={thorough.length ? thorough : suggestions} placeholder={thorough[0]?.label} onChange={(v) => update('model-thorough', v)} />
-          </div>
-        </div>
-        <div className="settings-row">
-          <div className="settings-row-label">
-            <span className="settings-label">Max parallel agents</span>
-            <span className="settings-description">Number of subagents to run in parallel (1–10)</span>
-          </div>
-          <input
-            type="number"
-            className="settings-model-input"
-            min={1}
-            max={10}
-            value={parseInt(state.subagents || '5', 10)}
-            onBlur={(e) => update('subagents', Math.max(1, Math.min(10, parseInt(e.target.value, 10) || 5)))}
-            onChange={(e) => update('subagents', e.target.value)}
-          />
-        </div>
-        <ProviderSettings state={state} update={update} providerType="cli" />
       </details>
     </>
   );

--- a/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
@@ -34,7 +34,7 @@ export default function CloudProviderTab({ providerId, providerConfig, state, up
         <div className="settings-budget-control">
           <input
             type="text"
-            className="settings-model-input"
+            className={`settings-model-input${!state.model ? ' settings-model-input--required' : ''}`}
             value={state.model}
             placeholder="e.g. qwen/qwen3.6-plus-preview:free"
             onChange={(e) => update('model', e.target.value)}
@@ -43,6 +43,7 @@ export default function CloudProviderTab({ providerId, providerConfig, state, up
             {testing ? 'Testing...' : 'Test'}
           </button>
         </div>
+        {!state.model && <span className="settings-model-hint">Required before running an evaluation</span>}
         {testResult && (
           <span className={`settings-description ${testResult.success ? '' : 'settings-error'}`}>
             {testResult.success ? `Connected (${testResult.latency_ms}ms)` : testResult.error}

--- a/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { testProviderConnection } from '../../../api/index.js';
-import ProviderSettings from './ProviderSettings.jsx';
+import { TimeLimitSetting, AdvancedAnalysisSettings } from './ProviderSettings.jsx';
 
 export default function CloudProviderTab({ providerId, providerConfig, state, update }) {
   const [testing, setTesting] = useState(false);
@@ -65,7 +65,13 @@ export default function CloudProviderTab({ providerId, providerConfig, state, up
           onChange={(e) => update('subagents', e.target.value)}
         />
       </div>
-      <ProviderSettings state={state} update={update} providerType="cloud-api" />
+      <TimeLimitSetting state={state} update={update} />
+      <details className="settings-advanced">
+        <summary className="settings-advanced-toggle">Advanced</summary>
+        <div className="settings-advanced-content">
+          <AdvancedAnalysisSettings state={state} update={update} />
+        </div>
+      </details>
     </>
   );
 }

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getOllamaModels, testOllamaConcurrency } from '../../../api/index.js';
 import ServerStatus from './ServerStatus.jsx';
-import ProviderSettings from './ProviderSettings.jsx';
+import { TimeLimitSetting, AdvancedAnalysisSettings } from './ProviderSettings.jsx';
 
 function ModelSelector({ value, models, onChange }) {
   const needsModel = !value;
@@ -59,7 +59,13 @@ export default function OllamaTab({ state, update }) {
         </div>
         {testResult && <span className="settings-description">Recommended: {testResult.recommended} agents</span>}
       </div>
-      <ProviderSettings state={state} update={update} providerType="local-api" />
+      <TimeLimitSetting state={state} update={update} />
+      <details className="settings-advanced">
+        <summary className="settings-advanced-toggle">Advanced</summary>
+        <div className="settings-advanced-content">
+          <AdvancedAnalysisSettings state={state} update={update} />
+        </div>
+      </details>
     </>
   );
 }

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
@@ -4,12 +4,14 @@ import ServerStatus from './ServerStatus.jsx';
 import ProviderSettings from './ProviderSettings.jsx';
 
 function ModelSelector({ value, models, onChange }) {
+  const needsModel = !value;
   return (
     <div className="settings-model-field">
-      <select className="settings-model-input" value={value} onChange={(e) => onChange(e.target.value)}>
-        <option value="">Click to select</option>
+      <select className={`settings-model-input${needsModel ? ' settings-model-input--required' : ''}`} value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">Select a model</option>
         {models.map((m) => <option key={m.name} value={m.name}>{m.name}</option>)}
       </select>
+      {needsModel && <span className="settings-model-hint">Required before running an evaluation</span>}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
@@ -1,34 +1,39 @@
-export default function ProviderSettings({ state, update, providerType }) {
+export function TimeLimitSetting({ state, update }) {
   const poolBudget = parseInt(state['pool-budget'] || '0', 10);
-  const perDimension = state['per-dimension'] !== 'false';
-  const verify = state['verify'] !== 'false';
   const unlimited = poolBudget === 0;
 
   return (
-    <>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">Analysis time limit</span>
-          <span className="settings-description">Max time per dimension. Unlimited runs until all files processed.</span>
-        </div>
-        <div className="settings-budget-control">
-          <div className="theme-toggle">
-            <button type="button" className={`theme-toggle-btn${unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '0')}>Unlimited</button>
-            <button type="button" className={`theme-toggle-btn${!unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '600')}>Limited</button>
-          </div>
-          <input
-            type="number"
-            className="settings-model-input"
-            min={1}
-            max={60}
-            value={unlimited ? '' : Math.round(poolBudget / 60)}
-            placeholder={unlimited ? '\u221E' : 'min'}
-            disabled={unlimited}
-            onChange={(e) => update('pool-budget', String(parseInt(e.target.value || '10', 10) * 60))}
-          />
-        </div>
+    <div className="settings-row">
+      <div className="settings-row-label">
+        <span className="settings-label">Analysis time limit</span>
+        <span className="settings-description">Max time per dimension. Unlimited runs until all files processed.</span>
       </div>
+      <div className="settings-budget-control">
+        <div className="theme-toggle">
+          <button type="button" className={`theme-toggle-btn${unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '0')}>Unlimited</button>
+          <button type="button" className={`theme-toggle-btn${!unlimited ? ' active' : ''}`} onClick={() => update('pool-budget', '600')}>Limited</button>
+        </div>
+        <input
+          type="number"
+          className="settings-model-input"
+          min={1}
+          max={60}
+          value={unlimited ? '' : Math.round(poolBudget / 60)}
+          placeholder={unlimited ? '\u221E' : 'min'}
+          disabled={unlimited}
+          onChange={(e) => update('pool-budget', String(parseInt(e.target.value || '10', 10) * 60))}
+        />
+      </div>
+    </div>
+  );
+}
 
+export function AdvancedAnalysisSettings({ state, update }) {
+  const perDimension = state['per-dimension'] !== 'false';
+  const verify = state['verify'] !== 'false';
+
+  return (
+    <>
       <div className="settings-row">
         <div className="settings-row-label">
           <span className="settings-label">Analysis mode</span>
@@ -40,7 +45,7 @@ export default function ProviderSettings({ state, update, providerType }) {
         </div>
       </div>
 
-      <div className="settings-row settings-row--last">
+      <div className="settings-row">
         <div className="settings-row-label">
           <span className="settings-label">Verify findings</span>
           <span className="settings-description">Re-check findings from previous runs against current code</span>
@@ -50,6 +55,15 @@ export default function ProviderSettings({ state, update, providerType }) {
           <button type="button" className={`theme-toggle-btn${!verify ? ' active' : ''}`} onClick={() => update('verify', 'false')}>Off</button>
         </div>
       </div>
+    </>
+  );
+}
+
+export default function ProviderSettings({ state, update, providerType }) {
+  return (
+    <>
+      <TimeLimitSetting state={state} update={update} />
+      <AdvancedAnalysisSettings state={state} update={update} />
     </>
   );
 }

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -89,7 +89,11 @@ export default function ServerSection() {
   }, [logLines]);
 
   function handlePopOut() {
-    window.open('/logs', '_blank', 'width=800,height=500');
+    if (window.pywebview && window.pywebview.api && window.pywebview.api.open_browser) {
+      window.pywebview.api.open_browser('/logs');
+    } else {
+      window.open(window.location.origin + '/logs', '_blank', 'width=800,height=500');
+    }
   }
 
   function handleClear() {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -550,6 +550,34 @@ textarea:focus {
   font-size: var(--text-sm);
 }
 
+.job-error-toast {
+  position: fixed;
+  top: var(--space-4, 16px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9999;
+  background: var(--color-danger, #dc3545);
+  color: #fff;
+  padding: var(--space-3, 12px) var(--space-6, 24px);
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
+  max-width: 540px;
+  text-align: center;
+  animation: toast-in 0.3s ease;
+  cursor: pointer;
+}
+
+.job-error-toast:hover {
+  opacity: 0.9;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(-12px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
 .no-data-cell {
   color: var(--color-text-muted);
   font-size: var(--text-sm);

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1355,6 +1355,36 @@ textarea:focus {
   margin-top: 4px;
 }
 
+.settings-advanced {
+  margin-top: var(--space-2, 8px);
+}
+
+.settings-advanced-toggle {
+  font-size: var(--text-sm, 0.875rem);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: var(--space-2, 8px) 0;
+  user-select: none;
+  list-style: none;
+}
+
+.settings-advanced-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.settings-advanced-toggle::before {
+  content: '\25B6';
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 0.65em;
+  transition: transform 150ms ease;
+}
+
+.settings-advanced[open] > .settings-advanced-toggle::before {
+  transform: rotate(90deg);
+}
+
 .settings-model-input[type="number"] {
   width: 80px;
   text-align: center;

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1356,47 +1356,45 @@ textarea:focus {
 }
 
 .settings-advanced {
-  margin-top: var(--space-4, 16px);
-  border-top: 1px solid var(--color-border);
-  padding-top: var(--space-2, 8px);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .settings-advanced-toggle {
-  font-size: var(--text-xs, 0.75rem);
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 8px);
+  width: 100%;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   color: var(--color-text-muted);
   cursor: pointer;
-  padding: var(--space-2, 8px) 0;
+  padding: var(--space-4, 16px) var(--space-6, 24px);
   user-select: none;
   list-style: none;
-  opacity: 0.7;
-  transition: opacity 150ms ease;
+  transition: color 150ms ease;
 }
 
 .settings-advanced-toggle:hover {
-  opacity: 1;
+  color: var(--color-text);
 }
 
 .settings-advanced-toggle::-webkit-details-marker {
   display: none;
 }
 
-.settings-advanced-toggle::before {
-  content: '\25B6';
-  display: inline-block;
-  margin-right: 8px;
-  font-size: 0.6em;
+.settings-advanced-toggle::after {
+  content: '\25B8';
+  font-size: 0.85em;
   transition: transform 150ms ease;
+  margin-left: auto;
 }
 
-.settings-advanced[open] > .settings-advanced-toggle::before {
+.settings-advanced[open] > .settings-advanced-toggle::after {
   transform: rotate(90deg);
 }
 
-.settings-advanced-content {
-  padding-top: var(--space-2, 8px);
+.settings-advanced-content .settings-row:last-child {
+  border-bottom: none;
 }
 
 .settings-model-input[type="number"] {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1339,6 +1339,22 @@ textarea:focus {
   border-color: var(--color-accent);
 }
 
+.settings-model-input--required {
+  border-color: var(--color-danger);
+  background: color-mix(in srgb, var(--color-danger) 5%, var(--color-bg-card));
+}
+
+.settings-model-input--required::placeholder {
+  color: var(--color-danger);
+  opacity: 0.7;
+}
+
+.settings-model-hint {
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--color-danger);
+  margin-top: 4px;
+}
+
 .settings-model-input[type="number"] {
   width: 80px;
   text-align: center;

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1356,17 +1356,27 @@ textarea:focus {
 }
 
 .settings-advanced {
-  margin-top: var(--space-2, 8px);
+  margin-top: var(--space-4, 16px);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-2, 8px);
 }
 
 .settings-advanced-toggle {
-  font-size: var(--text-sm, 0.875rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
   color: var(--color-text-muted);
   cursor: pointer;
   padding: var(--space-2, 8px) 0;
   user-select: none;
   list-style: none;
+  opacity: 0.7;
+  transition: opacity 150ms ease;
+}
+
+.settings-advanced-toggle:hover {
+  opacity: 1;
 }
 
 .settings-advanced-toggle::-webkit-details-marker {
@@ -1376,13 +1386,17 @@ textarea:focus {
 .settings-advanced-toggle::before {
   content: '\25B6';
   display: inline-block;
-  margin-right: 6px;
-  font-size: 0.65em;
+  margin-right: 8px;
+  font-size: 0.6em;
   transition: transform 150ms ease;
 }
 
 .settings-advanced[open] > .settings-advanced-toggle::before {
   transform: rotate(90deg);
+}
+
+.settings-advanced-content {
+  padding-top: var(--space-2, 8px);
 }
 
 .settings-model-input[type="number"] {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -552,7 +552,7 @@ textarea:focus {
 
 .job-error-toast {
   position: fixed;
-  top: var(--space-4, 16px);
+  bottom: var(--space-6, 24px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 9999;
@@ -574,7 +574,7 @@ textarea:focus {
 }
 
 @keyframes toast-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(-12px); }
+  from { opacity: 0; transform: translateX(-50%) translateY(12px); }
   to { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
 

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -315,7 +315,7 @@ class TestRunApiAnalysisBridge:
         provider = {"ollama": {"type": "api", "model": "llama3.1"}}
 
         with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
-             pytest.raises(Exception, match="No api_base configured"):
+             pytest.raises(Exception, match="No API base URL configured"):
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
 
     def test_empty_queue_writes_empty_files(self, tmp_path):

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 
 import pytest
 
-from quodeq.shared.prereqs import check_node, check_npm, check_claude_code, check_dashboard_prereqs, check_evaluate_prereqs
+from quodeq.shared.prereqs import (
+    check_node, check_npm, check_dashboard_prereqs, check_evaluate_prereqs,
+    _check_cli_provider, _check_api_provider, _is_provider_explicitly_configured,
+)
 
 
 class TestCheckNode:
@@ -42,16 +45,46 @@ class TestCheckNpm:
             check_npm()
 
 
-class TestCheckClaudeCode:
+class TestCheckCliProvider:
     def test_missing_claude_raises(self):
         with patch("subprocess.run", side_effect=FileNotFoundError):
-            with pytest.raises(RuntimeError, match="Claude Code"):
-                check_claude_code()
+            with pytest.raises(RuntimeError, match="configured as your AI provider but was not found"):
+                _check_cli_provider("claude")
+
+    def test_missing_provider_includes_settings_hint(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(RuntimeError, match="dashboard Settings"):
+                _check_cli_provider("codex")
 
     def test_valid_claude_passes(self):
         result = subprocess.CompletedProcess([], 0, stdout="1.0.0\n")
         with patch("subprocess.run", return_value=result):
-            check_claude_code()
+            _check_cli_provider("claude")
+
+
+class TestCheckApiProvider:
+    def test_ollama_not_running_raises(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("Connection refused")):
+            with pytest.raises(RuntimeError, match="server is not running"):
+                _check_api_provider("ollama")
+
+    def test_non_ollama_api_passes(self):
+        # Non-ollama API providers have no connectivity check
+        _check_api_provider("openrouter")
+
+
+class TestIsProviderExplicitlyConfigured:
+    def test_no_env_returns_false(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert not _is_provider_explicitly_configured()
+
+    def test_ai_provider_set_returns_true(self):
+        with patch.dict("os.environ", {"AI_PROVIDER": "ollama"}):
+            assert _is_provider_explicitly_configured()
+
+    def test_ai_cmd_set_returns_true(self):
+        with patch.dict("os.environ", {"AI_CMD": "claude"}):
+            assert _is_provider_explicitly_configured()
 
 
 class TestCompositeChecks:
@@ -61,7 +94,17 @@ class TestCompositeChecks:
         with patch("subprocess.run", side_effect=[node_result, npm_result]):
             check_dashboard_prereqs()
 
-    def test_evaluate_prereqs_checks_claude(self):
+    def test_evaluate_no_provider_configured_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError, match="No AI provider configured"):
+                check_evaluate_prereqs()
+
+    def test_evaluate_with_cli_provider_checks_binary(self):
         result = subprocess.CompletedProcess([], 0, stdout="1.0.0\n")
-        with patch("subprocess.run", return_value=result):
-            check_evaluate_prereqs()
+        with patch.dict("os.environ", {"AI_PROVIDER": "claude"}):
+            with patch("subprocess.run", return_value=result):
+                with patch(
+                    "quodeq.analysis._provider_cache.get_provider_configs",
+                    return_value={"claude": {"type": "cli", "cmd": "claude"}},
+                ):
+                    check_evaluate_prereqs()


### PR DESCRIPTION
## Summary

### Error handling
- Show toast notification (bottom center, 5s) instead of hidden inline banner for evaluation errors
- Toast re-triggers on every Evaluate click, even if same error
- Clear error messages: "No model selected", "No provider selected", "Select at least one dimension"
- CLI prereqs check the configured provider, not always Claude
- Ollama not running gets a specific "ollama serve" hint
- API errors include actionable next steps (dashboard Settings)

### Settings UX
- All providers highlight model field in red when empty
- CLI providers also prompt for model selection
- Advanced section (collapsed) contains: analysis mode, verify findings, and for CLI: power selector + analysis models
- Advanced toggle styled to match settings page pattern
- Max agents and time limit stay visible by default

### Evaluation buttons
- Renamed: "Scan incremental" and "Clean scan"
- Buttons always enabled, toast error when no dimensions selected

### Console pop-out
- Opens in system browser when running in native PyWebView window
- Added `open_browser` method to PyWebView API using `webbrowser.open`

## Test plan
- [x] Run `quodeq evaluate .` with no provider configured (CLI)
- [x] Click Evaluate in dashboard with no model selected
- [x] Click Evaluate with no dimensions selected
- [x] Click Evaluate twice rapidly with same error
- [x] Verify Advanced toggle opens/closes in settings for all providers
- [x] Verify model field shows red border when empty for all providers
- [x] Click Pop out on console in native window mode
- [x] All 1836 tests pass