### PR TITLE
fix: code-split recharts to eliminate 500kB chunk warning

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -1,11 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, lazy, Suspense } from 'react';
 import DimensionViolationsRow from './DimensionViolationsRow.jsx';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, scoreColorClass, complianceRatio } from '../../../utils/formatters.js';
 import { sortDimensionsByViolationSeverity } from '../../../utils/dimensionUtils.js';
 import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGrouping.js';
-import RunHistoryPanel from './RunHistoryPanel.jsx';
+const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
@@ -201,7 +201,9 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
       />
 
       <div className="history-panels-row">
-        <RunHistoryPanel trend={filteredDailyTrend} selectedRunId={currentOverviewRun} onBarClick={onRunClick} />
+        <Suspense fallback={null}>
+          <RunHistoryPanel trend={filteredDailyTrend} selectedRunId={currentOverviewRun} onBarClick={onRunClick} />
+        </Suspense>
         <DimensionScorePanel dimensions={filteredDimensions} onBarClick={onDimensionClick} runDate={filteredStats.lastRun.date} runId={filteredStats.lastRun.runId} />
       </div>
 

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, lazy, Suspense } from 'react';
 import HistoryRunRow from './HistoryRunRow.jsx';
-import HistoryChartPanel from './HistoryChartPanel.jsx';
+const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
@@ -50,7 +50,9 @@ function HistoryContent({ data, callbacks, showAll, setShowAll, runNav }) {
           </div>
         )}
       </div>
-      <HistoryChartPanel trend={trend} selectedRunId={selectedRunId} onBarClick={(runId) => onRunChange(runId)} />
+      <Suspense fallback={null}>
+        <HistoryChartPanel trend={trend} selectedRunId={selectedRunId} onBarClick={(runId) => onRunChange(runId)} />
+      </Suspense>
       <div className="section-header"><h3 className="section-title">Evaluations</h3></div>
       <div className="history-list">
         {visible.map((entry, i) => (

--- a/src/quodeq/ui/vite.config.js
+++ b/src/quodeq/ui/vite.config.js
@@ -11,6 +11,14 @@ export default defineConfig({
   build: {
     outDir: process.env.QUODEQ_BUILD_OUTDIR || '../static',
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-d3': ['d3-hierarchy'],
+        },
+      },
+    },
   },
   server: {
     port: Number(process.env.VITE_PORT) || DEFAULT_DEV_PORT,


### PR DESCRIPTION
## Summary
- Lazy-load `HistoryChartPanel` and `RunHistoryPanel` with `React.lazy` + `Suspense` so recharts is loaded on demand
- Add `manualChunks` in vite config to separate react and d3-hierarchy into their own vendor chunks
- Eliminates the vite build warning about chunks >500 kB (largest chunk goes from 902 kB → 368 kB)

## Test plan
- [x] `npx vite build` produces no chunk size warnings
- [x] Dashboard overview panel renders RunHistoryPanel correctly
- [x] History page renders HistoryChartPanel correctly