### PR TITLE
fix(dashboard): restore visibility of historical runs (regression from #246/#249)

### DIFF
--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -79,18 +79,15 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         manifest_exists = (run_dir / "evidence" / "manifest.json").exists()
         if not manifest_exists:
             continue
-        scan_exists = (run_dir / "scan.json").exists()
-        if scan_exists:
-            status = "complete"
-        else:
-            # Avoid circular import: import locally
-            from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
-            # resolve_external_pid expects (project_uuid, run_id, reports_root)
-            pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
-            if pid is None:
-                # No live process — abandoned run, skip entirely
-                continue
-            status = "in_progress"
+        # Status is "in_progress" only when a live process has its PID registered
+        # in the run directory (via .pid file written by `quodeq evaluate`). All
+        # other runs — historical, crashed, pre-.pid-era — are treated as
+        # "complete" so they remain visible in History with their normal
+        # score/grade rendering. Runs with live PIDs get the dimmed "Running…"
+        # treatment instead.
+        from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
+        pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
+        status = "in_progress" if pid is not None else "complete"
         date_iso, date_label = parse_run_date(reports_root, project, entry.name)
         run_infos.append(RunInfo(run_id=entry.name, date_iso=date_iso, date_label=date_label, status=status))
     run_infos.sort(key=lambda r: (r.date_iso or "", r.run_id), reverse=True)

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -2,131 +2,102 @@
 import os
 from pathlib import Path
 
-import pytest
 
-
-def test_list_runs_flags_in_progress_run(tmp_path: Path) -> None:
-    """A run with manifest.json, no scan.json, and a live PID should be flagged in_progress."""
+def test_list_runs_marks_in_progress_when_pid_is_live(tmp_path: Path) -> None:
+    """A run with a live .pid file should be flagged in_progress."""
     from quodeq.data.fs.report_parser.runs import list_runs
 
     project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "run-in-progress"
+    run_dir = tmp_path / project_uuid / "run-live"
     (run_dir / "evidence").mkdir(parents=True)
     (run_dir / "evidence" / "manifest.json").write_text("{}")
     (run_dir / "evaluation").mkdir()
-    # Write our own PID so the liveness check passes
+    # Write our own PID — the liveness check passes for os.getpid()
     (run_dir / ".pid").write_text(str(os.getpid()))
-    # Deliberately no scan.json
 
     runs = list_runs(tmp_path, project_uuid)
     assert len(runs) == 1
     assert runs[0].status == "in_progress"
 
 
-def test_list_runs_flags_complete_run(tmp_path: Path) -> None:
-    """A run directory with manifest.json and scan.json should be flagged complete."""
+def test_list_runs_marks_historical_runs_as_complete(tmp_path: Path) -> None:
+    """A historical run (manifest present, no live PID) shows as complete in History.
+
+    This preserves visibility of all past runs regardless of whether they
+    completed cleanly — the dashboard's job is to show the user everything
+    they've evaluated, and completion state is inferred from scored output
+    in the UI, not from a filesystem marker.
+    """
     from quodeq.data.fs.report_parser.runs import list_runs
 
     project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "run-done"
+    run_dir = tmp_path / project_uuid / "run-historical"
     (run_dir / "evidence").mkdir(parents=True)
     (run_dir / "evidence" / "manifest.json").write_text("{}")
     (run_dir / "evaluation").mkdir()
-    (run_dir / "scan.json").write_text("{}")
+    # No .pid, no scan.json — a typical historical run
 
     runs = list_runs(tmp_path, project_uuid)
     assert len(runs) == 1
     assert runs[0].status == "complete"
 
 
-def test_list_runs_skips_empty_run_dirs(tmp_path: Path) -> None:
-    """A directory with no manifest.json (pre-manifest abort) should not appear as a run."""
+def test_list_runs_dead_pid_is_historical(tmp_path: Path) -> None:
+    """A run whose .pid points to a dead process is treated as historical/complete."""
     from quodeq.data.fs.report_parser.runs import list_runs
 
     project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "empty-run"
-    run_dir.mkdir(parents=True)
-    # no evidence/, no manifest.json, no scan.json
+    run_dir = tmp_path / project_uuid / "run-dead-pid"
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    # A PID unlikely to exist on any system
+    (run_dir / ".pid").write_text("999999")
 
     runs = list_runs(tmp_path, project_uuid)
-    assert len(runs) == 0
+    assert len(runs) == 1
+    assert runs[0].status == "complete"
 
 
-def test_list_runs_mixes_complete_and_in_progress(tmp_path: Path) -> None:
-    """Both complete and in-progress runs coexist in the same project directory."""
+def test_list_runs_skips_dirs_without_manifest(tmp_path: Path) -> None:
+    """A directory without evidence/manifest.json (pre-manifest abort) is not a run."""
+    from quodeq.data.fs.report_parser.runs import list_runs
+
+    project_uuid = "proj-1"
+    empty_dir = tmp_path / project_uuid / "empty"
+    empty_dir.mkdir(parents=True)
+
+    runs = list_runs(tmp_path, project_uuid)
+    assert runs == []
+
+
+def test_list_runs_mixes_historical_and_in_progress(tmp_path: Path) -> None:
+    """Historical runs stay visible; only live-PID runs get the in_progress flag."""
     from quodeq.data.fs.report_parser.runs import list_runs
 
     project_uuid = "proj-2"
     project_dir = tmp_path / project_uuid
 
-    # Complete run
-    done_dir = project_dir / "run-done"
-    (done_dir / "evidence").mkdir(parents=True)
-    (done_dir / "evidence" / "manifest.json").write_text("{}")
-    (done_dir / "evaluation").mkdir()
-    (done_dir / "scan.json").write_text("{}")
+    # Historical run (no .pid)
+    old_dir = project_dir / "run-historical"
+    (old_dir / "evidence").mkdir(parents=True)
+    (old_dir / "evidence" / "manifest.json").write_text("{}")
+    (old_dir / "evaluation").mkdir()
 
-    # In-progress run (live PID required)
-    prog_dir = project_dir / "run-in-progress"
-    (prog_dir / "evidence").mkdir(parents=True)
-    (prog_dir / "evidence" / "manifest.json").write_text("{}")
-    (prog_dir / "evaluation").mkdir()
-    (prog_dir / ".pid").write_text(str(os.getpid()))
-    # no scan.json
+    # Live run (.pid with our PID)
+    live_dir = project_dir / "run-live"
+    (live_dir / "evidence").mkdir(parents=True)
+    (live_dir / "evidence" / "manifest.json").write_text("{}")
+    (live_dir / "evaluation").mkdir()
+    (live_dir / ".pid").write_text(str(os.getpid()))
 
-    # Abandoned run (no manifest)
-    abandoned_dir = project_dir / "run-abandoned"
-    abandoned_dir.mkdir(parents=True)
+    # Empty / pre-manifest dir — should be skipped
+    stray = project_dir / "stray"
+    stray.mkdir(parents=True)
 
     runs = list_runs(tmp_path, project_uuid)
-    assert len(runs) == 2
-    by_id = {r.run_id: r for r in runs}
-    assert by_id["run-done"].status == "complete"
-    assert by_id["run-in-progress"].status == "in_progress"
-    assert "run-abandoned" not in by_id
-
-
-def test_list_runs_excludes_abandoned_run(tmp_path: Path) -> None:
-    """A run with no scan.json and no live PID should be excluded entirely."""
-    from quodeq.data.fs.report_parser.runs import list_runs
-
-    project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "abandoned"
-    (run_dir / "evidence").mkdir(parents=True)
-    (run_dir / "evidence" / "manifest.json").write_text("{}")
-    (run_dir / "evaluation").mkdir()
-    # No scan.json, no .pid -> abandoned
-
-    runs = list_runs(tmp_path, project_uuid)
-    assert runs == []
-
-
-def test_list_runs_excludes_abandoned_with_dead_pid(tmp_path: Path) -> None:
-    """A run with a .pid pointing to a dead process should be excluded."""
-    from quodeq.data.fs.report_parser.runs import list_runs
-
-    project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "abandoned"
-    (run_dir / "evidence").mkdir(parents=True)
-    (run_dir / "evidence" / "manifest.json").write_text("{}")
-    (run_dir / "evaluation").mkdir()
-    (run_dir / ".pid").write_text("999999")  # unlikely to be a live PID
-
-    runs = list_runs(tmp_path, project_uuid)
-    assert runs == []
-
-
-def test_list_runs_includes_run_with_live_pid(tmp_path: Path) -> None:
-    """A run whose .pid points to a live process should appear as in_progress."""
-    from quodeq.data.fs.report_parser.runs import list_runs
-
-    project_uuid = "proj-1"
-    run_dir = tmp_path / project_uuid / "live"
-    (run_dir / "evidence").mkdir(parents=True)
-    (run_dir / "evidence" / "manifest.json").write_text("{}")
-    (run_dir / "evaluation").mkdir()
-    (run_dir / ".pid").write_text(str(os.getpid()))  # our own PID is alive
-
-    runs = list_runs(tmp_path, project_uuid)
-    assert len(runs) == 1
-    assert runs[0].status == "in_progress"
+    by_id = {r.run_id: r.status for r in runs}
+    assert by_id == {
+        "run-historical": "complete",
+        "run-live": "in_progress",
+    }


### PR DESCRIPTION
## Problem

After #246 + #249 merged, the History tab went from showing ~200 runs to showing just 1. Users lost visibility of all their past evaluations.

## Root cause

PR #246 introduced:
\`\`\`python
scan_exists = (run_dir / \"scan.json\").exists()
\`\`\`

as a \"run is complete\" marker. But **\`scan.json\` is written at the project root, not per-run**. It contains the file tree for the whole project, not a per-run completion flag. So \`scan_exists\` was always False → every run marked \`in_progress\`. 

Then #249 added the live-PID filter on top: runs without a live \`.pid\` → \"abandoned\" → excluded. Since historical runs don't have \`.pid\` files, they were all stripped out.

Net effect: only the currently-running evaluation (with a manually-written \`.pid\` in my case) appeared in History. Everything else — every completed run, every valuable historical data point — vanished.

## Fix

Stop using \`scan.json\` as a signal entirely. Use only the live-PID check from #247:

| Condition | Status |
|---|---|
| \`.pid\` file exists AND PID is alive | \`in_progress\` (dimmed Running…) |
| Anything else (including historical runs without \`.pid\`) | \`complete\` (rendered normally) |

Historical runs stay visible. The UI renders them with whatever scores exist in their \`evaluation/\` directory — same as before #246. Nothing is hidden.

## Why not try to detect \"truly complete\"?

- There's no single filesystem marker that reliably indicates completion
- Users have scoped runs (single dimension), incremental carry-forwards, and legacy data — all legitimate
- The UI already handles partial data gracefully; it knows how to render a run with 1 dimension scored
- Over-filtering is worse than showing partial data

## Tests

Replaced the test cases whose premise was wrong. New tests:

- \`test_list_runs_marks_in_progress_when_pid_is_live\` — \`.pid\` with \`os.getpid()\` → in_progress
- \`test_list_runs_marks_historical_runs_as_complete\` — no \`.pid\` → complete (stays visible)
- \`test_list_runs_dead_pid_is_historical\` — \`.pid\` with dead PID → complete
- \`test_list_runs_skips_dirs_without_manifest\` — pre-manifest abort → excluded (unchanged)
- \`test_list_runs_mixes_historical_and_in_progress\` — both shown, correctly flagged

Full suite: **1946 passing**.

## Test plan

- [x] Open dashboard on a machine with 100+ historical runs → all show up in History
- [x] Start \`quodeq evaluate\` in terminal → its run appears with Running… badge alongside the historical rows
- [x] Kill that process → next dashboard refresh shows it as a normal historical row (no longer Running)