### PR TITLE
fix: harden confirmDialog against XSS via DOM construction

### DIFF
--- a/src/quodeq/ui/src/utils/confirmDialog.js
+++ b/src/quodeq/ui/src/utils/confirmDialog.js
@@ -8,6 +8,8 @@
  *   const ok = await confirmDialog({ title: 'Delete run?', message: '...' });
  *   if (!ok) return;
  */
+const _ALLOWED_VARIANTS = new Set(['default', 'danger']);
+
 export function confirmDialog({
   title = 'Confirm',
   message = 'Are you sure?',
@@ -20,26 +22,42 @@ export function confirmDialog({
       resolve(false);
       return;
     }
+    const safeVariant = _ALLOWED_VARIANTS.has(variant) ? variant : 'default';
     const overlay = document.createElement('div');
     overlay.className = 'qd-confirm-overlay';
     overlay.setAttribute('role', 'dialog');
     overlay.setAttribute('aria-modal', 'true');
-    overlay.innerHTML = `
-      <div class="qd-confirm-dialog qd-confirm-dialog--${variant}">
-        <h3 class="qd-confirm-title"></h3>
-        <p class="qd-confirm-message"></p>
-        <div class="qd-confirm-actions">
-          <button type="button" class="qd-confirm-btn qd-confirm-btn--cancel"></button>
-          <button type="button" class="qd-confirm-btn qd-confirm-btn--confirm qd-confirm-btn--${variant}"></button>
-        </div>
-      </div>
-    `;
-    overlay.querySelector('.qd-confirm-title').textContent = title;
-    overlay.querySelector('.qd-confirm-message').textContent = message;
-    const cancelBtn = overlay.querySelector('.qd-confirm-btn--cancel');
-    const confirmBtn = overlay.querySelector('.qd-confirm-btn--confirm');
+
+    const dialog = document.createElement('div');
+    dialog.className = `qd-confirm-dialog qd-confirm-dialog--${safeVariant}`;
+
+    const titleEl = document.createElement('h3');
+    titleEl.className = 'qd-confirm-title';
+    titleEl.textContent = title;
+
+    const messageEl = document.createElement('p');
+    messageEl.className = 'qd-confirm-message';
+    messageEl.textContent = message;
+
+    const actions = document.createElement('div');
+    actions.className = 'qd-confirm-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'qd-confirm-btn qd-confirm-btn--cancel';
     cancelBtn.textContent = cancelLabel;
+
+    const confirmBtn = document.createElement('button');
+    confirmBtn.type = 'button';
+    confirmBtn.className = `qd-confirm-btn qd-confirm-btn--confirm qd-confirm-btn--${safeVariant}`;
     confirmBtn.textContent = confirmLabel;
+
+    actions.appendChild(cancelBtn);
+    actions.appendChild(confirmBtn);
+    dialog.appendChild(titleEl);
+    dialog.appendChild(messageEl);
+    dialog.appendChild(actions);
+    overlay.appendChild(dialog);
 
     function close(result) {
       overlay.remove();


### PR DESCRIPTION
## Summary

Defensive fix from the security-dimension triage. The previous \`confirmDialog\` built its skeleton with an \`innerHTML\` template literal interpolating \`variant\`. Title/message/labels were already safe (set via \`textContent\`), but \`variant\` was inserted raw into a class attribute, and the function exposes it as a parameter. A future caller wiring user-controlled input through \`variant\` would have been XSS.

## Changes

- Allowlist \`variant\` to \`'default' | 'danger'\`; unknown values fall back to \`'default'\`.
- Replace the \`innerHTML\` template literal with explicit \`createElement\` calls. No template literals leaving the function.

## Why only 1 of 393

The security-dimension report was generated against the **old** \`evaluation_rules.md\` (pre-#290) and the pre-fingerprint cache (pre-#291). The remaining ~390 entries fail at least one of:

- The test-file severity ceiling (e.g., critical findings on test fixtures containing \`eval(x)\` patterns by design)
- The architecture context (e.g., "no auth on /api/logs" on a localhost-only single-user CLI)
- Hedge words ("if path were user-controlled", "if attacker could write to reports dir")
- Misread code (\`<pre>{code}</pre>\` in React flagged as XSS — React auto-escapes; \`json.dumps()\` IS the escape)

This one survives all four checks: the variable IS user-influenceable via the function signature, the \`innerHTML\` write IS where it lands, and the fix is genuinely defensive.

## Test plan

- [x] \`pytest\` (full suite, 2098 pass)
- [x] \`npm test\` (UI, 100 pass)
- [x] \`npm run build\` (vite build succeeds)