### PR TITLE
fix: resolve 22 security violations

### DIFF
--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -59,9 +59,10 @@ if [ -z "$QUODEQ" ]; then
         # Using --only-binary :all: to reduce supply chain risk by avoiding
         # arbitrary code execution in source distributions (setup.py).
         # Using --no-deps to prevent transitive dependency attacks.
-        # Pin to exact major.minor to mitigate supply-chain risk.
+        # Pinned to exact version to mitigate supply-chain risk from version
+        # ranges. Update this pin when releasing new versions.
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq>=1.0.0b1,<2" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.0.5" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -23,10 +23,12 @@ from pydantic import BaseModel, Field
 from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
 from quodeq.core.standards.refs import load_compiled_requirements
 from quodeq.engine._ref_utils import load_compiled_refs
+from quodeq.shared.url_validation import validate_url_safe
 
 _log = logging.getLogger(__name__)
 
 _MAX_RETRIES = 2
+_OLLAMA_DEFAULT_BASE = "http://localhost:11434/v1"
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +95,8 @@ def _salvage_partial_findings(raw_json: str) -> list[dict]:
 
 def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
     """Call LLM via Instructor — returns validated finding dicts."""
+    if config.api_base and config.api_base != _OLLAMA_DEFAULT_BASE:
+        validate_url_safe(config.api_base, allow_private=True)
     client = instructor.from_openai(
         openai.OpenAI(base_url=config.api_base, api_key=config.api_key or "ollama"),
         mode=instructor.Mode.JSON,

--- a/src/quodeq/api/_log_routes.py
+++ b/src/quodeq/api/_log_routes.py
@@ -58,9 +58,9 @@ async function poll() {
       data.lines.forEach(e => {
         const line = document.createElement('div');
         const ts = e.timestamp ? e.timestamp.slice(11, 19) : '';
-        const ets = ts.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const ets = ts.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         line.innerHTML = '<span class="ts">[' + ets + ']</span> ' +
-          e.line.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+          e.line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         frag.appendChild(line);
         since = e.index;
       });

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -12,6 +12,7 @@ from quodeq.llm_bridge import (
     get_provider_configs,
 )
 from quodeq.llm_bridge._cloud import check_cloud_connection
+from quodeq.shared.url_validation import validate_url_safe
 
 
 def register_llm_bridge_routes(app: Flask) -> None:
@@ -46,8 +47,14 @@ def register_llm_bridge_routes(app: Flask) -> None:
     @app.post("/api/provider/test")
     def provider_test() -> Response:
         data = request.get_json() or {}
+        api_base = data.get("api_base", "")
+        if api_base:
+            try:
+                validate_url_safe(api_base, allow_private=True)
+            except ValueError as exc:
+                return jsonify({"error": str(exc)}), 400
         result = check_cloud_connection(
-            api_base=data.get("api_base", ""),
+            api_base=api_base,
             model=data.get("model", ""),
             api_key=data.get("api_key", ""),
         )

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -172,6 +172,15 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             return jsonify(body), status
 
         target_path = Path(target).resolve()
+        # Allowlist: only permit paths under user home or the evaluations directory
+        _home = Path.home().resolve()
+        _eval_dir = Path(reports_dir()).resolve()
+        _allowed_roots = (_home, _eval_dir)
+        if not any(target_path == root or target_path.is_relative_to(root) for root in _allowed_roots):
+            body, status = error_response(
+                "Scan path must be under home directory", HTTPStatus.FORBIDDEN, "FORBIDDEN",
+            )
+            return jsonify(body), status
         # Block scanning system directories to prevent information disclosure
         _blocked = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
         if any(str(target_path).startswith(b) for b in _blocked):

--- a/src/quodeq/api/standards_crud_routes.py
+++ b/src/quodeq/api/standards_crud_routes.py
@@ -38,7 +38,8 @@ def _handle_update(get_service, app: Flask, standard_id: str) -> Response:
     except FileNotFoundError:
         return error_response(f"Standard not found: {standard_id}", 404, "not_found")
     except PermissionError as exc:
-        return error_response(str(exc), 403, "forbidden")
+        logger.warning("standards.update permission error: %s", exc)
+        return error_response("Permission denied", 403, "forbidden")
     return jsonify(to_camel_dict(detail))
 
 
@@ -51,7 +52,8 @@ def _handle_delete(get_service, app: Flask, standard_id: str) -> tuple[str, int]
     except FileNotFoundError:
         return error_response(f"Standard not found: {standard_id}", 404, "not_found")
     except PermissionError as exc:
-        return error_response(str(exc), 403, "forbidden")
+        logger.warning("standards.delete permission error: %s", exc)
+        return error_response("Permission denied", 403, "forbidden")
     return "", 204
 
 

--- a/src/quodeq/api/standards_import_routes.py
+++ b/src/quodeq/api/standards_import_routes.py
@@ -29,7 +29,8 @@ def register_import_routes(app: Flask, get_service, get_library_client) -> None:
         try:
             library.import_standard(file_path, Path(app.config["STANDARDS_EVALUATORS_DIR"]))
         except ValueError as exc:
-            return error_response(str(exc), 409, "conflict")
+            logger.warning("Library import conflict: %s", exc)
+            return error_response("Import conflict", 409, "conflict")
         except Exception as exc:
             logger.warning("Library import failed: %s", exc)
             return error_response("Import from library failed", 502, "import_error")
@@ -48,9 +49,11 @@ def register_import_routes(app: Flask, get_service, get_library_client) -> None:
         try:
             result = svc.import_from_file(data, force=force)
         except ValueError as exc:
-            return error_response(str(exc), 400, "validation_error")
+            logger.warning("standards.import validation error: %s", exc)
+            return error_response("Invalid import data", 400, "validation_error")
         except PermissionError as exc:
-            return error_response(str(exc), 403, "forbidden")
+            logger.warning("standards.import permission error: %s", exc)
+            return error_response("Permission denied", 403, "forbidden")
         if result["status"] == "conflict":
             return jsonify({
                 "status": "conflict",

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -53,14 +53,24 @@ def _write_env(paths: ConfigPaths, provider: str, api_key_var: str, api_key_valu
         f"export AI_PROVIDER={provider}",
     ]
     if api_key_value:
-        # SECURITY: The raw API key value is written to the env file because it
-        # is sourced by subprocesses at runtime. The file is chmod 0600. For
-        # production, prefer a platform keychain or secrets manager.
+        # SECURITY: The raw API key value is written to the env file in
+        # cleartext because it must be sourced by subprocesses at runtime.
+        # The file is created with mode 0600 (owner read/write only) via
+        # atomic write + fchmod.  This is a known trade-off for local CLI
+        # tools where no platform keychain integration is available.
+        #
+        # For production / shared-server deployments:
+        #   - Use the QUODEQ_API_KEY environment variable directly, or
+        #   - Store the key in a platform keychain (macOS Keychain,
+        #     GNOME Keyring, Windows Credential Manager), or
+        #   - Use a secrets manager (Vault, AWS Secrets Manager, etc.)
         lines.append(f"export {api_key_var}={api_key_value}")
         masked = "***" + api_key_value[-4:] if len(api_key_value) > 4 else "****"
         log_warning(
-            f"API key ({masked}) written to {paths.env_file} (mode 0600). "
-            f"For production, prefer a platform keychain or secrets manager."
+            f"API key ({masked}) will be stored in cleartext at "
+            f"{paths.env_file} (mode 0600). For production deployments, "
+            f"prefer the QUODEQ_API_KEY environment variable, a platform "
+            f"keychain, or a secrets manager instead of writing keys to disk."
         )
     fd, tmp_path = tempfile.mkstemp(dir=str(paths.env_file.parent), suffix=".tmp")
     closed = False

--- a/src/quodeq/dashboard/_frozen.py
+++ b/src/quodeq/dashboard/_frozen.py
@@ -14,6 +14,15 @@ _MODULE_MAP = {
 
 _CMD_DISCOVERY_TIMEOUT_S = 5
 
+# SECURITY: Only allow well-known shell paths to prevent execution of
+# arbitrary binaries via a crafted $SHELL environment variable.
+_ALLOWED_SHELLS = {
+    "/bin/bash", "/bin/zsh", "/bin/sh",
+    "/usr/bin/bash", "/usr/bin/zsh", "/usr/bin/sh",
+    "/usr/local/bin/bash", "/usr/local/bin/zsh",
+    "/opt/homebrew/bin/bash", "/opt/homebrew/bin/zsh",
+}
+
 
 def is_frozen() -> bool:
     """Return True when running inside a PyInstaller bundle."""
@@ -43,6 +52,8 @@ def source_user_path() -> None:
         cmd = ('source ~/.zprofile 2>/dev/null; source ~/.zshrc 2>/dev/null; '
                'source ~/.bash_profile 2>/dev/null; echo $PATH')
         shell = os.environ.get("SHELL", "/bin/zsh")
+        if shell not in _ALLOWED_SHELLS:
+            shell = "/bin/zsh"
         result = subprocess.run(
             [shell, "-c", cmd], capture_output=True, text=True,
             timeout=_CMD_DISCOVERY_TIMEOUT_S,

--- a/src/quodeq/llm_bridge/_ollama.py
+++ b/src/quodeq/llm_bridge/_ollama.py
@@ -31,7 +31,8 @@ def get_ollama_status(base_url: str = _OLLAMA_BASE) -> dict:
                 "address": base_url.replace("http://", ""),
             }
     except (urllib.error.URLError, ConnectionRefusedError, OSError) as exc:
-        return {"running": False, "error": str(exc)}
+        _log.warning("Ollama status check failed: %s", exc)
+        return {"running": False, "error": "Connection failed"}
 
 
 def list_ollama_models(base_url: str = _OLLAMA_BASE) -> list[dict]:

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 import time
 from collections import deque
@@ -200,6 +201,8 @@ class FileJobStore:
     def __init__(self, persist_dir: Path | None = None) -> None:
         self._persist_dir = persist_dir or _DEFAULT_PERSIST_DIR
         self._persist_dir.mkdir(parents=True, exist_ok=True)
+        # SECURITY: restrict directory to owner-only access
+        os.chmod(self._persist_dir, 0o700)
         self._jobs: dict[str, Job] = {}
         self._lock = threading.Lock()
         self._load_all()
@@ -234,7 +237,10 @@ class FileJobStore:
         tmp = path.with_suffix(".tmp")
         try:
             tmp.write_text(json.dumps(_job_to_json(job), indent=2), encoding="utf-8")
+            # SECURITY: restrict job files to owner-only read/write
+            os.chmod(tmp, 0o600)
             tmp.replace(path)
+            os.chmod(path, 0o600)
         except OSError:
             _logger.warning("Failed to persist job %s", job.job_id, exc_info=True)
             tmp.unlink(missing_ok=True)

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -20,6 +20,7 @@ from quodeq.services.violations_parsing import (
 )
 from quodeq.config.paths import default_paths
 from quodeq.shared.utils import open_text
+from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None)
         evaluators_dir = default_paths().evaluators_dir
     if not evaluators_dir.is_dir():
         return {}
+    validate_path_segment(dimension)
     path = evaluators_dir / f"{dimension}.json"
     if not path.is_file():
         return {}

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -45,12 +45,18 @@ def _run_version_cmd(cmd: list[str]) -> str:
     """Run a command and return its stdout, or raise FileNotFoundError.
 
     ``shell=True`` is required on Windows so that ``where`` and other
-    shell built-ins resolve correctly.  The *cmd* list is always
-    hard-coded by callers in this module (never user-influenced),
-    so the shell injection risk does not apply.
+    shell built-ins resolve correctly and executables installed via npm
+    (which are .cmd shims) can be found on PATH.  The *cmd* parameter
+    is always a ``list[str]`` hard-coded by callers in this module
+    (never user-influenced), so the shell injection risk does not apply.
 
     SECURITY: Do not pass user-controlled strings into *cmd*.
+    All callers in this module construct *cmd* from string literals
+    (e.g. ``["node", "--version"]``).  If this function is ever
+    exposed to external input, ``shell=True`` MUST be removed.
     """
+    if not isinstance(cmd, list):
+        raise TypeError("cmd must be a list of strings, not a raw string")
     result = subprocess.run(
         cmd, capture_output=True, text=True, check=True, shell=_IS_WIN32,
         timeout=_VERSION_CMD_TIMEOUT_S,

--- a/src/quodeq/shared/url_validation.py
+++ b/src/quodeq/shared/url_validation.py
@@ -1,0 +1,33 @@
+"""URL validation helpers for SSRF prevention."""
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from quodeq.shared.ssrf import is_private_address
+
+
+def validate_url_safe(url: str, *, allow_private: bool = False) -> None:
+    """Raise ``ValueError`` if *url* uses a non-HTTP scheme or targets a private address.
+
+    Only ``http://`` and ``https://`` schemes are allowed.  The hostname is
+    resolved and checked against private/loopback/link-local ranges via
+    :func:`~quodeq.shared.ssrf.is_private_address`.
+
+    Set *allow_private* to ``True`` for endpoints that are intentionally on a
+    local network (e.g. self-hosted Ollama or LLM servers on a LAN).  This
+    still enforces the scheme allowlist but skips the private-IP check.
+    """
+    if not url:
+        raise ValueError("URL must not be empty")
+
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"URL scheme {parsed.scheme!r} is not allowed; use http or https")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL must include a hostname")
+
+    if not allow_private and is_private_address(hostname):
+        raise ValueError(f"URL targets a private/internal address: {hostname!r}")

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -89,6 +89,15 @@ function EvaluateHeader({ isRunning }) {
   );
 }
 
+function sanitizeErrorMessage(message) {
+  if (typeof message !== 'string') return 'An error occurred';
+  if (message.includes('\n') || /[/\\](?:usr|home|tmp|var|etc|src|node_modules)/.test(message) || message.length > 120) {
+    console.error('Raw error:', message);
+    return 'An error occurred. Check the console for details.';
+  }
+  return message;
+}
+
 function ErrorToast({ message, onDismiss }) {
   useEffect(() => {
     const timer = setTimeout(onDismiss, 5000);
@@ -97,7 +106,7 @@ function ErrorToast({ message, onDismiss }) {
 
   return (
     <div className="job-error-toast" onClick={onDismiss}>
-      {typeof message === 'string' ? message.slice(0, 200) : 'An error occurred'}
+      {sanitizeErrorMessage(message)}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -111,7 +111,8 @@ function createJobPoller(refs, setters, startDimensionPolling) {
         handleJobUpdate(updated, localRefs, setJob, callbacks);
       } catch (err) {
         setJob((prev) => prev ? { ...prev, status: 'lost' } : prev);
-        setJobError(err.message);
+        console.error('Poll error:', err);
+        setJobError('Evaluation polling failed');
         stopTimer(pollRef);
         stopTimer(dimPollRef);
       }
@@ -207,7 +208,8 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
       setJob({ ...created, repo: prepared.repo });
       startPolling(created.jobId);
     } catch (err) {
-      setJobError(err.message);
+      console.error('Start error:', err);
+      setJobError(err.message?.startsWith('No ') || err.message?.startsWith('Select ') ? err.message : 'Failed to start evaluation');
     }
   }
 
@@ -223,7 +225,8 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
       await cancelEvaluation(jobId);
       clearJob();
     } catch (err) {
-      setJobError(err.message);
+      console.error('Cancel error:', err);
+      setJobError('Failed to cancel evaluation');
     }
   }
 

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
@@ -1,4 +1,5 @@
 import { getThemeColors, rgb } from '../core/galaxyCore.js';
+import { escapeHtml } from '../../../../utils/escapeHtml.js';
 import { buildFolderScene, countDescendants } from './galaxyFolderScene.js';
 
 /**
@@ -37,7 +38,7 @@ export function createEventHandlers(refs, params) {
     const ff = refs.focusedFolderRef.current;
     const isFocused = h.type === 'folder' && ff && ff.starIdx === h.starIdx;
     const action = h.type === 'file' ? 'zoom in' : isFocused ? 'enter folder' : 'focus';
-    el.innerHTML = `<div style="font-weight:600;color:${nameCol};margin-bottom:4px">${name}</div>${rows.join('')}<div style="margin-top:6px;color:var(--color-text-muted);font-size:11px;opacity:0.6">Click to ${action}</div>`;
+    el.innerHTML = `<div style="font-weight:600;color:${nameCol};margin-bottom:4px">${escapeHtml(name)}</div>${rows.join('')}<div style="margin-top:6px;color:var(--color-text-muted);font-size:11px;opacity:0.6">Click to ${action}</div>`;
     el.style.display = 'block';
     el.style.left = Math.min(cx + 16, window.innerWidth - 200) + 'px';
     el.style.top = Math.min(cy + 16, window.innerHeight - 160) + 'px';

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
@@ -1,4 +1,5 @@
 import { rgb } from '../core/galaxyCore.js';
+import { escapeHtml } from '../../../../utils/escapeHtml.js';
 
 /**
  * Build tooltip HTML and position it.
@@ -35,7 +36,7 @@ export function updateTooltip(el, hovered, animating, cx, cy) {
     if (sn > 0) rows.push(row('Minor', sn, 'var(--color-sev-minor-text)'));
   }
   rows.push(row('Compliance', d.compliance));
-  el.innerHTML = `<div style="font-weight:600;color:${rgb(d.col)};margin-bottom:4px">${d.name}</div>
+  el.innerHTML = `<div style="font-weight:600;color:${rgb(d.col)};margin-bottom:4px">${escapeHtml(d.name)}</div>
     ${rows.join('')}
     <div style="margin-top:6px;color:var(--color-text-muted);font-size:11px;opacity:0.6">Click to explore</div>`;
   el.style.display = 'block';

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -27,6 +27,7 @@ export default function ServerSection() {
   const [health, setHealth] = useState(null);
   const [status, setStatus] = useState('checking');
   const [consoleOpen, setConsoleOpen] = useState(false);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [logLines, setLogLines] = useState([]);
   const sinceRef = useRef(-1);
   const logRef = useRef(null);
@@ -119,13 +120,27 @@ export default function ServerSection() {
         {status === 'online' && health?.address && <span className="server-address">{health.address}</span>}
       </div>
 
+      {/* Server details (port, PID, version) are intentionally available
+          for this local-only development tool to aid debugging. They are
+          hidden by default behind a toggle to avoid casual disclosure. */}
       {status === 'online' && health && (
         <div className="settings-row">
           <div className="settings-row-label">
-            <span className="settings-label">Details</span>
-            <span className="settings-description">
-              Port <strong>{health.port}</strong> &middot; PID <strong>{health.pid}</strong> &middot; v{health.version}
+            <span
+              className="settings-label"
+              role="button"
+              tabIndex={0}
+              style={{ cursor: 'pointer' }}
+              onClick={() => setDetailsOpen((o) => !o)}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setDetailsOpen((o) => !o); } }}
+            >
+              Details {detailsOpen ? '\u25BE' : '\u25B8'}
             </span>
+            {detailsOpen && (
+              <span className="settings-description">
+                Port <strong>{health.port}</strong> &middot; PID <strong>{health.pid}</strong> &middot; v{health.version}
+              </span>
+            )}
           </div>
         </div>
       )}

--- a/src/quodeq/ui/src/utils/escapeHtml.js
+++ b/src/quodeq/ui/src/utils/escapeHtml.js
@@ -1,0 +1,13 @@
+/**
+ * Escape HTML special characters to prevent XSS when interpolating
+ * user-supplied strings into innerHTML template literals.
+ */
+export function escapeHtml(str) {
+  if (typeof str !== 'string') return String(str);
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/tests/api/test_routes_project_list.py
+++ b/tests/api/test_routes_project_list.py
@@ -246,12 +246,19 @@ class TestScanPath:
         assert resp.get_json()["code"] == "MISSING_PATH"
 
     def test_path_not_directory(self, client):
-        resp = client.post("/api/scan", json={"path": "/nonexistent/path/abc"})
+        # Use a path under home that doesn't exist to pass the allowlist check
+        fake = str(Path.home() / "nonexistent_quodeq_test_path_abc")
+        resp = client.post("/api/scan", json={"path": fake})
         assert resp.status_code == 400
         assert resp.get_json()["code"] == "NOT_DIR"
 
     def test_system_dir_blocked(self, client):
         resp = client.post("/api/scan", json={"path": "/etc"})
+        assert resp.status_code == 403
+        assert resp.get_json()["code"] == "FORBIDDEN"
+
+    def test_outside_home_blocked(self, client):
+        resp = client.post("/api/scan", json={"path": "/nonexistent/path/abc"})
         assert resp.status_code == 403
         assert resp.get_json()["code"] == "FORBIDDEN"
 
@@ -265,6 +272,7 @@ class TestScanPath:
             files: int = 5
             languages: list = None
 
-        with patch("quodeq.services._fs_scan.scan_project", return_value=FakeScanResult(files=5, languages=["py"])):
+        with patch("quodeq.services._fs_scan.scan_project", return_value=FakeScanResult(files=5, languages=["py"])), \
+             patch("pathlib.Path.home", return_value=tmp_path):
             resp = client.post("/api/scan", json={"path": str(target)})
             assert resp.status_code == 200


### PR DESCRIPTION
## Summary

22 security violations fixed (3 critical, 17 major, 2 minor) across 18 files.

## Critical fixes

- **SSRF prevention**: URL scheme allowlist (http/https only) on LLM endpoints; private IPs allowed for self-hosted models
- **XSS in canvas tooltips**: `escapeHtml()` utility wraps all user data interpolated into `innerHTML`
- **XSS in log viewer**: ampersand escaping added before `<`/`>` replacement to prevent entity bypass

## Major fixes

| Category | Fix |
|----------|-----|
| Path traversal | `validate_path_segment()` on dimension names; `scan_path` restricted to `$HOME` |
| Error sanitization | 9 handlers replaced `str(exc)` with generic messages; originals logged server-side |
| Shell injection | Allowlisted shell paths in `_frozen.py`; subprocess guard in `prereqs.py` |
| File permissions | `chmod 0o600` on job artifacts after write |
| Info disclosure | Server details (port/PID) behind toggle; Ollama errors genericized |
| Supply chain | macOS launcher pinned to exact version with `--only-binary --no-deps` |

## Test plan

- [x] 1804 tests pass (1 new test added)
- [x] Vite production build clean
- [x] Security audit: 10/10 checks passed
- [x] LAN Ollama/self-hosted LLM endpoints verified working (allow_private=True)