### PR TITLE
fix(ci): stabilize Quodeq Review workflow (diff-scoped comments + ephemeral eval dir)

### DIFF
--- a/.github/workflows/quodeq-review.yml
+++ b/.github/workflows/quodeq-review.yml
@@ -55,13 +55,28 @@ jobs:
             echo "EVAL_DIR=$HOME/.quodeq/evaluations" >> "$GITHUB_ENV"
           fi
 
-      - name: Expand EVAL_DIR (~ → $HOME)
+      - name: Set up ephemeral PR eval directory
         run: |
-          # GITHUB_ENV is loaded into env for subsequent steps.
-          DIR="${EVAL_DIR:-$HOME/.quodeq/evaluations}"
-          DIR="${DIR/#\~/$HOME}"
-          mkdir -p "$DIR"
-          echo "EVAL_DIR=$DIR" >> "$GITHUB_ENV"
+          # PR reviews MUST NOT pollute the dashboard store. The dashboard's
+          # source of truth is nightly evaluations in $DASHBOARD_EVAL_DIR.
+          # PR runs write to a runner-temp dir that vanishes with the job —
+          # this also guarantees that if the PR run crashes, no stale entry
+          # leaks into the dashboard.
+          DASHBOARD_EVAL_DIR="${EVAL_DIR:-$HOME/.quodeq/evaluations}"
+          DASHBOARD_EVAL_DIR="${DASHBOARD_EVAL_DIR/#\~/$HOME}"
+          echo "DASHBOARD_EVAL_DIR=$DASHBOARD_EVAL_DIR" >> "$GITHUB_ENV"
+
+          PR_EVAL_DIR="$RUNNER_TEMP/quodeq-pr-eval"
+          rm -rf "$PR_EVAL_DIR"  # guard against leftovers from prior invocations
+          mkdir -p "$PR_EVAL_DIR"
+          echo "PR_EVAL_DIR=$PR_EVAL_DIR" >> "$GITHUB_ENV"
+
+          # Copy the project_index.json from the dashboard store so quodeq
+          # resolves the PR run to the SAME project UUID the nightlies use.
+          # This lets us find the nightly baseline by UUID below.
+          if [[ -f "$DASHBOARD_EVAL_DIR/project_index.json" ]]; then
+            cp "$DASHBOARD_EVAL_DIR/project_index.json" "$PR_EVAL_DIR/project_index.json"
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -85,10 +100,6 @@ jobs:
             echo "pool_budget=${{ github.event.inputs.pool_budget }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Snapshot evaluation dirs (for latest-run detection)
-        run: |
-          find "$EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | sort > /tmp/eval-dirs-before.txt || : > /tmp/eval-dirs-before.txt
-
       - name: Run evaluation
         id: eval
         run: |
@@ -107,27 +118,30 @@ jobs:
             --pool-budget "${{ steps.params.outputs.pool_budget }}" \
             --max-duration 120 \
             --n-subagents "${N_SUBAGENTS:-3}" \
-            --output "$EVAL_DIR"
+            --output "$PR_EVAL_DIR"
           echo "duration=$(( $(date +%s) - START ))" >> "$GITHUB_OUTPUT"
 
       - name: Locate this run's evaluation output
         id: eval_dir
         run: |
-          find "$EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | sort > /tmp/eval-dirs-after.txt || : > /tmp/eval-dirs-after.txt
-          # The new eval dir = in "after" but not "before"
-          NEW_DIR=$(comm -13 /tmp/eval-dirs-before.txt /tmp/eval-dirs-after.txt | head -1)
+          # PR_EVAL_DIR is ephemeral and starts empty; the single freshly-
+          # written evaluation dir is this run's output.
+          NEW_DIR=$(find "$PR_EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | head -1)
           if [[ -z "$NEW_DIR" ]]; then
-            echo "No new evaluation directory produced" >&2
+            echo "No evaluation directory produced in $PR_EVAL_DIR" >&2
             exit 1
           fi
           echo "path=$NEW_DIR" >> "$GITHUB_OUTPUT"
-          # For the baseline: pick the latest pre-existing evaluation dir in the
-          # same project as NEW_DIR (one level up is the run id, two levels up is project)
-          PROJECT_DIR=$(dirname "$(dirname "$NEW_DIR")")
-          BASELINE=$(find "$PROJECT_DIR" -path "*/evaluation" -type d ! -path "$NEW_DIR" 2>/dev/null | sort | tail -1)
+
+          # Baseline source of truth: the nightly evaluations in the dashboard
+          # store. We derive the project UUID from the current run_dir (the
+          # project_index.json copy ensures it matches the dashboard UUID)
+          # and look up the latest evaluation for that project.
+          PROJECT_UUID=$(basename "$(dirname "$(dirname "$NEW_DIR")")")
+          BASELINE=$(find "$DASHBOARD_EVAL_DIR/$PROJECT_UUID" -path "*/evaluation" -type d 2>/dev/null | sort | tail -1)
           echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
           echo "Current:  $NEW_DIR"
-          echo "Baseline: ${BASELINE:-<none>}"
+          echo "Baseline: ${BASELINE:-<none (nightly hasn't run yet for this project)>}"
 
       - name: Post PR review
         env:

--- a/src/quodeq/ci/cli.py
+++ b/src/quodeq/ci/cli.py
@@ -16,7 +16,12 @@ def handle_ci(args) -> int:
 
 def _handle_report(args) -> int:
     """Post evaluation results as a GitHub PR review."""
-    from quodeq.ci.reporter import build_review_payload, load_evaluation_reports, post_review
+    from quodeq.ci.reporter import (
+        build_review_payload,
+        fetch_pr_changed_lines,
+        load_evaluation_reports,
+        post_review,
+    )
     from quodeq.ci.review_builder import classify_violations
 
     token = args.token or os.environ.get("GITHUB_TOKEN")
@@ -48,12 +53,30 @@ def _handle_report(args) -> int:
 
     artifact_url: str | None = getattr(args, "artifact_url", None)
 
+    # Fetch the PR's changed lines so we only post comments GitHub will accept.
+    # GitHub rejects the WHOLE review with HTTP 422 if any comment references
+    # a path or line outside the PR's diff. On fetch failure, fall back to a
+    # summary-only review (comments=[]) rather than crashing the action.
+    changed_lines: dict[str, set[int]] | None
+    try:
+        changed_lines = fetch_pr_changed_lines(
+            owner=args.owner, repo=args.repo, pr_number=args.pr, token=token,
+        )
+    except Exception as exc:
+        print(
+            f"Warning: could not fetch PR diff to scope comments ({exc.__class__.__name__}: {exc}); "
+            "posting summary-only review.",
+            file=sys.stderr,
+        )
+        changed_lines = {}  # empty dict → all comments filtered out; summary still posts
+
     payload = build_review_payload(
         reports,
         baseline_violations=baseline_violations,
         duration_seconds=args.duration,
         baseline_available=baseline_available,
         artifact_url=artifact_url,
+        changed_lines=changed_lines,
     )
     post_review(
         owner=args.owner,
@@ -67,5 +90,9 @@ def _handle_report(args) -> int:
     for r in reports:
         all_current.extend(r.get("violations", []))
     new_v, existing_v = classify_violations(all_current, baseline_violations)
-    print(f"Posted review to PR #{args.pr}: {len(new_v)} new, {len(existing_v)} pre-existing")
+    in_diff = len(payload["comments"])
+    print(
+        f"Posted review to PR #{args.pr}: {len(new_v)} new, {len(existing_v)} pre-existing "
+        f"({in_diff} inline comment(s) in diff scope)"
+    )
     return 0

--- a/src/quodeq/ci/reporter.py
+++ b/src/quodeq/ci/reporter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 import urllib.error
 from urllib.request import Request, urlopen
@@ -17,6 +18,109 @@ from quodeq.ci.review_builder import (
 _logger = logging.getLogger(__name__)
 
 _GITHUB_API = "https://api.github.com"
+_FILES_PAGE_SIZE = 100
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def _parse_hunks(patch: str | None) -> set[int]:
+    """Extract RIGHT-side line numbers covered by any hunk in a unified diff.
+
+    Lines starting with '+' (added) or ' ' (context) advance the RIGHT-side
+    counter; '-' (removed) lines do not. '\\ No newline at end of file'
+    markers are ignored. Returns the set of line numbers in the new file that
+    appear anywhere inside a hunk — these are the lines GitHub will accept as
+    review-comment anchors.
+    """
+    if not patch:
+        return set()
+    lines: set[int] = set()
+    current_line = 0
+    for raw in patch.splitlines():
+        if raw.startswith("@@"):
+            m = _HUNK_HEADER_RE.match(raw)
+            if not m:
+                current_line = 0
+                continue
+            current_line = int(m.group(1))
+            continue
+        if current_line <= 0:
+            continue
+        if raw.startswith("\\"):
+            continue  # "No newline at end of file" marker
+        if raw.startswith("+"):
+            lines.add(current_line)
+            current_line += 1
+        elif raw.startswith("-"):
+            continue  # LEFT-only; doesn't advance RIGHT-side counter
+        else:
+            # Context line (" foo") or empty line at bottom of hunk — both advance.
+            lines.add(current_line)
+            current_line += 1
+    return lines
+
+
+def _github_get(url: str, token: str) -> list | dict:
+    """Authenticated GET to the GitHub API. Returns parsed JSON."""
+    req = Request(url, method="GET")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_pr_changed_lines(
+    owner: str, repo: str, pr_number: int, token: str,
+) -> dict[str, set[int]]:
+    """Return ``{filename: set of RIGHT-side line numbers in hunks}`` for a PR.
+
+    Paginates through ``GET /repos/{owner}/{repo}/pulls/{pr_number}/files``.
+    Files with no ``patch`` (binary, too-large, rename-only) are skipped —
+    they remain un-annotable by line-anchored review comments.
+    """
+    result: dict[str, set[int]] = {}
+    page = 1
+    while True:
+        url = (
+            f"{_GITHUB_API}/repos/{owner}/{repo}/pulls/{pr_number}/files"
+            f"?per_page={_FILES_PAGE_SIZE}&page={page}"
+        )
+        data = _github_get(url, token)
+        if not isinstance(data, list) or not data:
+            break
+        for entry in data:
+            name = entry.get("filename")
+            patch = entry.get("patch")
+            if not name or not patch:
+                continue
+            lines = _parse_hunks(patch)
+            if lines:
+                result.setdefault(name, set()).update(lines)
+        if len(data) < _FILES_PAGE_SIZE:
+            break
+        page += 1
+    return result
+
+
+def filter_comments_to_diff(
+    comments: list[dict],
+    changed_lines: dict[str, set[int]],
+) -> tuple[list[dict], int]:
+    """Keep only comments whose path+line falls within ``changed_lines``.
+
+    Returns ``(kept, dropped_count)``. Comments missing a ``line`` key are
+    always dropped — GitHub requires a line anchor for review comments.
+    """
+    kept: list[dict] = []
+    dropped = 0
+    for c in comments:
+        path = c.get("path")
+        line = c.get("line")
+        if path and line is not None and line in changed_lines.get(path, set()):
+            kept.append(c)
+        else:
+            dropped += 1
+    return kept, dropped
 
 
 def load_evaluation_reports(evaluation_dir: Path) -> list[dict]:
@@ -39,6 +143,7 @@ def build_review_payload(
     duration_seconds: int | None = None,
     baseline_available: bool = True,
     artifact_url: str | None = None,
+    changed_lines: dict[str, set[int]] | None = None,
 ) -> dict:
     """Build the full GitHub PR review API payload from evaluation reports.
 
@@ -48,6 +153,10 @@ def build_review_payload(
     baseline_available: when False, a note is added to the summary explaining
     that no baseline comparison was made (first-run scenario).
     artifact_url: when provided, a download link is appended to the summary.
+    changed_lines: when provided, review comments are filtered to only those
+    whose path+line fall within the PR's changed hunks. GitHub rejects
+    comments outside the diff with HTTP 422, so the CLI must fetch the PR's
+    files and pass this mapping. Dropped comments are counted in the summary.
     """
     all_violations: list[dict] = []
     for report in reports:
@@ -57,8 +166,15 @@ def build_review_payload(
         all_violations, baseline_violations or []
     )
 
-    comments = [violation_to_comment(v, status="new") for v in new_violations]
-    comments += [violation_to_comment(v, status="existing") for v in existing_violations]
+    all_comments = [violation_to_comment(v, status="new") for v in new_violations]
+    all_comments += [violation_to_comment(v, status="existing") for v in existing_violations]
+
+    if changed_lines is None:
+        comments = all_comments
+        out_of_diff_count = 0
+    else:
+        comments, out_of_diff_count = filter_comments_to_diff(all_comments, changed_lines)
+
     summary = build_review_summary(
         reports,
         new_violations,
@@ -66,6 +182,7 @@ def build_review_payload(
         duration_seconds=duration_seconds,
         baseline_available=baseline_available,
         artifact_url=artifact_url,
+        out_of_diff_count=out_of_diff_count,
     )
     verdict = determine_verdict(new_violations)
 

--- a/src/quodeq/ci/review_builder.py
+++ b/src/quodeq/ci/review_builder.py
@@ -76,8 +76,14 @@ def build_review_summary(
     duration_seconds: int | None = None,
     baseline_available: bool = True,
     artifact_url: str | None = None,
+    out_of_diff_count: int = 0,
 ) -> str:
-    """Build the review body summarizing all dimension results."""
+    """Build the review body summarizing all dimension results.
+
+    out_of_diff_count: number of violations that were found but fell outside
+    the PR's changed lines. They can't be posted as line-anchored comments
+    (GitHub would 422); this count is surfaced in the body so reviewers know.
+    """
     lines = ["## Quodeq Evaluation", ""]
 
     if not baseline_available:
@@ -118,6 +124,13 @@ def build_review_summary(
         minutes = duration_seconds // 60
         seconds = duration_seconds % 60
         lines.append(f"_Evaluation completed in {minutes}m {seconds}s_")
+
+    if out_of_diff_count > 0:
+        lines.append("")
+        lines.append(
+            f"_{out_of_diff_count} additional violation(s) found outside the PR diff — "
+            "see the full evaluation artifact._"
+        )
 
     if artifact_url is not None:
         lines.append("")

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -84,7 +84,7 @@ def test_handle_report_loads_baseline(tmp_path):
 
     from quodeq.ci.cli import _handle_report
 
-    # Create fake current report
+    # Create fake current report. Line numbers match the mocked PR diff below.
     current_eval = tmp_path / "current"
     current_eval.mkdir()
     (current_eval / "security.json").write_text(json.dumps({
@@ -92,8 +92,8 @@ def test_handle_report_loads_baseline(tmp_path):
         "overallScore": "7.5/10",
         "overallGrade": "B",
         "violations": [
-            {"file": "a.py", "snippet": "eval(x)", "severity": "critical", "title": "Eval", "reason": "Bad"},
-            {"file": "a.py", "snippet": "exec(y)", "severity": "high", "title": "Exec", "reason": "Bad"},
+            {"file": "a.py", "line": 1, "snippet": "eval(x)", "severity": "critical", "title": "Eval", "reason": "Bad"},
+            {"file": "a.py", "line": 2, "snippet": "exec(y)", "severity": "high", "title": "Exec", "reason": "Bad"},
         ],
         "totals": {"violationCount": 2, "severity": {"critical": 1, "major": 1, "minor": 0}},
     }))
@@ -106,7 +106,7 @@ def test_handle_report_loads_baseline(tmp_path):
         "overallScore": "7.5/10",
         "overallGrade": "B",
         "violations": [
-            {"file": "a.py", "snippet": "eval(x)", "severity": "critical", "title": "Eval", "reason": "Bad"},
+            {"file": "a.py", "line": 1, "snippet": "eval(x)", "severity": "critical", "title": "Eval", "reason": "Bad"},
         ],
         "totals": {"violationCount": 1, "severity": {"critical": 1, "major": 0, "minor": 0}},
     }))
@@ -127,7 +127,9 @@ def test_handle_report_loads_baseline(tmp_path):
         captured_payload.update(kwargs["payload"])
         return {"id": 1}
 
-    with patch("quodeq.ci.reporter.post_review", side_effect=fake_post):
+    # Mock the PR-diff fetch so both violation lines are in-scope for comments.
+    with patch("quodeq.ci.reporter.post_review", side_effect=fake_post), \
+         patch("quodeq.ci.reporter.fetch_pr_changed_lines", return_value={"a.py": {1, 2}}):
         exit_code = _handle_report(args)
 
     assert exit_code == 0

--- a/tests/ci/test_pr_diff_filter.py
+++ b/tests/ci/test_pr_diff_filter.py
@@ -1,0 +1,275 @@
+"""Tests for PR-diff-aware filtering of review comments.
+
+Root cause of prior `Quodeq Review` 422 failures: review comments referenced
+paths/lines outside the PR's actual diff, which GitHub rejects with
+"Path could not be resolved" / "Line could not be resolved".
+
+These tests cover the fix: fetch the PR's changed lines, parse the patch
+hunks, filter comments to in-diff scope before posting.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.ci.reporter import (
+    _parse_hunks,
+    build_review_payload,
+    fetch_pr_changed_lines,
+    filter_comments_to_diff,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_hunks — extract RIGHT-side line numbers from a unified diff patch
+# ---------------------------------------------------------------------------
+
+def test_parse_hunks_empty_patch() -> None:
+    assert _parse_hunks("") == set()
+    assert _parse_hunks(None) == set()
+
+
+def test_parse_hunks_simple_hunk_with_additions_and_context() -> None:
+    """A hunk starting at new_start=10 with 2 context + 1 addition + 1 context
+    covers lines 10, 11, 12, 13 on the RIGHT side."""
+    patch_text = (
+        "@@ -10,3 +10,4 @@\n"
+        " context line at 10\n"
+        " context line at 11\n"
+        "+added line at 12\n"
+        " context line at 13\n"
+    )
+    assert _parse_hunks(patch_text) == {10, 11, 12, 13}
+
+
+def test_parse_hunks_skips_removed_lines() -> None:
+    """Removed lines (starting with '-') are LEFT-only; they don't advance
+    the RIGHT-side counter and are not included in the set."""
+    patch_text = (
+        "@@ -20,3 +20,2 @@\n"
+        " context line at 20\n"
+        "-removed line (was line 21 on LEFT; not on RIGHT)\n"
+        " context line at 21\n"
+    )
+    assert _parse_hunks(patch_text) == {20, 21}
+
+
+def test_parse_hunks_multiple_hunks_union() -> None:
+    patch_text = (
+        "@@ -1,1 +1,2 @@\n"
+        " a\n"
+        "+b\n"
+        "@@ -50,1 +51,1 @@\n"
+        "+new line at 51\n"
+    )
+    assert _parse_hunks(patch_text) == {1, 2, 51}
+
+
+def test_parse_hunks_ignores_no_newline_marker() -> None:
+    """The `\\ No newline at end of file` marker must not advance the counter."""
+    patch_text = (
+        "@@ -1,1 +1,1 @@\n"
+        "-old\n"
+        "+new\n"
+        "\\ No newline at end of file\n"
+    )
+    assert _parse_hunks(patch_text) == {1}
+
+
+# ---------------------------------------------------------------------------
+# fetch_pr_changed_lines — call GitHub /pulls/<n>/files and build the map
+# ---------------------------------------------------------------------------
+
+def test_fetch_pr_changed_lines_single_page() -> None:
+    files_response = [
+        {
+            "filename": "src/a.py",
+            "patch": "@@ -5,0 +5,2 @@\n+line 5 added\n+line 6 added\n",
+        },
+        {
+            "filename": "src/b.py",
+            "patch": "@@ -100,1 +100,1 @@\n-old\n+replacement at 100\n",
+        },
+    ]
+    with patch("quodeq.ci.reporter._github_get") as mock_get:
+        mock_get.return_value = files_response
+        result = fetch_pr_changed_lines("quodeq", "quodeq", 42, "ghp_test")
+    assert result == {"src/a.py": {5, 6}, "src/b.py": {100}}
+    mock_get.assert_called_once()
+
+
+def test_fetch_pr_changed_lines_paginates() -> None:
+    page1 = [{"filename": f"f{i}.py", "patch": f"@@ -1,1 +1,1 @@\n+x\n"} for i in range(100)]
+    page2 = [{"filename": "last.py", "patch": "@@ -1,1 +1,1 @@\n+last\n"}]
+    with patch("quodeq.ci.reporter._github_get") as mock_get:
+        mock_get.side_effect = [page1, page2]
+        result = fetch_pr_changed_lines("o", "r", 1, "tok")
+    assert len(result) == 101
+    assert "last.py" in result
+    assert mock_get.call_count == 2
+
+
+def test_fetch_pr_changed_lines_skips_files_without_patch() -> None:
+    """Binary files (no `patch` in response) are skipped entirely."""
+    files_response = [
+        {"filename": "image.png"},  # binary, no patch key
+        {"filename": "text.py", "patch": "@@ -1,0 +1,1 @@\n+hi\n"},
+    ]
+    with patch("quodeq.ci.reporter._github_get") as mock_get:
+        mock_get.return_value = files_response
+        result = fetch_pr_changed_lines("o", "r", 1, "t")
+    assert result == {"text.py": {1}}
+
+
+# ---------------------------------------------------------------------------
+# filter_comments_to_diff — drop comments outside the PR's changed lines
+# ---------------------------------------------------------------------------
+
+def test_filter_comments_to_diff_keeps_in_diff() -> None:
+    comments = [
+        {"path": "src/a.py", "line": 10, "body": "issue in diff"},
+    ]
+    changed = {"src/a.py": {10, 11, 12}}
+    kept, dropped = filter_comments_to_diff(comments, changed)
+    assert kept == comments
+    assert dropped == 0
+
+
+def test_filter_comments_to_diff_drops_out_of_diff_path() -> None:
+    comments = [
+        {"path": "src/a.py", "line": 10, "body": "in diff"},
+        {"path": "src/z.py", "line": 10, "body": "NOT in diff"},
+    ]
+    changed = {"src/a.py": {10}}
+    kept, dropped = filter_comments_to_diff(comments, changed)
+    assert len(kept) == 1
+    assert kept[0]["path"] == "src/a.py"
+    assert dropped == 1
+
+
+def test_filter_comments_to_diff_drops_out_of_diff_line() -> None:
+    comments = [
+        {"path": "src/a.py", "line": 10, "body": "in diff"},
+        {"path": "src/a.py", "line": 999, "body": "in file but wrong line"},
+    ]
+    changed = {"src/a.py": {10}}
+    kept, dropped = filter_comments_to_diff(comments, changed)
+    assert len(kept) == 1
+    assert kept[0]["line"] == 10
+    assert dropped == 1
+
+
+def test_filter_comments_to_diff_drops_comments_with_no_line() -> None:
+    """Comments missing a `line` key can't be anchored to a diff position."""
+    comments = [
+        {"path": "src/a.py", "body": "no line info"},
+    ]
+    changed = {"src/a.py": {1, 2, 3}}
+    kept, dropped = filter_comments_to_diff(comments, changed)
+    assert kept == []
+    assert dropped == 1
+
+
+# ---------------------------------------------------------------------------
+# build_review_payload — integrates the filter when changed_lines is provided
+# ---------------------------------------------------------------------------
+
+def test_build_review_payload_filters_when_changed_lines_provided() -> None:
+    reports = [{
+        "dimension": "security",
+        "overallScore": "7/10",
+        "overallGrade": "B",
+        "violations": [
+            {"file": "src/a.py", "line": 10, "title": "in diff", "reason": "", "severity": "minor"},
+            {"file": "src/z.py", "line": 99, "title": "out of diff", "reason": "", "severity": "minor"},
+        ],
+        "totals": {"violationCount": 2, "severity": {"minor": 2}},
+    }]
+    payload = build_review_payload(reports, changed_lines={"src/a.py": {10}})
+    assert len(payload["comments"]) == 1
+    assert payload["comments"][0]["path"] == "src/a.py"
+
+
+def test_build_review_payload_summary_mentions_out_of_diff_count() -> None:
+    reports = [{
+        "dimension": "security",
+        "overallScore": "7/10",
+        "overallGrade": "B",
+        "violations": [
+            {"file": "src/z.py", "line": 99, "title": "out of diff", "reason": "", "severity": "major"},
+        ],
+        "totals": {"violationCount": 1, "severity": {"major": 1}},
+    }]
+    payload = build_review_payload(reports, changed_lines={})  # empty diff → all dropped
+    assert payload["comments"] == []
+    # Summary body should mention the dropped count so users aren't misled.
+    assert "outside the pr diff" in payload["body"].lower()
+
+
+def test_build_review_payload_no_filter_when_changed_lines_is_none() -> None:
+    """Backward compat: when changed_lines is not passed, all comments included."""
+    reports = [{
+        "dimension": "security",
+        "overallScore": "7/10",
+        "overallGrade": "B",
+        "violations": [
+            {"file": "src/a.py", "line": 10, "title": "x", "reason": "", "severity": "minor"},
+        ],
+        "totals": {"violationCount": 1, "severity": {"minor": 1}},
+    }]
+    payload = build_review_payload(reports)
+    assert len(payload["comments"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI fallback — fetch failure must still produce a summary-only review
+# ---------------------------------------------------------------------------
+
+def test_cli_handle_report_falls_back_on_fetch_failure(tmp_path, capsys) -> None:
+    """When fetch_pr_changed_lines raises, post a summary-only review (no crash)."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from quodeq.ci.cli import _handle_report
+
+    eval_dir = tmp_path / "eval"
+    eval_dir.mkdir()
+    (eval_dir / "security.json").write_text(json.dumps({
+        "dimension": "security",
+        "overallScore": "7/10",
+        "overallGrade": "B",
+        "violations": [
+            {"file": "a.py", "line": 5, "title": "T", "reason": "R", "severity": "major"},
+        ],
+        "totals": {"violationCount": 1, "severity": {"major": 1}},
+    }))
+
+    args = MagicMock()
+    args.evaluation_dir = str(eval_dir)
+    args.baseline_dir = None
+    args.owner = "o"
+    args.repo = "r"
+    args.pr = 1
+    args.token = "fake"
+    args.duration = 5
+    args.artifact_url = None
+
+    captured = {}
+
+    def fake_post(**kwargs):
+        captured.update(kwargs["payload"])
+        return {"id": 99}
+
+    with patch(
+        "quodeq.ci.reporter.fetch_pr_changed_lines",
+        side_effect=RuntimeError("simulated fetch failure"),
+    ), patch("quodeq.ci.reporter.post_review", side_effect=fake_post):
+        exit_code = _handle_report(args)
+
+    assert exit_code == 0, "fetch failure must NOT abort the report command"
+    # Fallback behavior: comments dropped, summary still posted.
+    assert captured["comments"] == []
+    assert "## Quodeq Evaluation" in captured["body"]
+    # Stderr mentions the fallback so operators see the warning.
+    assert "could not fetch PR diff" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
Two coordinated fixes for the Quodeq Review workflow, which has been failing on every PR and polluting the dashboard.

### 1. Filter review comments to PR-diff scope (fixes 422)
`POST /pulls/{n}/reviews` was being called with a comment per violation, no diff awareness. GitHub rejects the whole review with HTTP 422 when any comment's path/line isn't in the PR's diff ("Path could not be resolved" / "Line could not be resolved"). With hundreds of findings scattered across the repo, every review failed.

- New helper: `fetch_pr_changed_lines(owner, repo, pr, token)` — paginates `GET /pulls/<id>/files`, parses each file's unified-diff patch, returns `{filename: set[int of RIGHT-side lines in hunks]}`.
- New helper: `filter_comments_to_diff(comments, changed_lines)` — drops comments whose path/line falls outside the diff (+ drops comments missing the required `line` key).
- `build_review_payload(... changed_lines=...)` threads the filter through; summary body mentions the count of out-of-diff findings so reviewers aren't misled.
- `_handle_report` CLI fetches the PR diff, passes it through, falls back to a summary-only review on fetch failure instead of crashing the whole action.

### 2. PR runs stop polluting the dashboard
PR evaluations were writing to `$HOME/.quodeq/evaluations` — the dashboard's source-of-truth store. Transient PR entries appeared in the UI; if a PR run crashed, a stale entry lingered.

- PR evaluations now write to `$RUNNER_TEMP/quodeq-pr-eval` (ephemeral, per-job, runner-cleaned). A crashed PR run leaks nothing.
- `project_index.json` from the dashboard is copied into the ephemeral dir so the PR run resolves to the same project UUID as the nightlies — baseline lookup across stores still works.
- Baseline lookup now explicitly reads the dashboard store (`$DASHBOARD_EVAL_DIR/$PROJECT_UUID/`), not the PR output dir. Nightlies are the source of truth, by design.

## Test plan
- [x] `uv run pytest` — 2042 passing (+16 new tests: 5 for hunk parsing, 3 for PR-file fetch, 4 for comment filtering, 3 for payload integration, 1 for CLI fetch-failure fallback)
- [x] Existing `test_cli.py::test_handle_report_loads_baseline` updated to mock `fetch_pr_changed_lines`; still passes
- [x] Manual: open a test PR against this branch; Quodeq Review action runs to completion, posts a review with in-diff comments only, no 422, `~/.quodeq/evaluations/` unchanged after the workflow.
- [x] Manual: verify nightly workflow still writes to `~/.quodeq/evaluations/` (unchanged — only the review workflow was touched).
- [x] Manual: kill a running PR workflow mid-scan; verify no stale entry appears in the dashboard.

## Non-blocking follow-ups
- The ephemeral dir + index-copy approach works but creates a subtle coupling to `project_index.json` schema. If that file's format changes, the cross-store UUID resolution breaks. A more robust long-term fix would pass project identity (remote URL) to quodeq directly via a CLI flag and skip the index-file dance.
- PR runs that produce violations outside the PR diff currently surface them only as a count in the summary. A future improvement could emit a collapsible "All findings" table in the body with the first N out-of-diff entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)