### PR TITLE
Clean run history, detach scans from dashboard lifecycle, tighten eval prompt

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -259,7 +259,18 @@ def _run_pipeline_with_cleanup(
                 dimensions=dimensions_list,
             ) as lifecycle:
                 try:
+                    # Mark the pipeline as actively analyzing so dashboard
+                    # clients begin polling per-dimension partial results
+                    # (the UI gates dim-polling on phase in
+                    # {analyzing, scoring}).
+                    lifecycle.set_phase("analyzing")
                     result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
+                    # run_full writes per-dimension reports as each dimension
+                    # completes, so by the time it returns scoring is already
+                    # done. Record the last pre-finalize phase as "scoring"
+                    # so the UI shows a sensible state even if the process
+                    # lingers briefly before transition_to_finalizing.
+                    lifecycle.set_phase("scoring")
                     lifecycle.transition_to_finalizing()
                     return result
                 finally:

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from enum import Enum as _Enum
@@ -27,7 +28,7 @@ from quodeq.shared.url_validation import validate_url_safe
 
 _log = logging.getLogger(__name__)
 
-_MAX_RETRIES = 2
+_MAX_RETRIES = 1
 _OLLAMA_DEFAULT_BASE = "http://localhost:11434/v1"
 _OLLAMA_DEFAULT_API_KEY = "ollama"
 
@@ -109,8 +110,13 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
     )
 
     extra_body: dict = {"reasoning_effort": "none"}
-    if config.context_size > 0:
-        extra_body["num_ctx"] = config.context_size
+    ctx_size = config.context_size
+    if ctx_size <= 0:
+        env_val = os.environ.get("QUODEQ_CONTEXT_SIZE", "").strip()
+        if env_val.isdigit():
+            ctx_size = int(env_val)
+    if ctx_size > 0:
+        extra_body["num_ctx"] = ctx_size
 
     create_kwargs: dict = dict(
         model=config.model,

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -28,7 +28,9 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
     @app.get("/api/evaluations")
     def list_evaluations() -> Response:
         limit = request.args.get("limit", 0, type=int)
-        items = provider.list_evaluations(limit=limit, reports_dir=_reports_dir())
+        state_arg = request.args.get("state", "").strip()
+        states = {s for s in (v.strip() for v in state_arg.split(",")) if s} or None
+        items = provider.list_evaluations(limit=limit, reports_dir=_reports_dir(), states=states)
         return jsonify([to_camel_dict(j) for j in items])
 
     @app.post("/api/evaluations")
@@ -99,10 +101,22 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         return jsonify(to_camel_dict(job))
 
     @app.delete("/api/evaluations/<job_id>")
-    def cancel_evaluation(job_id: str) -> Response | tuple[Response, int]:
-        _logger.info("cancel_evaluation: job_id=%s, remote_addr=%s", job_id, request.remote_addr)
-        ok = provider.cancel_evaluation(job_id, reports_dir=_reports_dir())
-        if not ok:
-            body, status = error_response("Job not found or not running", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+    def cancel_or_delete_evaluation(job_id: str) -> Response | tuple[Response, int]:
+        """DELETE on a running job cancels it. DELETE on a finished job removes it from history."""
+        snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
+        if snapshot is None:
+            body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        return jsonify({"ok": True})
+        if snapshot.status == "running":
+            _logger.info("cancel_evaluation: job_id=%s, remote_addr=%s", job_id, request.remote_addr)
+            ok = provider.cancel_evaluation(job_id, reports_dir=_reports_dir())
+            if not ok:
+                body, status = error_response("Could not cancel job", HTTPStatus.CONFLICT, "CONFLICT")
+                return jsonify(body), status
+            return jsonify({"ok": True, "action": "cancelled"})
+        _logger.info("delete_evaluation: job_id=%s, remote_addr=%s", job_id, request.remote_addr)
+        ok = provider.delete_evaluation(job_id, reports_dir=_reports_dir())
+        if not ok:
+            body, status = error_response("Job could not be deleted", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify({"ok": True, "action": "deleted"})

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import atexit
 import logging
 import os
 import signal
@@ -115,15 +114,13 @@ def main(env: dict[str, str] | None = None) -> None:
     # consider a secrets manager or platform keychain instead.
     app = create_app(static_dist=get_static_dist(), api_key=_env.get("QUODEQ_API_KEY"))
 
-    # Kill running evaluation subprocesses on shutdown
-    def _cleanup_jobs():
-        provider = app.config.get("_provider")
-        if provider and hasattr(provider, "_jobs"):
-            provider._jobs.shutdown()
-    atexit.register(_cleanup_jobs)
-
+    # Evaluation subprocesses are spawned with start_new_session=True so they
+    # survive the API process dying. Intentionally do NOT kill them on API
+    # shutdown — otherwise launching a second dashboard (which calls
+    # _kill_stale_action_api on the first) would cascade and kill any scan in
+    # flight. Scans have their own lifecycle; use the UI cancel button or the
+    # DELETE endpoint for explicit stops.
     def _handle_shutdown(signum: int, frame: object) -> None:
-        _cleanup_jobs()
         raise SystemExit(0)
 
     if hasattr(signal, "SIGTERM"):

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -7,6 +7,7 @@ import os
 import signal
 import sys
 import threading
+import urllib.parse
 import urllib.request
 import webbrowser
 from pathlib import Path
@@ -51,22 +52,21 @@ class _WindowApi:
         self._base_url = base_url.rstrip('/')
 
     def close(self) -> None:
-        # Show closing overlay immediately so the user sees feedback
+        # Check for running evaluation FIRST. Don't render the closing
+        # overlay yet — it covers the screen and would hide the dialog.
+        job = self._get_running_evaluation() if self._window else None
+        if job and self._window:
+            choice = self._await_close_dialog(job)
+            if choice == 'back':
+                return
+            if choice == 'cancel':
+                self._cancel_evaluation(job.get("jobId") or job.get("job_id"))
+            # Any other value (including 'keep') falls through to the exit path.
+
+        # Show closing overlay (only reached when user actually closes).
         if self._window:
             try:
                 self._window.evaluate_js(CLOSING_OVERLAY_JS)
-            except Exception:
-                pass
-
-        # Check for running evaluation — fast path (0.5s timeout)
-        job = self._get_running_evaluation() if self._window else None
-        if job:
-            try:
-                choice = self._window.evaluate_js(self._build_close_dialog_js(job))
-                if choice == 'back':
-                    return
-                if choice == 'keep':
-                    os._exit(0)  # bypass cleanup — webview event loop would deadlock sys.exit
             except Exception:
                 pass
 
@@ -81,12 +81,57 @@ class _WindowApi:
         t.join(timeout=_CLEANUP_JOIN_TIMEOUT_S)
         os._exit(0)  # bypass cleanup — webview event loop would deadlock sys.exit
 
+    def _await_close_dialog(self, job: dict, timeout_s: float = 300.0) -> str | None:
+        """Render the close dialog and poll a JS global for the user's choice.
+
+        pywebview's evaluate_js does NOT await Promises — it returns None
+        immediately when given Promise-returning JS. That made the existing
+        `choice = evaluate_js(dialog_js)` call return None every time, skip
+        every if-branch, and fall through to os._exit. Instead, stash the
+        Promise result on a global and poll until it's set.
+        """
+        if not self._window:
+            return None
+        try:
+            self._window.evaluate_js(
+                "window._qd_close_result = null; "
+                "(" + self._build_close_dialog_js(job) + ")"
+                ".then(function(r){ window._qd_close_result = r; });"
+            )
+        except Exception:
+            return None
+        import time as _time  # noqa: PLC0415
+        deadline = _time.monotonic() + timeout_s
+        while _time.monotonic() < deadline:
+            try:
+                result = self._window.evaluate_js("window._qd_close_result")
+            except Exception:
+                result = None
+            if result:
+                return str(result)
+            _time.sleep(0.1)
+        return None
+
+    def _cancel_evaluation(self, job_id: str | None) -> None:
+        """Issue DELETE /api/evaluations/<job_id> to stop a running scan."""
+        if not job_id or not self._base_url:
+            return
+        try:
+            req = urllib.request.Request(
+                f"{self._base_url}/api/evaluations/{urllib.parse.quote(job_id)}",
+                method="DELETE",
+            )
+            with urllib.request.urlopen(req, timeout=_EVAL_CHECK_TIMEOUT_S):
+                pass
+        except Exception:
+            pass
+
     def _get_running_evaluation(self) -> dict | None:
         """Return the first running evaluation job, or None."""
+        if not self._base_url:
+            return None
         try:
-            url = self._window.get_current_url().split("#")[0].rstrip("/")
-            base = url.rsplit("/", 1)[0] if "/" in url.lstrip("http") else url
-            req = urllib.request.Request(f"{base}/api/evaluations")
+            req = urllib.request.Request(f"{self._base_url}/api/evaluations")
             with urllib.request.urlopen(req, timeout=_EVAL_CHECK_TIMEOUT_S) as resp:
                 jobs = json.loads(resp.read())
                 for j in (jobs if isinstance(jobs, list) else []):
@@ -122,7 +167,7 @@ class _WindowApi:
                     + '<h3 style="margin:0 0 12px;font-size:1rem">Evaluation in progress</h3>'
                     + '<div style="margin:0 0 16px;padding:10px 14px;background:var(--color-surface-alt,#161b22);border-radius:{_BUTTON_BORDER_RADIUS};font-size:{_DIALOG_FONT_SIZE};line-height:1.6;color:var(--color-text-muted,#8b949e)">{info_html}</div>'
                     + '<div style="display:flex;flex-direction:column;gap:8px">'
-                    + '<button id="_qd_close_keep" style="padding:{_BUTTON_PADDING};border:1px solid var(--color-border,#333);border-radius:{_BUTTON_BORDER_RADIUS};background:var(--color-surface-alt,#161b22);color:var(--color-text,#e6edf3);cursor:pointer;font-size:{_BUTTON_FONT_SIZE}">Close window (evaluation continues in background)</button>'
+                    + '<button id="_qd_close_keep" style="padding:{_BUTTON_PADDING};border:1px solid var(--color-border,#333);border-radius:{_BUTTON_BORDER_RADIUS};background:var(--color-surface-alt,#161b22);color:var(--color-text,#e6edf3);cursor:pointer;font-size:{_BUTTON_FONT_SIZE};line-height:1.5">Close window<br><span style="opacity:0.7;font-size:0.85em">evaluation continues in background</span></button>'
                     + '<button id="_qd_close_cancel" style="padding:{_BUTTON_PADDING};border:1px solid #da3633;border-radius:{_BUTTON_BORDER_RADIUS};background:transparent;color:#f85149;cursor:pointer;font-size:{_BUTTON_FONT_SIZE}">Cancel evaluation and close</button>'
                     + '<button id="_qd_close_back" style="padding:{_BUTTON_PADDING};border:none;border-radius:{_BUTTON_BORDER_RADIUS};background:transparent;color:var(--color-text-muted,#8b949e);cursor:pointer;font-size:{_BUTTON_FONT_SIZE}">Go back</button>'
                     + '</div></div>';
@@ -278,7 +323,31 @@ def main() -> None:
         window.show()
         window.evaluate_js(INJECT_JS)
 
+    def _on_closing() -> bool:
+        """Intercept native close (Cmd+Q, red button, window manager).
+
+        Runs on pywebview's main thread. If a scan is running, render the
+        close dialog synchronously and branch on the user's choice:
+          - 'back'   → block the native close (return False)
+          - 'keep'   → allow close; scan continues in background
+          - 'cancel' → issue cancel API call, then allow close
+        If no scan is running, allow the close without prompting.
+        """
+        try:
+            job = api._get_running_evaluation()
+        except Exception:
+            job = None
+        if not job:
+            return True
+        choice = api._await_close_dialog(job)
+        if choice == 'back':
+            return False
+        if choice == 'cancel':
+            api._cancel_evaluation(job.get("jobId") or job.get("job_id"))
+        return True
+
     window.events.loaded += _on_loaded
+    window.events.closing += _on_closing
 
     instance.start_listening(on_reload=_on_reload)
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -113,15 +113,23 @@ class _WindowApi:
         return None
 
     def _cancel_evaluation(self, job_id: str | None) -> None:
-        """Issue DELETE /api/evaluations/<job_id> to stop a running scan."""
+        """Issue DELETE /api/evaluations/<job_id> to stop a running scan.
+
+        The API enforces an Origin header to reject cross-site requests; a
+        missing header returns 403 which silently fails this call, so we
+        set Origin explicitly to self._base_url.
+        """
         if not job_id or not self._base_url:
             return
         try:
             req = urllib.request.Request(
                 f"{self._base_url}/api/evaluations/{urllib.parse.quote(job_id)}",
                 method="DELETE",
+                headers={"Origin": self._base_url},
             )
-            with urllib.request.urlopen(req, timeout=_EVAL_CHECK_TIMEOUT_S):
+            # Give the API enough time to SIGTERM the scan and respond —
+            # the 0.5s used for the eval-check poll is too tight here.
+            with urllib.request.urlopen(req, timeout=5.0):
                 pass
         except Exception:
             pass

--- a/src/quodeq/data/fs/report_parser/_run_info.py
+++ b/src/quodeq/data/fs/report_parser/_run_info.py
@@ -22,7 +22,7 @@ class RunInfo:
     date_label: str
     branch: str | None = None
     scope_path: str | None = None
-    status: str = "complete"  # "complete" | "in_progress"
+    status: str = "complete"  # "complete" | "in_progress" | "cancelled" | "failed"
 
 
 def safe_read_dir(path: Path) -> list[os.DirEntry[str]]:

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -60,6 +60,21 @@ def read_run_data(reports_root: Path, project: str, run_id: str) -> list[Dimensi
     return dimensions
 
 
+def _read_run_status(run_dir: Path) -> str | None:
+    """Read state from status.json if present. Returns the state string or None."""
+    import json as _json  # noqa: PLC0415
+    status_path = run_dir / "status.json"
+    if not status_path.is_file():
+        return None
+    try:
+        with status_path.open("r", encoding="utf-8") as fp:
+            data = _json.load(fp)
+    except (OSError, ValueError):
+        return None
+    state = data.get("state")
+    return state if isinstance(state, str) else None
+
+
 def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIMIT) -> list[RunInfo]:
     """Return runs for a project, sorted newest-first by date.
 
@@ -79,15 +94,17 @@ def list_runs(reports_root: Path, project: str, *, limit: int = _DEFAULT_RUN_LIM
         manifest_exists = (run_dir / "evidence" / "manifest.json").exists()
         if not manifest_exists:
             continue
-        # Status is "in_progress" only when a live process has its PID registered
-        # in the run directory (via .pid file written by `quodeq evaluate`). All
-        # other runs — historical, crashed, pre-.pid-era — are treated as
-        # "complete" so they remain visible in History with their normal
-        # score/grade rendering. Runs with live PIDs get the dimmed "Running…"
-        # treatment instead.
+        # Status precedence:
+        #   1. Live process holding the PID → "in_progress" (dimmed "Running…" in UI)
+        #   2. status.json state in {cancelled, failed} → pass through
+        #   3. Otherwise → "complete" (historical, crashed, pre-.pid-era runs)
         from quodeq.services._external_jobs import resolve_external_pid  # noqa: PLC0415
         pid = resolve_external_pid(project_dir.name, entry.name, reports_root)
-        status = "in_progress" if pid is not None else "complete"
+        if pid is not None:
+            status = "in_progress"
+        else:
+            raw_state = _read_run_status(run_dir)
+            status = raw_state if raw_state in ("cancelled", "failed") else "complete"
         date_iso, date_label = parse_run_date(reports_root, project, entry.name)
         run_infos.append(RunInfo(run_id=entry.name, date_iso=date_iso, date_label=date_label, status=status))
     run_infos.sort(key=lambda r: (r.date_iso or "", r.run_id), reverse=True)

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -10,14 +10,37 @@ Look for TWO types of issues:
 
 **Avoid false positives** — a string/number literal inside a constant definition or enum is NOT a magic literal; a long function that only registers routes with no extractable logic is not always splittable; duplicated test setup code may be intentional. If the code IS the remediation for the issue, it is not a violation.
 
+## Evidence requirement
+
+Every violation must cite code that is directly visible in the provided source.
+
+- Quote the specific expression, statement, or call that IS the problem in the `snippet` field.
+- Do NOT infer violations from imports, function names, file paths, module layout, or the *absence* of code — unless a requirement explicitly demands that the missing code be present in this file.
+- If you cannot point to a concrete line where the problem manifests, do not flag it.
+- Speculative concerns ("this could be vulnerable to X", "this might allow Y", "should consider Z") are NOT violations. Only report issues you can prove from the code shown.
+
 ## Severity
 
 For violations:
-- **critical** — Security vulnerability, data loss risk, or crash in production path
-- **major** — Significant quality issue that should be fixed
-- **minor** — Style issue, minor inefficiency, or improvement opportunity
+- **critical** — An exploitable vulnerability or production-breaking bug with clear, demonstrable impact visible in the code. Examples: SQL injection with user-controlled input reaching a raw query; hardcoded secret committed to source; authentication bypass; data loss on a code path that will execute in production. Do NOT use `critical` for missing best-practice controls, hardening gaps, defense-in-depth concerns, or hypothetical attack scenarios — those are `major` or `minor`. If you cannot describe a concrete attack or failure that this code enables right now, it is not critical.
+- **major** — Significant quality issue or real security weakness that should be fixed, but not directly exploitable or production-breaking as-is.
+- **minor** — Style issue, minor inefficiency, or improvement opportunity.
 
 For compliance — use the same severity to indicate the importance of what's done right:
 - **critical** — Security best practice correctly implemented, safe data handling
 - **major** — Significant quality pattern properly followed
 - **minor** — Good style, naming, or minor best practice followed
+
+## Severity self-check
+
+Before finalizing ANY violation, verify:
+
+1. **Evidence**: Can you quote the exact line of code that IS the problem? If you can only point to what's *missing* or *absent*, drop the finding.
+2. **Concreteness**: Can you state the problem in one specific sentence that refers to the quoted code? Vague concerns ("might not be safe", "could be improved") do not pass.
+
+Additionally for `critical` and `major`:
+
+3. **Attack/failure scenario**: Can you describe, in one sentence, a specific attack or failure this code enables *as written*? If your reasoning uses "could", "might", "may", or "should consider" — downgrade to `minor`.
+4. **Reachability**: Does this code execute in a realistic production path? Code in test files, examples, or dev-only scaffolding is not `critical`.
+
+If checks 1–2 fail, omit the finding. If checks 3–4 fail, downgrade to `minor` or omit. Being wrong on severity hurts the report more than missing a true positive at a lower severity.

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -90,8 +90,20 @@ class EvaluationActions(Protocol):
         """Cancel a running evaluation job. Return True on success."""
         ...
 
-    def list_evaluations(self, *, limit: int = 0, reports_dir: str | None = None) -> list[JobSnapshot]:
-        """Return all evaluation jobs (running, done, failed, cancelled)."""
+    def list_evaluations(
+        self,
+        *,
+        limit: int = 0,
+        reports_dir: str | None = None,
+        states: set[str] | None = None,
+    ) -> list[JobSnapshot]:
+        """Return evaluation jobs. If *states* is given, only jobs whose status
+        is in the set are returned (e.g. {"running", "done"} to hide cancelled/failed)."""
+        ...
+
+    def delete_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
+        """Delete a finished evaluation's on-disk artifacts and index row.
+        Refuses to delete a running job (returns False). Returns True on success."""
         ...
 
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -190,7 +190,10 @@ def _compute_dashboard_payload(
 ) -> _DashboardPayload:
     """Compute history-dependent parts of the dashboard response."""
     selected_dim_names = {d.dimension for d in ctx.dimensions}
-    history_runs = runs[:max(_MAX_HISTORY_RUNS, ctx.index + 1)]
+    # Exclude cancelled/failed runs — they produce misleading points on the
+    # history chart. They remain visible in availableRuns for the UI.
+    scoreable_runs = [r for r in runs if r.status not in ("cancelled", "failed")]
+    history_runs = scoreable_runs[:max(_MAX_HISTORY_RUNS, ctx.index + 1)]
     get_run_dimensions = _make_run_dimension_fetcher(
         reports_root, project, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
     )

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -258,14 +258,23 @@ class FsEvaluationMixin:
         _score_completed_evidence(reports_dir, job)
         return True
 
-    def list_evaluations(self, *, limit: int = 0, reports_dir: str | None = None) -> list[JobSnapshot]:
+    def list_evaluations(
+        self,
+        *,
+        limit: int = 0,
+        reports_dir: str | None = None,
+        states: set[str] | None = None,
+    ) -> list[JobSnapshot]:
         """Return evaluation jobs (running, done, failed, cancelled).
 
         When *limit* > 0 only the most recent *limit* jobs are returned.
         When *reports_dir* is provided, external in-progress runs are merged in.
+        When *states* is provided, only jobs with status in the set are returned.
         """
         reports_root = Path(reports_dir) if reports_dir else None
         jobs = self._jobs.list_jobs(reports_root=reports_root)
+        if states:
+            jobs = [j for j in jobs if j.status in states]
         return jobs[:limit] if limit > 0 else jobs
 
 

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -60,7 +60,12 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             self._index_db_path = Path(get_index_db_path())
         return _run_index.open_index(self._index_db_path)
 
-    def list_evaluations(self, limit: int = 0, reports_dir: Path | None = None) -> list[JobSnapshot]:
+    def list_evaluations(
+        self,
+        limit: int = 0,
+        reports_dir: Path | None = None,
+        states: set[str] | None = None,
+    ) -> list[JobSnapshot]:
         """Return runs from the SQLite index merged with in-memory JobManager jobs."""
         if reports_dir is None:
             from quodeq.shared._env import get_evaluations_dir
@@ -85,8 +90,49 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         for j in internal_jobs:
             by_id[j.job_id] = j  # internal dashboard-spawned jobs always take priority
         merged = list(by_id.values())
+        if states:
+            merged = [s for s in merged if s.status in states]
         merged.sort(key=lambda s: s.started_at or "", reverse=True)
         return merged[:limit] if limit and limit > 0 else merged
+
+    def delete_evaluation(self, job_id: str, reports_dir: Path | None = None) -> bool:
+        """Delete a run's on-disk dir and index row. Refuses to delete a running job."""
+        import shutil
+
+        snapshot = self.get_evaluation_status(job_id, reports_dir=reports_dir)
+        if snapshot is None:
+            return False
+        if snapshot.status == "running":
+            return False
+        if reports_dir is None:
+            from quodeq.shared._env import get_evaluations_dir
+            reports_dir = Path(get_evaluations_dir())
+        else:
+            reports_dir = Path(reports_dir)
+        # Job IDs of form "ext-<run_uuid>"; run_uuid is also the run directory name.
+        run_uuid = job_id[len("ext-"):] if job_id.startswith("ext-") else job_id
+        # Scan all project dirs for the run directory (runs are nested by project).
+        removed_dir = False
+        if reports_dir.is_dir():
+            for project_dir in reports_dir.iterdir():
+                candidate = project_dir / run_uuid
+                if candidate.is_dir():
+                    shutil.rmtree(candidate, ignore_errors=True)
+                    removed_dir = True
+                    break
+        # Remove from index regardless so stale rows get cleaned up.
+        db = self._open_index()
+        try:
+            _run_index.delete_run(db, job_id)
+        finally:
+            db.close()
+        # Also drop any in-memory JobManager entry.
+        try:
+            if hasattr(self._jobs, "delete"):
+                self._jobs.delete(job_id)
+        except (KeyError, AttributeError):
+            pass
+        return removed_dir
 
     def get_evaluation_status(self, job_id: str, reports_dir: Path | None = None) -> JobSnapshot | None:
         """Return a single run's snapshot.
@@ -135,7 +181,26 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         return self._run_row_to_snapshot(row)
 
     @staticmethod
-    def _run_row_to_snapshot(row: "_run_index.RunRow") -> JobSnapshot:
+    def _tail_run_log(run_dir: Path, max_lines: int = 500) -> list[str]:
+        """Return the last *max_lines* lines from run.log. Cheap for normal logs."""
+        log_path = run_dir / "run.log"
+        if not log_path.is_file():
+            return []
+        try:
+            with log_path.open("r", encoding="utf-8", errors="replace") as fp:
+                lines = fp.readlines()
+        except OSError:
+            return []
+        tail = lines[-max_lines:] if len(lines) > max_lines else lines
+        return [line.rstrip("\n") for line in tail]
+
+    def _run_row_to_snapshot(self, row: "_run_index.RunRow") -> JobSnapshot:
+        logs: list[str] = []
+        if row.run_dir:
+            try:
+                logs = self._tail_run_log(Path(row.run_dir))
+            except (OSError, ValueError):
+                logs = []
         return JobSnapshot(
             job_id=row.job_id,
             status=row.state,
@@ -143,7 +208,7 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             started_at=row.started_at,
             ended_at=row.finalized_at,
             exit_code=None,
-            logs=[],
+            logs=logs,
             output_project=row.project_uuid,
             output_run_id=row.run_id,
             phase=row.phase,

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -232,3 +232,10 @@ def rebuild_index(
     count = db.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
     elapsed_ms = int((_time.monotonic() - start) * 1000)
     return count, elapsed_ms
+
+
+def delete_run(db: sqlite3.Connection, job_id: str) -> bool:
+    """Remove a run from the index. Returns True if a row was deleted."""
+    with db:
+        cur = db.execute("DELETE FROM runs WHERE job_id = ?", (job_id,))
+    return cur.rowcount > 0

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -168,8 +168,12 @@ def get_project_scores(
     # Apply rescore to accumulated dimensions
     accumulated = _rescore_accumulated_response(accumulated, reports_root, project)
 
-    # Build trend using a rescoring fetcher (applies dismissals to each run)
-    history_runs = all_runs[:_max_history_runs()]
+    # Build trend using a rescoring fetcher (applies dismissals to each run).
+    # Exclude cancelled/failed runs — their partial scores are misleading on
+    # the history chart. They remain in availableRuns so the UI can show them
+    # when the user asks for them explicitly.
+    scoreable_runs = [r for r in all_runs if r.status not in ("cancelled", "failed")]
+    history_runs = scoreable_runs[:_max_history_runs()]
     rescoring_fetcher = _make_rescoring_fetcher(reports_root, project)
     trend = build_accumulated_trend(history_runs, rescoring_fetcher)
 

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -219,6 +219,7 @@ const ROUTE_RENDERERS = {
           onDimensionClick: (dim) => props.navigation.handleNavigate('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject }),
           onNavigate: props.navigation.handleNavigate,
           onRunChange: props.navigation.setHistorySelectedRun,
+          onRunDeleted: () => props.refreshDashboard?.(),
         }}
         projectInfo={props.navigation.projects?.find((p) => (p.id || p.name) === props.navigation.selectedProject) || null}
       />

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -112,10 +112,16 @@ export async function getAccumulated(projectId, asOfRun = null) {
 
 // ── Evaluations / Jobs ──────────────────────────────────────────────────
 
-/** @returns {Promise<import('../models/job.js').Job[]>} */
-export async function listEvaluations({ limit } = {}) {
-  const params = limit ? `?limit=${limit}` : '';
-  const data = await request(`/evaluations${params}`);
+/**
+ * @param {{ limit?: number, states?: string[] }} [options]
+ * @returns {Promise<import('../models/job.js').Job[]>}
+ */
+export async function listEvaluations({ limit, states } = {}) {
+  const params = new URLSearchParams();
+  if (limit) params.set('limit', String(limit));
+  if (states && states.length) params.set('state', states.join(','));
+  const qs = params.toString();
+  const data = await request(`/evaluations${qs ? `?${qs}` : ''}`);
   return (data || []).map(createJob);
 }
 
@@ -139,6 +145,17 @@ export async function getEvaluation(jobId) {
  * @returns {Promise<Object>}
  */
 export function cancelEvaluation(jobId) {
+  return request(`/evaluations/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
+}
+
+/**
+ * Permanently delete a non-running evaluation from history (removes scan dir + index row).
+ * The server DELETE endpoint routes running jobs to cancel and finished jobs to purge —
+ * this helper is the semantic alias UI callers use when they want the purge path.
+ * @param {string} jobId
+ * @returns {Promise<Object>}
+ */
+export function deleteEvaluation(jobId) {
   return request(`/evaluations/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
 }
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -222,6 +222,15 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
 
   async function cancelEvaluationJob(jobId) {
     if (!jobId) return;
+    const { confirmDialog } = await import('../../../utils/confirmDialog.js');
+    const ok = await confirmDialog({
+      title: 'Cancel evaluation?',
+      message: 'Stop the running scan. Any findings collected so far will still be saved.',
+      confirmLabel: 'Cancel evaluation',
+      cancelLabel: 'Keep running',
+      variant: 'danger',
+    });
+    if (!ok) return;
     try {
       await cancelEvaluation(jobId);
       clearJob();

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, lazy, Suspense } from 'react';
 import { gradeLabel, scoreColorClass } from '../../../utils/formatters.js';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { confirmDialog } from '../../../utils/confirmDialog.js';
 const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
@@ -8,6 +10,8 @@ import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 import FittedText from '../../../components/FittedText.jsx';
+
+const HIDDEN_STATUSES = new Set(['cancelled', 'failed']);
 
 const MAX_VISIBLE = 20;
 
@@ -83,9 +87,13 @@ function buildInProgressStubs(availableRuns, trend) {
  *
  *   [ DATE ][ TIME ][ GRADE ][ SCORE ][ Δ ][ DIMENSIONS (flex) ]
  */
-function HistoryRow({ className = '', onClick, cells }) {
+function HistoryRow({ className = '', onClick, cells, onDelete }) {
   const common = `history-row ${className}`.trim();
   const isHeader = className.includes('history-row--header');
+  function handleDeleteClick(e) {
+    e.stopPropagation();
+    onDelete?.();
+  }
   return (
     <div className={common} onClick={onClick} role={onClick ? 'button' : 'row'} tabIndex={onClick ? 0 : undefined}>
       <div className="history-row__col history-row__col--date">{cells.date}</div>
@@ -94,12 +102,29 @@ function HistoryRow({ className = '', onClick, cells }) {
       <div className="history-row__col history-row__col--score">{cells.score}</div>
       <div className="history-row__col history-row__col--delta">{cells.delta}</div>
       <div className="history-row__col history-row__col--dims">{cells.dims}</div>
-      <div className="history-row__col history-row__col--chevron" aria-hidden="true">{isHeader ? '' : '›'}</div>
+      <div className="history-row__col history-row__col--chevron" aria-hidden="true">
+        {isHeader ? '' : (
+          <>
+            {onDelete && (
+              <button
+                type="button"
+                className="history-row__delete"
+                aria-label="Delete run"
+                title="Delete run"
+                onClick={handleDeleteClick}
+              >
+                ×
+              </button>
+            )}
+            <span>›</span>
+          </>
+        )}
+      </div>
     </div>
   );
 }
 
-function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick }) {
+function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick, onDeleteRun }) {
   return (
     <section className="history-evaluations panel">
       <div className="history-evaluations__header">
@@ -127,6 +152,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick }) {
               key={entry.runId}
               className={isSelected ? 'history-row--selected' : ''}
               onClick={() => onRunClick(entry.runId, entry.dateLabel)}
+              onDelete={onDeleteRun ? () => onDeleteRun(entry.runId, entry.dateLabel || date) : undefined}
               cells={{
                 date,
                 time: <span className="history-row__muted">{time}</span>,
@@ -149,11 +175,20 @@ function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick }) {
 
 function HistoryContent({ data, callbacks, showAll, setShowAll, runNav, languageSub }) {
   const { trend, selectedRunId, availableRuns } = data;
-  const { onRunClick, onRunChange } = callbacks;
+  const { onRunClick, onRunChange, onDeleteRun } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
   const deltas = useMemo(() => computeDeltas(trend), [trend]);
   const inProgressStubs = useMemo(() => buildInProgressStubs(availableRuns, trend), [availableRuns, trend]);
-  const allEntries = useMemo(() => [...inProgressStubs, ...trend], [inProgressStubs, trend]);
+  const statusByRunId = useMemo(() => {
+    const map = new Map();
+    (availableRuns || []).forEach((r) => { if (r.runId) map.set(r.runId, r.status); });
+    return map;
+  }, [availableRuns]);
+  const isHiddenStatus = (runId) => HIDDEN_STATUSES.has(statusByRunId.get(runId));
+  const allEntries = useMemo(() => {
+    const combined = [...inProgressStubs, ...trend];
+    return combined.filter((entry) => !isHiddenStatus(entry.runId));
+  }, [inProgressStubs, trend, statusByRunId]);  // eslint-disable-line react-hooks/exhaustive-deps
   const visible = showAll ? allEntries : allEntries.slice(0, MAX_VISIBLE);
   const hasMore = allEntries.length > MAX_VISIBLE && !showAll;
 
@@ -190,6 +225,7 @@ function HistoryContent({ data, callbacks, showAll, setShowAll, runNav, language
         selectedRunId={selectedRunId}
         deltas={deltas}
         onRunClick={onRunClick}
+        onDeleteRun={onDeleteRun}
       />
 
       {hasMore && (
@@ -203,10 +239,31 @@ function HistoryContent({ data, callbacks, showAll, setShowAll, runNav, language
 
 export default function HistoryPage({ trend: rawTrend, selection, availableRuns, dimensions, callbacks, projectInfo }) {
   const { selectedRunId } = selection;
-  const { onRunClick, onDimensionClick, onNavigate, onRunChange } = callbacks;
+  const { onRunClick, onDimensionClick, onNavigate, onRunChange, onRunDeleted } = callbacks;
+  const { deleteEvaluation } = useApi();
   const [showAll, setShowAll] = useState(false);
   const visibleSet = useMemo(() => new Set(readVisibleStandardIds()), []);
   const trend = useMemo(() => filterTrendByVisibleStandards(rawTrend || [], visibleSet), [rawTrend, visibleSet]);
+
+  async function handleDeleteRun(runId, dateLabel) {
+    const label = dateLabel || runId;
+    const ok = await confirmDialog({
+      title: 'Delete run?',
+      message: `Remove the run "${label}" from history. This cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Keep',
+      variant: 'danger',
+    });
+    if (!ok) return;
+    const jobId = runId.startsWith('ext-') ? runId : `ext-${runId}`;
+    try {
+      await deleteEvaluation(jobId);
+    } catch (err) {
+      alert(`Failed to delete run: ${err.message || 'unknown error'}`);
+      return;
+    }
+    onRunDeleted?.(runId);
+  }
 
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = useRunNavigator({
     selectedRun: selectedRunId || 'latest',
@@ -239,7 +296,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   return (
     <HistoryContent
       data={{ trend, selectedRunId, availableRuns }}
-      callbacks={{ onRunClick, onRunChange }}
+      callbacks={{ onRunClick, onRunChange, onDeleteRun: handleDeleteRun }}
       showAll={showAll} setShowAll={setShowAll}
       runNav={{ runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest }}
       languageSub={languageSub}

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1045,18 +1045,102 @@
 .history-row__col--delta  { flex: 0 0 56px; text-align: left; font-variant-numeric: tabular-nums; }
 .history-row__col--dims   { flex: 1 1 auto; min-width: 0; }
 .history-row__col--chevron {
-  flex: 0 0 12px;
+  flex: 0 0 44px;
   color: var(--color-text-muted);
   text-align: right;
   font-size: 16px;
   line-height: 1;
   opacity: 0.5;
   transition: opacity 0.12s, transform 0.12s;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
 }
 .history-row:not(.history-row--header):hover .history-row__col--chevron {
   opacity: 1;
   transform: translateX(2px);
 }
+.history-row__delete {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s;
+}
+.history-row:not(.history-row--header):hover .history-row__delete {
+  opacity: 0.7;
+}
+.history-row__delete:hover {
+  opacity: 1;
+  color: var(--color-grade-bottom-text, var(--color-accent));
+}
+
+/* Generic confirmation dialog (confirmDialog utility) */
+.qd-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999999;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: qd-fade-in 0.12s ease-out;
+}
+@keyframes qd-fade-in { from { opacity: 0; } to { opacity: 1; } }
+.qd-confirm-dialog {
+  background: var(--color-surface, #1c2128);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 6px;
+  padding: 18px 22px;
+  max-width: 420px;
+  width: calc(100% - 40px);
+  color: var(--color-text, #e6edf3);
+  font-family: inherit;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+.qd-confirm-title {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+.qd-confirm-message {
+  margin: 0 0 16px;
+  color: var(--color-text-muted, #8b949e);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.qd-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.qd-confirm-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--color-border, #333);
+  border-radius: 4px;
+  background: var(--color-surface-alt, #161b22);
+  color: var(--color-text, #e6edf3);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.qd-confirm-btn:hover { background: var(--color-surface, #1c2128); }
+.qd-confirm-btn--confirm {
+  background: var(--color-accent, #2f81f7);
+  border-color: var(--color-accent, #2f81f7);
+  color: #fff;
+}
+.qd-confirm-btn--confirm.qd-confirm-btn--danger {
+  background: #da3633;
+  border-color: #da3633;
+}
+.qd-confirm-btn--confirm:hover { filter: brightness(1.12); }
 
 .history-row__muted { color: var(--color-text-muted); }
 .history-evaluations__header {

--- a/src/quodeq/ui/src/utils/confirmDialog.js
+++ b/src/quodeq/ui/src/utils/confirmDialog.js
@@ -1,0 +1,60 @@
+/**
+ * DOM-based confirmation dialog. Returns a Promise that resolves to true
+ * (confirm) or false (cancel / clicked-outside). We roll our own instead of
+ * using window.confirm because pywebview in frameless mode can suppress
+ * native dialogs, leaving callers no feedback path.
+ *
+ * Usage:
+ *   const ok = await confirmDialog({ title: 'Delete run?', message: '...' });
+ *   if (!ok) return;
+ */
+export function confirmDialog({
+  title = 'Confirm',
+  message = 'Are you sure?',
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default', // 'default' | 'danger'
+} = {}) {
+  return new Promise((resolve) => {
+    if (typeof document === 'undefined') {
+      resolve(false);
+      return;
+    }
+    const overlay = document.createElement('div');
+    overlay.className = 'qd-confirm-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.innerHTML = `
+      <div class="qd-confirm-dialog qd-confirm-dialog--${variant}">
+        <h3 class="qd-confirm-title"></h3>
+        <p class="qd-confirm-message"></p>
+        <div class="qd-confirm-actions">
+          <button type="button" class="qd-confirm-btn qd-confirm-btn--cancel"></button>
+          <button type="button" class="qd-confirm-btn qd-confirm-btn--confirm qd-confirm-btn--${variant}"></button>
+        </div>
+      </div>
+    `;
+    overlay.querySelector('.qd-confirm-title').textContent = title;
+    overlay.querySelector('.qd-confirm-message').textContent = message;
+    const cancelBtn = overlay.querySelector('.qd-confirm-btn--cancel');
+    const confirmBtn = overlay.querySelector('.qd-confirm-btn--confirm');
+    cancelBtn.textContent = cancelLabel;
+    confirmBtn.textContent = confirmLabel;
+
+    function close(result) {
+      overlay.remove();
+      document.removeEventListener('keydown', onKey);
+      resolve(result);
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') close(false);
+      if (e.key === 'Enter') close(true);
+    }
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(false); });
+    cancelBtn.addEventListener('click', () => close(false));
+    confirmBtn.addEventListener('click', () => close(true));
+    document.addEventListener('keydown', onKey);
+    document.body.appendChild(overlay);
+    confirmBtn.focus();
+  });
+}

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -129,7 +129,7 @@ class TestRunApiAnalysis:
             run_api_analysis(prompt="test", jsonl_file=jsonl_file, config=api_config)
 
             call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-            assert call_kwargs["max_retries"] == 2
+            assert call_kwargs["max_retries"] == 1
 
 
 class TestApiRunnerConfig:


### PR DESCRIPTION
## Summary

Three related improvements bundled together — they surfaced in sequence while debugging a security scan and it was cleanest to land them together since each built on the previous.

### Evaluation prompt quality
- Evidence gate in `evaluation_rules.md` bans speculative findings and requires every violation to quote visible code.
- Tighter `critical` severity rubric + per-finding self-check (evidence, concreteness, reachability).
- `QUODEQ_CONTEXT_SIZE` env var is now actually honored as a fallback `num_ctx`.
- Instructor `max_retries` dropped from 2 → 1 so a broken JSON response costs ~1 minute of silence instead of ~6.

### Clean run history + delete
- `GET /api/evaluations?state=running,done` — optional state filter.
- `DELETE /api/evaluations/<job_id>` routes running jobs to cancel (existing), finished jobs to purge (new — removes scan dir + index row).
- `list_runs` reads `status.json` so `RunInfo.status` distinguishes `cancelled` / `failed` / `complete` / `in_progress`.
- Dashboard history chart and trend exclude cancelled/failed runs so their partial scores stop polluting the timeline.
- `HistoryPage` hides cancelled/failed rows and adds a subtle `×` delete button per row.
- New `confirmDialog` utility replaces `window.confirm` (pywebview suppresses native dialogs in frameless mode, which left cancel and delete with no confirmation prompt).

### Scans survive dashboard restart
Root cause: launching a second dashboard called `_kill_stale_action_api` on the first API, whose `atexit` handler then ran `provider._jobs.shutdown()` and killed every running scan.
- Drop the atexit + signal auto-kill in `api/app.py`. Scans are already spawned with `start_new_session=True` — the cleanup was the thing actively tearing them down.
- `_cli_evaluation.py` sets `lifecycle.phase = "analyzing"` at pipeline start and `"scoring"` after `run_full`. The UI gates live-violation polling on phase, so CLI-launched scans now stream violations to the dashboard properly.
- `filesystem.py` tails the last 500 lines of `run.log` when serializing external runs → `ConsoleLogViewer` works for scans this dashboard didn't spawn itself.

### Close dialog — now actually works
The keep / cancel / back close dialog has never fired since the feature was written:
1. `_get_running_evaluation` derived its base URL by `rsplit("/", 1)` on `"http://host:port"`, producing `"http:/"` — every request failed → function returned `None` → dialog gated out.
2. `evaluate_js` does not await Promise-returning JS in pywebview. It fires and returns `None` immediately, so Python saw `choice=None`, matched no branch, and hit `os._exit(0)` at the bottom of `close()`.

Fixed by using `self._base_url` directly and polling a JS global (`.then(r => window._qd_close_result = r)` + 100ms Python polling loop). Same helper now powers both the in-app close button and the native-OS close intercept (`Cmd+Q`, red X).

## Test plan

- [x] 2096 backend tests pass (`uv run pytest`)
- [x] 100 UI tests pass (`npm run test`)
- [x] Run a scan from the dashboard UI, close the window while it's running — verify 3-option dialog appears and each choice does what it says
- [x] Launch a second dashboard while a scan is running — verify the scan keeps running and the new dashboard sees it with live logs + live violations
- [x] Verify cancelled / failed runs no longer appear in history or in the score_history chart
- [x] Use the × delete button on a finished run in history — verify confirmation, deletion, and auto-refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)