### PR TITLE
fix: project identity from git remote URL (unify same repo across paths)

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -86,7 +86,18 @@ def _setup_run_dirs(args: argparse.Namespace, src: Path) -> tuple[Path, Path, Pa
     project_name = project_name_from_repo(args.repo)
     location = "online" if is_repo_url(args.repo) else "local"
     scope = getattr(args, "scope", None)
-    project_uuid = resolve_project_uuid(reports_root, ProjectIdentity(project_name, str(src), None, location, scope_path=scope))
+
+    # Detect the git 'origin' remote so two clones of the same repo in
+    # different local paths share a single project identity.
+    remote_url = None
+    if location == "local":
+        from quodeq.shared._repo import git_remote_url
+        remote_url = git_remote_url(str(src))
+
+    project_uuid = resolve_project_uuid(
+        reports_root,
+        ProjectIdentity(project_name, str(src), None, location, scope_path=scope, remote_url=remote_url),
+    )
 
     run_id = str(uuid.uuid4())
     evidence_dir = reports_root / project_uuid / run_id / "evidence"

--- a/src/quodeq/data/fs/_models.py
+++ b/src/quodeq/data/fs/_models.py
@@ -31,3 +31,4 @@ class ProjectIdentity:
     discipline: str | None = None
     location: str = "local"
     scope_path: str | None = None
+    remote_url: str | None = None

--- a/src/quodeq/data/fs/_resolution.py
+++ b/src/quodeq/data/fs/_resolution.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 
 from quodeq.data.fs._index_io import _MAX_LEGACY_SCAN
@@ -16,8 +17,16 @@ _URL_PREFIXES = ("https://", "git@")
 
 
 def _index_key(identity: ProjectIdentity) -> str:
-    """Return a stable string key for the (name, path[, scope]) tuple."""
-    base = f"{identity.project_name}\x00{identity.repo_path}"
+    """Return a stable string key for the identity.
+
+    When a git remote URL is present, use it as the primary key component so
+    that two clones of the same repo in different local paths resolve to the
+    same key. Otherwise fall back to the absolute local path (legacy behavior).
+    """
+    if identity.remote_url:
+        base = f"{identity.project_name}\x00remote:{identity.remote_url}"
+    else:
+        base = f"{identity.project_name}\x00{identity.repo_path}"
     if identity.scope_path:
         return f"{base}\x00{identity.scope_path}"
     return base
@@ -29,7 +38,7 @@ def _find_existing_project(
     load_fn: Callable[[Path], dict[str, str]],
     save_fn: Callable[[Path, dict[str, str]], None],
 ) -> str | None:
-    """Look up project by (name, path) in the index; fall back to directory scan for
+    """Look up project by identity in the index; fall back to directory scan for
     projects created before the index existed, updating the index on success."""
     key = _index_key(identity)
     index = load_fn(reports_dir)
@@ -38,6 +47,17 @@ def _find_existing_project(
             return index[key]
         del index[key]
         save_fn(reports_dir, index)
+
+    # Legacy path-based key migration: when a remote_url is set, also try the
+    # path-based key that would have been used before remote-URL identity.
+    if identity.remote_url:
+        legacy_identity = replace(identity, remote_url=None)
+        legacy_key = _index_key(legacy_identity)
+        if legacy_key in index and (reports_dir / index[legacy_key]).is_dir():
+            uuid_value = index[legacy_key]
+            index[key] = uuid_value
+            save_fn(reports_dir, index)
+            return uuid_value
 
     scanned = 0
     for entry in reports_dir.iterdir():
@@ -53,7 +73,14 @@ def _find_existing_project(
             info = json.loads(info_file.read_text())
         except (json.JSONDecodeError, OSError):
             continue
-        if info.get("name") == identity.project_name and info.get("path") == identity.repo_path:
+        if info.get("name") != identity.project_name:
+            continue
+        # Prefer remote_url match when both sides have one
+        if identity.remote_url and info.get("remote_url") == identity.remote_url:
+            index[key] = entry.name
+            save_fn(reports_dir, index)
+            return entry.name
+        if info.get("path") == identity.repo_path:
             index[key] = entry.name
             save_fn(reports_dir, index)
             return entry.name
@@ -87,6 +114,8 @@ def _create_project(
     }
     if identity.scope_path:
         info["scopePath"] = identity.scope_path
+    if identity.remote_url:
+        info["remote_url"] = identity.remote_url
     if parent_uuid:
         info["parent"] = parent_uuid
     try:

--- a/src/quodeq/data/fs/project_resolver.py
+++ b/src/quodeq/data/fs/project_resolver.py
@@ -32,6 +32,7 @@ def _resolve_scoped(
     """Resolve a scoped project: ensure parent exists, then resolve child."""
     parent_identity = ProjectIdentity(
         identity.project_name, resolved_path, identity.discipline, identity.location,
+        remote_url=identity.remote_url,
     )
     parent_uuid = _find_existing_project(reports_dir, parent_identity, load_fn, save_fn)
     if not parent_uuid:
@@ -40,7 +41,7 @@ def _resolve_scoped(
     child_name = f"{identity.project_name}/{identity.scope_path}"
     child_identity = ProjectIdentity(
         child_name, resolved_path, identity.discipline, identity.location,
-        scope_path=identity.scope_path,
+        scope_path=identity.scope_path, remote_url=identity.remote_url,
     )
     existing = _find_existing_project(reports_dir, child_identity, load_fn, save_fn)
     if existing:
@@ -57,6 +58,7 @@ def _resolve_unscoped(
     """Resolve an unscoped project, creating a dot-child if children exist."""
     resolved = ProjectIdentity(
         identity.project_name, resolved_path, identity.discipline, identity.location,
+        remote_url=identity.remote_url,
     )
     existing = _find_existing_project(reports_dir, resolved, load_fn, save_fn)
     if existing:
@@ -64,6 +66,7 @@ def _resolve_unscoped(
             dot_identity = ProjectIdentity(
                 f"{identity.project_name}/.", resolved_path,
                 identity.discipline, identity.location, scope_path=".",
+                remote_url=identity.remote_url,
             )
             dot_existing = _find_existing_project(reports_dir, dot_identity, load_fn, save_fn)
             if dot_existing:

--- a/src/quodeq/shared/_repo.py
+++ b/src/quodeq/shared/_repo.py
@@ -1,6 +1,7 @@
 """Repository URL helpers."""
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 
@@ -23,3 +24,58 @@ def project_name_from_repo(repo: str) -> str:
     if is_repo_url(repo):
         return repo.split("/")[-1].replace(".git", "")
     return Path(repo).resolve().name
+
+
+def git_remote_url(repo_path: str) -> str | None:
+    """Return the normalized canonical URL of the git 'origin' remote, if any.
+
+    Reads the origin remote URL via ``git config`` from *repo_path*.
+    Returns ``None`` if:
+    - path is not a git repo
+    - no 'origin' remote configured
+    - git is not installed
+    - remote URL is malformed / empty
+
+    Normalization maps these equivalent forms to a single canonical form:
+      - ``git@github.com:owner/repo.git`` -> ``github.com/owner/repo``
+      - ``https://github.com/owner/repo.git`` -> ``github.com/owner/repo``
+      - ``https://github.com/owner/repo`` -> ``github.com/owner/repo``
+      - ``ssh://git@github.com/owner/repo.git`` -> ``github.com/owner/repo``
+
+    Trailing ``.git`` is stripped. Leading ``https://`` / ``ssh://`` / ``git@``
+    is stripped. The colon in ``git@host:path`` form is converted to ``/``.
+    Non-standard ports (e.g. ``host:22/path``) are not supported.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    url = result.stdout.strip()
+    if not url:
+        return None
+
+    # Strip known scheme prefixes
+    if url.startswith("https://"):
+        url = url[len("https://"):]
+    elif url.startswith("ssh://"):
+        url = url[len("ssh://"):]
+    if url.startswith("git@"):
+        url = url[len("git@"):]
+
+    # Convert git@host:path form to host/path.
+    # First colon splits host from path when path isn't numeric (port).
+    if ":" in url:
+        head, _sep, tail = url.partition(":")
+        if tail and not tail[:1].isdigit():
+            url = f"{head}/{tail}"
+
+    if url.endswith(".git"):
+        url = url[:-4]
+    url = url.rstrip("/")
+    return url or None

--- a/src/quodeq/shared/_repo.py
+++ b/src/quodeq/shared/_repo.py
@@ -22,4 +22,4 @@ def project_name_from_repo(repo: str) -> str:
     """Extract a human-readable project name from a repo path or URL."""
     if is_repo_url(repo):
         return repo.split("/")[-1].replace(".git", "")
-    return Path(repo).name
+    return Path(repo).resolve().name

--- a/tests/data/fs/test_project_identity_remote.py
+++ b/tests/data/fs/test_project_identity_remote.py
@@ -1,0 +1,80 @@
+"""Tests verifying that the same remote resolves to a single UUID across paths."""
+from __future__ import annotations
+
+
+def test_same_remote_different_paths_resolve_to_same_uuid(tmp_path):
+    from quodeq.data.fs._models import ProjectIdentity
+    from quodeq.data.fs.project_resolver import resolve_project_uuid
+
+    reports = tmp_path / "evaluations"
+    reports.mkdir()
+
+    remote = "github.com/quodeq/quodeq"
+    id_a = ProjectIdentity("quodeq", "/Users/alice/code/quodeq", location="local", remote_url=remote)
+    id_b = ProjectIdentity("quodeq", "/Users/alice/ci/_work/quodeq/quodeq", location="local", remote_url=remote)
+
+    uuid_a = resolve_project_uuid(reports, id_a)
+    uuid_b = resolve_project_uuid(reports, id_b)
+    assert uuid_a == uuid_b
+
+
+def test_different_remotes_resolve_to_different_uuids(tmp_path):
+    from quodeq.data.fs._models import ProjectIdentity
+    from quodeq.data.fs.project_resolver import resolve_project_uuid
+
+    reports = tmp_path / "evaluations"
+    reports.mkdir()
+
+    id_a = ProjectIdentity("foo", "/p1", location="local", remote_url="github.com/o/foo")
+    id_b = ProjectIdentity("foo", "/p2", location="local", remote_url="github.com/o/bar")
+
+    uuid_a = resolve_project_uuid(reports, id_a)
+    uuid_b = resolve_project_uuid(reports, id_b)
+    assert uuid_a != uuid_b
+
+
+def test_legacy_path_based_entry_migrates_to_remote_key(tmp_path):
+    """An existing project with only a path-based index key should be re-found
+    when a new ProjectIdentity with a remote URL comes in, and the index should
+    be updated to include the remote key."""
+    from quodeq.data.fs._models import ProjectIdentity
+    from quodeq.data.fs.project_resolver import resolve_project_uuid
+
+    reports = tmp_path / "evaluations"
+    reports.mkdir()
+
+    # Simulate an old project resolved without remote_url.
+    # Use tmp_path subdir so that Path.resolve() inside the resolver produces
+    # a stable absolute path.
+    legacy_path = tmp_path / "legacy" / "path"
+    legacy_path.mkdir(parents=True)
+    legacy_id = ProjectIdentity("quodeq", str(legacy_path), location="local")
+    legacy_uuid = resolve_project_uuid(reports, legacy_id)
+
+    # Now the same repo is accessed with a remote URL detected
+    new_id = ProjectIdentity(
+        "quodeq", str(legacy_path), location="local", remote_url="github.com/q/q"
+    )
+    new_uuid = resolve_project_uuid(reports, new_id)
+
+    assert legacy_uuid == new_uuid
+
+
+def test_no_remote_falls_back_to_path_identity(tmp_path):
+    """Projects without a remote (e.g. local scratch dirs) still get path-based identity."""
+    from quodeq.data.fs._models import ProjectIdentity
+    from quodeq.data.fs.project_resolver import resolve_project_uuid
+
+    reports = tmp_path / "evaluations"
+    reports.mkdir()
+
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    dir_a.mkdir()
+    dir_b.mkdir()
+    id_a = ProjectIdentity("scratch", str(dir_a), location="local")
+    id_b = ProjectIdentity("scratch", str(dir_b), location="local")
+
+    uuid_a = resolve_project_uuid(reports, id_a)
+    uuid_b = resolve_project_uuid(reports, id_b)
+    assert uuid_a != uuid_b

--- a/tests/shared/test_repo_remote_url.py
+++ b/tests/shared/test_repo_remote_url.py
@@ -1,0 +1,69 @@
+"""Tests for git_remote_url and project_name_from_repo edge cases."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+
+def test_project_name_resolves_dot_to_basename(tmp_path, monkeypatch):
+    """Path('.') should resolve to the current directory's basename, not empty."""
+    from quodeq.shared._repo import project_name_from_repo
+    project = tmp_path / "my-project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    assert project_name_from_repo(".") == "my-project"
+
+
+def test_project_name_url_unchanged():
+    from quodeq.shared._repo import project_name_from_repo
+    assert project_name_from_repo("https://github.com/quodeq/quodeq.git") == "quodeq"
+
+
+def test_git_remote_url_normalizes_https():
+    from quodeq.shared._repo import git_remote_url
+    mock = subprocess.CompletedProcess(["git"], 0, stdout="https://github.com/quodeq/quodeq.git\n", stderr="")
+    with patch("subprocess.run", return_value=mock):
+        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+
+
+def test_git_remote_url_normalizes_ssh():
+    from quodeq.shared._repo import git_remote_url
+    mock = subprocess.CompletedProcess(["git"], 0, stdout="git@github.com:quodeq/quodeq.git\n", stderr="")
+    with patch("subprocess.run", return_value=mock):
+        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+
+
+def test_git_remote_url_normalizes_ssh_scheme():
+    from quodeq.shared._repo import git_remote_url
+    mock = subprocess.CompletedProcess(
+        ["git"], 0, stdout="ssh://git@github.com/quodeq/quodeq.git\n", stderr=""
+    )
+    with patch("subprocess.run", return_value=mock):
+        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+
+
+def test_git_remote_url_strips_trailing_slash_and_git():
+    from quodeq.shared._repo import git_remote_url
+    mock = subprocess.CompletedProcess(["git"], 0, stdout="https://github.com/quodeq/quodeq/\n", stderr="")
+    with patch("subprocess.run", return_value=mock):
+        assert git_remote_url("/any/path") == "github.com/quodeq/quodeq"
+
+
+def test_git_remote_url_returns_none_when_not_a_repo():
+    from quodeq.shared._repo import git_remote_url
+    error = subprocess.CalledProcessError(128, ["git"], stderr="not a git repo")
+    with patch("subprocess.run", side_effect=error):
+        assert git_remote_url("/any/path") is None
+
+
+def test_git_remote_url_returns_none_when_git_missing():
+    from quodeq.shared._repo import git_remote_url
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        assert git_remote_url("/any/path") is None
+
+
+def test_git_remote_url_returns_none_on_empty_output():
+    from quodeq.shared._repo import git_remote_url
+    mock = subprocess.CompletedProcess(["git"], 0, stdout="\n", stderr="")
+    with patch("subprocess.run", return_value=mock):
+        assert git_remote_url("/any/path") is None


### PR DESCRIPTION
## Bugs

### Bug 1: Empty project name when \`.\` is passed as repo argument
\`Path(".").name\` returns an empty string. In CI (where evaluations are often invoked with \`quodeq evaluate .\`), this produced projects with \`name = ""\` that show as a UUID in the dashboard.

### Bug 2: Same GitHub repo in different local paths = different project UUIDs
\`~/code/quodeq\` and \`~/actions-runner/_work/quodeq/quodeq\` are the same repo, but the path-based identity key treated them as two separate projects in the dashboard.

## Fixes

**Bug 1** — \`project_name_from_repo\` now calls \`Path(repo).resolve().name\`, so \`.\` produces the current directory's basename.

**Bug 2** — Project identity now incorporates the git remote URL when available:
- New \`git_remote_url(path)\` helper reads \`remote.origin.url\` via \`git -C <path> config\`, normalizes across \`https://\`, \`git@host:\`, and \`ssh://\` forms (strips trailing \`.git\`, collapses to \`host/owner/repo\`)
- \`ProjectIdentity\` carries an optional \`remote_url\` field
- Index key prefers \`{name}\\0remote:{url}\` when a remote is available, falls back to \`{name}\\0{path}\` otherwise (preserving existing behavior for non-git dirs)
- Legacy path-based entries migrate automatically on the first lookup after upgrade: if a project resolved under the old path-only key, the new remote-based key is added pointing to the same UUID (non-destructive)
- \`repository_info.json\` gains a \`remote_url\` field when available

### Behavior after the fix
| Scenario | Before | After |
|---|---|---|
| \`quodeq evaluate .\` in CI | name = \"\" (empty) | name = \"quodeq\" |
| Local clone + CI runner (same repo) | Two separate projects | Same project UUID via remote match |
| Existing user upgrading | Projects stay intact (legacy path-key lookup + auto-migration) | Same |
| Directory with no git remote | Path-based identity (unchanged) | Path-based identity (unchanged) |

## Known caveat

The index key still includes \`project_name\`, so someone running from a git worktree with a differently-named parent directory gets a separate project from their main clone (e.g. \`worktrees/epic-bouman\` creates a separate \"epic-bouman\" project even though it shares a remote with the main \`quodeq\` clone).

This is acceptable because (a) worktrees often represent distinct development contexts and (b) unifying further would require dropping the name from the key, which is a bigger behavior change. Happy to revisit if desired.

## Tests

- \`tests/shared/test_repo_remote_url.py\` (new) — 9 tests covering \`.\` resolution, URL normalization across HTTPS/SSH/ssh schemes, and \`None\`-return cases (not a git repo, git missing, empty output)
- \`tests/data/fs/test_project_identity_remote.py\` (new) — 4 tests: same-remote-different-paths unify, different-remotes stay separate, legacy path-only entry migrates, no-remote still uses path
- All 1908 existing tests still pass. Full run: 1921 passed.

## Test plan

- [x] Run tests: \`uv run pytest tests/\`
- [x] Sanity: \`uv run python3 -c \"from quodeq.shared._repo import git_remote_url; print(git_remote_url('.'))\"\` from a Quodeq clone → prints \`github.com/<owner>/<repo>\`
- [x] Fresh CI run against an existing local project: new run appears under the existing project in the dashboard (not a separate entry)