### PR TITLE
feat(dashboard): show externally-launched evaluations in Evaluation tab (with cancel)

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -195,15 +195,28 @@ def _run_pipeline_with_cleanup(
     """Set up directories, build config, run the pipeline, and clean up cloned repos."""
     _reports_root, evidence_dir, evaluation_dir = paths
     print(f"Report path: {evaluation_dir}", file=sys.stderr)
-    run_id = evaluation_dir.parent.name
-    project_uuid = evaluation_dir.parent.parent.name
+    run_dir = evaluation_dir.parent
+    run_id = run_dir.name
+    project_uuid = run_dir.parent.name
     emit_marker("report_path", project=project_uuid, runId=run_id)
     _save_manifest(inputs.manifest, evidence_dir)
+
+    # Write a .pid file so the dashboard can detect and cancel this external run
+    pid_file = run_dir / ".pid"
+    try:
+        pid_file.write_text(str(os.getpid()))
+    except OSError:
+        pass  # non-fatal; cancel-by-filesystem just won't work for this run
 
     config = _build_run_config(args, inputs=inputs, evidence_dir=evidence_dir)
     try:
         return _execute_pipeline(args, config, evidence_dir, evaluation_dir)
     finally:
+        # Clean up .pid file on exit so we don't leave stale PIDs
+        try:
+            pid_file.unlink(missing_ok=True)
+        except OSError:
+            pass
         if is_repo_url(args.repo):
             cleanup_cloned_repo(str(inputs.src))
         worktree_dir = getattr(args, "_worktree_dir", None)

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -28,7 +28,7 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
     @app.get("/api/evaluations")
     def list_evaluations() -> Response:
         limit = request.args.get("limit", 0, type=int)
-        items = provider.list_evaluations(limit=limit)
+        items = provider.list_evaluations(limit=limit, reports_dir=_reports_dir())
         return jsonify([to_camel_dict(j) for j in items])
 
     @app.post("/api/evaluations")
@@ -81,7 +81,7 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
 
     @app.get("/api/evaluations/<job_id>")
     def get_evaluation(job_id: str) -> Response | tuple[Response, int]:
-        job = provider.get_evaluation_status(job_id)
+        job = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if not job:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/core/types/job.py
+++ b/src/quodeq/core/types/job.py
@@ -18,3 +18,4 @@ class JobSnapshot:
     current_dimension: str | None = None
     dimensions: list[str] | None = None
     error: str | None = None
+    source: str = "internal"  # "internal" | "external"

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -1,0 +1,164 @@
+"""Detect externally-launched evaluations by scanning the filesystem.
+
+External jobs are evaluations spawned outside the dashboard UI (CI runners,
+`quodeq evaluate` in another terminal). They write the same filesystem
+artifacts as UI-launched jobs but do not register with JobManager.
+
+This module reconstructs JobSnapshot objects from those artifacts so they
+can be surfaced in the Evaluation tab with live progress.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from quodeq.core.types.job import JobSnapshot
+
+_logger = logging.getLogger(__name__)
+
+_EXTERNAL_JOB_ID_PREFIX = "ext-"
+_PID_FILENAME = ".pid"
+_MANIFEST_PATH = "evidence/manifest.json"
+_SCAN_FILENAME = "scan.json"
+
+
+def find_external_runs(reports_root: Path) -> list[JobSnapshot]:
+    """Scan all projects for in-progress runs not tracked by any JobStore.
+
+    Returns JobSnapshots in 'running' status with inferred phase/dimension.
+    Caller is responsible for de-duplicating against JobManager-tracked jobs.
+    """
+    if not reports_root.is_dir():
+        return []
+    snapshots: list[JobSnapshot] = []
+    # Two-level: reports_root / {project_uuid} / {run_id} /
+    for project_dir in reports_root.iterdir():
+        if not project_dir.is_dir() or project_dir.name.startswith("."):
+            continue
+        for run_dir in project_dir.iterdir():
+            if not run_dir.is_dir() or run_dir.name.startswith("."):
+                continue
+            snapshot = _run_dir_to_snapshot(project_dir.name, run_dir)
+            if snapshot is not None:
+                snapshots.append(snapshot)
+    return snapshots
+
+
+def _run_dir_to_snapshot(project_uuid: str, run_dir: Path) -> JobSnapshot | None:
+    """Convert a run directory to a JobSnapshot if it's an in-progress external run."""
+    manifest_path = run_dir / _MANIFEST_PATH
+    scan_path = run_dir / _SCAN_FILENAME
+
+    if not manifest_path.exists():
+        return None  # not a real run
+    if scan_path.exists():
+        return None  # run is complete, not external-in-progress
+
+    # Infer phase, current dimension, dimensions list
+    eval_dir = run_dir / "evaluation"
+    evidence_dir = run_dir / "evidence"
+    dimensions, current_dimension, phase = _infer_progress(eval_dir, evidence_dir)
+
+    # External job_id is prefixed so the frontend/backend can distinguish it
+    job_id = f"{_EXTERNAL_JOB_ID_PREFIX}{run_dir.name}"
+    started_at_iso = _manifest_started_at(manifest_path)
+
+    return JobSnapshot(
+        job_id=job_id,
+        status="running",
+        phase=phase,
+        current_dimension=current_dimension,
+        dimensions=dimensions if dimensions else None,
+        output_project=project_uuid,
+        output_run_id=run_dir.name,
+        started_at=started_at_iso,
+        ended_at=None,
+        exit_code=None,
+        logs=[],  # no live log stream for externals; frontend shows filesystem state
+        source="external",
+    )
+
+
+def _infer_progress(eval_dir: Path, evidence_dir: Path) -> tuple[list[str], str | None, str]:
+    """From filesystem state, infer dimensions list, current_dimension, and phase."""
+    # Completed dimensions: every {dim}.json in evaluation/ (not _full.json)
+    completed: list[str] = []
+    if eval_dir.is_dir():
+        for f in sorted(eval_dir.iterdir()):
+            if f.is_file() and f.suffix == ".json" and not f.stem.endswith("_full"):
+                completed.append(f.stem)
+
+    # In-progress dimensions: evidence/{dim}_evidence.jsonl present but no {dim}.json
+    in_progress_dims: list[str] = []
+    if evidence_dir.is_dir():
+        for f in evidence_dir.iterdir():
+            if f.name.endswith("_evidence.jsonl"):
+                dim = f.name[: -len("_evidence.jsonl")]
+                if dim not in completed:
+                    in_progress_dims.append(dim)
+
+    dimensions = completed + in_progress_dims
+
+    # Current dimension: the most-recently-modified in-progress evidence file
+    current: str | None = None
+    if in_progress_dims and evidence_dir.is_dir():
+        candidates = [(evidence_dir / f"{d}_evidence.jsonl", d) for d in in_progress_dims]
+        candidates = [(p, d) for p, d in candidates if p.exists()]
+        if candidates:
+            candidates.sort(key=lambda pd: pd[0].stat().st_mtime, reverse=True)
+            current = candidates[0][1]
+
+    # Phase inference
+    if not completed and not in_progress_dims:
+        phase = "setup"
+    elif in_progress_dims:
+        phase = "analyzing"
+    else:
+        phase = "scoring"
+
+    return dimensions, current, phase
+
+
+def _manifest_started_at(manifest_path: Path) -> str:
+    """Use manifest.json mtime as started_at (ISO 8601)."""
+    ts = manifest_path.stat().st_mtime
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> int | None:
+    """Find the PID of the process running an external job, for cancellation.
+
+    Looks for a `.pid` file written by `quodeq evaluate` at run start. Returns
+    None if not found or the process is already gone.
+    """
+    pid_file = reports_root / project_uuid / run_id / _PID_FILENAME
+    if not pid_file.exists():
+        return None
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    # Verify the process exists
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    return pid
+
+
+def cancel_external_run(project_uuid: str, run_id: str, reports_root: Path) -> bool:
+    """Send SIGTERM to the external run's process. Returns True if signal sent."""
+    pid = resolve_external_pid(project_uuid, run_id, reports_root)
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+        return True
+    except OSError as exc:
+        _logger.warning("Failed to signal pid %s: %s", pid, exc)
+        return False

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -82,7 +82,7 @@ class EvaluationActions(Protocol):
         """Start an asynchronous evaluation job and return job metadata."""
         ...
 
-    def get_evaluation_status(self, job_id: str) -> JobSnapshot | None:
+    def get_evaluation_status(self, job_id: str, reports_dir: str | None = None) -> JobSnapshot | None:
         """Return current status of an evaluation job."""
         ...
 
@@ -90,7 +90,7 @@ class EvaluationActions(Protocol):
         """Cancel a running evaluation job. Return True on success."""
         ...
 
-    def list_evaluations(self) -> list[JobSnapshot]:
+    def list_evaluations(self, *, limit: int = 0, reports_dir: str | None = None) -> list[JobSnapshot]:
         """Return all evaluation jobs (running, done, failed, cancelled)."""
         ...
 

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -214,15 +214,21 @@ class FsEvaluationMixin:
                 cwd = str(resolved)
         return self.dispatcher.dispatch(cmd, cwd=cwd, env=env)
 
-    def get_evaluation_status(self, job_id: str) -> JobSnapshot | None:
-        """Return the current status of an evaluation job."""
-        return self._jobs.get_job(job_id)
+    def get_evaluation_status(self, job_id: str, reports_dir: str | None = None) -> JobSnapshot | None:
+        """Return the current status of an evaluation job.
+
+        Passes *reports_dir* to ``JobManager.get_job`` so that external jobs
+        (``ext-`` prefix) can be looked up from the filesystem.
+        """
+        reports_root = Path(reports_dir) if reports_dir else None
+        return self._jobs.get_job(job_id, reports_root=reports_root)
 
     def cancel_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
         """Cancel a running evaluation job and score any completed dimensions."""
-        # Get job info before cancellation
-        job = self._jobs.get_job(job_id)
-        ok = self._jobs.cancel_job(job_id)
+        reports_root = Path(reports_dir) if reports_dir else None
+        # Get job info before cancellation (supports ext- prefix)
+        job = self._jobs.get_job(job_id, reports_root=reports_root)
+        ok = self._jobs.cancel_job(job_id, reports_root=reports_root)
         if ok and reports_dir and job:
             _score_completed_evidence(reports_dir, {
                 "outputProject": job.output_project,
@@ -238,12 +244,14 @@ class FsEvaluationMixin:
         _score_completed_evidence(reports_dir, job)
         return True
 
-    def list_evaluations(self, *, limit: int = 0) -> list[JobSnapshot]:
+    def list_evaluations(self, *, limit: int = 0, reports_dir: str | None = None) -> list[JobSnapshot]:
         """Return evaluation jobs (running, done, failed, cancelled).
 
         When *limit* > 0 only the most recent *limit* jobs are returned.
+        When *reports_dir* is provided, external in-progress runs are merged in.
         """
-        jobs = self._jobs.list_jobs()
+        reports_root = Path(reports_dir) if reports_dir else None
+        jobs = self._jobs.list_jobs(reports_root=reports_root)
         return jobs[:limit] if limit > 0 else jobs
 
 

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 import json
 import os
+from pathlib import Path
 import threading
 import uuid
 from typing import Any, Callable, Iterable
@@ -117,8 +118,18 @@ class JobManager:
 
         return job.to_dict()
 
-    def cancel_job(self, job_id: str) -> bool:
-        """Terminate a running job. Return True if cancelled successfully."""
+    def cancel_job(self, job_id: str, reports_root: Path | None = None) -> bool:
+        """Terminate a running job. Return True if cancelled successfully.
+
+        For external jobs (``ext-`` prefix), sends SIGTERM to the process that
+        owns the run.  For internal jobs, kills the tracked subprocess.
+        """
+        if job_id.startswith("ext-") and reports_root is not None:
+            return self._cancel_external(job_id, reports_root)
+        return self._cancel_internal(job_id)
+
+    def _cancel_internal(self, job_id: str) -> bool:
+        """Kill an internal tracked subprocess."""
         with self._lock:
             job = self._store.get(job_id)
             process = self._processes.get(job_id)
@@ -131,6 +142,17 @@ class JobManager:
             _kill_tree(process.pid)
         return True
 
+    def _cancel_external(self, job_id: str, reports_root: Path) -> bool:
+        """Send SIGTERM to an external run's process."""
+        from quodeq.services._external_jobs import cancel_external_run
+        run_id = job_id[len("ext-"):]
+        for project_dir in reports_root.iterdir():
+            if not project_dir.is_dir():
+                continue
+            if (project_dir / run_id).is_dir():
+                return cancel_external_run(project_dir.name, run_id, reports_root)
+        return False
+
     def shutdown(self) -> None:
         """Kill all running job subprocesses. Called on server shutdown."""
         with self._lock:
@@ -141,22 +163,68 @@ class JobManager:
                     pass
             self._processes.clear()
 
-    def get_job(self, job_id: str) -> JobSnapshot | None:
-        """Return the current state of a job, or None if not found."""
+    def get_job(self, job_id: str, reports_root: Path | None = None) -> JobSnapshot | None:
+        """Return the current state of a job, or None if not found.
+
+        For external jobs (``ext-`` prefix), reconstructs the snapshot from
+        the filesystem instead of the in-process store.
+        """
+        if job_id.startswith("ext-") and reports_root is not None:
+            return self._get_external(job_id, reports_root)
         with self._lock:
             job = self._store.get(job_id)
             if not job:
                 return None
             return job.to_dict()
 
-    def list_jobs(self, *, limit: int = _DEFAULT_LIST_LIMIT, offset: int = 0) -> list[JobSnapshot]:
+    def _get_external(self, job_id: str, reports_root: Path) -> JobSnapshot | None:
+        """Reconstruct a JobSnapshot for an external run from its run directory."""
+        from quodeq.services._external_jobs import _run_dir_to_snapshot
+        run_id = job_id[len("ext-"):]
+        for project_dir in reports_root.iterdir():
+            if not project_dir.is_dir():
+                continue
+            run_dir = project_dir / run_id
+            if run_dir.is_dir():
+                return _run_dir_to_snapshot(project_dir.name, run_dir)
+        return None
+
+    def list_jobs(
+        self,
+        *,
+        limit: int = _DEFAULT_LIST_LIMIT,
+        offset: int = 0,
+        reports_root: Path | None = None,
+    ) -> list[JobSnapshot]:
         """Return tracked jobs as frozen snapshots with pagination.
+
+        When *reports_root* is provided, external in-progress runs are merged
+        in.  Internal jobs take priority: if both share the same
+        (output_project, output_run_id), the internal entry wins.
 
         When *limit* is 0 all jobs are returned (no cap).
         """
         with self._lock:
-            all_jobs = [job.to_dict() for job in self._store.list()]
-        page = all_jobs[offset:] if offset else all_jobs
+            internal = [job.to_dict() for job in self._store.list()]
+
+        merged: list[JobSnapshot] = list(internal)
+
+        if reports_root is not None and reports_root.is_dir():
+            from quodeq.services._external_jobs import find_external_runs
+            externals = find_external_runs(reports_root)
+            internal_keys = {
+                (j.output_project, j.output_run_id)
+                for j in internal
+                if j.output_project and j.output_run_id
+            }
+            for ext in externals:
+                key = (ext.output_project, ext.output_run_id)
+                if key not in internal_keys:
+                    merged.append(ext)
+
+        # Sort newest-first, then paginate
+        merged.sort(key=lambda j: j.started_at or "", reverse=True)
+        page = merged[offset:] if offset else merged
         return page[:limit] if limit > 0 else page
 
     @staticmethod

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -48,10 +48,20 @@ function lastRelevantLog(logs) {
   return null;
 }
 
+function ExternalRunBadge() {
+  return (
+    <div className="job-meta-item">
+      <span className="job-meta-label">Source</span>
+      <span className="job-meta-value">Running outside the dashboard</span>
+    </div>
+  );
+}
+
 function ConsolePanel({ job, consoleOpen, setConsoleOpen, logViewerRef, hasEvaluations }) {
   const isRunning = job.status === STATUS.RUNNING;
   const isFailed = job.status === STATUS.FAILED;
   const isLost = job.status === STATUS.LOST;
+  const isExternal = job.source === 'external';
   const [showDot, setShowDot] = useState(() => {
     if (hasEvaluations) return false;
     try { return !localStorage.getItem(CONSOLE_DOT_DISMISSED_KEY); } catch { return true; }
@@ -89,7 +99,9 @@ function ConsolePanel({ job, consoleOpen, setConsoleOpen, logViewerRef, hasEvalu
       {consoleOpen && (
         <div className="console-output">
           <pre ref={logViewerRef}>
-            {job.logs?.length ? job.logs.join('\n') : 'Waiting for output\u2026'}
+            {isExternal
+              ? 'Live logs unavailable for external runs \u2014 progress inferred from filesystem'
+              : (job.logs?.length ? job.logs.join('\n') : 'Waiting for output\u2026')}
           </pre>
         </div>
       )}
@@ -128,6 +140,7 @@ function JobProviderBadge() {
 }
 
 function JobMeta({ job, projectName }) {
+  const isExternal = job.source === 'external';
   return (
     <div className="job-meta">
       {projectName && (
@@ -136,7 +149,7 @@ function JobMeta({ job, projectName }) {
           <span className="job-meta-value">{projectName}</span>
         </div>
       )}
-      <JobProviderBadge />
+      {isExternal ? <ExternalRunBadge /> : <JobProviderBadge />}
       <div className="job-meta-item">
         <span className="job-meta-label">Job ID</span>
         <div className="job-meta-id-row">

--- a/src/quodeq/ui/src/models/job.js
+++ b/src/quodeq/ui/src/models/job.js
@@ -15,6 +15,7 @@
  * @property {string|null}   endedAt
  * @property {number|null}   exitCode
  * @property {string|null}   error
+ * @property {'internal'|'external'} source  - 'internal' = launched from dashboard; 'external' = CLI/CI
  */
 
 /**
@@ -39,5 +40,6 @@ export function createJob(raw) {
     endedAt:          raw.endedAt ?? null,
     exitCode:         raw.exitCode ?? null,
     error:            raw.error ?? null,
+    source:           raw.source ?? 'internal',
   };
 }

--- a/tests/api/test_action_api.py
+++ b/tests/api/test_action_api.py
@@ -37,15 +37,15 @@ class StubProvider(ActionProvider):
     def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> dict:
         return {"jobId": "job-1", "status": "running", "logs": []}
 
-    def get_evaluation_status(self, job_id: str):
+    def get_evaluation_status(self, job_id: str, reports_dir: str | None = None):
         if job_id == "job-1":
             return {"jobId": "job-1", "status": "done", "logs": []}
         return None
 
-    def cancel_evaluation(self, job_id: str) -> bool:
+    def cancel_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
         return False
 
-    def list_evaluations(self) -> list[dict]:
+    def list_evaluations(self, *, limit: int = 0, reports_dir: str | None = None) -> list[dict]:
         return []
 
     def delete_project(self, reports_dir: str, project: str) -> bool:

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -1,0 +1,260 @@
+"""Tests for filesystem-based external job detection."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# find_external_runs
+# ---------------------------------------------------------------------------
+
+def test_find_external_runs_identifies_in_progress(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    project = tmp_path / "proj-1"
+    run = project / "run-A"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "evaluation").mkdir()
+    # No scan.json -> in-progress
+
+    results = find_external_runs(tmp_path)
+    assert len(results) == 1
+    snap = results[0]
+    assert snap.status == "running"
+    assert snap.source == "external"
+    assert snap.job_id == "ext-run-A"
+    assert snap.output_project == "proj-1"
+    assert snap.output_run_id == "run-A"
+
+
+def test_find_external_runs_skips_complete(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    run = tmp_path / "proj" / "done"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "scan.json").write_text("{}")
+
+    assert find_external_runs(tmp_path) == []
+
+
+def test_find_external_runs_skips_run_without_manifest(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    run = tmp_path / "proj" / "no-manifest"
+    (run / "evidence").mkdir(parents=True)
+    # No manifest.json -> skip
+
+    assert find_external_runs(tmp_path) == []
+
+
+def test_find_external_runs_infers_phase_analyzing(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    run = tmp_path / "proj" / "active"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "evidence" / "security_evidence.jsonl").write_text("")
+    (run / "evaluation").mkdir()
+
+    results = find_external_runs(tmp_path)
+    assert len(results) == 1
+    assert results[0].phase == "analyzing"
+    assert results[0].current_dimension == "security"
+
+
+def test_find_external_runs_scoring_phase_when_all_evidence_complete(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    run = tmp_path / "proj" / "active"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "evidence" / "security_evidence.jsonl").write_text("")
+    (run / "evaluation").mkdir()
+    (run / "evaluation" / "security.json").write_text("{}")
+
+    results = find_external_runs(tmp_path)
+    # security completed, no in-progress evidence -> scoring
+    assert len(results) == 1
+    assert results[0].phase == "scoring"
+
+
+def test_find_external_runs_setup_phase_when_no_evidence(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    run = tmp_path / "proj" / "active"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "evaluation").mkdir()
+    # No evidence files at all -> setup
+
+    results = find_external_runs(tmp_path)
+    assert len(results) == 1
+    assert results[0].phase == "setup"
+
+
+def test_find_external_runs_skips_dot_dirs(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    hidden = tmp_path / ".hidden" / "run"
+    (hidden / "evidence").mkdir(parents=True)
+    (hidden / "evidence" / "manifest.json").write_text("{}")
+
+    assert find_external_runs(tmp_path) == []
+
+
+def test_find_external_runs_empty_reports_root(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    assert find_external_runs(tmp_path) == []
+
+
+def test_find_external_runs_nonexistent_reports_root(tmp_path):
+    from quodeq.services._external_jobs import find_external_runs
+
+    assert find_external_runs(tmp_path / "does-not-exist") == []
+
+
+# ---------------------------------------------------------------------------
+# PID resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_external_pid_returns_none_without_pid_file(tmp_path):
+    from quodeq.services._external_jobs import resolve_external_pid
+
+    (tmp_path / "proj" / "run").mkdir(parents=True)
+    assert resolve_external_pid("proj", "run", tmp_path) is None
+
+
+def test_resolve_external_pid_returns_pid_when_alive(tmp_path):
+    from quodeq.services._external_jobs import resolve_external_pid
+
+    run_dir = tmp_path / "proj" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / ".pid").write_text(str(os.getpid()))
+    assert resolve_external_pid("proj", "run", tmp_path) == os.getpid()
+
+
+def test_resolve_external_pid_returns_none_when_process_dead(tmp_path):
+    from quodeq.services._external_jobs import resolve_external_pid
+
+    run_dir = tmp_path / "proj" / "run"
+    run_dir.mkdir(parents=True)
+    # Use a very high PID that's almost certainly not in use
+    (run_dir / ".pid").write_text("999999")
+    assert resolve_external_pid("proj", "run", tmp_path) is None
+
+
+def test_resolve_external_pid_returns_none_for_corrupt_pid_file(tmp_path):
+    from quodeq.services._external_jobs import resolve_external_pid
+
+    run_dir = tmp_path / "proj" / "run"
+    run_dir.mkdir(parents=True)
+    (run_dir / ".pid").write_text("not-a-number")
+    assert resolve_external_pid("proj", "run", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# cancel_external_run
+# ---------------------------------------------------------------------------
+
+def test_cancel_external_run_returns_false_without_pid_file(tmp_path):
+    from quodeq.services._external_jobs import cancel_external_run
+
+    (tmp_path / "proj" / "run").mkdir(parents=True)
+    assert cancel_external_run("proj", "run", tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# JobManager list_jobs merge/dedup
+# ---------------------------------------------------------------------------
+
+def _make_in_progress_run(reports_root: Path, project: str, run_id: str) -> None:
+    """Create an in-progress run directory structure."""
+    run_dir = reports_root / project / run_id
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    # No scan.json => in-progress
+
+
+def test_list_jobs_merges_external_runs(tmp_path):
+    from quodeq.services.jobs import JobManager
+
+    _make_in_progress_run(tmp_path, "proj-ext", "run-ext-1")
+
+    jm = JobManager()
+    jobs = jm.list_jobs(reports_root=tmp_path)
+
+    assert any(j.job_id == "ext-run-ext-1" for j in jobs)
+    assert any(j.source == "external" for j in jobs)
+
+
+def test_list_jobs_deduplicates_by_output_project_run_id(tmp_path):
+    """An internal job tracking the same run must suppress the external snapshot."""
+    from quodeq.services.jobs import JobManager
+    from quodeq.services._job_model import Job
+    from collections import deque
+
+    _make_in_progress_run(tmp_path, "proj-shared", "run-shared")
+
+    jm = JobManager()
+    # Register an internal job that claims the same (project, run_id)
+    internal = Job(
+        job_id="internal-abc",
+        status="running",
+        command=[],
+        started_at="2026-01-01T00:00:00+00:00",
+        ended_at=None,
+        exit_code=None,
+        output_project="proj-shared",
+        output_run_id="run-shared",
+    )
+    jm._store.put(internal)
+
+    jobs = jm.list_jobs(reports_root=tmp_path)
+    job_ids = [j.job_id for j in jobs]
+    # Internal wins; external must be absent
+    assert "internal-abc" in job_ids
+    assert "ext-run-shared" not in job_ids
+
+
+def test_list_jobs_without_reports_root_only_returns_internal(tmp_path):
+    from quodeq.services.jobs import JobManager
+
+    _make_in_progress_run(tmp_path, "proj-ext", "run-ext-2")
+
+    jm = JobManager()
+    jobs = jm.list_jobs()  # no reports_root
+    assert not any(j.source == "external" for j in jobs)
+
+
+def test_get_job_handles_ext_prefix(tmp_path):
+    from quodeq.services.jobs import JobManager
+
+    _make_in_progress_run(tmp_path, "proj-ext", "run-ext-3")
+
+    jm = JobManager()
+    snap = jm.get_job("ext-run-ext-3", reports_root=tmp_path)
+    assert snap is not None
+    assert snap.job_id == "ext-run-ext-3"
+    assert snap.source == "external"
+
+
+def test_get_job_ext_prefix_returns_none_when_not_found(tmp_path):
+    from quodeq.services.jobs import JobManager
+
+    jm = JobManager()
+    assert jm.get_job("ext-nonexistent", reports_root=tmp_path) is None
+
+
+def test_get_job_ext_prefix_requires_reports_root():
+    from quodeq.services.jobs import JobManager
+
+    jm = JobManager()
+    # Without reports_root, falls through to internal store -> None
+    assert jm.get_job("ext-anything") is None


### PR DESCRIPTION
> **Stacked on #246.** This PR's base is \`fix/dashboard-inprogress-runs\`. When #246 merges to develop, GitHub will auto-retarget this PR to \`develop\`.

## Problem

Quodeq's Evaluation tab only shows evaluations **launched from the dashboard UI itself**. Any evaluation running on the user's machine from another source — a CLI invocation, a CI runner writing to the same \`~/.quodeq/evaluations/\` — is invisible in the tab. You can't see its progress and you can't cancel it from the UI.

For a **local-only dashboard**, this is surprising: processes running on your machine should be visible and controllable from your dashboard.

## Fix

### Backend: \`src/quodeq/services/_external_jobs.py\` (new)

Filesystem-based detector that reconstructs \`JobSnapshot\` objects for in-progress runs the Job Manager doesn't know about:

- **Detection**: any \`{project_uuid}/{run_id}/\` with \`evidence/manifest.json\` present and no \`scan.json\` is treated as an in-progress external run.
- **Progress inference**:
  - Completed dimensions → files matching \`evaluation/{dim}.json\` (excluding \`_full.json\`)
  - Current dimension → newest-modified \`evidence/{dim}_evidence.jsonl\` not yet scored
  - Phase → \`setup\` / \`analyzing\` / \`scoring\` based on artifact presence
- **Source tagging**: \`JobSnapshot.source = \"external\"\` (new field; defaults to \`\"internal\"\`)
- **Job ID**: prefixed with \`ext-{run_id}\` so backend and frontend can route it appropriately.

### Backend: \`JobManager\` (\`src/quodeq/services/jobs.py\`)

- \`list_jobs(reports_root)\` merges internal + external jobs, de-duplicating by \`(output_project, output_run_id)\` — internal always wins if both see the same run.
- \`get_job(job_id, reports_root)\` routes \`ext-\` IDs to the filesystem detector.
- \`cancel_job(job_id, reports_root)\` supports external cancellation.

### Backend: Cancellation

\`quodeq evaluate\` now writes a \`.pid\` file into the run directory at start and unlinks it on exit. The dashboard's cancel flow reads this file and sends \`SIGTERM\` to the PID. Graceful, no process-tree guessing.

### Backend: Plumbing

- \`reports_root\` is threaded through the mixin, provider, and API routes as an optional kwarg. All call sites keep working with defaults.
- API routes \`GET /api/evaluations\`, \`GET /api/evaluations/{id}\`, \`DELETE /api/evaluations/{id}\` now pass \`reports_root\` through.

### Frontend

- \`job\` model propagates the new \`source\` field.
- \`EvaluationStatus.jsx\` shows an \"External run\" badge when \`source === \"external\"\`.
- Logs panel for external runs shows a note: \"Live logs unavailable for external runs — progress inferred from filesystem\" (we don't have the external process's stdout).
- Cancel button works for external runs via the updated backend path.
- Dimension polling and live progress reuse the existing flow — no changes needed because external snapshots populate the same fields.

## Tests

- \`tests/services/test_external_jobs.py\` (new) — 20 tests covering detection, phase inference, PID resolution, cancellation, edge cases
- \`tests/api/test_action_api.py\` — stub methods updated to accept the new \`reports_root\` kwarg
- **1945 total tests pass**, up from 1925 after #246

## Security considerations

The user explicitly chose to treat this as local-only software: *\"If something is running on your computer, you should be aware of it and have control of it.\"* The dashboard's existing posture (localhost-only unless \`QUODEQ_API_KEY\` is set, CSRF-protected mutations) remains. External job detection runs filesystem scans of the user's own \`~/.quodeq/evaluations/\` — no network exposure beyond what already exists. Cancellation is scoped to processes whose PID we can read from the run directory (written by \`quodeq evaluate\` itself), so there's no arbitrary-PID kill vector.

## Test plan

- [x] Full test suite: \`uv run pytest tests/\`
- [x] Open dashboard
- [x] In another terminal, run: \`quodeq evaluate . --pool-budget 600 --dimensions sec\`
- [x] Switch to Evaluation tab → external run should appear with \"External run\" badge, live phase/dimension, violation count
- [x] Click Cancel → the CLI process should receive SIGTERM, status should transition to cancelled