### PR TITLE
fix: cancel actually terminates running subagents (provider-agnostic)

### DIFF
--- a/src/quodeq/analysis/_process.py
+++ b/src/quodeq/analysis/_process.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from quodeq.analysis._config import AnalysisConfig, _SpawnPaths
 from quodeq.analysis.errors import ProviderError
 from quodeq.analysis.stream.progress_reader import _IncrementalProgressReader
+from quodeq.shared import cancellation
 from quodeq.shared.logging import log_warning
 from quodeq.shared.utils import sanitize_sensitive as _sanitize_stderr
 
@@ -70,6 +71,9 @@ def _run_with_heartbeat(
         try:
             process.wait(timeout=config.heartbeat_interval)
         except subprocess.TimeoutExpired:
+            if cancellation.is_cancelled():
+                _terminate_process(process)
+                return timed_out
             elapsed += config.heartbeat_interval
             if config.heartbeat_callback:
                 config.heartbeat_callback(elapsed, reader.read_progress())

--- a/src/quodeq/shared/cancellation.py
+++ b/src/quodeq/shared/cancellation.py
@@ -1,0 +1,29 @@
+"""Process-wide cancellation signal for long-running evaluations.
+
+One evaluation runs per Python process. The SIGTERM/SIGINT handler in
+run_lifecycle calls ``request_cancel()``; worker threads deep in the
+analysis pipeline poll ``is_cancelled()`` (or wait on ``get_event()``) so
+they can terminate their child AI CLI subprocesses promptly instead of
+blocking ``ThreadPoolExecutor.shutdown`` on long Ollama inference calls.
+"""
+from __future__ import annotations
+
+import threading
+
+_event = threading.Event()
+
+
+def get_event() -> threading.Event:
+    return _event
+
+
+def is_cancelled() -> bool:
+    return _event.is_set()
+
+
+def request_cancel() -> None:
+    _event.set()
+
+
+def reset() -> None:
+    _event.clear()

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
+from quodeq.shared import cancellation
 from quodeq.shared.run_heartbeat import HeartbeatThread
 from quodeq.shared.run_status import (
     RunState,
@@ -70,6 +71,7 @@ class RunLifecycleContext:
     # ---- Context protocol --------------------------------------------------
 
     def __enter__(self) -> "RunLifecycleContext":
+        cancellation.reset()
         self._write(RunState.PENDING)
         self._install_signal_handlers()
         atexit.register(self._finalize_on_atexit)
@@ -140,6 +142,9 @@ class RunLifecycleContext:
                 name = signal.Signals(signum).name
             except ValueError:
                 name = f"signal_{signum}"
+            # Signal worker threads (subagent pool, AI CLI subprocess monitors)
+            # to stop waiting on long-running operations and terminate promptly.
+            cancellation.request_cancel()
             # Avoid using the transition-validating path — we may be mid-state.
             self._heartbeat.stop()
             write_status(

--- a/tests/analysis/test_process_coverage.py
+++ b/tests/analysis/test_process_coverage.py
@@ -113,6 +113,44 @@ class TestRunWithHeartbeat:
             result = _run_with_heartbeat(proc, cfg, stream)
             assert result is True
 
+    def test_cancellation_terminates_mid_wait(self, tmp_path):
+        """When cancellation is requested mid-inference, the subprocess is terminated
+        and the loop exits after that tick — without waiting for max_duration."""
+        from quodeq.analysis._process import _run_with_heartbeat
+        from quodeq.analysis._config import AnalysisConfig
+        from quodeq.shared import cancellation
+
+        cancellation.reset()
+        proc = MagicMock()
+        # Subprocess never exits on its own — without cancel support, the loop hangs.
+        proc.poll.return_value = None
+
+        wait_calls = [0]
+
+        def fake_wait(*args, **kwargs):
+            wait_calls[0] += 1
+            if wait_calls[0] == 1:
+                cancellation.request_cancel()
+                raise subprocess.TimeoutExpired("cmd", 1)
+            # If the loop misbehaves and keeps waiting after cancel, fail fast
+            # instead of hanging the test run.
+            raise AssertionError("heartbeat loop did not exit after cancel")
+
+        proc.wait = fake_wait
+        cfg = AnalysisConfig(
+            heartbeat_interval=1, heartbeat_callback=None,
+            max_duration=None, jsonl_file=None,
+        )
+        stream = tmp_path / "stream.jsonl"
+        stream.write_text("")
+        try:
+            with patch("quodeq.analysis._process._terminate_process") as mock_term:
+                _run_with_heartbeat(proc, cfg, stream)
+                mock_term.assert_called_once_with(proc)
+                assert wait_calls[0] == 1
+        finally:
+            cancellation.reset()
+
 
 class TestCheckProcessResult:
     def test_zero_exit_ok(self, tmp_path):

--- a/tests/shared/test_cancellation.py
+++ b/tests/shared/test_cancellation.py
@@ -1,0 +1,64 @@
+"""Tests for the process-wide cancellation signal.
+
+One evaluation runs per Python process. The cancellation module exposes a
+module-level threading.Event so the SIGTERM/SIGINT handler in
+run_lifecycle can notify worker threads deep in the analysis pipeline
+without threading a cancel token through every call site.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancellation():
+    from quodeq.shared import cancellation
+
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+def test_starts_not_cancelled() -> None:
+    from quodeq.shared import cancellation
+
+    assert cancellation.is_cancelled() is False
+
+
+def test_request_cancel_marks_cancelled() -> None:
+    from quodeq.shared import cancellation
+
+    cancellation.request_cancel()
+    assert cancellation.is_cancelled() is True
+
+
+def test_reset_clears_cancelled() -> None:
+    from quodeq.shared import cancellation
+
+    cancellation.request_cancel()
+    cancellation.reset()
+    assert cancellation.is_cancelled() is False
+
+
+def test_event_is_shared_threading_event() -> None:
+    """Workers need an Event so they can block-wait with a timeout."""
+    from quodeq.shared import cancellation
+
+    event = cancellation.get_event()
+    assert isinstance(event, threading.Event)
+    assert event.is_set() is False
+    cancellation.request_cancel()
+    assert event.is_set() is True
+
+
+def test_event_is_stable_across_calls() -> None:
+    """Callers that cache the event must see the same instance across cancels/resets."""
+    from quodeq.shared import cancellation
+
+    event_before = cancellation.get_event()
+    cancellation.request_cancel()
+    cancellation.reset()
+    event_after = cancellation.get_event()
+    assert event_before is event_after

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -60,6 +60,36 @@ def test_signal_handler_writes_cancelled(tmp_path: Path) -> None:
     assert status["exit_reason"] == "signal_SIGTERM"
 
 
+def test_signal_handler_sets_process_cancel_event(tmp_path: Path) -> None:
+    """SIGTERM must set the shared cancel event so worker threads can unblock."""
+    import os
+    from quodeq.shared import cancellation
+
+    cancellation.reset()
+    try:
+        with pytest.raises(SystemExit):
+            with RunLifecycleContext(run_dir=tmp_path, job_id="ext-cancel-event", dimensions=[]):
+                assert cancellation.is_cancelled() is False
+                os.kill(os.getpid(), signal.SIGTERM)
+        assert cancellation.is_cancelled() is True
+    finally:
+        cancellation.reset()
+
+
+def test_context_enter_resets_stale_cancel_event(tmp_path: Path) -> None:
+    """Entering a new lifecycle context must clear leftover cancel state
+    so a second run in the same process does not see cancellation from the first."""
+    from quodeq.shared import cancellation
+
+    cancellation.request_cancel()
+    assert cancellation.is_cancelled() is True
+    try:
+        with _ctx(tmp_path):
+            assert cancellation.is_cancelled() is False
+    finally:
+        cancellation.reset()
+
+
 def test_restores_previous_signal_handlers(tmp_path: Path) -> None:
     """After __exit__, signal handlers revert to what they were before __enter__."""
     sentinel = signal.getsignal(signal.SIGINT)


### PR DESCRIPTION
## Summary
- **Bug:** Cancelling a running evaluation wrote `status=cancelled` to `status.json` but the Python process hung for minutes (until `max_duration` or the provider returned), keeping Ollama/GPU slots busy and leaking zombie "cancelled" runs that were still actually running.
- **Root cause:** `ThreadPoolExecutor` in `SubagentPool.run()` blocks on shutdown joining workers that are stuck in `_run_with_heartbeat` → `process.wait()`. The AI CLI subprocess is spawned with `start_new_session=True` so SIGTERM to the Python orchestrator never reaches it.
- **Fix:** Process-wide `threading.Event` in a new `quodeq.shared.cancellation` module. `RunLifecycleContext`'s signal handler sets it; `_run_with_heartbeat` polls it each tick and calls `_terminate_process` on the AI CLI process tree. Worker unwinds, executor shutdown completes, SystemExit propagates, process exits promptly.

## Provider-agnostic
The fix kills the AI CLI subprocess, not the provider. When the subprocess dies, its HTTP connection closes — works identically for Ollama (local), Claude API, OpenAI, or any future provider.

## Behavior for cancelled runs
- `status.json` state is `cancelled` + `exit_reason=signal_SIGTERM` (unchanged).
- Dashboard `StatusChip` shows `cancelled`, "View Results" button only appears on `done` — cancelled runs are NOT surfaced as success.
- Partial per-dimension scoring (pre-existing graceful-cancel behavior) is preserved.

## Test plan
- [x] RED/GREEN TDD for `cancellation` module (5 tests)
- [x] RED/GREEN for `RunLifecycleContext` signal wiring + context-enter reset (2 tests)
- [x] RED/GREEN for `_run_with_heartbeat` cancel-mid-wait termination (1 test)
- [x] Full suite: `2096 passed`
- [x] Manual: start an Ollama scan, cancel via dashboard, verify the Python process exits within seconds instead of minutes