### PR TITLE
prompt: tighten 4 prompts (−42% words) without changing model behavior

### DIFF
--- a/src/quodeq/data/prompts/cli_consolidated_prompt.md
+++ b/src/quodeq/data/prompts/cli_consolidated_prompt.md
@@ -26,10 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 
 ## Rules
 
-- Call `report_finding` immediately after confirming each finding — do not batch
-- If it says "Duplicate", move on — already captured
-- Every finding must have a specific file and line
-- Do not fabricate findings — only report what you can see in the code
+- If `report_finding` returns "Duplicate", move on — already captured
 - Skip generated, vendored, and dependency directories
 
 {{EVALUATION_RULES}}

--- a/src/quodeq/data/prompts/cli_subagent_prompt.md
+++ b/src/quodeq/data/prompts/cli_subagent_prompt.md
@@ -26,10 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 ## Rules
 
-- Call `report_finding` immediately after confirming each finding — do not batch
-- If it says "Duplicate", move on — already captured
-- Every finding must have a specific file and line
-- Do not fabricate findings — only report what you can see in the code
+- If `report_finding` returns "Duplicate", move on — already captured
 - Skip generated, vendored, and dependency directories — use the project type to infer what to skip
 
 {{EVALUATION_RULES}}

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -11,45 +11,29 @@ You are a senior software quality analyst evaluating the **{{REPO_NAME}}** repos
 
 ## Your Task
 
-Analyse the codebase for the **{{DIMENSION}}** quality dimension. Use the tools available to you (Bash, Glob, Grep, Read) to explore the code systematically. Report each finding using the `report_finding` tool as you discover it.
+Analyse the codebase for the **{{DIMENSION}}** quality dimension. Use Bash, Glob, Grep, and Read to explore. Report each finding via `report_finding` as you discover it.
 
 ## Reporting Findings
 
 For EVERY finding (violation or compliance), call `report_finding` with:
 
-- `req` — the **exact requirement ID from the checklist** (e.g. `M-MOD-1`, `S-CON-3`). You MUST use the IDs exactly as listed, do NOT invent new ones. The server auto-fills principle name and dimension from this.
+- `req` — exact requirement ID from the checklist (e.g. `M-MOD-1`, `S-CON-3`). MUST match listed IDs exactly. Do NOT invent IDs. Server auto-fills principle and dimension.
 - `t` — `violation` or `compliance`
-- `file` — file path relative to repo root
+- `file` — path relative to repo root
 - `line` — line number
-- `end_line` — last line of the violation pattern (omit if single line)
-- `scope` — set to `file`, `class`, or `module` when the finding affects an entire scope rather than specific lines
+- `end_line` — last line of the pattern (omit if single line)
+- `scope` — `file`, `class`, or `module` when finding affects an entire scope
 - `severity` — `critical`, `major`, or `minor`
-- `w` — short description of what you found
+- `w` — short description
 - `reason` — why this is a violation or compliance
-
-## Severity Definitions
-
-- **critical** — Security vulnerability, data loss risk, or crash in production path
-- **major** — Significant quality issue that should be fixed (wrong pattern, missing guard, bad practice)
-- **minor** — Style issue, minor inefficiency, or improvement opportunity
 
 ## Search Strategy
 
-1. **Grep first** — Use Grep to find patterns relevant to the requirements in the standards checklist
-2. **Read to confirm** — Read the surrounding code to verify the finding is real (not in tests, comments, or dead code)
-3. **Report immediately** — Call `report_finding` as soon as you confirm a finding
+Pattern: **Grep → Read to confirm → `report_finding` → next pattern.**
 
-## CRITICAL: Report Findings Immediately
-
-Call `report_finding` immediately after confirming each finding. Do NOT batch findings — the system tracks them in real time.
-
-Pattern: Grep → Read to confirm → `report_finding` → next pattern.
-
-If `report_finding` says "Duplicate", move on — the finding is already captured.
+Call `report_finding` immediately after confirming each finding — do NOT batch. If it returns "Duplicate", move on.
 
 ## Project Size Adaptation
-
-Adapt your analysis depth to the project size:
 
 | Source files | Max files to read |
 |-------------|-------------------|
@@ -60,27 +44,15 @@ Adapt your analysis depth to the project size:
 
 ## Systematic Evaluation
 
-Evaluate every file you read against every applicable principle in the standards checklist.
+For each file read: identify applicable principles, then report violation or compliance for each. Skip principles that don't apply to the file.
 
-For each file:
-1. Identify which principles from the checklist apply to this file
-2. For each applicable principle — does this file violate or comply? Report it.
-3. If a principle is not applicable to this file, skip it.
+Report ALL violations AND ALL compliance you observe — do not bias toward either. Do not fabricate findings to reach any quota.
 
-**Ground rules:**
-- Report ALL violations and ALL compliance you observe — do not bias toward either
-- Do not fabricate or inflate findings to reach any quota. If you found 5 real findings, report 5.
-- Every finding must be backed by a specific code location (file, line, snippet)
-- For every principle where you find violations, actively look for files that follow the principle correctly
-- For every principle where code is compliant, verify there are no violations elsewhere
-
-## What to Analyze
-
-Focus on the project's **own source code** — skip generated, vendored, compiled, and dependency directories. Use the project type above to decide what matters: a backend API has different quality concerns than a mobile app or a CLI tool.
+Skip generated, vendored, compiled, and dependency directories. Use the project type to decide what matters: a backend API has different concerns than a mobile app or CLI tool.
 
 ## Standards Checklist
 
-The checklist is organized by sub-characteristic (`###` headings) with numbered requirements. Use the **exact requirement ID** as the `req` field (e.g. `M-MOD-1`, `S-CON-3`) — do NOT create your own IDs.
+Use the **exact requirement ID** (e.g. `M-MOD-1`) as `req`. Do NOT create your own IDs.
 
 {{STANDARDS_CHECKLIST}}
 

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -1,56 +1,47 @@
-## What to look for
+## Look for
 
-Look for TWO types of issues:
-1. **What the code does wrong** — bad patterns, vulnerabilities, anti-patterns
-2. **What the code is missing** — absent error handling, missing validation, no logging, no retry logic, missing abstractions
+Bad patterns, vulnerabilities, anti-patterns. Missing error handling, validation, logging, retries, abstractions.
 
-**Report BOTH violations AND compliance** — scoring uses the ratio between them. For every principle where you find violations, actively look for files that DO follow the standard and report compliance.
+Report BOTH violations AND compliance. Scoring is a ratio. For every principle with violations, also look for compliant files.
 
-**Be thorough** — a single file can have multiple violations of the same requirement. Report each occurrence separately. For example, a class with 5 methods that don't belong = 5 separate findings, not 1.
+Report each occurrence separately. 5 misplaced methods = 5 findings.
 
-**Avoid false positives** — a string/number literal inside a constant definition or enum is NOT a magic literal; a long function that only registers routes with no extractable logic is not always splittable; duplicated test setup code may be intentional. If the code IS the remediation for the issue, it is not a violation.
+NOT a violation: literal inside a constant/enum definition; long function that only registers routes; duplicated test setup; code that IS the remediation for the issue.
 
-## Evidence requirement
+## Evidence
 
-Every violation must cite code that is directly visible in the provided source.
+Quote the specific problem expression in `snippet`. Code must be visible in source.
 
-- Quote the specific expression, statement, or call that IS the problem in the `snippet` field.
-- Do NOT infer violations from imports, function names, file paths, module layout, or the *absence* of code — unless a requirement explicitly demands that the missing code be present in this file.
-- If you cannot point to a concrete line where the problem manifests, do not flag it.
-- Speculative concerns ("this could be vulnerable to X", "this might allow Y", "should consider Z") are NOT violations. Only report issues you can prove from the code shown.
+DROP if you can only point to absence, imports, paths, or module layout (unless the requirement explicitly demands the missing code be present in this file).
+
+DROP speculative concerns: "could", "might", "should consider".
 
 ## Severity
 
-For violations:
-- **critical** — An exploitable vulnerability or production-breaking bug with clear, demonstrable impact visible in the code. Examples: SQL injection with user-controlled input reaching a raw query; hardcoded secret committed to source; authentication bypass; data loss on a code path that will execute in production. Do NOT use `critical` for missing best-practice controls, hardening gaps, defense-in-depth concerns, or hypothetical attack scenarios — those are `major` or `minor`. If you cannot describe a concrete attack or failure that this code enables right now, it is not critical.
-- **major** — Significant quality issue or real security weakness that should be fixed, but not directly exploitable or production-breaking as-is.
-- **minor** — A real, observable defect in the quoted code: a style violation, a measurable inefficiency, or a concrete improvement opportunity. `minor` is NOT a dumping ground for findings that fail the higher-severity bar — it has its own bar (see Severity self-check). Speculative concerns, hedged reasoning, and "could be slow under hypothetical load" findings are NOT minors; they are dropped.
+- **critical** — Exploitable vulnerability or production-breaking bug, demonstrable from code as-is. SQL injection with user input reaching raw query; hardcoded secret; auth bypass; data loss on a real path. Hardening gaps, defense-in-depth, hypotheticals → NOT critical.
+- **major** — Real quality or security issue. Should be fixed. Not directly exploitable.
+- **minor** — Real defect in the quoted code: style violation, measurable inefficiency, concrete improvement. NOT a fallback for findings that fail the higher bar.
 
-For compliance — use the same severity to indicate the importance of what's done right:
-- **critical** — Security best practice correctly implemented, safe data handling
-- **major** — Significant quality pattern properly followed
-- **minor** — Good style, naming, or minor best practice followed
+Compliance uses the same scale to mark importance of what's done right.
 
-## Test file severity ceiling
+## Test files
 
-If the file being analyzed is a test file, `minor` is the maximum allowed severity — never report `critical` or `major` on a test file. Use your judgment to decide: if the file's purpose is to test or describe behavior of other code (test fixtures, mock setups, test configs, spec files in any language), cap it at `minor`.
+Test file → max severity `minor`. Never `critical`/`major` on tests, fixtures, mocks, or specs.
 
-Why: test files routinely contain patterns that look vulnerable (`eval(x)`, hardcoded secrets, path-traversal payloads, SQL strings) *on purpose* — they exist to verify the scanner catches those patterns. Flagging the fixture itself as critical produces noise, not signal. A genuine exploitable issue in a test still shows up as `minor`, which is enough for a reviewer to investigate.
+Test files contain `eval(x)`, secrets, path-traversal payloads on purpose. A real issue surfaces as `minor`; that's enough.
 
-## Severity self-check
+## Self-check (every finding, including minor)
 
-Before finalizing ANY violation — including `minor` — verify:
+1. **Evidence** — Quote the problem line. Only "missing"/"absent" → drop.
+2. **Concrete** — State the problem in one sentence about the quoted code.
+3. **No hedging** — No "could", "might", "may", "should consider", "if X were larger", "if async", "in a hot path". Describe what the line does wrong AS WRITTEN.
+4. **Impact** — Name the observable consequence. "Could be slow under load" without a profile is speculation.
 
-1. **Evidence**: Can you quote the exact line of code that IS the problem? If you can only point to what's *missing* or *absent*, drop the finding.
-2. **Concreteness**: Can you state the problem in one specific sentence that refers to the quoted code? Vague concerns ("might not be safe", "could be improved") do not pass.
-3. **No hedging**: Does your reasoning rely on "could", "might", "may", "should consider", "if X were larger", "if this were async", "in a hot path"? If yes, the finding is conditional on a hypothetical — drop it. A real `minor` describes what the quoted line does wrong *as written today*, not what it might do under imagined load.
-4. **Demonstrable impact**: Can you name the *observable* consequence of the quoted code (a measurable inefficiency, a style rule violated, a concrete improvement)? "Linear scan over a deque", "synchronous I/O blocks event loop", or "could become slow as log grows" without a known load profile are not demonstrable — they are speculation.
+For `critical`/`major` also:
 
-Additionally for `critical` and `major`:
+5. **Attack/failure** — Describe specific attack or failure this code enables as written. Hedge words → `minor` only if 1–4 hold; else drop.
+6. **Reachable** — Production code path. Tests, examples, dev scaffolding are not `critical`.
 
-5. **Attack/failure scenario**: Can you describe, in one sentence, a specific attack or failure this code enables *as written*? If your reasoning uses hedge words (see check 3) — downgrade to `minor` only if checks 1–4 still hold; otherwise drop.
-6. **Reachability**: Does this code execute in a realistic production path? Code in test files, examples, or dev-only scaffolding is not `critical`.
+**Decision**: 1–4 fail → DROP entirely. 5–6 fail → `minor` only if 1–4 hold, else drop. `minor` is not a fallback bucket.
 
-**Decision rule**: If checks 1–4 fail, **drop the finding entirely** — do NOT relabel it as `minor`. `minor` is not a fallback bucket. If checks 5–6 fail, downgrade to `minor` only when checks 1–4 still hold; otherwise drop.
-
-A clean report with fewer, sharper findings is more valuable than a long report padded with speculative minors.
+Fewer sharper findings beats long reports padded with speculation.


### PR DESCRIPTION
## Summary

Cuts ~1100 tokens per prompt build by removing rationale prose, duplicate severity definitions, and rules already enforced by `evaluation_rules.md` (injected into every other prompt via `{{EVALUATION_RULES}}`).

| File | Before | After | Δ |
|---|---|---|---|
| `evaluation_rules.md` | 911 | 385 | −58% |
| `compass.md` | 592 | 320 | −46% |
| `cli_subagent_prompt.md` | 254 | 217 | −15% |
| `cli_consolidated_prompt.md` | 227 | 190 | −16% |
| `api_prompt.md` | 103 | 103 | unchanged |
| **Total** | **2087** | **1215** | **−42%** |

## What was cut (zero behavior risk)

- **Rationale prose** — "Why test files contain `eval(x)`...", "A clean report > long reports padded with speculation". The model needs the rule, not the explanation.
- **Duplicate Severity Definitions** in `compass.md` — already in `evaluation_rules.md` (injected via `{{EVALUATION_RULES}}`).
- **"CRITICAL: Report Findings Immediately"** in `compass.md` — overlapped with the workflow step + Search Strategy pattern.
- Per-prompt rules already in `evaluation_rules.md`:
  - "Every finding must have a specific file and line" → covered by Evidence section
  - "Do not fabricate findings" → covered by Evidence section
  - "Call `report_finding` immediately — do not batch" → covered by workflow + pattern

## What was preserved verbatim

- All four self-check items (1–4) — core FP suppression
- Both critical/major checks (5, 6)
- Decision rule ("1–4 fail → DROP entirely; 5–6 fail → minor only if 1–4 hold, else drop")
- Test file ceiling, with the `eval(x)`/secrets/path-traversal example list — smaller models anchor on examples
- All hedge words (`could`/`might`/`may`/`should consider`/`if X were larger`/`in a hot path`) — the rule depends on the explicit list
- **"Report ALL violations AND ALL compliance — do not bias toward either"** in `compass.md` — explicit balance instruction smaller models need

## Why this matters

Each chat completion replays the prompt. With 4 quodeq agents × ~10 completions per file × ~1100 saved tokens, that's ~45k fewer prefill tokens per file. On gemma 26B / M4 Max this should recover ~10–15% of the throughput hit from the previous prompt growth (#272/#290/minor-severity tightening).

Larger models (Claude/GPT) won't see a measurable speed gain but should produce identical findings.

## ⚠️ Verification before merge

This PR changes prompts that drive LLM behavior. Don't merge blindly.

**Plan**:

1. Check out `prompt/tighten-eval-rules` and run a security scan on a known project (the quodeq codebase itself works).
2. Compare against a recent baseline scan on the same project (any recent run on develop).
3. Acceptance criteria:
   - Total finding count within ±15%
   - Severity distribution (critical/major/minor ratio) shifts by no more than ±10%
   - No principle gets dramatically more or fewer findings than baseline
4. **If counts drift outside the bands**: restore the keeper lines (likely "no hedging" needs another anchor in compass, or test-file rationale needs a sentence back) and re-test.
5. **If counts hold**: merge.

## Test plan

- [x] `pytest` (full suite, 2098 pass — purely content changes, no logic)
- [x] Comparison run on a known project (manual, before merge)