### PR TITLE
feat: add risk analysis section to fix plan templates

### DIFF
--- a/src/quodeq/ui/src/utils/planBuilder.js
+++ b/src/quodeq/ui/src/utils/planBuilder.js
@@ -37,6 +37,15 @@ export const PLAN_COMPLETION_CHECKLIST = [
   '- [ ] **No violations were skipped.** If a violation cannot be fixed, state why explicitly — do not silently omit it.',
   '- [ ] **Tests pass.** Run the full test suite after all changes.',
   '- [ ] **Verify metrics.** For each function-length or file-length violation, confirm the result is within limits (e.g., `wc -l`, AST line count).',
+  '',
+  '## Risk analysis (before commit)', '',
+  'After all fixes are applied and tests pass, perform a production-safety audit:', '',
+  '1. **New files committed?** Run `git ls-files --others --exclude-standard` — all new files must be staged.',
+  '2. **Default behavior preserved?** For any changed defaults (limits, timeouts, URLs), verify all callers still work without explicit config.',
+  '3. **Caller compatibility?** For changed function signatures, imports, or module paths — grep for all call sites and confirm they match.',
+  '4. **Non-standard setups?** Consider users with LAN-hosted services, custom ports, external drives, or non-default paths.',
+  '5. **Build verification?** Run both the test suite and the production build — test pass alone doesn\'t catch missing JS/asset files.',
+  '6. **Report findings** to the user before committing. Do not silently commit known risks.',
 ].join('\n');
 
 export { FIX_HINTS };


### PR DESCRIPTION
## Summary

Adds a "Risk analysis (before commit)" section to the fix plan completion checklist, ensuring AI agents and engineers verify production safety before committing code-quality fixes.

## Motivation

During the maintainability/security/performance/flexibility fix batches, we caught several production issues only during post-fix review:
- SSRF blocking LAN-hosted Ollama
- `list_runs` default limit truncating accumulated scores
- Missing new files not committed (`ApiContext.jsx`, `_rate_limit_file_store.py`)
- Launcher pinned to old version

## Changes

`src/quodeq/ui/src/utils/planBuilder.js` — appended 6 risk checks to `PLAN_COMPLETION_CHECKLIST`:

1. New files committed?
2. Default behavior preserved?
3. Caller compatibility?
4. Non-standard setups?
5. Build verification (tests + production build)?
6. Report findings before committing

Applies to both dimension-level and grouped fix plans.

## Test plan

- [x] 22 plan builder tests pass
- [x] 1804 backend tests pass
- [x] Vite build clean