### PR TITLE
fix: map dark mode toggle not updating theme colors

### DIFF
--- a/src/quodeq/ui/src/features/map/viz/core/galaxyCore.js
+++ b/src/quodeq/ui/src/features/map/viz/core/galaxyCore.js
@@ -25,7 +25,10 @@ let _themeColors = null;
 let _themeSourceEl = null;
 let _themeObserver = null;
 export function getThemeColors(sourceEl) {
-  const el = sourceEl || document.documentElement;
+  // Prefer previously-set source element (the .map-viz-container) so that
+  // callers without an explicit element (scoreRGB, sevRGB) still read the
+  // correct scoped CSS variables (e.g. .map-viz-dark overrides).
+  const el = sourceEl || _themeSourceEl || document.documentElement;
   if (_themeColors && _themeSourceEl === el) return _themeColors;
   _themeSourceEl = el;
   const style = getComputedStyle(el);
@@ -49,13 +52,18 @@ export function getThemeColors(sourceEl) {
     surface: raw('--color-surface') || '#1a1a2e',
   };
   if (!_themeObserver) {
-    _themeObserver = new MutationObserver(() => { _themeColors = null; _themeSourceEl = null; });
+    _themeObserver = new MutationObserver(() => { _themeColors = null; });
     _themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
+  }
+  // Also watch the source element itself for class changes (e.g. map-viz-dark toggle)
+  if (el !== document.documentElement && el._themeObs === undefined) {
+    el._themeObs = new MutationObserver(() => { _themeColors = null; });
+    el._themeObs.observe(el, { attributes: true, attributeFilter: ['class'] });
   }
   return _themeColors;
 }
 
-export function invalidateThemeColors() { _themeColors = null; _themeSourceEl = null; }
+export function invalidateThemeColors() { _themeColors = null; }
 
 // score is 0-10 scale (matching the app's grading system)
 export function scoreRGB(score) {


### PR DESCRIPTION
## Summary
- Toggling the map's dark/light switch wasn't updating canvas colors because `getThemeColors()` fell back to `document.documentElement` instead of the `.map-viz-container` where the dark CSS variables are scoped
- `invalidateThemeColors()` was also clearing the source element reference, losing track of the container
- Now the source element is retained across calls and a MutationObserver on the container detects `.map-viz-dark` class changes

## Test plan
- [x] Open map in light app theme, toggle the dark switch off and on — canvas colors should update immediately
- [x] Verify severity and grade colors match the expected dark/light palette