### PR TITLE
fix: update static build assets

### DIFF
--- a/src/quodeq/static/index.html
+++ b/src/quodeq/static/index.html
@@ -8,8 +8,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-OKjkOYwo.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-CbFOSqNR.css">
+    <script type="module" crossorigin src="/assets/index-D9ILIwzh.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/vendor-react-N--QU9DW.js">
+    <link rel="modulepreload" crossorigin href="/assets/vendor-d3-CKcP1auH.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-Dn3E2N6Y.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Update `index.html` asset references to match latest UI build output
- Adds modulepreload hints for vendor-react and vendor-d3 chunks (code-split)

## Test plan
- [x] Dashboard loads correctly with updated asset paths
- [x] No 404s on JS/CSS resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)