### PR TITLE
polish: batch cleanup (arch docs, actionlint, deprecation, test gaps, scoring reconcile)

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,32 @@
+name: Workflow Lint
+
+# Catches bash mistakes in GitHub Actions workflows BEFORE they ship.
+# actionlint validates GH Actions YAML and shellchecks inline `run:` blocks
+# natively — it would have caught the apostrophe-in-parameter-default bug
+# from #260 (line 18: unexpected EOF while looking for matching `'`).
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [develop, main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install actionlint
+        run: |
+          bash <(curl -sfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest .
+          ./actionlint -version
+
+      - name: Run actionlint on all workflows
+        run: ./actionlint -color -verbose

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,3 +43,94 @@ config/        -> stdlib, shared/
 - Public APIs live in the parent `__init__.py` with re-exports for backward compatibility.
 - Frozen dataclasses for data transfer objects.
 - `services/ports.py` is the single boundary between services and data layers.
+
+## Runtime State Model
+
+Each evaluation has a directory under `~/.quodeq/evaluations/<project_uuid>/<run_id>/`. The files together describe the run's state; no single file is load-bearing.
+
+### Per-run files
+
+| File | Writer | Role |
+|---|---|---|
+| `status.json` | CLI (`shared/run_status.py`) | **Authoritative lifecycle state.** Atomic write-tmp-then-rename. Schema-versioned. |
+| `.heartbeat` | CLI (`shared/run_heartbeat.py`) | Empty file whose mtime is the liveness signal. Touched every 5s while `state ∈ {running, finalizing}`. |
+| `.pid` | CLI (`_cli_evaluation.py`) | OS PID. Used by the cancel flow (`services/_external_jobs.py`) to deliver SIGTERM. |
+| `evidence/manifest.json` | Analysis engine | Scan inputs. Presence marks "a run was started." |
+| `evidence/<dim>_evidence.jsonl` | Subagent pool | Per-dimension findings stream. |
+| `evaluation/<dim>.json` | Scoring engine | Per-dimension report (the UI's "report" artifact). |
+| `run.log` | CLI + dashboard subprocess | Verbatim stderr tee. Consumed by the live-terminal SSE endpoint and for historical replay. |
+| `scan.json` | Report assembly | Aggregate report (legacy lifecycle signal; superseded by `status.json`). |
+
+### Process-wide state
+
+- **`~/.quodeq/index.db`** (SQLite, WAL) — one row per run. Mirrors `status.json` for fast dashboard queries. **Derived state** — delete at any time; rebuilt on next dashboard read via `services/run_index.sync_index`.
+- **`JobManager`** (`services/jobs.py`) — in-memory registry of dashboard-spawned subprocesses. Authoritative for live progress of UI-started runs (log ring-buffer, phase markers). Per-process; evaporates on API restart.
+
+## Lifecycle State Machine
+
+```
+pending ─► running ─► finalizing ─► done
+            │            │
+            ├────────────┴──────► failed     (exception)
+            │            │
+            └────────────┴──────► cancelled  (signal / atexit / stale-detected)
+```
+
+States defined in `shared/run_status.py::RunState`. Terminal states (`done`, `failed`, `cancelled`) are sticky — never re-entered.
+
+**Guarantee matrix** (in `shared/run_lifecycle.py::RunLifecycleContext`):
+
+| Exit cause | Final state | `exit_reason` |
+|---|---|---|
+| Normal completion | `done` | `null` |
+| `AnalysisError` / `EvaluationError` | `failed` | `exception: <ClassName>` |
+| SIGINT / SIGTERM / SIGHUP | `cancelled` | `signal_SIGINT` / `signal_SIGTERM` / `signal_SIGHUP` |
+| atexit fallback | `cancelled` | `atexit_unfinalized` |
+| SIGKILL / power-off | (uncatchable) → caught by heartbeat staleness | `stale_detected` |
+
+Stale detection runs inside `services/_index_sync._check_stale_and_promote` during `sync_index`: if `state ∈ {running, finalizing}` AND `.heartbeat` > 30s old AND the PID is dead, the dashboard promotes to `cancelled(stale_detected)` by calling `write_status` on the run directory — so the resolution is durable across dashboard sessions.
+
+## Data Flow — Dashboard Request
+
+```
+GET /api/evaluations
+  → FilesystemActionProvider.list_evaluations
+  → sync_index(db, evaluations_root)          (upsert changed rows, stale-check non-terminals)
+  → list_runs(db) → [RunRow, ...]
+  → _run_row_to_snapshot → [JobSnapshot, ...]
+  → merge in-memory JobManager jobs           (dashboard-spawned live jobs override)
+  → JSON response
+```
+
+## Data Flow — Live Terminal
+
+```
+Evaluator process (CLI or subprocess)
+  ├─► stderr ────► run.log (tee via RunLogWriter + RunLogHandler)
+  └─► stdout markers {"_cc": ...} ─► JobManager phase updates (filtered out of run.log)
+
+Dashboard
+  ├─► probes GET /api/jobs/<id>/logs?since=0  (404 → placeholder, skip SSE)
+  └─► opens  GET /api/jobs/<id>/logs/stream   (SSE: replay + tail; `event: done` on terminal)
+```
+
+## Key Design Rules
+
+1. **`status.json` is authoritative.** The index never holds state not derivable from `status.json` + filesystem signals. Delete `index.db` → next read rebuilds.
+2. **PR evaluations don't write to the dashboard store.** The `quodeq-review.yml` workflow sets `--output $RUNNER_TEMP/quodeq-pr-eval`, so PR runs stay ephemeral. The dashboard's source of truth is nightly runs.
+3. **Signal handlers in `RunLifecycleContext` cover every exit mode except SIGKILL.** SIGKILL + heartbeat staleness together close the loop.
+4. **Legacy runs (pre-Plan-A, no `status.json`) are synthesized in the index only.** The filesystem is a pure audit log — we never mutate historical artifacts.
+
+## Key Files (quick map)
+
+| Concern | File |
+|---|---|
+| State machine | `src/quodeq/shared/run_status.py` |
+| Heartbeat | `src/quodeq/shared/run_heartbeat.py` |
+| Lifecycle context (signals + atexit + exc) | `src/quodeq/shared/run_lifecycle.py` |
+| Run log writer | `src/quodeq/shared/run_log.py` |
+| SQLite index + sync | `src/quodeq/services/run_index.py`, `_index_sync.py` |
+| Provider (DB-backed) | `src/quodeq/services/filesystem.py` |
+| In-memory jobs | `src/quodeq/services/jobs.py` |
+| Live terminal SSE | `src/quodeq/api/_log_stream_routes.py` |
+| Live terminal UI | `src/quodeq/ui/src/features/evaluation/components/LiveTerminal.jsx` |

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -229,10 +229,19 @@ class FsEvaluationMixin:
         return self._jobs.get_job(job_id, reports_root=reports_root)
 
     def cancel_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
-        """Cancel a running evaluation job and score any completed dimensions."""
+        """Cancel a running evaluation job and score any completed dimensions.
+
+        Uses ``self.get_evaluation_status`` rather than a bare
+        ``self._jobs.get_job`` so that external runs (``ext-`` prefix) also
+        resolve correctly via the SQLite index (Plan B1 override on
+        ``FilesystemActionProvider``). Before this, ``get_job`` returned
+        ``None`` for ``ext-`` ids and the scoring block was dead for them.
+        ``_score_completed_evidence`` is idempotent (skips dimensions whose
+        report file already exists), so double-firing with the route-level
+        scoring in ``_evaluation_routes`` is a no-op.
+        """
         reports_root = Path(reports_dir) if reports_dir else None
-        # Get job info before cancellation (supports ext- prefix)
-        job = self._jobs.get_job(job_id, reports_root=reports_root)
+        job = self.get_evaluation_status(job_id, reports_dir=reports_dir)
         ok = self._jobs.cancel_job(job_id, reports_root=reports_root)
         if ok and reports_dir and job:
             _score_completed_evidence(reports_dir, {

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -204,9 +204,17 @@ class JobManager:
 
         External runs are served via the SQLite index, not JobManager. The
         ``reports_root`` kwarg is retained for signature compatibility with
-        callers that still pass it; it is ignored here.
+        callers that still pass it; it is deprecated and ignored.
         """
-        _ = reports_root  # intentional: retained for compat, not used
+        if reports_root is not None:
+            import warnings
+            warnings.warn(
+                "JobManager.list_jobs(reports_root=...) is deprecated and ignored. "
+                "External runs are now served via FilesystemActionProvider + the "
+                "SQLite index; pass reports_root=None (or omit the kwarg).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         with self._lock:
             internal = [job.to_dict() for job in self._store.list()]
         # Preserve existing ordering (newest first).

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test 'src/**/*.test.js'",
+    "test:ui": "vitest run",
+    "test:all": "npm run test && npm run test:ui",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/src/quodeq/ui/vitest.config.js
+++ b/src/quodeq/ui/vitest.config.js
@@ -7,5 +7,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.js'],
+    // Only discover component/JSX tests. Pure-JS utility tests in `.test.js`
+    // files use Node's native `node:test` runner (see `npm test`) and must
+    // be excluded here so vitest doesn't mis-report them as failed suites.
+    include: ['**/*.test.jsx'],
   },
 });

--- a/tests/api/test_index_backed_provider.py
+++ b/tests/api/test_index_backed_provider.py
@@ -89,3 +89,65 @@ def test_provider_list_repeated_call_works(tmp_path, monkeypatch) -> None:
     jobs = provider.list_evaluations(limit=0, reports_dir=reports)
     assert len(jobs) >= 1
     assert any(j.job_id == "ext-rA" for j in jobs)
+
+
+def test_list_evaluations_internal_job_overrides_index_row(tmp_path, monkeypatch) -> None:
+    """When JobManager has an in-memory job with the same job_id as an index
+    row, the in-memory version wins. Covers the Plan B1 precedence rule that
+    had no explicit test before.
+
+    Scenario: a dashboard-spawned job is running live (fresh `status="running"`,
+    live logs in JobManager). Separately, the SQLite index has a stale row for
+    the same job_id (e.g., from an earlier sync that picked up the run_dir).
+    The authoritative live state must come from JobManager, not the index.
+    """
+    from unittest.mock import MagicMock
+    from quodeq.shared.run_status import RunState, write_status
+    from quodeq.services.filesystem import FilesystemActionProvider
+    from quodeq.core.types.job import JobSnapshot
+
+    reports = tmp_path / "reports"
+    # Seed an index row for job-id "internal-42" — as if the index already
+    # knew about this run from a prior sync.
+    run = reports / "p" / "internal-42"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evidence" / "manifest.json").write_text("{}")
+    write_status(
+        run, state=RunState.RUNNING, job_id="internal-42",
+        started_at="2026-04-20T00:00:00+00:00", dimensions=[],
+    )
+
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(reports))
+
+    # Stub JobManager.list_jobs to return the authoritative in-memory snapshot
+    # with RICHER data (phase="analyzing", current_dimension="security") — the
+    # index-synced row wouldn't have those because sync_index reads status.json
+    # which is stale.
+    live_snapshot = JobSnapshot(
+        job_id="internal-42",
+        status="running",
+        started_at="2026-04-20T00:00:00+00:00",
+        phase="analyzing",
+        current_dimension="security",
+        source="internal",
+    )
+    fake_jobs = MagicMock()
+    fake_jobs.list_jobs.return_value = [live_snapshot]
+
+    provider = FilesystemActionProvider(
+        job_manager=fake_jobs,
+        index_db_path=tmp_path / "idx.db",
+    )
+    jobs = provider.list_evaluations(limit=0, reports_dir=reports)
+
+    by_id = {j.job_id: j for j in jobs}
+    result = by_id.get("internal-42")
+    assert result is not None, f"internal-42 missing from merged list: {by_id.keys()}"
+    # The in-memory snapshot won — phase/current_dimension carry through.
+    assert result.phase == "analyzing"
+    assert result.current_dimension == "security"
+    assert result.source == "internal"
+    # And JobManager.list_jobs was called with reports_root=None (new contract
+    # after the deprecation warning).
+    fake_jobs.list_jobs.assert_called_once()
+    assert fake_jobs.list_jobs.call_args.kwargs.get("reports_root") is None

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -277,6 +277,39 @@ class TestCancelEvaluation:
         result = m.cancel_evaluation("j1")
         assert result is True
 
+    def test_cancel_scores_external_jobs_via_get_evaluation_status(self):
+        """External (ext-) cancels must still score completed dimensions.
+
+        Before this refactor, cancel_evaluation used self._jobs.get_job which
+        returns None for ext- ids after Plan B2, so the scoring block was dead
+        for externals. Now it goes through self.get_evaluation_status, which
+        the FilesystemActionProvider overrides to resolve ext- ids via the
+        SQLite index. This test mocks that override pattern on the mixin
+        itself.
+        """
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        # Simulate Plan B2 behavior: JobManager.get_job returns None for ext-.
+        m._jobs.get_job.return_value = None
+        # Simulate the FilesystemActionProvider override: get_evaluation_status
+        # resolves ext- via the index and returns a real snapshot.
+        ext_snapshot = JobSnapshot(
+            job_id="ext-run-42", status="running",
+            output_project="proj-uuid", output_run_id="run-42",
+        )
+        with patch.object(FsEvaluationMixin, "get_evaluation_status", return_value=ext_snapshot), \
+             patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score:
+            result = m.cancel_evaluation("ext-run-42", reports_dir="/reports")
+        assert result is True
+        mock_score.assert_called_once()
+        # Scoring was passed the snapshot's project/run ids, proving it came
+        # from get_evaluation_status (not the dead get_job path).
+        call_args = mock_score.call_args
+        assert call_args.args[0] == "/reports"
+        assert call_args.args[1]["outputProject"] == "proj-uuid"
+        assert call_args.args[1]["outputRunId"] == "run-42"
+
 
 class TestScoreFailedEvaluation:
     def test_returns_false_for_running_job(self):

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -389,3 +389,31 @@ class TestMonitorProcess:
         mgr._monitor_process("j1", proc)
         assert job.exit_code == _EXIT_CODE_TIMEOUT
         assert job.status == STATUS_FAILED
+
+
+def test_list_jobs_warns_on_deprecated_reports_root_kwarg(tmp_path):
+    """Passing reports_root= to list_jobs emits DeprecationWarning and is ignored.
+
+    External runs have been served via the SQLite index since Plan B1/B2;
+    this kwarg was left for transitional compat and should stop being used.
+    """
+    import warnings
+    from quodeq.services.jobs import JobManager, InMemoryJobStore
+
+    mgr = JobManager(job_store=InMemoryJobStore())
+
+    # No warning when kwarg is omitted.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        mgr.list_jobs()  # must not raise
+
+    # DeprecationWarning when kwarg is passed — ignored value is safe (empty list).
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        result = mgr.list_jobs(reports_root=tmp_path)
+    assert result == []
+    assert any(
+        issubclass(w.category, DeprecationWarning)
+        and "reports_root" in str(w.message)
+        for w in caught
+    ), f"expected DeprecationWarning about reports_root, got: {[str(w.message) for w in caught]}"


### PR DESCRIPTION
## Summary
Six small independent polish items surfaced during reviews of the lifecycle/terminal work. Each has its own commit; none depend on the others. Ordered roughly by audience: infra first, code next, docs last.

### Commits

**1. `ci: add actionlint workflow`** — `actionlint` runs shellcheck on every `run:` block in workflow files. Would have caught the apostrophe-in-parameter-default bug from #260 statically at PR time.

**2. `chore(ui): isolate vitest from node:test files`** — `vitest run` was reporting 6 "failed" files on every run because it was picking up the pre-existing `.test.js` files that use Node's native `node:test` runner. Restricted vitest discovery to `**/*.test.jsx`. Added `test:ui` (vitest only) and `test:all` (both runners) npm scripts. Existing `npm test` unchanged.

**3. `refactor(jobs): DeprecationWarning on JobManager.list_jobs(reports_root=)`** — After Plan B2 removed the external-merge branch from `list_jobs`, the kwarg became silently ignored. Now it emits `DeprecationWarning` when passed. New test asserts the warning fires when the kwarg is passed and NOT when omitted.

**4. `test: assert JobManager in-memory job overrides matching index row`** — Plan B1 established this precedence rule; no test covered it. Added a focused test using a stubbed `JobManager.list_jobs` returning a live snapshot with richer state, seeded an index row for the same `job_id`, asserted the merged list carries the in-memory version's `phase`/`current_dimension`. Also asserts `list_jobs` is called with `reports_root=None` per the new contract.

**5. `refactor(mixin): cancel_evaluation uses get_evaluation_status for ext-`** — Plan B1 reviewer flagged that `cancel_evaluation`'s scoring block was dead for external runs (`_jobs.get_job("ext-…")` returns `None` after Plan B2). Now routes through `self.get_evaluation_status`, which the provider overrides to resolve ext- via the index. `_score_completed_evidence` is idempotent so the route-level scoring path remains a safe no-op on second call. New test `test_cancel_scores_external_jobs_via_get_evaluation_status` covers the ext- path explicitly.

**6. `docs(arch): document runtime state model, lifecycle, and data flows`** — `ARCHITECTURE.md` previously described layer/import/conventions only and predated all the Plan A/B work. Appended sections covering: per-run file inventory (`status.json`, `.heartbeat`, `.pid`, `run.log`, evidence/evaluation dirs), process-wide state (`index.db`, `JobManager`), lifecycle state machine + guarantee matrix, dashboard request and live-terminal data flows, four key design rules, and a 'where is X implemented' quick map.

## Test plan
- [x] `uv run pytest` — 2051 passing (+3 from baseline: 1 deprecation, 1 precedence, 1 ext- cancel)
- [x] `npm run test:ui` — 2 passed files, 13 tests (no more phantom 'failed' entries)
- [x] `npm test` (node:test) — 0 failures
- [x] `npm run build` — exits 0
- [x] Manual: push a PR that modifies `.github/workflows/**` → actionlint runs, flags any shell issues
- [x] Manual: check `ARCHITECTURE.md` renders cleanly on GitHub

## Non-blocking follow-ups (deliberately not in this PR)
- Profile `sync_index` at scale; memoize filesystem walks if the hot path becomes noticeable.
- Consider removing `node:test` files entirely and migrating their assertions to vitest (unifies runners; adds jsdom as unnecessary overhead for pure-JS util tests, so keep split for now).
- Future: write a `quodeq doctor` / health-check command that verifies `status.json` is writable, `index.db` schema is current, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)