### PR TITLE
feat: PR diff mode (scoped analysis + evidence-only reporting)

### DIFF
--- a/.github/workflows/quodeq-review.yml
+++ b/.github/workflows/quodeq-review.yml
@@ -22,6 +22,9 @@ on:
       pool_budget:
         description: "Pool budget in seconds"
         default: "180"
+      base_ref:
+        description: "Base ref to diff against (for workflow_dispatch)"
+        default: "origin/develop"
 
 # GITHUB_TOKEN permissions — needed to post PR reviews via the GitHub API.
 # Default token is read-only; pull-requests:write enables review creation.
@@ -59,26 +62,13 @@ jobs:
 
       - name: Set up ephemeral PR eval directory
         run: |
-          # PR reviews MUST NOT pollute the dashboard store. The dashboard's
-          # source of truth is nightly evaluations in $DASHBOARD_EVAL_DIR.
-          # PR runs write to a runner-temp dir that vanishes with the job —
-          # this also guarantees that if the PR run crashes, no stale entry
-          # leaks into the dashboard.
-          DASHBOARD_EVAL_DIR="${EVAL_DIR:-$HOME/.quodeq/evaluations}"
-          DASHBOARD_EVAL_DIR="${DASHBOARD_EVAL_DIR/#\~/$HOME}"
-          echo "DASHBOARD_EVAL_DIR=$DASHBOARD_EVAL_DIR" >> "$GITHUB_ENV"
-
+          # PR evaluations are ephemeral — they write to a runner-temp dir
+          # that vanishes with the job. Diff mode doesn't use the dashboard
+          # store for baselines, so we no longer copy project_index.json.
           PR_EVAL_DIR="$RUNNER_TEMP/quodeq-pr-eval"
           rm -rf "$PR_EVAL_DIR"  # guard against leftovers from prior invocations
           mkdir -p "$PR_EVAL_DIR"
           echo "PR_EVAL_DIR=$PR_EVAL_DIR" >> "$GITHUB_ENV"
-
-          # Copy the project_index.json from the dashboard store so quodeq
-          # resolves the PR run to the SAME project UUID the nightlies use.
-          # This lets us find the nightly baseline by UUID below.
-          if [[ -f "$DASHBOARD_EVAL_DIR/project_index.json" ]]; then
-            cp "$DASHBOARD_EVAL_DIR/project_index.json" "$PR_EVAL_DIR/project_index.json"
-          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -91,23 +81,37 @@ jobs:
 
       - name: Determine parameters
         id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER_EVENT: ${{ github.event.pull_request.number }}
+          DIMS_INPUT: ${{ github.event.inputs.dimensions }}
+          POOL_INPUT: ${{ github.event.inputs.pool_budget }}
+          BASE_REF_INPUT: ${{ github.event.inputs.base_ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             {
-              echo "pr=${{ github.event.pull_request.number }}"
+              echo "pr=$PR_NUMBER_EVENT"
               echo "dimensions=sec"
               echo "pool_budget=180"
+              echo "base_ref=origin/$PR_BASE_REF"
             } >> "$GITHUB_OUTPUT"
           else
             {
-              echo "pr=${{ github.event.inputs.pr_number }}"
-              echo "dimensions=${{ github.event.inputs.dimensions }}"
-              echo "pool_budget=${{ github.event.inputs.pool_budget }}"
+              echo "pr=$PR_NUMBER_INPUT"
+              echo "dimensions=$DIMS_INPUT"
+              echo "pool_budget=$POOL_INPUT"
+              echo "base_ref=${BASE_REF_INPUT:-origin/develop}"
             } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run evaluation
         id: eval
+        env:
+          BASE_REF: ${{ steps.params.outputs.base_ref }}
+          DIMS: ${{ steps.params.outputs.dimensions }}
+          POOL_BUDGET: ${{ steps.params.outputs.pool_budget }}
         run: |
           START=$(date +%s)
 
@@ -119,9 +123,9 @@ jobs:
           trap 'kill $HEART 2>/dev/null || true' EXIT
 
           uv run quodeq evaluate . \
-            --incremental \
-            --dimensions "${{ steps.params.outputs.dimensions }}" \
-            --pool-budget "${{ steps.params.outputs.pool_budget }}" \
+            --diff-from "$BASE_REF" \
+            --dimensions "$DIMS" \
+            --pool-budget "$POOL_BUDGET" \
             --max-duration 120 \
             --n-subagents "${N_SUBAGENTS:-3}" \
             --output "$PR_EVAL_DIR"
@@ -130,46 +134,35 @@ jobs:
       - name: Locate this runs evaluation output
         id: eval_dir
         run: |
-          # PR_EVAL_DIR is ephemeral and starts empty; the single freshly-
-          # written evaluation dir is the output of this workflow run.
-          NEW_DIR=$(find "$PR_EVAL_DIR" -path "*/evaluation" -type d 2>/dev/null | head -1)
-          if [[ -z "$NEW_DIR" ]]; then
-            echo "No evaluation directory produced in $PR_EVAL_DIR" >&2
+          # Diff-mode runs write evidence/ only (no evaluation/). Find the
+          # run dir = parent of the freshly-written evidence/ directory.
+          EVIDENCE_DIR=$(find "$PR_EVAL_DIR" -path "*/evidence" -type d 2>/dev/null | head -1)
+          if [[ -z "$EVIDENCE_DIR" ]]; then
+            echo "No evidence directory produced in $PR_EVAL_DIR" >&2
             exit 1
           fi
-          echo "path=$NEW_DIR" >> "$GITHUB_OUTPUT"
-
-          # Baseline source of truth: the nightly evaluations in the dashboard
-          # store. We derive the project UUID from the current run_dir (the
-          # project_index.json copy ensures it matches the dashboard UUID)
-          # and look up the latest evaluation for that project.
-          PROJECT_UUID=$(basename "$(dirname "$(dirname "$NEW_DIR")")")
-          BASELINE=$(find "$DASHBOARD_EVAL_DIR/$PROJECT_UUID" -path "*/evaluation" -type d 2>/dev/null | sort | tail -1)
-          echo "baseline=$BASELINE" >> "$GITHUB_OUTPUT"
-          echo "Current:  $NEW_DIR"
-          if [[ -n "$BASELINE" ]]; then
-            echo "Baseline: $BASELINE"
-          else
-            echo "Baseline: <none - no nightly has run yet for this project>"
-          fi
+          RUN_DIR=$(dirname "$EVIDENCE_DIR")
+          echo "path=$RUN_DIR" >> "$GITHUB_OUTPUT"
+          echo "Run dir: $RUN_DIR"
 
       - name: Post PR review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVAL_PATH: ${{ steps.eval_dir.outputs.path }}
+          OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUM: ${{ steps.params.outputs.pr }}
+          DURATION: ${{ steps.eval.outputs.duration }}
         run: |
-          # Use an array so each flag+value is a discrete argv entry
-          # (avoids SC2086 word-splitting issues with unquoted $ARGS).
-          ARGS=(ci report
-                --evaluation-dir "${{ steps.eval_dir.outputs.path }}"
-                --owner "${{ github.repository_owner }}"
-                --repo "${{ github.event.repository.name }}"
-                --pr "${{ steps.params.outputs.pr }}"
-                --duration "${{ steps.eval.outputs.duration }}")
-          BASELINE="${{ steps.eval_dir.outputs.baseline }}"
-          if [[ -n "$BASELINE" ]]; then
-            ARGS+=(--baseline-dir "$BASELINE")
-          fi
-          uv run quodeq "${ARGS[@]}"
+          # --from-evidence: read violations from evidence JSONL (diff-mode
+          # runs skip the scoring phase, so no scored reports exist).
+          uv run quodeq ci report \
+            --evaluation-dir "$EVAL_PATH" \
+            --from-evidence \
+            --owner "$OWNER" \
+            --repo "$REPO_NAME" \
+            --pr "$PR_NUM" \
+            --duration "$DURATION"
 
       - name: Upload evaluation artifact
         if: always() && steps.eval_dir.outputs.path != ''

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -116,28 +116,42 @@ def _setup_run_dirs(args: argparse.Namespace, src: Path) -> tuple[Path, Path, Pa
 def _execute_pipeline(args: argparse.Namespace, config: RunConfig, evidence_dir: Path, evaluation_dir: Path) -> int:
     """Execute the evidence/scoring pipeline and print results.
 
+    Three modes:
+    - scoring (default): run_full → scored evaluation/<dim>.json reports
+    - --evidence-only: run() → merged <language>_evidence.json, no scoring
+    - PR diff (skip_scoring): run() → per-dimension JSONL only, no merged json, no scoring
+
     Domain errors (AnalysisError, EvaluationError) are intentionally *not*
     caught here — they propagate to _run_pipeline_with_cleanup so that
     RunLifecycleContext.__exit__ can write state=failed before the error is
     mapped to exit code 1.
     """
-    if args.evidence_only:
-        log_info("Starting evidence collection (this may take several minutes per dimension)...")
+    if args.evidence_only or config.options.skip_scoring:
+        label = "PR diff" if config.options.skip_scoring else "evidence collection"
+        log_info(f"Starting {label} (this may take several minutes per dimension)...")
         evidence = run(config)
-        out_file = evidence_dir / f"{config.language}_evidence.json"
-        try:
-            write_text(out_file, json.dumps(evidence.to_evidence_dict(), indent=2))
-        except OSError as exc:
-            log_error(f"Failed to write evidence file {out_file}: {exc}")
-            return 1
-        log_info(f"Evidence written to {out_file}")
-    else:
-        log_info("Starting evaluation (this may take several minutes per dimension)...")
-        scores = run_full(config, evaluation_dir, mode=args.mode)
-        log_info(f"Report path: {evaluation_dir}/")
-        log_info(f"Reports written to {evaluation_dir}/")
-        for dim, score in scores.items():
-            print(f"  {dim}: {score}")
+        if config.options.skip_scoring:
+            # PR diff mode: per-dimension JSONL is already written by the
+            # pipeline. No merged whole-repo artifact — PR reviews consume
+            # the JSONL directly via `ci report --from-evidence`.
+            log_info(f"PR diff evaluation complete — evidence written to {evidence_dir}/")
+        else:
+            # --evidence-only: write the merged whole-repo Evidence JSON.
+            out_file = evidence_dir / f"{config.language}_evidence.json"
+            try:
+                write_text(out_file, json.dumps(evidence.to_evidence_dict(), indent=2))
+            except OSError as exc:
+                log_error(f"Failed to write evidence file {out_file}: {exc}")
+                return 1
+            log_info(f"Evidence written to {out_file}")
+        return 0
+
+    log_info("Starting evaluation (this may take several minutes per dimension)...")
+    scores = run_full(config, evaluation_dir, mode=args.mode)
+    log_info(f"Report path: {evaluation_dir}/")
+    log_info(f"Reports written to {evaluation_dir}/")
+    for dim, score in scores.items():
+        print(f"  {dim}: {score}")
     return 0
 
 

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -24,6 +24,7 @@ from quodeq.shared.repo_handler import cleanup_cloned_repo
 from quodeq.engine._runner_markers import emit_marker
 from quodeq.shared.prereqs import check_evaluate_prereqs
 from quodeq.analysis._dimension_aliases import expand_dimension_aliases
+from quodeq.analysis._diff_resolver import DiffResolveError, resolve_diff_files
 from quodeq.shared.run_lifecycle import RunLifecycleContext
 
 # Re-export resolution helpers — keep the public API stable
@@ -168,6 +169,19 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
     subagent_model_val = _subagent_model(env=env)
     effective_ai_model = ai_model or subagent_model_val
 
+    diff_from = getattr(args, "diff_from", None)
+    incremental_file_filter: set[str] | None = None
+    skip_scoring = False
+    if diff_from:
+        try:
+            diff_files = resolve_diff_files(inputs.src, diff_from)
+        except DiffResolveError as exc:
+            log_error(f"Error: could not resolve --diff-from {diff_from!r}: {exc}")
+            raise
+        incremental_file_filter = set(diff_files)
+        skip_scoring = True
+        log_info(f"PR diff mode: {len(diff_files)} changed file(s) vs {diff_from}")
+
     return RunConfig(
         src=inputs.src,
         language=inputs.language,
@@ -187,7 +201,10 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
             consolidated=consolidated,
             pool_budget=args.pool_budget if args.pool_budget is not None else _env_int(_ENV_POOL_BUDGET, None, env=env),
             incremental=args.incremental,
+            incremental_file_filter=incremental_file_filter,
             dry_run=getattr(args, "dry_run", False),
+            diff_from=diff_from,
+            skip_scoring=skip_scoring,
         ),
     )
 

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -263,6 +263,14 @@ def _run_pipeline_with_cleanup(
 
 def run_evaluate(args: argparse.Namespace) -> int:
     """Run the evaluation pipeline."""
+    if getattr(args, "incremental", False) and getattr(args, "diff_from", None):
+        log_error(
+            "Error: --incremental and --diff-from are mutually exclusive. "
+            "--incremental is for nightly whole-repo runs; --diff-from is for "
+            "PR-scoped analysis."
+        )
+        return 1
+
     if not getattr(args, "dry_run", False):
         try:
             check_evaluate_prereqs()

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -170,17 +170,9 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
     effective_ai_model = ai_model or subagent_model_val
 
     diff_from = getattr(args, "diff_from", None)
-    incremental_file_filter: set[str] | None = None
-    skip_scoring = False
-    if diff_from:
-        try:
-            diff_files = resolve_diff_files(inputs.src, diff_from)
-        except DiffResolveError as exc:
-            log_error(f"Error: could not resolve --diff-from {diff_from!r}: {exc}")
-            raise
-        incremental_file_filter = set(diff_files)
-        skip_scoring = True
-        log_info(f"PR diff mode: {len(diff_files)} changed file(s) vs {diff_from}")
+    diff_files: set[str] | None = getattr(args, "_diff_files", None)
+    incremental_file_filter: set[str] | None = diff_files
+    skip_scoring = diff_from is not None
 
     return RunConfig(
         src=inputs.src,
@@ -298,6 +290,21 @@ def run_evaluate(args: argparse.Namespace) -> int:
     inputs = _resolve_evaluation_inputs(args)
     if inputs is None:
         return 1
+
+    # Resolve --diff-from here (not inside _build_run_config) so a
+    # DiffResolveError fails fast before any run directory is created.
+    # This keeps the lifecycle contract: once a run dir exists, its state
+    # is always written by RunLifecycleContext.
+    diff_from = getattr(args, "diff_from", None)
+    if diff_from:
+        try:
+            args._diff_files = set(resolve_diff_files(inputs.src, diff_from))
+        except DiffResolveError as exc:
+            log_error(f"Error: could not resolve --diff-from {diff_from!r}: {exc}")
+            return 1
+        log_info(f"PR diff mode: {len(args._diff_files)} changed file(s) vs {diff_from}")
+    else:
+        args._diff_files = None
 
     try:
         paths = _setup_run_dirs(args, inputs.src)

--- a/src/quodeq/analysis/_diff_resolver.py
+++ b/src/quodeq/analysis/_diff_resolver.py
@@ -1,0 +1,46 @@
+"""Resolve the set of files changed between HEAD and a base git ref.
+
+Used by PR diff mode to scope analysis to just the PR's changes. The base
+ref is the PR's target branch (e.g., ``origin/develop``). Uses
+``git merge-base`` so that changes on the base branch since the PR was
+opened are not falsely attributed to the PR.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_GIT_TIMEOUT_S = 15
+
+
+class DiffResolveError(RuntimeError):
+    """Raised when ``git diff`` against the base ref cannot be computed."""
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DiffResolveError(f"git {' '.join(args)} failed: {exc}") from exc
+    if result.returncode != 0:
+        raise DiffResolveError(
+            f"git {' '.join(args)} exited {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def resolve_diff_files(src: Path, ref: str) -> list[str]:
+    """Return files changed between ``HEAD`` and ``merge-base(ref, HEAD)``.
+
+    Deleted files (in diff but absent from ``HEAD``) are dropped — PR mode
+    only analyzes files that still exist on the PR branch.
+    """
+    base_sha = _git(["merge-base", ref, "HEAD"], src).strip()
+    if not base_sha:
+        raise DiffResolveError(f"empty merge-base output for ref {ref!r}")
+    raw = _git(["diff", "--name-only", f"{base_sha}..HEAD"], src)
+    candidates = [line.strip() for line in raw.splitlines() if line.strip()]
+    return [f for f in candidates if (src / f).is_file()]

--- a/src/quodeq/analysis/_incremental_evidence.py
+++ b/src/quodeq/analysis/_incremental_evidence.py
@@ -25,7 +25,7 @@ def save_dimension_fingerprint(
     Skipped in PR diff mode (skip_scoring=True) — PR runs don't persist any
     artifacts that would be consumed by future incremental runs.
     """
-    if getattr(config.options, "skip_scoring", False):
+    if config.options.skip_scoring:
         return
     try:
         evidence_dir = config.work_dir or config.src

--- a/src/quodeq/analysis/_incremental_evidence.py
+++ b/src/quodeq/analysis/_incremental_evidence.py
@@ -20,7 +20,13 @@ def save_dimension_fingerprint(
     config: RunConfig, dimension: str, files: list[str] | None = None,
     analyzed_files: set[str] | None = None,
 ) -> None:
-    """Save a fingerprint after any successful dimension analysis."""
+    """Save a fingerprint after any successful dimension analysis.
+
+    Skipped in PR diff mode (skip_scoring=True) — PR runs don't persist any
+    artifacts that would be consumed by future incremental runs.
+    """
+    if getattr(config.options, "skip_scoring", False):
+        return
     try:
         evidence_dir = config.work_dir or config.src
         if files is None:

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -73,6 +73,10 @@ def _run_dimensions(
 
     dimensions, ctx = load_analysis_context(config)
 
+    # Diff mode always per-dimension — consolidated/incremental loops are
+    # incompatible with evidence-only runs (no prior fingerprint, no
+    # cross-dimension scoring). Explicit branch keeps intent clear even if
+    # the consolidated fall-through later changes.
     if config.options.diff_from:
         emit_marker("setup", dimensions=dimensions)
         return run_per_dimension_loop(

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -73,6 +73,14 @@ def _run_dimensions(
 
     dimensions, ctx = load_analysis_context(config)
 
+    if config.options.diff_from:
+        emit_marker("setup", dimensions=dimensions)
+        return run_per_dimension_loop(
+            config, dimensions, ctx,
+            process_fn=_process_single_dimension,
+            on_dimension_done=on_dimension_done,
+        )
+
     if config.options.incremental:
         emit_marker("setup", dimensions=dimensions)
         return run_incremental_loop(

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -33,6 +33,11 @@ class AnalysisOptions:
     incremental: bool = False
     incremental_file_filter: set[str] | None = None
     dry_run: bool = False
+    # PR diff mode: analyze only files changed since `diff_from`.
+    # When set, skip_scoring is also set by the CLI layer so that fingerprint
+    # persistence and scoring are suppressed — PR runs are evidence-only.
+    diff_from: str | None = None
+    skip_scoring: bool = False
 
 
 @dataclass

--- a/src/quodeq/ci/_evidence_reader.py
+++ b/src/quodeq/ci/_evidence_reader.py
@@ -1,0 +1,71 @@
+"""Read violations directly from ``<dim>_evidence.jsonl`` files.
+
+Used by ``quodeq ci report --from-evidence`` in PR diff mode, where no
+scored ``evaluation/<dim>.json`` reports exist. Returns the same dict shape
+that ``build_review_payload`` consumes from the scored reports, so the
+downstream payload builder is unchanged.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def _judgment_to_violation(obj: dict) -> dict | None:
+    """Normalize a raw JSONL judgment dict into the payload-builder shape.
+
+    Returns None for non-violation verdicts or malformed rows.
+    """
+    if obj.get("t") != "violation":
+        return None
+    file = obj.get("file")
+    if not file:
+        return None
+    out: dict = {
+        "file": file,
+        "severity": obj.get("severity", "minor"),
+        "title": obj.get("w", ""),
+        "reason": obj.get("reason", ""),
+        "snippet": obj.get("snippet", ""),
+        "dimension": obj.get("d", ""),
+    }
+    line = obj.get("line")
+    if line is not None:
+        out["line"] = int(line)
+    req = obj.get("req")
+    if req:
+        out["req"] = req
+    return out
+
+
+def load_violations_from_evidence(evidence_dir: Path) -> list[dict]:
+    """Scan ``<evidence_dir>/*_evidence.jsonl`` and return normalized violations.
+
+    Malformed lines and non-violation rows are skipped silently (logged at
+    DEBUG). Missing directories return an empty list.
+    """
+    if not evidence_dir.is_dir():
+        return []
+    violations: list[dict] = []
+    for path in sorted(evidence_dir.glob("*_evidence.jsonl")):
+        try:
+            raw = path.read_text()
+        except OSError as exc:
+            _logger.debug("Could not read %s: %s", path, exc)
+            continue
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                _logger.debug("Skipping malformed line in %s: %s", path, exc)
+                continue
+            v = _judgment_to_violation(obj)
+            if v is not None:
+                violations.append(v)
+    return violations

--- a/src/quodeq/ci/cli.py
+++ b/src/quodeq/ci/cli.py
@@ -16,6 +16,7 @@ def handle_ci(args) -> int:
 
 def _handle_report(args) -> int:
     """Post evaluation results as a GitHub PR review."""
+    from quodeq.ci._evidence_reader import load_violations_from_evidence
     from quodeq.ci.reporter import (
         build_review_payload,
         fetch_pr_changed_lines,
@@ -34,22 +35,38 @@ def _handle_report(args) -> int:
         print(f"Error: evaluation directory not found: {evaluation_dir}", file=sys.stderr)
         return 1
 
-    reports = load_evaluation_reports(evaluation_dir)
-    if not reports:
-        print("No evaluation reports found, skipping review.", file=sys.stderr)
-        return 0
+    from_evidence = getattr(args, "from_evidence", False)
 
-    baseline_violations: list[dict] = []
-    baseline_available = False
-    if args.baseline_dir:
-        baseline_dir = Path(args.baseline_dir)
-        if baseline_dir.is_dir():
-            baseline_reports = load_evaluation_reports(baseline_dir)
-            for r in baseline_reports:
-                baseline_violations.extend(r.get("violations", []))
-            baseline_available = True
-        else:
-            print(f"Warning: baseline directory not found: {baseline_dir}", file=sys.stderr)
+    if from_evidence:
+        # Evidence mode: read raw JSONL, no scored reports, no baseline.
+        violations = load_violations_from_evidence(evaluation_dir / "evidence")
+        if not violations:
+            print("No findings from evidence; posting no review.", file=sys.stderr)
+            return 0
+        reports = [{
+            "dimension": "pr-diff",
+            "violations": violations,
+            "overallScore": "N/A",
+            "overallGrade": "N/A",
+        }]
+        baseline_violations: list[dict] = []
+        baseline_available = False
+    else:
+        reports = load_evaluation_reports(evaluation_dir)
+        if not reports:
+            print("No evaluation reports found, skipping review.", file=sys.stderr)
+            return 0
+        baseline_violations = []
+        baseline_available = False
+        if args.baseline_dir:
+            baseline_dir = Path(args.baseline_dir)
+            if baseline_dir.is_dir():
+                baseline_reports = load_evaluation_reports(baseline_dir)
+                for r in baseline_reports:
+                    baseline_violations.extend(r.get("violations", []))
+                baseline_available = True
+            else:
+                print(f"Warning: baseline directory not found: {baseline_dir}", file=sys.stderr)
 
     artifact_url: str | None = getattr(args, "artifact_url", None)
 

--- a/src/quodeq/ci/cli.py
+++ b/src/quodeq/ci/cli.py
@@ -39,10 +39,10 @@ def _handle_report(args) -> int:
 
     if from_evidence:
         # Evidence mode: read raw JSONL, no scored reports, no baseline.
+        # Always produce a report tuple — even with zero violations, we post
+        # an approving review so the PR shows "Quodeq ran and found nothing"
+        # rather than silence (which CI cannot distinguish from "job broken").
         violations = load_violations_from_evidence(evaluation_dir / "evidence")
-        if not violations:
-            print("No findings from evidence; posting no review.", file=sys.stderr)
-            return 0
         reports = [{
             "dimension": "pr-diff",
             "violations": violations,

--- a/src/quodeq/ci/review.py
+++ b/src/quodeq/ci/review.py
@@ -10,7 +10,6 @@ import time
 from pathlib import Path
 
 from quodeq.analysis._dimension_aliases import expand_dimension_aliases
-from quodeq.ci.reporter import build_review_payload, load_evaluation_reports, post_review
 from quodeq.shared.utils import get_evaluations_dir
 
 _logger = logging.getLogger(__name__)
@@ -95,10 +94,16 @@ def get_repo_info() -> tuple[str, str]:
 
 
 def snapshot_run_dirs(output_dir: Path) -> set[Path]:
-    """Snapshot existing evaluation run directories."""
+    """Snapshot existing run directories (those containing an evidence/ subdir).
+
+    Both full/incremental runs and diff-mode runs write ``evidence/``, so
+    globbing on it catches every run shape. Diff-mode runs do not write
+    ``evaluation/``, so the old "glob on evaluation" approach would miss
+    them.
+    """
     if not output_dir.exists():
         return set()
-    return {p for p in output_dir.rglob("evaluation") if p.is_dir()}
+    return {p.parent for p in output_dir.rglob("evidence") if p.is_dir()}
 
 
 def handle_review(args) -> int:
@@ -117,32 +122,27 @@ def handle_review(args) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    # Determine output dir (use default or user-specified)
     output_dir = Path(getattr(args, "output", None) or get_evaluations_dir())
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Snapshot existing runs before evaluation
     baseline_runs = snapshot_run_dirs(output_dir)
 
-    # Build evaluate args and call run_evaluate directly
     from quodeq.cli_parser import build_parser
     eval_parser_argv = [
         "evaluate", ".",
-        "--incremental",
+        "--diff-from", f"origin/{base_branch}",
         "--output", str(output_dir),
     ]
     dims = getattr(args, "dimensions", None)
     if dims:
         eval_parser_argv.extend(["--dimensions", expand_dimension_aliases(dims)])
-    # Pool budget default (short for local dev)
     pool_budget = getattr(args, "pool_budget", None) or 300
     eval_parser_argv.extend(["--pool-budget", str(pool_budget)])
 
     parser = build_parser()
     eval_args = parser.parse_args(eval_parser_argv)
 
-    dims_label = eval_args.dimensions if eval_args.dimensions else "all"
-    print(f"Running evaluation ({dims_label})...")
+    print(f"Running PR diff evaluation (base: origin/{base_branch})...")
     start = time.time()
     from quodeq._cli_evaluation import run_evaluate
     exit_code = run_evaluate(eval_args)
@@ -152,43 +152,34 @@ def handle_review(args) -> int:
         print(f"Evaluation failed with exit code {exit_code}", file=sys.stderr)
         return exit_code
 
-    # Find the new run (set difference)
     all_runs = snapshot_run_dirs(output_dir)
     new_runs = all_runs - baseline_runs
     if not new_runs:
         print("Error: no new evaluation directory produced.", file=sys.stderr)
         return 1
-    # Latest new run by mtime
-    current_eval_dir = max(new_runs, key=lambda p: p.stat().st_mtime)
+    current_run_dir = max(new_runs, key=lambda p: p.stat().st_mtime)
+    evidence_dir = current_run_dir / "evidence"
 
-    # Baseline: latest pre-existing run (if any)
-    baseline_eval_dir = None
-    baseline_available = False
-    if baseline_runs:
-        baseline_eval_dir = max(baseline_runs, key=lambda p: p.stat().st_mtime)
-        baseline_available = True
+    from quodeq.ci._evidence_reader import load_violations_from_evidence
+    violations = load_violations_from_evidence(evidence_dir)
 
-    # Load reports
-    current_reports = load_evaluation_reports(current_eval_dir)
-    baseline_violations: list[dict] = []
-    if baseline_eval_dir:
-        for r in load_evaluation_reports(baseline_eval_dir):
-            baseline_violations.extend(r.get("violations", []))
+    reports = [{
+        "dimension": "pr-diff",
+        "violations": violations,
+        "overallScore": "N/A",
+        "overallGrade": "N/A",
+    }]
 
-    # Build payload
+    from quodeq.ci.reporter import build_review_payload
     payload = build_review_payload(
-        current_reports,
-        baseline_violations=baseline_violations,
+        reports,
+        baseline_violations=[],
         duration_seconds=duration,
-        baseline_available=baseline_available,
+        baseline_available=False,
     )
 
-    # Summarize findings
-    total_violations = sum(len(r.get("violations", [])) for r in current_reports)
-    new_count = sum(1 for c in payload.get("comments", []) if "NEW" in c.get("body", ""))
-    existing_count = len(payload.get("comments", [])) - new_count
-    print(f"Evaluation complete: {total_violations} violation(s) total "
-          f"({new_count} new, {existing_count} pre-existing)")
+    total_violations = len(violations)
+    print(f"Evaluation complete: {total_violations} violation(s) found in diff")
     print(f"Verdict: {payload['event']}")
 
     if getattr(args, "dry_run", False):
@@ -197,13 +188,13 @@ def handle_review(args) -> int:
         print("--- end review body ---")
         return 0
 
-    # Get token and post
     try:
         token = get_github_token()
     except ReviewError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
+    from quodeq.ci.reporter import post_review
     print(f"Posting review to {owner}/{repo} PR #{pr_number}...")
     post_review(owner=owner, repo=repo, pr_number=pr_number, payload=payload, token=token)
     print(f"Review posted to https://github.com/{owner}/{repo}/pull/{pr_number}")

--- a/src/quodeq/ci/review.py
+++ b/src/quodeq/ci/review.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import subprocess
 import sys
 import time

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -81,6 +81,16 @@ def _add_evaluate_args(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Skip AI calls and generate placeholder findings (for CI pipeline testing)",
     )
+    parser.add_argument(
+        "--diff-from",
+        default=None,
+        metavar="REF",
+        help=(
+            "PR mode: analyze only files changed since <ref> (e.g., "
+            "origin/develop). Mutually exclusive with --incremental. "
+            "Produces evidence only — no scored evaluation reports."
+        ),
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -124,6 +124,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--artifact-url",
         help="URL to the workflow run page where the evaluation artifact can be downloaded (optional)",
     )
+    report_parser.add_argument(
+        "--from-evidence",
+        action="store_true",
+        dest="from_evidence",
+        help=(
+            "Read violations from <evaluation-dir>/evidence/<dim>_evidence.jsonl "
+            "instead of scored evaluation/<dim>.json reports. Use for PR diff "
+            "mode runs that skip the scoring phase."
+        ),
+    )
 
     review_parser = subparsers.add_parser(
         "review",

--- a/tests/analysis/test_diff_mode_pipeline.py
+++ b/tests/analysis/test_diff_mode_pipeline.py
@@ -1,0 +1,93 @@
+"""Pipeline dispatch for diff mode — must skip incremental loop and fingerprint save."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.analysis._pipeline import _run_dimensions
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.manifest_models import SourceManifest
+from quodeq.core.evidence.model import Evidence
+
+
+def _minimal_config(diff_from: str | None, skip_scoring: bool, incremental: bool = False) -> RunConfig:
+    manifest = SourceManifest()
+    return RunConfig(
+        src=Path("/tmp"),
+        language="python",
+        manifest=manifest,
+        dimensions_data={"applies": [{"id": "security"}]},
+        options=AnalysisOptions(
+            diff_from=diff_from,
+            skip_scoring=skip_scoring,
+            incremental=incremental,
+            incremental_file_filter={"a.py"} if diff_from else None,
+            consolidated=False,
+            max_subagents=1,
+        ),
+    )
+
+
+def _fake_evidence() -> Evidence:
+    return Evidence(
+        repository="/tmp",
+        language="python",
+        date="2026-04-21T00:00:00+00:00",
+        source_file_count=1,
+        files_read=1,
+        coverage_pct=100.0,
+    )
+
+
+def test_diff_mode_uses_per_dimension_loop_not_incremental() -> None:
+    """diff_from set: the incremental loop must NOT be used (no baseline)."""
+    config = _minimal_config(diff_from="main", skip_scoring=True)
+    with patch("quodeq.analysis._pipeline.run_incremental_loop") as incr, \
+         patch("quodeq.analysis._pipeline.run_per_dimension_loop") as per, \
+         patch("quodeq.analysis._pipeline.load_analysis_context") as ctx:
+        ctx.return_value = (["security"], type("C", (), {"total": 1})())
+        per.return_value = {"security": _fake_evidence()}
+        _run_dimensions(config)
+    incr.assert_not_called()
+    per.assert_called_once()
+
+
+def test_incremental_mode_uses_incremental_loop() -> None:
+    """Baseline: --incremental path remains unchanged."""
+    config = _minimal_config(diff_from=None, skip_scoring=False, incremental=True)
+    with patch("quodeq.analysis._pipeline.run_incremental_loop") as incr, \
+         patch("quodeq.analysis._pipeline.run_per_dimension_loop") as per, \
+         patch("quodeq.analysis._pipeline.load_analysis_context") as ctx:
+        ctx.return_value = (["security"], type("C", (), {"total": 1})())
+        incr.return_value = {"security": _fake_evidence()}
+        _run_dimensions(config)
+    incr.assert_called_once()
+    per.assert_not_called()
+
+
+def test_save_dimension_fingerprint_is_noop_when_skip_scoring(tmp_path: Path) -> None:
+    """The underlying save_dimension_fingerprint must short-circuit in diff mode.
+
+    Gating here (not at call sites) covers all callers: _process_single_dimension,
+    _run_dry_run, etc.
+    """
+    from quodeq.analysis._incremental_evidence import save_dimension_fingerprint
+
+    config = _minimal_config(diff_from="main", skip_scoring=True)
+    config.work_dir = tmp_path
+    # With skip_scoring True, no fingerprint file should be written.
+    save_dimension_fingerprint(config, "security")
+    assert not list(tmp_path.glob("*_fingerprint.json"))
+
+
+def test_save_dimension_fingerprint_writes_when_not_skip_scoring(tmp_path: Path) -> None:
+    """Baseline: normal mode must still write the fingerprint."""
+    from quodeq.analysis._incremental_evidence import save_dimension_fingerprint
+
+    config = _minimal_config(diff_from=None, skip_scoring=False)
+    config.work_dir = tmp_path
+    # Patch the underlying save_fingerprint so we don't exercise the full
+    # fingerprint-build path (which requires source files on disk).
+    with patch("quodeq.analysis._incremental_evidence.save_fingerprint") as real_save:
+        save_dimension_fingerprint(config, "security", files=[], analyzed_files=set())
+    real_save.assert_called_once()

--- a/tests/analysis/test_diff_mode_pipeline.py
+++ b/tests/analysis/test_diff_mode_pipeline.py
@@ -73,7 +73,9 @@ def test_save_dimension_fingerprint_is_noop_when_skip_scoring(tmp_path: Path) ->
     """
     from quodeq.analysis._incremental_evidence import save_dimension_fingerprint
 
-    config = _minimal_config(diff_from="main", skip_scoring=True)
+    # Isolate on skip_scoring specifically: leave diff_from=None so the gate
+    # can only be reading skip_scoring, not diff_from.
+    config = _minimal_config(diff_from=None, skip_scoring=True)
     config.work_dir = tmp_path
     # With skip_scoring True, no fingerprint file should be written.
     save_dimension_fingerprint(config, "security")

--- a/tests/analysis/test_diff_resolver.py
+++ b/tests/analysis/test_diff_resolver.py
@@ -1,0 +1,70 @@
+"""Tests for resolve_diff_files."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._diff_resolver import DiffResolveError, resolve_diff_files
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=str(cwd), check=True, capture_output=True)
+
+
+def _init_repo_with_base_and_changes(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], repo)
+    _run(["git", "config", "user.email", "t@t"], repo)
+    _run(["git", "config", "user.name", "t"], repo)
+    (repo / "keep.py").write_text("a = 1\n")
+    (repo / "drop.py").write_text("b = 2\n")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "base"], repo)
+    _run(["git", "checkout", "-q", "-b", "feature"], repo)
+    (repo / "new.py").write_text("c = 3\n")
+    (repo / "keep.py").write_text("a = 99\n")
+    (repo / "drop.py").unlink()
+    _run(["git", "add", "-A"], repo)
+    _run(["git", "commit", "-q", "-m", "change"], repo)
+    return repo
+
+
+def test_returns_added_and_modified_files(tmp_path: Path) -> None:
+    repo = _init_repo_with_base_and_changes(tmp_path)
+    result = resolve_diff_files(repo, "main")
+    assert set(result) == {"new.py", "keep.py"}
+
+
+def test_drops_deleted_files(tmp_path: Path) -> None:
+    repo = _init_repo_with_base_and_changes(tmp_path)
+    result = resolve_diff_files(repo, "main")
+    assert "drop.py" not in result
+
+
+def test_empty_diff_returns_empty_list(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], repo)
+    _run(["git", "config", "user.email", "t@t"], repo)
+    _run(["git", "config", "user.name", "t"], repo)
+    (repo / "f.py").write_text("x = 1\n")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "only"], repo)
+    result = resolve_diff_files(repo, "main")
+    assert result == []
+
+
+def test_unknown_ref_raises_diff_resolve_error(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], repo)
+    _run(["git", "config", "user.email", "t@t"], repo)
+    _run(["git", "config", "user.name", "t"], repo)
+    (repo / "f.py").write_text("x = 1\n")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "c"], repo)
+    with pytest.raises(DiffResolveError):
+        resolve_diff_files(repo, "does-not-exist")

--- a/tests/analysis/test_options_diff_mode.py
+++ b/tests/analysis/test_options_diff_mode.py
@@ -1,0 +1,24 @@
+"""Tests for diff-mode fields on AnalysisOptions."""
+from __future__ import annotations
+
+from quodeq.analysis._types import AnalysisOptions
+
+
+def test_diff_from_defaults_to_none() -> None:
+    opts = AnalysisOptions()
+    assert opts.diff_from is None
+
+
+def test_skip_scoring_defaults_to_false() -> None:
+    opts = AnalysisOptions()
+    assert opts.skip_scoring is False
+
+
+def test_diff_from_is_storable() -> None:
+    opts = AnalysisOptions(diff_from="origin/develop")
+    assert opts.diff_from == "origin/develop"
+
+
+def test_skip_scoring_is_storable() -> None:
+    opts = AnalysisOptions(skip_scoring=True)
+    assert opts.skip_scoring is True

--- a/tests/ci/test_cli.py
+++ b/tests/ci/test_cli.py
@@ -120,6 +120,7 @@ def test_handle_report_loads_baseline(tmp_path):
     args.token = "fake"
     args.duration = 10
     args.artifact_url = None
+    args.from_evidence = False
 
     captured_payload = {}
 

--- a/tests/ci/test_evidence_reader.py
+++ b/tests/ci/test_evidence_reader.py
@@ -1,0 +1,62 @@
+"""Tests for loading violations directly from evidence JSONL."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.ci._evidence_reader import load_violations_from_evidence
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+
+
+def test_reads_violations_only(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    _write_jsonl(evidence_dir / "security_evidence.jsonl", [
+        {"p": "SEC-01", "t": "violation", "d": "security",
+         "file": "app.py", "line": 12, "severity": "high",
+         "reason": "hardcoded secret", "w": "Hardcoded token"},
+        {"p": "SEC-02", "t": "compliance", "d": "security",
+         "file": "ok.py", "line": 5},
+    ])
+    result = load_violations_from_evidence(evidence_dir)
+    assert len(result) == 1
+    v = result[0]
+    assert v["file"] == "app.py"
+    assert v["line"] == 12
+    assert v["severity"] == "high"
+    assert v["title"] == "Hardcoded token"
+
+
+def test_multiple_dimensions_aggregated(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    _write_jsonl(evidence_dir / "security_evidence.jsonl", [
+        {"p": "SEC", "t": "violation", "d": "security",
+         "file": "a.py", "line": 1, "severity": "high"},
+    ])
+    _write_jsonl(evidence_dir / "reliability_evidence.jsonl", [
+        {"p": "REL", "t": "violation", "d": "reliability",
+         "file": "b.py", "line": 2, "severity": "medium"},
+    ])
+    result = load_violations_from_evidence(evidence_dir)
+    assert len(result) == 2
+    files = {v["file"] for v in result}
+    assert files == {"a.py", "b.py"}
+
+
+def test_missing_dir_returns_empty(tmp_path: Path) -> None:
+    assert load_violations_from_evidence(tmp_path / "nope") == []
+
+
+def test_skips_malformed_lines(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "security_evidence.jsonl").write_text(
+        'not-json\n'
+        '{"p": "SEC", "t": "violation", "d": "security", "file": "x.py", "line": 1}\n'
+    )
+    result = load_violations_from_evidence(evidence_dir)
+    assert len(result) == 1
+    assert result[0]["file"] == "x.py"

--- a/tests/ci/test_pr_diff_filter.py
+++ b/tests/ci/test_pr_diff_filter.py
@@ -254,6 +254,7 @@ def test_cli_handle_report_falls_back_on_fetch_failure(tmp_path, capsys) -> None
     args.token = "fake"
     args.duration = 5
     args.artifact_url = None
+    args.from_evidence = False
 
     captured = {}
 

--- a/tests/ci/test_report_from_evidence.py
+++ b/tests/ci/test_report_from_evidence.py
@@ -1,0 +1,54 @@
+"""ci report --from-evidence reads evidence JSONL, not scored reports."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.ci.cli import _handle_report
+
+
+def _args(eval_dir: Path, from_evidence: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        ci_action="report",
+        evaluation_dir=str(eval_dir),
+        owner="o", repo="r", pr=1,
+        token="t", duration=None, baseline_dir=None,
+        artifact_url=None, from_evidence=from_evidence,
+    )
+
+
+def test_from_evidence_reads_evidence_not_scored(tmp_path: Path) -> None:
+    eval_dir = tmp_path / "run"
+    evidence_dir = eval_dir / "evidence"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security_evidence.jsonl").write_text(
+        json.dumps({
+            "p": "SEC", "t": "violation", "d": "security",
+            "file": "x.py", "line": 3, "severity": "high",
+            "w": "Hardcoded password",
+        }) + "\n"
+    )
+
+    with patch("quodeq.ci.reporter.fetch_pr_changed_lines", return_value={"x.py": {3}}), \
+         patch("quodeq.ci.reporter.post_review") as posted:
+        exit_code = _handle_report(_args(eval_dir, from_evidence=True))
+
+    assert exit_code == 0
+    assert posted.call_count == 1
+    payload = posted.call_args.kwargs["payload"]
+    assert len(payload["comments"]) == 1
+    assert payload["comments"][0]["path"] == "x.py"
+
+
+def test_from_evidence_no_findings_exits_zero_without_posting(tmp_path: Path) -> None:
+    """Empty evidence dir -> exit 0, no review posted."""
+    eval_dir = tmp_path / "run"
+    eval_dir.mkdir()
+    # No evidence/ subdir means load_violations_from_evidence returns [].
+    with patch("quodeq.ci.reporter.fetch_pr_changed_lines"), \
+         patch("quodeq.ci.reporter.post_review") as posted:
+        exit_code = _handle_report(_args(eval_dir, from_evidence=True))
+    assert exit_code == 0
+    posted.assert_not_called()

--- a/tests/ci/test_report_from_evidence.py
+++ b/tests/ci/test_report_from_evidence.py
@@ -42,13 +42,53 @@ def test_from_evidence_reads_evidence_not_scored(tmp_path: Path) -> None:
     assert payload["comments"][0]["path"] == "x.py"
 
 
-def test_from_evidence_no_findings_exits_zero_without_posting(tmp_path: Path) -> None:
-    """Empty evidence dir -> exit 0, no review posted."""
+def test_from_evidence_no_findings_posts_approving_review(tmp_path: Path) -> None:
+    """Empty evidence -> approving review with no comments (not silence).
+
+    In CI, "no findings" is the success case — PR authors must see that
+    Quodeq ran and passed, not an absence of output indistinguishable from
+    a broken job.
+    """
     eval_dir = tmp_path / "run"
     eval_dir.mkdir()
     # No evidence/ subdir means load_violations_from_evidence returns [].
-    with patch("quodeq.ci.reporter.fetch_pr_changed_lines"), \
+    with patch("quodeq.ci.reporter.fetch_pr_changed_lines", return_value={}), \
          patch("quodeq.ci.reporter.post_review") as posted:
         exit_code = _handle_report(_args(eval_dir, from_evidence=True))
     assert exit_code == 0
-    posted.assert_not_called()
+    assert posted.call_count == 1
+    payload = posted.call_args.kwargs["payload"]
+    assert payload["event"] == "APPROVE"
+    assert payload["comments"] == []
+
+
+def test_from_evidence_ignores_baseline_dir(tmp_path: Path) -> None:
+    """In evidence mode, --baseline-dir is ignored entirely.
+
+    Locks in the contract: PR diff mode is baseline-free. Even if a caller
+    mistakenly passes --baseline-dir, we must not load it.
+    """
+    eval_dir = tmp_path / "run"
+    evidence_dir = eval_dir / "evidence"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "security_evidence.jsonl").write_text(
+        json.dumps({
+            "p": "SEC", "t": "violation", "d": "security",
+            "file": "x.py", "line": 3, "severity": "high",
+            "w": "X",
+        }) + "\n"
+    )
+    baseline_dir = tmp_path / "baseline"
+    baseline_dir.mkdir()
+
+    args = _args(eval_dir, from_evidence=True)
+    args.baseline_dir = str(baseline_dir)
+
+    with patch("quodeq.ci.reporter.fetch_pr_changed_lines", return_value={"x.py": {3}}), \
+         patch("quodeq.ci.reporter.post_review"), \
+         patch("quodeq.ci.reporter.load_evaluation_reports") as loader:
+        exit_code = _handle_report(args)
+
+    assert exit_code == 0
+    # Evidence mode must not load scored reports, even for a provided baseline.
+    loader.assert_not_called()

--- a/tests/ci/test_review.py
+++ b/tests/ci/test_review.py
@@ -73,15 +73,17 @@ def test_snapshot_run_dirs_empty_when_nonexistent(tmp_path):
     assert result == set()
 
 
-def test_snapshot_run_dirs_finds_evaluation_dirs(tmp_path):
+def test_snapshot_run_dirs_finds_run_dirs_by_evidence(tmp_path):
     from quodeq.ci.review import snapshot_run_dirs
-    # Create a fake structure
-    (tmp_path / "project-a" / "run-1" / "evaluation").mkdir(parents=True)
-    (tmp_path / "project-a" / "run-2" / "evaluation").mkdir(parents=True)
-    (tmp_path / "project-a" / "run-1" / "evidence").mkdir(parents=True)  # not counted
+
+    (tmp_path / "project-a" / "run-1" / "evidence").mkdir(parents=True)
+    (tmp_path / "project-a" / "run-2" / "evidence").mkdir(parents=True)
+
     result = snapshot_run_dirs(tmp_path)
     assert len(result) == 2
-    assert all(p.name == "evaluation" for p in result)
+    # snapshot returns run dirs (parents of evidence/), not evidence dirs themselves
+    assert all(p.parent.name == "project-a" for p in result)
+    assert {p.name for p in result} == {"run-1", "run-2"}
 
 
 def test_review_subcommand_parses(tmp_path):
@@ -219,3 +221,51 @@ def test_handle_review_expands_dimension_alias(tmp_path):
 
     idx = captured_argv.index("--dimensions")
     assert captured_argv[idx + 1] == "security"
+
+
+def test_review_invokes_evaluate_with_diff_from_not_incremental(tmp_path, monkeypatch):
+    """quodeq review must call evaluate --diff-from origin/<base>, not --incremental."""
+    import argparse
+    from quodeq.ci.review import handle_review
+
+    captured_argv: list[list[str]] = []
+
+    def fake_parse_args(argv):
+        captured_argv.append(list(argv))
+        # Return a minimal namespace; run_evaluate is mocked separately.
+        return argparse.Namespace()
+
+    monkeypatch.setattr("quodeq.ci.review.detect_pr", lambda pr_override=None: (42, "develop"))
+    monkeypatch.setattr("quodeq.ci.review.get_repo_info", lambda: ("owner", "repo"))
+    monkeypatch.setattr("quodeq.ci.review.get_github_token", lambda: "t")
+    monkeypatch.setattr("quodeq.ci.review.snapshot_run_dirs", lambda d: set())
+    # run_evaluate and build_parser are imported INSIDE handle_review; patch
+    # them at their source modules so the in-function imports pick up the
+    # patches.
+    monkeypatch.setattr("quodeq._cli_evaluation.run_evaluate", lambda args: 0)
+    monkeypatch.setattr(
+        "quodeq.cli_parser.build_parser",
+        lambda: type("P", (), {"parse_args": staticmethod(fake_parse_args)})(),
+    )
+    # short-circuit the post/report stage for this test. load_violations_from_evidence
+    # is imported inside handle_review, so patch at its source.
+    monkeypatch.setattr(
+        "quodeq.ci._evidence_reader.load_violations_from_evidence",
+        lambda d: [],
+    )
+
+    args = argparse.Namespace(
+        pr=42, dimensions=None, pool_budget=None,
+        output=str(tmp_path / "out"), dry_run=True,
+    )
+
+    rc = handle_review(args)
+    # handle_review may exit 1 if no new runs are found (expected — we mock
+    # snapshot_run_dirs to return empty both before and after). We don't care
+    # about the exit code for this test; we care about the argv built for
+    # evaluate.
+    assert captured_argv, "review did not build an evaluate argv"
+    argv = captured_argv[0]
+    assert "--diff-from" in argv
+    assert "origin/develop" in argv
+    assert "--incremental" not in argv

--- a/tests/engine/test_incremental_fingerprint.py
+++ b/tests/engine/test_incremental_fingerprint.py
@@ -41,6 +41,7 @@ class TestSaveDimensionFingerprintJsonlUnion:
         config.work_dir = evidence_dir
         config.src = tmp_path
         config.options.incremental_file_filter = None
+        config.options.skip_scoring = False  # MagicMock would auto-truthy, triggering the diff-mode skip.
         config.standards_dir = None
 
         save_dimension_fingerprint(config, "security")
@@ -81,6 +82,7 @@ class TestSaveDimensionFingerprintJsonlUnion:
         config.work_dir = evidence_dir
         config.src = tmp_path
         config.options.incremental_file_filter = None
+        config.options.skip_scoring = False  # MagicMock would auto-truthy, triggering the diff-mode skip.
         config.standards_dir = None
 
         save_dimension_fingerprint(config, "security")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -49,6 +49,7 @@ class TestExecutePipeline:
         mock_run.return_value = mock_evidence
         config = MagicMock()
         config.language = "python"
+        config.options.skip_scoring = False
         result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
         assert result == 0
         mock_run.assert_called_once_with(config)
@@ -67,6 +68,7 @@ class TestExecutePipeline:
         mock_run.return_value = mock_evidence
         config = MagicMock()
         config.language = "python"
+        config.options.skip_scoring = False
         result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
         assert result == 1
         assert "Failed to write" in capsys.readouterr().err
@@ -81,6 +83,7 @@ class TestExecutePipeline:
         args = argparse.Namespace(evidence_only=False, mode="numerical")
         mock_run_full.return_value = {"security": 8.5, "reliability": 7.0}
         config = MagicMock()
+        config.options.skip_scoring = False
         result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
         assert result == 0
 
@@ -99,6 +102,7 @@ class TestExecutePipeline:
         args = argparse.Namespace(evidence_only=False, mode="numerical")
         mock_run_full.side_effect = AnalysisError("AI failed")
         config = MagicMock()
+        config.options.skip_scoring = False
         with pytest.raises(AnalysisError, match="AI failed"):
             _execute_pipeline(args, config, evidence_dir, evaluation_dir)
 

--- a/tests/test_cli_diff_from.py
+++ b/tests/test_cli_diff_from.py
@@ -1,10 +1,6 @@
 """Parser and mutex tests for --diff-from."""
 from __future__ import annotations
 
-import argparse
-
-import pytest
-
 from quodeq.cli_parser import build_parser
 
 

--- a/tests/test_cli_diff_from.py
+++ b/tests/test_cli_diff_from.py
@@ -1,0 +1,35 @@
+"""Parser and mutex tests for --diff-from."""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from quodeq.cli_parser import build_parser
+
+
+def test_diff_from_accepts_ref() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["evaluate", ".", "--diff-from", "origin/develop"])
+    assert args.diff_from == "origin/develop"
+
+
+def test_diff_from_defaults_to_none() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["evaluate", "."])
+    assert args.diff_from is None
+
+
+def test_incremental_and_diff_from_mutually_exclusive(capsys) -> None:
+    # The CLI must reject --incremental + --diff-from and exit non-zero
+    # *before* running the pipeline. run_evaluate is the enforcement point.
+    from quodeq._cli_evaluation import run_evaluate
+
+    parser = build_parser()
+    args = parser.parse_args([
+        "evaluate", ".", "--incremental", "--diff-from", "origin/develop",
+    ])
+    exit_code = run_evaluate(args)
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "--incremental" in err and "--diff-from" in err

--- a/tests/test_cli_diff_from_wiring.py
+++ b/tests/test_cli_diff_from_wiring.py
@@ -1,0 +1,83 @@
+"""Test that --diff-from populates RunConfig options correctly."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from quodeq._cli_evaluation import _build_run_config
+from quodeq._cli_resolution import ResolvedInputs
+from quodeq.analysis.manifest_models import SourceManifest
+
+
+def _make_repo_with_diff(tmp_path: Path) -> Path:
+    """One-file repo with main + feature branch that adds changed.py."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    def run(cmd: list[str]) -> None:
+        subprocess.run(cmd, cwd=str(repo), check=True, capture_output=True)
+    run(["git", "init", "-q", "-b", "main"])
+    run(["git", "config", "user.email", "t@t"])
+    run(["git", "config", "user.name", "t"])
+    (repo / "base.py").write_text("x = 1\n")
+    run(["git", "add", "."])
+    run(["git", "commit", "-q", "-m", "base"])
+    run(["git", "checkout", "-q", "-b", "feature"])
+    (repo / "changed.py").write_text("y = 2\n")
+    run(["git", "add", "."])
+    run(["git", "commit", "-q", "-m", "add changed"])
+    return repo
+
+
+def _args(repo: Path, **overrides) -> argparse.Namespace:
+    defaults = dict(
+        repo=str(repo),
+        output=str(repo / "out"),
+        language=None,
+        dimensions=None,
+        max_turns=None,
+        max_duration=None,
+        n_subagents=1,
+        no_verify=False,
+        pool_budget=None,
+        no_consolidated=False,
+        incremental=False,
+        diff_from=None,
+        dry_run=False,
+        mode="numerical",
+        evidence_only=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _inputs(repo: Path) -> ResolvedInputs:
+    # SourceManifest's modern API uses targets; an empty manifest is fine
+    # because _build_run_config only passes it through to RunConfig.
+    manifest = SourceManifest()
+    return ResolvedInputs(
+        src=repo,
+        language="python",
+        manifest=manifest,
+        dims_data={"applies": []},
+    )
+
+
+def test_diff_from_populates_file_filter_and_skip_scoring(tmp_path: Path) -> None:
+    repo = _make_repo_with_diff(tmp_path)
+    args = _args(repo, diff_from="main")
+    config = _build_run_config(args, inputs=_inputs(repo), evidence_dir=repo / "evi")
+    assert config.options.diff_from == "main"
+    assert config.options.skip_scoring is True
+    assert config.options.incremental_file_filter == {"changed.py"}
+
+
+def test_no_diff_from_leaves_file_filter_unset(tmp_path: Path) -> None:
+    repo = _make_repo_with_diff(tmp_path)
+    args = _args(repo, diff_from=None)
+    config = _build_run_config(args, inputs=_inputs(repo), evidence_dir=repo / "evi")
+    assert config.options.diff_from is None
+    assert config.options.skip_scoring is False
+    assert config.options.incremental_file_filter is None

--- a/tests/test_cli_diff_from_wiring.py
+++ b/tests/test_cli_diff_from_wiring.py
@@ -68,6 +68,7 @@ def _inputs(repo: Path) -> ResolvedInputs:
 def test_diff_from_populates_file_filter_and_skip_scoring(tmp_path: Path) -> None:
     repo = _make_repo_with_diff(tmp_path)
     args = _args(repo, diff_from="main")
+    args._diff_files = {"changed.py"}  # normally set by run_evaluate
     config = _build_run_config(args, inputs=_inputs(repo), evidence_dir=repo / "evi")
     assert config.options.diff_from == "main"
     assert config.options.skip_scoring is True
@@ -81,3 +82,37 @@ def test_no_diff_from_leaves_file_filter_unset(tmp_path: Path) -> None:
     assert config.options.diff_from is None
     assert config.options.skip_scoring is False
     assert config.options.incremental_file_filter is None
+
+
+def test_run_evaluate_fails_fast_on_unknown_diff_ref(tmp_path: Path, capsys) -> None:
+    """An unresolvable --diff-from must return 1 BEFORE any run dir is created."""
+    from quodeq._cli_evaluation import run_evaluate
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    import subprocess
+    def run(cmd: list[str]) -> None:
+        subprocess.run(cmd, cwd=str(repo), check=True, capture_output=True)
+    run(["git", "init", "-q", "-b", "main"])
+    run(["git", "config", "user.email", "t@t"])
+    run(["git", "config", "user.name", "t"])
+    (repo / "f.py").write_text("x = 1\n")
+    run(["git", "add", "."])
+    run(["git", "commit", "-q", "-m", "c"])
+
+    output = tmp_path / "out"
+    args = _args(repo, diff_from="does-not-exist", output=str(output))
+    # run_evaluate also needs a few more default attrs that _args doesn't set
+    args.no_prescan = False
+    args.branch = None
+    args.scope = None
+    # Skip AI-provider prereqs so the test exercises diff-from fail-fast,
+    # not the unrelated "no AI provider configured" check.
+    args.dry_run = True
+
+    exit_code = run_evaluate(args)
+    assert exit_code == 1
+    err = capsys.readouterr().err
+    assert "diff-from" in err or "does-not-exist" in err
+    # No run dir should have been created
+    assert not output.exists() or not any(output.rglob("evidence"))

--- a/tests/test_diff_mode_e2e.py
+++ b/tests/test_diff_mode_e2e.py
@@ -1,0 +1,86 @@
+"""End-to-end smoke test for PR diff mode via the CLI.
+
+Exercises the full ``uv run quodeq evaluate . --diff-from <ref> --dry-run``
+flow against a real ephemeral git repo. The --dry-run flag skips AI calls
+but still runs the whole pipeline: diff resolution, source file listing,
+evidence writing, lifecycle. The assertions pin the behaviors that
+define PR diff mode: evidence is produced, evaluation reports are not,
+and the --incremental / --diff-from mutex is enforced at the process
+boundary (not just at the argparse layer).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=str(cwd), check=True, capture_output=True)
+
+
+def _setup_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q", "-b", "main"], repo)
+    _run(["git", "config", "user.email", "t@t"], repo)
+    _run(["git", "config", "user.name", "t"], repo)
+    (repo / "base.py").write_text("def f(): return 1\n")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "base"], repo)
+    _run(["git", "checkout", "-q", "-b", "feature"], repo)
+    (repo / "pr_change.py").write_text("def g(): return 2\n")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "pr"], repo)
+    return repo
+
+
+def test_diff_mode_dry_run_produces_evidence_no_evaluation(tmp_path: Path) -> None:
+    """Dry-run diff mode writes evidence JSONL and no scored evaluation JSON."""
+    repo = _setup_repo(tmp_path)
+    output = tmp_path / "out"
+    result = subprocess.run(
+        [
+            "uv", "run", "quodeq", "evaluate", ".",
+            "--diff-from", "main",
+            "--dry-run",
+            "--output", str(output),
+        ],
+        cwd=str(repo), capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"stderr:\n{result.stderr}\nstdout:\n{result.stdout}"
+
+    evidence_dirs = list(output.rglob("evidence"))
+    assert evidence_dirs, (
+        f"no evidence/ dir produced; out tree:\n"
+        + "\n".join(str(p) for p in output.rglob("*"))
+    )
+    run_dir = evidence_dirs[0].parent
+
+    # Diff mode writes per-dimension JSONL (empty in dry-run — the files exist
+    # but have no rows because no AI ran). The directory-presence check is the
+    # essential invariant: downstream `ci report --from-evidence` reads this.
+    jsonl_files = list((run_dir / "evidence").glob("*_evidence.jsonl"))
+    assert jsonl_files, "no evidence JSONL files produced"
+
+    # Most importantly: no scored reports. The evaluation/ subdir may exist
+    # (created by _setup_run_dirs) but must contain no <dim>.json reports.
+    eval_dir = run_dir / "evaluation"
+    if eval_dir.exists():
+        eval_jsons = list(eval_dir.glob("*.json"))
+        assert not eval_jsons, f"unexpected scored reports in diff mode: {eval_jsons}"
+
+
+def test_diff_mode_incremental_mutex_is_enforced(tmp_path: Path) -> None:
+    """--diff-from + --incremental must return 1 at the process boundary."""
+    repo = _setup_repo(tmp_path)
+    result = subprocess.run(
+        [
+            "uv", "run", "quodeq", "evaluate", ".",
+            "--diff-from", "main", "--incremental",
+            "--output", str(tmp_path / "out"),
+        ],
+        cwd=str(repo), capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    combined = result.stdout + result.stderr
+    assert "--incremental" in combined and "--diff-from" in combined

--- a/tests/test_execute_pipeline_skip_scoring.py
+++ b/tests/test_execute_pipeline_skip_scoring.py
@@ -1,0 +1,79 @@
+"""_execute_pipeline must skip scoring when options.skip_scoring is set."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq._cli_evaluation import _execute_pipeline
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.manifest_models import SourceManifest
+from quodeq.core.evidence.model import Evidence
+
+
+def _args(tmp: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        evidence_only=False, mode="numerical", repo=str(tmp),
+    )
+
+
+def _config(skip_scoring: bool) -> RunConfig:
+    manifest = SourceManifest()
+    return RunConfig(
+        src=Path("/tmp"), language="python", manifest=manifest,
+        dimensions_data={"applies": [{"id": "security"}]},
+        options=AnalysisOptions(skip_scoring=skip_scoring),
+    )
+
+
+def _fake_evidence() -> Evidence:
+    return Evidence(
+        repository="/tmp", language="python", date="x",
+        source_file_count=1, files_read=1, coverage_pct=100.0,
+    )
+
+
+def test_skip_scoring_calls_run_not_run_full(tmp_path: Path) -> None:
+    """PR diff mode: run() is called (evidence pipeline), run_full is NOT."""
+    args = _args(tmp_path)
+    config = _config(skip_scoring=True)
+    with patch("quodeq._cli_evaluation.run", return_value=_fake_evidence()) as r, \
+         patch("quodeq._cli_evaluation.run_full") as rf:
+        exit_code = _execute_pipeline(args, config, tmp_path / "evi", tmp_path / "eval")
+    assert exit_code == 0
+    r.assert_called_once()
+    rf.assert_not_called()
+
+
+def test_skip_scoring_does_not_write_merged_json(tmp_path: Path) -> None:
+    """PR diff mode: no merged <language>_evidence.json file in the evidence dir."""
+    args = _args(tmp_path)
+    config = _config(skip_scoring=True)
+    evidence_dir = tmp_path / "evi"
+    evidence_dir.mkdir()
+    with patch("quodeq._cli_evaluation.run", return_value=_fake_evidence()):
+        _execute_pipeline(args, config, evidence_dir, tmp_path / "eval")
+    assert not (evidence_dir / "python_evidence.json").exists()
+
+
+def test_scoring_enabled_calls_run_full(tmp_path: Path) -> None:
+    """Baseline: normal mode calls run_full (scoring)."""
+    args = _args(tmp_path)
+    config = _config(skip_scoring=False)
+    with patch("quodeq._cli_evaluation.run") as r, \
+         patch("quodeq._cli_evaluation.run_full", return_value={}) as rf:
+        exit_code = _execute_pipeline(args, config, tmp_path / "evi", tmp_path / "eval")
+    assert exit_code == 0
+    rf.assert_called_once()
+
+
+def test_evidence_only_writes_merged_json(tmp_path: Path) -> None:
+    """Baseline: --evidence-only still writes the merged JSON file (existing behavior)."""
+    args = _args(tmp_path)
+    args.evidence_only = True
+    config = _config(skip_scoring=False)
+    evidence_dir = tmp_path / "evi"
+    evidence_dir.mkdir()
+    with patch("quodeq._cli_evaluation.run", return_value=_fake_evidence()):
+        _execute_pipeline(args, config, evidence_dir, tmp_path / "eval")
+    assert (evidence_dir / "python_evidence.json").exists()


### PR DESCRIPTION
## Summary

PR reviews no longer piggyback on `--incremental`. A new `--diff-from <ref>` mode on `quodeq evaluate` scopes analysis to files changed since the base ref, skips the scoring phase, and emits evidence only. `ci report --from-evidence` reads that evidence directly. Nightly is untouched.

This fixes the "analyzing all 789 files on every PR" behavior caused by the ephemeral PR eval dir having no prior fingerprint to diff against — the previous `--incremental` path degraded to a full re-analysis because its baseline lookup depends on files in the output dir.

## Semantics

| Mode | Flag | Scope | Baseline | Output |
|------|------|-------|----------|--------|
| Nightly | `--incremental` | Whole repo | Prior fingerprint in same output dir | Scored `evaluation/<dim>.json` + fingerprint |
| PR Review | `--diff-from <ref>` | Files in `git diff <merge-base>..HEAD` | None (fresh) | Evidence JSONL only — no scored reports |
| Ad-hoc | neither | Whole repo | None | Scored `evaluation/<dim>.json` |

The two modes are mutually exclusive — `run_evaluate` rejects the combination at the process boundary (before any run directory is created).

## Changes

- `analysis/_diff_resolver.py` — `resolve_diff_files(src, ref)` via `git merge-base` + `git diff --name-only`, drops deletions
- `AnalysisOptions.diff_from` + `skip_scoring` fields
- `evaluate --diff-from REF` CLI flag (mutex with `--incremental`)
- `_build_run_config` resolves the diff eagerly via `args._diff_files` (stashed by `run_evaluate` **before** any run dir exists, so `DiffResolveError` fails cleanly)
- Pipeline branches to per-dimension loop for diff mode; `save_dimension_fingerprint` short-circuits when `skip_scoring=True`
- `_execute_pipeline` skips `run_full` when `skip_scoring=True` — produces evidence JSONL only
- `ci/_evidence_reader.py::load_violations_from_evidence` reads `<dim>_evidence.jsonl` into the dict shape `build_review_payload` already consumes
- `ci report --from-evidence` routes through the evidence reader; empty-findings case now posts an approving review (CI must not be silent)
- `quodeq review` (local command) switches to `--diff-from origin/<base>` + evidence reader; `snapshot_run_dirs` globs `evidence/` instead of `evaluation/` and returns run-dir parents
- `.github/workflows/quodeq-review.yml`: swap `--incremental` → `--diff-from`, drop `project_index.json` copy and baseline lookup, add `--from-evidence`, pass `${{ github.* }}` contexts via `env:` (actionlint-clean)

## Test plan

- [x] 2083/2083 unit + integration tests pass (`uv run pytest -q`)
- [x] End-to-end smoke test (`tests/test_diff_mode_e2e.py`) exercises the full CLI pipeline via `--dry-run` on a real ephemeral git repo: asserts evidence JSONL is produced, no scored reports, and the mutex is enforced at the process boundary
- [x] `actionlint` passes clean on the updated workflow
- [x] Nightly workflow untouched — regression-tested by existing `tests/analysis/` suite (340 passing)
- [x] CI: Quodeq Review on this PR should analyze ~15 files (the actual PR diff), not the whole repo