### PR TITLE
VirtualList: auto-detect scroll parent (fixes huge-empty-scroll on detail pages)

### DIFF
--- a/src/quodeq/ui/src/components/VirtualList.jsx
+++ b/src/quodeq/ui/src/components/VirtualList.jsx
@@ -30,6 +30,32 @@ function normaliseScrollParent(parent) {
   return parent;
 }
 
+/**
+ * Walk up the DOM from `el` and return the nearest ancestor whose `overflow-y`
+ * is `auto` or `scroll` (i.e. the element that actually scrolls this subtree).
+ * Fall back to `window` if no such ancestor exists — that matches the classic
+ * full-page-scroll layout.
+ *
+ * Needed because the dashboard's terminal-style restyle put the main scroll
+ * inside an inner element, not on the document. With VirtualList defaulting
+ * to `window`, it never saw scroll events and collapsed to rendering only
+ * the top overscan rows — leaving a huge reserved-but-empty scroll area.
+ */
+function findScrollParent(el) {
+  if (typeof window === 'undefined' || !el) return null;
+  let node = el.parentElement;
+  while (node && node !== document.body && node !== document.documentElement) {
+    const style = window.getComputedStyle(node);
+    const overflowY = style.overflowY;
+    if ((overflowY === 'auto' || overflowY === 'scroll')
+        && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return window;
+}
+
 function getScrollTop(scrollEl) {
   if (!scrollEl || scrollEl === window) {
     return window.scrollY || document.documentElement.scrollTop || 0;
@@ -58,8 +84,18 @@ export default function VirtualList({
   const [scrollTop, setScrollTop] = useState(0);
   const [containerTop, setContainerTop] = useState(0);
   const [viewport, setViewport] = useState(() => (typeof window === 'undefined' ? 0 : window.innerHeight));
+  const [autoScrollEl, setAutoScrollEl] = useState(null);
 
-  const scrollEl = useMemo(() => normaliseScrollParent(scrollParent) || (typeof window !== 'undefined' ? window : null), [scrollParent]);
+  // Explicit scrollParent prop wins; otherwise walk up from the container
+  // looking for a scrollable ancestor (computed after mount). Falling back
+  // to `window` silently caused the empty-rows regression on the restyled
+  // terminal layout.
+  const scrollEl = useMemo(() => {
+    const explicit = normaliseScrollParent(scrollParent);
+    if (explicit) return explicit;
+    if (autoScrollEl) return autoScrollEl;
+    return typeof window !== 'undefined' ? window : null;
+  }, [scrollParent, autoScrollEl]);
 
   // ── offsets & total height, derived from measured-or-estimated per row ──
   const { offsets, totalHeight } = useMemo(() => {
@@ -89,6 +125,18 @@ export default function VirtualList({
   }, [scrollEl]);
 
   useLayoutEffect(() => { syncGeometry(); }, [syncGeometry, items.length]);
+
+  // Detect the nearest scrollable ancestor once the container is mounted.
+  // Re-run only if the explicit scrollParent prop changes — the DOM
+  // ancestor chain is stable for the lifetime of the component.
+  useLayoutEffect(() => {
+    if (normaliseScrollParent(scrollParent)) return;
+    const detected = findScrollParent(containerRef.current);
+    if (detected && detected !== autoScrollEl) {
+      setAutoScrollEl(detected === window ? null : detected);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollParent]);
 
   useEffect(() => {
     if (!scrollEl) return undefined;

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { ACTIVE_PROVIDER_KEY, providerKey, DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET } from '../../../constants.js';
+import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 const DIMENSION_POLL_INITIAL_MS = 2000;
 const DIMENSION_POLL_MAX_MS = 8000;
@@ -239,7 +240,6 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
 
   async function cancelEvaluationJob(jobId) {
     if (!jobId) return;
-    const { confirmDialog } = await import('../../../utils/confirmDialog.js');
     const ok = await confirmDialog({
       title: 'Cancel evaluation?',
       message: 'Stop the running scan. Any findings collected so far will still be saved.',


### PR DESCRIPTION
## Summary

Reported: detail pages (capacity, principle, file) show a big empty scroll area with only a handful of rows visible at the top or bottom.

## Root cause

\`VirtualList\` defaulted to listening on \`window\` for scroll events. That's fine for the classic document-scroll layout, but after the recent terminal-style restyle the dashboard's main scroll moved onto an inner element (\`<main>\` with \`overflow-y: auto\`). VirtualList still listened on \`window\`, never got scroll events from the inner container, so scrollTop stayed at 0 forever. It reserved \`totalHeight\` for the full list (hence the huge empty scroll) but only rendered the initial viewport-plus-overscan window.

## Fix

After the container mounts, walk up the DOM looking for the nearest ancestor with \`overflow-y: auto | scroll\` + actual overflow, and use that as the scroll parent. Explicit \`scrollParent\` prop still wins. Falls back to \`window\` when nothing scrollable exists above, preserving the old behavior for full-page layouts.

Also folds in a tiny tweak: make \`confirmDialog.js\` statically imported from \`useEvaluation.js\` too, since it was already static in \`HistoryPage.jsx\`. Silences the \`vite:reporter\` dynamic-vs-static warning.

## Test plan

- [x] 100 UI tests pass
- [x] \`npm run build\` clean (no vite:reporter warning)
- [ ] Manual: open any detail page with > 20 violations, scroll, verify rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)