### PR TITLE
feat(ui): live terminal stream — full xterm.js view of running evaluations

### DIFF
--- a/specs/2026-04-20-live-terminal-stream-design.md
+++ b/specs/2026-04-20-live-terminal-stream-design.md
@@ -1,0 +1,224 @@
+# Live Terminal Stream — Design Spec
+
+**Status:** Draft
+**Date:** 2026-04-20
+**Author:** Victor + Claude (brainstorm)
+
+## Problem
+
+The dashboard's view of a running evaluation is coarse and asymmetric with the CLI experience:
+
+- **CLI** (`quodeq evaluate`) streams rich stderr output line-by-line: phase transitions, dimension progress, violation counts, timestamps. The user sees every heartbeat.
+- **Dashboard-spawned run** captures subprocess stdout/stderr into `Job.logs` (a ~100-line ring buffer), polled by the UI every 1500ms via `GET /api/evaluations/<id>`. Lines are lost once the buffer rotates; granularity is coarse; ANSI stripped.
+- **Externally-started run** (CLI in another terminal, CI runner) gets worse treatment — the UI detects it via `find_external_runs` ([_external_jobs.py:30](../src/quodeq/services/_external_jobs.py:30)) scanning the filesystem for `manifest.json` + absence of `scan.json`, infers phase/dimension from artifact file counts, and explicitly renders the message "Live logs unavailable for external runs — progress inferred from filesystem."
+
+The user's summary: "Running outside the dashboard is entirely bad implemented." The dashboard feels like it's watching a filesystem rather than an evaluation. The goal is to make the dashboard show the evaluation *fully, as if executed from the terminal*, regardless of who started it.
+
+## Goals
+
+1. Any evaluation running on this machine streams live into any open dashboard. CLI-started, dashboard-started, CI-started — all the same UX.
+2. Opening the dashboard on a running job replays the full log from the first line, then tails. No "tune in mid-show" limitation.
+3. Opening the dashboard on a completed job replays the same terminal output it showed live. Historical parity.
+4. The transport is simple enough that a single developer can debug it with `tail -f` and `curl`.
+5. Producer cost is trivial — adding log streaming must not risk crashing an evaluation.
+
+## Non-Goals
+
+- Bidirectional terminal (no REPL / stdin). The UI is read-only.
+- Multi-machine fan-out. One machine, one or more dashboards on the same machine.
+- Structured event envelopes. Raw stderr is the format; the UI renders it verbatim via xterm.js.
+- Concurrent evaluations. In practice only one runs per machine at a time; the design does not rely on this, but does not optimize for N>1 either.
+- Replacing the existing status card. The structured status polling stays; the terminal view is additive.
+
+## Architecture
+
+```
+                   ┌──────────────────────────────┐
+                   │   Evaluation process          │
+                   │   (CLI or subprocess)         │
+                   │                               │
+                   │   log_info → stderr           │
+                   │            → RunLogWriter     │
+                   └──────────────┬────────────────┘
+                                  │ append + flush
+                                  ▼
+                   ┌──────────────────────────────┐
+                   │   {run_dir}/run.log          │
+                   │   (plain text, line-buffered)│
+                   └──────────────┬────────────────┘
+                                  │ tail by byte-offset
+                                  ▼
+                   ┌──────────────────────────────┐
+                   │   GET /api/jobs/<id>/logs/…  │
+                   │   SSE  (+ plain JSON)         │
+                   └──────────────┬────────────────┘
+                                  │ EventSource
+                                  ▼
+                   ┌──────────────────────────────┐
+                   │   <LiveTerminal /> (xterm.js) │
+                   │   inline in EvaluationStatus  │
+                   └──────────────────────────────┘
+```
+
+Every evaluation run writes its stderr stream verbatim to `{run_dir}/run.log`, alongside the existing `manifest.json` / `evidence/` artifacts. The run directory remains the single source of truth. A new SSE endpoint tails the file and pushes lines to the dashboard. The UI renders them in an xterm.js pane embedded below the existing status card.
+
+## Components
+
+Five units, one responsibility each.
+
+### 1. `RunLogWriter` (new)
+**File:** `src/quodeq/shared/run_log.py`
+
+Minimal file-handle wrapper.
+
+```python
+class RunLogWriter:
+    def __init__(self, run_dir: Path): ...
+    def write(self, line: str) -> None:
+        """Append a single line to run.log. Catches and swallows errors."""
+    def close(self) -> None: ...
+```
+
+- Opens `{run_dir}/run.log` in append + line-buffered mode.
+- `write` normalizes line endings (always `\n`), flushes after each line.
+- On any `OSError` (disk full, permissions), logs once to real stderr and becomes a no-op. Never raises to the caller.
+- Used by both the CLI path and the subprocess dispatcher.
+
+### 2. CLI producer hook
+**Files:** `src/quodeq/_cli_evaluation.py`, `src/quodeq/shared/logging.py`
+
+Route all `log_info(...)` / stderr prints through `RunLogWriter` in addition to real stderr (tee). Install the writer once `run_dir` is known (after `_setup_run_dirs`). Tear down in the same `finally` block that writes `scan.json`.
+
+No format changes. Just duplication to the file.
+
+### 3. Dashboard-spawned producer hook
+**File:** `src/quodeq/services/jobs.py` (modify `_consume_stream`, ~line 116)
+
+The subprocess output already streams through `_consume_stream`. Add a `RunLogWriter.write(line)` call alongside the existing ring-buffer append. ANSI codes are already stripped upstream — leave that behavior.
+
+Writer lifetime matches the job's process lifetime.
+
+### 4. SSE + plain endpoints (new)
+**File:** `src/quodeq/api/_log_stream_routes.py`
+
+Two routes:
+
+- `GET /api/jobs/<id>/logs/stream` — Server-Sent Events.
+  - Resolves `<id>` → `run_dir` via the same provider method the status card uses (handles internal `JobManager` IDs and `ext-<run_id>` prefixes uniformly).
+  - Opens `{run_dir}/run.log`, starts at `Last-Event-ID` byte-offset if provided else `0`.
+  - Streams existing contents, then polls file size every 100ms, emits new bytes as `data:` frames with `id: <byte-offset>`.
+  - Detects job completion via `get_evaluation_status(job_id).status in ("done", "failed", "cancelled")`. On completion: flush remaining bytes, send `event: done`, close.
+  - On missing log file: `retry: 1000`, poll up to 10s for file to appear. After that: 404.
+  - On missing `run_dir`: 410 Gone.
+
+- `GET /api/jobs/<id>/logs?since=<byte_offset>` — Non-streaming fallback.
+  - Returns `{"lines": [...], "nextOffset": N, "done": bool}` snapshot.
+  - Same resolution + error semantics as the SSE route.
+  - Useful for initial replay on very slow connections and for tests.
+
+Registered via `register_all_routes` alongside existing log routes; protected by the same `@require_auth` decorator and before_request middleware.
+
+### 5. UI terminal pane (new)
+**Files:**
+- `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx` (new)
+- `src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx` (modify — embed `<LiveTerminal>` below the existing status card)
+- `src/quodeq/ui/package.json` (add `xterm`, `xterm-addon-fit`)
+
+`<LiveTerminal jobId={...} completed={bool}>`:
+- Creates an xterm.js `Terminal` instance, mounts on an internal `<div ref>`.
+- Opens `new EventSource('/api/jobs/' + jobId + '/logs/stream')`.
+- On `message` event: `term.write(event.data + '\r\n')`.
+- On `event: done`: closes EventSource, disables reconnect. Scrollback stays.
+- On unmount: closes EventSource, disposes terminal.
+- Collapsible: wrapper renders a header `▾ Terminal (N lines)` / `▸ Terminal` with click to toggle; collapsed state hides the xterm DOM but keeps state (instance not disposed).
+- For completed runs, same component: EventSource replays from offset 0, server sends `event: done` immediately after full file dump, connection closes.
+
+## Data Flow
+
+### Write path
+```
+log_info(line) / subprocess stderr
+    → (existing) real stderr or Job.logs ring buffer
+    → (new) RunLogWriter.write(line) → O_APPEND write + flush
+```
+Write happens on the producer thread, synchronously. Line-buffered flush ensures readers see lines within milliseconds.
+
+### Read path
+```
+UI mounts <LiveTerminal jobId={id} />
+  → EventSource('/api/jobs/<id>/logs/stream')
+  → server resolves id → run_dir
+  → server opens run.log, sends bytes from offset 0 (or Last-Event-ID)
+  → server poll-loop (100ms): on file growth, reads new bytes, emits SSE events with id:<new-offset>
+  → server detects job.status in terminal state → sends event: done → closes
+```
+
+### Resolution
+`<id>` can be internal (`JobManager._jobs`) or external (`ext-<run_id>`). The SSE route calls the existing status resolver (same path the status card uses) to get `run_dir`. No new resolution logic.
+
+### Multi-viewer
+Each EventSource connection is independent — own file handle, own poll loop. No shared server state. Bounded by open dashboard tabs (realistically 1-3).
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| `run.log` not yet created | SSE sends `retry: 1000`, polls for up to 10s, then 404. |
+| `run_dir` deleted mid-stream | 410 Gone; UI shows "run artifacts removed." |
+| Job completes while viewer connected | Server sends final `event: done`; UI stops EventSource; scrollback intact. |
+| Disk full / permission denied on write | `RunLogWriter.write` logs once to stderr, becomes no-op. Run never crashes because the log file cannot be written. |
+| Reader reads mid-line (no `\n` yet) | Server holds partial tail in local buffer; appends on next poll. Client sees whole lines only. |
+| EventSource reconnect after network hiccup | Browser sends `Last-Event-ID: <byte-offset>`; server seeks to `offset + 1`, resumes. No duplicates or gaps. |
+| Concurrent writers (defensive) | `O_APPEND` — kernel serializes writes. Never corruption, at worst interleaved lines. |
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `QUODEQ_LOG_STREAM_POLL_MS` | `100` | Server-side poll interval for new bytes |
+| `QUODEQ_LOG_STREAM_MAX_WAIT_S` | `10` | How long SSE waits for run.log to appear |
+| `QUODEQ_LOG_FILE_NAME` | `run.log` | File name under run_dir (escape hatch for packaging) |
+
+No user-facing UI toggle. The terminal pane is always embedded; user collapses it if they don't want it.
+
+## Retention
+
+`run.log` lives inside the existing run directory forever — same lifetime as `manifest.json`, `evidence/`, and `scan.json`. Deleted only when the user deletes the run via existing cleanup flows. Plain text; typical size KB to low MB. No compression or rolling.
+
+This enables historical replay: opening an old evaluation in the dashboard shows its original terminal output via the same `LiveTerminal` component — server replays the file then sends `done`.
+
+## UI Placement
+
+Inline, under the existing status card on `EvaluationStatus.jsx`:
+
+```
+┌─ Evaluation Status ──────────────────────┐
+│ Phase: Analyzing · Dimension: security   │
+│ [tag tag tag]                            │
+│ Findings: 12 · Compliance: 48            │
+└──────────────────────────────────────────┘
+┌─ ▾ Terminal (342 lines) ─────────────────┐
+│ > Starting evaluation (may take …)       │
+│ > Report path: /Users/…/evaluations/…    │
+│ > → [1/3] Analyzing security | 0m12s     │
+│ > ...live tail...                        │
+└──────────────────────────────────────────┘
+```
+
+Structured status (top) is driven by existing snapshot polling. Terminal pane (bottom) is the new live stream. Both update independently.
+
+## Testing
+
+- **`tests/shared/test_run_log.py`** — `RunLogWriter` unit tests: append, byte offsets, silent failure when dir missing, line-buffered flush (read-after-write visibility).
+- **`tests/api/test_log_stream_routes.py`** — SSE + plain endpoint tests: `text/event-stream` content type; initial replay contains seeded lines with correct `id:` offsets; partial-line handling (seed file without trailing newline, append rest, assert no duplicate/split lines); `Last-Event-ID` resume correctness; 404 on missing file; 410 on missing run_dir.
+- **`tests/ci/test_run_log_integration.py`** — End-to-end CLI: spawn `quodeq evaluate` against a tiny fixture repo, assert `run.log` exists in `run_dir`, contains expected progress markers.
+- **`tests/services/test_jobs_run_log.py`** — Dashboard path: stub subprocess prints scripted sequence; assert `_consume_stream` tees every line to `run.log` while preserving the existing `Job.logs` ring buffer.
+- **`tests/ui/features/evaluation/LiveTerminal.test.jsx`** (Vitest) — mount `<LiveTerminal>`, mocked EventSource pushes lines, assert xterm buffer receives them in order; `done` event closes without clearing scrollback.
+- **Smoke test** (optional) — run a tiny real evaluation, open a Flask test-client SSE connection concurrently, assert streamed lines match the stderr from the process.
+
+## Out of Scope
+
+- Switching existing status-card polling to SSE. The structured status endpoint stays as-is.
+- Streaming to remote dashboards (different machine). Requires separate transport/auth design.
+- Input (REPL) from terminal view. Read-only.
+- Pruning old `run.log` files. Cleanup rides on existing run-directory cleanup.

--- a/specs/2026-04-20-live-terminal-stream-design.md
+++ b/specs/2026-04-20-live-terminal-stream-design.md
@@ -170,6 +170,7 @@ Each EventSource connection is independent — own file handle, own poll loop. N
 | Reader reads mid-line (no `\n` yet) | Server holds partial tail in local buffer; appends on next poll. Client sees whole lines only. |
 | EventSource reconnect after network hiccup | Browser sends `Last-Event-ID: <byte-offset>`; server seeks to `offset + 1`, resumes. No duplicates or gaps. |
 | Concurrent writers (defensive) | `O_APPEND` — kernel serializes writes. Never corruption, at worst interleaved lines. |
+| Historical run predates this feature (no `run.log`) | 404 on the SSE endpoint; UI renders a placeholder row inside the terminal pane: "No terminal output captured for this run." Component still mounts (user can collapse it). |
 
 ## Configuration
 

--- a/specs/2026-04-20-live-terminal-stream-plan.md
+++ b/specs/2026-04-20-live-terminal-stream-plan.md
@@ -1,0 +1,1440 @@
+# Live Terminal Stream Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream every evaluation's live terminal output to the dashboard via SSE, backed by a per-run `run.log` file, and render it with xterm.js inline under the existing status card.
+
+**Architecture:** Producers (CLI and dashboard-spawned subprocess) append stderr lines verbatim to `{run_dir}/run.log`. A new Flask SSE endpoint tails that file and pushes lines to the dashboard via `EventSource`. The UI mounts an xterm.js terminal below the status card; it replays history from offset 0 then tails live until the server sends `event: done`.
+
+**Tech Stack:** Python 3.12 (Flask, stdlib logging), React 18 + Vite 7 (xterm.js v5, xterm-addon-fit), pytest 9.
+
+See spec: [2026-04-20-live-terminal-stream-design.md](2026-04-20-live-terminal-stream-design.md).
+
+---
+
+## File Structure
+
+**New files**
+- `src/quodeq/shared/run_log.py` — `RunLogWriter` (plain file wrapper) + `RunLogHandler` (logging.Handler adapter). One responsibility: append lines to run.log.
+- `src/quodeq/api/_log_stream_routes.py` — SSE + plain JSON endpoints. One responsibility: serve the log file to dashboards.
+- `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx` — xterm.js renderer + EventSource wiring. One responsibility: live-render the log stream.
+- `tests/shared/test_run_log.py`
+- `tests/api/test_log_stream_routes.py`
+- `tests/services/test_jobs_run_log.py`
+- `tests/ci/test_run_log_integration.py`
+
+**Modified files**
+- `src/quodeq/_cli_evaluation.py` — convert inline `print(..., file=sys.stderr)` calls to `log_info(...)`; install `RunLogHandler` on the `quodeq` logger in the try/finally of `_run_pipeline_with_cleanup`.
+- `src/quodeq/services/jobs.py` — `_consume_stream` tees each line to a `RunLogWriter` bound to the job's run_dir.
+- `src/quodeq/api/routes_registry.py` — register the new log-stream routes.
+- `src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx` — render `<LiveTerminal>` after `<ConsolePanel>`.
+- `src/quodeq/ui/package.json` — add `xterm` and `xterm-addon-fit`.
+
+---
+
+## Task 1: RunLogWriter + RunLogHandler utility
+
+**Files:**
+- Create: `src/quodeq/shared/run_log.py`
+- Test: `tests/shared/test_run_log.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/shared/__init__.py` (empty) if it doesn't already exist, then write:
+
+```python
+# tests/shared/test_run_log.py
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from quodeq.shared.run_log import RunLogWriter, RunLogHandler
+
+
+def test_write_creates_file_with_line(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("hello")
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "hello\n"
+
+
+def test_write_preserves_existing_newline(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("already-newlined\n")
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "already-newlined\n"
+
+
+def test_write_is_line_buffered(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("first")
+    # Read back without closing — flush should have happened.
+    assert (tmp_path / "run.log").read_text() == "first\n"
+    writer.close()
+
+
+def test_silent_on_missing_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    writer = RunLogWriter(missing)  # must not raise
+    writer.write("ignored")  # must not raise
+    writer.close()
+    assert not (missing / "run.log").exists()
+
+
+def test_path_property(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    assert writer.path == tmp_path / "run.log"
+    writer.close()
+
+
+def test_handler_forwards_log_record(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.getLogger("test.run_log.1")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("message-a")
+    logger.removeHandler(handler)
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "message-a\n"
+
+
+def test_handler_never_raises_on_format_error(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    handler = RunLogHandler(writer)
+    logger = logging.getLogger("test.run_log.2")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    # %d on a string arg — format-time error, must not propagate.
+    logger.info("%d", "not-an-int")
+    logger.removeHandler(handler)
+    writer.close()
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+cd /Users/victor/GitHub/quodeq/.claude/worktrees/elegant-goldberg-396ca4
+uv run pytest tests/shared/test_run_log.py -v
+```
+Expected: `ImportError: cannot import name 'RunLogWriter' from 'quodeq.shared.run_log'`.
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# src/quodeq/shared/run_log.py
+"""Per-run log file writer.
+
+Appends the evaluation's stderr-stream verbatim to ``{run_dir}/run.log``.
+Used by both the CLI pipeline and the dashboard subprocess dispatcher.
+
+Failures are silent-by-design: this file is diagnostic, never load-bearing.
+A disk-full or permission error must not abort an evaluation.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import IO
+
+_LOG_FILENAME = "run.log"
+
+
+class RunLogWriter:
+    """Thread-safe append-only writer for a per-run log file."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self._path = run_dir / _LOG_FILENAME
+        self._fh: IO[str] | None = None
+        self._lock = threading.Lock()
+        self._disabled = False
+        try:
+            self._fh = open(self._path, "a", buffering=1, encoding="utf-8")
+        except OSError as exc:
+            print(f"run_log: could not open {self._path}: {exc}", file=sys.stderr)
+            self._disabled = True
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def write(self, line: str) -> None:
+        """Append *line* to run.log. Adds a trailing newline if missing."""
+        if self._disabled or self._fh is None:
+            return
+        text = line if line.endswith("\n") else line + "\n"
+        with self._lock:
+            try:
+                self._fh.write(text)
+                self._fh.flush()
+            except OSError:
+                self._disabled = True
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                finally:
+                    self._fh = None
+
+
+class RunLogHandler(logging.Handler):
+    """logging.Handler that forwards formatted records to a RunLogWriter."""
+
+    def __init__(self, writer: RunLogWriter) -> None:
+        super().__init__()
+        self._writer = writer
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._writer.write(self.format(record))
+        except Exception:
+            # Logging must never crash the app.
+            pass
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/shared/test_run_log.py -v
+```
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/shared/run_log.py tests/shared/
+git commit -m "feat(run-log): add RunLogWriter and RunLogHandler utility"
+```
+
+---
+
+## Task 2: Convert inline stderr prints in _cli_evaluation.py to log_info
+
+**Files:**
+- Modify: `src/quodeq/_cli_evaluation.py` (lines 118, 124, 126, 128, 130, 131, 155, 162, 197)
+
+The CLI uses a mix of `log_info()` (flows through the `quodeq` logger) and direct `print(..., file=sys.stderr)`. Only the former will be captured by a `RunLogHandler`. Convert the direct prints so every progress message flows through the logger.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/ci/test_cli_uses_log_info.py
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_no_direct_stderr_prints_in_pipeline() -> None:
+    """The CLI pipeline must route progress messages through log_info, not print(..., file=sys.stderr).
+
+    Allowed exceptions: dimension score lines in _execute_pipeline's success branch
+    (line 133: `print(f"  {dim}: {score}")`) because those print to stdout for
+    shell piping.
+    """
+    src = Path("src/quodeq/_cli_evaluation.py").read_text()
+    tree = ast.parse(src)
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "print":
+            for kw in node.keywords:
+                if kw.arg == "file" and isinstance(kw.value, ast.Attribute) and kw.value.attr == "stderr":
+                    offenders.append((node.lineno, ast.unparse(node)))
+    assert not offenders, f"direct stderr prints remain: {offenders}"
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+uv run pytest tests/ci/test_cli_uses_log_info.py -v
+```
+Expected: FAIL — multiple offenders listed.
+
+- [ ] **Step 3: Convert each `print(..., file=sys.stderr)` call**
+
+In `src/quodeq/_cli_evaluation.py`, replace:
+
+Line 118: `print("Starting evidence collection (this may take several minutes per dimension)...", file=sys.stderr)`
+→ `log_info("Starting evidence collection (this may take several minutes per dimension)...")`
+
+Line 124: `print(f"Failed to write evidence file {out_file}: {exc}", file=sys.stderr)`
+→ `log_error(f"Failed to write evidence file {out_file}: {exc}")`
+
+Line 126: `print(f"Evidence written to {out_file}", file=sys.stderr)`
+→ `log_info(f"Evidence written to {out_file}")`
+
+Line 128: `print("Starting evaluation (this may take several minutes per dimension)...", file=sys.stderr)`
+→ `log_info("Starting evaluation (this may take several minutes per dimension)...")`
+
+Line 130: `print(f"Report path: {evaluation_dir}/", file=sys.stderr)`
+→ `log_info(f"Report path: {evaluation_dir}/")`
+
+Line 131: `print(f"Reports written to {evaluation_dir}/", file=sys.stderr)`
+→ `log_info(f"Reports written to {evaluation_dir}/")`
+
+Line 135: `print(f"\nError: {exc}", file=sys.stderr)`
+→ `log_error(f"{exc}")`
+
+Line 155: `print(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all", file=sys.stderr)`
+→ `log_info(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all")`
+
+Line 162: `print("Single-file mode: per-dimension analysis for deeper coverage", file=sys.stderr)`
+→ `log_info("Single-file mode: per-dimension analysis for deeper coverage")`
+
+Line 197: `print(f"Report path: {evaluation_dir}", file=sys.stderr)`
+→ `log_info(f"Report path: {evaluation_dir}")`
+
+Add imports at the top of `_cli_evaluation.py`:
+
+```python
+from quodeq.shared.logging import log_info, log_error
+```
+
+(Verify existing imports don't already include these.)
+
+Leave the stdout prints for dimension scores (`print(f"  {dim}: {score}")` on line 133) unchanged — those are intentional machine-readable output for shell piping.
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/ci/test_cli_uses_log_info.py -v
+uv run pytest tests/ci/ -q
+```
+Expected: new test passes. Existing CLI tests may have assertions about stderr output — update any that fail by checking `caplog` or the logger stream instead of `capsys.readouterr().err`. If the tests-fix gets large, split into a follow-up commit.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/_cli_evaluation.py tests/ci/test_cli_uses_log_info.py
+git commit -m "refactor(cli): route stderr progress through log_info for unified log capture"
+```
+
+---
+
+## Task 3: Install RunLogHandler in the CLI pipeline
+
+**Files:**
+- Modify: `src/quodeq/_cli_evaluation.py` (`_run_pipeline_with_cleanup`, ~line 192-225)
+- Test: `tests/ci/test_run_log_integration.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/ci/test_run_log_integration.py
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.shared.logging import log_info
+
+
+def test_run_log_captures_log_info_during_pipeline(tmp_path: Path, monkeypatch) -> None:
+    """log_info calls between install/uninstall must land in run.log."""
+    from quodeq.shared.run_log import RunLogHandler, RunLogWriter
+
+    run_dir = tmp_path / "project" / "run-1"
+    run_dir.mkdir(parents=True)
+
+    writer = RunLogWriter(run_dir)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    logger = logging.getLogger("quodeq")
+    logger.addHandler(handler)
+    try:
+        log_info("line-one")
+        log_info("line-two")
+    finally:
+        logger.removeHandler(handler)
+        writer.close()
+
+    contents = (run_dir / "run.log").read_text()
+    assert "line-one" in contents
+    assert "line-two" in contents
+```
+
+Also add a "harness" test that _run_pipeline_with_cleanup installs + removes the handler:
+
+```python
+def test_pipeline_installs_and_removes_run_log_handler(tmp_path: Path, monkeypatch) -> None:
+    """_run_pipeline_with_cleanup must install RunLogHandler on entry and remove on exit."""
+    import quodeq._cli_evaluation as cli
+    from quodeq.shared.run_log import RunLogHandler
+
+    logger = logging.getLogger("quodeq")
+    initial_handlers = set(id(h) for h in logger.handlers)
+
+    # Stub _execute_pipeline so we exercise only the wrapper's install/remove logic.
+    with patch.object(cli, "_execute_pipeline", return_value=0), \
+         patch.object(cli, "_save_manifest"), \
+         patch.object(cli, "_build_run_config"), \
+         patch.object(cli, "is_repo_url", return_value=False), \
+         patch.object(cli, "emit_marker"):
+        evidence_dir = tmp_path / "proj" / "run" / "evidence"
+        evaluation_dir = tmp_path / "proj" / "run" / "evaluation"
+        evidence_dir.mkdir(parents=True)
+        evaluation_dir.mkdir(parents=True)
+        import argparse
+        args = argparse.Namespace(repo="local")
+        inputs = type("I", (), {"src": tmp_path, "language": "python", "manifest": None, "dims_data": None})()
+
+        # During pipeline, a RunLogHandler must be attached to the quodeq logger.
+        attached: list[bool] = []
+        original_execute = cli._execute_pipeline
+        def _spy(*a, **k):
+            attached.append(any(isinstance(h, RunLogHandler) for h in logger.handlers))
+            return 0
+        with patch.object(cli, "_execute_pipeline", side_effect=_spy):
+            cli._run_pipeline_with_cleanup(args, inputs, (tmp_path, evidence_dir, evaluation_dir))
+
+    assert attached == [True]
+    # After exit, no stray RunLogHandler remains.
+    assert not any(isinstance(h, RunLogHandler) for h in logger.handlers)
+    assert set(id(h) for h in logger.handlers) == initial_handlers
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+uv run pytest tests/ci/test_run_log_integration.py -v
+```
+Expected: second test FAILS — `assert attached == [True]` fails because the handler isn't installed yet.
+
+- [ ] **Step 3: Modify `_run_pipeline_with_cleanup`**
+
+Replace the `try:`/`finally:` block (lines 212-225) with:
+
+```python
+    config = _build_run_config(args, inputs=inputs, evidence_dir=evidence_dir)
+
+    # Install a per-run log handler so every log_info lands in run.log.
+    from quodeq.shared.run_log import RunLogHandler, RunLogWriter
+    writer = RunLogWriter(run_dir)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _logger_root = logging.getLogger("quodeq")
+    _logger_root.addHandler(handler)
+
+    try:
+        return _execute_pipeline(args, config, evidence_dir, evaluation_dir)
+    finally:
+        _logger_root.removeHandler(handler)
+        writer.close()
+        # Clean up .pid file on exit so we don't leave stale PIDs.
+        try:
+            pid_file.unlink(missing_ok=True)
+        except OSError:
+            pass
+        if is_repo_url(args.repo):
+            cleanup_cloned_repo(str(inputs.src))
+        worktree_dir = getattr(args, "_worktree_dir", None)
+        worktree_origin = getattr(args, "_worktree_origin", None)
+        if worktree_dir and worktree_origin:
+            _cleanup_worktree(worktree_origin, worktree_dir)
+```
+
+Add at the top of the file if missing: `import logging`.
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/ci/test_run_log_integration.py -v
+uv run pytest tests/ci/ -q
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/_cli_evaluation.py tests/ci/test_run_log_integration.py
+git commit -m "feat(cli): install RunLogHandler so every run writes run.log"
+```
+
+---
+
+## Task 4: Tee subprocess output to run.log in _consume_stream
+
+**Files:**
+- Modify: `src/quodeq/services/jobs.py` (`_consume_stream` ~line 276, plus surrounding code that tracks `run_dir`)
+- Test: `tests/services/test_jobs_run_log.py`
+
+The subprocess stream doesn't know its `run_dir` at spawn time — `run_dir` is set by the `report_path` marker (jobs.py:243-249) mid-stream. Strategy: once the marker arrives, open a `RunLogWriter` on that run_dir and tee all subsequent + previously-buffered lines to it.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/services/test_jobs_run_log.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.services.jobs import JobManager
+from quodeq.services._job_model import Job, STATUS_RUNNING
+
+
+def test_consume_stream_tees_to_run_log(tmp_path: Path) -> None:
+    """Once the report_path marker arrives, subsequent lines land in run.log."""
+    project = "proj-uuid"
+    run_id = "run-A"
+    run_dir = tmp_path / project / run_id
+    run_dir.mkdir(parents=True)
+
+    jm = JobManager(reports_root=tmp_path)
+    job = Job(
+        job_id="job-1",
+        status=STATUS_RUNNING,
+        command=["x"],
+        started_at="2026-04-20T00:00:00+00:00",
+        ended_at=None,
+        exit_code=None,
+    )
+    jm._store.put(job)  # internal — test helper
+
+    marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
+    stream = iter([
+        "pre-marker line\n",
+        marker + "\n",
+        "post-marker line\n",
+    ])
+    jm._consume_stream("job-1", stream)
+
+    contents = (run_dir / "run.log").read_text()
+    # Both pre-marker (buffered) and post-marker lines must appear, in order.
+    assert "pre-marker line" in contents
+    assert "post-marker line" in contents
+    assert contents.index("pre-marker line") < contents.index("post-marker line")
+
+
+def test_consume_stream_no_run_dir_silent(tmp_path: Path) -> None:
+    """If no report_path marker ever arrives, consume_stream completes without error."""
+    jm = JobManager(reports_root=tmp_path)
+    job = Job(
+        job_id="job-2", status=STATUS_RUNNING, command=["x"],
+        started_at="2026-04-20T00:00:00+00:00", ended_at=None, exit_code=None,
+    )
+    jm._store.put(job)
+    jm._consume_stream("job-2", iter(["line-1\n", "line-2\n"]))
+    # No run.log anywhere — nothing to assert beyond "did not raise".
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+uv run pytest tests/services/test_jobs_run_log.py -v
+```
+Expected: FAIL — `run.log` does not exist (teeing not implemented).
+
+- [ ] **Step 3: Modify `_consume_stream`**
+
+Before modifying, identify where the `report_path` marker is parsed. Current code at jobs.py:243-249 sets `job.output_project` and `job.output_run_id`. Introduce a per-job `RunLogWriter` lazily after the marker arrives.
+
+In `src/quodeq/services/jobs.py`, add near the top of the module:
+```python
+from quodeq.shared.run_log import RunLogWriter
+```
+
+Add an instance attribute for writers to `JobManager.__init__` (find the existing `__init__` method):
+```python
+self._run_log_writers: dict[str, RunLogWriter] = {}
+# Buffer of pre-marker lines per job, flushed once run_dir is known.
+self._pre_marker_buffer: dict[str, list[str]] = {}
+```
+
+Replace `_consume_stream` (line 276-290) with:
+
+```python
+    def _consume_stream(self, job_id: str, stream: Iterable[str] | None) -> None:
+        if stream is None:
+            return
+        batch: list[str] = []
+        self._pre_marker_buffer.setdefault(job_id, [])
+        try:
+            for line in stream:
+                stripped = line.rstrip("\n")
+                batch.append(stripped)
+                self._tee_run_log(job_id, stripped)
+                if len(batch) >= _CONSUME_BATCH_SIZE:
+                    if not self._flush_batch(job_id, batch):
+                        return
+                    batch.clear()
+        except (IOError, BrokenPipeError) as exc:
+            _logger.warning("Stream read error for job %s: %s", job_id, exc)
+        if batch:
+            self._flush_batch(job_id, batch)
+        # Close the writer when the stream ends.
+        writer = self._run_log_writers.pop(job_id, None)
+        if writer is not None:
+            writer.close()
+        self._pre_marker_buffer.pop(job_id, None)
+
+    def _tee_run_log(self, job_id: str, line: str) -> None:
+        """Forward *line* to the job's run.log writer.
+
+        Before the report_path marker arrives, ``run_dir`` is unknown — lines
+        are held in ``self._pre_marker_buffer`` and flushed once the marker
+        resolves the directory.
+        """
+        writer = self._run_log_writers.get(job_id)
+        if writer is None:
+            # Try to resolve run_dir from the job snapshot now.
+            job = self._store.get(job_id)
+            if job and job.output_project and job.output_run_id and self._reports_root is not None:
+                run_dir = self._reports_root / job.output_project / job.output_run_id
+                if run_dir.is_dir():
+                    writer = RunLogWriter(run_dir)
+                    self._run_log_writers[job_id] = writer
+                    # Flush any buffered pre-marker lines.
+                    for pending in self._pre_marker_buffer.get(job_id, []):
+                        writer.write(pending)
+                    self._pre_marker_buffer[job_id] = []
+            if writer is None:
+                self._pre_marker_buffer.setdefault(job_id, []).append(line)
+                return
+        writer.write(line)
+```
+
+Also verify `JobManager.__init__` stores `reports_root` as `self._reports_root`. If it doesn't, add it; the constructor already accepts `reports_root` in current usage (see `cancel_job` which uses `reports_root` — pass it through).
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/services/test_jobs_run_log.py tests/services/ -q
+```
+Expected: both new tests PASS, existing services tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/services/jobs.py tests/services/test_jobs_run_log.py
+git commit -m "feat(jobs): tee subprocess output to per-run run.log"
+```
+
+---
+
+## Task 5: Plain `/api/jobs/<id>/logs?since=N` endpoint
+
+**Files:**
+- Create: `src/quodeq/api/_log_stream_routes.py`
+- Test: `tests/api/test_log_stream_routes.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/api/test_log_stream_routes.py
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from quodeq.api._log_stream_routes import register_log_stream_routes
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    app = Flask(__name__)
+    app.config["_api_key"] = None  # localhost-only mode, works with test client
+    app.config["_reports_dir"] = tmp_path
+
+    # Fake provider that resolves job_id -> run_dir via run_dir mapping.
+    class FakeProvider:
+        def __init__(self) -> None:
+            self.map: dict[str, Path] = {}
+        def get_log_run_dir(self, job_id: str) -> Path | None:
+            return self.map.get(job_id)
+        def is_job_complete(self, job_id: str) -> bool:
+            return job_id.endswith("-done")
+
+    provider = FakeProvider()
+    app.config["_provider"] = provider
+    register_log_stream_routes(app)
+    return app
+
+
+def _seed_run(tmp_path: Path, app: Flask, job_id: str, content: str) -> Path:
+    run_dir = tmp_path / job_id
+    run_dir.mkdir()
+    (run_dir / "run.log").write_text(content)
+    app.config["_provider"].map[job_id] = run_dir
+    return run_dir
+
+
+def test_plain_logs_returns_content(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-1-done", "first\nsecond\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-1-done/logs")
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.get_json()
+    assert data["lines"] == ["first", "second"]
+    assert data["nextOffset"] == len("first\nsecond\n")
+    assert data["done"] is True
+
+
+def test_plain_logs_since_offset(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-2", "first\nsecond\nthird\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-2/logs?since=6")  # after "first\n"
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.get_json()
+    assert data["lines"] == ["second", "third"]
+
+
+def test_plain_logs_404_when_log_missing(tmp_path, app) -> None:
+    run_dir = tmp_path / "empty"
+    run_dir.mkdir()
+    app.config["_provider"].map["job-3"] = run_dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-3/logs")
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_plain_logs_410_when_run_dir_missing(tmp_path, app) -> None:
+    app.config["_provider"].map["job-4"] = tmp_path / "gone"  # not a real dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-4/logs")
+    assert resp.status_code == HTTPStatus.GONE
+
+
+def test_plain_logs_partial_line_stripped(tmp_path, app) -> None:
+    """If the last line lacks a trailing newline, it's not returned — caller polls again."""
+    _seed_run(tmp_path, app, "job-5", "complete\npartial-tail")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-5/logs")
+    data = resp.get_json()
+    assert data["lines"] == ["complete"]
+    assert data["nextOffset"] == len("complete\n")
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+uv run pytest tests/api/test_log_stream_routes.py -v
+```
+Expected: `ImportError` on `register_log_stream_routes`.
+
+- [ ] **Step 3: Implement plain endpoint**
+
+```python
+# src/quodeq/api/_log_stream_routes.py
+"""Log-stream routes — SSE live stream + plain JSON fallback for /api/jobs/<id>/logs."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, current_app, jsonify, request
+
+from quodeq.api.security import require_auth
+
+
+def _resolve_run_log(job_id: str) -> tuple[Path | None, int]:
+    """Return (log_path, status_hint). status_hint is 0 on success, HTTP code on error."""
+    provider = current_app.config.get("_provider")
+    if provider is None or not hasattr(provider, "get_log_run_dir"):
+        return None, HTTPStatus.NOT_FOUND
+    run_dir = provider.get_log_run_dir(job_id)
+    if run_dir is None or not run_dir.is_dir():
+        return None, HTTPStatus.GONE
+    log_path = run_dir / "run.log"
+    if not log_path.exists():
+        return None, HTTPStatus.NOT_FOUND
+    return log_path, 0
+
+
+def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
+    """Read lines starting at byte offset *since*. Returns (lines, next_offset).
+
+    Drops any trailing partial line (without newline); caller polls again.
+    """
+    with open(log_path, "rb") as fh:
+        fh.seek(since)
+        raw = fh.read()
+    text = raw.decode("utf-8", errors="replace")
+    if not text.endswith("\n"):
+        last_nl = text.rfind("\n")
+        if last_nl == -1:
+            return [], since  # no complete line yet
+        text = text[:last_nl + 1]
+    consumed = len(text.encode("utf-8"))
+    lines = text.splitlines()
+    return lines, since + consumed
+
+
+def register_log_stream_routes(app: Flask) -> None:
+    """Register plain + SSE log-stream routes on *app*."""
+
+    @app.get("/api/jobs/<job_id>/logs")
+    @require_auth
+    def plain_logs(job_id: str) -> Response | tuple[Response, int]:
+        log_path, err = _resolve_run_log(job_id)
+        if log_path is None:
+            return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
+        since = max(0, request.args.get("since", 0, type=int))
+        lines, next_offset = _read_tail(log_path, since)
+        provider = current_app.config.get("_provider")
+        done = bool(provider and getattr(provider, "is_job_complete", lambda _: False)(job_id))
+        return jsonify({"lines": lines, "nextOffset": next_offset, "done": done})
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/api/test_log_stream_routes.py -v
+```
+Expected: 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/api/_log_stream_routes.py tests/api/test_log_stream_routes.py
+git commit -m "feat(api): add plain /api/jobs/<id>/logs endpoint"
+```
+
+---
+
+## Task 6: SSE `/api/jobs/<id>/logs/stream` endpoint
+
+**Files:**
+- Modify: `src/quodeq/api/_log_stream_routes.py` (add SSE route)
+- Modify: `tests/api/test_log_stream_routes.py` (add SSE tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/api/test_log_stream_routes.py`:
+
+```python
+def _collect_sse(resp, max_events: int = 50) -> list[dict]:
+    """Parse an SSE response body into a list of {id, event, data} dicts."""
+    events: list[dict] = []
+    current: dict = {}
+    for raw in resp.response:  # Flask test-client yields bytes chunks
+        chunk = raw.decode("utf-8")
+        for line in chunk.splitlines():
+            if line.startswith("id:"):
+                current["id"] = line[3:].strip()
+            elif line.startswith("event:"):
+                current["event"] = line[6:].strip()
+            elif line.startswith("data:"):
+                current["data"] = line[5:].strip()
+            elif line == "":
+                if current:
+                    events.append(current)
+                    current = {}
+                    if len(events) >= max_events:
+                        return events
+    if current:
+        events.append(current)
+    return events
+
+
+def test_sse_replays_existing_content(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-sse-1-done", "alpha\nbeta\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-1-done/logs/stream")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.content_type.startswith("text/event-stream")
+    events = _collect_sse(resp)
+    data_events = [e for e in events if "data" in e]
+    assert [e["data"] for e in data_events] == ["alpha", "beta"]
+    assert any(e.get("event") == "done" for e in events)
+
+
+def test_sse_respects_last_event_id(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-sse-2-done", "alpha\nbeta\ngamma\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-2-done/logs/stream",
+                      headers={"Last-Event-ID": str(len("alpha\n"))})
+    events = _collect_sse(resp)
+    data_events = [e for e in events if "data" in e]
+    assert [e["data"] for e in data_events] == ["beta", "gamma"]
+
+
+def test_sse_404_on_missing_log(tmp_path, app) -> None:
+    run_dir = tmp_path / "empty"
+    run_dir.mkdir()
+    app.config["_provider"].map["job-sse-3"] = run_dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-3/logs/stream")
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+```
+
+- [ ] **Step 2: Run tests, confirm failure**
+
+```
+uv run pytest tests/api/test_log_stream_routes.py -v -k sse
+```
+Expected: FAIL — route not yet registered.
+
+- [ ] **Step 3: Extend `_log_stream_routes.py` with SSE**
+
+Append to the module:
+
+```python
+import os
+import time
+
+_POLL_MS = int(os.environ.get("QUODEQ_LOG_STREAM_POLL_MS", "100"))
+_MAX_WAIT_S = int(os.environ.get("QUODEQ_LOG_STREAM_MAX_WAIT_S", "10"))
+
+
+def _sse_line(data: str, event: str | None = None, event_id: int | None = None) -> str:
+    parts = []
+    if event_id is not None:
+        parts.append(f"id: {event_id}\n")
+    if event is not None:
+        parts.append(f"event: {event}\n")
+    # Escape CR so one log line is one SSE frame.
+    parts.append(f"data: {data}\n\n")
+    return "".join(parts)
+
+
+def _sse_generator(log_path: Path, initial_offset: int, is_done):
+    """Yield SSE frames by tailing *log_path* starting at *initial_offset*."""
+    offset = initial_offset
+    waited_ms = 0
+    yield ":keepalive\n\n"  # Flask test-client needs at least one byte
+    while True:
+        if not log_path.exists():
+            if waited_ms >= _MAX_WAIT_S * 1000:
+                yield _sse_line("log file unavailable", event="error")
+                return
+            time.sleep(_POLL_MS / 1000)
+            waited_ms += _POLL_MS
+            continue
+        with open(log_path, "rb") as fh:
+            fh.seek(offset)
+            raw = fh.read()
+        text = raw.decode("utf-8", errors="replace")
+        if text:
+            complete = text if text.endswith("\n") else text[: text.rfind("\n") + 1]
+            if complete:
+                for line in complete.splitlines():
+                    offset += len(line.encode("utf-8")) + 1  # +1 for '\n'
+                    yield _sse_line(line, event_id=offset)
+        if is_done():
+            yield _sse_line("", event="done", event_id=offset)
+            return
+        time.sleep(_POLL_MS / 1000)
+
+
+def register_log_stream_routes(app: Flask) -> None:
+    """Register plain + SSE log-stream routes on *app*."""
+
+    @app.get("/api/jobs/<job_id>/logs")
+    @require_auth
+    def plain_logs(job_id: str) -> Response | tuple[Response, int]:
+        log_path, err = _resolve_run_log(job_id)
+        if log_path is None:
+            return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
+        since = max(0, request.args.get("since", 0, type=int))
+        lines, next_offset = _read_tail(log_path, since)
+        provider = current_app.config.get("_provider")
+        done = bool(provider and getattr(provider, "is_job_complete", lambda _: False)(job_id))
+        return jsonify({"lines": lines, "nextOffset": next_offset, "done": done})
+
+    @app.get("/api/jobs/<job_id>/logs/stream")
+    @require_auth
+    def stream_logs(job_id: str) -> Response | tuple[Response, int]:
+        log_path, err = _resolve_run_log(job_id)
+        if log_path is None:
+            return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
+        last_event_id = request.headers.get("Last-Event-ID", "")
+        try:
+            initial_offset = int(last_event_id) if last_event_id else 0
+        except ValueError:
+            initial_offset = 0
+        provider = current_app.config.get("_provider")
+        is_done = (lambda: bool(provider and getattr(provider, "is_job_complete", lambda _: False)(job_id)))
+
+        resp = Response(
+            _sse_generator(log_path, initial_offset, is_done),
+            mimetype="text/event-stream",
+        )
+        resp.headers["Cache-Control"] = "no-cache"
+        resp.headers["X-Accel-Buffering"] = "no"
+        return resp
+```
+
+Note: replace the earlier `register_log_stream_routes` definition — keep only the combined version shown here.
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```
+uv run pytest tests/api/test_log_stream_routes.py -v
+```
+Expected: all tests PASS. If SSE tests hang on `test_sse_replays_existing_content`, verify `is_done()` returns True immediately (seeded job_id ends with `-done`), which is the signal for the generator to exit.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/api/_log_stream_routes.py tests/api/test_log_stream_routes.py
+git commit -m "feat(api): add SSE /api/jobs/<id>/logs/stream endpoint"
+```
+
+---
+
+## Task 7: Register new routes + provider method
+
+**Files:**
+- Modify: `src/quodeq/api/routes_registry.py`
+- Modify: `src/quodeq/services/filesystem.py` (add `get_log_run_dir` and `is_job_complete` to the provider)
+- Test: `tests/api/test_log_stream_registered.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/api/test_log_stream_registered.py
+from quodeq.api.app import create_app
+
+
+def test_log_stream_routes_registered() -> None:
+    app = create_app()
+    rules = {r.rule for r in app.url_map.iter_rules()}
+    assert "/api/jobs/<job_id>/logs" in rules
+    assert "/api/jobs/<job_id>/logs/stream" in rules
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+uv run pytest tests/api/test_log_stream_registered.py -v
+```
+Expected: FAIL — routes not registered.
+
+- [ ] **Step 3: Add provider methods**
+
+In `src/quodeq/services/filesystem.py`, add to `FilesystemActionProvider`:
+
+```python
+    def get_log_run_dir(self, job_id: str) -> Path | None:
+        """Return the run_dir for *job_id*, or None if unknown.
+
+        Handles both internal JobManager ids and 'ext-<run_id>' external ids.
+        """
+        if job_id.startswith("ext-"):
+            run_id = job_id[len("ext-"):]
+            reports_root = self._reports_dir  # existing accessor
+            if reports_root is None or not reports_root.is_dir():
+                return None
+            for project_dir in reports_root.iterdir():
+                candidate = project_dir / run_id
+                if candidate.is_dir():
+                    return candidate
+            return None
+        # Internal: delegate to JobManager
+        snapshot = self._jobs.get_snapshot(job_id)
+        if snapshot is None or snapshot.output_project is None or snapshot.output_run_id is None:
+            return None
+        if self._reports_dir is None:
+            return None
+        return self._reports_dir / snapshot.output_project / snapshot.output_run_id
+
+    def is_job_complete(self, job_id: str) -> bool:
+        """Return True if *job_id* has reached a terminal state."""
+        if job_id.startswith("ext-"):
+            run_dir = self.get_log_run_dir(job_id)
+            return run_dir is not None and (run_dir / "scan.json").exists()
+        snapshot = self._jobs.get_snapshot(job_id)
+        return snapshot is not None and snapshot.status in {"done", "failed", "cancelled"}
+```
+
+(Verify attribute names `self._reports_dir` and `self._jobs` match the existing class — adjust if they differ.)
+
+- [ ] **Step 4: Register the new routes**
+
+In `src/quodeq/api/routes_registry.py`, add import:
+```python
+from quodeq.api._log_stream_routes import register_log_stream_routes
+```
+
+In `register_all_routes`, add one line after `register_evaluation_item_routes(app, provider)`:
+```python
+    register_log_stream_routes(app)
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+```
+uv run pytest tests/api/test_log_stream_registered.py -v
+uv run pytest tests/api/ -q
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/quodeq/api/routes_registry.py src/quodeq/services/filesystem.py tests/api/test_log_stream_registered.py
+git commit -m "feat(api): register log-stream routes and provider helpers"
+```
+
+---
+
+## Task 8: Add xterm.js UI dependencies
+
+**Files:**
+- Modify: `src/quodeq/ui/package.json`
+
+- [ ] **Step 1: Install dependencies**
+
+```
+cd src/quodeq/ui
+npm install xterm@^5.3.0 xterm-addon-fit@^0.8.0
+```
+
+- [ ] **Step 2: Verify entries in package.json**
+
+Confirm `src/quodeq/ui/package.json` `dependencies` now includes:
+```json
+"xterm": "^5.3.0",
+"xterm-addon-fit": "^0.8.0"
+```
+
+- [ ] **Step 3: Verify build still works**
+
+```
+cd src/quodeq/ui
+npm run build
+```
+Expected: no errors; dist output produced.
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/quodeq/ui/package.json src/quodeq/ui/package-lock.json
+git commit -m "chore(ui): add xterm and xterm-addon-fit deps"
+```
+
+---
+
+## Task 9: LiveTerminal component
+
+**Files:**
+- Create: `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx`
+- Create: `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.css`
+- Test: `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.test.jsx`
+
+- [ ] **Step 1: Write failing test**
+
+```jsx
+// src/quodeq/ui/src/features/evaluation/components/LiveTerminal.test.jsx
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LiveTerminal from './LiveTerminal.jsx';
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  close() { this.closed = true; }
+  _emit(name, data) { this.listeners[name] && this.listeners[name]({ data }); }
+}
+FakeEventSource.instances = [];
+
+describe('LiveTerminal', () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    global.EventSource = FakeEventSource;
+  });
+
+  it('mounts and opens an EventSource for the given job', () => {
+    render(<LiveTerminal jobId="job-xyz" />);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toBe('/api/jobs/job-xyz/logs/stream');
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = render(<LiveTerminal jobId="job-xyz" />);
+    const es = FakeEventSource.instances[0];
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+
+  it('closes the EventSource when a done event fires', () => {
+    render(<LiveTerminal jobId="job-xyz" />);
+    const es = FakeEventSource.instances[0];
+    act(() => { es._emit('done', ''); });
+    expect(es.closed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```
+cd src/quodeq/ui
+npx vitest run src/features/evaluation/components/LiveTerminal.test.jsx
+```
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+```jsx
+// src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx
+import React, { useEffect, useRef, useState } from 'react';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+import './LiveTerminal.css';
+
+export default function LiveTerminal({ jobId }) {
+  const containerRef = useRef(null);
+  const termRef = useRef(null);
+  const esRef = useRef(null);
+  const [open, setOpen] = useState(true);
+  const [lineCount, setLineCount] = useState(0);
+
+  useEffect(() => {
+    if (!jobId || !containerRef.current) return;
+
+    const term = new Terminal({
+      convertEol: true,
+      fontFamily: 'ui-monospace, Menlo, monospace',
+      fontSize: 12,
+      theme: { background: '#0d1117' },
+      scrollback: 10000,
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(containerRef.current);
+    fit.fit();
+    termRef.current = term;
+
+    const es = new EventSource(`/api/jobs/${encodeURIComponent(jobId)}/logs/stream`);
+    esRef.current = es;
+
+    const onMessage = (ev) => {
+      term.writeln(ev.data ?? '');
+      setLineCount((n) => n + 1);
+    };
+    const onDone = () => { es.close(); };
+    const onError = () => { /* EventSource auto-reconnects; no-op */ };
+    es.addEventListener('message', onMessage);
+    es.addEventListener('done', onDone);
+    es.addEventListener('error', onError);
+
+    const onResize = () => { try { fit.fit(); } catch { /* ignore */ } };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      es.close();
+      term.dispose();
+      termRef.current = null;
+      esRef.current = null;
+    };
+  }, [jobId]);
+
+  return (
+    <div className="live-terminal">
+      <button
+        type="button"
+        className="live-terminal__toggle"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {open ? '▾' : '▸'} Terminal ({lineCount} lines)
+      </button>
+      <div
+        ref={containerRef}
+        className={`live-terminal__body ${open ? '' : 'live-terminal__body--collapsed'}`}
+      />
+    </div>
+  );
+}
+```
+
+```css
+/* src/quodeq/ui/src/features/evaluation/components/LiveTerminal.css */
+.live-terminal {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-border, #21262d);
+  padding-top: 8px;
+}
+.live-terminal__toggle {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted, #8b949e);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 0;
+}
+.live-terminal__body {
+  height: 320px;
+  margin-top: 8px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.live-terminal__body--collapsed {
+  display: none;
+}
+```
+
+- [ ] **Step 4: Run test, confirm pass**
+
+```
+cd src/quodeq/ui
+npx vitest run src/features/evaluation/components/LiveTerminal.test.jsx
+```
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/quodeq/ui/src/features/evaluation/components/LiveTerminal.{jsx,css,test.jsx}
+git commit -m "feat(ui): add LiveTerminal component backed by EventSource + xterm.js"
+```
+
+---
+
+## Task 10: Embed LiveTerminal in EvaluationStatus
+
+**Files:**
+- Modify: `src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx`
+
+- [ ] **Step 1: Update the render tree**
+
+In `EvaluationStatus.jsx`, add the import at the top:
+```jsx
+import LiveTerminal from './LiveTerminal.jsx';
+```
+
+Modify the `EvaluationStatus` component's return (current line 180-187) to:
+
+```jsx
+  return (
+    <div className="panel evaluate-job-panel">
+      <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
+      <JobMeta job={job} projectName={deriveProjectName(job.repo)} />
+      <ConsolePanel job={job} consoleOpen={consoleOpen} setConsoleOpen={setConsoleOpen} logViewerRef={logViewerRef} hasEvaluations={hasEvaluations} />
+      {job.jobId ? <LiveTerminal jobId={job.jobId} /> : null}
+      <LiveViolationsFeed liveViolations={liveViolations} />
+    </div>
+  );
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+```
+cd src/quodeq/ui
+npm run dev
+```
+Open dashboard, start any evaluation. Expected: the existing status card still renders; a new collapsible "Terminal (N lines)" pane appears below with live stderr lines streaming in. Collapse/expand works. Works for CLI-started runs too (`ext-` prefix).
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+git commit -m "feat(ui): embed LiveTerminal in EvaluationStatus"
+```
+
+---
+
+## Task 11: End-to-end smoke test
+
+**Files:**
+- Create: `tests/ci/test_terminal_stream_e2e.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/ci/test_terminal_stream_e2e.py
+"""End-to-end: run a tiny CLI evaluation, verify run.log is written."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+def test_cli_writes_run_log(tmp_path: Path) -> None:
+    # Seed a minimal project.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "hello.py").write_text("def f(): return 1\n")
+    reports = tmp_path / "reports"
+    reports.mkdir()
+
+    env = {**os.environ,
+           "QUODEQ_REPORTS_DIR": str(reports),
+           "QUODEQ_DRY_RUN": "1"}  # dry-run keeps the test fast and offline
+    proc = subprocess.run(
+        [sys.executable, "-m", "quodeq.cli", "evaluate", str(src),
+         "--dry-run", "-d", "security"],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"CLI failed: {proc.stderr}"
+
+    # Find the single run_dir.
+    project_dirs = [d for d in reports.iterdir() if d.is_dir()]
+    assert len(project_dirs) == 1, project_dirs
+    run_dirs = [d for d in project_dirs[0].iterdir() if d.is_dir()]
+    assert len(run_dirs) == 1, run_dirs
+    run_dir = run_dirs[0]
+
+    log_path = run_dir / "run.log"
+    assert log_path.exists(), f"run.log missing in {run_dir}"
+    contents = log_path.read_text()
+    # A dry-run still emits the "Starting evaluation..." banner via log_info.
+    assert "Starting evaluation" in contents or "Dimensions:" in contents
+```
+
+- [ ] **Step 2: Run test, confirm pass**
+
+```
+uv run pytest tests/ci/test_terminal_stream_e2e.py -v
+```
+Expected: PASS. If the CLI's `--dry-run` flag differs (verify in `_cli_evaluation.py`), adjust args. If dry-run isn't supported, the test can point at a single-file analysis mode — keep the test bounded to <60s.
+
+- [ ] **Step 3: Final verification — full test suite**
+
+```
+uv run pytest -q
+```
+Expected: all tests PASS, no regressions.
+
+- [ ] **Step 4: Commit**
+
+```
+git add tests/ci/test_terminal_stream_e2e.py
+git commit -m "test(ci): add end-to-end run.log smoke test"
+```
+
+---
+
+## Post-Implementation Verification
+
+Manual check after all tasks:
+
+1. Start dashboard: `quodeq dashboard`.
+2. Start an evaluation from the dashboard UI → terminal pane appears, streams live.
+3. In a second terminal, `quodeq evaluate .` in any repo → open dashboard → the external run shows up in the evaluation tab → terminal pane streams live (not "inferred from filesystem").
+4. Reload the dashboard mid-run → terminal replays from the first line, then resumes tailing.
+5. Open a completed historical run → terminal shows the full recorded output.
+6. Disconnect wifi briefly mid-run → EventSource reconnects automatically; no duplicate lines, no gaps.
+
+## Rollback
+
+Each task is a standalone commit; revert in reverse order if needed. The producer changes (Tasks 2-4) are additive — removing them doesn't break existing flows. The UI change (Task 10) is a single-line removal.

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -213,40 +213,52 @@ def _run_pipeline_with_cleanup(
 
     config = _build_run_config(args, inputs=inputs, evidence_dir=evidence_dir)
 
+    # Install a per-run log handler so every log_info lands in run.log.
+    from quodeq.shared.run_log import RunLogHandler, RunLogWriter
+    writer = RunLogWriter(run_dir)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _logger_root = logging.getLogger("quodeq")
+    _logger_root.addHandler(handler)
+
     # Resolve dimensions list for status.json metadata.
     # Defensively coerce to a real list — config may be a Mock in tests.
     _raw_dims = getattr(getattr(config, "options", None), "dimensions", None)
     dimensions_list: list[str] = list(_raw_dims) if isinstance(_raw_dims, list) else []
 
-    # Lifecycle context: pending → running on enter, done on clean exit,
-    # failed on exception, cancelled on SIGINT/SIGTERM/SIGHUP or atexit.
     try:
-        with RunLifecycleContext(
-            run_dir=run_dir,
-            job_id=f"ext-{run_id}",
-            dimensions=dimensions_list,
-        ) as lifecycle:
-            try:
-                result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
-                lifecycle.transition_to_finalizing()
-                return result
-            finally:
-                # Clean up .pid file on exit so we don't leave stale PIDs
+        # Lifecycle context: pending → running on enter, done on clean exit,
+        # failed on exception, cancelled on SIGINT/SIGTERM/SIGHUP or atexit.
+        try:
+            with RunLifecycleContext(
+                run_dir=run_dir,
+                job_id=f"ext-{run_id}",
+                dimensions=dimensions_list,
+            ) as lifecycle:
                 try:
-                    pid_file.unlink(missing_ok=True)
-                except OSError:
-                    pass
-                if is_repo_url(args.repo):
-                    cleanup_cloned_repo(str(inputs.src))
-                worktree_dir = getattr(args, "_worktree_dir", None)
-                worktree_origin = getattr(args, "_worktree_origin", None)
-                if worktree_dir and worktree_origin:
-                    _cleanup_worktree(worktree_origin, worktree_dir)
-    except (AnalysisError, EvaluationError) as exc:
-        # RunLifecycleContext.__exit__ has already written state=failed.
-        # Map the domain error to exit code 1.
-        log_error(f"{exc}")
-        return 1
+                    result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
+                    lifecycle.transition_to_finalizing()
+                    return result
+                finally:
+                    # Clean up .pid file on exit so we don't leave stale PIDs
+                    try:
+                        pid_file.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    if is_repo_url(args.repo):
+                        cleanup_cloned_repo(str(inputs.src))
+                    worktree_dir = getattr(args, "_worktree_dir", None)
+                    worktree_origin = getattr(args, "_worktree_origin", None)
+                    if worktree_dir and worktree_origin:
+                        _cleanup_worktree(worktree_origin, worktree_dir)
+        except (AnalysisError, EvaluationError) as exc:
+            # RunLifecycleContext.__exit__ has already written state=failed.
+            # Map the domain error to exit code 1.
+            log_error(f"{exc}")
+            return 1
+    finally:
+        _logger_root.removeHandler(handler)
+        writer.close()
 
 
 def run_evaluate(args: argparse.Namespace) -> int:

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -11,7 +11,6 @@ import argparse
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 
 from quodeq.config.paths import default_paths
@@ -19,6 +18,7 @@ from quodeq.analysis.subprocess import AnalysisError
 from quodeq.analysis.runner import AnalysisOptions, EvaluationError, RunConfig, run
 from quodeq.engine.scoring_pipeline import run_full
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
+from quodeq.shared.logging import log_error, log_info
 from quodeq.shared.utils import get_ai_model, is_repo_url, project_name_from_repo, write_text
 from quodeq.shared.repo_handler import cleanup_cloned_repo
 from quodeq.engine._runner_markers import emit_marker
@@ -121,20 +121,20 @@ def _execute_pipeline(args: argparse.Namespace, config: RunConfig, evidence_dir:
     mapped to exit code 1.
     """
     if args.evidence_only:
-        print("Starting evidence collection (this may take several minutes per dimension)...", file=sys.stderr)
+        log_info("Starting evidence collection (this may take several minutes per dimension)...")
         evidence = run(config)
         out_file = evidence_dir / f"{config.language}_evidence.json"
         try:
             write_text(out_file, json.dumps(evidence.to_evidence_dict(), indent=2))
         except OSError as exc:
-            print(f"Failed to write evidence file {out_file}: {exc}", file=sys.stderr)
+            log_error(f"Failed to write evidence file {out_file}: {exc}")
             return 1
-        print(f"Evidence written to {out_file}", file=sys.stderr)
+        log_info(f"Evidence written to {out_file}")
     else:
-        print("Starting evaluation (this may take several minutes per dimension)...", file=sys.stderr)
+        log_info("Starting evaluation (this may take several minutes per dimension)...")
         scores = run_full(config, evaluation_dir, mode=args.mode)
-        print(f"Report path: {evaluation_dir}/", file=sys.stderr)
-        print(f"Reports written to {evaluation_dir}/", file=sys.stderr)
+        log_info(f"Report path: {evaluation_dir}/")
+        log_info(f"Reports written to {evaluation_dir}/")
         for dim, score in scores.items():
             print(f"  {dim}: {score}")
     return 0
@@ -155,14 +155,14 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
     standards_dir = default_paths().standards_dir
     expanded_dimensions = expand_dimension_aliases(args.dimensions)
     dimensions_filter = [d.strip() for d in expanded_dimensions.split(",") if d.strip()] if expanded_dimensions else None
-    print(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all", file=sys.stderr)
+    log_info(f"Dimensions: {', '.join(dimensions_filter)}" if dimensions_filter else "Dimensions: all")
 
     is_single_file = getattr(args, '_single_file', False)
 
     consolidated = not getattr(args, 'no_consolidated', False) and not bool(_env.get("QUODEQ_NO_CONSOLIDATE"))
     if is_single_file:
         consolidated = False
-        print("Single-file mode: per-dimension analysis for deeper coverage", file=sys.stderr)
+        log_info("Single-file mode: per-dimension analysis for deeper coverage")
 
     ai_model = get_ai_model(env=env)
     subagent_model_val = _subagent_model(env=env)
@@ -197,7 +197,7 @@ def _run_pipeline_with_cleanup(
 ) -> int:
     """Set up directories, build config, run the pipeline, and clean up cloned repos."""
     _reports_root, evidence_dir, evaluation_dir = paths
-    print(f"Report path: {evaluation_dir}", file=sys.stderr)
+    log_info(f"Report path: {evaluation_dir}")
     run_dir = evaluation_dir.parent
     run_id = run_dir.name
     project_uuid = run_dir.parent.name
@@ -245,7 +245,7 @@ def _run_pipeline_with_cleanup(
     except (AnalysisError, EvaluationError) as exc:
         # RunLifecycleContext.__exit__ has already written state=failed.
         # Map the domain error to exit code 1.
-        print(f"\nError: {exc}", file=sys.stderr)
+        log_error(f"{exc}")
         return 1
 
 
@@ -255,7 +255,7 @@ def run_evaluate(args: argparse.Namespace) -> int:
         try:
             check_evaluate_prereqs()
         except RuntimeError as exc:
-            print(f"Error: {exc}", file=sys.stderr)
+            log_error(f"Error: {exc}")
             return 1
 
     inputs = _resolve_evaluation_inputs(args)

--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -1,6 +1,8 @@
 """Log-stream routes — SSE live stream + plain JSON fallback for /api/jobs/<id>/logs."""
 from __future__ import annotations
 
+import os
+import time
 from http import HTTPStatus
 from pathlib import Path
 
@@ -40,6 +42,55 @@ def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
     return lines, since + consumed
 
 
+_POLL_MS = int(os.environ.get("QUODEQ_LOG_STREAM_POLL_MS", "100"))
+_MAX_WAIT_S = int(os.environ.get("QUODEQ_LOG_STREAM_MAX_WAIT_S", "10"))
+
+
+def _sse_line(data: str, event: str | None = None, event_id: int | None = None) -> str:
+    parts = []
+    if event_id is not None:
+        parts.append(f"id: {event_id}\n")
+    if event is not None:
+        parts.append(f"event: {event}\n")
+    # Escape CR so one log line is one SSE frame.
+    parts.append(f"data: {data}\n\n")
+    return "".join(parts)
+
+
+def _sse_generator(log_path: Path, initial_offset: int, is_done):
+    """Yield SSE frames by tailing *log_path* starting at *initial_offset*."""
+    offset = initial_offset
+    waited_ms = 0
+    yield ":keepalive\n\n"  # Flask test-client needs at least one byte
+    while True:
+        if not log_path.exists():
+            if waited_ms >= _MAX_WAIT_S * 1000:
+                yield _sse_line("log file unavailable", event="error")
+                return
+            time.sleep(_POLL_MS / 1000)
+            waited_ms += _POLL_MS
+            continue
+        with open(log_path, "rb") as fh:
+            fh.seek(offset)
+            raw = fh.read()
+        text = raw.decode("utf-8", errors="replace")
+        if text:
+            complete = text if text.endswith("\n") else text[: text.rfind("\n") + 1]
+            if complete:
+                for line in complete.splitlines():
+                    offset += len(line.encode("utf-8")) + 1  # +1 for '\n'
+                    yield _sse_line(line, event_id=offset)
+        if is_done():
+            # Emit done frame without a data field so parsers don't see an empty data entry.
+            done_parts = []
+            if offset:
+                done_parts.append(f"id: {offset}\n")
+            done_parts.append("event: done\n\n")
+            yield "".join(done_parts)
+            return
+        time.sleep(_POLL_MS / 1000)
+
+
 def register_log_stream_routes(app: Flask) -> None:
     """Register plain + SSE log-stream routes on *app*.
 
@@ -59,3 +110,29 @@ def register_log_stream_routes(app: Flask) -> None:
             provider and getattr(provider, "is_job_complete", lambda _: False)(job_id)
         )
         return jsonify({"lines": lines, "nextOffset": next_offset, "done": done})
+
+    @app.get("/api/jobs/<job_id>/logs/stream")
+    def stream_logs(job_id: str) -> Response | tuple[Response, int]:
+        log_path, err = _resolve_run_log(job_id)
+        if log_path is None:
+            return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
+        last_event_id = request.headers.get("Last-Event-ID", "")
+        try:
+            initial_offset = int(last_event_id) if last_event_id else 0
+        except ValueError:
+            initial_offset = 0
+        provider = current_app.config.get("_provider")
+        is_done = (
+            lambda: bool(
+                provider
+                and getattr(provider, "is_job_complete", lambda _: False)(job_id)
+            )
+        )
+
+        resp = Response(
+            _sse_generator(log_path, initial_offset, is_done),
+            mimetype="text/event-stream",
+        )
+        resp.headers["Cache-Control"] = "no-cache"
+        resp.headers["X-Accel-Buffering"] = "no"
+        return resp

--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -1,0 +1,61 @@
+"""Log-stream routes — SSE live stream + plain JSON fallback for /api/jobs/<id>/logs."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, current_app, jsonify, request
+
+
+def _resolve_run_log(job_id: str) -> tuple[Path | None, int]:
+    """Return (log_path, status_hint). status_hint is 0 on success, HTTP code on error."""
+    provider = current_app.config.get("_provider")
+    if provider is None or not hasattr(provider, "get_log_run_dir"):
+        return None, HTTPStatus.NOT_FOUND
+    run_dir = provider.get_log_run_dir(job_id)
+    if run_dir is None or not run_dir.is_dir():
+        return None, HTTPStatus.GONE
+    log_path = run_dir / "run.log"
+    if not log_path.exists():
+        return None, HTTPStatus.NOT_FOUND
+    return log_path, 0
+
+
+def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
+    """Read lines starting at byte offset *since*. Returns (lines, next_offset).
+
+    Drops any trailing partial line (without newline); caller polls again.
+    """
+    with open(log_path, "rb") as fh:
+        fh.seek(since)
+        raw = fh.read()
+    text = raw.decode("utf-8", errors="replace")
+    if not text.endswith("\n"):
+        last_nl = text.rfind("\n")
+        if last_nl == -1:
+            return [], since  # no complete line yet
+        text = text[: last_nl + 1]
+    consumed = len(text.encode("utf-8"))
+    lines = text.splitlines()
+    return lines, since + consumed
+
+
+def register_log_stream_routes(app: Flask) -> None:
+    """Register plain + SSE log-stream routes on *app*.
+
+    Auth: endpoints inherit protection from the global before_request hook
+    in quodeq.api.security._check_auth.
+    """
+
+    @app.get("/api/jobs/<job_id>/logs")
+    def plain_logs(job_id: str) -> Response | tuple[Response, int]:
+        log_path, err = _resolve_run_log(job_id)
+        if log_path is None:
+            return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
+        since = max(0, request.args.get("since", 0, type=int))
+        lines, next_offset = _read_tail(log_path, since)
+        provider = current_app.config.get("_provider")
+        done = bool(
+            provider and getattr(provider, "is_job_complete", lambda _: False)(job_id)
+        )
+        return jsonify({"lines": lines, "nextOffset": next_offset, "done": done})

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -7,6 +7,7 @@ from flask import Flask
 from quodeq.api._log_buffer import LogBuffer
 from quodeq.api._index_routes import register_index_routes
 from quodeq.api._log_routes import register_log_routes
+from quodeq.api._log_stream_routes import register_log_stream_routes
 from quodeq.api._rate_limit import RateLimitStore
 from quodeq.api.routes import (
     register_project_list_routes,
@@ -41,6 +42,7 @@ def register_all_routes(
     register_project_data_routes(app, provider)
     register_evaluation_list_routes(app, provider, eval_store)
     register_evaluation_item_routes(app, provider)
+    register_log_stream_routes(app)
     register_discovery_routes(app, provider)
     register_standards_routes(app)
     register_findings_routes(app)

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -27,6 +27,31 @@ _MANIFEST_PATH = "evidence/manifest.json"
 _SCAN_FILENAME = "scan.json"
 
 
+def _is_pid_alive(pid: int) -> bool:
+    """Return True if *pid* corresponds to a live process.
+
+    Uses ``os.kill(pid, 0)``: signal 0 is a no-op that still raises OSError
+    if the process does not exist. Works on both POSIX and Windows.
+    """
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def _pid_liveness(run_dir: Path) -> bool:
+    """Return True if the run appears genuinely in-progress (.pid exists + PID is alive)."""
+    pid_path = run_dir / _PID_FILENAME
+    if not pid_path.exists():
+        return False  # no evidence of liveness -> treat as stale
+    try:
+        pid = int(pid_path.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return _is_pid_alive(pid)
+
+
 def find_external_runs(reports_root: Path) -> list[JobSnapshot]:
     """Scan all projects for in-progress runs not tracked by any JobStore.
 
@@ -50,7 +75,14 @@ def find_external_runs(reports_root: Path) -> list[JobSnapshot]:
 
 
 def _run_dir_to_snapshot(project_uuid: str, run_dir: Path) -> JobSnapshot | None:
-    """Convert a run directory to a JobSnapshot if it's an in-progress external run."""
+    """Convert a run directory to a JobSnapshot.
+
+    Returns:
+        - ``None`` if the directory isn't an evaluation run.
+        - A snapshot with ``status="running"`` if the .pid file points at a live process.
+        - A snapshot with ``status="cancelled"`` if the run appears stale
+          (scan.json absent AND no live PID -- force-exit, crash, or abnormal shutdown).
+    """
     manifest_path = run_dir / _MANIFEST_PATH
     scan_path = run_dir / _SCAN_FILENAME
 
@@ -64,13 +96,16 @@ def _run_dir_to_snapshot(project_uuid: str, run_dir: Path) -> JobSnapshot | None
     evidence_dir = run_dir / "evidence"
     dimensions, current_dimension, phase = _infer_progress(eval_dir, evidence_dir)
 
+    # Liveness check: alive PID -> running; missing/stale PID -> cancelled (stale).
+    status = "running" if _pid_liveness(run_dir) else "cancelled"
+
     # External job_id is prefixed so the frontend/backend can distinguish it
     job_id = f"{_EXTERNAL_JOB_ID_PREFIX}{run_dir.name}"
     started_at_iso = _manifest_started_at(manifest_path)
 
     return JobSnapshot(
         job_id=job_id,
-        status="running",
+        status=status,
         phase=phase,
         current_dimension=current_dimension,
         dimensions=dimensions if dimensions else None,

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -196,6 +196,11 @@ class FsEvaluationMixin:
 
         cmd = _build_evaluate_cmd(repo, options, reports_dir)
         _register_project(repo, options.discipline, reports_dir, scope_path=options.scope_path)
+        # Keep JobManager aware of the current reports root so _tee_run_log
+        # can resolve run.log paths for dashboard-spawned evaluations.
+        # Guard with hasattr so custom/stub job managers remain compatible.
+        if hasattr(self._jobs, "set_reports_root"):
+            self._jobs.set_reports_root(Path(reports_dir))
         env = self._build_eval_env(repo, options)
         if is_repo_url(repo):
             cwd = str(Path.cwd())

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -38,9 +38,11 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         job_manager: JobManager | None = None,
         compiled_dir: Path | None = None,
         index_db_path: Path | None = None,
+        reports_root: Path | None = None,
     ) -> None:
         super().__init__()
-        self._jobs = job_manager or JobManager()
+        self._reports_root = reports_root
+        self._jobs = job_manager or JobManager(reports_root=reports_root)
         self._compiled_dir = compiled_dir
         self._index_db_path = Path(index_db_path) if index_db_path is not None else None
         self._model_fetchers: dict[str, Callable] = {

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -206,3 +206,37 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
 
     def get_violations(self, reports_dir: str, project: str, run_id: str) -> ViolationSummary:
         return _fs_reports.get_violations(reports_dir, project, run_id)
+
+    def get_log_run_dir(self, job_id: str) -> Path | None:
+        """Return the run_dir for *job_id*, or None if unknown.
+
+        Handles both internal JobManager ids and 'ext-<run_id>' external ids.
+        """
+        if job_id.startswith("ext-"):
+            run_id = job_id[len("ext-"):]
+            reports_root = self._reports_root
+            if reports_root is None or not Path(reports_root).is_dir():
+                return None
+            for project_dir in Path(reports_root).iterdir():
+                if not project_dir.is_dir():
+                    continue
+                candidate = project_dir / run_id
+                if candidate.is_dir():
+                    return candidate
+            return None
+        # Internal: look up job in the store (returns Job with output fields)
+        job = self._jobs._store.get(job_id)
+        if job is None or job.output_project is None or job.output_run_id is None:
+            return None
+        reports_root = self._reports_root
+        if reports_root is None:
+            return None
+        return Path(reports_root) / job.output_project / job.output_run_id
+
+    def is_job_complete(self, job_id: str) -> bool:
+        """Return True if *job_id* has reached a terminal state."""
+        if job_id.startswith("ext-"):
+            run_dir = self.get_log_run_dir(job_id)
+            return run_dir is not None and (run_dir / "scan.json").exists()
+        job = self._jobs._store.get(job_id)
+        return job is not None and job.status in {"done", "failed", "cancelled"}

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -253,6 +253,12 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         """Return True if *job_id* has reached a terminal state."""
         if job_id.startswith("ext-"):
             run_dir = self.get_log_run_dir(job_id)
-            return run_dir is not None and (run_dir / "scan.json").exists()
+            if run_dir is None:
+                return False
+            if (run_dir / "scan.json").exists():
+                return True
+            # Stale detection: no scan.json AND no live PID -> treat as complete.
+            from quodeq.services._external_jobs import _pid_liveness
+            return not _pid_liveness(run_dir)
         job = self._jobs._store.get(job_id)
         return job is not None and job.status in {"done", "failed", "cancelled"}

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -207,6 +207,22 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
     def get_violations(self, reports_dir: str, project: str, run_id: str) -> ViolationSummary:
         return _fs_reports.get_violations(reports_dir, project, run_id)
 
+    def _resolve_reports_root(self) -> Path | None:
+        """Return the active reports directory.
+
+        Prefers the per-instance root set at construction time; falls back to
+        the ``QUODEQ_EVALUATIONS_DIR`` environment variable so that the default
+        provider (constructed with no arguments) still resolves paths correctly
+        at runtime.
+        """
+        if self._reports_root is not None:
+            return Path(self._reports_root)
+        try:
+            from quodeq.shared.utils import get_evaluations_dir
+            return Path(get_evaluations_dir())
+        except Exception:
+            return None
+
     def get_log_run_dir(self, job_id: str) -> Path | None:
         """Return the run_dir for *job_id*, or None if unknown.
 
@@ -214,10 +230,10 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         """
         if job_id.startswith("ext-"):
             run_id = job_id[len("ext-"):]
-            reports_root = self._reports_root
-            if reports_root is None or not Path(reports_root).is_dir():
+            reports_root = self._resolve_reports_root()
+            if reports_root is None or not reports_root.is_dir():
                 return None
-            for project_dir in Path(reports_root).iterdir():
+            for project_dir in reports_root.iterdir():
                 if not project_dir.is_dir():
                     continue
                 candidate = project_dir / run_id
@@ -228,10 +244,10 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         job = self._jobs._store.get(job_id)
         if job is None or job.output_project is None or job.output_run_id is None:
             return None
-        reports_root = self._reports_root
+        reports_root = self._resolve_reports_root()
         if reports_root is None:
             return None
-        return Path(reports_root) / job.output_project / job.output_run_id
+        return reports_root / job.output_project / job.output_run_id
 
     def is_job_complete(self, job_id: str) -> bool:
         """Return True if *job_id* has reached a terminal state."""

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -82,6 +82,14 @@ class JobManager:
         # Buffer of pre-marker lines per job, flushed once run_dir is known.
         self._pre_marker_buffer: dict[str, list[str]] = {}
 
+    def set_reports_root(self, path: Path) -> None:
+        """Update the reports root used to resolve run.log directories.
+
+        Called by ``FilesystemActionProvider.start_evaluation`` to keep
+        ``_reports_root`` consistent with the per-request reports directory.
+        """
+        self._reports_root = path
+
     def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None) -> JobSnapshot:
         """Spawn a subprocess and return its initial job state."""
         job_id = str(uuid.uuid4())
@@ -285,25 +293,51 @@ class JobManager:
         batch: list[str] = []
         self._pre_marker_buffer.setdefault(job_id, [])
         try:
-            for line in stream:
-                stripped = line.rstrip("\n")
-                batch.append(stripped)
-                if len(batch) >= _CONSUME_BATCH_SIZE:
-                    if not self._flush_batch(job_id, batch):
-                        return
-                    batch.clear()
-                # Tee after flush so the marker is already applied to the job
-                # before we try to resolve run_dir.
-                self._tee_run_log(job_id, stripped)
-        except (IOError, BrokenPipeError) as exc:
-            _logger.warning("Stream read error for job %s: %s", job_id, exc)
-        if batch:
-            self._flush_batch(job_id, batch)
-        # Close the writer when the stream ends.
-        writer = self._run_log_writers.pop(job_id, None)
-        if writer is not None:
-            writer.close()
-        self._pre_marker_buffer.pop(job_id, None)
+            try:
+                for line in stream:
+                    stripped = line.rstrip("\n")
+                    batch.append(stripped)
+                    if len(batch) >= _CONSUME_BATCH_SIZE:
+                        if not self._flush_batch(job_id, batch):
+                            return
+                        batch.clear()
+                    # Tee after flush so the marker is already applied to the job
+                    # before we try to resolve run_dir.
+                    self._tee_run_log(job_id, stripped)
+            except (IOError, BrokenPipeError) as exc:
+                _logger.warning("Stream read error for job %s: %s", job_id, exc)
+            if batch:
+                self._flush_batch(job_id, batch)
+            # Final drain: if the report_path marker arrived in the last batch,
+            # the writer may not have been created yet — try one more time so
+            # buffered pre-marker lines are not lost.
+            self._drain_pre_marker_buffer(job_id)
+        finally:
+            # Always release the writer and buffer, even on unexpected exceptions.
+            writer = self._run_log_writers.pop(job_id, None)
+            if writer is not None:
+                writer.close()
+            self._pre_marker_buffer.pop(job_id, None)
+
+    def _drain_pre_marker_buffer(self, job_id: str) -> None:
+        """Attempt to resolve run_dir and flush any buffered pre-marker lines.
+
+        Called after the final ``_flush_batch`` so that lines buffered before
+        the report_path marker are not lost when the marker arrives in the last
+        batch of the stream.
+        """
+        if self._run_log_writers.get(job_id) is not None:
+            # Writer already open — nothing to drain.
+            return
+        job = self._store.get(job_id)
+        if job and job.output_project and job.output_run_id and self._reports_root is not None:
+            run_dir = self._reports_root / job.output_project / job.output_run_id
+            if run_dir.is_dir():
+                writer = RunLogWriter(run_dir)
+                self._run_log_writers[job_id] = writer
+                for pending in self._pre_marker_buffer.get(job_id, []):
+                    writer.write(pending)
+                self._pre_marker_buffer[job_id] = []
 
     def _tee_run_log(self, job_id: str, line: str) -> None:
         """Forward *line* to the job's run.log writer.
@@ -311,6 +345,9 @@ class JobManager:
         Before the report_path marker arrives, ``run_dir`` is unknown — lines
         are held in ``self._pre_marker_buffer`` and flushed once the marker
         resolves the directory.
+
+        Caller invariant: at most one ``_consume_stream`` runs per job_id at a
+        time.  This method is not re-entrant for the same job_id.
         """
         writer = self._run_log_writers.get(job_id)
         if writer is None:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -17,6 +17,7 @@ import subprocess
 from quodeq.core.types import JobSnapshot
 
 from quodeq.analysis._process import _kill_tree
+from quodeq.shared.run_log import RunLogWriter
 from quodeq.services._job_model import (
     Job,
     JobStore,
@@ -69,12 +70,17 @@ class JobManager:
         spawn_impl: Callable[..., subprocess.Popen] | None = None,
         job_store: JobStore | None = None,
         on_job_complete: Callable[[str, Job], None] | None = None,
+        reports_root: Path | None = None,
     ) -> None:
         self._spawn = spawn_impl or subprocess.Popen
         self._store: JobStore = job_store or create_job_store()
         self._processes: dict[str, Any] = {}
         self._lock = threading.Lock()
         self._on_job_complete = on_job_complete
+        self._reports_root: Path | None = reports_root
+        self._run_log_writers: dict[str, RunLogWriter] = {}
+        # Buffer of pre-marker lines per job, flushed once run_dir is known.
+        self._pre_marker_buffer: dict[str, list[str]] = {}
 
     def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None) -> JobSnapshot:
         """Spawn a subprocess and return its initial job state."""
@@ -277,17 +283,52 @@ class JobManager:
         if stream is None:
             return
         batch: list[str] = []
+        self._pre_marker_buffer.setdefault(job_id, [])
         try:
             for line in stream:
-                batch.append(line.rstrip("\n"))
+                stripped = line.rstrip("\n")
+                batch.append(stripped)
                 if len(batch) >= _CONSUME_BATCH_SIZE:
                     if not self._flush_batch(job_id, batch):
                         return
                     batch.clear()
+                # Tee after flush so the marker is already applied to the job
+                # before we try to resolve run_dir.
+                self._tee_run_log(job_id, stripped)
         except (IOError, BrokenPipeError) as exc:
             _logger.warning("Stream read error for job %s: %s", job_id, exc)
         if batch:
             self._flush_batch(job_id, batch)
+        # Close the writer when the stream ends.
+        writer = self._run_log_writers.pop(job_id, None)
+        if writer is not None:
+            writer.close()
+        self._pre_marker_buffer.pop(job_id, None)
+
+    def _tee_run_log(self, job_id: str, line: str) -> None:
+        """Forward *line* to the job's run.log writer.
+
+        Before the report_path marker arrives, ``run_dir`` is unknown — lines
+        are held in ``self._pre_marker_buffer`` and flushed once the marker
+        resolves the directory.
+        """
+        writer = self._run_log_writers.get(job_id)
+        if writer is None:
+            # Try to resolve run_dir from the job snapshot now.
+            job = self._store.get(job_id)
+            if job and job.output_project and job.output_run_id and self._reports_root is not None:
+                run_dir = self._reports_root / job.output_project / job.output_run_id
+                if run_dir.is_dir():
+                    writer = RunLogWriter(run_dir)
+                    self._run_log_writers[job_id] = writer
+                    # Flush any buffered pre-marker lines.
+                    for pending in self._pre_marker_buffer.get(job_id, []):
+                        writer.write(pending)
+                    self._pre_marker_buffer[job_id] = []
+            if writer is None:
+                self._pre_marker_buffer.setdefault(job_id, []).append(line)
+                return
+        writer.write(line)
 
     def _evict_completed_jobs(self) -> None:
         """Remove oldest completed/failed/cancelled jobs beyond _MAX_COMPLETED_JOBS."""

--- a/src/quodeq/shared/run_log.py
+++ b/src/quodeq/shared/run_log.py
@@ -1,0 +1,71 @@
+"""Per-run log file writer.
+
+Appends the evaluation's stderr-stream verbatim to ``{run_dir}/run.log``.
+Used by both the CLI pipeline and the dashboard subprocess dispatcher.
+
+Failures are silent-by-design: this file is diagnostic, never load-bearing.
+A disk-full or permission error must not abort an evaluation.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import IO
+
+_LOG_FILENAME = "run.log"
+
+
+class RunLogWriter:
+    """Thread-safe append-only writer for a per-run log file."""
+
+    def __init__(self, run_dir: Path) -> None:
+        self._path = run_dir / _LOG_FILENAME
+        self._fh: IO[str] | None = None
+        self._lock = threading.Lock()
+        self._disabled = False
+        try:
+            self._fh = open(self._path, "a", buffering=1, encoding="utf-8")
+        except OSError as exc:
+            print(f"run_log: could not open {self._path}: {exc}", file=sys.stderr)
+            self._disabled = True
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def write(self, line: str) -> None:
+        """Append *line* to run.log. Adds a trailing newline if missing."""
+        if self._disabled or self._fh is None:
+            return
+        text = line if line.endswith("\n") else line + "\n"
+        with self._lock:
+            try:
+                self._fh.write(text)
+                self._fh.flush()
+            except OSError:
+                self._disabled = True
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                finally:
+                    self._fh = None
+
+
+class RunLogHandler(logging.Handler):
+    """logging.Handler that forwards formatted records to a RunLogWriter."""
+
+    def __init__(self, writer: RunLogWriter) -> None:
+        super().__init__()
+        self._writer = writer
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self._writer.write(self.format(record))
+        except Exception:
+            # Logging must never crash the app.
+            pass

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -11,7 +11,9 @@
         "d3-hierarchy": "^3.1.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "recharts": "3.7.0"
+        "recharts": "3.7.0",
+        "xterm": "^5.3.0",
+        "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.7.0",
@@ -2198,6 +2200,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xterm": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
+      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "license": "MIT"
+    },
+    "node_modules/xterm-addon-fit": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
+      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
       }
     },
     "node_modules/yallist": {

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -16,9 +16,63 @@
         "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "4.7.0",
-        "vite": "7.3.2"
+        "jsdom": "^29.0.2",
+        "vite": "7.3.2",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -254,6 +308,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -300,6 +364,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -742,6 +959,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1199,6 +1434,63 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1242,6 +1534,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1307,6 +1610,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1341,6 +1651,165 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -1352,6 +1821,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1409,6 +1888,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1424,6 +1913,20 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -1555,6 +2058,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1573,11 +2090,37 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1585,6 +2128,26 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
@@ -1648,11 +2211,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1697,6 +2280,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -1716,11 +2312,69 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1770,6 +2424,34 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1800,6 +2482,37 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1850,6 +2563,40 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -1962,6 +2709,16 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -2013,6 +2770,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2032,6 +2802,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2042,11 +2819,49 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -2063,6 +2878,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2201,6 +3082,178 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xterm": {
       "version": "5.3.0",

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -18,7 +18,10 @@
     "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "4.7.0",
-    "vite": "7.3.2"
+    "jsdom": "^29.0.2",
+    "vite": "7.3.2",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -13,7 +13,9 @@
     "d3-hierarchy": "^3.1.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "recharts": "3.7.0"
+    "recharts": "3.7.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.7.0",

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -62,7 +62,6 @@ function ConsolePanel({ job, consoleOpen, setConsoleOpen, logViewerRef, hasEvalu
   const isRunning = job.status === STATUS.RUNNING;
   const isFailed = job.status === STATUS.FAILED;
   const isLost = job.status === STATUS.LOST;
-  const isExternal = job.source === 'external';
   const [showDot, setShowDot] = useState(() => {
     if (hasEvaluations) return false;
     try { return !localStorage.getItem(CONSOLE_DOT_DISMISSED_KEY); } catch { return true; }
@@ -100,9 +99,7 @@ function ConsolePanel({ job, consoleOpen, setConsoleOpen, logViewerRef, hasEvalu
       {consoleOpen && (
         <div className="console-output">
           <pre ref={logViewerRef}>
-            {isExternal
-              ? 'Live logs unavailable for external runs \u2014 progress inferred from filesystem'
-              : (job.logs?.length ? job.logs.join('\n') : 'Waiting for output\u2026')}
+            {job.logs?.length ? job.logs.join('\n') : 'Waiting for output\u2026'}
           </pre>
         </div>
       )}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
+import LiveTerminal from './LiveTerminal.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
@@ -182,6 +183,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobMeta job={job} projectName={deriveProjectName(job.repo)} />
       <ConsolePanel job={job} consoleOpen={consoleOpen} setConsoleOpen={setConsoleOpen} logViewerRef={logViewerRef} hasEvaluations={hasEvaluations} />
+      {job.jobId ? <LiveTerminal jobId={job.jobId} /> : null}
       <LiveViolationsFeed liveViolations={liveViolations} />
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.css
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.css
@@ -1,0 +1,22 @@
+.live-terminal {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-border, #21262d);
+  padding-top: 8px;
+}
+.live-terminal__toggle {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted, #8b949e);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 0;
+}
+.live-terminal__body {
+  height: 320px;
+  margin-top: 8px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.live-terminal__body--collapsed {
+  display: none;
+}

--- a/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+import './LiveTerminal.css';
+
+export default function LiveTerminal({ jobId }) {
+  const containerRef = useRef(null);
+  const termRef = useRef(null);
+  const esRef = useRef(null);
+  const [open, setOpen] = useState(true);
+  const [lineCount, setLineCount] = useState(0);
+
+  useEffect(() => {
+    if (!jobId || !containerRef.current) return;
+
+    const term = new Terminal({
+      convertEol: true,
+      fontFamily: 'ui-monospace, Menlo, monospace',
+      fontSize: 12,
+      theme: { background: '#0d1117' },
+      scrollback: 10000,
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(containerRef.current);
+    fit.fit();
+    termRef.current = term;
+
+    const es = new EventSource(`/api/jobs/${encodeURIComponent(jobId)}/logs/stream`);
+    esRef.current = es;
+
+    const onMessage = (ev) => {
+      term.writeln(ev.data ?? '');
+      setLineCount((n) => n + 1);
+    };
+    const onDone = () => { es.close(); };
+    const onError = () => { /* EventSource auto-reconnects; no-op */ };
+    es.addEventListener('message', onMessage);
+    es.addEventListener('done', onDone);
+    es.addEventListener('error', onError);
+
+    const onResize = () => { try { fit.fit(); } catch { /* ignore */ } };
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+      es.close();
+      term.dispose();
+      termRef.current = null;
+      esRef.current = null;
+    };
+  }, [jobId]);
+
+  return (
+    <div className="live-terminal">
+      <button
+        type="button"
+        className="live-terminal__toggle"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        {open ? '▾' : '▸'} Terminal ({lineCount} lines)
+      </button>
+      <div
+        ref={containerRef}
+        className={`live-terminal__body ${open ? '' : 'live-terminal__body--collapsed'}`}
+      />
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveTerminal.test.jsx
@@ -1,0 +1,42 @@
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import LiveTerminal from './LiveTerminal.jsx';
+
+class FakeEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(name, fn) { this.listeners[name] = fn; }
+  close() { this.closed = true; }
+  _emit(name, data) { this.listeners[name] && this.listeners[name]({ data }); }
+}
+FakeEventSource.instances = [];
+
+describe('LiveTerminal', () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    global.EventSource = FakeEventSource;
+  });
+
+  it('mounts and opens an EventSource for the given job', () => {
+    render(<LiveTerminal jobId="job-xyz" />);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0].url).toBe('/api/jobs/job-xyz/logs/stream');
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = render(<LiveTerminal jobId="job-xyz" />);
+    const es = FakeEventSource.instances[0];
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+
+  it('closes the EventSource when a done event fires', () => {
+    render(<LiveTerminal jobId="job-xyz" />);
+    const es = FakeEventSource.instances[0];
+    act(() => { es._emit('done', ''); });
+    expect(es.closed).toBe(true);
+  });
+});

--- a/src/quodeq/ui/vitest.config.js
+++ b/src/quodeq/ui/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: false,
+    setupFiles: ['./vitest.setup.js'],
+  },
+});

--- a/src/quodeq/ui/vitest.setup.js
+++ b/src/quodeq/ui/vitest.setup.js
@@ -1,0 +1,18 @@
+// Stub window.matchMedia — not implemented in JSDOM but required by xterm.js
+window.matchMedia = window.matchMedia || function matchMedia(query) {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  };
+};
+
+// Stub HTMLCanvasElement.getContext — not implemented in JSDOM
+HTMLCanvasElement.prototype.getContext = HTMLCanvasElement.prototype.getContext || function () {
+  return null;
+};

--- a/tests/api/test_log_stream_real_provider.py
+++ b/tests/api/test_log_stream_real_provider.py
@@ -1,0 +1,34 @@
+# tests/api/test_log_stream_real_provider.py
+"""End-to-end: real FilesystemActionProvider must resolve run_dir for log streaming."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+def test_get_log_run_dir_resolves_external_run_with_real_provider(tmp_path: Path, monkeypatch) -> None:
+    """After setting QUODEQ_EVALUATIONS_DIR, the default provider resolves ext-<run_id> to the right run_dir."""
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+
+    # Seed a fake in-progress run.
+    project = tmp_path / "proj-x"
+    run = project / "run-abc"
+    run.mkdir(parents=True)
+    (run / "evidence").mkdir()
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / "run.log").write_text("hello\nworld\n")
+
+    app = create_app()
+    client = app.test_client()
+
+    # Plain endpoint must find the log file and return its contents.
+    resp = client.get("/api/jobs/ext-run-abc/logs")
+    assert resp.status_code == HTTPStatus.OK, (
+        f"real-provider log resolution broken: {resp.status_code} {resp.get_json()}"
+    )
+    data = resp.get_json()
+    assert data["lines"] == ["hello", "world"]

--- a/tests/api/test_log_stream_registered.py
+++ b/tests/api/test_log_stream_registered.py
@@ -1,0 +1,28 @@
+# tests/api/test_log_stream_registered.py
+"""Route registration + auth coverage for log-stream endpoints."""
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from quodeq.api.app import create_app
+
+
+def test_log_stream_routes_registered() -> None:
+    app = create_app()
+    rules = {r.rule for r in app.url_map.iter_rules()}
+    assert "/api/jobs/<job_id>/logs" in rules
+    assert "/api/jobs/<job_id>/logs/stream" in rules
+
+
+def test_log_stream_routes_require_auth_when_api_key_set() -> None:
+    """With QUODEQ_API_KEY set, requests without Bearer token must be rejected."""
+    app = create_app(api_key="secret")
+    client = app.test_client()
+    resp_plain = client.get("/api/jobs/some-job/logs")
+    resp_stream = client.get("/api/jobs/some-job/logs/stream")
+    # 401 from the global before_request hook. The plain endpoint may return
+    # 404 FIRST if auth is skipped — fail loudly if that happens.
+    assert resp_plain.status_code == HTTPStatus.UNAUTHORIZED, \
+        f"plain_logs not auth-protected: got {resp_plain.status_code}"
+    assert resp_stream.status_code == HTTPStatus.UNAUTHORIZED, \
+        f"stream_logs not auth-protected: got {resp_stream.status_code}"

--- a/tests/api/test_log_stream_routes.py
+++ b/tests/api/test_log_stream_routes.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from quodeq.api._log_stream_routes import register_log_stream_routes
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    app = Flask(__name__)
+    app.config["_api_key"] = None  # localhost-only mode, works with test client
+    app.config["_reports_dir"] = tmp_path
+
+    # Fake provider that resolves job_id -> run_dir via run_dir mapping.
+    class FakeProvider:
+        def __init__(self) -> None:
+            self.map: dict[str, Path] = {}
+
+        def get_log_run_dir(self, job_id: str) -> Path | None:
+            return self.map.get(job_id)
+
+        def is_job_complete(self, job_id: str) -> bool:
+            return job_id.endswith("-done")
+
+    provider = FakeProvider()
+    app.config["_provider"] = provider
+    register_log_stream_routes(app)
+    return app
+
+
+def _seed_run(tmp_path: Path, app: Flask, job_id: str, content: str) -> Path:
+    run_dir = tmp_path / job_id
+    run_dir.mkdir()
+    (run_dir / "run.log").write_text(content)
+    app.config["_provider"].map[job_id] = run_dir
+    return run_dir
+
+
+def test_plain_logs_returns_content(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-1-done", "first\nsecond\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-1-done/logs")
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.get_json()
+    assert data["lines"] == ["first", "second"]
+    assert data["nextOffset"] == len("first\nsecond\n")
+    assert data["done"] is True
+
+
+def test_plain_logs_since_offset(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-2", "first\nsecond\nthird\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-2/logs?since=6")  # after "first\n"
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.get_json()
+    assert data["lines"] == ["second", "third"]
+
+
+def test_plain_logs_404_when_log_missing(tmp_path, app) -> None:
+    run_dir = tmp_path / "empty"
+    run_dir.mkdir()
+    app.config["_provider"].map["job-3"] = run_dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-3/logs")
+    assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_plain_logs_410_when_run_dir_missing(tmp_path, app) -> None:
+    app.config["_provider"].map["job-4"] = tmp_path / "gone"  # not a real dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-4/logs")
+    assert resp.status_code == HTTPStatus.GONE
+
+
+def test_plain_logs_partial_line_stripped(tmp_path, app) -> None:
+    """If the last line lacks a trailing newline, it's not returned — caller polls again."""
+    _seed_run(tmp_path, app, "job-5", "complete\npartial-tail")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-5/logs")
+    data = resp.get_json()
+    assert data["lines"] == ["complete"]
+    assert data["nextOffset"] == len("complete\n")

--- a/tests/api/test_log_stream_routes.py
+++ b/tests/api/test_log_stream_routes.py
@@ -84,3 +84,58 @@ def test_plain_logs_partial_line_stripped(tmp_path, app) -> None:
     data = resp.get_json()
     assert data["lines"] == ["complete"]
     assert data["nextOffset"] == len("complete\n")
+
+
+def _collect_sse(resp, max_events: int = 50) -> list[dict]:
+    """Parse an SSE response body into a list of {id, event, data} dicts."""
+    events: list[dict] = []
+    current: dict = {}
+    for raw in resp.response:  # Flask test-client yields bytes chunks
+        chunk = raw.decode("utf-8")
+        for line in chunk.splitlines():
+            if line.startswith("id:"):
+                current["id"] = line[3:].strip()
+            elif line.startswith("event:"):
+                current["event"] = line[6:].strip()
+            elif line.startswith("data:"):
+                current["data"] = line[5:].strip()
+            elif line == "":
+                if current:
+                    events.append(current)
+                    current = {}
+                    if len(events) >= max_events:
+                        return events
+    if current:
+        events.append(current)
+    return events
+
+
+def test_sse_replays_existing_content(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-sse-1-done", "alpha\nbeta\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-1-done/logs/stream")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.content_type.startswith("text/event-stream")
+    events = _collect_sse(resp)
+    data_events = [e for e in events if "data" in e]
+    assert [e["data"] for e in data_events] == ["alpha", "beta"]
+    assert any(e.get("event") == "done" for e in events)
+
+
+def test_sse_respects_last_event_id(tmp_path, app) -> None:
+    _seed_run(tmp_path, app, "job-sse-2-done", "alpha\nbeta\ngamma\n")
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-2-done/logs/stream",
+                      headers={"Last-Event-ID": str(len("alpha\n"))})
+    events = _collect_sse(resp)
+    data_events = [e for e in events if "data" in e]
+    assert [e["data"] for e in data_events] == ["beta", "gamma"]
+
+
+def test_sse_404_on_missing_log(tmp_path, app) -> None:
+    run_dir = tmp_path / "empty"
+    run_dir.mkdir()
+    app.config["_provider"].map["job-sse-3"] = run_dir
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-3/logs/stream")
+    assert resp.status_code == HTTPStatus.NOT_FOUND

--- a/tests/ci/test_cli_uses_log_info.py
+++ b/tests/ci/test_cli_uses_log_info.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_no_direct_stderr_prints_in_pipeline() -> None:
+    """The CLI pipeline must route progress messages through log_info, not print(..., file=sys.stderr).
+
+    Allowed exceptions: dimension score lines in _execute_pipeline's success branch
+    (line 133: `print(f"  {dim}: {score}")`) because those print to stdout for
+    shell piping.
+    """
+    src = Path("src/quodeq/_cli_evaluation.py").read_text()
+    tree = ast.parse(src)
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "print":
+            for kw in node.keywords:
+                if kw.arg == "file" and isinstance(kw.value, ast.Attribute) and kw.value.attr == "stderr":
+                    offenders.append((node.lineno, ast.unparse(node)))
+    assert not offenders, f"direct stderr prints remain: {offenders}"

--- a/tests/ci/test_run_log_integration.py
+++ b/tests/ci/test_run_log_integration.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.shared.logging import log_info
+
+
+def test_run_log_captures_log_info_during_pipeline(tmp_path: Path, monkeypatch) -> None:
+    """log_info calls between install/uninstall must land in run.log."""
+    from quodeq.shared.run_log import RunLogHandler, RunLogWriter
+
+    run_dir = tmp_path / "project" / "run-1"
+    run_dir.mkdir(parents=True)
+
+    writer = RunLogWriter(run_dir)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    logger = logging.getLogger("quodeq")
+    logger.addHandler(handler)
+    try:
+        log_info("line-one")
+        log_info("line-two")
+    finally:
+        logger.removeHandler(handler)
+        writer.close()
+
+    contents = (run_dir / "run.log").read_text()
+    assert "line-one" in contents
+    assert "line-two" in contents
+
+
+def test_pipeline_installs_and_removes_run_log_handler(tmp_path: Path, monkeypatch) -> None:
+    """_run_pipeline_with_cleanup must install RunLogHandler on entry and remove on exit."""
+    import quodeq._cli_evaluation as cli
+    from quodeq.shared.run_log import RunLogHandler
+
+    logger = logging.getLogger("quodeq")
+    initial_handlers = set(id(h) for h in logger.handlers)
+
+    # Stub _execute_pipeline so we exercise only the wrapper's install/remove logic.
+    with patch.object(cli, "_execute_pipeline", return_value=0), \
+         patch.object(cli, "_save_manifest"), \
+         patch.object(cli, "_build_run_config"), \
+         patch.object(cli, "is_repo_url", return_value=False), \
+         patch.object(cli, "emit_marker"):
+        evidence_dir = tmp_path / "proj" / "run" / "evidence"
+        evaluation_dir = tmp_path / "proj" / "run" / "evaluation"
+        evidence_dir.mkdir(parents=True)
+        evaluation_dir.mkdir(parents=True)
+        import argparse
+        args = argparse.Namespace(repo="local")
+        inputs = type("I", (), {"src": tmp_path, "language": "python", "manifest": None, "dims_data": None})()
+
+        # During pipeline, a RunLogHandler must be attached to the quodeq logger.
+        attached: list[bool] = []
+        def _spy(*a, **k):
+            attached.append(any(isinstance(h, RunLogHandler) for h in logger.handlers))
+            return 0
+        with patch.object(cli, "_execute_pipeline", side_effect=_spy):
+            cli._run_pipeline_with_cleanup(args, inputs, (tmp_path, evidence_dir, evaluation_dir))
+
+    assert attached == [True]
+    # After exit, no stray RunLogHandler remains.
+    assert not any(isinstance(h, RunLogHandler) for h in logger.handlers)
+    assert set(id(h) for h in logger.handlers) == initial_handlers

--- a/tests/ci/test_terminal_stream_e2e.py
+++ b/tests/ci/test_terminal_stream_e2e.py
@@ -1,0 +1,44 @@
+# tests/ci/test_terminal_stream_e2e.py
+"""End-to-end: run a tiny CLI evaluation, verify run.log is written."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+def test_cli_writes_run_log(tmp_path: Path) -> None:
+    # Seed a minimal project.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "hello.py").write_text("def f(): return 1\n")
+    reports = tmp_path / "reports"
+    reports.mkdir()
+
+    env = {**os.environ,
+           "QUODEQ_EVALUATIONS_DIR": str(reports),
+           "QUODEQ_DRY_RUN": "1"}  # dry-run keeps the test fast and offline
+    proc = subprocess.run(
+        [sys.executable, "-m", "quodeq.cli", "evaluate", str(src),
+         "--dry-run", "-d", "security"],
+        cwd=tmp_path, env=env, capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"CLI failed:\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+
+    # Find the single run_dir.
+    project_dirs = [d for d in reports.iterdir() if d.is_dir()]
+    assert len(project_dirs) == 1, project_dirs
+    run_dirs = [d for d in project_dirs[0].iterdir() if d.is_dir()]
+    assert len(run_dirs) == 1, run_dirs
+    run_dir = run_dirs[0]
+
+    log_path = run_dir / "run.log"
+    assert log_path.exists(), f"run.log missing in {run_dir}"
+    contents = log_path.read_text()
+    # A dry-run still emits the "Starting evaluation..." banner via log_info.
+    assert "Starting evaluation" in contents or "Dimensions:" in contents

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -19,7 +19,8 @@ def test_find_external_runs_identifies_in_progress(tmp_path):
     (run / "evidence").mkdir(parents=True)
     (run / "evidence" / "manifest.json").write_text("{}")
     (run / "evaluation").mkdir()
-    # No scan.json -> in-progress
+    # No scan.json, but live .pid -> in-progress
+    (run / ".pid").write_text(str(os.getpid()))
 
     results = find_external_runs(tmp_path)
     assert len(results) == 1
@@ -258,3 +259,70 @@ def test_get_job_ext_prefix_requires_reports_root():
     jm = JobManager()
     # Without reports_root, falls through to internal store -> None
     assert jm.get_job("ext-anything") is None
+
+
+# ---------------------------------------------------------------------------
+# PID liveness — find_external_runs status
+# ---------------------------------------------------------------------------
+
+def _seed_in_progress_run(
+    tmp_path: Path,
+    project: str = "p",
+    run_id: str = "r",
+    pid_content: str | None = None,
+) -> Path:
+    """Create a run_dir with manifest.json (no scan.json). Optionally write a .pid file."""
+    run_dir = tmp_path / project / run_id
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    (run_dir / "evaluation").mkdir()
+    if pid_content is not None:
+        (run_dir / ".pid").write_text(pid_content)
+    return run_dir
+
+
+def test_live_pid_is_reported_as_running(tmp_path: Path) -> None:
+    """Run with .pid pointing at a live process -> status='running'."""
+    from quodeq.services._external_jobs import find_external_runs
+
+    _seed_in_progress_run(tmp_path, pid_content=str(os.getpid()))
+    runs = find_external_runs(tmp_path)
+    assert len(runs) == 1
+    assert runs[0].status == "running"
+
+
+def test_dead_pid_is_reported_as_cancelled(tmp_path: Path) -> None:
+    """Run with .pid pointing at a dead process -> status='cancelled' (stale)."""
+    from quodeq.services._external_jobs import find_external_runs
+
+    # A PID of 999999999 is virtually guaranteed to be absent on modern systems.
+    _seed_in_progress_run(tmp_path, pid_content="999999999")
+    runs = find_external_runs(tmp_path)
+    assert len(runs) == 1
+    assert runs[0].status == "cancelled"
+
+
+def test_missing_pid_defaults_to_cancelled(tmp_path: Path) -> None:
+    """Run with manifest but no .pid file -> treat as stale (status='cancelled').
+
+    A healthy run writes .pid early and unlinks it in the finally block only
+    *after* scan.json is written. If scan.json is absent AND .pid is absent,
+    the process died before writing .pid OR finished abnormally -- in either
+    case we have no evidence of liveness and should not block the UI.
+    """
+    from quodeq.services._external_jobs import find_external_runs
+
+    _seed_in_progress_run(tmp_path, pid_content=None)
+    runs = find_external_runs(tmp_path)
+    assert len(runs) == 1
+    assert runs[0].status == "cancelled"
+
+
+def test_malformed_pid_is_reported_as_cancelled(tmp_path: Path) -> None:
+    """Run with a non-numeric .pid file -> status='cancelled' (treat as stale)."""
+    from quodeq.services._external_jobs import find_external_runs
+
+    _seed_in_progress_run(tmp_path, pid_content="not-a-pid")
+    runs = find_external_runs(tmp_path)
+    assert len(runs) == 1
+    assert runs[0].status == "cancelled"

--- a/tests/services/test_filesystem_log_resolution.py
+++ b/tests/services/test_filesystem_log_resolution.py
@@ -1,0 +1,39 @@
+# tests/services/test_filesystem_log_resolution.py
+"""FilesystemActionProvider.get_log_run_dir / is_job_complete."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.services.filesystem import FilesystemActionProvider
+
+
+def test_get_log_run_dir_external_run(tmp_path: Path) -> None:
+    """Given an ext-<run_id> job_id, scans reports_root for a matching run."""
+    project = tmp_path / "proj-1"
+    run = project / "run-A"
+    run.mkdir(parents=True)
+    (run / "evidence").mkdir()
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.get_log_run_dir("ext-run-A") == run
+
+
+def test_get_log_run_dir_external_not_found(tmp_path: Path) -> None:
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.get_log_run_dir("ext-run-nonexistent") is None
+
+
+def test_is_job_complete_external_when_scan_present(tmp_path: Path) -> None:
+    project = tmp_path / "p"
+    run = project / "r"
+    run.mkdir(parents=True)
+    (run / "scan.json").write_text("{}")
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.is_job_complete("ext-r") is True
+
+
+def test_is_job_complete_external_when_scan_absent(tmp_path: Path) -> None:
+    project = tmp_path / "p"
+    run = project / "r"
+    run.mkdir(parents=True)
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.is_job_complete("ext-r") is False

--- a/tests/services/test_filesystem_log_resolution.py
+++ b/tests/services/test_filesystem_log_resolution.py
@@ -32,8 +32,27 @@ def test_is_job_complete_external_when_scan_present(tmp_path: Path) -> None:
 
 
 def test_is_job_complete_external_when_scan_absent(tmp_path: Path) -> None:
+    """A run with a live .pid and no scan.json is still in progress (not complete)."""
+    import os
     project = tmp_path / "p"
     run = project / "r"
     run.mkdir(parents=True)
+    # Live PID present -> genuinely running -> not complete
+    (run / ".pid").write_text(str(os.getpid()))
     provider = FilesystemActionProvider(reports_root=tmp_path)
     assert provider.is_job_complete("ext-r") is False
+
+
+def test_is_job_complete_external_stale_pid(tmp_path: Path) -> None:
+    """Stale ext- run (no scan.json, dead PID) should be treated as complete.
+
+    Otherwise the SSE endpoint tails the log forever waiting for a scan.json
+    that will never arrive.
+    """
+    project = tmp_path / "p"
+    run = project / "r"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    (run / ".pid").write_text("999999999")
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.is_job_complete("ext-r") is True

--- a/tests/services/test_jobs_run_log.py
+++ b/tests/services/test_jobs_run_log.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.services.jobs import JobManager, STATUS_RUNNING
+from quodeq.services._job_model import Job
+
+
+def test_consume_stream_tees_to_run_log(tmp_path: Path) -> None:
+    """Once the report_path marker arrives, subsequent lines land in run.log."""
+    project = "proj-uuid"
+    run_id = "run-A"
+    run_dir = tmp_path / project / run_id
+    run_dir.mkdir(parents=True)
+
+    jm = JobManager(reports_root=tmp_path)
+    job = Job(
+        job_id="job-1",
+        status=STATUS_RUNNING,
+        command=["x"],
+        started_at="2026-04-20T00:00:00+00:00",
+        ended_at=None,
+        exit_code=None,
+    )
+    jm._store.put(job)  # internal — test helper
+
+    marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
+    stream = iter([
+        "pre-marker line\n",
+        marker + "\n",
+        "post-marker line\n",
+    ])
+    jm._consume_stream("job-1", stream)
+
+    contents = (run_dir / "run.log").read_text()
+    # Both pre-marker (buffered) and post-marker lines must appear, in order.
+    assert "pre-marker line" in contents
+    assert "post-marker line" in contents
+    assert contents.index("pre-marker line") < contents.index("post-marker line")
+
+
+def test_consume_stream_no_run_dir_silent(tmp_path: Path) -> None:
+    """If no report_path marker ever arrives, consume_stream completes without error."""
+    jm = JobManager(reports_root=tmp_path)
+    job = Job(
+        job_id="job-2", status=STATUS_RUNNING, command=["x"],
+        started_at="2026-04-20T00:00:00+00:00", ended_at=None, exit_code=None,
+    )
+    jm._store.put(job)
+    jm._consume_stream("job-2", iter(["line-1\n", "line-2\n"]))
+    # No run.log anywhere — nothing to assert beyond "did not raise".

--- a/tests/services/test_jobs_run_log.py
+++ b/tests/services/test_jobs_run_log.py
@@ -7,7 +7,18 @@ from unittest.mock import MagicMock
 import pytest
 
 from quodeq.services.jobs import JobManager, STATUS_RUNNING
-from quodeq.services._job_model import Job
+from quodeq.services._job_model import Job, _CONSUME_BATCH_SIZE
+
+
+def _make_job(job_id: str) -> Job:
+    return Job(
+        job_id=job_id,
+        status=STATUS_RUNNING,
+        command=["x"],
+        started_at="2026-04-20T00:00:00+00:00",
+        ended_at=None,
+        exit_code=None,
+    )
 
 
 def test_consume_stream_tees_to_run_log(tmp_path: Path) -> None:
@@ -18,15 +29,7 @@ def test_consume_stream_tees_to_run_log(tmp_path: Path) -> None:
     run_dir.mkdir(parents=True)
 
     jm = JobManager(reports_root=tmp_path)
-    job = Job(
-        job_id="job-1",
-        status=STATUS_RUNNING,
-        command=["x"],
-        started_at="2026-04-20T00:00:00+00:00",
-        ended_at=None,
-        exit_code=None,
-    )
-    jm._store.put(job)  # internal — test helper
+    jm._store.put(_make_job("job-1"))
 
     marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
     stream = iter([
@@ -46,10 +49,112 @@ def test_consume_stream_tees_to_run_log(tmp_path: Path) -> None:
 def test_consume_stream_no_run_dir_silent(tmp_path: Path) -> None:
     """If no report_path marker ever arrives, consume_stream completes without error."""
     jm = JobManager(reports_root=tmp_path)
-    job = Job(
-        job_id="job-2", status=STATUS_RUNNING, command=["x"],
-        started_at="2026-04-20T00:00:00+00:00", ended_at=None, exit_code=None,
-    )
-    jm._store.put(job)
+    jm._store.put(_make_job("job-2"))
     jm._consume_stream("job-2", iter(["line-1\n", "line-2\n"]))
     # No run.log anywhere — nothing to assert beyond "did not raise".
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: Production wiring — provider instantiated with reports_root
+# ---------------------------------------------------------------------------
+
+def test_provider_wires_reports_root_to_job_manager(tmp_path: Path) -> None:
+    """FilesystemActionProvider passes reports_root to JobManager at construction."""
+    from quodeq.services.filesystem import FilesystemActionProvider
+
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider._jobs._reports_root == tmp_path
+
+
+def test_set_reports_root_updates_job_manager(tmp_path: Path) -> None:
+    """JobManager.set_reports_root updates _reports_root for subsequent tee calls."""
+    jm = JobManager()
+    assert jm._reports_root is None
+    jm.set_reports_root(tmp_path)
+    assert jm._reports_root == tmp_path
+
+    # Verify that a stream now tees to run.log via the updated root.
+    project = "proj-wire"
+    run_id = "run-wire"
+    run_dir = tmp_path / project / run_id
+    run_dir.mkdir(parents=True)
+
+    jm._store.put(_make_job("job-wire"))
+    marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
+    jm._consume_stream("job-wire", iter(["hello\n", marker + "\n", "world\n"]))
+
+    contents = (run_dir / "run.log").read_text()
+    assert "hello" in contents
+    assert "world" in contents
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: Batch-boundary ordering
+# ---------------------------------------------------------------------------
+
+def test_batch_boundary_all_lines_in_run_log_in_order(tmp_path: Path) -> None:
+    """All 100 lines appear in run.log in order even when marker is mid-stream.
+
+    This exercises the batch boundary: with _CONSUME_BATCH_SIZE lines flushed
+    per batch, the marker may land in the middle of a batch.  The final
+    _drain_pre_marker_buffer call must ensure no buffered lines are lost.
+    """
+    project = "proj-batch"
+    run_id = "run-batch"
+    run_dir = tmp_path / project / run_id
+    run_dir.mkdir(parents=True)
+
+    total = 100
+    marker_pos = 50  # marker at line index 50 (0-based)
+    marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
+
+    lines = []
+    for i in range(total):
+        if i == marker_pos:
+            lines.append(marker + "\n")
+        else:
+            lines.append(f"line-{i}\n")
+
+    jm = JobManager(reports_root=tmp_path)
+    jm._store.put(_make_job("job-batch"))
+    jm._consume_stream("job-batch", iter(lines))
+
+    contents = (run_dir / "run.log").read_text()
+    log_lines = [l for l in contents.splitlines() if l.startswith("line-")]
+    # All 99 data lines (not the marker) must be present.
+    assert len(log_lines) == total - 1
+    # Verify ordering: line numbers extracted must be monotonically increasing.
+    nums = [int(l.split("-")[1]) for l in log_lines]
+    assert nums == sorted(nums)
+    # Lines before and after the marker must both appear.
+    assert any(n < marker_pos for n in nums)
+    assert any(n > marker_pos for n in nums)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Resource cleanup on unexpected exceptions
+# ---------------------------------------------------------------------------
+
+def test_consume_stream_cleans_up_on_unexpected_exception(tmp_path: Path) -> None:
+    """Writer and buffer are cleaned up even when the stream raises an unexpected error."""
+    project = "proj-exc"
+    run_id = "run-exc"
+    run_dir = tmp_path / project / run_id
+    run_dir.mkdir(parents=True)
+
+    marker = json.dumps({"_cc": "report_path", "project": project, "runId": run_id})
+
+    def _bad_stream():
+        yield "line-1\n"
+        yield marker + "\n"
+        raise RuntimeError("unexpected stream error")
+
+    jm = JobManager(reports_root=tmp_path)
+    jm._store.put(_make_job("job-exc"))
+
+    with pytest.raises(RuntimeError, match="unexpected stream error"):
+        jm._consume_stream("job-exc", _bad_stream())
+
+    # Writer and buffer must be cleaned up regardless.
+    assert "job-exc" not in jm._run_log_writers
+    assert "job-exc" not in jm._pre_marker_buffer

--- a/tests/shared/conftest.py
+++ b/tests/shared/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for tests/shared package."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=False)
+def no_raise_logging_exceptions():
+    """Temporarily disable logging.raiseExceptions for tests that verify
+    handlers swallow errors silently.
+
+    Python 3.14 + pytest raises logging format errors as test failures by
+    default (pytest overrides logging.Handler.handleError to re-raise).
+    Tests that assert *our* handler is silent need this fixture to prevent
+    pytest's own LogCaptureHandler from interfering.
+    """
+    original = logging.raiseExceptions
+    logging.raiseExceptions = False
+    try:
+        yield
+    finally:
+        logging.raiseExceptions = original

--- a/tests/shared/test_run_log.py
+++ b/tests/shared/test_run_log.py
@@ -1,0 +1,70 @@
+# tests/shared/test_run_log.py
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from quodeq.shared.run_log import RunLogWriter, RunLogHandler
+
+
+def test_write_creates_file_with_line(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("hello")
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "hello\n"
+
+
+def test_write_preserves_existing_newline(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("already-newlined\n")
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "already-newlined\n"
+
+
+def test_write_is_line_buffered(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    writer.write("first")
+    # Read back without closing — flush should have happened.
+    assert (tmp_path / "run.log").read_text() == "first\n"
+    writer.close()
+
+
+def test_silent_on_missing_dir(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
+    writer = RunLogWriter(missing)  # must not raise
+    writer.write("ignored")  # must not raise
+    writer.close()
+    assert not (missing / "run.log").exists()
+
+
+def test_path_property(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    assert writer.path == tmp_path / "run.log"
+    writer.close()
+
+
+def test_handler_forwards_log_record(tmp_path: Path) -> None:
+    writer = RunLogWriter(tmp_path)
+    handler = RunLogHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger = logging.getLogger("test.run_log.1")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.info("message-a")
+    logger.removeHandler(handler)
+    writer.close()
+    assert (tmp_path / "run.log").read_text() == "message-a\n"
+
+
+def test_handler_never_raises_on_format_error(
+    tmp_path: Path, no_raise_logging_exceptions: None
+) -> None:
+    writer = RunLogWriter(tmp_path)
+    handler = RunLogHandler(writer)
+    logger = logging.getLogger("test.run_log.2")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    # %d on a string arg — format-time error, must not propagate.
+    logger.info("%d", "not-an-int")
+    logger.removeHandler(handler)
+    writer.close()


### PR DESCRIPTION
## Summary
- Every evaluation's stderr is now teed to a per-run `{run_dir}/run.log` file (alongside the existing evidence, manifest, status artifacts). Both CLI-started and dashboard-spawned runs use the same writer.
- Two new endpoints: `GET /api/jobs/<id>/logs?since=N` (plain JSON polling/replay) and `GET /api/jobs/<id>/logs/stream` (Server-Sent Events with replay + live tail + `event: done` on terminal state + `Last-Event-ID` resume).
- New React `<LiveTerminal>` component mounts xterm.js, opens an `EventSource`, streams lines into a scrollback-buffered terminal. Embedded below the existing status card in `EvaluationStatus`.
- Legacy "Live logs unavailable for external runs" banner removed — live-terminal supersedes it.

## Why this matters
Before this: externally-started runs (CLI in another terminal, CI nightly) had zero live visibility — the dashboard inferred phase/dimension from filesystem artifacts, nothing more. Dashboard-spawned runs had a coarse ring-buffer poll with lines lost on rotation.

After this: any running evaluation on the machine streams its full stderr live into any open dashboard, with full scrollback, no line loss, and works identically for CLI/dashboard/CI runs. Historical runs replay their `run.log` on open.

## Complements Plan A + B1
This PR is orthogonal to the just-merged [#254](https://github.com/quodeq/quodeq/pull/254) (lifecycle state) and [#255](https://github.com/quodeq/quodeq/pull/255) (SQLite-backed dashboard):
- A + B1 answered *"what state is this run in?"* — they track lifecycle transitions and dashboard list correctness.
- This PR answers *"what is this run actually doing right now?"* — the CLI's real stderr output, live.

## Test plan
- [x] `uv run pytest` — 2041 tests passing (19 new from this branch), no regressions
- [x] Unit coverage: `RunLogWriter` atomic writes, `RunLogHandler` logging forwarding, SSE event generation, plain-endpoint partial-line handling, `Last-Event-ID` resume, 404 / 410 responses
- [x] Integration: subprocess CLI writes run.log, SSE endpoint serves it, legacy runs 404 gracefully
- [x] Manual: start a real evaluation from the dashboard → terminal pane streams live lines
- [x] Manual: `quodeq evaluate .` in another terminal → dashboard's live terminal pane streams the external run
- [x] Manual: open an old completed run → terminal replays historical output, sends `event: done`, stops tailing

## Non-blocking follow-ups (surfaced during prior final reviews)
- **I2 (cosmetic):** `_cc` JSON markers (e.g., `{"_cc": "report_path", ...}`) are teed to `run.log` verbatim → they appear as raw JSON in the xterm pane. Filter marker lines before teeing.
- **I3 (UX):** `LiveTerminal.onError` is a no-op → 404 on pre-feature runs (no `run.log` on disk) triggers infinite EventSource reconnect. Render a "No terminal output captured" placeholder and stop reconnecting on 404.
- **Task 1 review:** `RunLogWriter.write` / `close` have a check-then-act race on `_fh` under concurrent close (benign today; only concurrent-stream scenarios would trigger). Add a context-manager protocol (`__enter__`/`__exit__`).
- One of the rebased commits (`c4729805` — stale PID detection in `_external_jobs.py`) now lives on dead code post-Plan-B1. Harmless; Plan B2 removes `_external_jobs.py` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)