### PR TITLE
fix(ci): drop scored-mode cruft from PR diff review body

### DIFF
--- a/src/quodeq/ci/review_builder.py
+++ b/src/quodeq/ci/review_builder.py
@@ -84,30 +84,41 @@ def build_review_summary(
     the PR's changed lines. They can't be posted as line-anchored comments
     (GitHub would 422); this count is surfaced in the body so reviewers know.
     """
+    # Diff mode is signaled by reports with unscored ("N/A") dimensions —
+    # PR diff runs skip scoring, so the per-dimension score table and the
+    # "no baseline" note (which frames absence-of-baseline as a scoring
+    # concern) don't apply. Detect from the data the caller already passes.
+    is_diff_mode = bool(reports) and all(
+        r.get("overallScore") == "N/A" for r in reports
+    )
+
     lines = ["## Quodeq Evaluation", ""]
 
-    if not baseline_available:
+    if not baseline_available and not is_diff_mode:
         lines.append(
             "> **Note:** No baseline available — this is the first run. "
             "All violations are shown as new; no baseline comparison was made."
         )
         lines.append("")
 
-    # Per-dimension scores
-    for report in reports:
-        dimension = report.get("dimension", "unknown")
-        score = report.get("overallScore", "N/A")
-        grade = report.get("overallGrade", "N/A")
-        lines.append(f"**{dimension.title()}**: {score} ({grade})")
-
-    lines.append("")
+    # Per-dimension scores (skipped in diff mode — nothing was scored).
+    if not is_diff_mode:
+        for report in reports:
+            dimension = report.get("dimension", "unknown")
+            score = report.get("overallScore", "N/A")
+            grade = report.get("overallGrade", "N/A")
+            lines.append(f"**{dimension.title()}**: {score} ({grade})")
+        lines.append("")
 
     # Violation breakdown
     new_count = len(new_violations)
     existing_count = len(existing_violations)
-    lines.append(f"🆕 **{new_count} new** violation(s) introduced by this PR")
-    if existing_count > 0:
-        lines.append(f"⚠️ **{existing_count} pre-existing** issue(s) in changed files (not introduced by this PR)")
+    if is_diff_mode:
+        lines.append(f"🔍 **{new_count} violation(s) found in PR diff**")
+    else:
+        lines.append(f"🆕 **{new_count} new** violation(s) introduced by this PR")
+        if existing_count > 0:
+            lines.append(f"⚠️ **{existing_count} pre-existing** issue(s) in changed files (not introduced by this PR)")
     lines.append("")
 
     if new_count > 0:

--- a/tests/ci/test_review_builder.py
+++ b/tests/ci/test_review_builder.py
@@ -191,3 +191,61 @@ def test_build_review_summary_no_artifact_link_when_not_provided():
     reports = [{"dimension": "security", "overallScore": "8/10", "overallGrade": "A"}]
     summary = build_review_summary(reports, [], [])
     assert "Download full report" not in summary
+
+
+# --- PR diff mode summary framing --------------------------------------------
+# Diff mode reports carry overallScore="N/A" — the sentinel synthesized by
+# `ci report --from-evidence` / `quodeq review`. `build_review_summary` reads
+# that to suppress two pieces of cruft that don't apply in diff mode:
+# 1. The per-dimension score line ("Pr-Diff: N/A (N/A)") — nothing was scored.
+# 2. The "No baseline available" note — baseline is not a concept in diff
+#    mode; the scope IS the diff.
+
+
+def test_diff_mode_suppresses_per_dimension_score_line():
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "pr-diff", "violations": [],
+                "overallScore": "N/A", "overallGrade": "N/A"}]
+    summary = build_review_summary(reports, [], [], baseline_available=False)
+    # The confusing "Pr-Diff: N/A (N/A)" line must not appear.
+    assert "Pr-Diff: N/A" not in summary
+    assert "N/A (N/A)" not in summary
+
+
+def test_diff_mode_suppresses_no_baseline_note():
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "pr-diff", "violations": [],
+                "overallScore": "N/A", "overallGrade": "N/A"}]
+    summary = build_review_summary(reports, [], [], baseline_available=False)
+    # The "No baseline available" note is wrong-framed in diff mode.
+    assert "No baseline available" not in summary
+
+
+def test_diff_mode_uses_diff_phrasing_for_violation_count():
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "pr-diff", "violations": [],
+                "overallScore": "N/A", "overallGrade": "N/A"}]
+    new = [{"severity": "high"}, {"severity": "minor"}]
+    summary = build_review_summary(reports, new, [], baseline_available=False)
+    # In diff mode there's no baseline, so "NEW vs. PR" framing is meaningless.
+    # Use "found in PR diff" phrasing instead.
+    assert "found in PR diff" in summary
+    assert "introduced by this PR" not in summary
+
+
+def test_scored_mode_preserves_existing_summary_shape():
+    """Regression guard: scored reports still get the old framing."""
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "security", "overallScore": "7.5/10", "overallGrade": "B"}]
+    summary = build_review_summary(reports, [{"severity": "high"}], [],
+                                   baseline_available=False)
+    # Per-dimension score line present
+    assert "Security" in summary and "7.5/10" in summary
+    # "No baseline" note present (it's a genuine signal in scored mode)
+    assert "No baseline available" in summary
+    # Old phrasing
+    assert "introduced by this PR" in summary


### PR DESCRIPTION
## Summary

The PR diff review posted by ``ci report --from-evidence`` was leaking two scored-mode artifacts into the summary body:

1. \`> Note: No baseline available — this is the first run. All violations are shown as new; no baseline comparison was made.\`
2. \`Pr-Diff: N/A (N/A)\`

Both are wrong-framed in diff mode:
- Baseline is not a concept — the scope IS the diff.
- Nothing was scored — diff-mode evaluations produce evidence only (no \`evaluation/<dim>.json\`).

## Fix

Detect diff mode inside \`build_review_summary\` from data the caller already passes — the synthesized \`pr-diff\` report dict sets \`overallScore="N/A"\`, which is a natural sentinel.

- Drop the per-dimension score line when all reports are unscored
- Drop the "No baseline available" note when in diff mode
- Reframe the count from \`"N new violation(s) introduced by this PR"\` to \`"N violation(s) found in PR diff"\` — the NEW/EXISTING distinction requires a baseline

All inside one function, no new parameters, no changes to \`build_review_payload\` / \`_handle_report\` / \`handle_review\`.

## Before / After

**Before (posted on #264):**
\`\`\`
## Quodeq Evaluation

> Note: No baseline available — this is the first run. All violations are shown as new; no baseline comparison was made.

Pr-Diff: N/A (N/A)

🆕 12 new violation(s) introduced by this PR

New violations by severity: 5 major, 6 minor, 1 critical

_Evaluation completed in 2m 39s_
\`\`\`

**After:**
\`\`\`
## Quodeq Evaluation

🔍 12 violation(s) found in PR diff

New violations by severity: 5 major, 6 minor, 1 critical

_Evaluation completed in 2m 39s_
\`\`\`

## Test plan

- [x] 4 new tests pin the diff-mode framing (score line suppressed, baseline note suppressed, phrasing changed)
- [x] 1 new test pins the scored-mode framing as a regression guard
- [x] Full \`tests/ci/\` suite passes (80/80)