### PR TITLE
fix(dashboard): exclude abandoned runs (dead/missing PID) from History list

### DIFF
--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -80,7 +80,17 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         if not manifest_exists:
             continue
         scan_exists = (run_dir / "scan.json").exists()
-        status = "complete" if scan_exists else "in_progress"
+        if scan_exists:
+            status = "complete"
+        else:
+            # Avoid circular import: import locally
+            from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
+            # resolve_external_pid expects (project_uuid, run_id, reports_root)
+            pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
+            if pid is None:
+                # No live process — abandoned run, skip entirely
+                continue
+            status = "in_progress"
         date_iso, date_label = parse_run_date(reports_root, project, entry.name)
         run_infos.append(RunInfo(run_id=entry.name, date_iso=date_iso, date_label=date_label, status=status))
     run_infos.sort(key=lambda r: (r.date_iso or "", r.run_id), reverse=True)

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -1,11 +1,12 @@
 """Tests for list_runs() run discovery and status detection."""
+import os
 from pathlib import Path
 
 import pytest
 
 
 def test_list_runs_flags_in_progress_run(tmp_path: Path) -> None:
-    """A run directory with manifest.json but no scan.json should be flagged in_progress."""
+    """A run with manifest.json, no scan.json, and a live PID should be flagged in_progress."""
     from quodeq.data.fs.report_parser.runs import list_runs
 
     project_uuid = "proj-1"
@@ -13,6 +14,8 @@ def test_list_runs_flags_in_progress_run(tmp_path: Path) -> None:
     (run_dir / "evidence").mkdir(parents=True)
     (run_dir / "evidence" / "manifest.json").write_text("{}")
     (run_dir / "evaluation").mkdir()
+    # Write our own PID so the liveness check passes
+    (run_dir / ".pid").write_text(str(os.getpid()))
     # Deliberately no scan.json
 
     runs = list_runs(tmp_path, project_uuid)
@@ -63,11 +66,12 @@ def test_list_runs_mixes_complete_and_in_progress(tmp_path: Path) -> None:
     (done_dir / "evaluation").mkdir()
     (done_dir / "scan.json").write_text("{}")
 
-    # In-progress run
+    # In-progress run (live PID required)
     prog_dir = project_dir / "run-in-progress"
     (prog_dir / "evidence").mkdir(parents=True)
     (prog_dir / "evidence" / "manifest.json").write_text("{}")
     (prog_dir / "evaluation").mkdir()
+    (prog_dir / ".pid").write_text(str(os.getpid()))
     # no scan.json
 
     # Abandoned run (no manifest)
@@ -80,3 +84,49 @@ def test_list_runs_mixes_complete_and_in_progress(tmp_path: Path) -> None:
     assert by_id["run-done"].status == "complete"
     assert by_id["run-in-progress"].status == "in_progress"
     assert "run-abandoned" not in by_id
+
+
+def test_list_runs_excludes_abandoned_run(tmp_path: Path) -> None:
+    """A run with no scan.json and no live PID should be excluded entirely."""
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-1"
+    run_dir = tmp_path / project_uuid / "abandoned"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    # No scan.json, no .pid -> abandoned
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert runs == []
+
+
+def test_list_runs_excludes_abandoned_with_dead_pid(tmp_path: Path) -> None:
+    """A run with a .pid pointing to a dead process should be excluded."""
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-1"
+    run_dir = tmp_path / project_uuid / "abandoned"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    (run_dir / ".pid").write_text("999999")  # unlikely to be a live PID
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert runs == []
+
+
+def test_list_runs_includes_run_with_live_pid(tmp_path: Path) -> None:
+    """A run whose .pid points to a live process should appear as in_progress."""
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-1"
+    run_dir = tmp_path / project_uuid / "live"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    (run_dir / ".pid").write_text(str(os.getpid()))  # our own PID is alive
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert len(runs) == 1
+    assert runs[0].status == "in_progress"


### PR DESCRIPTION
## Problem

After #246 shipped, any run directory with \`manifest.json\` but no \`scan.json\` is classified as \`in_progress\` and shown in the History tab with a \`⟳ Running…\` badge. That was the intent for **live** runs — but it also catches:

- Old runs that were cancelled or killed and will never resume
- Runs from before #247 added \`.pid\` file writing

These abandoned runs pile up and all show as \"Running…\" forever, which is misleading and visually noisy. In a project with ~200 historical runs and several killed-mid-flight nightlies, the History tab becomes hard to read.

## Fix

Use the \`.pid\` file from #247 to distinguish **truly running** from **abandoned**:

| State | \`.pid\` file | PID alive | After this PR |
|---|---|---|---|
| Running now | exists | yes | \`in_progress\` (shown with Running badge) |
| Crashed/killed/never-completed | exists | no (or missing \`.pid\`) | **Excluded from History entirely** |
| Pre-#247 legacy run | missing | — | **Excluded from History entirely** |
| Completed | — | — | \`complete\` (shown normally) |

### Why exclude instead of showing abandoned?

Abandoned runs have no scored output. They're not useful in a score-history view. Users who want to inspect them can still find them on the filesystem. Keeping them visible as a third \"incomplete\" state was considered but adds UI complexity without a clear benefit — the feedback was \"abandoned shouldn't belong to history.\"

## Implementation

In \`src/quodeq/data/fs/report_parser/runs.py\`'s \`list_runs()\`: when \`scan.json\` is missing, call \`resolve_external_pid(project, run_id, reports_root)\` (from #247). If it returns \`None\` (no \`.pid\`, malformed \`.pid\`, or dead PID) the run is skipped via \`continue\`. Only a live PID reaches \`status = \"in_progress\"\`.

Local import of \`resolve_external_pid\` inside the function to avoid circular imports.

## Tests

- \`test_list_runs_excludes_abandoned_run\` — no \`.pid\`, no \`scan.json\` → excluded
- \`test_list_runs_excludes_abandoned_with_dead_pid\` — \`.pid\` points to dead PID → excluded
- \`test_list_runs_includes_run_with_live_pid\` — \`.pid\` points to current process (\`os.getpid()\`) → included as \`in_progress\`
- Existing in-progress test updated to create a live \`.pid\` so it still passes

Full suite: **1948 passing**, up from 1945 (+3 new tests).

## Test plan

- [x] \`uv run pytest tests/\`
- [x] Open dashboard with several old cancelled runs on disk → should NOT show them as Running in History
- [x] Start \`quodeq evaluate\` in a terminal → its run DOES show as Running while it runs, disappears from the list only when Kill'd abruptly (or flips to complete when finished)