### PR TITLE
fix(ci): clear remaining actionlint finding in enforce-main-source

### DIFF
--- a/.github/workflows/enforce-main-source.yml
+++ b/.github/workflows/enforce-main-source.yml
@@ -10,8 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR source is develop or release
+        # SOURCE is passed via env (not ${{ }} interpolation) so bash treats
+        # the branch name as data — prevents script injection if a branch
+        # name contains shell metacharacters.
+        env:
+          SOURCE: ${{ github.head_ref }}
         run: |
-          SOURCE="${{ github.head_ref }}"
           if [ "$SOURCE" = "develop" ] || [[ "$SOURCE" == release/* ]]; then
             echo "Source branch '$SOURCE' is allowed. OK."
           else


### PR DESCRIPTION
## Summary

- actionlint flagged `.github/workflows/enforce-main-source.yml:13` after the workflow-lint action landed in #261.
- `${{ github.head_ref }}` was interpolated directly into an inline bash script — a branch name like `foo\$(rm -rf ~)` would be evaluated by the shell. Classic script-injection vector on PRs to `main`.
- Fix per [GitHub's secure-use guide](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks): pass the ref through the step's `env:` block so bash reads it as data (`$SOURCE`), not code.

This is the last finding blocking the Workflow Lint check; #262 cleared the nightly/review files but missed this one (pre-existing).

## Test plan

- [x] Ran `actionlint 1.7.12` locally against all 8 workflows — 0 findings.
- [ ] CI: Workflow Lint check should go green on this PR.