### PR TITLE
Expose dimensions list for ext-jobs so live violations actually show on reconnect

### DIFF
--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -194,13 +194,33 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         tail = lines[-max_lines:] if len(lines) > max_lines else lines
         return [line.rstrip("\n") for line in tail]
 
+    @staticmethod
+    def _read_dimensions_from_status(run_dir: Path) -> list[str] | None:
+        """Read the `dimensions` list from status.json, or None if unavailable."""
+        import json as _json  # noqa: PLC0415
+        status_path = run_dir / "status.json"
+        if not status_path.is_file():
+            return None
+        try:
+            data = _json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        dims = data.get("dimensions")
+        return dims if isinstance(dims, list) else None
+
     def _run_row_to_snapshot(self, row: "_run_index.RunRow") -> JobSnapshot:
         logs: list[str] = []
+        dimensions: list[str] | None = None
         if row.run_dir:
+            run_dir_path = Path(row.run_dir)
             try:
-                logs = self._tail_run_log(Path(row.run_dir))
+                logs = self._tail_run_log(run_dir_path)
             except (OSError, ValueError):
                 logs = []
+            try:
+                dimensions = self._read_dimensions_from_status(run_dir_path)
+            except (OSError, ValueError):
+                dimensions = None
         return JobSnapshot(
             job_id=row.job_id,
             status=row.state,
@@ -213,7 +233,7 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             output_run_id=row.run_id,
             phase=row.phase,
             current_dimension=row.current_dimension,
-            dimensions=None,
+            dimensions=dimensions,
             error=row.exit_reason,
             source="external" if row.job_id.startswith("ext-") else "internal",
             exit_reason=row.exit_reason,


### PR DESCRIPTION
## Summary

Follow-up to #280 — live violations *still* didn't appear after a dashboard restart because my UI seed in that PR was gated on \`updated.dimensions.length\`, and the API was returning \`dimensions: null\` for every ext-job. Verified by hitting the endpoint directly:

\`\`\`json
{
  \"outputProject\": \"d33f1fd0-…\",
  \"outputRunId\": \"4af64d0e-…\",
  \"dimensions\": null,
  \"phase\": \"analyzing\",
  \"currentDimension\": null
}
\`\`\`

\`_run_row_to_snapshot\` hardcoded \`dimensions=None\` and \`RunRow\` doesn't carry the list, so there was no way for the UI to learn which dimensions were requested.

## Fix

Read \`status.json\` (which already holds \`dimensions: [...]\`) when serializing the row. Cheap IO alongside the existing \`run.log\` tail. Source of truth for which dimensions the pipeline was asked to run.

## Test plan

- [x] 559 services tests pass
- [x] Restart dashboard with a scan running, open Evaluate — live violations panel should populate within a poll tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)