### PR TITLE
polish: code-review follow-ups (timeouts, streaming JSONL, thread-discipline doc, sigkill test)

### DIFF
--- a/src/quodeq/ci/_evidence_reader.py
+++ b/src/quodeq/ci/_evidence_reader.py
@@ -52,20 +52,20 @@ def load_violations_from_evidence(evidence_dir: Path) -> list[dict]:
     violations: list[dict] = []
     for path in sorted(evidence_dir.glob("*_evidence.jsonl")):
         try:
-            raw = path.read_text()
+            with path.open(encoding="utf-8") as fh:
+                for raw in fh:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        _logger.debug("Skipping malformed line in %s: %s", path, exc)
+                        continue
+                    v = _judgment_to_violation(obj)
+                    if v is not None:
+                        violations.append(v)
         except OSError as exc:
             _logger.debug("Could not read %s: %s", path, exc)
             continue
-        for line in raw.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError as exc:
-                _logger.debug("Skipping malformed line in %s: %s", path, exc)
-                continue
-            v = _judgment_to_violation(obj)
-            if v is not None:
-                violations.append(v)
     return violations

--- a/src/quodeq/ci/reporter.py
+++ b/src/quodeq/ci/reporter.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 _GITHUB_API = "https://api.github.com"
 _FILES_PAGE_SIZE = 100
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+_REQUEST_TIMEOUT_SECONDS = 30.0
 
 
 def _parse_hunks(patch: str | None) -> set[int]:
@@ -65,7 +66,7 @@ def _github_get(url: str, token: str) -> list | dict:
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
-    with urlopen(req) as resp:
+    with urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
         return json.loads(resp.read())
 
 
@@ -215,7 +216,7 @@ def _github_request(url: str, payload: dict, token: str) -> dict:
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
 
     try:
-        with urlopen(req) as resp:
+        with urlopen(req, timeout=_REQUEST_TIMEOUT_SECONDS) as resp:
             return json.loads(resp.read())
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -78,8 +78,11 @@ class JobManager:
         self._lock = threading.Lock()
         self._on_job_complete = on_job_complete
         self._reports_root: Path | None = reports_root
+        # _run_log_writers and _pre_marker_buffer are owned exclusively by the
+        # per-job _consume_stream thread started in start_job(). No other code
+        # path may read or mutate these dicts — doing so reintroduces the
+        # use-after-close race that self._lock does not protect against.
         self._run_log_writers: dict[str, RunLogWriter] = {}
-        # Buffer of pre-marker lines per job, flushed once run_dir is known.
         self._pre_marker_buffer: dict[str, list[str]] = {}
 
     def set_reports_root(self, path: Path) -> None:

--- a/tests/services/test_index_sync.py
+++ b/tests/services/test_index_sync.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import sqlite3
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -158,6 +161,60 @@ def test_stale_promotion_live_pid_not_promoted(tmp_path: Path) -> None:
         row = db.execute("SELECT state FROM runs WHERE job_id = ?", ("ext-r8",)).fetchone()
         assert row[0] == "running"
     finally:
+        db.close()
+
+
+def test_stale_promotion_after_sigkill_real_subprocess(tmp_path: Path) -> None:
+    """SIGKILL leaves status.json as RUNNING — stale-promote must recover it.
+
+    Spawns a real subprocess so we get a PID that is genuinely alive, records
+    it in status.json, then `kill -9`s the process without any cleanup hook
+    running. After the heartbeat ages out, `_check_stale_and_promote` must
+    mark the run CANCELLED with exit_reason="stale_detected".
+    """
+    db = open_index(tmp_path / "idx.db")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        run = _make_run_dir(tmp_path, "p", "r10")
+        write_status(
+            run,
+            state=RunState.RUNNING,
+            job_id="ext-r10",
+            started_at="2026-04-20T00:00:00+00:00",
+            dimensions=[],
+            pid=proc.pid,
+        )
+        _upsert_from_status(db, run, project_uuid="p", run_id="r10")
+        heartbeat = run / ".heartbeat"
+        heartbeat.touch()
+
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=5)
+        deadline = time.time() + 2
+        while _is_pid_alive(proc.pid) and time.time() < deadline:
+            time.sleep(0.05)
+        assert not _is_pid_alive(proc.pid), "subprocess PID still alive after kill -9"
+
+        old = time.time() - 120
+        os.utime(heartbeat, (old, old))
+
+        promoted = _check_stale_and_promote(
+            db, run, project_uuid="p", run_id="r10", stale_seconds=30,
+        )
+        assert promoted is True
+        row = db.execute(
+            "SELECT state, exit_reason FROM runs WHERE job_id = ?",
+            ("ext-r10",),
+        ).fetchone()
+        assert row == ("cancelled", "stale_detected")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
         db.close()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1291,7 +1291,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

Follow-up hardening items surfaced by a review of `develop` vs `main`. None were blocking bugs — closing the gaps before cutting the next release.

- **`ci/reporter.py`** — 30s timeout on GitHub API `urlopen` calls so a hung connection can't block CI indefinitely.
- **`ci/_evidence_reader.py`** — stream JSONL line-by-line instead of loading the whole file. Keeps memory flat for whole-repo evidence files.
- **`services/jobs.py`** — documented the single-thread ownership invariant on `_run_log_writers` / `_pre_marker_buffer`. These dicts are mutated without `self._lock`; the safety comes from "only the per-job `_consume_stream` thread touches them." If a future refactor adds a second caller the race reappears, so the contract is now explicit.
- **`tests/services/test_index_sync.py`** — new `test_stale_promotion_after_sigkill_real_subprocess`: spawns a real subprocess, records its PID in `status.json`, `kill -9`s it (no cleanup), ages the heartbeat, and asserts `_check_stale_and_promote` marks the run `cancelled` with `exit_reason="stale_detected"`. Covers the end-to-end path the existing mocked tests don't.

`uv.lock` entry for `quodeq` bumped 1.0.5 → 1.0.6 to match `pyproject.toml` (pre-existing drift, incidentally resynced).

## Test plan

- [x] `uv run pytest` — 2084 passed (was 2083 + 1 new test)
- [x] Focused runs green: `tests/services/test_index_sync.py`, `tests/services/test_jobs_run_log.py`, `tests/test_cli_diff_from.py`, `-k evidence` (94 tests)
- [x] CI workflows (Quodeq Review + Nightly) still green on this branch