### PR TITLE
Dashboard: don't die silently on Linux; real quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,25 +56,51 @@ Each finding includes a reason, the offending code, and a fix plan. Results are 
 
 ## Getting Started
 
+### 1. Prerequisites
+
+| OS | Command |
+|---|---|
+| **macOS** | `brew install python node pipx` |
+| **Debian / Ubuntu** | `sudo apt install -y python3.12 python3-pip pipx nodejs npm` |
+| **Fedora / RHEL** | `sudo dnf install -y python3.12 python3-pip pipx nodejs npm` |
+| **Arch** | `sudo pacman -S python python-pipx nodejs npm` |
+
+> **Debian/Ubuntu heads-up:** `nodejs` and `npm` are separate packages. `apt install nodejs` alone is not enough. If you also use the native desktop window (not `--browser`), you'll need `sudo apt install -y python3-gi gir1.2-webkit2-4.1` too — otherwise quodeq will auto-fall-back to opening the dashboard in your default browser.
+
+Minimum versions: Python 3.12+, Node.js 18+, npm 9+.
+
+### 2. Install quodeq
+
 ```bash
-pipx install quodeq    # Install quodeq
-quodeq                 # Launch the dashboard
+pipx install quodeq    # isolated, recommended
+# or: pip install quodeq
 ```
 
-Running `quodeq` opens the dashboard, where you can point to any project and run evaluations from the UI. Also available via `pip install quodeq`.
+### 3. Pick an AI provider
 
-**Requirements:** [Python 3.12+](https://www.python.org/downloads/), [Node.js 18+](https://nodejs.org/) and npm 9+ (for the dashboard UI).
+Quodeq needs an LLM to do the evaluation. You have two options:
 
-Install Node.js + npm from [nodejs.org](https://nodejs.org/) or via your package manager:
-
+**Local, free, private** — [Ollama](https://ollama.com/download) with Gemma 4:
 ```bash
-brew install node                    # macOS — ships node + npm together
-sudo apt install -y nodejs npm       # Debian/Ubuntu — two separate packages
-sudo dnf install -y nodejs npm       # Fedora/RHEL
-pacman -S nodejs npm                 # Arch
+# install ollama from https://ollama.com/download, then:
+ollama pull gemma4-26b-32k
+ollama serve    # runs in the background
 ```
 
-> **Heads-up for Debian/Ubuntu users:** on Ubuntu `nodejs` and `npm` are separate packages. `apt install nodejs` alone is not enough.
+**Cloud, faster** — one of the agentic CLIs (at least one):
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) — `npm install -g @anthropic-ai/claude-code`
+- [Codex CLI](https://developers.openai.com/codex/quickstart) — `npm install -g @openai/codex`
+- [Gemini CLI](https://geminicli.com/docs/get-started/installation/) — `npm install -g @anthropic-ai/gemini-cli`
+
+### 4. Launch the dashboard
+
+```bash
+quodeq
+```
+
+The dashboard opens at `http://127.0.0.1:4173`. Use **Settings → AI Provider** to select the one you installed in step 3, then **Evaluate** to point at a project and start your first scan.
+
+If the native window doesn't show up (common on Linux without GTK), run `quodeq --browser` instead.
 
 ### macOS App (beta)
 

--- a/src/quodeq/dashboard/_server.py
+++ b/src/quodeq/dashboard/_server.py
@@ -111,7 +111,14 @@ def _serve_native(
     action_api_process: subprocess.Popen | None,
     stop_children: typing.Callable,
 ) -> None:
-    """Open a PyWebView native window with single-instance support."""
+    """Open a PyWebView native window with single-instance support.
+
+    On Linux, pywebview additionally needs a working GTK+/WebKit2GTK stack
+    (python3-gi, gir1.2-webkit2-4.1) that isn't shipped with the pip wheel.
+    When those bindings are missing we fall back to --browser mode instead
+    of silently dying after spawning a webview subprocess that immediately
+    crashes on import.
+    """
     try:
         import webview  # noqa: F401
     except ImportError:
@@ -119,6 +126,17 @@ def _serve_native(
             "pywebview is not installed. "
             "Try reinstalling with 'pip install --upgrade quodeq' or use --browser."
         )
+
+    if sys.platform.startswith("linux") and not _linux_webview_backend_available():
+        logging.getLogger(__name__).warning(
+            "pywebview's Linux GTK+/WebKit backend is missing — "
+            "falling back to opening the dashboard in your browser. "
+            "Install 'python3-gi' and 'gir1.2-webkit2-4.1' (Debian/Ubuntu) "
+            "or 'python3-gobject' + 'webkit2gtk4.1' (Fedora/Arch) to get the native window.",
+        )
+        webbrowser.open(action_api_url)
+        _serve_blocking(action_api_process, stop_children)
+        return
 
     from quodeq.dashboard._instance import InstanceController
 
@@ -141,12 +159,46 @@ def _serve_native(
     # Pass Flask PID so the webview process can kill it on window close.
     api_pid = str(action_api_process.pid) if action_api_process else ""
 
+    # Route webview stderr to a log file (not DEVNULL) so a platform import
+    # failure or GTK error is actually recoverable from ~/.quodeq/run/.
+    webview_log_path = Path.home() / ".quodeq" / "run" / "webview.log"
+    try:
+        webview_log_path.parent.mkdir(parents=True, exist_ok=True)
+        webview_stderr = webview_log_path.open("a", encoding="utf-8")
+    except OSError:
+        webview_stderr = subprocess.DEVNULL
+
     subprocess.Popen(
         subprocess_cmd("webview", [action_api_url, str(instance.sock_path), api_pid]),
         start_new_session=True,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stderr=webview_stderr,
     )
+
+    # Block on the API process, not the webview. If the webview subprocess
+    # crashes (missing platform bindings, GTK errors, etc.) the API survives
+    # and the user can still reach the dashboard in their browser. Without
+    # this block the whole `quodeq dashboard` command returned immediately
+    # after spawning the detached webview child and the API was torn down.
+    _serve_blocking(action_api_process, stop_children)
+
+
+def _linux_webview_backend_available() -> bool:
+    """Return True if pywebview's GTK backend can actually load on Linux.
+
+    pywebview-on-Linux needs PyGObject + WebKit2GTK; neither is a pip
+    dependency of the `pywebview` wheel. Importing the GTK backend is the
+    only reliable probe — a successful `import webview` only proves the
+    Python package installed, not that its Linux backend is usable.
+    """
+    try:
+        import gi  # type: ignore[import-untyped]
+        gi.require_version("WebKit2", "4.1")
+        from gi.repository import WebKit2  # noqa: F401
+        return True
+    except (ImportError, ValueError):
+        # ValueError: "Namespace WebKit2 not available"
+        return False
 
 
 # Public alias for cross-module use within the dashboard package


### PR DESCRIPTION
## Summary

Second round of user feedback from the Ubuntu install:

> Running \`quodeq\` or \`quodeq dashboard\` says it's started a server listening on localhost:4173, but then the server immediately exits. Unfortunately that means I can't configure an LLM provider! … I really think it would be good to include a bit more of a quick start guide.

Two independent causes:

1. **Silent exit after "Dashboard running at …"** — \`_serve_native\` spawned the webview subprocess with \`start_new_session=True\` and \`stderr=DEVNULL\`, then returned immediately. \`run_dashboard\` returned, the API process got torn down with it, and the user saw the success line followed by nothing. On Linux the webview child also crashes on import when pywebview's GTK+/WebKit bindings aren't installed (the pip wheel doesn't pull them in).

2. **No real quickstart** — the README jumped from \`pipx install\` to launch with no mention that you still need an LLM provider configured before anything useful happens.

## Changes

### Runtime (\`src/quodeq/dashboard/_server.py\`)
- Block on the API process after spawning the webview, matching browser-mode behavior. If the webview crashes, the API stays up and the user can still hit \`http://127.0.0.1:4173\` in a browser.
- On Linux, probe for the GTK2.x + WebKit2GTK bindings. If missing, log an actionable message listing the distro packages needed and auto-fall-back to \`webbrowser.open(url)\` + blocking on the API.
- Route webview stderr to \`~/.quodeq/run/webview.log\` instead of \`/dev/null\` so future backend failures are diagnosable.

### Docs (\`README.md\`)
4-step quickstart replacing the old two-line block:
1. Prereqs per OS (Homebrew / apt / dnf / pacman — including the Debian/Ubuntu \`nodejs npm\` two-package note + GTK packages for the native window).
2. \`pipx install quodeq\`.
3. Pick an AI provider — Ollama (local/free) or one of Claude Code / Codex CLI / Gemini CLI (cloud).
4. \`quodeq\` → Settings → AI Provider → Evaluate.

## Test plan

- [x] Dashboard + prereq test suites pass (116 tests)
- [x] Manually verify on a Linux VM without \`python3-gi\`: \`quodeq\` should log the GTK warning + fall back to the browser, API should stay up.
- [x] On macOS: \`quodeq\` should still open the native window as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)