### PR TITLE
fix: 4 real resource-utilisation wins

### DIFF
--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -25,6 +25,7 @@ _JSONRPC_METHOD_NOT_FOUND = -32601
 _MCP_DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 _SERVER_NAME = "quodeq-findings"
 _SERVER_VERSION = "1.0.0"
+_MAX_FILE_BATCH_SIZE = 1000
 
 
 def handle_initialize(request_id: object, msg: dict) -> dict:
@@ -77,6 +78,7 @@ def handle_tools_call(
         count = args.get("count", _DEFAULT_FILE_BATCH_SIZE)
         if not isinstance(count, int) or count < 1:
             count = _DEFAULT_FILE_BATCH_SIZE
+        count = min(count, _MAX_FILE_BATCH_SIZE)
         files = queue.take(count, agent_id=agent_id)
         if not files:
             return _ok(request_id, {

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+from collections import OrderedDict
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from math import ceil
@@ -36,7 +37,8 @@ class EvidencePaths:
     dimension_key: str
 
 
-_cached_file_queues: dict[Path, WorkQueue] = {}
+_QUEUE_CACHE_MAX_SIZE = 64
+_cached_file_queues: OrderedDict[Path, WorkQueue] = OrderedDict()
 
 
 def get_queue(queue: WorkQueue | None, queue_path: Path) -> WorkQueue:
@@ -44,14 +46,19 @@ def get_queue(queue: WorkQueue | None, queue_path: Path) -> WorkQueue:
 
     When *queue* is None a ``FileQueue`` is constructed from *queue_path*.
     The result is cached by path so repeated calls avoid rebuilding the queue.
+    The cache is bounded (LRU): in long-running sessions that touch many
+    distinct queue paths, the oldest entry is evicted once the cap is hit.
     """
     if queue is not None:
         return queue
     cached = _cached_file_queues.get(queue_path)
     if cached is not None:
+        _cached_file_queues.move_to_end(queue_path)
         return cached
     fq: WorkQueue = FileQueue(queue_path)
     _cached_file_queues[queue_path] = fq
+    if len(_cached_file_queues) > _QUEUE_CACHE_MAX_SIZE:
+        _cached_file_queues.popitem(last=False)
     return fq
 
 

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -11,6 +11,7 @@ from quodeq.shared.utils import get_ai_provider
 
 _AI_PROVIDER_EXPORT_PREFIX = "export AI_PROVIDER="
 _OWNER_RW_PERMS = 0o600
+_API_KEY_FORBIDDEN_CHARS = ("\n", "\r", "\0")
 
 PROVIDERS = {
     "claude": ("ANTHROPIC_API_KEY", "claude"),
@@ -53,6 +54,10 @@ def _write_env(paths: ConfigPaths, provider: str, api_key_var: str, api_key_valu
         f"export AI_PROVIDER={provider}",
     ]
     if api_key_value:
+        # Reject control characters that would let a malformed input append
+        # extra `export …` lines to the env file.
+        if any(ch in api_key_value for ch in _API_KEY_FORBIDDEN_CHARS):
+            raise ValueError("API key contains forbidden control characters")
         # SECURITY: The raw API key value is written to the env file in
         # cleartext because it must be sourced by subprocesses at runtime.
         # The file is created with mode 0600 (owner read/write only) via

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -436,6 +436,8 @@
   color: var(--color-console-text);
   white-space: pre-wrap;
   word-break: break-word;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 22px;
 }
 
 .console-log-empty {


### PR DESCRIPTION
## Summary

Targeted fixes for the four entries from the Resource Utilisation eval that survive the same triage applied in #289 / #290. Everything else in the 225-entry plan is the speculative pattern those PRs were designed to suppress on the next run.

## Changes

1. **`ai_provider._write_env()`** — reject `api_key_value` containing `\n`, `\r`, or `\0`. Without this, a multi-line value would inject extra `export …` lines into `~/.quodeq/quodeq.env`. The plan called this CWE-789 (memory) but the real concern is CWE-77/74-shaped command injection into a sourced file. Defensive validation, not exploitable from current call sites, but cheap to harden.

2. **`_pool_scaling._cached_file_queues`** — change from plain `dict` to `OrderedDict` with `_QUEUE_CACHE_MAX_SIZE = 64`, LRU-evict on insert. Long-running sessions that touch many queue paths no longer grow this cache without bound.

3. **`mcp.handlers` `tools/call` for GET_NEXT_FILES** — clamp the agent-supplied `count` to `_MAX_FILE_BATCH_SIZE = 1000`. Existing code already validated `int >= 1`; this caps the upper bound so a buggy or adversarial subagent can't request a multi-million-file batch.

4. **`.console-log-line` CSS** — add `content-visibility: auto; contain-intrinsic-size: auto 22px;`. Same pattern used in #286 for `vdetail-row` / `history-row`. Large log streams now render lazily without changing the React component.

## Why only 4 of 225

The eval that produced this plan ran against the old `evaluation_rules.md` (pre-#290) and the pre-fingerprint cache (pre-#291). The remaining ~220 entries are dominated by:

- *"could lead to high memory if X is large"* applied to <1MB JSON configs
- *"no upper bound on integer parameter"* on env-vars and CLI args
- One-shot startup paths flagged as unbounded
- Caches that are bounded by the project's file count

Re-running the eval after #290 + #291 will produce a much smaller, signal-heavy list. **Don't fix-plan against the current report.**

## Test plan

- [x] `pytest` (full suite, 2098 pass)
- [x] `npm test` (UI, 100 pass)
- [x] `npm run build` (vite build succeeds)