### PR TITLE
feat(ui): Clean scan toggle replaces Clean scan button; gate carry-forward on incremental flag

### DIFF
--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -112,15 +112,21 @@ def _run_verification_step(
     if not prev_findings:
         return []
 
-    if prev_fingerprint is None:
-        prev_fingerprint, _ = find_previous_fingerprint(evidence_dir, dim_id)
+    if not config.options.incremental:
+        # Clean scan: every previous finding goes back through verification.
+        log_info(f"  [{dim_id}] Clean scan — re-verifying all previous findings")
+        carry_forward: list[dict] = []
+        needs_verify: list[dict] = list(prev_findings)
+    else:
         if prev_fingerprint is None:
-            log_info(f"  [{dim_id}] No previous fingerprint — all findings need verification")
+            prev_fingerprint, _ = find_previous_fingerprint(evidence_dir, dim_id)
+            if prev_fingerprint is None:
+                log_info(f"  [{dim_id}] No previous fingerprint — all findings need verification")
 
-    carry_forward, needs_verify = partition_findings_by_fingerprint(
-        prev_findings, prev_fingerprint, config.src,
-        standards_dir=config.standards_dir, dimension=dim_id,
-    )
+        carry_forward, needs_verify = partition_findings_by_fingerprint(
+            prev_findings, prev_fingerprint, config.src,
+            standards_dir=config.standards_dir, dimension=dim_id,
+        )
     if carry_forward:
         written = write_carry_forward_findings(carry_forward, evidence_dir, dim_id)
         log_info(f"  [{dim_id}] {written} findings carried forward (unchanged files)")

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -82,12 +82,15 @@ def _prepare_findings_and_queue(
     prev_findings = _load_and_filter_previous(config, dc.dim_id, dc.evidence_dir)
     carry_forward: list[dict] = []
     needs_verify: list[dict] = []
-    if prev_findings:
+    if prev_findings and config.options.incremental:
         prev_fp, _ = find_previous_fingerprint(dc.evidence_dir, dc.dim_id)
         carry_forward, needs_verify = partition_findings_by_fingerprint(
             prev_findings, prev_fp, config.src,
             standards_dir=config.standards_dir, dimension=dc.dim_id,
         )
+    elif prev_findings:
+        # Clean scan: every previous finding goes back through verification.
+        needs_verify = list(prev_findings)
     if carry_forward:
         written = write_carry_forward_findings(carry_forward, dc.evidence_dir, dc.dim_id)
         log_info(f"  [{dc.idx}/{dc.ctx.total}] {dc.dim_id} -- {written} findings carried forward")

--- a/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'quodeq.cleanScan.permanent';
+
+function readPermanent() {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function writePermanent(on) {
+  try {
+    if (on) localStorage.setItem(STORAGE_KEY, '1');
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+/**
+ * Tri-state Clean Scan toggle. State is one of:
+ *  - 'off'        — incremental mode (default)
+ *  - 'once'       — clean for next scan only; resets to 'off' after submit
+ *  - 'permanent'  — clean for every scan; persisted to localStorage
+ *
+ * `value` is the current state, `onChange` receives the new state. When the
+ * toggle is off and the user clicks it, a popup asks whether to enable for
+ * one scan, always, or cancel.
+ */
+export default function CleanScanToggle({ value, onChange, disabled = false }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  useEffect(() => {
+    // First mount: hydrate 'permanent' from localStorage so the toggle reflects
+    // the user's saved preference. We only do this when the parent passes
+    // 'off' as the initial value (no in-flight 'once' state to clobber).
+    if (value === 'off' && readPermanent()) onChange('permanent');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const isOn = value === 'once' || value === 'permanent';
+
+  function handleClick() {
+    if (disabled) return;
+    if (isOn) {
+      // Turning off: clear localStorage too, regardless of which 'on' state.
+      writePermanent(false);
+      onChange('off');
+      return;
+    }
+    setConfirmOpen(true);
+  }
+
+  function pickOnce() {
+    setConfirmOpen(false);
+    onChange('once');
+  }
+  function pickPermanent() {
+    setConfirmOpen(false);
+    writePermanent(true);
+    onChange('permanent');
+  }
+  function cancel() {
+    setConfirmOpen(false);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`clean-scan-toggle${isOn ? ' clean-scan-toggle--on' : ''}${value === 'permanent' ? ' clean-scan-toggle--permanent' : ''}`}
+        onClick={handleClick}
+        disabled={disabled}
+        title={
+          value === 'permanent'
+            ? 'Clean scan: always (click to disable)'
+            : value === 'once'
+              ? 'Clean scan: just this scan (click to disable)'
+              : 'Clean scan: drops carry-forward; every file goes through the LLM again'
+        }
+        aria-pressed={isOn}
+      >
+        Clean scan
+        {value === 'permanent' && <span className="clean-scan-toggle__dot" aria-hidden="true" />}
+      </button>
+
+      {confirmOpen && (
+        <div className="qd-confirm-overlay" role="dialog" aria-modal="true" onClick={(e) => { if (e.target === e.currentTarget) cancel(); }}>
+          <div className="qd-confirm-dialog">
+            <h3 className="qd-confirm-title">Clean scan</h3>
+            <div className="qd-confirm-message">
+              <p>Drops carry-forward from previous runs. Every file goes through the LLM again — slower, but produces fresh findings under the current prompts and standards.</p>
+            </div>
+            <div className="qd-confirm-actions clean-scan-confirm-actions">
+              <button type="button" className="qd-confirm-btn qd-confirm-btn--cancel" onClick={cancel}>Cancel</button>
+              <button type="button" className="qd-confirm-btn qd-confirm-btn--confirm" onClick={pickOnce}>Just this scan</button>
+              <button type="button" className="qd-confirm-btn qd-confirm-btn--confirm qd-confirm-btn--danger" onClick={pickPermanent}>
+                Always <span className="clean-scan-confirm-meta">(all projects)</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CleanScanToggle.jsx
@@ -91,7 +91,8 @@ export default function CleanScanToggle({ value, onChange, disabled = false }) {
           <div className="qd-confirm-dialog">
             <h3 className="qd-confirm-title">Clean scan</h3>
             <div className="qd-confirm-message">
-              <p>Drops carry-forward from previous runs. Every file goes through the LLM again — slower, but produces fresh findings under the current prompts and standards.</p>
+              <p>Reanalyze every file from scratch. Slower than a normal scan, but findings will reflect your current standards and settings.</p>
+              <p>Use this after you change a standard, or whenever you want a fresh second opinion.</p>
             </div>
             <div className="qd-confirm-actions clean-scan-confirm-actions">
               <button type="button" className="qd-confirm-btn qd-confirm-btn--cancel" onClick={cancel}>Cancel</button>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -138,7 +138,7 @@ export default function EvaluationForm({ onStart, disabled, selectedProject }) {
         )}
 
         <button type="submit" className="evaluate-submit-btn" disabled={!canSubmit}>
-          {disabled ? 'Running Evaluation...' : 'Start Evaluation'}
+          {disabled ? 'Running...' : 'Scan'}
         </button>
       </form>
 

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -235,7 +235,6 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
         <CloneSection info={info} cloning={cloning} cloneDest={cloneDest} cloneError={cloneError} setCloneBrowserOpen={setCloneBrowserOpen} />
 
         <div className="re-eval-toggle-row">
-          <CleanScanToggle value={cleanScan} onChange={setCleanScan} disabled={!canStart} />
           {scope.isLocal && (
             <BranchScopeSelector
               branches={scope.scanData?.branches}
@@ -245,6 +244,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
               scopePath={scope.scopePath}
             />
           )}
+          <CleanScanToggle value={cleanScan} onChange={setCleanScan} disabled={!canStart} />
         </div>
 
         <div className={`re-eval-actions-group${cloning ? ' re-eval-disabled-section' : ''}`}>

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -3,6 +3,7 @@ import { useApi } from '../../../api/ApiContext.jsx';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import { useScanData } from '../hooks/useScanData.js';
 import BranchScopeSelector from './BranchScopeSelector.jsx';
+import CleanScanToggle from './CleanScanToggle.jsx';
 import DimensionSelector from './DimensionSelector.jsx';
 import FolderBrowser from './FolderBrowser.jsx';
 
@@ -54,6 +55,7 @@ function useReEvalInfo(project, initialInfo, { getProjectInfo, relocateProject }
 
 function useDimensionSelection(allDimensions, info, branch, scopePath, onStart) {
   const [selectedDims, setSelectedDims] = useState(new Set());
+  const [cleanScan, setCleanScan] = useState('off');
 
   const toggleDim = (id) => {
     setSelectedDims((prev) => {
@@ -65,17 +67,20 @@ function useDimensionSelection(allDimensions, info, branch, scopePath, onStart) 
   };
   const selectAll = () => setSelectedDims(new Set(allDimensions.map((d) => d.id)));
   const clearAll = () => setSelectedDims(new Set());
-  const buildPayload = (extra) => {
-    const payload = { repo: info.path, ...extra };
+  const buildPayload = () => {
+    const payload = { repo: info.path };
     payload.dimensions = [...selectedDims];
     if (branch) payload.branch = branch;
     if (scopePath) payload.scopePath = scopePath;
+    payload.incremental = cleanScan === 'off';
     return payload;
   };
-  const handleStart = () => onStart(buildPayload());
-  const handleIncremental = () => onStart(buildPayload({ incremental: true }));
+  const handleScan = () => {
+    onStart(buildPayload());
+    if (cleanScan === 'once') setCleanScan('off');
+  };
 
-  return { selectedDims, toggleDim, selectAll, clearAll, handleStart, handleIncremental };
+  return { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan };
 }
 
 function useReEvaluateCard(project, onStart, projectInfo) {
@@ -95,7 +100,7 @@ function useReEvaluateCard(project, onStart, projectInfo) {
   const isLocal = info?.location === 'local';
   const { scanData } = useScanData(isLocal ? project : null);
 
-  const { selectedDims, toggleDim, selectAll, clearAll, handleStart, handleIncremental } =
+  const { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan } =
     useDimensionSelection(allDimensions, info, branch, scopePath, onStart);
 
   async function handleCloneToLocal(destination) {
@@ -115,7 +120,7 @@ function useReEvaluateCard(project, onStart, projectInfo) {
 
   return {
     info, error, allDimensions, selectedDims,
-    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
     isLocal, scanData, branch, setBranch, scopePath, setScopePath,
@@ -185,28 +190,17 @@ function CloneSection({ info, cloning, cloneDest, cloneError, setCloneBrowserOpe
   );
 }
 
-function ActionButtons({ info, project, disabled, canStart, cloning, handleIncremental, handleStart }) {
+function ActionButtons({ disabled, canStart, handleScan }) {
   return (
     <div style={buttonRowStyle}>
       <button
         type="button"
         className="evaluate-submit-btn"
-        style={{ flex: 3 }}
+        style={flexButtonStyle}
         disabled={!canStart}
-        onClick={handleIncremental}
-        title="Only analyze files changed since last evaluation"
+        onClick={handleScan}
       >
-        {disabled ? 'Running...' : 'Scan incremental'}
-      </button>
-      <button
-        type="button"
-        className="evaluate-submit-btn evaluate-submit-btn--secondary"
-        style={{ flex: 1 }}
-        disabled={!canStart}
-        onClick={handleStart}
-        title="Fresh re-evaluation of all selected dimensions"
-      >
-        Clean scan
+        {disabled ? 'Running...' : 'Scan'}
       </button>
     </div>
   );
@@ -215,7 +209,7 @@ function ActionButtons({ info, project, disabled, canStart, cloning, handleIncre
 function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scope }) {
   const { all: allDimensions, selected: selectedDims } = dimensions;
   const {
-    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
   } = actions;
@@ -240,19 +234,22 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
 
         <CloneSection info={info} cloning={cloning} cloneDest={cloneDest} cloneError={cloneError} setCloneBrowserOpen={setCloneBrowserOpen} />
 
-        {scope.isLocal && (
-          <BranchScopeSelector
-            branches={scope.scanData?.branches}
-            currentBranch={scope.scanData?.currentBranch || scope.branch}
-            projectPath={info.path}
-            onScopeChange={scope.setScopePath}
-            scopePath={scope.scopePath}
-          />
-        )}
+        <div className="re-eval-toggle-row">
+          <CleanScanToggle value={cleanScan} onChange={setCleanScan} disabled={!canStart} />
+          {scope.isLocal && (
+            <BranchScopeSelector
+              branches={scope.scanData?.branches}
+              currentBranch={scope.scanData?.currentBranch || scope.branch}
+              projectPath={info.path}
+              onScopeChange={scope.setScopePath}
+              scopePath={scope.scopePath}
+            />
+          )}
+        </div>
 
         <div className={`re-eval-actions-group${cloning ? ' re-eval-disabled-section' : ''}`}>
           <DimensionSelectionSection allDimensions={allDimensions} selectedDims={selectedDims} cloning={cloning} toggleDim={toggleDim} selectAll={selectAll} clearAll={clearAll} />
-          <ActionButtons info={info} project={project} disabled={disabled} canStart={canStart} cloning={cloning} handleIncremental={handleIncremental} handleStart={handleStart} />
+          <ActionButtons disabled={disabled} canStart={canStart} handleScan={handleScan} />
         </div>
       </div>
 
@@ -271,7 +268,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
 export default function ReEvaluateCard({ project, projectInfo, onStart, disabled }) {
   const {
     info, error, allDimensions, selectedDims,
-    toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+    toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
     isLocal, scanData, branch, setBranch, scopePath, setScopePath,
@@ -291,7 +288,7 @@ export default function ReEvaluateCard({ project, projectInfo, onStart, disabled
       disabled={disabled}
       dimensions={{ all: allDimensions, selected: selectedDims }}
       actions={{
-        toggleDim, selectAll, clearAll, handleStart, handleIncremental,
+        toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan,
         urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
         cloneBrowserOpen, setCloneBrowserOpen, cloning, cloneDest, cloneError, handleCloneToLocal,
       }}

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1020,6 +1020,14 @@
   margin-left: 4px;
 }
 
+.qd-confirm-message p {
+  margin: 0 0 8px;
+}
+
+.qd-confirm-message p:last-child {
+  margin-bottom: 0;
+}
+
 .scope-compact-btn {
   padding: 2px 8px;
   background: var(--color-surface-alt);

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -947,10 +947,77 @@
 }
 
 .scope-toggle-group {
-  margin-bottom: 12px;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+}
+
+.re-eval-toggle-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: 12px;
+  min-height: 22px;
+}
+
+.re-eval-toggle-row .scope-toggle-group {
+  margin-bottom: 0;
+}
+
+.clean-scan-toggle {
+  padding: 2px 8px;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.clean-scan-toggle:hover:not(:disabled) {
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.clean-scan-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.clean-scan-toggle--on {
+  background: var(--color-accent);
+  color: var(--color-on-accent, #fff);
+  border-color: var(--color-accent);
+}
+
+.clean-scan-toggle--on:hover:not(:disabled) {
+  background: var(--color-accent);
+  color: var(--color-on-accent, #fff);
+}
+
+.clean-scan-toggle__dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.85;
+}
+
+.clean-scan-confirm-actions {
+  flex-wrap: wrap;
+}
+
+.clean-scan-confirm-meta {
+  font-size: 0.7em;
+  opacity: 0.75;
+  margin-left: 4px;
 }
 
 .scope-compact-btn {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -955,7 +955,7 @@
 .re-eval-toggle-row {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   gap: var(--space-2);
   margin-bottom: 12px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1142,12 +1142,17 @@
   border-color: var(--color-accent, #2f81f7);
   color: var(--color-on-accent, #fff);
 }
-.qd-confirm-btn--confirm.qd-confirm-btn--danger {
+.qd-confirm-btn--confirm:hover {
+  background: var(--color-accent, #2f81f7);
+  color: var(--color-on-accent, #fff);
+  filter: brightness(1.12);
+}
+.qd-confirm-btn--confirm.qd-confirm-btn--danger,
+.qd-confirm-btn--confirm.qd-confirm-btn--danger:hover {
   background: var(--color-danger, #da3633);
   border-color: var(--color-danger, #da3633);
   color: #fff;
 }
-.qd-confirm-btn--confirm:hover { filter: brightness(1.12); }
 
 .history-row__muted { color: var(--color-text-muted); }
 .history-evaluations__header {

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1140,11 +1140,12 @@
 .qd-confirm-btn--confirm {
   background: var(--color-accent, #2f81f7);
   border-color: var(--color-accent, #2f81f7);
-  color: #fff;
+  color: var(--color-on-accent, #fff);
 }
 .qd-confirm-btn--confirm.qd-confirm-btn--danger {
-  background: #da3633;
-  border-color: #da3633;
+  background: var(--color-danger, #da3633);
+  border-color: var(--color-danger, #da3633);
+  color: #fff;
 }
 .qd-confirm-btn--confirm:hover { filter: brightness(1.12); }
 

--- a/tests/analysis/test_verification_coverage.py
+++ b/tests/analysis/test_verification_coverage.py
@@ -146,7 +146,7 @@ class TestRunVerificationStep:
         from quodeq.analysis.subagents._verification import _run_verification_step
         mock_load.return_value = [{"file": "a.py", "p": "", "line": 0}]
         mock_partition.return_value = ([{"file": "a.py"}], [])
-        config = RunConfig(src=tmp_path, language="python")
+        config = RunConfig(src=tmp_path, language="python", options=AnalysisOptions(incremental=True))
         evidence_dir = tmp_path / "evidence"
         evidence_dir.mkdir()
         result = _run_verification_step(config, "security", evidence_dir, ["a.py"], prev_fingerprint={})
@@ -182,7 +182,7 @@ class TestRunVerificationStep:
         from quodeq.analysis.subagents._verification import _run_verification_step
         mock_load.return_value = [{"file": "a.py", "p": "", "line": 0}]
         mock_partition.return_value = ([], [{"file": "a.py"}])
-        config = RunConfig(src=tmp_path, language="python")
+        config = RunConfig(src=tmp_path, language="python", options=AnalysisOptions(incremental=True))
         evidence_dir = tmp_path / "evidence"
         evidence_dir.mkdir()
         _run_verification_step(config, "security", evidence_dir, ["a.py"], prev_fingerprint=None)

--- a/tests/engine/test_mechanical_verify_fingerprint.py
+++ b/tests/engine/test_mechanical_verify_fingerprint.py
@@ -86,7 +86,7 @@ class TestRunVerificationStepFingerprint:
         evidence_dir = tmp_path / "evidence"
         evidence_dir.mkdir(parents=True)
 
-        config = self._make_config(tmp_path)
+        config = self._make_config(tmp_path, incremental=True)
         config.src = src
 
         mock_load_findings.return_value = findings


### PR DESCRIPTION
## Summary

Two changes that together solve the cache-staleness problem we hit after #290 / #291.

### Backend: gate carry-forward on `options.incremental`

The old `Clean scan` button only disabled the *file-classification* short-circuit. The verification step still called `partition_findings_by_fingerprint` and carried any previously-accepted finding on an unchanged file straight into the new run — bypassing the LLM under the new prompt rules. The button was clean in name only.

This PR adds a single gate in `subagents/runner.py` and `subagents/_verification.py`: when `options.incremental == False`, every previous finding goes back through verification. No carry-forward.

Two test fixtures (`test_carry_forward_only`, `test_no_prev_fingerprint_looks_it_up`, `test_unchanged_files_carried_forward_not_sent_to_pool`) explicitly assert the carry-forward path and now set `incremental=True` — that's the precise behavior moved under the new gate.

### UI: tri-state toggle

The two old buttons (`Scan incremental` + `Clean scan`) are replaced by one `Scan` button plus a `Clean scan` toggle to the left of the Scope badge.

Toggle states:
- **off** (default) — incremental, carry-forward kept
- **once** — clean for the next scan only; resets to `off` after submit
- **permanent** — clean for every scan; persisted via localStorage globally (`quodeq.cleanScan.permanent`)

The first time a user clicks the toggle while it's off, a popup asks: `Just this scan` / `Always (all projects)` / `Cancel`. Turning the toggle off (from any on-state) clears the localStorage flag. The current state is reflected in the button styling (lit) and a small dot for `permanent`.

The new-evaluation form's `Start Evaluation` button is renamed to `Scan` to standardize. No toggle there — a fresh project has no fingerprint to bust.

## Why a toggle, not a settings entry

This is an action modifier, not a persistent preference. Settings is for things you set once and forget (provider, context size, model). Cache invalidation is decision-time information answered next to the Scan button.

Settings would have three failure modes:
1. The "once" option doesn't fit a settings pattern.
2. Forgotten state — users would never notice they left it on.
3. Discovery — "why is this slow?" is answered by looking at the button row, not by remembering to check Settings.

## Test plan

- [x] `pytest` (full suite, 2098 pass)
- [x] `npm test` (UI, 100 pass)
- [x] `npm run build` (vite build succeeds)
- [x] Manual: open re-evaluate card, click toggle, confirm popup shows three options
- [x] Manual: pick "Just this scan", run, verify next render shows toggle off again
- [x] Manual: pick "Always", reload the page, verify toggle is still on with the dot
- [x] Manual: re-run an existing project with toggle on; verify findings reflect current prompt rules (test the original symptom)