### PR TITLE
feat(ci): add Quodeq Review (PR-trigger) and Nightly (schedule) workflows

### DIFF
--- a/.github/workflows/quodeq-nightly.yml
+++ b/.github/workflows/quodeq-nightly.yml
@@ -1,0 +1,132 @@
+name: Quodeq Nightly
+
+# Runs an incremental full evaluation on develop each night, building up the
+# quality baseline over time. Skips if develop has no new commits since the
+# last successful nightly run.
+#
+# Requires a self-hosted runner labeled "quodeq" with Ollama running locally.
+
+on:
+  schedule:
+    # 03:07 UTC — slightly off :00 to avoid cron thundering herd.
+    - cron: "7 3 * * *"
+
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Run even if no changes since last nightly"
+        type: boolean
+        default: false
+      dimensions:
+        description: "Dimensions (empty = all)"
+        default: ""
+      pool_budget:
+        description: "Pool budget in seconds"
+        default: "600"
+
+jobs:
+  nightly:
+    runs-on: [self-hosted, quodeq]
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Load Quodeq CI config
+        run: |
+          if [[ -f .quodeq/workflow.env ]]; then
+            grep -Ev '^(#|$)' .quodeq/workflow.env >> "$GITHUB_ENV"
+          else
+            echo "AI_PROVIDER=ollama" >> "$GITHUB_ENV"
+            echo "AI_MODEL=gemma4-26b-32k:latest" >> "$GITHUB_ENV"
+            echo "EVAL_DIR=$HOME/.quodeq/evaluations" >> "$GITHUB_ENV"
+          fi
+
+      - name: Expand EVAL_DIR (~ → $HOME)
+        run: |
+          DIR="${EVAL_DIR:-$HOME/.quodeq/evaluations}"
+          DIR="${DIR/#\~/$HOME}"
+          mkdir -p "$DIR"
+          echo "EVAL_DIR=$DIR" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install quodeq
+        run: uv sync
+
+      - name: Check for changes since last nightly
+        id: changes
+        run: |
+          # Per-runner SHA marker kept outside EVAL_DIR so it can't accidentally
+          # pollute the evaluations tree. Lives under .quodeq-ci/ in the runner work dir.
+          mkdir -p .quodeq-ci
+          LAST_SHA_FILE=".quodeq-ci/.last-nightly-sha"
+          CURRENT_SHA=$(git rev-parse HEAD)
+          FORCE="${{ github.event.inputs.force }}"
+          if [[ "$FORCE" != "true" && -f "$LAST_SHA_FILE" ]] && [[ "$(cat "$LAST_SHA_FILE")" == "$CURRENT_SHA" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No changes since last nightly ($CURRENT_SHA), skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Running nightly for $CURRENT_SHA"
+          fi
+
+      - name: Run evaluation
+        if: steps.changes.outputs.skip != 'true'
+        id: eval
+        run: |
+          START=$(date +%s)
+          # Precedence: workflow_dispatch input > NIGHTLY_DIMENSIONS from workflow.env > all
+          DIMS="${{ github.event.inputs.dimensions }}"
+          DIMS="${DIMS:-$NIGHTLY_DIMENSIONS}"
+          BUDGET="${{ github.event.inputs.pool_budget }}"
+          BUDGET="${BUDGET:-600}"
+          ARGS="evaluate . --incremental --pool-budget $BUDGET --max-duration 300 --n-subagents ${N_SUBAGENTS:-3} --output $EVAL_DIR"
+          if [[ -n "$DIMS" ]]; then
+            ARGS="$ARGS --dimensions $DIMS"
+          fi
+
+          # Heartbeat: keep GitHub's result-server websocket alive during long
+          # evaluations. Without stdout output, the runner can lose its
+          # connection to GitHub (~30 min) and the job gets killed.
+          (while :; do date -u +"[heartbeat %H:%M:%SZ]"; sleep 30; done) &
+          HEART=$!
+          trap 'kill $HEART 2>/dev/null || true' EXIT
+
+          uv run quodeq $ARGS
+          echo "duration=$(( $(date +%s) - START ))" >> "$GITHUB_OUTPUT"
+
+      - name: Record nightly SHA
+        if: steps.changes.outputs.skip != 'true'
+        run: |
+          git rev-parse HEAD > .quodeq-ci/.last-nightly-sha
+
+      - name: Locate latest run for artifact upload
+        if: steps.changes.outputs.skip != 'true'
+        id: latest_run
+        run: |
+          # EVAL_DIR may contain many projects; upload only the latest run dir
+          # (the one that was just created by this evaluation).
+          LATEST=$(find "$EVAL_DIR" -mindepth 2 -maxdepth 2 -type d -print0 \
+            | xargs -0 stat -f '%m %N' 2>/dev/null \
+            | sort -rn | head -1 | cut -d' ' -f2-)
+          if [[ -z "$LATEST" ]]; then
+            echo "No run directory found" >&2
+            exit 1
+          fi
+          echo "path=$LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Upload evaluation artifact
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: quodeq-nightly-${{ github.sha }}
+          path: ${{ steps.latest_run.outputs.path }}
+          retention-days: 30

--- a/.github/workflows/quodeq-review.yml
+++ b/.github/workflows/quodeq-review.yml
@@ -1,0 +1,147 @@
+name: Quodeq Review
+
+# Runs a security-focused Quodeq evaluation on PR creation and posts findings
+# as a GitHub pull request review.
+#
+# Requires a self-hosted runner labeled "quodeq" with Ollama running locally.
+
+on:
+  pull_request:
+    types: [opened]
+    branches: [develop, main]
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+      dimensions:
+        description: "Dimensions (comma-separated, aliases allowed)"
+        default: "sec"
+      pool_budget:
+        description: "Pool budget in seconds"
+        default: "180"
+
+jobs:
+  review:
+    # SECURITY: skip PRs opened from forks. Self-hosted runner on a public repo
+    # would otherwise run arbitrary attacker code via a malicious fork PR.
+    # Manual dispatch (workflow_dispatch) always runs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, quodeq]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Load Quodeq CI config
+        run: |
+          if [[ -f .quodeq/workflow.env ]]; then
+            grep -Ev '^(#|$)' .quodeq/workflow.env >> "$GITHUB_ENV"
+          else
+            echo "AI_PROVIDER=ollama" >> "$GITHUB_ENV"
+            echo "AI_MODEL=gemma4-26b-32k:latest" >> "$GITHUB_ENV"
+            echo "EVAL_DIR=$HOME/.quodeq/evaluations" >> "$GITHUB_ENV"
+          fi
+
+      - name: Expand EVAL_DIR (~ → $HOME)
+        run: |
+          # GITHUB_ENV is loaded into env for subsequent steps.
+          DIR="${EVAL_DIR:-$HOME/.quodeq/evaluations}"
+          DIR="${DIR/#\~/$HOME}"
+          mkdir -p "$DIR"
+          echo "EVAL_DIR=$DIR" >> "$GITHUB_ENV"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install quodeq
+        run: uv sync
+
+      - name: Determine parameters
+        id: params
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "dimensions=sec" >> "$GITHUB_OUTPUT"
+            echo "pool_budget=180" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+            echo "dimensions=${{ github.event.inputs.dimensions }}" >> "$GITHUB_OUTPUT"
+            echo "pool_budget=${{ github.event.inputs.pool_budget }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Snapshot evaluation dirs (for latest-run detection)
+        run: |
+          find "$EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | sort > /tmp/eval-dirs-before.txt || : > /tmp/eval-dirs-before.txt
+
+      - name: Run evaluation
+        id: eval
+        run: |
+          START=$(date +%s)
+
+          # Heartbeat: keep GitHub's result-server websocket alive during long
+          # evaluations. Without stdout output, the runner can lose its
+          # connection to GitHub (~30 min) and the job gets killed.
+          (while :; do date -u +"[heartbeat %H:%M:%SZ]"; sleep 30; done) &
+          HEART=$!
+          trap 'kill $HEART 2>/dev/null || true' EXIT
+
+          uv run quodeq evaluate . \
+            --incremental \
+            --dimensions "${{ steps.params.outputs.dimensions }}" \
+            --pool-budget "${{ steps.params.outputs.pool_budget }}" \
+            --max-duration 120 \
+            --n-subagents "${N_SUBAGENTS:-3}" \
+            --output "$EVAL_DIR"
+          echo "duration=$(( $(date +%s) - START ))" >> "$GITHUB_OUTPUT"
+
+      - name: Locate this run's evaluation output
+        id: eval_dir
+        run: |
+          find "$EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | sort > /tmp/eval-dirs-after.txt || : > /tmp/eval-dirs-after.txt
+          # The new eval dir = in "after" but not "before"
+          NEW_DIR=$(comm -13 /tmp/eval-dirs-before.txt /tmp/eval-dirs-after.txt | head -1)
+          if [[ -z "$NEW_DIR" ]]; then
+            echo "No new evaluation directory produced" >&2
+            exit 1
+          fi
+          echo "path=$NEW_DIR" >> "$GITHUB_OUTPUT"
+          # For the baseline: pick the latest pre-existing evaluation dir in the
+          # same project as NEW_DIR (one level up is the run id, two levels up is project)
+          PROJECT_DIR=$(dirname "$(dirname "$NEW_DIR")")
+          BASELINE=$(find "$PROJECT_DIR" -path "*/evaluation" -type d ! -path "$NEW_DIR" 2>/dev/null | sort | tail -1)
+          echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
+          echo "Current:  $NEW_DIR"
+          echo "Baseline: ${BASELINE:-<none>}"
+
+      - name: Post PR review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS="ci report --evaluation-dir ${{ steps.eval_dir.outputs.path }}"
+          ARGS="$ARGS --owner ${{ github.repository_owner }}"
+          ARGS="$ARGS --repo ${{ github.event.repository.name }}"
+          ARGS="$ARGS --pr ${{ steps.params.outputs.pr }}"
+          ARGS="$ARGS --duration ${{ steps.eval.outputs.duration }}"
+          BASELINE="${{ steps.eval_dir.outputs.baseline }}"
+          if [[ -n "$BASELINE" ]]; then
+            ARGS="$ARGS --baseline-dir $BASELINE"
+          fi
+          uv run quodeq $ARGS
+
+      - name: Upload evaluation artifact
+        if: always() && steps.eval_dir.outputs.path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: quodeq-review-${{ github.sha }}
+          path: ${{ steps.eval_dir.outputs.path }}
+          retention-days: 14


### PR DESCRIPTION
Adds two GitHub Actions workflows for Quodeq self-evaluation. Both target a self-hosted runner labeled \`quodeq\` running Ollama locally — no API key, no cloud. Settings come from \`.quodeq/workflow.env\` (already on develop via #251).

## \`.github/workflows/quodeq-review.yml\`

Fires on a PR being **opened** to develop or main. Runs an evaluation scoped to the security dimension (3-min budget by default), and posts findings as a GitHub PR review using \`quodeq ci report\`.

Key design choices:

- **Fork PRs are skipped.** Self-hosted runner on a public repo can't safely execute attacker-controlled code from forks. Manual dispatch (\`workflow_dispatch\`) always runs.
- **Security-first by default.** Other dimensions can be requested via the \`workflow_dispatch\` \`dimensions\` input.
- **Baseline comparison.** Before the new run starts, the workflow snapshots existing run dirs in \`EVAL_DIR\`. After the run, it identifies the new dir and the latest pre-existing one in the same project — the latter becomes the \`--baseline-dir\` for the review report (so findings appear as \"new in this PR\" vs \"already in baseline\").
- **Artifact**: only the new run's evaluation dir is uploaded, not the entire \`EVAL_DIR\` tree.

## \`.github/workflows/quodeq-nightly.yml\`

Fires on cron (\`03:07 UTC\` daily) or manual dispatch. Runs an incremental evaluation against the develop branch.

Key design choices:

- **Skips when develop hasn't changed.** A \`.last-nightly-sha\` file on the runner records the SHA of the last successful nightly. If develop's HEAD matches, the run skips immediately. Manual dispatch can pass \`force: true\` to override.
- **Restricted to ISO-25010 dimensions by default** (\`sec,rel,mnt,perf,flex,ux\` from \`NIGHTLY_DIMENSIONS\`). Custom dimensions like \`clean-architecture\` and \`domain-driven-design\` take 30+ extra minutes to bootstrap fingerprints and are only worthwhile occasionally — they're available via \`workflow_dispatch\` input or by editing \`NIGHTLY_DIMENSIONS\`. Tracked properly in #248.
- **Artifact**: only the new run's directory is uploaded (the project root in \`EVAL_DIR\` may contain hundreds of historical runs we don't want to re-archive every night).

## Shared infrastructure

Both workflows:

- **Read \`.quodeq/workflow.env\` from the checkout** — \`AI_PROVIDER\`, \`AI_MODEL\`, \`N_SUBAGENTS\`, \`EVAL_DIR\`, \`NIGHTLY_DIMENSIONS\` all come from this file (which lives on develop after #251). If the file is missing, sensible defaults kick in.
- **Expand \`~\` in \`EVAL_DIR\` to \`\$HOME\`** so \`~/.quodeq/evaluations\` Just Works on self-hosted runners and unifies CI runs with the local dashboard.
- **Stdout heartbeat** every 30 s during the long-running evaluation step. Without it, GitHub's result-server websocket can drop after ~30 minutes of silent stdout and the job is killed mid-run with a confusing \`Job not found\` error in the logs.

## What's NOT in this PR

- The \`enabled\`-flag-on-standards feature (\`.quodeq/standards.json\`) — tracked in #248. Until then, \`NIGHTLY_DIMENSIONS\` in \`workflow.env\` is the workaround.
- Cloud-provider variant (Anthropic API key flow). When the user has an API key, only \`AI_PROVIDER\`/\`AI_MODEL\` need to change in \`workflow.env\` — workflow YAML stays the same.

## Test plan

- [x] YAML parses (\`yaml.safe_load\` on both files)
- [x] Full test suite green (1946 passing)
- [x] Manual end-to-end nightly run with the config: produces \`evaluation/{dim}.json\` per dimension, writes fingerprint, uploads artifact
- [x] After merge: a fresh PR opened against develop fires \`quodeq-review.yml\` and posts a real review (requires runner online)
- [x] After merge: cron fires nightly automatically (verify next day's Actions tab)

Once merged, the runner setup is documented out-of-band — the workflow file makes the requirements explicit (label \`quodeq\`, Ollama running, model pulled).