### PR TITLE
fix(ui): post-restyle polish pass (breadcrumb, state cache, theme, overview/violations/map)

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
-import NavBreadcrumb from './features/explorer/components/NavBreadcrumb.jsx';
+import NavBreadcrumb, { labelFor as navLabelFor } from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
 import FileDetailPage from './features/explorer/components/FileDetailPage.jsx';
 import PrincipleDetailPage from './features/explorer/components/PrincipleDetailPage.jsx';
@@ -244,10 +244,10 @@ function MainContent({ activePage, props }) {
 }
 
 /**
- * @param {{ sidebar: JSX.Element, header: JSX.Element|null, breadcrumb: JSX.Element|null, content: JSX.Element }} props
+ * @param {{ sidebar: JSX.Element, header: JSX.Element|null, content: JSX.Element }} props
  * @returns {JSX.Element}
  */
-function AppShell({ sidebar, header, breadcrumb, content }) {
+function AppShell({ sidebar, header, content }) {
   return (
     <div className={`app-shell${header ? ' app-shell--with-topbar' : ''}`}>
       {header && <div className="app-shell__topbar">{header}</div>}
@@ -255,7 +255,6 @@ function AppShell({ sidebar, header, breadcrumb, content }) {
         {sidebar}
         <div className="app-shell__main-column">
           <main className="dashboard">
-            {breadcrumb}
             {content}
           </main>
         </div>
@@ -372,9 +371,18 @@ export default function App() {
           evaluating={state.evalLifecycle?.job?.status === 'running'}
           onProviderClick={() => navTab('settings')}
           onMenuToggle={() => setSidebarPinned((v) => !v)}
+          breadcrumb={
+            <NavBreadcrumb
+              stack={navStack}
+              onBack={navPop}
+              onGoTo={navGoTo}
+            />
+          }
+          mobileTitle={navStack.length ? navLabelFor(navStack[navStack.length - 1]) : (activeTab || '')}
+          canGoBack={navStack.length > 1}
+          onBack={navPop}
         />
       }
-      breadcrumb={navStack.length > 1 ? <NavBreadcrumb stack={navStack} onBack={navPop} onGoTo={navGoTo} /> : null}
       content={<div className="tab-fade" key={activeTab}><MainContent activePage={activePage} props={contentProps} /></div>}
     />
   );

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import DashboardPage from './features/dashboard/components/DashboardPage.jsx';
 import NavBreadcrumb, { labelFor as navLabelFor } from './features/explorer/components/NavBreadcrumb.jsx';
 import ExplorerPage from './features/explorer/components/ExplorerPage.jsx';
@@ -25,6 +25,29 @@ import { readVisibleStandardIds } from './utils/visibleStandards.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
 
 const NO_PROJECT_TABS = ['evaluate', 'standards', 'settings', 'help'];
+
+/**
+ * Returns whether the app is currently rendering dark, taking the saved
+ * theme mode and — when it's 'system' — the OS preference into account.
+ * Kept in App so the topbar's theme toggle reflects what's on screen
+ * rather than the mode literal.
+ */
+function useEffectiveDark(themeMode) {
+  const [prefersDark, setPrefersDark] = useState(() =>
+    typeof window !== 'undefined'
+      && window.matchMedia?.('(prefers-color-scheme: dark)').matches
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e) => setPrefersDark(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+  if (themeMode === 'dark') return true;
+  if (themeMode === 'light') return false;
+  return prefersDark;
+}
 
 /**
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
@@ -280,6 +303,14 @@ export default function App() {
     [state.dashboard?.trend, state.currentOverviewRun, state.dailyRuns, state.overviewRunIndex]
   );
 
+  // Resolve whether the UI is currently rendering dark. Used by the
+  // topbar's moon/sun toggle so the icon reflects what's on-screen,
+  // not just the saved mode preference.
+  const effectiveDark = useEffectiveDark(state.settings.themeMode);
+  const toggleTheme = () => {
+    state.settings.applyMode(effectiveDark ? 'light' : 'dark');
+  };
+
   // Sidebar counts should respect the user's currently-visible standards so
   // they match the numbers shown on the Violations and History pages.
   const visibleSet = useMemo(() => new Set(readVisibleStandardIds()), []);
@@ -381,6 +412,8 @@ export default function App() {
           mobileTitle={navStack.length ? navLabelFor(navStack[navStack.length - 1]) : (activeTab || '')}
           canGoBack={navStack.length > 1}
           onBack={navPop}
+          effectiveDark={effectiveDark}
+          onToggleTheme={toggleTheme}
         />
       }
       content={<div className="tab-fade" key={activeTab}><MainContent activePage={activePage} props={contentProps} /></div>}

--- a/src/quodeq/ui/src/components/HeatGridCells.jsx
+++ b/src/quodeq/ui/src/components/HeatGridCells.jsx
@@ -1,25 +1,36 @@
-import { severityCellStyle, complianceRateCellStyle } from '../features/map/viz/core/mapColors.js';
+import { severityCellStyle, complianceRateCellStyle, severityColor, complianceRateColor } from '../features/map/viz/core/mapColors.js';
 
 const SEVERITY_LEVELS = ['critical', 'major', 'minor'];
 
 /**
  * Renders the severity + violations + health cells for a heat grid row.
  * Shared between HeatGridView (file tree) and DimensionHeatGridView (violations).
+ *
+ * The two consumers want different visual weights: the file-tree view
+ * keeps the filled "heat-map" cells, while the violations table wants a
+ * leaner text-only treatment. Pass `variant="flat"` to opt into the
+ * text-only variant.
  */
-export default function HeatGridCells({ row, onCellClick }) {
+export default function HeatGridCells({ row, onCellClick, variant = 'heat' }) {
   const total = row.violations + row.compliance;
   const rate = total > 0 ? Math.round(row.complianceRate * 100) + '%' : '—';
+  const flat = variant === 'flat';
 
   return (
     <>
       {SEVERITY_LEVELS.map((sev) => {
         const count = row.severity[sev];
         const hasValue = count > 0;
+        const style = !hasValue
+          ? undefined
+          : flat
+            ? { color: severityColor(sev) }
+            : severityCellStyle(sev);
         return (
           <td key={sev}>
             <div
               className={`heat-grid-cell${hasValue ? ' clickable' : ' empty'}`}
-              style={hasValue ? severityCellStyle(sev) : undefined}
+              style={style}
               onClick={() => hasValue && onCellClick?.({ row, severity: sev })}
               role={hasValue ? 'button' : undefined}
               aria-label={`${sev}: ${count} violation${count !== 1 ? 's' : ''} in ${row.name || 'row'}`}
@@ -41,7 +52,13 @@ export default function HeatGridCells({ row, onCellClick }) {
       <td>
         <div
           className={`heat-grid-cell${total > 0 ? ' health' : ' empty'}`}
-          style={total > 0 ? complianceRateCellStyle(row.complianceRate) : undefined}
+          style={
+            total === 0
+              ? undefined
+              : flat
+                ? { color: complianceRateColor(row.complianceRate) }
+                : complianceRateCellStyle(row.complianceRate)
+          }
         >
           {rate}
         </div>

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -177,25 +177,25 @@ export default function Sidebar({
       </nav>
 
         <nav className="sidebar-nav sidebar-block">
-          <NavButton id="overview"   label="Overview"   icon={ICON_OVERVIEW}   activeTab={activeTab} onNavTab={handleNav} />
-          <NavButton id="violations" label="Violations" icon={ICON_VIOLATIONS} activeTab={activeTab} onNavTab={handleNav} count={violationsCount} />
-          <NavButton id="map"        label="Map"        icon={ICON_MAP}        activeTab={activeTab} onNavTab={handleNav} />
-          <NavButton id="history"    label="History"    icon={ICON_HISTORY}    activeTab={activeTab} onNavTab={handleNav} count={historyCount} />
+          <NavButton id="overview"   label="overview"   icon={ICON_OVERVIEW}   activeTab={activeTab} onNavTab={handleNav} />
+          <NavButton id="violations" label="violations" icon={ICON_VIOLATIONS} activeTab={activeTab} onNavTab={handleNav} count={violationsCount} />
+          <NavButton id="map"        label="map"        icon={ICON_MAP}        activeTab={activeTab} onNavTab={handleNav} />
+          <NavButton id="history"    label="history"    icon={ICON_HISTORY}    activeTab={activeTab} onNavTab={handleNav} count={historyCount} />
         </nav>
 
         <nav className="sidebar-nav sidebar-block">
           <NavButton
             id="evaluate"
-            label="Evaluate"
+            label="evaluate"
             icon={ICON_EVALUATE}
             activeTab={activeTab}
             onNavTab={(id) => { try { localStorage.setItem(EVALUATE_DOT_DISMISSED_KEY, '1'); } catch {} handleNav(id); }}
             showDot={readyToEvaluate}
           />
-          <NavButton id="standards" label="Standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
+          <NavButton id="standards" label="standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
           <NavButton
             id="settings"
-            label="Settings"
+            label="settings"
             icon={ICON_SETTINGS}
             activeTab={activeTab}
             onNavTab={(id) => { try { localStorage.setItem(SETTINGS_DOT_DISMISSED_KEY, '1'); } catch {} handleNav(id); }}
@@ -227,7 +227,7 @@ export default function Sidebar({
             )}
           </div>
           <div className="sidebar-nav sidebar-block sidebar-block--flush">
-            <NavButton id="help" label="Help" icon={ICON_HELP} activeTab={activeTab} onNavTab={handleNav} />
+            <NavButton id="help" label="help" icon={ICON_HELP} activeTab={activeTab} onNavTab={handleNav} />
           </div>
         </div>
       </aside>

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -1,8 +1,11 @@
 /**
  * TopBar — global app header sitting above the page content.
  *
- * Layout (left → right):
- *   [ breadcrumb `project / activeTab` ]           [ live pill | model pill | ⌘K | Report | + Evaluate ]
+ * Desktop layout (left → right):
+ *   [ breadcrumb (projectName / page / …) ]        [ provider pill | Report | + Evaluate ]
+ *
+ * Mobile layout (left → right):
+ *   [ ‹ back ]  [ current page title ]                                          [ burger ]
  *
  * Stateless; the parent passes the data it has.
  */
@@ -11,28 +14,20 @@ function Dot({ ok }) {
   return <span className={`topbar-dot ${ok ? 'topbar-dot--ok' : 'topbar-dot--err'}`} aria-hidden="true" />;
 }
 
-const TAB_TITLES = {
-  overview: 'Overview',
-  violations: 'Violations',
-  map: 'Map',
-  history: 'History',
-  evaluate: 'Evaluate',
-  standards: 'Standards',
-  settings: 'Settings',
-  projects: 'Projects',
-  help: 'Help',
-  file: 'File',
-  evalprinciple: 'Principle',
-  finding: 'Finding',
-  explorer: 'Explorer',
-};
-
 function BurgerIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <line x1="3" y1="6" x2="21" y2="6" />
       <line x1="3" y1="12" x2="21" y2="12" />
       <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  );
+}
+
+function BackIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="15 18 9 12 15 6" />
     </svg>
   );
 }
@@ -49,25 +44,32 @@ export default function TopBar({
   evaluating = false,
   onProviderClick,
   onMenuToggle,
+  breadcrumb = null,
+  mobileTitle = '',
+  canGoBack = false,
+  onBack,
 }) {
-  const tabTitle = TAB_TITLES[activeTab] || activeTab || '';
   return (
     <header className="topbar">
-      {onMenuToggle && (
+      {/* Compact-mode back button. Hidden entirely at the root of the
+          nav stack — showing a disabled arrow adds visual noise without
+          giving the user anything to click. */}
+      {canGoBack && (
         <button
           type="button"
-          className="topbar-menu-btn"
-          onClick={onMenuToggle}
-          aria-label="Open menu"
+          className="topbar-back-btn"
+          onClick={onBack}
+          aria-label="Go back"
         >
-          <BurgerIcon />
+          <BackIcon />
         </button>
       )}
-      <div className="topbar-breadcrumb">
-        {projectName && <span className="topbar-breadcrumb-parent">{projectName}</span>}
-        {projectName && tabTitle && <span className="topbar-breadcrumb-sep">/</span>}
-        {tabTitle && <span className="topbar-breadcrumb-current">{tabTitle}</span>}
-      </div>
+
+      {/* Desktop: full breadcrumb chain. Mobile: just the current page title. */}
+      {breadcrumb && <div className="topbar-breadcrumb-slot">{breadcrumb}</div>}
+      <div className="topbar-mobile-title" aria-hidden={!mobileTitle}>{mobileTitle}</div>
+
+      <div className="topbar-spacer" />
 
       <div className="topbar-actions">
         {(provider || model) && (
@@ -114,6 +116,18 @@ export default function TopBar({
                 <span>Evaluate</span>
               </>
             )}
+          </button>
+        )}
+
+        {/* Burger is mobile-only and lives on the right. Desktop hides it. */}
+        {onMenuToggle && (
+          <button
+            type="button"
+            className="topbar-menu-btn"
+            onClick={onMenuToggle}
+            aria-label="Open menu"
+          >
+            <BurgerIcon />
           </button>
         )}
       </div>

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -32,6 +32,23 @@ function BackIcon() {
   );
 }
 
+function MoonIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
 export default function TopBar({
   projectName,
   activeTab,
@@ -48,6 +65,12 @@ export default function TopBar({
   mobileTitle = '',
   canGoBack = false,
   onBack,
+  /* Theme toggle — parent owns the cycle (light ↔ dark within the
+     current family). `effectiveDark` reflects what's actually showing
+     (so "system" on a light OS still renders the moon icon since the
+     next click will flip to dark). */
+  effectiveDark = false,
+  onToggleTheme,
 }) {
   return (
     <header className="topbar">
@@ -96,6 +119,17 @@ export default function TopBar({
         {onReport && (
           <button type="button" className="topbar-btn" onClick={onReport}>
             Report
+          </button>
+        )}
+        {onToggleTheme && (
+          <button
+            type="button"
+            className="topbar-btn topbar-btn--icon topbar-btn--theme"
+            onClick={onToggleTheme}
+            aria-label={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
+            title={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
+          >
+            {effectiveDark ? <SunIcon /> : <MoonIcon />}
           </button>
         )}
         {onEvaluate && (

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -129,8 +129,10 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
 
 function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, selectedDayDimNames }) {
   return (
-    <>
-      <SectionLabel>quality_dimensions · {sortedDimensions.length}</SectionLabel>
+    <section className="quality-dimensions" aria-label="Quality dimensions">
+      <div className="quality-dimensions__head">
+        <SectionLabel>quality_dimensions · {sortedDimensions.length}</SectionLabel>
+      </div>
       <div className="dimensions-panel">
         <DimensionCardsGrid
           sortedDimensions={sortedDimensions}
@@ -138,7 +140,7 @@ function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, sele
           selectedDayDimNames={selectedDayDimNames}
         />
       </div>
-    </>
+    </section>
   );
 }
 

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -157,10 +157,14 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, onDimension
       ) : (
         <>
           <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} stats={{ runSummary, runTopFiles, runUniquePrinciples }} />
-          <SectionLabel>quality_dimensions · {dimCount}</SectionLabel>
-          <div className="dimensions-panel">
-            <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} trendDeltas={trendDeltas} />
-          </div>
+          <section className="quality-dimensions" aria-label="Quality dimensions">
+            <div className="quality-dimensions__head">
+              <SectionLabel>quality_dimensions · {dimCount}</SectionLabel>
+            </div>
+            <div className="dimensions-panel">
+              <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} trendDeltas={trendDeltas} />
+            </div>
+          </section>
           <RunFileViolations runTopFiles={runTopFiles} onFileClick={onFileClick} />
         </>
       )}

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -1,45 +1,73 @@
 import { Fragment } from 'react';
 
-export default function NavBreadcrumb({ stack, onBack, onGoTo }) {
-  if (stack.length <= 1) return null;
+const PAGE_LABELS = {
+  overview: 'overview',
+  violations: 'violations',
+  map: 'map',
+  history: 'history',
+  evaluate: 'evaluate',
+  standards: 'standards',
+  settings: 'settings',
+  projects: 'projects',
+  help: 'help',
+};
 
-  const segments = stack.map((entry, i) => {
-    let label;
-    switch (entry.page) {
-      case 'overview':      label = 'Overview'; break;
-      case 'run':           label = entry.label || entry.runId || 'Run'; break;
-      case 'explorer':      label = entry.dimension
-        ? entry.dimension.charAt(0).toUpperCase() + entry.dimension.slice(1)
-        : 'Dimension'; break;
-      case 'violation':     label = entry.label || entry.principle?.name || 'Violation'; break;
-      case 'evaluate':      label = 'Evaluate'; break;
-      case 'file':          label = entry.label || 'File Detail'; break;
-      case 'principle':     label = entry.label || 'Principle Detail'; break;
-      case 'evalprinciple': label = entry.label || entry.principleName || 'Principle'; break;
-      default:              label = entry.label || entry.page;
-    }
-    return { label, index: i };
-  });
+export function labelFor(entry) {
+  if (PAGE_LABELS[entry.page]) return PAGE_LABELS[entry.page];
+  switch (entry.page) {
+    case 'run':           return entry.label || entry.runId || 'run';
+    case 'history-run':   return entry.dateLabel || entry.runId || 'run';
+    case 'explorer':      return entry.dimension
+      ? entry.dimension.toLowerCase()
+      : 'dimension';
+    case 'violation':     return entry.label || entry.principle?.name || 'violation';
+    case 'file':          return entry.label || entry.file?.path || 'file';
+    case 'principle':     return entry.label || 'principle';
+    case 'evalprinciple': return entry.label || entry.principleName || 'principle';
+    case 'finding':       return entry.label || 'finding';
+    default:              return entry.label || entry.page;
+  }
+}
+
+/**
+ * NavBreadcrumb — the app's single breadcrumb bar.
+ *
+ * Renders as a thin strip under the topbar / right of the sidebar (the
+ * AppShell places it directly above page content). Always visible while
+ * navigating in a project; falls back to showing just the project root +
+ * current tab when the user hasn't drilled in yet.
+ *
+ * Style: slash-separated plain text, monospace, muted. Intermediate
+ * segments are clickable to pop the nav stack; the current segment is
+ * accent-colored and non-interactive.
+ */
+export default function NavBreadcrumb({ stack, onGoTo, projectName }) {
+  const crumbs = [];
+  if (projectName) crumbs.push({ label: projectName, index: -1 });
+  stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));
+
+  if (crumbs.length === 0) return null;
 
   return (
-    <nav className="nav-breadcrumb">
-      <button className="nav-back-btn" onClick={onBack} title="Go back">
-        ‹
-      </button>
-      <div className="nav-crumbs">
-        {segments.map((seg, i) => (
-          <Fragment key={i}>
-            {i > 0 && <span className="nav-crumb-sep">›</span>}
-            <button
-              className={`nav-crumb-btn${i === segments.length - 1 ? ' active' : ''}`}
-              onClick={() => onGoTo(seg.index)}
-              disabled={i === segments.length - 1}
-            >
-              {seg.label}
-            </button>
-          </Fragment>
-        ))}
-      </div>
+    <nav className="nav-breadcrumb" aria-label="Breadcrumb">
+      <ol className="nav-breadcrumb__crumbs">
+        {crumbs.map((seg, i) => {
+          const isLast = i === crumbs.length - 1;
+          const isClickable = !isLast && seg.index >= 0;
+          return (
+            <Fragment key={`${seg.label}-${i}`}>
+              {i > 0 && <li className="nav-breadcrumb__sep" aria-hidden="true">/</li>}
+              <li className={`nav-breadcrumb__crumb${isLast ? ' is-current' : ''}`}>
+                {isClickable ? (
+                  <button type="button" onClick={() => onGoTo(seg.index)}>{seg.label}</button>
+                ) : (
+                  <span>{seg.label}</span>
+                )}
+              </li>
+            </Fragment>
+          );
+        })}
+      </ol>
     </nav>
   );
 }

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -17,6 +17,8 @@ const CHART_HEIGHT = 220;
 const REF_LINE_LOW = 2.5;
 const REF_LINE_MID = 5;
 const REF_LINE_HIGH = 7.5;
+const REF_LINE_FLOOR = 0;
+const REF_LINE_CEIL = 10;
 const DESELECTED_BAR_OPACITY = 0.62;
 const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
 const HOVER_STROKE_WIDTH = 1.5;
@@ -98,9 +100,11 @@ function ScoreHistoryChart({ data, interaction }) {
         <XAxis dataKey="dateLabel" hide />
         <YAxis domain={[0, 10]} hide />
         <Tooltip cursor={false} isAnimationActive={false} offset={20} content={({ active }) => <RunHistoryTooltip active={active} hoveredIndex={hoveredIndex} data={data} />} />
-        <ReferenceLine y={REF_LINE_LOW}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
-        <ReferenceLine y={REF_LINE_MID}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
-        <ReferenceLine y={REF_LINE_HIGH} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_FLOOR} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.6} />
+        <ReferenceLine y={REF_LINE_LOW}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_MID}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_HIGH}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_CEIL}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.6} />
         <Bar
           dataKey="numericAverage"
           radius={[0, 0, 0, 0]}

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -53,16 +53,22 @@ function DimensionFilter({ allDimensions, selectedDimensions, onToggle }) {
 
   if (allDimensions.length <= 1) return null;
 
-  const activeCount = selectedDimensions.size === allDimensions.length ? allDimensions.length : selectedDimensions.size;
-  const label = activeCount === allDimensions.length ? 'All dimensions' : `${activeCount} of ${allDimensions.length}`;
+  const isFiltered = selectedDimensions.size !== allDimensions.length;
 
   return (
     <div className="map-filter-wrap" ref={ref}>
-      <button type="button" className="map-pill map-filter-btn" onClick={() => setOpen((v) => !v)}>
+      <button
+        type="button"
+        className={`map-pill map-filter-btn${isFiltered ? ' is-filtered' : ''}`}
+        onClick={() => setOpen((v) => !v)}
+        title={isFiltered ? `${selectedDimensions.size} of ${allDimensions.length} dimensions` : 'All dimensions'}
+        aria-label={isFiltered ? `Dimensions (${selectedDimensions.size} of ${allDimensions.length} active)` : 'Dimensions'}
+      >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
         </svg>
-        {label}
+        Dimensions
+        {isFiltered && <span className="map-filter-btn__dot" aria-hidden="true" />}
       </button>
       {open && (
         <div className="map-filter-dropdown">
@@ -168,11 +174,11 @@ export default function MapPage(props) {
 
   return (
     <div className="map-page map-page--terminal">
-      <TermHeader
-        name="map"
-        sub={`${viol} violation${viol !== 1 ? 's' : ''} · ratio ${ratio}`}
-      />
-      <div className="map-header map-header--terminal">
+      <div className="map-page__top">
+        <TermHeader
+          name="map"
+          sub={`${viol} violation${viol !== 1 ? 's' : ''} · ratio ${ratio}`}
+        />
         <MapControls viewState={state.viewState} galaxyState={state.galaxyState} dimensionState={state.dimensionState} />
       </div>
       <MapVizContainer vizState={state.vizState} treeState={state.treeState} dimensions={state.dimensions} callbacks={state.callbacks} display={state.display} />

--- a/src/quodeq/ui/src/features/map/components/useMapPageState.js
+++ b/src/quodeq/ui/src/features/map/components/useMapPageState.js
@@ -2,6 +2,7 @@ import { useState, useMemo, useRef, useEffect } from 'react';
 import { buildFileTree, treeNodeToFileObj } from '../viz/index.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { listStandards } from '../../../api/standards.js';
+import { readCachedState, writeCachedState, resetCachedScope } from '../../../utils/pageStateCache.js';
 
 const MAP_LABELS_KEY = 'quodeq-map-labels';
 const MAP_DARK_KEY = 'quodeq-map-dark';
@@ -43,18 +44,23 @@ function buildBreadcrumbPath(root, path) {
 }
 
 export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
-  const savedMapPathRef = useRef('');
-  // UI defaults for map visualisation mode. These are presentation-layer
-  // defaults only; they do not affect evaluation logic or server behaviour.
-  const savedVizStyleRef = useRef('zoompack');
-  const savedViewModeRef = useRef('health');
-  const savedGalaxyModeRef = useRef('filesystem');
-  const lastTabKeyRef = useRef(null);
+  const selectedProject = data?.projectName || data?.selectedProject || '__map__';
 
-  // Reset only on fresh tab click (tabKey changed), not on back from detail
-  const isFreshTabClick = lastTabKeyRef.current !== null && tabKey !== lastTabKeyRef.current;
-  lastTabKeyRef.current = tabKey;
-  if (isFreshTabClick) savedMapPathRef.current = '';
+  // Fresh tab click drops the cache; round-tripping through a detail view
+  // does not change tabKey, so cached state survives unmount/remount.
+  const lastTabKeyRef = useRef(tabKey);
+  if (lastTabKeyRef.current !== tabKey) {
+    resetCachedScope('map', selectedProject);
+    lastTabKeyRef.current = tabKey;
+  }
+
+  const cached = readCachedState('map', selectedProject, {
+    currentPath: '',
+    vizStyle: 'zoompack',
+    viewMode: 'health',
+    galaxyMode: 'filesystem',
+    selectedDimensionsArr: [],
+  });
 
   // Lock parent to viewport height while map is active.
   // Uses document.querySelector because the .dashboard ancestor is outside
@@ -85,12 +91,12 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
   }, []);
 
   const allDimensions = data?.accumulated?.dimensions || data?.dashboard?.dimensions || [];
-  const [viewMode, _setViewMode] = useState(savedViewModeRef.current);
-  const setViewMode = (v) => { savedViewModeRef.current = v; _setViewMode(v); };
-  const [vizStyle, _setVizStyle] = useState(savedVizStyleRef.current);
-  const setVizStyle = (v) => { savedVizStyleRef.current = v; _setVizStyle(v); };
-  const [galaxyMode, _setGalaxyMode] = useState(savedGalaxyModeRef.current);
-  const setGalaxyMode = (v) => { savedGalaxyModeRef.current = v; _setGalaxyMode(v); };
+  const [viewMode, _setViewMode] = useState(cached.viewMode);
+  const setViewMode = (v) => { writeCachedState('map', selectedProject, { viewMode: v }); _setViewMode(v); };
+  const [vizStyle, _setVizStyle] = useState(cached.vizStyle);
+  const setVizStyle = (v) => { writeCachedState('map', selectedProject, { vizStyle: v }); _setVizStyle(v); };
+  const [galaxyMode, _setGalaxyMode] = useState(cached.galaxyMode);
+  const setGalaxyMode = (v) => { writeCachedState('map', selectedProject, { galaxyMode: v }); _setGalaxyMode(v); };
   const [showLabels, _setShowLabels] = useState(() => { try { const v = localStorage.getItem(MAP_LABELS_KEY); return v === null ? true : v === '1'; } catch { return true; } });
   const setShowLabels = (v) => { _setShowLabels(v); try { localStorage.setItem(MAP_LABELS_KEY, v ? '1' : '0'); } catch {} };
   const [darkMode, _setDarkMode] = useState(() => {
@@ -106,8 +112,8 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
     obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
     return () => obs.disconnect();
   }, []);
-  const [currentPath, _setCurrentPath] = useState(savedMapPathRef.current);
-  const setCurrentPath = (p) => { savedMapPathRef.current = p; _setCurrentPath(p); };
+  const [currentPath, _setCurrentPath] = useState(cached.currentPath);
+  const setCurrentPath = (p) => { writeCachedState('map', selectedProject, { currentPath: p }); _setCurrentPath(p); };
 
   // Animate back to root when tab is re-clicked while already on map
   const prevTabKey = useRef(tabKey);
@@ -130,8 +136,16 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
     [visibleDimensions]
   );
 
-  // Selected dimensions filter — defaults to all visible
-  const [selectedDimensions, setSelectedDimensions] = useState(() => new Set());
+  // Selected dimensions filter — defaults to all visible. Empty set means
+  // "no filter applied" (show all). Persisted across unmount as an array.
+  const [selectedDimensions, _setSelectedDimensions] = useState(() => new Set(cached.selectedDimensionsArr));
+  const setSelectedDimensions = (updater) => {
+    _setSelectedDimensions((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      writeCachedState('map', selectedProject, { selectedDimensionsArr: Array.from(next) });
+      return next;
+    });
+  };
   const effectiveSelected = useMemo(
     () => selectedDimensions.size === 0 ? new Set(dimensionNames) : selectedDimensions,
     [selectedDimensions, dimensionNames]

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridCells.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridCells.jsx
@@ -1,25 +1,35 @@
-import { severityCellStyle, complianceRateCellStyle } from '../core/mapColors.js';
+import { severityCellStyle, complianceRateCellStyle, severityColor, complianceRateColor } from '../core/mapColors.js';
 
 const SEVERITY_LEVELS = ['critical', 'major', 'minor'];
 
 /**
  * Renders the severity + violations + health cells for a heat grid row.
- * Shared between HeatGridView (file tree) and DimensionHeatGridView (violations).
+ *
+ * Shared between HeatGridView (file tree) and DimensionHeatGridView
+ * (violations). Pass `variant="flat"` to get the text-only variant used
+ * by the Violations tab's by-dimension and by-file tables. The Map
+ * page's own file-tree keeps the default filled-heat variant.
  */
-export default function HeatGridCells({ row, onCellClick }) {
+export default function HeatGridCells({ row, onCellClick, variant = 'heat' }) {
   const total = row.violations + row.compliance;
   const rate = total > 0 ? Math.round(row.complianceRate * 100) + '%' : '—';
+  const flat = variant === 'flat';
 
   return (
     <>
       {SEVERITY_LEVELS.map((sev) => {
         const count = row.severity[sev];
         const hasValue = count > 0;
+        const style = !hasValue
+          ? undefined
+          : flat
+            ? { color: severityColor(sev) }
+            : severityCellStyle(sev);
         return (
           <td key={sev}>
             <div
               className={`heat-grid-cell${hasValue ? ' clickable' : ' empty'}`}
-              style={hasValue ? severityCellStyle(sev) : undefined}
+              style={style}
               onClick={() => hasValue && onCellClick?.({ row, severity: sev })}
               role={hasValue ? 'button' : undefined}
               tabIndex={hasValue ? 0 : undefined}
@@ -41,7 +51,13 @@ export default function HeatGridCells({ row, onCellClick }) {
       <td>
         <div
           className={`heat-grid-cell${total > 0 ? ' health' : ' empty'}`}
-          style={total > 0 ? complianceRateCellStyle(row.complianceRate) : undefined}
+          style={
+            total === 0
+              ? undefined
+              : flat
+                ? { color: complianceRateColor(row.complianceRate) }
+                : complianceRateCellStyle(row.complianceRate)
+          }
         >
           {rate}
         </div>

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
@@ -34,7 +34,7 @@ function sortRows(items, sortCol, sortDir) {
   });
 }
 
-export default function HeatGridView({ node, onDrillDown, onFileClick, onCellClick }) {
+export default function HeatGridView({ node, onDrillDown, onFileClick, onCellClick, variant = 'heat' }) {
   const [sortCol, setSortCol] = useState(COL_VIOLATIONS);
   const [sortDir, setSortDir] = useState('desc');
 
@@ -57,9 +57,13 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
     return <p className="empty-state">No data available for this view.</p>;
   }
 
+  const flat = variant === 'flat';
+  const wrapCls = `heat-grid-wrap${flat ? ' heat-grid-wrap--flat' : ''}`;
+  const tableCls = `heat-grid${flat ? ' heat-grid--flat' : ''}`;
+
   return (
-    <div className="heat-grid-wrap">
-      <table className="heat-grid">
+    <div className={wrapCls}>
+      <table className={tableCls}>
         <thead>
           <tr>
             {COLUMNS.map((col) => (
@@ -86,7 +90,7 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
                     {row.isFile ? '' : '\uD83D\uDCC1 '}{row.name}
                   </div>
                 </td>
-                <HeatGridCells row={row} onCellClick={onCellClick} />
+                <HeatGridCells row={row} onCellClick={onCellClick} variant={variant} />
               </tr>
             );
           })}

--- a/src/quodeq/ui/src/features/violations/components/DimensionHeatGridView.jsx
+++ b/src/quodeq/ui/src/features/violations/components/DimensionHeatGridView.jsx
@@ -136,8 +136,8 @@ export default function DimensionHeatGridView({ dimensions, onDimensionClick, on
   }
 
   return (
-    <div className="heat-grid-wrap">
-      <table className="heat-grid">
+    <div className="heat-grid-wrap heat-grid-wrap--flat">
+      <table className="heat-grid heat-grid--flat">
         <thead>
           <tr>
             {COLUMNS.map((col) => (
@@ -164,7 +164,7 @@ export default function DimensionHeatGridView({ dimensions, onDimensionClick, on
                     {row.name}
                   </div>
                 </td>
-                <HeatGridCells row={row} onCellClick={onCellClick} />
+                <HeatGridCells row={row} onCellClick={onCellClick} variant="flat" />
               </tr>
             );
           })}

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
-import { complianceRatio } from '../../../utils/formatters.js';
+import { readCachedState, writeCachedState, resetCachedScope } from '../../../utils/pageStateCache.js';
 import { buildFileTree, treeNodeToFileObj, HeatGridView } from '../../map/viz/index.js';
 import DimensionHeatGridView from './DimensionHeatGridView.jsx';
 import DismissedSubTab from './DismissedSubTab.jsx';
-import { TermHeader, StatStrip, Stat, SevBadge, FlagPill } from '../../../components/terminal/index.js';
+import { TermHeader, SevBadge, FlagPill } from '../../../components/terminal/index.js';
 
 const MAX_TREE_DEPTH = 64;
 
@@ -88,7 +88,7 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
   return (
     <>
       <FileBreadcrumb path={breadcrumb} onNavigate={setCurrentPath} onBack={() => setCurrentPath(findParentPath(fullTree, currentPath))} />
-      <HeatGridView node={currentNode} onDrillDown={setCurrentPath} onFileClick={handleFileClick} onCellClick={handleCellClick} />
+      <HeatGridView node={currentNode} onDrillDown={setCurrentPath} onFileClick={handleFileClick} onCellClick={handleCellClick} variant="flat" />
     </>
   );
 }
@@ -126,11 +126,17 @@ function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
   return { dismissed, handleRestore, handleRestoreAll };
 }
 
-function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, savedSubTabRef, savedFilePathRef }) {
-  const [activeSubTab, _setActiveSubTab] = useState(savedSubTabRef.current);
-  const setActiveSubTab = (v) => { savedSubTabRef.current = v; _setActiveSubTab(v); };
-  const [fileCurrentPath, _setFileCurrentPath] = useState(savedFilePathRef.current);
-  const setFileCurrentPath = (v) => { savedFilePathRef.current = v; _setFileCurrentPath(v); };
+function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, initialSubTab, initialFilePath }) {
+  const [activeSubTab, _setActiveSubTab] = useState(initialSubTab);
+  const setActiveSubTab = (v) => {
+    writeCachedState('violations', selectedProject, { activeSubTab: v });
+    _setActiveSubTab(v);
+  };
+  const [fileCurrentPath, _setFileCurrentPath] = useState(initialFilePath);
+  const setFileCurrentPath = (v) => {
+    writeCachedState('violations', selectedProject, { fileCurrentPath: v });
+    _setFileCurrentPath(v);
+  };
 
   const [restoreError, setRestoreError] = useState(null);
   const { dismissed, handleRestore, handleRestoreAll } = useDismissedFindings(selectedProject, onRefresh, setRestoreError);
@@ -160,24 +166,15 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
   };
 }
 
-function ViolationsStatsGrid({ summary, topFilesCount, uniquePrinciples, dimensionCount }) {
-  const sev = summary.severity || {};
-  const sevBadges = (sev.critical || sev.major || sev.minor) ? (
+function SevInline({ severity }) {
+  const sev = severity || {};
+  if (!(sev.critical || sev.major || sev.minor)) return null;
+  return (
     <span className="violations-sev-row">
       {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} />}
       {sev.major > 0    && <SevBadge level="major" count={sev.major} />}
       {sev.minor > 0    && <SevBadge level="minor" count={sev.minor} />}
     </span>
-  ) : null;
-  return (
-    <StatStrip bordered>
-      <Stat label="VIOLATIONS" value={summary.totalViolations || 0} hint={sevBadges} />
-      <Stat label="COMPLIANCE" value={summary.totalCompliance || 0} />
-      <Stat label="RATIO" value={complianceRatio(summary.totalViolations || 0, summary.totalCompliance || 0)} />
-      <Stat label="FILES" value={topFilesCount} />
-      <Stat label="PRINCIPLES" value={uniquePrinciples} />
-      <Stat label="DIMENSIONS" value={dimensionCount} />
-    </StatStrip>
   );
 }
 
@@ -198,16 +195,23 @@ function ViolationsSubTabContent(props) {
 }
 
 export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
-  const savedSubTabRef = useRef('dimension');
-  const savedFilePathRef = useRef('');
-  const lastViolationsTabKeyRef = useRef(null);
-
-  const isFreshTabClick = lastViolationsTabKeyRef.current !== null && tabKey !== lastViolationsTabKeyRef.current;
-  lastViolationsTabKeyRef.current = tabKey;
-  if (isFreshTabClick) savedFilePathRef.current = '';
-
   const { accumulatedDimensions, selectedProject } = data;
   const { onRefresh } = callbacks;
+
+  // Fresh tab click (tabKey changed) drops the cached navigation state so
+  // the user lands at the default sub-tab / root path. Round-tripping
+  // through a file detail does NOT change tabKey, so the cache survives
+  // unmount and the page resumes where it was.
+  const lastTabKeyRef = useRef(tabKey);
+  if (lastTabKeyRef.current !== tabKey) {
+    resetCachedScope('violations', selectedProject);
+    lastTabKeyRef.current = tabKey;
+  }
+
+  const cached = readCachedState('violations', selectedProject, {
+    activeSubTab: 'dimension',
+    fileCurrentPath: '',
+  });
 
   useEffect(() => {
     onRefresh?.();
@@ -218,21 +222,39 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     handleRestore, handleRestoreAll, restoreError, visibleDimensions,
     summary, topFilesCount, uniquePrinciples,
     fileCurrentPath, setFileCurrentPath,
-  } = useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, savedSubTabRef, savedFilePathRef });
+  } = useViolationsData({
+    accumulatedDimensions,
+    selectedProject,
+    onRefresh,
+    initialSubTab: cached.activeSubTab,
+    initialFilePath: cached.fileCurrentPath,
+  });
+
+  const total = summary.totalViolations || 0;
+  const subParts = [
+    `${total} total`,
+    `${visibleDimensions.length} dim${visibleDimensions.length !== 1 ? 's' : ''}`,
+    `${uniquePrinciples} princ.`,
+    `${topFilesCount} files`,
+  ];
+  const subLine = (
+    <span className="violations-sub">
+      <span className="violations-sub__text">{subParts.join(' · ')}</span>
+      <SevInline severity={summary.severity} />
+    </span>
+  );
 
   return (
     <div className="violations-page violations-page--terminal">
       {restoreError && <div className="error-banner">{restoreError}</div>}
-      <TermHeader
-        name="violations"
-        sub={`${summary.totalViolations || 0} total · ${visibleDimensions.length} dimensions · ${uniquePrinciples} principles`}
-      />
-      <div className="violations-flag-row">
-        <FlagPill flag="by-dimension" active={activeSubTab === 'dimension'} onClick={() => setActiveSubTab('dimension')} />
-        <FlagPill flag="by-file"      active={activeSubTab === 'file'}      onClick={() => setActiveSubTab('file')} />
-        <FlagPill flag="dismissed"    active={activeSubTab === 'dismissed'} count={dismissed.length || undefined} onClick={() => setActiveSubTab('dismissed')} />
+      <div className="violations-page__top">
+        <TermHeader name="violations" sub={subLine} />
+        <div className="violations-flag-row">
+          <FlagPill flag="by-dimension" active={activeSubTab === 'dimension'} onClick={() => setActiveSubTab('dimension')} />
+          <FlagPill flag="by-file"      active={activeSubTab === 'file'}      onClick={() => setActiveSubTab('file')} />
+          <FlagPill flag="dismissed"    active={activeSubTab === 'dismissed'} count={dismissed.length || undefined} onClick={() => setActiveSubTab('dismissed')} />
+        </div>
       </div>
-      <ViolationsStatsGrid summary={summary} topFilesCount={topFilesCount} uniquePrinciples={uniquePrinciples} dimensionCount={visibleDimensions.length} />
       <ViolationsSubTabContent
         activeSubTab={activeSubTab} visibleDimensions={visibleDimensions} dismissed={dismissed}
         callbacks={callbacks} fileCurrentPath={fileCurrentPath} setFileCurrentPath={setFileCurrentPath}

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -56,7 +56,10 @@ applyInitialTheme();
 
 // Tag <html> with the host platform so CSS can reserve space for native
 // chrome that overlays the window (e.g. the macOS traffic-light buttons
-// in the pywebview frameless app shell).
+// in the pywebview frameless app shell). A separate `in-webview` class
+// gates chrome-reservation rules to the native shell only — in a regular
+// browser the OS draws its own chrome outside the viewport, so we
+// shouldn't leave a gap for it.
 try {
   const ua = navigator.userAgent || '';
   const platform = navigator.platform || '';
@@ -65,6 +68,15 @@ try {
 } catch {
   // ignore — platform detection is a progressive enhancement
 }
+
+// pywebview injects `window.pywebview` before `pywebviewready` fires.
+// Listen for that event AND probe once on load in case the script
+// loaded after the injection.
+function markWebview() {
+  if (window.pywebview) document.documentElement.classList.add('in-webview');
+}
+markWebview();
+window.addEventListener('pywebviewready', markWebview);
 
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element #root not found in DOM');

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -235,6 +235,9 @@ body {
 .sidebar-nav-label {
   opacity: 0;
   transition: opacity 150ms ease;
+  /* Labels are authored lowercase to match the mono breadcrumb style;
+     explicit `lowercase` neutralises any inherited `capitalize` rules. */
+  text-transform: lowercase;
 }
 
 .sidebar:hover .sidebar-nav-label {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -558,6 +558,12 @@
 .dimensions-panel {
   margin-bottom: 28px;
 }
+/* Inside the terminal-style quality_dimensions panel the wrapping panel
+   itself provides the surrounding rhythm; kill the legacy margin so the
+   grid doesn't add extra whitespace to the panel's bottom. */
+.quality-dimensions .dimensions-panel {
+  margin-bottom: 0;
+}
 
 /* ── Dimension cards ──────────────────────────────────── */
 

--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -159,56 +159,76 @@
 .fix-it-btn:hover:not(:disabled) { background: var(--color-accent-hover); }
 .fix-it-btn:disabled { opacity: 0.5; cursor: default; }
 
-/* Breadcrumb navigation */
+/* --------------------------------------------------------------
+   Single canonical breadcrumb — lives in the TopBar on desktop,
+   hidden on mobile (replaced by a compact title + back button).
+   Slash-separated plain text, no chips.
+   -------------------------------------------------------------- */
 .nav-breadcrumb {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  flex-shrink: 0;
-}
-
-.nav-back-btn {
-  display: none;
-}
-
-.nav-crumbs {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.nav-crumb-sep {
-  color: var(--color-text-subtle);
-  font-size: 0.7rem;
-  user-select: none;
-  padding: 0 1px;
-}
-
-.nav-crumb-btn {
-  background: color-mix(in srgb, var(--color-text-muted) 6%, transparent);
-  border: none;
+  gap: 8px;
+  min-width: 0;
+  font-family: var(--term-font-mono, ui-monospace, Menlo, monospace);
+  font-size: 12px;
   color: var(--color-text-muted);
-  font-family: var(--font-sans);
-  font-size: 0.75rem;
-  font-weight: var(--weight-medium);
+  user-select: none;
+}
+
+.nav-breadcrumb__crumbs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.nav-breadcrumb__sep {
+  color: var(--color-text-subtle);
+  opacity: 0.55;
+  font-weight: 400;
+}
+
+.nav-breadcrumb__crumb {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+.nav-breadcrumb__crumb > button,
+.nav-breadcrumb__crumb > span {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.nav-breadcrumb__crumb > button {
   cursor: pointer;
-  padding: 3px 10px;
-  border-radius: 12px;
-  transition: background 120ms ease, color 120ms ease;
+  transition: color 120ms ease;
+}
+.nav-breadcrumb__crumb > button:hover {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+.nav-breadcrumb__crumb.is-current > span,
+.nav-breadcrumb__crumb.is-current > button {
+  color: var(--color-text);
+  font-weight: 500;
 }
 
-.nav-crumb-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
-  color: var(--color-text);
-}
-
-.nav-crumb-btn.active,
-.nav-crumb-btn:disabled {
-  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
-  color: var(--color-text);
-  cursor: default;
-  font-weight: var(--weight-semibold);
-}
+/* Legacy chip-trail classes — kept inert in case a stray consumer
+   imports them; the new breadcrumb does not use them. */
+.nav-back-btn,
+.nav-crumbs,
+.nav-crumb-sep,
+.nav-crumb-btn { display: none; }
 
 /* ── File detail ──────────────────────────────────────── */
 

--- a/src/quodeq/ui/src/styles/map.css
+++ b/src/quodeq/ui/src/styles/map.css
@@ -31,6 +31,27 @@
   margin-left: auto;
 }
 
+/* Header row: TermHeader on the left, controls on the right.
+   Controls gravitate to the bottom of the row so they baseline-align
+   with the sub line rather than floating up by the page title.
+   Wraps onto a second row on narrow viewports via flex-wrap. */
+.map-page__top {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.map-page__top > .term-header {
+  margin: 0;
+}
+
+.map-page__top > .map-controls {
+  flex: 0 1 auto;
+}
+
 .map-total-count {
   font-size: 1rem;
   color: var(--color-text-muted);
@@ -47,7 +68,7 @@
 .map-controls {
   display: flex;
   align-items: center;
-  gap: var(--space-6);
+  gap: var(--space-2);
   flex-wrap: wrap;
 }
 
@@ -57,7 +78,6 @@
   background: var(--color-surface-alt);
   border-radius: 6px;
   padding: 2px;
-  margin-bottom: 32px;
 }
 
 .map-pill {
@@ -109,10 +129,37 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  /* Match the pill's padding/shape so the filter reads as part of the
+     same control strip instead of a floating button. */
+  background: var(--color-surface-alt);
+  border: none;
+  border-radius: 6px;
+  padding: 5px 10px;
+  position: relative;
+}
+
+.map-filter-btn:hover {
+  background: color-mix(in srgb, var(--color-surface-alt) 65%, var(--color-surface));
+  color: var(--color-text);
 }
 
 .map-filter-btn svg {
   opacity: 0.6;
+}
+
+/* Active-state dot: floats in the top-right corner of the button
+   when a subset of dimensions is active (standard notification dot
+   pattern — does not affect the button's width). */
+.map-filter-btn__dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-surface);
+  pointer-events: none;
 }
 
 .map-filter-dropdown {
@@ -324,6 +371,72 @@
   border: 1px solid transparent;
   transition: opacity 150ms ease;
 }
+
+/* -------------------------------------------------------------------
+   Flat variant — used by the Violations > by-dimension table.
+   Strips the "heat-map" fills down to colored text on a plain table,
+   matching the monospace/minimal aesthetic used across the rest of the
+   terminal restyle. The filled-cell default still applies to the Map
+   page's file tree view via the base .heat-grid rules above.
+   ------------------------------------------------------------------- */
+.heat-grid--flat {
+  border-collapse: collapse;
+  border-spacing: 0;
+  font-family: var(--term-font-mono, var(--font-sans));
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.heat-grid--flat th {
+  padding: 10px 12px;
+  position: static;
+  background: transparent;
+  font-family: var(--term-font-mono, var(--font-sans));
+  font-size: 11px;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+  text-align: right;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 30%, transparent);
+}
+.heat-grid--flat th.left { text-align: left; }
+
+.heat-grid--flat td {
+  padding: 10px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 18%, transparent);
+  text-align: right;
+}
+.heat-grid--flat tbody tr:last-child td { border-bottom: 0; }
+.heat-grid--flat td:first-child { text-align: left; }
+
+.heat-grid--flat .heat-grid-file { padding: 0; font-size: 13px; }
+.heat-grid--flat .heat-grid-num {
+  padding: 0;
+  font-weight: var(--weight-bold);
+  text-align: right;
+  display: block;
+}
+
+/* Severity/health cells in the flat variant: no fill, no border, just
+   colored text (color comes from inline style in HeatGridCells). */
+.heat-grid--flat .heat-grid-cell {
+  display: inline-block;
+  min-width: 0;
+  height: auto;
+  padding: 0;
+  border: 0;
+  background: none !important;
+  box-shadow: none;
+  font-weight: var(--weight-medium);
+  font-size: 13px;
+  transition: color 120ms ease;
+}
+.heat-grid--flat .heat-grid-cell.empty {
+  color: var(--color-text-subtle);
+  font-weight: var(--weight-regular);
+}
+.heat-grid--flat .heat-grid-cell.clickable:hover { text-decoration: underline; }
 
 .heat-grid-cell:hover {
   opacity: 0.8;

--- a/src/quodeq/ui/src/styles/map.css
+++ b/src/quodeq/ui/src/styles/map.css
@@ -410,7 +410,16 @@
 .heat-grid--flat tbody tr:last-child td { border-bottom: 0; }
 .heat-grid--flat td:first-child { text-align: left; }
 
-.heat-grid--flat .heat-grid-file { padding: 0; font-size: 13px; }
+.heat-grid--flat .heat-grid-file,
+.heat-grid--flat .heat-grid-dim-row td:first-child .heat-grid-file {
+  padding: 0;
+  font-size: 13px;
+  /* Match the mono/lowercase aesthetic used elsewhere in the terminal
+     restyle. The second selector explicitly targets dimension header
+     rows (Maintainability, Flexibility, …) since their existing rule
+     has higher specificity than the plain `.heat-grid-file` override. */
+  text-transform: lowercase;
+}
 .heat-grid--flat .heat-grid-num {
   padding: 0;
   font-weight: var(--weight-bold);

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -425,12 +425,36 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--term-space-2);
-  margin: 0 0 var(--term-space-3);
+  margin: 0;
 }
 .violations-sev-row {
   display: inline-flex;
   gap: var(--term-space-1);
   align-items: center;
+  margin-left: var(--term-space-2);
+}
+
+/* Violations title row: TermHeader on the left, flag pills on the right.
+   Controls gravity-bottom to align with the sub line; wraps onto a new
+   row on narrow viewports. Mirrors the Map page pattern. */
+.violations-page--terminal .violations-page__top {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--term-space-3);
+  margin-bottom: var(--term-space-4);
+}
+.violations-page--terminal .violations-page__top > .term-header {
+  margin: 0;
+}
+
+/* Inline severity badges next to the sub text */
+.violations-sub {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--term-space-2);
+  flex-wrap: wrap;
 }
 
 /* ------------------------------------------------------------

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -715,7 +715,7 @@
 /* Single breakpoint for the "compact" layout: sidebar becomes a drawer,
    topbar flips to back + title + burger. Desktop shows the full rail
    sidebar and the full breadcrumb above this width. */
-@media (max-width: 1200px) {
+@media (max-width: 900px) {
   /* Mobile: the sidebar disappears entirely from the flow. The TopBar burger
      is the only way to open it, and when open it floats over the content as
      a drawer instead of squeezing layout. */

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -770,7 +770,8 @@
   }
   .topbar-breadcrumb-slot { display: none !important; }
   .topbar-pill,
-  .topbar-btn--evaluate { display: none !important; }
+  .topbar-btn--evaluate,
+  .topbar-btn--theme { display: none !important; }
   .topbar-actions { gap: var(--term-space-1); }
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-brand-text,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-version,
@@ -1525,17 +1526,22 @@
   justify-content: flex-end;
 }
 .topbar-pill {
+  /* Matched footprint with .topbar-btn (Evaluate / Report) so the
+     provider pill reads as part of the same control row: same height,
+     corner radius, font size, and padding. */
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 5px 10px;
+  padding: 4px 10px;
   border: 1px solid var(--color-border);
-  border-radius: 999px;
-  font-size: 11px;
+  border-radius: var(--term-radius);
+  font-size: 12px;
+  font-weight: 500;
   color: var(--color-text-muted);
   font-variant-numeric: tabular-nums;
   background: transparent;
   font-family: inherit;
+  line-height: 1.4;
 }
 /* Clickable provider pill — same visuals as the span variant plus hover */
 .topbar-pill--button {
@@ -1589,6 +1595,22 @@
 .topbar-btn:hover {
   background: var(--color-surface-alt);
   border-color: var(--color-text-muted);
+}
+
+/* Icon-only variant — square-ish, same height as .topbar-btn for a
+   consistent row. Used by the theme toggle. Matches Report's neutral
+   text color so it reads as a secondary action rather than picking up
+   the theme accent. */
+.topbar-btn--icon {
+  padding: 4px 7px;
+  color: var(--color-text);
+}
+.topbar-btn--icon:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
+}
+.topbar-btn--icon svg {
+  display: block;
 }
 /* Evaluate button: same footprint as Report, with an accent-tinted
    border + text so it still reads as the primary action without

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -836,7 +836,8 @@
    ------------------------------------------------------------ */
 .run-history-panel--terminal,
 .dim-score-panel--terminal,
-.top-findings {
+.top-findings,
+.quality-dimensions {
   border: 1px solid var(--color-border) !important;
   border-radius: var(--term-radius) !important;
   box-shadow: none !important;
@@ -849,6 +850,7 @@
    contrast tint, and a bottom divider. Used in all three overview panels. */
 .run-history-panel--terminal .run-history-panel__header,
 .top-findings__head,
+.quality-dimensions__head,
 .dim-score-panel--terminal .dim-score-panel__header {
   display: flex;
   align-items: baseline;
@@ -865,13 +867,15 @@
   text-transform: uppercase;
 }
 .run-history-panel--terminal .run-history-panel__header .term-section-label,
-.top-findings__head .term-section-label {
+.top-findings__head .term-section-label,
+.quality-dimensions__head .term-section-label {
   padding: 0;
 }
 
 /* Panel body padding — all content under the banner uses consistent padding */
 .run-history-panel--terminal > *:not(.run-history-panel__header),
 .top-findings > *:not(.top-findings__head),
+.quality-dimensions > *:not(.quality-dimensions__head),
 .dim-score-panel--terminal > *:not(.dim-score-panel__header) {
   padding: var(--term-space-3);
 }

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -712,8 +712,10 @@
    untouched above the breakpoint.
    ------------------------------------------------------------ */
 
-/* Tablet: 900px is the existing breakpoint used elsewhere. */
-@media (max-width: 900px) {
+/* Single breakpoint for the "compact" layout: sidebar becomes a drawer,
+   topbar flips to back + title + burger. Desktop shows the full rail
+   sidebar and the full breadcrumb above this width. */
+@media (max-width: 1200px) {
   /* Mobile: the sidebar disappears entirely from the flow. The TopBar burger
      is the only way to open it, and when open it floats over the content as
      a drawer instead of squeezing layout. */
@@ -728,17 +730,18 @@
   }
   /* Mobile: the sidebar is ALWAYS mounted as a fixed overlay. It translates
      off-screen when closed and back when pinned, so the close animation
-     mirrors the open animation. */
+     mirrors the open animation. The burger lives on the top-right, so the
+     drawer slides in from the right edge. */
   .sidebar.sidebar--expanded {
     position: fixed !important;
-    left: 0;
+    right: 0;
     top: 0;
     bottom: 0;
     width: min(280px, 85vw) !important;
     z-index: 50;
     display: flex !important;
     box-shadow: 0 0 32px rgba(0, 0, 0, 0.35);
-    transform: translateX(-100%);
+    transform: translateX(100%);
     transition: transform 200ms ease !important;
     animation: none !important;
     pointer-events: none;
@@ -748,9 +751,24 @@
     pointer-events: auto;
   }
 
-  /* TopBar: show the burger, hide desktop-only pills and the primary
-     `+ Evaluate` button (the sidebar already has an Evaluate nav item). */
+  /* TopBar compact layout: back + (centered title) + burger.
+     The title is absolutely centered relative to the topbar so it
+     stays in the optical middle regardless of back-button width.
+     `!important` overrides the default desktop rules later in the file. */
+  .topbar { position: relative; }
   .topbar-menu-btn { display: inline-flex !important; }
+  .topbar-back-btn { display: inline-flex !important; }
+  .topbar-mobile-title {
+    display: inline-flex !important;
+    align-items: center;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    max-width: calc(100% - 160px);
+    pointer-events: none;
+  }
+  .topbar-breadcrumb-slot { display: none !important; }
   .topbar-pill,
   .topbar-btn--evaluate { display: none !important; }
   .topbar-actions { gap: var(--term-space-1); }
@@ -831,6 +849,7 @@
     height: auto;
   }
 }
+
 
 /* ------------------------------------------------------------
    Responsive .history-panels-row — wrap chart + dimensions onto
@@ -1181,8 +1200,14 @@
   overflow-y: auto;
 }
 /* Full-width topbar: align breadcrumb with dashboard content below.
-   sidebar-width (64px) + dashboard padding (32px) = 96px left-inset. */
+   Only reserve 96px (traffic-light chrome + sidebar rail) when we're
+   running inside the pywebview native shell on macOS. In a regular
+   browser the OS draws its own chrome outside the viewport, so the
+   topbar can start flush-left against the sidebar rail. */
 .app-shell--with-topbar .topbar {
+  padding-left: var(--term-space-3);
+}
+.platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 96px;
 }
 
@@ -1441,23 +1466,56 @@
   font-family: var(--term-font-mono);
   font-size: 13px;
 }
-.topbar-breadcrumb {
+/* --------------------------------------------------------------
+   TopBar breadcrumb zone. Desktop shows the full NavBreadcrumb
+   chain; mobile swaps it for a back button on the left, the
+   last segment as a title, and pushes the burger to the right.
+   -------------------------------------------------------------- */
+.topbar-spacer { flex: 1; }
+
+.topbar-breadcrumb-slot {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.topbar-back-btn {
+  display: none; /* shown in compact mode (topbar--compact) and on mobile */
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin-right: var(--term-space-2);
+  border: 0;
+  background: transparent;
   color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 120ms ease, color 120ms ease;
 }
-.topbar-breadcrumb-parent {
-  color: var(--color-text-muted);
-}
-.topbar-breadcrumb-sep {
-  color: var(--color-text-subtle, var(--color-text-muted));
-  opacity: 0.55;
-}
-.topbar-breadcrumb-current {
+.topbar-back-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--color-text-muted) 12%, transparent);
   color: var(--color-text);
-  font-weight: 500;
 }
+.topbar-back-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.topbar-mobile-title {
+  display: none; /* shown in compact mode (topbar--compact) and on mobile */
+  font-family: var(--term-font-mono);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text);
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 
 .topbar-actions {
   display: inline-flex;

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -551,6 +551,7 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-accent:       var(--primitive-crimson-500);
   --color-accent-hover: var(--primitive-crimson-600);
   --color-accent-soft:  color-mix(in srgb, var(--primitive-crimson-500) 6%, transparent);
+  --color-on-accent:    #ffffff;
 
   --color-danger:  var(--primitive-red-600);
   --color-success: var(--primitive-green-700);
@@ -727,6 +728,10 @@ html[data-theme="galadriel-light"]:root, [data-theme="galadriel-light"] {
   --color-accent:       #1b6b3a;
   --color-accent-hover: #145228;
   --color-accent-soft:  color-mix(in srgb, #1b6b3a 8%, transparent);
+  /* Light mode on dark-green accent — explicit white for AA contrast
+     (#1b6b3a vs #ffffff ≈ 8.5:1). Without this the base fallback can
+     get shadowed by other theme blocks, leaving dark-on-dark text. */
+  --color-on-accent:    #ffffff;
 
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
@@ -883,6 +888,7 @@ html[data-theme="neo-light"]:root, [data-theme="neo-light"] {
   --color-accent:       var(--primitive-neo-accent-dark);
   --color-accent-hover: #006622;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-neo-accent-dark) 8%, transparent);
+  --color-on-accent:    #ffffff;
   --color-danger:  #c0392b;
   --color-success: #2d7a4f;
   --color-sev-critical-text:   var(--primitive-neo-sev-critical-light);
@@ -1032,6 +1038,7 @@ html[data-theme="ifrit-light"]:root, [data-theme="ifrit-light"] {
   --color-accent:       var(--primitive-ifrit-accent-light);
   --color-accent-hover: #a84a08;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-ifrit-accent-light) 8%, transparent);
+  --color-on-accent:    #ffffff;
 
   --color-danger:  #b82010;
   --color-success: #2a8a40;
@@ -1204,6 +1211,7 @@ html[data-theme="deckard-light"]:root, [data-theme="deckard-light"] {
   --color-accent:       var(--primitive-deckard-accent-light);
   --color-accent-hover: #b01888;
   --color-accent-soft:  color-mix(in srgb, var(--primitive-deckard-accent-light) 8%, transparent);
+  --color-on-accent:    #ffffff;
 
   --color-danger:  #e02050;
   --color-success: #0098a8;

--- a/src/quodeq/ui/src/utils/pageStateCache.js
+++ b/src/quodeq/ui/src/utils/pageStateCache.js
@@ -1,0 +1,46 @@
+/**
+ * Module-scoped state cache for pages that unmount when the user drills
+ * into a detail view.
+ *
+ * Problem: Map and Violations pages unmount when the user navigates to a
+ * file or principle detail (the app's nav stack only renders the top
+ * entry). Coming back remounts the page — useState/useRef defaults win,
+ * and the prior navigation state (current path, active sub-tab, viz mode,
+ * dimension filter) is lost.
+ *
+ * Fix: store the small slice of state that needs to survive unmount in a
+ * Map keyed by a scope string (typically the selected project id). A
+ * fresh click on the tab itself should still reset — call `resetScope()`
+ * when `tabKey` changes.
+ *
+ * This is deliberately session-only and not persisted to storage — page
+ * reloads start fresh, which matches the user's existing expectation.
+ */
+
+const STORES = new Map(); // namespace -> Map<scope, state object>
+
+function storeFor(namespace) {
+  let s = STORES.get(namespace);
+  if (!s) {
+    s = new Map();
+    STORES.set(namespace, s);
+  }
+  return s;
+}
+
+export function readCachedState(namespace, scope, defaults) {
+  const existing = storeFor(namespace).get(scope || '__global__');
+  if (existing) return { ...defaults, ...existing };
+  return { ...defaults };
+}
+
+export function writeCachedState(namespace, scope, patch) {
+  const key = scope || '__global__';
+  const store = storeFor(namespace);
+  const prev = store.get(key) || {};
+  store.set(key, { ...prev, ...patch });
+}
+
+export function resetCachedScope(namespace, scope) {
+  storeFor(namespace).delete(scope || '__global__');
+}


### PR DESCRIPTION
## Summary
Polish pass across the terminal UI restyle. Everything is UI-only; no backend, no data contract changes.

### Commits
- `feat(ui/overview)` — unify panel chrome around `quality_dimensions` so it matches `SCORE_HISTORY`/`TOP_FINDINGS`/`RUN_HISTORY`.
- `feat(ui/map)` — tighter header, filters move next to the title, dimension filter becomes a pill with a corner dot badge when filtered.
- `feat(ui/violations)` — drop `ViolationsStatsGrid`, inline sev badges next to the sub line, introduce a flat `heat-grid--flat` variant used by the by-dimension and by-file tables. Map page's own file-tree view keeps filled heat cells.
- `feat(ui/history)` — reference lines at 0 and 10 on the score history chart.
- `feat(ui/breadcrumb)` — single canonical breadcrumb. Desktop shows it in the topbar; <1200px the compact layout kicks in (back arrow + last-segment title centered + burger on the right, drawer slides in from the right).
- `feat(ui/state-cache)` — module-scoped `pageStateCache.js` preserves Map and Violations navigation state across detail round-trips.
- `feat(ui/topbar)` — provider pill matched visually with the Evaluate button; new moon/sun theme toggle (light ↔ dark within the current family). Neutral text color, doesn't compete with the accent.
- `style(ui/sidebar)` + `style(ui)` — lowercase nav labels + flat-table rows to match the breadcrumb style, override inherited `text-transform: capitalize`.
- `fix(ui/theme)` — ensure `--color-on-accent: #ffffff` is defined in every light theme (light, galadriel-light, neo-light, ifrit-light, deckard-light). Fixes dark-on-dark active pill in light mode.

### Scope
- 22 files, +767 / −236 lines. UI only.
- Added: `src/quodeq/ui/src/utils/pageStateCache.js`.

## Test plan
- [x] Overview: `quality_dimensions` block has the same banner header + panel chrome as `SCORE_HISTORY` / `TOP_FINDINGS`. Same on history-run (per-run Overview).
- [x] Map: controls sit next to the title on the same row (gravity-bottom); dimension pill shows a dot when a subset is selected; filters wrap to next row on narrow viewports.
- [x] Violations: header is single sub line with inline sev badges; by-dimension and by-file tables render flat (mono, hairline rows, colored numbers, no filled heat cells). Map page's file-tree Map still renders filled heat cells.
- [x] History chart: reference lines at 0 and 10 in addition to 2.5 / 5 / 7.5.
- [x] Breadcrumb: `>1200px` — full trail in topbar (`overview / flexibility / principle`); `≤1200px` — back arrow + last segment centered + burger on the right. Drawer slides from the right.
- [x] Navigation state: open Violations > by-file, drill into a folder or file detail, come back — the sub-tab and current folder are preserved. Same for Map drill-downs + viz style + dimension filter. Tab re-click still resets.
- [x] Topbar: provider pill + theme toggle align with Evaluate/Report; moon/sun flips light↔dark; icons neutral (not accent-colored).
- [x] Lowercase: sidebar nav (`overview`, `violations`, `map`, `history`, …) and flat violations rows (`maintainability`, `analyzability`, …).
- [x] Light theme (galadriel-light etc.): active `--by-dimension` pill has white text on the accent (AA contrast).