### PR TITLE
fix(ci): avoid apostrophe in bash parameter-expansion default

### DIFF
--- a/.github/workflows/quodeq-review.yml
+++ b/.github/workflows/quodeq-review.yml
@@ -121,11 +121,11 @@ jobs:
             --output "$PR_EVAL_DIR"
           echo "duration=$(( $(date +%s) - START ))" >> "$GITHUB_OUTPUT"
 
-      - name: Locate this run's evaluation output
+      - name: Locate this runs evaluation output
         id: eval_dir
         run: |
           # PR_EVAL_DIR is ephemeral and starts empty; the single freshly-
-          # written evaluation dir is this run's output.
+          # written evaluation dir is the output of this workflow run.
           NEW_DIR=$(find "$PR_EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | head -1)
           if [[ -z "$NEW_DIR" ]]; then
             echo "No evaluation directory produced in $PR_EVAL_DIR" >&2
@@ -141,7 +141,11 @@ jobs:
           BASELINE=$(find "$DASHBOARD_EVAL_DIR/$PROJECT_UUID" -path "*/evaluation" -type d 2>/dev/null | sort | tail -1)
           echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
           echo "Current:  $NEW_DIR"
-          echo "Baseline: ${BASELINE:-<none (nightly hasn't run yet for this project)>}"
+          if [[ -n "$BASELINE" ]]; then
+            echo "Baseline: $BASELINE"
+          else
+            echo "Baseline: <none - no nightly has run yet for this project>"
+          fi
 
       - name: Post PR review
         env:


### PR DESCRIPTION
## Summary
The `Locate this run's evaluation output` step in the Quodeq Review workflow (introduced by #258) fails on PRs where no nightly baseline exists yet:

```
line 18: unexpected EOF while looking for matching `''`
Current:  /Users/.../evaluation
Error: Process completed with exit code 2.
```

The `Current:` line prints successfully, then bash chokes on the next line.

## Root cause
```bash
echo "Baseline: ${BASELINE:-<none (nightly hasn't run yet for this project)>}"
```

The default value inside a `${var:-default}` expansion is not a fully-sealed context — bash performs parameter/command/arithmetic expansion there, and apostrophes are still quote-parsing significant in some bash versions (including macOS default bash 3.2 on the self-hosted runner). The `'` in `hasn't` opens a single-quote state that is never closed.

The bug only fires when `BASELINE` is empty (first PR on a project with no nightly yet); PRs with an existing baseline never evaluate the default, which is why #258 passed its tests but failed in production.

## Fix
Replace the parameter-expansion default with an explicit `if/else`:

```bash
if [[ -n "$BASELINE" ]]; then
  echo "Baseline: $BASELINE"
else
  echo "Baseline: <none - no nightly has run yet for this project>"
fi
```

No apostrophe, no parameter-expansion tricks. Also dropped the apostrophe in the step name (belt-and-suspenders — step names are YAML metadata, but this keeps the workflow grep-friendly and avoids any future toolchain quirk).

## Test plan
- [x] Open a test PR against a project with no nightly baseline → workflow runs to completion, "Baseline: <none...>" prints, review posts successfully.
- [x] Re-run a PR that previously failed with the quoting error → now completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)