### PR TITLE
fix: include prompts content in incremental fingerprint

### DIFF
--- a/src/quodeq/analysis/_incr_change_detection.py
+++ b/src/quodeq/analysis/_incr_change_detection.py
@@ -5,7 +5,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from quodeq.analysis.fingerprint import _hash_file, _hash_standards
+from quodeq.analysis.fingerprint import _hash_file, _hash_prompts, _hash_standards
 
 _GIT_DIFF_TIMEOUT_S = 10
 
@@ -56,6 +56,12 @@ def detect_changed_files(
         prev_std = prev_fingerprint.get("standards_checksum")
         if current_std != prev_std and prev_std is not None:
             return ChangeDetectionResult(full_reanalysis=True, reason="standards changed")
+
+    prev_prompts = prev_fingerprint.get("prompts_checksum")
+    if prev_prompts is not None:
+        current_prompts = _hash_prompts()
+        if current_prompts != prev_prompts:
+            return ChangeDetectionResult(full_reanalysis=True, reason="prompts changed")
 
     prev_commit = prev_fingerprint.get("git_commit")
     file_set = set(files)

--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.analysis.subagents.verify import resolve_evidence_paths
+from quodeq.config.paths import default_paths
 from quodeq.data.fs.report_parser.runs import list_runs
 from quodeq.shared.validation import validate_path_segment
 
@@ -62,6 +63,29 @@ def _hash_standards(standards_dir: Path, dimension: str) -> str | None:
     return _hash_file(compiled)
 
 
+def _hash_prompts(prompts_dir: Path | None = None) -> str | None:
+    """SHA-256 over the concatenated *.md prompt files in *prompts_dir*.
+
+    A change to any prompt template (notably ``evaluation_rules.md``) shifts
+    LLM behavior even when source files and standards are byte-identical.
+    Mixing the prompt directory's content into the fingerprint forces
+    re-analysis after a prompt update — otherwise carry-forward keeps
+    serving findings produced under the old rules.
+    """
+    if prompts_dir is None:
+        prompts_dir = default_paths().prompts_dir
+    if prompts_dir is None or not prompts_dir.is_dir():
+        return None
+    h = hashlib.sha256()
+    for path in sorted(prompts_dir.glob("*.md")):
+        per_file = _hash_file(path)
+        if per_file is None:
+            continue
+        h.update(path.name.encode())
+        h.update(per_file.encode())
+    return h.hexdigest()
+
+
 def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir: Path | None, *, analyzed_files: set[str] | None = None) -> dict:
     """Build a fingerprint for the current evaluation state."""
     file_hashes = {}
@@ -74,6 +98,7 @@ def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir
         "git_commit": _get_git_commit(src),
         "file_hashes": file_hashes,
         "standards_checksum": _hash_standards(standards_dir, dimension) if standards_dir else None,
+        "prompts_checksum": _hash_prompts(),
         "analyzed_files": sorted(analyzed_files) if analyzed_files else [],
         "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
     }

--- a/src/quodeq/analysis/subagents/_verify_filter.py
+++ b/src/quodeq/analysis/subagents/_verify_filter.py
@@ -69,7 +69,7 @@ def partition_findings_by_fingerprint(
     If standards changed since the previous run, all findings need verification
     regardless of file hashes (findings were evaluated under different criteria).
     """
-    from quodeq.analysis.fingerprint import _hash_standards
+    from quodeq.analysis.fingerprint import _hash_prompts, _hash_standards
 
     if not prev_fingerprint or not findings:
         return [], list(findings)
@@ -80,5 +80,11 @@ def partition_findings_by_fingerprint(
         prev_std = prev_fingerprint.get("standards_checksum")
         if prev_std is not None and current_std != prev_std:
             return [], list(findings)
+
+    # Prompts guard: a prompt-rule change shifts what counts as a violation,
+    # so previously-accepted findings must be re-verified.
+    prev_prompts = prev_fingerprint.get("prompts_checksum")
+    if prev_prompts is not None and _hash_prompts() != prev_prompts:
+        return [], list(findings)
 
     return _classify_findings(findings, prev_fingerprint.get("file_hashes", {}), src)


### PR DESCRIPTION
## Summary

Closes a cache-staleness gap exposed by #290: a change to a prompt template (notably `evaluation_rules.md`) didn't invalidate the incremental fingerprint, so unchanged source files still carry forward verdicts produced under the old rules. After tightening the minor-severity bar, the carry-forward path would mask the improvement.

## Changes

- **`fingerprint.py`** — `build_fingerprint()` now stores a `prompts_checksum`: SHA-256 over every `*.md` in `default_paths().prompts_dir`, computed from `(filename, file_hash)` pairs in sorted order so the result is stable across machines.
- **`_incr_change_detection.detect_changed_files()`** — forces full reanalysis when the previous run's `prompts_checksum` differs from the current one. Mirrors the existing standards-checksum guard; same shape, same fallback behavior.
- **`_verify_filter.partition_findings_by_fingerprint()`** — applies the same guard to per-finding carry-forward in the verification path. If prompts changed, every finding goes back through verification rather than being silently kept.

## Backward compatibility

Fingerprints written before this change have no `prompts_checksum` field. The new code treats `prev == None` as no-info and skips the guard — same pattern as the existing standards guard. So existing run history continues to work; only runs *after* this lands gain the protection.

The first run after merging won't trigger the new guard (no prior `prompts_checksum` to compare against). The second run will. That's the standard cache-warmup behavior.

## Why this matters now

After #290 tightened the minor-severity rule, anyone running quodeq incrementally would have seen *no improvement* — carry-forward would keep serving the old speculative findings. With this PR, prompt edits behave like standards edits: they trip the cache and force re-evaluation.

## Test plan

- [x] `pytest` (full suite, 2098 pass)
- [x] Re-run a Time Behaviour eval after merge and verify the count drops (the same self-scan that produced 216 should produce sharply fewer findings under the tightened prompt + busted cache)