### PR TITLE
refactor: unify scoring data flow with server-side rescore

### DIFF
--- a/src/quodeq/api/_scores_routes.py
+++ b/src/quodeq/api/_scores_routes.py
@@ -1,0 +1,57 @@
+"""Unified scoring API endpoints.
+
+/api/projects/{project}/scores          -- full dashboard payload (accumulated + trend)
+/api/projects/{project}/scores/{runId}  -- single run detail (for Explorer)
+
+All rescore logic happens server-side. The frontend never calls /api/rescore
+directly when using these endpoints.
+"""
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.api.helpers import error_response
+from quodeq.api.routes_common import reports_dir
+from quodeq.services.scoring import get_project_scores, get_scores_raw
+from quodeq.shared.validation import validate_path_segment
+
+
+def register_scores_routes(app: Flask) -> None:
+    """Register unified scoring endpoints."""
+
+    def _validate(*params: str) -> tuple[Response, int] | None:
+        try:
+            validate_path_segment(*params)
+        except ValueError:
+            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        return None
+
+    @app.get("/api/projects/<project>/scores")
+    def project_scores(project: str) -> Response | tuple[Response, int]:
+        err = _validate(project)
+        if err:
+            return err
+        as_of = request.args.get("asOf")
+        eval_dir = reports_dir()
+        result = get_project_scores(Path(eval_dir), project, as_of)
+        if result is None:
+            body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(result)
+
+    @app.get("/api/projects/<project>/scores/<run_id>")
+    def project_run_scores(project: str, run_id: str) -> Response | tuple[Response, int]:
+        err = _validate(project, run_id)
+        if err:
+            return err
+        eval_dir = reports_dir()
+        try:
+            result = get_scores_raw(Path(eval_dir), project, run_id)
+        except FileNotFoundError:
+            body, status = error_response("Run not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(result)

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -19,6 +19,7 @@ from quodeq.api.standards_routes import register_standards_routes
 from quodeq.api.routes_findings import register_findings_routes
 from quodeq.api.llm_bridge_routes import register_llm_bridge_routes
 from quodeq.api.routes_rescore import register_rescore_routes
+from quodeq.api._scores_routes import register_scores_routes
 from quodeq.services.base import ActionProvider
 
 
@@ -43,6 +44,7 @@ def register_all_routes(
     register_standards_routes(app)
     register_findings_routes(app)
     register_rescore_routes(app)
+    register_scores_routes(app)
     register_llm_bridge_routes(app)
     if log_buffer:
         register_log_routes(app, log_buffer)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -1,0 +1,187 @@
+"""Unified scoring module -- single source of truth for all score data.
+
+Public API
+----------
+- ``get_scores_raw(reports_root, project, run_id)`` -- rescored data for one run
+- ``get_project_scores(reports_root, project, as_of)`` -- full dashboard payload
+
+All functions apply dismissals server-side and return the same data shapes
+as the existing endpoints, so the frontend sees no schema change.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable
+
+from quodeq.core.types import DimensionResult, to_camel_dict
+from quodeq.services.accumulated import compute_accumulated
+from quodeq.services.dashboard import (
+    DashboardCacheConfig,
+    _make_run_dimension_fetcher,
+)
+from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services.dismissed import dismissed_keys
+from quodeq.services.ports import RunInfo, list_runs
+from quodeq.services.rescore import _rescore_dimension
+from quodeq.services.scoring._rescore import rescore_run_raw
+
+
+_MAX_HISTORY_RUNS = 100
+
+
+def get_scores_raw(
+    reports_root: Path, project: str, run_id: str,
+) -> dict:
+    """Return raw rescore dict for a single run (explorer detail compat)."""
+    return rescore_run_raw(reports_root, project, run_id)
+
+
+def _make_rescoring_fetcher(
+    reports_root: Path, project: str,
+) -> Callable[[str], list[DimensionResult]]:
+    """Return a dimension fetcher that applies rescore (dismissals) to results.
+
+    Wraps the standard cached fetcher so that build_accumulated_trend
+    automatically gets rescored data.
+    """
+    base_fetcher = _make_run_dimension_fetcher(reports_root, project)
+    dismissed = dismissed_keys(reports_root / project)
+    if not dismissed:
+        return base_fetcher
+
+    def rescoring_fetcher(run_id: str) -> list[DimensionResult]:
+        dims = base_fetcher(run_id)
+        return [_rescore_dimension(d, dismissed) for d in dims]
+
+    return rescoring_fetcher
+
+
+def _rescore_accumulated_response(
+    accumulated: dict[str, Any],
+    reports_root: Path,
+    project: str,
+) -> dict[str, Any]:
+    """Apply rescore to an accumulated response dict (in-place compatible shape).
+
+    Filters dismissed violations from each dimension, recalculates scores,
+    and recomputes the summary.
+    """
+    dismissed = dismissed_keys(reports_root / project)
+    if not dismissed or not accumulated:
+        return accumulated
+
+    from quodeq.services.rescore import rescore_dimensions
+    from quodeq.services.ports import read_run_data
+    from quodeq.services._cache import make_lru_dimension_fetcher
+
+    # The accumulated response has camelCase dicts, but we need DimensionResult
+    # objects to rescore. We can rescore each dimension's source run and map back.
+    dims = accumulated.get("dimensions", [])
+    if not dims:
+        return accumulated
+
+    # Build a map: dimension_key -> run_id from accumulated dimensions
+    dim_to_run: dict[str, str] = {}
+    for d in dims:
+        key = (d.get("dimension") or "").lower()
+        rid = d.get("fromRunId") or d.get("runId")
+        if key and rid:
+            dim_to_run[key] = rid
+
+    # Rescore each unique run
+    fetcher = _make_run_dimension_fetcher(reports_root, project)
+    rescored_by_dim: dict[str, dict] = {}
+    seen_runs: dict[str, dict[str, dict]] = {}
+    for dim_key, run_id in dim_to_run.items():
+        if run_id not in seen_runs:
+            run_dims = fetcher(run_id)
+            result = rescore_dimensions(run_dims, dismissed)
+            seen_runs[run_id] = {
+                (rd.get("dimension") or "").lower(): rd
+                for rd in result.get("dimensions", [])
+            }
+        rd = seen_runs[run_id].get(dim_key)
+        if rd:
+            rescored_by_dim[dim_key] = rd
+
+    # Merge rescored data into accumulated dimensions
+    new_dims = []
+    for d in dims:
+        key = (d.get("dimension") or "").lower()
+        rd = rescored_by_dim.get(key)
+        if rd:
+            new_dims.append({
+                **d,
+                "overallScore": rd.get("overallScore"),
+                "overallGrade": rd.get("overallGrade"),
+                "violations": rd.get("violations", d.get("violations", [])),
+                "compliance": rd.get("compliance", d.get("compliance", [])),
+                "principles": rd.get("principles", d.get("principles", [])),
+                "totals": rd.get("totals", d.get("totals")),
+            })
+        else:
+            new_dims.append(d)
+
+    # Recompute summary from rescored dimensions
+    from quodeq.services.scoring._summary import recompute_summary
+    new_summary = recompute_summary(new_dims, accumulated.get("summary", {}))
+
+    return {**accumulated, "dimensions": new_dims, "summary": new_summary}
+
+
+def get_project_scores(
+    reports_root: Path, project: str, as_of: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the full scores payload for the dashboard.
+
+    Returns a dict with:
+      - accumulated: { dimensions, summary } (same shape as /accumulated endpoint)
+      - trend: [{ runId, dateISO, ... }] (same shape as dashboard.trend)
+      - availableRuns: [{ runId, dateLabel }]
+
+    All scores have dismissals applied server-side.
+    """
+    if not (reports_root / project).exists():
+        return None
+
+    all_runs = list_runs(reports_root, project)
+    if not all_runs:
+        return {
+            "accumulated": {"dimensions": [], "summary": {}},
+            "trend": [],
+            "availableRuns": [],
+        }
+
+    # Build accumulated using the existing service (returns full data with violations)
+    accumulated = compute_accumulated(
+        str(reports_root), project, as_of,
+    )
+    if accumulated is None:
+        accumulated = {"dimensions": [], "summary": {}}
+
+    # Apply rescore to accumulated dimensions
+    accumulated = _rescore_accumulated_response(accumulated, reports_root, project)
+
+    # Build trend using a rescoring fetcher (applies dismissals to each run)
+    history_runs = all_runs[:_MAX_HISTORY_RUNS]
+    rescoring_fetcher = _make_rescoring_fetcher(reports_root, project)
+    trend = build_accumulated_trend(history_runs, rescoring_fetcher)
+
+    # Build available runs list
+    available_runs = [
+        {"runId": r.run_id, "dateLabel": r.date_label}
+        for r in all_runs
+    ]
+
+    return {
+        "accumulated": accumulated,
+        "trend": trend,
+        "availableRuns": available_runs,
+    }
+
+
+__all__ = [
+    "get_scores_raw",
+    "get_project_scores",
+]

--- a/src/quodeq/services/scoring/_accumulated.py
+++ b/src/quodeq/services/scoring/_accumulated.py
@@ -1,0 +1,186 @@
+"""Build accumulated state across runs with dismissals applied server-side."""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from quodeq.core.types import DimensionResult
+from quodeq.core.scoring.internals import score_to_grade_label
+from quodeq.services.ports import RunInfo, calculate_trend, most_frequent_grade
+from quodeq.services.scoring._run_scores import get_run_dimensions, parse_score
+from quodeq.services.scoring._rescore import rescore_run
+from quodeq.services.scoring._types import (
+    AccumulatedSummary,
+    ScoredDimension,
+)
+
+
+def build_accumulated(
+    reports_root: Path,
+    project: str,
+    all_runs: list[RunInfo],
+) -> tuple[list[ScoredDimension], AccumulatedSummary]:
+    """Build accumulated dimensions and summary across all runs.
+
+    Walks runs newest-first, keeping the latest occurrence of each
+    dimension. Applies dismissals via rescore_run for each run that
+    contributes a dimension.
+
+    Returns (dimensions, summary).
+    """
+    # Track which runs we need to rescore (only those contributing a latest dimension)
+    latest_by_dim: dict[str, tuple[ScoredDimension, RunInfo]] = {}
+    prev_occurrence: dict[str, ScoredDimension] = {}
+    prev_run_latest: dict[str, ScoredDimension] = {}
+
+    # Cache rescored runs to avoid re-rescoring the same run
+    rescored_cache: dict[str, dict[str, ScoredDimension]] = {}
+
+    for run_idx, run_info in enumerate(all_runs):
+        run_id = run_info.run_id
+        if run_id not in rescored_cache:
+            scored_dims = rescore_run(reports_root, project, run_id)
+            rescored_cache[run_id] = {sd.dimension.lower(): sd for sd in scored_dims}
+
+        run_dims = rescored_cache[run_id]
+        for dim_key, sd in run_dims.items():
+            if not sd.dimension:
+                continue
+            # Enrich with run metadata
+            enriched = ScoredDimension(
+                dimension=sd.dimension,
+                overall_score=sd.overall_score,
+                overall_grade=sd.overall_grade,
+                violation_count=sd.violation_count,
+                compliance_count=sd.compliance_count,
+                severity_critical=sd.severity_critical,
+                severity_major=sd.severity_major,
+                severity_minor=sd.severity_minor,
+                from_run_id=run_id,
+                from_date_iso=run_info.date_iso,
+                from_date_label=run_info.date_label,
+            )
+            if dim_key not in latest_by_dim:
+                latest_by_dim[dim_key] = (enriched, run_info)
+            elif dim_key not in prev_occurrence:
+                prev_occurrence[dim_key] = enriched
+            # First non-latest run's dimensions for previous average
+            if run_idx > 0 and dim_key not in prev_run_latest:
+                prev_run_latest[dim_key] = enriched
+
+    # Compute trends by comparing latest to previous occurrence
+    dimensions: list[ScoredDimension] = []
+    for dim_key, (sd, _run_info) in latest_by_dim.items():
+        prev = prev_occurrence.get(dim_key)
+        trend_str = _compute_trend(sd.overall_score, prev.overall_score if prev else None)
+        dimensions.append(ScoredDimension(
+            dimension=sd.dimension,
+            overall_score=sd.overall_score,
+            overall_grade=sd.overall_grade,
+            violation_count=sd.violation_count,
+            compliance_count=sd.compliance_count,
+            severity_critical=sd.severity_critical,
+            severity_major=sd.severity_major,
+            severity_minor=sd.severity_minor,
+            trend=trend_str,
+            previous_score=prev.overall_score if prev else None,
+            previous_run_id=prev.from_run_id if prev else None,
+            from_run_id=sd.from_run_id,
+            from_date_iso=sd.from_date_iso,
+            from_date_label=sd.from_date_label,
+            from_project=sd.from_project,
+            stale=sd.stale,
+        ))
+
+    # Build summary
+    summary = _build_summary(dimensions, list(prev_run_latest.values()))
+    return dimensions, summary
+
+
+def build_accumulated_with_children(
+    reports_root: Path,
+    project: str,
+    own_runs: list[RunInfo],
+    children: list[str],
+) -> tuple[list[ScoredDimension], AccumulatedSummary]:
+    """Build accumulated state including child project dimensions."""
+    from quodeq.services.ports import list_runs
+
+    all_dims: list[ScoredDimension] = []
+    if own_runs:
+        own_dims, _ = build_accumulated(reports_root, project, own_runs)
+        all_dims.extend(own_dims)
+
+    for child in children:
+        child_runs = list_runs(reports_root, child)
+        if not child_runs:
+            continue
+        child_dims, _ = build_accumulated(reports_root, child, child_runs)
+        # Tag each dimension with its source child project
+        for sd in child_dims:
+            all_dims.append(ScoredDimension(
+                dimension=sd.dimension,
+                overall_score=sd.overall_score,
+                overall_grade=sd.overall_grade,
+                violation_count=sd.violation_count,
+                compliance_count=sd.compliance_count,
+                severity_critical=sd.severity_critical,
+                severity_major=sd.severity_major,
+                severity_minor=sd.severity_minor,
+                trend=sd.trend,
+                previous_score=sd.previous_score,
+                previous_run_id=sd.previous_run_id,
+                from_run_id=sd.from_run_id,
+                from_date_iso=sd.from_date_iso,
+                from_date_label=sd.from_date_label,
+                from_project=child,
+                stale=sd.stale,
+            ))
+
+    summary = _build_summary(all_dims, [])
+    return all_dims, summary
+
+
+def _compute_trend(current: float | None, previous: float | None) -> str:
+    """Compute trend string from numeric scores."""
+    if current is None or previous is None:
+        return "none"
+    diff = current - previous
+    if abs(diff) < 0.05:
+        return "same"
+    return "up" if diff > 0 else "down"
+
+
+def _build_summary(
+    dimensions: list[ScoredDimension],
+    prev_dims: list[ScoredDimension],
+) -> AccumulatedSummary:
+    """Build an AccumulatedSummary from dimensions."""
+    scores = [d.overall_score for d in dimensions if d.overall_score is not None]
+    avg = round(sum(scores) / len(scores), 1) if scores else None
+    prev_scores = [d.overall_score for d in prev_dims if d.overall_score is not None]
+    prev_avg = round(sum(prev_scores) / len(prev_scores), 1) if prev_scores else None
+
+    grades = [d.overall_grade for d in dimensions if d.overall_grade]
+    overall_grade = (
+        score_to_grade_label(avg) if avg is not None
+        else most_frequent_grade(grades) if grades else None
+    )
+
+    total_v = sum(d.violation_count for d in dimensions)
+    total_c = sum(d.compliance_count for d in dimensions)
+    crit = sum(d.severity_critical for d in dimensions)
+    maj = sum(d.severity_major for d in dimensions)
+    minor = sum(d.severity_minor for d in dimensions)
+
+    return AccumulatedSummary(
+        overall_grade=overall_grade,
+        numeric_average=avg,
+        previous_numeric_average=prev_avg,
+        total_violations=total_v,
+        total_compliance=total_c,
+        dimension_count=len(dimensions),
+        severity_critical=crit,
+        severity_major=maj,
+        severity_minor=minor,
+    )

--- a/src/quodeq/services/scoring/_rescore.py
+++ b/src/quodeq/services/scoring/_rescore.py
@@ -1,0 +1,95 @@
+"""Rescore dimensions with dismissals applied.
+
+Reuses the SAME scoring engine as the original evaluation, including
+the 4-stage formula. This module delegates to the existing
+``services.rescore`` module for the actual computation, and converts
+the result into our typed ScoredDimension objects.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.types import DimensionResult
+from quodeq.services.dismissed import dismissed_keys
+from quodeq.services.rescore import rescore_dimensions as _raw_rescore
+from quodeq.services.scoring._run_scores import get_run_dimensions, parse_score
+from quodeq.services.scoring._types import ScoredDimension
+
+
+def _dim_result_to_scored(d: dict, from_run_id: str | None = None, from_project: str | None = None) -> ScoredDimension:
+    """Convert a camelCase dict (from rescore_dimensions) to ScoredDimension."""
+    totals = d.get("totals", {})
+    severity = totals.get("severity", {})
+    return ScoredDimension(
+        dimension=d.get("dimension", ""),
+        overall_score=parse_score(d.get("overallScore")),
+        overall_grade=d.get("overallGrade"),
+        violation_count=totals.get("violationCount", 0),
+        compliance_count=totals.get("complianceCount", 0),
+        severity_critical=severity.get("critical", 0),
+        severity_major=severity.get("major", 0),
+        severity_minor=severity.get("minor", 0),
+        from_run_id=from_run_id,
+        from_project=from_project,
+    )
+
+
+def rescore_run(
+    reports_root: Path, project: str, run_id: str,
+) -> list[ScoredDimension]:
+    """Rescore all dimensions in a run with current dismissals applied.
+
+    Returns typed ScoredDimension objects with rescored scores.
+    """
+    dimensions = get_run_dimensions(reports_root, project, run_id)
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    if not dismissed:
+        return _dims_to_scored(dimensions, run_id)
+
+    result = _raw_rescore(dimensions, dismissed)
+    return [
+        _dim_result_to_scored(d, from_run_id=run_id)
+        for d in result.get("dimensions", [])
+    ]
+
+
+def rescore_run_raw(
+    reports_root: Path, project: str, run_id: str,
+) -> dict:
+    """Return the raw rescore dict (for backward compat with explorer detail).
+
+    Returns the same shape as the old /api/rescore endpoint.
+    """
+    dimensions = get_run_dimensions(reports_root, project, run_id)
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    if not dismissed:
+        from quodeq.data.fs.report_parser.grades import summarize_dimensions
+        from quodeq.core.types import to_camel_dict
+        return {
+            "dimensions": [to_camel_dict(d) for d in dimensions],
+            "summary": to_camel_dict(summarize_dimensions(dimensions)),
+        }
+    return _raw_rescore(dimensions, dismissed)
+
+
+def _dims_to_scored(
+    dimensions: list[DimensionResult], run_id: str,
+) -> list[ScoredDimension]:
+    """Convert raw DimensionResult objects to ScoredDimension (no dismissals)."""
+    result = []
+    for d in dimensions:
+        totals = d.totals
+        result.append(ScoredDimension(
+            dimension=d.dimension or "",
+            overall_score=parse_score(d.overall_score),
+            overall_grade=d.overall_grade,
+            violation_count=totals.violation_count if totals else 0,
+            compliance_count=totals.compliance_count if totals else 0,
+            severity_critical=totals.severity.critical if totals else 0,
+            severity_major=totals.severity.major if totals else 0,
+            severity_minor=totals.severity.minor if totals else 0,
+            from_run_id=run_id,
+        ))
+    return result

--- a/src/quodeq/services/scoring/_run_scores.py
+++ b/src/quodeq/services/scoring/_run_scores.py
@@ -1,0 +1,41 @@
+"""Read scores from a single run -- the ONLY module that touches disk."""
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from pathlib import Path
+
+from quodeq.core.types import DimensionResult
+from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services.ports import RunInfo, list_runs, parse_numeric_score
+
+_DEFAULT_CACHE_MAX = 256
+
+# Module-level shared cache so all callers within the same process share it.
+_cache: OrderedDict[tuple, list[DimensionResult]] = OrderedDict()
+_cache_lock = threading.Lock()
+
+
+def get_run_dimensions(
+    reports_root: Path, project: str, run_id: str,
+    *, cache: OrderedDict | None = None,
+    cache_lock: threading.Lock | None = None,
+    cache_max: int = _DEFAULT_CACHE_MAX,
+) -> list[DimensionResult]:
+    """Return dimension data for a single run, using the shared LRU cache."""
+    c = cache if cache is not None else _cache
+    lk = cache_lock if cache_lock is not None else _cache_lock
+    fetcher = make_lru_dimension_fetcher(reports_root, project, c, lk, cache_max)
+    return fetcher(run_id)
+
+
+def get_available_runs(reports_root: Path, project: str) -> list[RunInfo]:
+    """Return all runs for a project, sorted newest-first."""
+    return list_runs(reports_root, project)
+
+
+def parse_score(score_str: str | None) -> float | None:
+    """Parse a score string like '7.5/10' into a float."""
+    if not score_str:
+        return None
+    return parse_numeric_score(score_str)

--- a/src/quodeq/services/scoring/_summary.py
+++ b/src/quodeq/services/scoring/_summary.py
@@ -1,0 +1,56 @@
+"""Recompute accumulated summary from rescored dimension dicts."""
+from __future__ import annotations
+
+from typing import Any
+
+from quodeq.core.scoring.internals import score_to_grade_label
+from quodeq.services.ports import most_frequent_grade, parse_numeric_score
+
+
+def recompute_summary(
+    dimensions: list[dict[str, Any]],
+    old_summary: dict[str, Any],
+) -> dict[str, Any]:
+    """Recompute the accumulated summary from rescored camelCase dimension dicts."""
+    scores: list[float] = []
+    grades: list[str] = []
+    total_violations = 0
+    total_compliance = 0
+    critical = major = minor = 0
+
+    for d in dimensions:
+        score_str = d.get("overallScore")
+        if score_str:
+            val = parse_numeric_score(score_str)
+            if val is not None:
+                scores.append(val)
+        grade = d.get("overallGrade")
+        if grade:
+            grades.append(grade)
+        totals = d.get("totals") or {}
+        total_violations += totals.get("violationCount", 0)
+        total_compliance += totals.get("complianceCount", 0)
+        severity = totals.get("severity") or {}
+        critical += severity.get("critical", 0)
+        major += severity.get("major", 0)
+        minor += severity.get("minor", 0)
+
+    avg = round(sum(scores) / len(scores), 1) if scores else None
+    overall_grade = (
+        score_to_grade_label(avg) if avg is not None
+        else (most_frequent_grade(grades) if grades else None)
+    )
+
+    return {
+        **old_summary,
+        "overallGrade": overall_grade,
+        "numericAverage": avg,
+        "totalViolations": total_violations,
+        "totalCompliance": total_compliance,
+        "dimensionCount": len(dimensions),
+        "severity": {
+            "critical": critical,
+            "major": major,
+            "minor": minor,
+        },
+    }

--- a/src/quodeq/services/scoring/_trend.py
+++ b/src/quodeq/services/scoring/_trend.py
@@ -1,0 +1,102 @@
+"""Build trend from runs with accumulated progression and dismissals applied."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.scoring.internals import score_to_grade_label
+from quodeq.services.ports import RunInfo, most_frequent_grade
+from quodeq.services.scoring._rescore import rescore_run
+from quodeq.services.scoring._types import ScoredDimension, TrendEntry
+
+
+def build_trend(
+    reports_root: Path,
+    project: str,
+    runs: list[RunInfo],
+) -> list[TrendEntry]:
+    """Build trend with accumulated progression, dismissals applied server-side.
+
+    Walks runs oldest-first to build accumulated state at each point.
+    Returns trend entries newest-first (matching frontend convention).
+    """
+    trend: list[TrendEntry] = []
+    acc_by_dim: dict[str, ScoredDimension] = {}
+    prev_by_dim: dict[str, ScoredDimension] = {}
+
+    for run_info in reversed(runs):  # oldest -> newest
+        run_dims = rescore_run(reports_root, project, run_info.run_id)
+        if not run_dims:
+            continue
+
+        # Update accumulated state
+        for sd in run_dims:
+            if sd.dimension:
+                acc_by_dim[sd.dimension.lower()] = sd
+
+        # Build dimension details with deltas
+        details = _build_dimension_details(run_dims, prev_by_dim)
+
+        # Compute averages
+        acc_dims = list(acc_by_dim.values())
+        acc_scores = [d.overall_score for d in acc_dims if d.overall_score is not None]
+        acc_avg = round(sum(acc_scores) / len(acc_scores), 1) if acc_scores else None
+        run_scores = [d.overall_score for d in run_dims if d.overall_score is not None]
+        run_avg = round(sum(run_scores) / len(run_scores), 1) if run_scores else None
+
+        acc_grades = [d.overall_grade for d in acc_dims if d.overall_grade]
+        run_grades = [d.overall_grade for d in run_dims if d.overall_grade]
+        run_dim_names = sorted(d.dimension for d in run_dims if d.dimension)
+
+        trend.append(TrendEntry(
+            run_id=run_info.run_id,
+            date_iso=run_info.date_iso,
+            date_label=run_info.date_label,
+            dimensions_count=len(run_dim_names),
+            dimensions=run_dim_names,
+            dimension_details=details,
+            accumulated_dimensions_count=len(acc_by_dim),
+            run_numeric_average=run_avg,
+            run_overall_grade=(
+                score_to_grade_label(run_avg) if run_avg is not None
+                else (most_frequent_grade(run_grades) if run_grades else None)
+            ),
+            numeric_average=acc_avg,
+            overall_grade=(
+                score_to_grade_label(acc_avg) if acc_avg is not None
+                else (most_frequent_grade(acc_grades) if acc_grades else None)
+            ),
+        ))
+
+        # Track previous for next iteration
+        for sd in run_dims:
+            if sd.dimension:
+                prev_by_dim[sd.dimension.lower()] = sd
+
+    trend.reverse()  # newest first
+    return trend
+
+
+def _build_dimension_details(
+    run_dims: list[ScoredDimension],
+    prev_by_dim: dict[str, ScoredDimension],
+) -> list[dict]:
+    """Build per-dimension detail dicts with score deltas."""
+    details = []
+    for sd in sorted(run_dims, key=lambda d: d.dimension or ""):
+        if not sd.dimension:
+            continue
+        prev = prev_by_dim.get(sd.dimension.lower())
+        score = sd.overall_score
+        prev_score = prev.overall_score if prev else None
+        delta = (
+            round(score - prev_score, 2)
+            if score is not None and prev_score is not None
+            else None
+        )
+        details.append({
+            "dimension": sd.dimension,
+            "score": score,
+            "grade": sd.overall_grade,
+            "delta": delta,
+        })
+    return details

--- a/src/quodeq/services/scoring/_types.py
+++ b/src/quodeq/services/scoring/_types.py
@@ -1,0 +1,137 @@
+"""Shared types for the unified scoring module."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ScoredDimension:
+    """A single dimension's score, grade, and violation summary.
+
+    This is the unified shape returned by all scoring module functions.
+    It replaces the ad-hoc dicts and partial DimensionResult overlays
+    used by the old code.
+    """
+    dimension: str
+    overall_score: float | None = None
+    overall_grade: str | None = None
+    violation_count: int = 0
+    compliance_count: int = 0
+    severity_critical: int = 0
+    severity_major: int = 0
+    severity_minor: int = 0
+    trend: str | None = None          # "up", "down", "same", "none"
+    previous_score: float | None = None
+    previous_run_id: str | None = None
+    from_run_id: str | None = None
+    from_date_iso: str | None = None
+    from_date_label: str | None = None
+    from_project: str | None = None
+    stale: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "dimension": self.dimension,
+            "overallScore": f"{self.overall_score}/10" if self.overall_score is not None else None,
+            "overallGrade": self.overall_grade,
+            "totals": {
+                "violationCount": self.violation_count,
+                "complianceCount": self.compliance_count,
+                "severity": {
+                    "critical": self.severity_critical,
+                    "major": self.severity_major,
+                    "minor": self.severity_minor,
+                },
+            },
+            "trend": self.trend,
+            "previousScore": f"{self.previous_score}/10" if self.previous_score is not None else None,
+            "previousRunId": self.previous_run_id,
+            "fromRunId": self.from_run_id,
+            "fromDateIso": self.from_date_iso,
+            "fromDateLabel": self.from_date_label,
+            "stale": self.stale,
+        }
+        if self.from_project is not None:
+            d["fromProject"] = self.from_project
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class AccumulatedSummary:
+    """Summary stats for an accumulated view."""
+    overall_grade: str | None = None
+    numeric_average: float | None = None
+    previous_numeric_average: float | None = None
+    total_violations: int = 0
+    total_compliance: int = 0
+    dimension_count: int = 0
+    severity_critical: int = 0
+    severity_major: int = 0
+    severity_minor: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "overallGrade": self.overall_grade,
+            "numericAverage": self.numeric_average,
+            "previousNumericAverage": self.previous_numeric_average,
+            "totalViolations": self.total_violations,
+            "totalCompliance": self.total_compliance,
+            "dimensionCount": self.dimension_count,
+            "severity": {
+                "critical": self.severity_critical,
+                "major": self.severity_major,
+                "minor": self.severity_minor,
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TrendEntry:
+    """A single point in the accumulated trend (one run)."""
+    run_id: str
+    date_iso: str | None = None
+    date_label: str | None = None
+    dimensions_count: int = 0
+    dimensions: list[str] = field(default_factory=list)
+    dimension_details: list[dict[str, Any]] = field(default_factory=list)
+    accumulated_dimensions_count: int = 0
+    run_numeric_average: float | None = None
+    run_overall_grade: str | None = None
+    numeric_average: float | None = None
+    overall_grade: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "runId": self.run_id,
+            "dateISO": self.date_iso,
+            "dateLabel": self.date_label,
+            "dimensionsCount": self.dimensions_count,
+            "dimensions": self.dimensions,
+            "dimensionDetails": self.dimension_details,
+            "accumulatedDimensionsCount": self.accumulated_dimensions_count,
+            "runNumericAverage": self.run_numeric_average,
+            "runOverallGrade": self.run_overall_grade,
+            "numericAverage": self.numeric_average,
+            "overallGrade": self.overall_grade,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AccumulatedState:
+    """Full accumulated response payload."""
+    project: str
+    dimensions: list[ScoredDimension] = field(default_factory=list)
+    summary: AccumulatedSummary = field(default_factory=AccumulatedSummary)
+    trend: list[TrendEntry] = field(default_factory=list)
+    available_runs: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accumulated": {
+                "dimensions": [d.to_dict() for d in self.dimensions],
+                "summary": self.summary.to_dict(),
+            },
+            "trend": [t.to_dict() for t in self.trend],
+            "availableRuns": self.available_runs,
+        }

--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-BXVG-_o_.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BHz_dj7h.css">
+    <script type="module" crossorigin src="/assets/index-OKjkOYwo.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-CbFOSqNR.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -249,7 +249,7 @@ export default function App() {
   const contentProps = {
     dashboardData: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
-      dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, rescoreLookup: state.rescoreLookup, loading: state.loading, error: state.error,
+      dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, error: state.error,
       availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
       selectedDisplayName: state.selectedDisplayName,
     },

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -78,6 +78,19 @@ export function cloneToLocal(projectId, destination) {
   });
 }
 
+// ── Unified Scores ─────────────────────────────────────────────────────
+
+/** @returns {Promise<{accumulated: Object, trend: Array, availableRuns: Array}>} */
+export async function getProjectScores(projectId, asOfRun = null) {
+  const q = asOfRun ? `?asOf=${encodeURIComponent(asOfRun)}` : '';
+  return request(`/projects/${encodeURIComponent(projectId)}/scores${q}`);
+}
+
+/** @returns {Promise<{dimensions: Array, summary: Object}>} */
+export async function getRunScores(projectId, runId) {
+  return request(`/projects/${encodeURIComponent(projectId)}/scores/${encodeURIComponent(runId)}`);
+}
+
 // ── Dashboard ───────────────────────────────────────────────────────────
 
 /** @returns {Promise<import('../models/dashboard.js').Dashboard>} */

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -8,7 +8,8 @@ import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGroupin
 import RunHistoryPanel from './RunHistoryPanel.jsx';
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
-import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
+import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
+import { filterTrendByVisibleStandardsDaily, filterAccumulatedByVisibleStandards } from '../../../utils/scoreFiltering.js';
 import CopyButton, { FileTextIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildOverviewReport } from '../../../utils/reportBuilder.js';
@@ -112,14 +113,14 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
   );
 }
 
-function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, dimensionsWithViolations, selectedDayDimNames, rescoreLookup }) {
+function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, dimensionsWithViolations, selectedDayDimNames }) {
   return (
     <>
       <div className="section-header">
         <h3 className="section-title">Quality Dimensions</h3>
       </div>
       <div className="dimensions-panel">
-        <DimensionCardsGrid sortedDimensions={sortedDimensions} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} rescoreLookup={rescoreLookup} />
+        <DimensionCardsGrid sortedDimensions={sortedDimensions} onDimensionClick={onDimensionClick} selectedDayDimNames={selectedDayDimNames} />
       </div>
 
       {dimensionsWithViolations.length > 0 && (
@@ -145,65 +146,6 @@ function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, dime
       )}
     </>
   );
-}
-
-// ---------------------------------------------------------------------------
-// Pure computation helpers extracted from the component
-// ---------------------------------------------------------------------------
-
-const roundOneDecimal = (n) => Math.round(n * 10) / 10;
-
-function buildFilteredTrend(trend, dailyTrend, visibleSet) {
-  const accByDim = {};
-  const accByDate = new Map(); // date string → accAvg
-  const visibleDates = new Set();
-  const rawReversed = [...trend].reverse(); // oldest first
-  for (const entry of rawReversed) {
-    let hasVisible = false;
-    for (const d of (entry.dimensionDetails || [])) {
-      const dimId = (d.dimension || '').toLowerCase();
-      if (visibleSet.has(dimId) && d.score != null) {
-        accByDim[dimId] = d.score;
-        hasVisible = true;
-      }
-    }
-    if (hasVisible) {
-      const accScores = Object.values(accByDim).filter((s) => s != null);
-      const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
-      const datePart = (entry.dateISO || '').slice(0, 10);
-      accByDate.set(datePart, accAvg);
-      visibleDates.add(datePart);
-    }
-  }
-  // Match daily entries by date, only include days with visible evaluations
-  return dailyTrend
-    .filter((entry) => visibleDates.has((entry.dateISO || '').slice(0, 10)))
-    .map((entry) => {
-      const datePart = (entry.dateISO || '').slice(0, 10);
-      const accAvg = accByDate.get(datePart) ?? null;
-      const details = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
-      const runScores = details.map((d) => d.score).filter((s) => s != null);
-      const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;
-      const dims = (entry.dimensions || []).filter((d) => visibleSet.has(d.toLowerCase()));
-      return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: details, dimensions: dims, dimensionsCount: dims.length };
-    });
-}
-
-function buildFilteredAccumulated(accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun) {
-  if (!accumulated) return accumulated;
-  // Use the trend's accumulated average (consistent with History) instead of
-  // recomputing from rescored dimensions which can produce different values.
-  const selectedIdx = currentOverviewRun ? filteredDailyTrend.findIndex((t) => t.runId === currentOverviewRun) : 0;
-  const idx = selectedIdx >= 0 ? selectedIdx : 0;
-  const trendAvg = idx < filteredDailyTrend.length ? parseFloat(filteredDailyTrend[idx]?.numericAverage) : null;
-  const numericAverage = (trendAvg != null && !isNaN(trendAvg)) ? trendAvg : null;
-  const prevIdx = idx + 1;
-  const prevAvg = prevIdx < filteredDailyTrend.length ? parseFloat(filteredDailyTrend[prevIdx]?.numericAverage) : null;
-  const { totalViolations, totalCompliance, severity } = computeSummaryFromDimensions(filteredDimensions);
-  return {
-    ...accumulated,
-    summary: { ...accumulated.summary, numericAverage, previousNumericAverage: prevAvg, totalViolations, totalCompliance, severity },
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -236,15 +178,15 @@ function useAccumulatedComputations(data) {
 
   const visibleIds = useMemo(() => readVisibleStandardIds(), [accumulatedDimensions]);
   const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
-  const filteredDailyTrend = useMemo(() => buildFilteredTrend(trend, dailyTrend, visibleSet), [trend, dailyTrend, visibleSet]);
+  const filteredDailyTrend = useMemo(() => filterTrendByVisibleStandardsDaily(trend, dailyTrend, visibleSet), [trend, dailyTrend, visibleSet]);
   const filteredDimensions = useMemo(() => accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase())), [accumulatedDimensions, visibleIds]);
-  const filteredAccumulated = useMemo(() => buildFilteredAccumulated(accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun), [accumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
+  const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredDailyTrend, currentOverviewRun), [accumulated, visibleSet, filteredDailyTrend, currentOverviewRun]);
   const filteredStats = useMemo(() => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun), [filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
 
   return { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats };
 }
 
-export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLookup }) {
+export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { onRunClick, onDimensionClick } = callbacks;
   const { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredDimensions, filteredAccumulated, filteredStats } = useAccumulatedComputations(data);
 
@@ -268,7 +210,6 @@ export default function AccumulatedOverviewPanel({ data, callbacks, rescoreLooku
         onDimensionClick={onDimensionClick}
         dimensionsWithViolations={filteredStats.dimsWithViolations}
         selectedDayDimNames={selectedDayDimNames}
-        rescoreLookup={rescoreLookup}
       />
     </>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -5,7 +5,7 @@ import RunOverviewPanel from './RunOverviewPanel.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex, selectedProject } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
   const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick } = callbacks;
   if (runMode) {
@@ -44,7 +44,6 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
       callbacks={{
         onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick,
       }}
-      rescoreLookup={rescoreLookup}
     />
   );
 }
@@ -70,7 +69,7 @@ function useDashboardHandlers(onNavigate, dashboard) {
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, rescoreLookup = {}, loading, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
+  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
   const { onNavigate, onRunSelect } = callbacks;
   const [focusedDimension, setFocusedDimension] = useState(null);
   const selectedRunId = dashboard?.selectedRun?.runId || selectedRun;
@@ -82,16 +81,8 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       setFocusedDimension(null);
     }
   }, [selectedRunId]);
-  // Merge rescored grades into accumulated dimensions so all cards reflect live scores
-  const accumulatedDimensions = useMemo(() => {
-    const dims = accumulated?.dimensions || [];
-    if (Object.keys(rescoreLookup).length === 0) return dims;
-    return dims.map((dim) => {
-      const match = rescoreLookup[(dim.dimension || '').toLowerCase()];
-      if (!match) return dim;
-      return { ...dim, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? dim.totals };
-    });
-  }, [accumulated, rescoreLookup]);
+  // Accumulated dimensions are pre-rescored from the server — no client-side merge needed
+  const accumulatedDimensions = useMemo(() => accumulated?.dimensions || [], [accumulated]);
   const focusedDimensionData = useMemo(() => focusedDimension ? (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null : null, [focusedDimension, dashboard]);
   const handlers = useDashboardHandlers(onNavigate, dashboard);
 
@@ -109,7 +100,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, rescoreLookup, availableRuns, dailyRuns, overviewRunIndex, selectedProject }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
           callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick }}
         />

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionCardsGrid.jsx
@@ -2,19 +2,17 @@ import { useMemo } from 'react';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import { formatRunId, scoreColorClass, splitScore, complianceRatio } from '../../../utils/formatters.js';
 
-function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true, rescoreLookup }) {
-  const match = rescoreLookup?.[(item.dimension || '').toLowerCase()];
-  const effectiveItem = match ? { ...item, overallScore: match.overallScore, overallGrade: match.overallGrade, totals: match.totals ?? item.totals } : item;
-  const currScore = parseFloat(effectiveItem.overallScore);
-  const prevScore = parseFloat(effectiveItem.previousScore);
+function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true }) {
+  const currScore = parseFloat(item.overallScore);
+  const prevScore = parseFloat(item.previousScore);
   const delta = !isNaN(currScore) && !isNaN(prevScore) ? currScore - prevScore : null;
-  const score = splitScore(effectiveItem.overallScore);
+  const score = splitScore(item.overallScore);
   const gradeClass = scoreColorClass(currScore);
   const staleClass = evaluatedToday ? 'qd-card--active' : 'qd-card-stale qd-card--carried';
   return (
     <article
       className={`qd-card ${staleClass} ${gradeClass}`}
-      onClick={() => onDimensionClick(effectiveItem)}
+      onClick={() => onDimensionClick(item)}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDimensionClick(item); } }}
@@ -33,12 +31,12 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true, resco
         <div className="qd-card-col-divider" />
         <div className="qd-card-col">
           <span className="qd-card-col-label">Viol</span>
-          <span className="qd-card-col-value">{effectiveItem.totals?.violationCount ?? 0}</span>
+          <span className="qd-card-col-value">{item.totals?.violationCount ?? 0}</span>
         </div>
         <div className="qd-card-col-divider" />
         <div className="qd-card-col">
           <span className="qd-card-col-label">Ratio</span>
-          <span className="qd-card-col-value">{complianceRatio(effectiveItem.totals?.violationCount ?? 0, effectiveItem.totals?.complianceCount ?? 0)}</span>
+          <span className="qd-card-col-value">{complianceRatio(item.totals?.violationCount ?? 0, item.totals?.complianceCount ?? 0)}</span>
         </div>
       </div>
       <div className="qd-card-footer">
@@ -50,7 +48,7 @@ function AccDimensionCard({ item, onDimensionClick, evaluatedToday = true, resco
   );
 }
 
-export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames, rescoreLookup }) {
+export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick, selectedDayDimNames }) {
   const dimNameSet = selectedDayDimNames instanceof Set ? selectedDayDimNames : new Set();
   const sorted = useMemo(() => [...sortedDimensions].sort((a, b) => {
     if (dimNameSet.size === 0) return a.dimension.localeCompare(b.dimension);
@@ -70,7 +68,6 @@ export default function DimensionCardsGrid({ sortedDimensions, onDimensionClick,
             item={item}
             onDimensionClick={onDimensionClick}
             evaluatedToday={isActive}
-            rescoreLookup={rescoreLookup}
           />
         );
       })}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,43 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { getDashboard, getAccumulated, getRescore } from '../../../api/index.js';
-import { createDimension } from '../../../models/dimension.js';
+import { getDashboard } from '../../../api/index.js';
+import { useProjectScores, clearScoresCache } from '../../../hooks/useProjectScores.js';
 
 const REFRESH_DEBOUNCE_MS = 300;
 
-function dimKey(d) { return (d.dimension || '').toLowerCase(); }
-
-const RESCORE_CONCURRENCY = 5;
-
-/** Rescore multiple runs with bounded concurrency, returning { [runId]: rescoreData } */
-async function fetchRescores(project, runIds) {
-  const byRun = {};
-  for (let i = 0; i < runIds.length; i += RESCORE_CONCURRENCY) {
-    const batch = runIds.slice(i, i + RESCORE_CONCURRENCY);
-    const results = await Promise.all(
-      batch.map(rid => getRescore(project, rid).then(r => ({ rid, ...r })).catch(() => null))
-    );
-    for (const r of results) { if (r) byRun[r.rid] = r; }
-  }
-  return byRun;
-}
-
-// Run data is static — cache by (project, runId) to avoid refetching on date switch.
-// Cleared by clearDashboardCache() when mutations happen.
+// Run data cache — only for the per-run dashboard view (dimensions/summary).
+// The unified scores endpoint handles accumulated + rescore + trend.
 const _runCache = new Map();
-
 function _runCacheKey(project, run) { return `${project}\0${run || 'latest'}`; }
 
 export function clearDashboardCache(project) {
+  clearScoresCache(project);
   if (project) {
     for (const key of [..._runCache.keys()]) {
       if (key.startsWith(project + '\0')) _runCache.delete(key);
     }
-    for (const key of [..._accCache.keys()]) {
-      if (key.startsWith(project + '\0')) _accCache.delete(key);
-    }
   } else {
     _runCache.clear();
-    _accCache.clear();
   }
 }
 
@@ -47,7 +26,7 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
   const cacheKey = _runCacheKey(selectedProject, selectedRun);
   const cached = _runCache.get(cacheKey);
   if (cached) {
-    setDashboard(prev => ({ ...cached, trend: prev?.trend || cached.trend }));
+    setDashboard(cached);
     setLoading(false);
     return undefined;
   }
@@ -56,20 +35,10 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
   setError(null);
 
   getDashboard(selectedProject, selectedRun)
-    .then(async (payload) => {
+    .then((payload) => {
       if (!active) return;
-      const runId = payload?.selectedRun?.runId || selectedRun;
-      let dimensions = payload.dimensions;
-      let summary = payload.summary;
-      try {
-        const rescored = await getRescore(selectedProject, runId);
-        if (!active) return;
-        dimensions = (rescored.dimensions || []).map(createDimension);
-        summary = { ...payload.summary, ...rescored.summary };
-      } catch { /* non-fatal */ }
-      const result = { ...payload, dimensions, summary };
-      _runCache.set(cacheKey, result);
-      if (active) setDashboard(prev => ({ ...result, trend: prev?.trend || result.trend }));
+      _runCache.set(cacheKey, payload);
+      if (active) setDashboard(payload);
     })
     .catch(() => { if (active) setError('Failed to load dashboard data.'); })
     .finally(() => { if (active) setLoading(false); });
@@ -77,206 +46,66 @@ function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoa
   return () => { active = false; };
 }
 
-function fetchTrendEffect(selectedProject, setDashboard) {
-  if (!selectedProject) return;
-  let active = true;
-
-  getDashboard(selectedProject, 'latest')
-    .then(async (payload) => {
-      if (!active) return;
-      const trend = payload.trend || [];
-      const runIds = [...new Set(trend.map(t => t.runId).filter(Boolean))];
-      if (runIds.length === 0) { if (active) setDashboard(prev => ({ ...prev, trend })); return; }
-      try {
-        const byRun = await fetchRescores(selectedProject, runIds);
-        if (!active) return;
-        const rescoredTrend = trend.map(t => {
-          const r = byRun[t.runId];
-          if (!r) return t;
-          const dl = {};
-          for (const d of (r.dimensions || [])) dl[dimKey(d)] = d;
-          const details = (t.dimensionDetails || []).map(dd => {
-            const rd = dl[dimKey(dd)];
-            if (!rd) return dd;
-            return {
-              ...dd,
-              score: rd.overallScore ? parseFloat(rd.overallScore) : dd.score,
-              overallGrade: rd.overallGrade || dd.overallGrade,
-            };
-          });
-          return {
-            ...t,
-            dimensionDetails: details,
-            runNumericAverage: r.summary?.numericAverage ?? t.runNumericAverage,
-            runOverallGrade: r.summary?.overallGrade ?? t.runOverallGrade,
-          };
-        });
-        if (active) setDashboard(prev => ({ ...prev, trend: rescoredTrend }));
-      } catch {
-        if (active) setDashboard(prev => ({ ...prev, trend }));
-      }
-    })
-    .catch(() => {});
-
-  return () => { active = false; };
-}
-
-const _accCache = new Map();
-
-function fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError, rescore = false) {
-  if (!selectedProject) { setAccumulated(null); return; }
-
-  const asOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
-  const accCacheKey = _runCacheKey(selectedProject, `acc-${asOf || 'latest'}${rescore ? '-r' : ''}`);
-  const cached = _accCache.get(accCacheKey);
-  if (cached) {
-    setAccumulated(cached);
-    return undefined;
-  }
-
-  let active = true;
-
-  getAccumulated(selectedProject, asOf)
-    .then(async (data) => {
-      if (!active) return;
-      let patched = data;
-      if (rescore && data?.dimensions?.length > 0) {
-        try {
-          // Group runs by source project — parent dimensions may reference child projects
-          const runsByProject = {};
-          for (const d of data.dimensions) {
-            const proj = d.fromProject || selectedProject;
-            const rid = d.fromRunId || d.runId;
-            if (rid) {
-              if (!runsByProject[proj]) runsByProject[proj] = new Set();
-              runsByProject[proj].add(rid);
-            }
-          }
-          // Map each dimension to its specific run to avoid cross-contamination
-          const dimToRun = {};
-          for (const d of data.dimensions) {
-            const key = dimKey(d);
-            const rid = d.fromRunId || d.runId;
-            if (key && rid) dimToRun[key] = rid;
-          }
-          const lookup = {};
-          for (const [proj, rids] of Object.entries(runsByProject)) {
-            const byRun = await fetchRescores(proj, [...rids]);
-            if (!active) return;
-            for (const [rid, r] of Object.entries(byRun)) {
-              for (const d of (r.dimensions || []).map(createDimension)) {
-                const key = dimKey(d);
-                if (dimToRun[key] === rid) lookup[key] = d;
-              }
-            }
-          }
-          patched = {
-            ...data,
-            dimensions: data.dimensions.map(dim => {
-              const rescored = lookup[dimKey(dim)];
-              return rescored ? { ...dim, ...rescored } : dim;
-            }),
-          };
-        } catch { /* non-fatal */ }
-      }
-      const final = patched ? { ...patched, _rescored: true } : patched;
-      _accCache.set(accCacheKey, final);
-      if (active) setAccumulated(final);
-    })
-    .catch((err) => {
-      console.error('Dashboard load failed:', err);
-      if (active) setError('Failed to load accumulated data');
-    });
-
-  return () => { active = false; };
-}
-
-function rescoreAllRunsEffect(project, accumulated, setRescoreLookup) {
-  if (!project || !accumulated?.dimensions) return;
-  if (accumulated._rescored) return;
-  const dimToRun = {};
-  for (const d of accumulated.dimensions) {
-    const key = dimKey(d);
-    const rid = d.fromRunId || d.runId;
-    if (key && rid) dimToRun[key] = rid;
-  }
-  const runIds = [...new Set(Object.values(dimToRun))];
-  if (runIds.length === 0) return;
-
-  let active = true;
-  fetchRescores(project, runIds)
-    .then((byRun) => {
-      if (!active) return;
-      const lookup = {};
-      for (const [rid, r] of Object.entries(byRun)) {
-        for (const d of (r.dimensions || [])) {
-          const key = dimKey(d);
-          if (dimToRun[key] === rid) lookup[key] = d;
-        }
-      }
-      setRescoreLookup(lookup);
-    });
-  return () => { active = false; };
-}
-
-function buildAvailableRuns(dashboard) {
-  const trendRows = dashboard?.trend || [];
-  if (trendRows.length === 0) return [];
-  return trendRows.map((row) => ({
-    runId: row.runId,
-    dateLabel: row.dateLabel || row.runId,
-  }));
-}
-
 export function useDashboard({ selectedProject, selectedRun }) {
   const [dashboard, setDashboard] = useState(null);
-  const [accumulated, setAccumulated] = useState(null);
-  const [latestAccumulated, setLatestAccumulated] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [rescoreLookup, setRescoreLookup] = useState({});
 
-  // Clear stale data immediately when project or run changes to prevent rendering old data
+  // Unified scores: accumulated + trend + rescore, all server-side
+  const { scores, latestScores, loading: scoresLoading, error: scoresError, availableRuns, refreshScores } = useProjectScores({ selectedProject, selectedRun });
+
+  // Clear stale data immediately when project changes
   const prevProjectRef = useRef(selectedProject);
   const prevRunRef = useRef(selectedRun);
   if (prevProjectRef.current !== selectedProject) {
     prevProjectRef.current = selectedProject;
     prevRunRef.current = selectedRun;
     setDashboard(null);
-    setAccumulated(null);
-    setLatestAccumulated(null);
-    setRescoreLookup({});
     setError(null);
   } else if (prevRunRef.current !== selectedRun) {
     prevRunRef.current = selectedRun;
-    // Apply cached data synchronously to avoid multi-render flash
     const dashKey = _runCacheKey(selectedProject, selectedRun);
-    const accAsOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
-    const accKey = _runCacheKey(selectedProject, `acc-${accAsOf || 'latest'}-r`);
     const cachedDash = _runCache.get(dashKey);
-    const cachedAcc = _accCache.get(accKey);
-    if (cachedDash) setDashboard(prev => ({ ...cachedDash, trend: prev?.trend || cachedDash.trend }));
-    if (cachedAcc) setAccumulated(cachedAcc);
+    if (cachedDash) setDashboard(cachedDash);
   }
 
-  // Trend: loads once per project, rescored once — stable across run changes
-  useEffect(() => fetchTrendEffect(selectedProject, setDashboard), [selectedProject, refreshKey]);
-  // Dashboard (dimensions/summary): loads per run
-  useEffect(() => { setLoading(true); return fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError); }, [selectedProject, selectedRun, refreshKey]);
-  useEffect(() => fetchAccumulatedEffect(selectedProject, selectedRun, setAccumulated, setError, true), [selectedProject, selectedRun, refreshKey]);
-  useEffect(() => fetchAccumulatedEffect(selectedProject, 'latest', setLatestAccumulated, setError, true), [selectedProject, selectedRun, refreshKey]);
-  useEffect(() => rescoreAllRunsEffect(selectedProject, accumulated, setRescoreLookup), [selectedProject, accumulated]);
-  const availableRuns = useMemo(() => buildAvailableRuns(dashboard), [dashboard]);
+  // Dashboard (run-specific dimensions/summary) — no rescore needed,
+  // the unified scores endpoint handles that for accumulated views.
+  useEffect(() => {
+    setLoading(true);
+    return fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError);
+  }, [selectedProject, selectedRun, refreshKey]);
+
+  // Merge trend from unified scores into dashboard for components that read dashboard.trend
+  const dashboardWithTrend = useMemo(() => {
+    if (!dashboard) return null;
+    const trend = scores?.trend || latestScores?.trend || dashboard.trend || [];
+    return { ...dashboard, trend };
+  }, [dashboard, scores, latestScores]);
+
+  // Accumulated data from unified scores
+  const accumulated = scores?.accumulated || null;
+  const latestAccumulated = latestScores?.accumulated || null;
 
   const refreshTimerRef = useRef(null);
   const refreshDashboard = useCallback(() => {
     clearDashboardCache(selectedProject);
+    refreshScores();
     if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
     refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), REFRESH_DEBOUNCE_MS);
-  }, [selectedProject]);
+  }, [selectedProject, refreshScores]);
 
   useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
 
-  return { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, error, availableRuns, refreshDashboard };
+  return {
+    dashboard: dashboardWithTrend,
+    accumulated,
+    latestAccumulated,
+    rescoreLookup: {}, // No longer needed — scores are pre-rescored server-side
+    loading: loading || scoresLoading,
+    error: error || scoresError,
+    availableRuns,
+    refreshDashboard,
+  };
 }

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { getDimensionEval, getRescore } from '../../../api/index.js';
+import { getDimensionEval, getRunScores } from '../../../api/index.js';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
 import CopyButton, { SparkleIcon, FileTextIcon } from '../../../components/CopyButton.jsx';
@@ -250,7 +250,7 @@ function mergeRescoreIntoEval(prev, dimData) {
 async function fetchAndRescore(project, runId, dimension) {
   const [data, rescored] = await Promise.all([
     getDimensionEval(project, runId, dimension),
-    getRescore(project, runId).catch(() => null),
+    getRunScores(project, runId).catch(() => null),
   ]);
   if (rescored) {
     const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
@@ -275,7 +275,7 @@ function useExplorerData(project, dimension, runId, refreshSignal) {
   useEffect(() => {
     if (refreshSignal === initialRef.current) return;
     if (!evalData || !project || !runId) return;
-    getRescore(project, runId).then((rescored) => {
+    getRunScores(project, runId).then((rescored) => {
       const dimData = (rescored.dimensions || []).find((d) => d.dimension === dimension);
       if (dimData) setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
     }).catch(() => {});

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -4,7 +4,7 @@ import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
 import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
-import { getRescore } from '../../../api/index.js';
+import { getRunScores } from '../../../api/index.js';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 
@@ -172,7 +172,7 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
     setDismissedSet((prev) => new Set(prev).add(`${v.file}:${v.line}`));
     // Fire rescore to update principle score/grade
     if (project && runId) {
-      getRescore(project, runId).then((rescored) => {
+      getRunScores(project, runId).then((rescored) => {
         const dimMap = new Map((rescored.dimensions || []).map((d) => [d.dimension, d]));
         const dimData = dimMap.get(dimension);
         if (!dimData) return;

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -5,43 +5,8 @@ import HistoryChartPanel from './HistoryChartPanel.jsx';
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
+import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js';
 const MAX_VISIBLE = 20;
-
-function roundOneDecimal(n) {
-  return Math.round(n * 10) / 10;
-}
-
-/**
- * Recompute accumulated and run averages using only visible dimensions.
- * Uses the same accumulation logic as Overview's buildFilteredTrend:
- * walks all runs oldest-first to build acc state, then maps each run
- * with the accumulated average at that point in time.
- */
-function filterTrendByVisibleStandards(trend, visibleSet) {
-  const accByDim = {};
-  const accByRun = new Map();
-  const rawReversed = [...trend].reverse();
-  for (const entry of rawReversed) {
-    for (const d of (entry.dimensionDetails || [])) {
-      const dimId = (d.dimension || '').toLowerCase();
-      if (visibleSet.has(dimId) && d.score != null) {
-        accByDim[dimId] = d.score;
-      }
-    }
-    const accScores = Object.values(accByDim).filter((s) => s != null);
-    const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
-    accByRun.set(entry.runId, accAvg);
-  }
-  return trend
-    .map((entry) => {
-      const accAvg = accByRun.get(entry.runId) ?? null;
-      const visibleDetails = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
-      const runScores = visibleDetails.map((d) => d.score).filter((s) => s != null);
-      const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;
-      return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: visibleDetails };
-    })
-    .filter((entry) => entry.dimensionDetails.length > 0);
-}
 
 function computeDeltas(trend) {
   return trend.map((entry, i) => {

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -1,0 +1,129 @@
+/**
+ * useProjectScores -- single hook for all score data.
+ *
+ * Fetches from the unified /scores endpoint which returns pre-rescored data.
+ * No client-side rescore calls. One source of truth consumed by Overview,
+ * History, Explorer, etc.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getProjectScores } from '../api/index.js';
+
+const REFRESH_DEBOUNCE_MS = 300;
+
+// Cache by (project, asOf) to avoid refetching on view changes.
+// Cleared by clearScoresCache() when mutations happen (dismiss/restore).
+const _cache = new Map();
+function _cacheKey(project, asOf) { return `${project}\0${asOf || 'all'}`; }
+
+export function clearScoresCache(project) {
+  if (project) {
+    for (const key of [..._cache.keys()]) {
+      if (key.startsWith(project + '\0')) _cache.delete(key);
+    }
+  } else {
+    _cache.clear();
+  }
+}
+
+/**
+ * @param {{ selectedProject: string, selectedRun: string }} opts
+ * @returns {{
+ *   scores: { accumulated: Object, trend: Array, availableRuns: Array } | null,
+ *   latestScores: { accumulated: Object, trend: Array, availableRuns: Array } | null,
+ *   loading: boolean,
+ *   error: string | null,
+ *   availableRuns: Array,
+ *   refreshScores: () => void,
+ * }}
+ */
+export function useProjectScores({ selectedProject, selectedRun }) {
+  const [scores, setScores] = useState(null);
+  const [latestScores, setLatestScores] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Clear stale data on project change
+  const prevProjectRef = useRef(selectedProject);
+  const prevRunRef = useRef(selectedRun);
+  if (prevProjectRef.current !== selectedProject) {
+    prevProjectRef.current = selectedProject;
+    prevRunRef.current = selectedRun;
+    setScores(null);
+    setLatestScores(null);
+    setError(null);
+  } else if (prevRunRef.current !== selectedRun) {
+    prevRunRef.current = selectedRun;
+    // Apply cached data synchronously
+    const asOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
+    const cached = _cache.get(_cacheKey(selectedProject, asOf));
+    if (cached) setScores(cached);
+  }
+
+  // Fetch scores for selected run (as_of)
+  useEffect(() => {
+    if (!selectedProject) { setScores(null); setError(null); return; }
+    const asOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
+    const key = _cacheKey(selectedProject, asOf);
+    const cached = _cache.get(key);
+    if (cached) {
+      setScores(cached);
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    getProjectScores(selectedProject, asOf)
+      .then((data) => {
+        if (!active) return;
+        _cache.set(key, data);
+        setScores(data);
+      })
+      .catch(() => { if (active) setError('Failed to load score data.'); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [selectedProject, selectedRun, refreshKey]);
+
+  // Fetch latest scores (no as_of) separately for components that always need latest
+  useEffect(() => {
+    if (!selectedProject) { setLatestScores(null); return; }
+    const key = _cacheKey(selectedProject, null);
+    const cached = _cache.get(key);
+    if (cached) {
+      setLatestScores(cached);
+      return;
+    }
+
+    let active = true;
+    getProjectScores(selectedProject)
+      .then((data) => {
+        if (!active) return;
+        _cache.set(key, data);
+        setLatestScores(data);
+      })
+      .catch(() => {}); // non-fatal for latest
+    return () => { active = false; };
+  }, [selectedProject, refreshKey]);
+
+  const availableRuns = useMemo(() => {
+    const trend = scores?.trend || latestScores?.trend || [];
+    if (trend.length === 0) return [];
+    return trend.map((row) => ({
+      runId: row.runId,
+      dateLabel: row.dateLabel || row.runId,
+    }));
+  }, [scores, latestScores]);
+
+  const refreshTimerRef = useRef(null);
+  const refreshScores = useCallback(() => {
+    clearScoresCache(selectedProject);
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), REFRESH_DEBOUNCE_MS);
+  }, [selectedProject]);
+
+  useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
+
+  return { scores, latestScores, loading, error, availableRuns, refreshScores };
+}

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -1,0 +1,168 @@
+/**
+ * Pure functions for filtering scores by visible standards.
+ *
+ * No side effects, no API calls. These operate on the pre-rescored data
+ * returned by the unified /scores endpoint.
+ */
+
+const roundOneDecimal = (n) => Math.round(n * 10) / 10;
+
+/**
+ * Filter trend entries to only include visible dimensions and recompute averages.
+ *
+ * Walks all runs oldest-first to build accumulated state at each point,
+ * then maps each run with the accumulated average at that point in time.
+ *
+ * @param {Array} trend - Raw trend entries (newest-first)
+ * @param {Set<string>} visibleSet - Lowercase dimension IDs to include
+ * @returns {Array} Filtered trend entries (newest-first)
+ */
+export function filterTrendByVisibleStandards(trend, visibleSet) {
+  const accByDim = {};
+  const accByRun = new Map();
+  const rawReversed = [...trend].reverse(); // oldest first
+  for (const entry of rawReversed) {
+    for (const d of (entry.dimensionDetails || [])) {
+      const dimId = (d.dimension || '').toLowerCase();
+      if (visibleSet.has(dimId) && d.score != null) {
+        accByDim[dimId] = d.score;
+      }
+    }
+    const accScores = Object.values(accByDim).filter((s) => s != null);
+    const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
+    accByRun.set(entry.runId, accAvg);
+  }
+  return trend
+    .map((entry) => {
+      const accAvg = accByRun.get(entry.runId) ?? null;
+      const visibleDetails = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
+      const runScores = visibleDetails.map((d) => d.score).filter((s) => s != null);
+      const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;
+      const dims = (entry.dimensions || []).filter((d) => visibleSet.has(d.toLowerCase()));
+      return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: visibleDetails, dimensions: dims, dimensionsCount: dims.length };
+    })
+    .filter((entry) => entry.dimensionDetails.length > 0);
+}
+
+/**
+ * Filter trend and collapse to daily entries (one per calendar day).
+ *
+ * Walks the raw trend oldest-first to build accumulated averages,
+ * then maps onto dailyTrend entries (collapsed by day) for display.
+ * Used by the Overview panel where bars represent days, not individual runs.
+ *
+ * @param {Array} trend - Raw trend entries (newest-first)
+ * @param {Array} dailyTrend - Daily-collapsed trend entries (from collapseByDay)
+ * @param {Set<string>} visibleSet - Lowercase dimension IDs to include
+ * @returns {Array} Filtered daily trend entries (newest-first)
+ */
+export function filterTrendByVisibleStandardsDaily(trend, dailyTrend, visibleSet) {
+  const accByDim = {};
+  const accByDate = new Map(); // date string -> accAvg
+  const visibleDates = new Set();
+  const rawReversed = [...trend].reverse(); // oldest first
+  for (const entry of rawReversed) {
+    let hasVisible = false;
+    for (const d of (entry.dimensionDetails || [])) {
+      const dimId = (d.dimension || '').toLowerCase();
+      if (visibleSet.has(dimId) && d.score != null) {
+        accByDim[dimId] = d.score;
+        hasVisible = true;
+      }
+    }
+    if (hasVisible) {
+      const accScores = Object.values(accByDim).filter((s) => s != null);
+      const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
+      const datePart = (entry.dateISO || '').slice(0, 10);
+      accByDate.set(datePart, accAvg);
+      visibleDates.add(datePart);
+    }
+  }
+  // Match daily entries by date, only include days with visible evaluations
+  return dailyTrend
+    .filter((entry) => visibleDates.has((entry.dateISO || '').slice(0, 10)))
+    .map((entry) => {
+      const datePart = (entry.dateISO || '').slice(0, 10);
+      const accAvg = accByDate.get(datePart) ?? null;
+      const details = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
+      const runScores = details.map((d) => d.score).filter((s) => s != null);
+      const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;
+      const dims = (entry.dimensions || []).filter((d) => visibleSet.has(d.toLowerCase()));
+      return { ...entry, numericAverage: accAvg, runNumericAverage: runAvg, dimensionDetails: details, dimensions: dims, dimensionsCount: dims.length };
+    });
+}
+
+/**
+ * Filter accumulated dimensions by visible standards and recompute summary.
+ *
+ * @param {Object} accumulated - { dimensions, summary }
+ * @param {Set<string>} visibleSet - Lowercase dimension IDs to include
+ * @param {Array} filteredTrend - Already-filtered trend (for consistent averages)
+ * @param {string|null} selectedRunId - Currently selected run
+ * @returns {Object} Filtered accumulated with recomputed summary
+ */
+export function filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredTrend, selectedRunId) {
+  if (!accumulated) return accumulated;
+  const filteredDimensions = (accumulated.dimensions || []).filter((d) =>
+    visibleSet.has((d.dimension || '').toLowerCase())
+  );
+
+  // Use the trend's accumulated average (consistent with History)
+  const selectedIdx = selectedRunId ? filteredTrend.findIndex((t) => t.runId === selectedRunId) : 0;
+  const idx = selectedIdx >= 0 ? selectedIdx : 0;
+  const trendAvg = idx < filteredTrend.length ? parseFloat(filteredTrend[idx]?.numericAverage) : null;
+  const numericAverage = (trendAvg != null && !isNaN(trendAvg)) ? trendAvg : null;
+  const prevIdx = idx + 1;
+  const prevAvg = prevIdx < filteredTrend.length ? parseFloat(filteredTrend[prevIdx]?.numericAverage) : null;
+
+  const { totalViolations, totalCompliance, severity } = computeSummaryFromFilteredDimensions(filteredDimensions);
+
+  return {
+    ...accumulated,
+    dimensions: filteredDimensions,
+    summary: {
+      ...accumulated.summary,
+      numericAverage,
+      previousNumericAverage: prevAvg,
+      totalViolations,
+      totalCompliance,
+      severity,
+    },
+  };
+}
+
+/**
+ * Compute summary stats from a filtered dimensions array.
+ * Handles both camelCase (API response) and array-based violations.
+ *
+ * @param {Array} dimensions
+ * @returns {{ totalViolations: number, totalCompliance: number, severity: Object }}
+ */
+export function computeSummaryFromFilteredDimensions(dimensions) {
+  let totalViolations = 0;
+  let totalCompliance = 0;
+  const severity = { critical: 0, major: 0, minor: 0 };
+  for (const d of dimensions) {
+    // Support both totals-based (from unified endpoint) and violations-array-based
+    const totals = d.totals;
+    if (totals) {
+      totalViolations += totals.violationCount || 0;
+      totalCompliance += totals.complianceCount || 0;
+      const sev = totals.severity || {};
+      severity.critical += sev.critical || 0;
+      severity.major += sev.major || 0;
+      severity.minor += sev.minor || 0;
+    } else {
+      const violations = d.violations || [];
+      totalViolations += violations.length;
+      totalCompliance += d.compliance?.length || 0;
+      for (const v of violations) {
+        const s = (v.severity || '').toLowerCase();
+        if (s === 'critical') severity.critical++;
+        else if (s === 'major') severity.major++;
+        else if (s === 'minor') severity.minor++;
+      }
+    }
+  }
+  return { totalViolations, totalCompliance, severity };
+}


### PR DESCRIPTION
## Summary

- Move all rescore (dismissal) logic server-side via new `/api/projects/{project}/scores` endpoint, eliminating 5 separate client-side rescore paths that caused score drift between Overview, History, and Explorer
- New `services/scoring/` backend module with clean separation: disk I/O, rescore, accumulated, trend, summary
- New `useProjectScores` hook + `scoreFiltering.js` utility replace scattered frontend rescore effects and duplicate filtering functions

## Changes

**Backend (new):**
- `services/scoring/` — unified scoring module (`_run_scores.py`, `_rescore.py`, `_accumulated.py`, `_trend.py`, `_summary.py`, `_types.py`)
- `api/_scores_routes.py` — two endpoints: `/scores` (full dashboard payload) and `/scores/{runId}` (explorer detail)

**Frontend (simplified):**
- `useProjectScores.js` — single hook, single fetch for all score data
- `scoreFiltering.js` — shared pure functions for visible-standards filtering
- `useDashboard.js` — stripped of all rescore effects, delegates to new hook
- Components no longer receive or merge `rescoreLookup`

**Removed:**
- `fetchRescores()`, `rescoreAllRunsEffect()`, client-side rescore in `fetchTrendEffect`/`fetchAccumulatedEffect`
- Inline `buildFilteredTrend()`, `buildFilteredAccumulated()`, `filterTrendByVisibleStandards()` duplicated across components

## Test plan

- [x] All 1836 backend tests pass
- [x] Frontend builds clean
- [x] Overview shows correct scores, bars grouped by day
- [x] History shows correct filtered trend
- [x] Violations page shows violation data
- [x] Map page shows data
- [x] Explorer shows rescored dimension detail
- [x] Dismiss/restore a finding → all views update consistently
- [x] Change visible standards → all views filter identically
- [x] No `/api/rescore` calls in browser network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)