### PR TITLE
feat(ui): live scan progress with collapsible per-dimension breakdown

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from copy import copy
 from dataclasses import replace
 from collections.abc import Callable
@@ -13,6 +15,22 @@ from quodeq.core.evidence.model import Evidence
 from quodeq.engine._runner_markers import emit_marker
 # NOTE: logging in inner layer — tracked for middleware extraction
 from quodeq.shared.logging import log_info, log_warning
+
+
+def _silence_broken_stdout() -> None:
+    """Redirect stdout/stderr to /dev/null after a BrokenPipeError.
+
+    Once the parent has closed its end of the pipe every subsequent write to
+    stdout/stderr raises BrokenPipeError. The actual analysis work (evidence
+    files, MCP calls, etc.) doesn't depend on those streams — only logging
+    does. Swapping the streams to /dev/null lets remaining dimensions run.
+    """
+    try:
+        devnull = open(os.devnull, "w")  # noqa: SIM115 — long-lived
+        sys.stdout = devnull
+        sys.stderr = devnull
+    except OSError:
+        pass
 
 
 def check_zero_findings(
@@ -64,12 +82,19 @@ def run_incremental_loop(
         log_info(f"\u2192 [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
         try:
             ev = run_dimension_incremental(config, dimension, idx, ctx)
+        except BrokenPipeError:
+            _silence_broken_stdout()
+            ev = None
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 incremental failed: {exc}, falling back to full")
             fallback_options = copy(config.options)
             fallback_options.incremental_file_filter = None
             fallback_config = replace(config, options=fallback_options)
-            ev = process_fn(fallback_config, dimension, idx, ctx)
+            try:
+                ev = process_fn(fallback_config, dimension, idx, ctx)
+            except BrokenPipeError:
+                _silence_broken_stdout()
+                ev = None
         if ev:
             log_result_fn(ev, dimension, idx, ctx.total)
             result[dimension] = ev
@@ -102,6 +127,15 @@ def run_per_dimension_loop(
     for idx, dimension in enumerate(dimensions, 1):
         try:
             ev = process_fn(config, dimension, idx, ctx)
+        except BrokenPipeError:
+            # Parent closed the pipe mid-run. The current dim is treated as
+            # skipped — its evidence may already be on disk (scoring will
+            # pick that up via _score_completed_evidence on the API side),
+            # but we don't try to recover it here. Silence stdout so the
+            # remaining dims can run without every log call re-raising.
+            _silence_broken_stdout()
+            skipped_count += 1
+            continue
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 failed: {exc}")
             skipped_count += 1

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -18,6 +18,7 @@ from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.api.routes import _reports_dir
 from quodeq.services.base import ActionProvider
 from quodeq.services.evaluation_mixin import _score_completed_evidence
+from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
 
 _logger = logging.getLogger(__name__)
 
@@ -99,6 +100,28 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
             except Exception as exc:
                 _logger.debug("Could not score cancelled dimension for %s: %s", job_id, exc)
         return jsonify(to_camel_dict(job))
+
+    @app.get("/api/evaluations/<job_id>/progress")
+    def get_evaluation_progress(job_id: str) -> Response | tuple[Response, int]:
+        """Return live progress for a scan (works for internal and external runs)."""
+        run_dir = provider.get_log_run_dir(job_id) if hasattr(provider, "get_log_run_dir") else None
+        if run_dir is None:
+            body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        # Pool budget for the running dim's bar — only available for jobs the
+        # JobManager started; external runs surface no budget metadata.
+        pool_budget_s: int | None = None
+        snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
+        if snapshot is not None:
+            options = getattr(snapshot, "options", None) or {}
+            raw = options.get("poolBudget") if isinstance(options, dict) else None
+            if isinstance(raw, int) and raw > 0:
+                pool_budget_s = raw
+        progress = build_scan_progress(job_id, run_dir, pool_budget_s=pool_budget_s)
+        if progress is None:
+            body, status = error_response("Run not ready", HTTPStatus.NOT_FOUND, "NOT_FOUND")
+            return jsonify(body), status
+        return jsonify(to_camel_dict(progress_to_dict(progress)))
 
     @app.delete("/api/evaluations/<job_id>")
     def cancel_or_delete_evaluation(job_id: str) -> Response | tuple[Response, int]:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -234,7 +234,15 @@ def build_scan_progress(
         )
 
         if queue is not None:
-            taken = len(queue.get("taken") or [])
+            # `taken` is a list of batch entries [{"files": [...], "agent": ..., "ts": ...}, ...].
+            # Match FileQueue.stats(): flatten file counts across batches so the
+            # number matches the heartbeat log.
+            taken_entries = queue.get("taken") or []
+            taken = 0
+            for entry in taken_entries:
+                fs = entry.get("files") if isinstance(entry, dict) else None
+                if isinstance(fs, list):
+                    taken += len(fs)
             pending = len(queue.get("pending") or [])
             files = {"taken": taken, "total": taken + pending}
         elif d_state == "pending":

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -109,16 +109,35 @@ def _active_agents(evidence_dir: Path, dim_id: str) -> int:
     return count
 
 
-def _dim_state(dim_id: str, status: dict, terminal: bool) -> str:
+def _dim_state(
+    dim_id: str,
+    status: dict,
+    terminal: bool,
+    *,
+    has_queue: bool,
+    has_evaluation: bool,
+) -> str:
     """Classify a dimension as done | running | pending.
 
-    A dim is *done* if its evidence file exists AND it isn't the current_dimension
-    of a still-running scan. Falls back to current_dimension match for *running*.
+    Order of checks:
+    1. If a scored evaluation file exists for this dim → done
+    2. If the run reached a terminal state → done (whatever state on disk)
+    3. If the queue file exists (dim has been started) → running
+    4. If current_dimension matches → running (covers the moment after queue
+       creation, before takens are written)
+    5. Otherwise → pending
     """
-    current = status.get("current_dimension")
-    if terminal:
+    if has_evaluation:
         return "done"
-    if current == dim_id:
+    if terminal:
+        # If the run terminated and this dim has a queue but no eval, the
+        # dimension is *partially done* — surfaces visually via the
+        # taken < total signal in the UI. Dims with no queue at all never
+        # ran; keep them as pending so they don't claim completion.
+        return "done" if has_queue else "pending"
+    if has_queue:
+        return "running"
+    if status.get("current_dimension") == dim_id:
         return "running"
     return "pending"
 
@@ -205,12 +224,15 @@ def build_scan_progress(
 
     dim_results: list[_DimProgress] = []
     for dim_id in dim_ids:
-        # Treat all dims as "done" once the run reaches a terminal state — a dim
-        # that started and wasn't the current_dimension at termination is finished.
-        d_state = _dim_state(dim_id, status, terminal=is_terminal)
-
         queue_path = evidence_dir / f"{dim_id}_queue.json"
+        eval_path = run_dir / "evaluation" / f"{dim_id}.json"
         queue = _read_json(queue_path) if queue_path.is_file() else None
+        d_state = _dim_state(
+            dim_id, status, terminal=is_terminal,
+            has_queue=queue is not None,
+            has_evaluation=eval_path.is_file(),
+        )
+
         if queue is not None:
             taken = len(queue.get("taken") or [])
             pending = len(queue.get("pending") or [])

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -1,0 +1,252 @@
+"""Read live scan progress from a run directory.
+
+Pure-on-disk: works for both internal (started via dashboard) and external
+(started via `quodeq evaluate` in another terminal) runs. No reliance on
+the in-memory JobManager state.
+
+Sources:
+- ``status.json``                 — phase, current_dimension, started_at, dimensions
+- ``scan.json``                   — total_files (project-wide upper bound for pending dims)
+- ``<dim>_queue.json``            — taken / pending counts (precise once dim has started)
+- ``<dim>_evidence.jsonl``        — violation / compliance counters
+- ``<dim>_agent-*.stream`` mtime  — per-dim active-agents heuristic
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+_AGENT_ACTIVE_WINDOW_S = 30
+
+
+@dataclass
+class _DimProgress:
+    id: str
+    state: str  # "done" | "running" | "pending"
+    files: dict
+    violations: int = 0
+    compliance: int = 0
+    elapsed_s: float | None = None
+    budget_s: int | None = None
+    active_agents: int = 0
+
+
+@dataclass
+class _ScanProgress:
+    job_id: str
+    state: str
+    phase: str | None
+    current_dimension: str | None
+    project_files: int
+    total_elapsed_s: float | None
+    dimensions: list[_DimProgress] = field(default_factory=list)
+
+
+def _read_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _project_total_files(run_dir: Path) -> int:
+    """Read project_files (upper bound for pending dims) from scan.json."""
+    project_dir = run_dir.parent
+    scan = _read_json(project_dir / "scan.json")
+    if not scan:
+        return 0
+    raw = scan.get("total_files")
+    return int(raw) if isinstance(raw, int) else 0
+
+
+def _count_jsonl_findings(jsonl_path: Path) -> tuple[int, int]:
+    """Return (violation_count, compliance_count) from a dimension's JSONL.
+
+    Tolerant: malformed lines are skipped silently.
+    """
+    if not jsonl_path.is_file():
+        return 0, 0
+    violations = 0
+    compliance = 0
+    try:
+        with jsonl_path.open(encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("t")
+                if t == "violation":
+                    violations += 1
+                elif t == "compliance":
+                    compliance += 1
+    except OSError:
+        pass
+    return violations, compliance
+
+
+def _active_agents(evidence_dir: Path, dim_id: str) -> int:
+    """Heuristic: count <dim>_agent-*.stream files modified in the last 30s."""
+    if not evidence_dir.is_dir():
+        return 0
+    cutoff = time.time() - _AGENT_ACTIVE_WINDOW_S
+    count = 0
+    try:
+        for p in evidence_dir.glob(f"{dim_id}_agent-*.stream"):
+            try:
+                if p.stat().st_mtime >= cutoff:
+                    count += 1
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return count
+
+
+def _dim_state(dim_id: str, status: dict, terminal: bool) -> str:
+    """Classify a dimension as done | running | pending.
+
+    A dim is *done* if its evidence file exists AND it isn't the current_dimension
+    of a still-running scan. Falls back to current_dimension match for *running*.
+    """
+    current = status.get("current_dimension")
+    if terminal:
+        return "done"
+    if current == dim_id:
+        return "running"
+    return "pending"
+
+
+def _parse_started_at(status: dict) -> datetime | None:
+    raw = status.get("started_at")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _dim_elapsed_s(dim_id: str, run_dir: Path, state: str) -> float | None:
+    """Per-dim elapsed time, derived from queue file mtime / status timing.
+
+    Best-effort: queue creation time approximates the dimension start. For done
+    dims we use the youngest agent-stream mtime as the end. For running dims we
+    use now. For pending dims we return None.
+    """
+    if state == "pending":
+        return None
+    queue = run_dir / "evidence" / f"{dim_id}_queue.json"
+    if not queue.is_file():
+        return None
+    try:
+        start = queue.stat().st_mtime
+    except OSError:
+        return None
+    if state == "running":
+        return max(0.0, time.time() - start)
+    # done: use latest agent-stream mtime
+    end = start
+    try:
+        for s in (run_dir / "evidence").glob(f"{dim_id}_agent-*.stream"):
+            try:
+                end = max(end, s.stat().st_mtime)
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return max(0.0, end - start)
+
+
+def build_scan_progress(
+    job_id: str,
+    run_dir: Path,
+    *,
+    pool_budget_s: int | None = None,
+) -> _ScanProgress | None:
+    """Compute progress for a run.
+
+    Reads only on-disk state — works for internal and external runs uniformly.
+    Returns None if the run dir is missing or has no status.json.
+    """
+    if not run_dir.is_dir():
+        return None
+    status = _read_json(run_dir / "status.json") or {}
+    if not status:
+        return None
+
+    state = status.get("state") or "unknown"
+    terminal_states = {"done", "failed", "cancelled"}
+    is_terminal = state in terminal_states
+
+    started_at = _parse_started_at(status)
+    if state == "running" and started_at:
+        total_elapsed_s: float | None = max(
+            0.0, (datetime.now(timezone.utc) - started_at).total_seconds(),
+        )
+    elif started_at and status.get("finalized_at"):
+        try:
+            end = datetime.fromisoformat(status["finalized_at"])
+            total_elapsed_s = max(0.0, (end - started_at).total_seconds())
+        except (ValueError, TypeError):
+            total_elapsed_s = None
+    else:
+        total_elapsed_s = None
+
+    project_files = _project_total_files(run_dir)
+    dim_ids = list(status.get("dimensions") or [])
+    evidence_dir = run_dir / "evidence"
+
+    dim_results: list[_DimProgress] = []
+    for dim_id in dim_ids:
+        # Treat all dims as "done" once the run reaches a terminal state — a dim
+        # that started and wasn't the current_dimension at termination is finished.
+        d_state = _dim_state(dim_id, status, terminal=is_terminal)
+
+        queue_path = evidence_dir / f"{dim_id}_queue.json"
+        queue = _read_json(queue_path) if queue_path.is_file() else None
+        if queue is not None:
+            taken = len(queue.get("taken") or [])
+            pending = len(queue.get("pending") or [])
+            files = {"taken": taken, "total": taken + pending}
+        elif d_state == "pending":
+            files = {"taken": 0, "total": project_files}
+        else:
+            files = {"taken": 0, "total": 0}
+
+        v, c = _count_jsonl_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
+        elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
+        budget = pool_budget_s if (d_state == "running" and pool_budget_s and pool_budget_s > 0) else None
+        active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
+
+        dim_results.append(_DimProgress(
+            id=dim_id,
+            state=d_state,
+            files=files,
+            violations=v,
+            compliance=c,
+            elapsed_s=elapsed,
+            budget_s=budget,
+            active_agents=active,
+        ))
+
+    return _ScanProgress(
+        job_id=job_id,
+        state=state,
+        phase=status.get("phase"),
+        current_dimension=status.get("current_dimension"),
+        project_files=project_files,
+        total_elapsed_s=total_elapsed_s,
+        dimensions=dim_results,
+    )
+
+
+def progress_to_dict(progress: _ScanProgress) -> dict:
+    """Serialize for the API response (snake_case → camelCase done at the route)."""
+    return asdict(progress)

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -141,6 +141,16 @@ export async function getEvaluation(jobId) {
 }
 
 /**
+ * Live progress for a scan. Pure on-disk read — works for internal and
+ * external (CLI-started) runs uniformly.
+ * @param {string} jobId
+ * @returns {Promise<Object>}
+ */
+export function getEvaluationProgress(jobId) {
+  return request(`/evaluations/${encodeURIComponent(jobId)}/progress`);
+}
+
+/**
  * @param {string} jobId
  * @returns {Promise<Object>}
  */

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
 import ConsoleLogViewer from './ConsoleLogViewer.jsx';
+import ScanProgress from './ScanProgress.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
@@ -179,6 +180,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
     <div className="panel evaluate-job-panel">
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobMeta job={job} projectName={deriveProjectName(job.repo)} />
+      <ScanProgress jobId={job.jobId} status={job.status} />
       <ConsolePanel job={job} consoleOpen={consoleOpen} setConsoleOpen={setConsoleOpen} hasEvaluations={hasEvaluations} />
       <LiveViolationsFeed liveViolations={liveViolations} />
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,15 +1,10 @@
-import { useState } from 'react';
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
-import ConsoleLogViewer from './ConsoleLogViewer.jsx';
 import ScanProgress from './ScanProgress.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
-import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
 import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
 
 const STATUS = { RUNNING: 'running', DONE: 'done', FAILED: 'failed', LOST: 'lost' };
-const DOT_OFFSET_TOP = -2;
-const DOT_OFFSET_RIGHT = -4;
 
 function deriveProjectName(repo) {
   if (!repo) return null;
@@ -24,81 +19,12 @@ function statusTitle(status) {
   return 'Evaluation Cancelled';
 }
 
-function phaseLabel(job) {
-  if (!job || job.status !== STATUS.RUNNING) return null;
-  switch (job.phase) {
-    case 'setup': return 'Setting up';
-    case 'analyzing': return 'Analyzing';
-    case 'scoring': return 'Scoring';
-    default: return 'Starting';
-  }
-}
-
-const STATUS_MARKERS = { arrow: '\u2192', check: '\u2713', error: 'Error:', failed: 'failed' };
-
-function isStatusLine(line) {
-  const prefixes = [STATUS_MARKERS.arrow, STATUS_MARKERS.check, STATUS_MARKERS.error];
-  return prefixes.some((p) => line.startsWith(p)) || line.includes(STATUS_MARKERS.failed);
-}
-
-function lastRelevantLog(logs) {
-  if (!logs?.length) return null;
-  for (let i = logs.length - 1; i >= 0; i--) {
-    const line = logs[i].trim();
-    if (isStatusLine(line)) return line;
-  }
-  return null;
-}
-
 function ExternalRunBadge() {
   return (
     <div className="job-meta-item">
       <span className="job-meta-label">Source</span>
       <span className="job-meta-value">External</span>
     </div>
-  );
-}
-
-function ConsolePanel({ job, consoleOpen, setConsoleOpen, hasEvaluations }) {
-  const isRunning = job.status === STATUS.RUNNING;
-  const isFailed = job.status === STATUS.FAILED;
-  const isLost = job.status === STATUS.LOST;
-  const [showDot, setShowDot] = useState(() => {
-    if (hasEvaluations) return false;
-    try { return !localStorage.getItem(CONSOLE_DOT_DISMISSED_KEY); } catch { return true; }
-  });
-  return (
-    <>
-      <div
-        className="eval-status-row eval-status-row--clickable"
-        role="button"
-        tabIndex={0}
-        onClick={() => { setConsoleOpen(o => !o); if (showDot) { setShowDot(false); try { localStorage.setItem(CONSOLE_DOT_DISMISSED_KEY, '1'); } catch {} } }}
-        onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setConsoleOpen(o => !o); } }}
-        aria-label={consoleOpen ? 'Hide console' : 'Show console'}
-      >
-        {isRunning && <span className="eval-status-phase">{phaseLabel(job)}</span>}
-        {isFailed && <span className="eval-status-phase eval-status-phase--error">{lastRelevantLog(job.logs) || 'Analysis failed'}</span>}
-        {isLost && <span className="eval-status-phase eval-status-phase--error">Server restarted — job tracking lost</span>}
-        {isRunning && job.dimensions?.length > 0 && (
-          <span className="eval-status-dims">
-            {job.dimensions.map(d => (
-              <span key={d} className={`eval-dim-tag${d === job.currentDimension ? ' active' : ''}`}>{d}</span>
-            ))}
-          </span>
-        )}
-        <span className="eval-console-indicator" style={{ position: 'relative' }}>
-          <svg className="eval-console-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="1" y="2" width="14" height="12" rx="2" />
-            <polyline points="4.5,6.5 7,9 4.5,11.5" />
-            <line x1="9" y1="11" x2="12" y2="11" />
-          </svg>
-          {consoleOpen ? '▾' : '▸'}
-          {showDot && !consoleOpen && <span className="sidebar-nav-dot" style={{ top: DOT_OFFSET_TOP, right: DOT_OFFSET_RIGHT }} />}
-        </span>
-      </div>
-      {consoleOpen && <ConsoleLogViewer logs={job.logs} />}
-    </>
   );
 }
 
@@ -172,16 +98,13 @@ function JobMeta({ job, projectName }) {
 }
 
 export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
-  const [consoleOpen, setConsoleOpen] = useState(false);
-
   if (!job) return null;
 
   return (
     <div className="panel evaluate-job-panel">
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobMeta job={job} projectName={deriveProjectName(job.repo)} />
-      <ScanProgress jobId={job.jobId} status={job.status} />
-      <ConsolePanel job={job} consoleOpen={consoleOpen} setConsoleOpen={setConsoleOpen} hasEvaluations={hasEvaluations} />
+      <ScanProgress job={job} hasEvaluations={hasEvaluations} />
       <LiveViolationsFeed liveViolations={liveViolations} />
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -4,6 +4,7 @@ import EvaluationStatus from './EvaluationStatus.jsx';
 
 // Mock child components so we isolate what we care about.
 vi.mock('./LiveViolationsFeed.jsx', () => ({ default: () => null }));
+vi.mock('./ScanProgress.jsx', () => ({ default: () => null }));
 
 const baseJob = {
   jobId: 'ext-test',

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -79,38 +79,56 @@ function ViolationLiveRow({ violation, index }) {
   );
 }
 
-export default function LiveViolationsFeed({ liveViolations }) {
-  const dims = Object.keys(liveViolations ?? {});
-  const totalCount = dims.reduce((sum, d) => sum + (liveViolations[d]?.length ?? 0), 0);
+function DimensionGroup({ dim, violations, defaultOpen }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const count = violations.length;
+  return (
+    <div className={`vlive-dimension-group${open ? '' : ' vlive-dimension-group--collapsed'}`}>
+      <button
+        type="button"
+        className="vlive-dimension-label"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className={`vlive-dimension-caret${open ? ' vlive-dimension-caret--open' : ''}`} aria-hidden="true">▸</span>
+        <span className="vlive-dimension-name">{dim}</span>
+        <span className="vlive-dimension-count">{count}</span>
+      </button>
+      {open && violations.map((v, i) => (
+        <ViolationLiveRow key={`${dim}-${v.file}-${v.principle}-${String(v.line ?? '')}`} violation={v} index={i} />
+      ))}
+    </div>
+  );
+}
 
-  const sortedByDim = useMemo(() => {
-    const result = {};
-    for (const dim of Object.keys(liveViolations ?? {})) {
-      result[dim] = [...(liveViolations[dim] ?? [])].sort((a, b) =>
-        severityOrder(a.severity) - severityOrder(b.severity)
-      );
-    }
-    return result;
+export default function LiveViolationsFeed({ liveViolations }) {
+  const orderedDims = useMemo(() => {
+    const entries = Object.entries(liveViolations ?? {})
+      .map(([dim, vs]) => ({
+        dim,
+        violations: [...(vs ?? [])].sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity)),
+      }))
+      .filter(({ violations }) => violations.length > 0)
+      .sort((a, b) => b.violations.length - a.violations.length);
+    return entries;
   }, [liveViolations]);
 
+  const totalCount = orderedDims.reduce((sum, d) => sum + d.violations.length, 0);
   if (!totalCount) return null;
 
   return (
     <div className="vlive-feed">
       <div className="vlive-counter">
-        {totalCount} violation{totalCount !== 1 ? 's' : ''} found across {dims.length} dimension{dims.length !== 1 ? 's' : ''}
+        {totalCount} violation{totalCount !== 1 ? 's' : ''} found across {orderedDims.length} dimension{orderedDims.length !== 1 ? 's' : ''}
       </div>
-      {dims.map(dim => {
-        const violations = sortedByDim[dim] || [];
-        return (
-          <div key={dim} className="vlive-dimension-group">
-            <div className="vlive-dimension-label">{dim}</div>
-            {violations.map((v, i) => (
-              <ViolationLiveRow key={`${dim}-${v.file}-${v.principle}-${String(v.line ?? '')}`} violation={v} index={i} />
-            ))}
-          </div>
-        );
-      })}
+      {orderedDims.map(({ dim, violations }, idx) => (
+        <DimensionGroup
+          key={dim}
+          dim={dim}
+          violations={violations}
+          defaultOpen={idx === 0}
+        />
+      ))}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -125,10 +125,11 @@ function ConsoleButton({ open, showDot, onToggle }) {
   return (
     <button
       type="button"
-      className="scan-progress__console-btn"
+      className={`scan-progress__console-btn${open ? ' scan-progress__console-btn--open' : ''}`}
       onClick={(e) => { e.stopPropagation(); onToggle(); }}
       aria-label={open ? 'Hide console' : 'Show console'}
       aria-expanded={open}
+      title={open ? 'Hide console' : 'Show console'}
     >
       <svg className="scan-progress__console-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
         <rect x="1" y="2" width="14" height="12" rx="2" />

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react';
+import { getEvaluationProgress } from '../../../api/index.js';
+
+const POLL_INTERVAL_MS = 2000;
+const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
+
+function formatClock(s) {
+  if (s == null || !Number.isFinite(s)) return '—';
+  const total = Math.max(0, Math.floor(s));
+  const m = Math.floor(total / 60);
+  const sec = total % 60;
+  return `${m}:${String(sec).padStart(2, '0')}`;
+}
+
+function pct(taken, total) {
+  if (!total || total <= 0) return 0;
+  return Math.min(100, Math.round((taken / total) * 100));
+}
+
+function DimRow({ dim }) {
+  const taken = dim.files?.taken ?? 0;
+  const total = dim.files?.total ?? 0;
+  const p = pct(taken, total);
+  const isDone = dim.state === 'done';
+  const isRunning = dim.state === 'running';
+  const isPending = dim.state === 'pending';
+
+  const isPartial = isDone && total > 0 && taken < total;
+
+  let icon = '○';
+  let iconClass = '';
+  if (isDone) {
+    icon = isPartial ? '◐' : '✓';
+    iconClass = isPartial ? 'scan-progress__dim-icon--partial' : 'scan-progress__dim-icon--done';
+  } else if (isRunning) {
+    icon = '▶';
+    iconClass = 'scan-progress__dim-icon--running';
+  }
+
+  let meta;
+  if (isPending) {
+    meta = <span className="scan-progress__dim-meta-pending">pending</span>;
+  } else if (isDone) {
+    meta = (
+      <>
+        {isPartial ? (
+          <>
+            {`${taken} / ${total}`} · <span className="scan-progress__partial">partial</span>
+          </>
+        ) : (
+          total > 0 ? `${total} files` : ''
+        )}
+        {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
+        {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
+        {dim.elapsedS != null && <> · {formatClock(dim.elapsedS)}</>}
+      </>
+    );
+  } else {
+    // running
+    let budgetPart;
+    if (dim.budgetS) {
+      const overrun = dim.elapsedS != null && dim.elapsedS > dim.budgetS;
+      const cls = overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget';
+      budgetPart = (
+        <span className={cls}>
+          {formatClock(dim.elapsedS)} / {formatClock(dim.budgetS)} budget
+        </span>
+      );
+    } else {
+      budgetPart = <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>;
+    }
+    meta = (
+      <>
+        {`${taken} / ${total}`}
+        {dim.activeAgents > 0 && <> · {dim.activeAgents} agents</>}
+        {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
+        {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
+        {' · '}
+        {budgetPart}
+      </>
+    );
+  }
+
+  const fillClass = isDone
+    ? (isPartial ? 'scan-progress__bar-fill--partial' : 'scan-progress__bar-fill--done')
+    : '';
+
+  return (
+    <div className={`scan-progress__dim${isPending ? ' scan-progress__dim--pending' : ''}`}>
+      <span className={`scan-progress__dim-icon ${iconClass}`}>{icon}</span>
+      <span className="scan-progress__dim-name">{dim.id}</span>
+      <div className="scan-progress__bar">
+        <div className={`scan-progress__bar-fill ${fillClass}`} style={{ width: `${p}%` }} />
+      </div>
+      <span className="scan-progress__dim-meta">{meta}</span>
+    </div>
+  );
+}
+
+export default function ScanProgress({ jobId, status }) {
+  const [progress, setProgress] = useState(null);
+  const [open, setOpen] = useState(false);
+  const timerRef = useRef(null);
+  const isTerminal = TERMINAL_STATES.has(status);
+
+  useEffect(() => {
+    if (!jobId) return undefined;
+    let stopped = false;
+
+    async function tick() {
+      try {
+        const data = await getEvaluationProgress(jobId);
+        if (!stopped) setProgress(data);
+      } catch {
+        // ignore — progress is best-effort
+      }
+    }
+
+    tick();
+    if (!isTerminal) {
+      timerRef.current = setInterval(tick, POLL_INTERVAL_MS);
+    }
+    return () => {
+      stopped = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [jobId, isTerminal]);
+
+  if (!progress) return null;
+
+  const dims = progress.dimensions || [];
+  const totalFiles = dims.reduce((acc, d) => acc + (d.files?.total ?? 0), 0);
+  const takenFiles = dims.reduce((acc, d) => acc + (d.files?.taken ?? 0), 0);
+  const overallPct = pct(takenFiles, totalFiles);
+  const phaseLabel = progress.currentDimension
+    ? <>running <span className="scan-progress__dim-active">{progress.currentDimension}</span></>
+    : progress.phase
+      ? <>phase: <span className="scan-progress__dim-active">{progress.phase}</span></>
+      : null;
+
+  return (
+    <div className="scan-progress">
+      <button
+        type="button"
+        className="scan-progress__row"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={`scan-progress-detail-${jobId}`}
+      >
+        <div className="scan-progress__bar-wrap">
+          <div className="scan-progress__bar">
+            <div className="scan-progress__bar-fill" style={{ width: `${overallPct}%` }} />
+          </div>
+          <div className="scan-progress__meta">
+            <span>
+              <strong>{takenFiles} / {totalFiles}</strong> files · {overallPct}%
+              {phaseLabel && <> · {phaseLabel}</>}
+            </span>
+            {progress.totalElapsedS != null && (
+              <span><strong>{formatClock(progress.totalElapsedS)}</strong> total</span>
+            )}
+          </div>
+        </div>
+        <span className={`scan-progress__caret${open ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
+      </button>
+      {open && (
+        <div className="scan-progress__expanded" id={`scan-progress-detail-${jobId}`}>
+          <div className="scan-progress__expanded-label">Per-dimension</div>
+          {dims.map((d) => <DimRow key={d.id} dim={d} />)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -34,13 +34,15 @@ function lastRelevantLog(logs) {
   return null;
 }
 
-function DimRow({ dim }) {
+function DimRow({ dim, fallbackTotal }) {
   const taken = dim.files?.taken ?? 0;
-  const total = dim.files?.total ?? 0;
+  const isPending = dim.state === 'pending';
+  // Pending dims don't have a real queue yet. Use the running/done dims'
+  // queue total as a better estimate than the project-wide upper bound.
+  const total = isPending && fallbackTotal ? fallbackTotal : (dim.files?.total ?? 0);
   const p = pct(taken, total);
   const isDone = dim.state === 'done';
   const isRunning = dim.state === 'running';
-  const isPending = dim.state === 'pending';
 
   const isPartial = isDone && total > 0 && taken < total;
 
@@ -56,15 +58,9 @@ function DimRow({ dim }) {
 
   let meta;
   if (isPending) {
-    meta = (
-      <>
-        {total > 0
-          ? <>0 / <span className="scan-progress__dim-meta-projected">{total}</span></>
-          : null}
-        {' · '}
-        <span className="scan-progress__dim-meta-pending">pending</span>
-      </>
-    );
+    meta = total > 0
+      ? <span className="scan-progress__dim-meta-projected">0 / {total}</span>
+      : null;
   } else if (isDone) {
     meta = (
       <>
@@ -251,7 +247,17 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       {detailOpen && dims.length > 0 && (
         <div className="scan-progress__expanded" id={`scan-progress-detail-${jobId}`}>
           <div className="scan-progress__expanded-label">Per-dimension</div>
-          {dims.map((d) => <DimRow key={d.id} dim={d} />)}
+          {(() => {
+            // Best estimate for pending dims: the largest queue total observed
+            // among dims that have actually started (running or done). Falls
+            // back to whatever total the backend gave (project-wide ceiling).
+            const observed = dims
+              .filter((d) => d.state !== 'pending')
+              .map((d) => d.files?.total ?? 0)
+              .filter((n) => n > 0);
+            const fallbackTotal = observed.length > 0 ? Math.max(...observed) : 0;
+            return dims.map((d) => <DimRow key={d.id} dim={d} fallbackTotal={fallbackTotal} />);
+          })()}
         </div>
       )}
       {consoleOpen && <ConsoleLogViewer logs={job.logs} />}

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -1,8 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
 import { getEvaluationProgress } from '../../../api/index.js';
+import ConsoleLogViewer from './ConsoleLogViewer.jsx';
+import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
 
 const POLL_INTERVAL_MS = 2000;
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
+const STATUS_MARKERS = { arrow: '\u2192', check: '\u2713', error: 'Error:', failed: 'failed' };
 
 function formatClock(s) {
   if (s == null || !Number.isFinite(s)) return '—';
@@ -15,6 +18,20 @@ function formatClock(s) {
 function pct(taken, total) {
   if (!total || total <= 0) return 0;
   return Math.min(100, Math.round((taken / total) * 100));
+}
+
+function isStatusLine(line) {
+  const prefixes = [STATUS_MARKERS.arrow, STATUS_MARKERS.check, STATUS_MARKERS.error];
+  return prefixes.some((p) => line.startsWith(p)) || line.includes(STATUS_MARKERS.failed);
+}
+
+function lastRelevantLog(logs) {
+  if (!logs?.length) return null;
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const line = logs[i].trim();
+    if (isStatusLine(line)) return line;
+  }
+  return null;
 }
 
 function DimRow({ dim }) {
@@ -64,7 +81,6 @@ function DimRow({ dim }) {
       </>
     );
   } else {
-    // running
     let budgetPart;
     if (dim.budgetS) {
       const overrun = dim.elapsedS != null && dim.elapsedS > dim.budgetS;
@@ -105,9 +121,40 @@ function DimRow({ dim }) {
   );
 }
 
-export default function ScanProgress({ jobId, status }) {
+function ConsoleButton({ open, showDot, onToggle }) {
+  return (
+    <button
+      type="button"
+      className="scan-progress__console-btn"
+      onClick={(e) => { e.stopPropagation(); onToggle(); }}
+      aria-label={open ? 'Hide console' : 'Show console'}
+      aria-expanded={open}
+    >
+      <svg className="scan-progress__console-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="1" y="2" width="14" height="12" rx="2" />
+        <polyline points="4.5,6.5 7,9 4.5,11.5" />
+        <line x1="9" y1="11" x2="12" y2="11" />
+      </svg>
+      <span className="scan-progress__console-caret">{open ? '▾' : '▸'}</span>
+      {showDot && !open && <span className="scan-progress__console-dot" />}
+    </button>
+  );
+}
+
+export default function ScanProgress({ job, hasEvaluations = false }) {
+  const jobId = job?.jobId;
+  const status = job?.status;
+  const isRunning = status === 'running';
+  const isFailed = status === 'failed';
+  const isLost = status === 'lost';
+
   const [progress, setProgress] = useState(null);
-  const [open, setOpen] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [consoleOpen, setConsoleOpen] = useState(false);
+  const [showDot, setShowDot] = useState(() => {
+    if (hasEvaluations) return false;
+    try { return !localStorage.getItem(CONSOLE_DOT_DISMISSED_KEY); } catch { return true; }
+  });
   const timerRef = useRef(null);
   const isTerminal = TERMINAL_STATES.has(status);
 
@@ -120,7 +167,7 @@ export default function ScanProgress({ jobId, status }) {
         const data = await getEvaluationProgress(jobId);
         if (!stopped) setProgress(data);
       } catch {
-        // ignore — progress is best-effort
+        /* progress is best-effort */
       }
     }
 
@@ -134,26 +181,54 @@ export default function ScanProgress({ jobId, status }) {
     };
   }, [jobId, isTerminal]);
 
-  if (!progress) return null;
+  if (!jobId) return null;
 
-  const dims = progress.dimensions || [];
+  const dims = progress?.dimensions || [];
   const totalFiles = dims.reduce((acc, d) => acc + (d.files?.total ?? 0), 0);
   const takenFiles = dims.reduce((acc, d) => acc + (d.files?.taken ?? 0), 0);
   const overallPct = pct(takenFiles, totalFiles);
-  const phaseLabel = progress.currentDimension
+  const inlineLabel = progress?.currentDimension
     ? <>running <span className="scan-progress__dim-active">{progress.currentDimension}</span></>
-    : progress.phase
+    : progress?.phase
       ? <>phase: <span className="scan-progress__dim-active">{progress.phase}</span></>
+      : null;
+
+  function toggleDetail() {
+    setDetailOpen((v) => !v);
+  }
+  function toggleConsole() {
+    setConsoleOpen((v) => !v);
+    if (showDot) {
+      setShowDot(false);
+      try { localStorage.setItem(CONSOLE_DOT_DISMISSED_KEY, '1'); } catch { /* ignore */ }
+    }
+  }
+  function rowKey(e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleDetail();
+    }
+  }
+
+  // Failed / lost: show the error message inline above the progress bar.
+  const errorBanner = isFailed
+    ? <div className="scan-progress__error">{lastRelevantLog(job.logs) || 'Analysis failed'}</div>
+    : isLost
+      ? <div className="scan-progress__error">Server restarted — job tracking lost</div>
       : null;
 
   return (
     <div className="scan-progress">
-      <button
-        type="button"
+      {errorBanner}
+      <div
         className="scan-progress__row"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
+        role="button"
+        tabIndex={0}
+        onClick={toggleDetail}
+        onKeyDown={rowKey}
+        aria-expanded={detailOpen}
         aria-controls={`scan-progress-detail-${jobId}`}
+        aria-label={detailOpen ? 'Hide per-dimension detail' : 'Show per-dimension detail'}
       >
         <div className="scan-progress__bar-wrap">
           <div className="scan-progress__bar">
@@ -161,22 +236,24 @@ export default function ScanProgress({ jobId, status }) {
           </div>
           <div className="scan-progress__meta">
             <span>
-              <strong>{takenFiles} / {totalFiles}</strong> files · {overallPct}%
-              {phaseLabel && <> · {phaseLabel}</>}
+              {totalFiles > 0 ? <><strong>{takenFiles} / {totalFiles}</strong> files · {overallPct}%</> : <strong>preparing…</strong>}
+              {isRunning && inlineLabel && <> · {inlineLabel}</>}
             </span>
-            {progress.totalElapsedS != null && (
+            {progress?.totalElapsedS != null && (
               <span><strong>{formatClock(progress.totalElapsedS)}</strong> total</span>
             )}
           </div>
         </div>
-        <span className={`scan-progress__caret${open ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
-      </button>
-      {open && (
+        <span className={`scan-progress__caret${detailOpen ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
+        <ConsoleButton open={consoleOpen} showDot={showDot} onToggle={toggleConsole} />
+      </div>
+      {detailOpen && dims.length > 0 && (
         <div className="scan-progress__expanded" id={`scan-progress-detail-${jobId}`}>
           <div className="scan-progress__expanded-label">Per-dimension</div>
           {dims.map((d) => <DimRow key={d.id} dim={d} />)}
         </div>
       )}
+      {consoleOpen && <ConsoleLogViewer logs={job.logs} />}
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -39,7 +39,15 @@ function DimRow({ dim }) {
 
   let meta;
   if (isPending) {
-    meta = <span className="scan-progress__dim-meta-pending">pending</span>;
+    meta = (
+      <>
+        {total > 0
+          ? <>0 / <span className="scan-progress__dim-meta-projected">{total}</span></>
+          : null}
+        {' · '}
+        <span className="scan-progress__dim-meta-pending">pending</span>
+      </>
+    );
   } else if (isDone) {
     meta = (
       <>

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2639,11 +2639,20 @@
   transition: background 0.15s, box-shadow 0.15s;
 }
 .scan-progress__row:hover {
-  background: var(--color-surface-alt);
-  box-shadow: inset 2px 0 0 var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
 }
-.scan-progress__row:hover .scan-progress__caret { color: var(--color-accent); }
-.scan-progress__row:focus-visible { outline: 1px solid var(--color-accent); outline-offset: -1px; }
+.scan-progress__row:hover .scan-progress__caret {
+  color: var(--color-accent);
+  transform: translateX(2px);
+}
+.scan-progress__row:hover .scan-progress__bar {
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface-alt));
+}
+.scan-progress__row:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+}
+.scan-progress__caret { transition: transform 0.18s, color 0.15s; }
 
 .scan-progress__error {
   padding: 8px 0;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2662,7 +2662,7 @@
 .scan-progress__caret { transition: transform 0.18s, color 0.15s; }
 
 .scan-progress__error {
-  padding: 8px 0;
+  padding: 8px 10px;
   font-size: 11px;
   color: var(--color-sev-critical-text, #f85149);
   border-bottom: 1px solid var(--color-border-soft, var(--color-border));
@@ -2763,7 +2763,7 @@
 
 .scan-progress__expanded {
   border-top: 1px solid var(--color-border-soft, var(--color-border));
-  padding: 10px 0 12px;
+  padding: 10px 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2593,9 +2593,9 @@
 
 .scan-progress__row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
   width: 100%;
   padding: 9px 18px;
   background: transparent;
@@ -2607,6 +2607,47 @@
   transition: background 0.15s;
 }
 .scan-progress__row:hover { background: var(--color-surface-alt); }
+.scan-progress__row:focus-visible { outline: 1px solid var(--color-accent); outline-offset: -1px; }
+
+.scan-progress__error {
+  padding: 8px 18px;
+  font-size: 11px;
+  color: var(--color-sev-critical-text, #f85149);
+  border-bottom: 1px solid var(--color-border-soft, var(--color-border));
+}
+
+.scan-progress__console-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  position: relative;
+  border-radius: 2px;
+  transition: color 0.15s, background 0.15s;
+}
+.scan-progress__console-btn:hover {
+  color: var(--color-text);
+  background: var(--color-surface-alt);
+}
+.scan-progress__console-btn:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 1px;
+}
+.scan-progress__console-icon { width: 14px; height: 14px; }
+.scan-progress__console-caret { font-size: 10px; line-height: 1; }
+.scan-progress__console-dot {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent);
+}
 
 .scan-progress__bar-wrap {
   display: flex;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2585,3 +2585,132 @@
   border-color: var(--color-accent);
   background: rgba(88, 166, 255, 0.08);
 }
+
+/* ─── ScanProgress ─── */
+.scan-progress {
+  border-bottom: 1px solid var(--color-border-soft, var(--color-border));
+}
+
+.scan-progress__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 9px 18px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.scan-progress__row:hover { background: var(--color-surface-alt); }
+
+.scan-progress__bar-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.scan-progress__bar {
+  height: 4px;
+  background: var(--color-surface-alt);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.scan-progress__bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  transition: width 0.3s ease;
+}
+.scan-progress__bar-fill--done    { background: var(--color-success, #56d364); }
+.scan-progress__bar-fill--partial { background: var(--color-warn, #d29922); }
+
+.scan-progress__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 10px;
+  color: var(--color-text-dim, var(--color-text-muted));
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+.scan-progress__meta strong {
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.scan-progress__dim-active {
+  color: var(--color-accent);
+  text-transform: lowercase;
+}
+
+.scan-progress__caret {
+  color: var(--color-text-dim, var(--color-text-muted));
+  font-size: 10px;
+  user-select: none;
+  transition: transform 0.18s;
+}
+.scan-progress__caret--open {
+  transform: rotate(90deg);
+  color: var(--color-text-muted);
+}
+
+.scan-progress__expanded {
+  border-top: 1px solid var(--color-border-soft, var(--color-border));
+  padding: 10px 18px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scan-progress__expanded-label {
+  font-size: 10px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--color-text-dim, var(--color-text-muted));
+  margin-bottom: 2px;
+}
+
+.scan-progress__dim {
+  display: grid;
+  grid-template-columns: 14px 130px 1fr 240px;
+  gap: 12px;
+  align-items: center;
+  font-size: 11px;
+}
+.scan-progress__dim--pending { color: var(--color-text-dim, var(--color-text-muted)); }
+
+.scan-progress__dim-icon {
+  font-size: 11px;
+  color: var(--color-text-dim, var(--color-text-muted));
+  text-align: center;
+}
+.scan-progress__dim-icon--done    { color: var(--color-success, #56d364); }
+.scan-progress__dim-icon--running { color: var(--color-accent); }
+.scan-progress__dim-icon--partial { color: var(--color-warn, #d29922); }
+
+.scan-progress__dim-name {
+  color: var(--color-text);
+  text-transform: lowercase;
+}
+.scan-progress__dim--pending .scan-progress__dim-name { color: var(--color-text-dim, var(--color-text-muted)); }
+
+.scan-progress__dim-meta {
+  text-align: right;
+  color: var(--color-text-muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.scan-progress__dim-meta-pending {
+  color: var(--color-text-dim, var(--color-text-muted));
+  font-style: italic;
+}
+.scan-progress__v        { color: var(--color-sev-critical-text, #f85149); }
+.scan-progress__c        { color: var(--color-success, #56d364); }
+.scan-progress__budget   { color: var(--color-warn, #d29922); }
+.scan-progress__budget--overrun { color: var(--color-sev-critical-text, #f85149); }
+.scan-progress__partial  { color: var(--color-warn, #d29922); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2629,7 +2629,7 @@
   align-items: center;
   gap: 12px;
   width: 100%;
-  padding: 9px 18px;
+  padding: 9px 0;
   background: transparent;
   border: 0;
   text-align: left;
@@ -2646,7 +2646,7 @@
 .scan-progress__row:focus-visible { outline: 1px solid var(--color-accent); outline-offset: -1px; }
 
 .scan-progress__error {
-  padding: 8px 18px;
+  padding: 8px 0;
   font-size: 11px;
   color: var(--color-sev-critical-text, #f85149);
   border-bottom: 1px solid var(--color-border-soft, var(--color-border));
@@ -2747,7 +2747,7 @@
 
 .scan-progress__expanded {
   border-top: 1px solid var(--color-border-soft, var(--color-border));
-  padding: 10px 18px 12px;
+  padding: 10px 0 12px;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2709,6 +2709,10 @@
   color: var(--color-text-dim, var(--color-text-muted));
   font-style: italic;
 }
+.scan-progress__dim-meta-projected {
+  color: var(--color-text-dim, var(--color-text-muted));
+  font-style: italic;
+}
 .scan-progress__v        { color: var(--color-sev-critical-text, #f85149); }
 .scan-progress__c        { color: var(--color-success, #56d364); }
 .scan-progress__budget   { color: var(--color-warn, #d29922); }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2636,9 +2636,13 @@
   font: inherit;
   color: inherit;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background 0.15s, box-shadow 0.15s;
 }
-.scan-progress__row:hover { background: var(--color-surface-alt); }
+.scan-progress__row:hover {
+  background: var(--color-surface-alt);
+  box-shadow: inset 2px 0 0 var(--color-accent);
+}
+.scan-progress__row:hover .scan-progress__caret { color: var(--color-accent); }
 .scan-progress__row:focus-visible { outline: 1px solid var(--color-accent); outline-offset: -1px; }
 
 .scan-progress__error {
@@ -2654,20 +2658,29 @@
   gap: 4px;
   padding: 4px 6px;
   background: transparent;
-  border: 0;
+  border: 1px solid transparent;
   color: var(--color-text-muted);
   cursor: pointer;
   position: relative;
   border-radius: 2px;
-  transition: color 0.15s, background 0.15s;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 .scan-progress__console-btn:hover {
-  color: var(--color-text);
+  color: var(--color-accent);
   background: var(--color-surface-alt);
+  border-color: var(--color-border);
 }
 .scan-progress__console-btn:focus-visible {
   outline: 1px solid var(--color-accent);
   outline-offset: 1px;
+}
+.scan-progress__console-btn--open {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+.scan-progress__console-btn--open:hover {
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 .scan-progress__console-icon { width: 14px; height: 14px; }
 .scan-progress__console-caret { font-size: 10px; line-height: 1; }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2623,15 +2623,22 @@
   border-bottom: 1px solid var(--color-border-soft, var(--color-border));
 }
 
+.scan-progress {
+  /* Negative margin so the hover bg can extend visually past the row's
+     content while the row itself still sits at the panel's 24px inset. */
+  margin: 0 -10px;
+}
+
 .scan-progress__row {
   display: grid;
   grid-template-columns: 1fr auto auto;
   align-items: center;
   gap: 12px;
   width: 100%;
-  padding: 9px 0;
+  padding: 9px 10px;
   background: transparent;
   border: 0;
+  border-radius: 4px;
   text-align: left;
   font: inherit;
   color: inherit;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -1887,12 +1887,44 @@
 }
 
 .vlive-dimension-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
   padding: 4px 0 6px;
+  background: transparent;
+  border: 0;
   font-size: var(--text-xs);
   font-weight: var(--weight-semibold);
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+.vlive-dimension-label:hover { color: var(--color-text); }
+.vlive-dimension-label:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.vlive-dimension-caret {
+  font-size: 10px;
+  color: var(--color-text-dim, var(--color-text-muted));
+  transition: transform 0.18s;
+  user-select: none;
+}
+.vlive-dimension-caret--open { transform: rotate(90deg); }
+.vlive-dimension-name { flex: 1; }
+.vlive-dimension-count {
+  font-size: 10px;
+  font-weight: var(--weight-regular);
+  color: var(--color-text-dim, var(--color-text-muted));
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border-soft, var(--color-border));
+  border-radius: 2px;
 }
 
 /* Entrance animation */


### PR DESCRIPTION
## Summary

Adds a thin live progress bar to the top of `EvaluationStatus` (between `JobMeta` and the console row). Shows overall scan progress at a glance; click to expand for per-dimension detail.

Works identically for **internal** scans (started from the dashboard) and **external** scans (started from \`quodeq evaluate\` in another terminal) — pure on-disk read, no JobManager dependency.

## What you see

**Collapsed (default):**

\`\`\`
████░░░░░░░░░░░  234 / 789 files · 30% · running reliability    6:23 total  ▸
\`\`\`

**Expanded (click the row):**

\`\`\`
PER-DIMENSION
✓  security        ███████████████  234 files · 47v · 12c · 4:12
▶  reliability     █████░░░░░░░░░░  89 / 234 · 4 agents · 8v · 2:11 / 10:00 budget
○  maintainability ░░░░░░░░░░░░░░░  pending
\`\`\`

**Partial-done (e.g. dim cancelled mid-scan by budget):**

\`\`\`
◐  reliability  ████████░░░░░░░  180 / 234 · PARTIAL · 5v · 2c · 10:34
\`\`\`
Yellow icon + amber bar + "PARTIAL" label make the silent-truncation footgun visible.

## Time semantics (verified during design)

- **Total elapsed** (top-right of collapsed row): wall-clock from \`started_at\`. No hard limit, informational.
- **Per-dim elapsed**: shown only in expanded view. Done dims show final elapsed; running dim shows current.
- **Pool budget** (per-dim, default 600s): shown only on the running dim, only when set (\`pool_budget > 0\`). Turns red on overrun.

Each dimension's pool budget resets to 0 when the next dim starts (sequential).

## Backend

\`services/scan_progress.py\` reads:
- \`status.json\` — phase, current_dimension, started_at, dimensions
- \`scan.json\` — total_files (upper bound for pending dims)
- \`<dim>_queue.json\` — taken/pending counts (precise once dim has started)
- \`<dim>_evidence.jsonl\` — violation/compliance counters
- \`<dim>_agent-*.stream\` mtime — per-dim active-agents heuristic (30s window)

\`GET /api/evaluations/<job_id>/progress\` returns camelCase JSON. Resolves \`ext-*\` job IDs via the existing \`get_log_run_dir\` helper.

## UI

- \`ScanProgress.jsx\` polls \`/progress\` every 2s while \`job.status === 'running'\`, stops on terminal.
- Wired into \`EvaluationStatus.jsx\` between JobMeta and ConsolePanel — covers both new-evaluation and re-evaluate flows since they share the status panel.
- Theme-token CSS, no hardcoded colors.

## Test plan

- [x] \`pytest tests/api/ tests/services/\` — 757 pass
- [x] \`npm test\` — 100 pass
- [x] \`npm run build\` — vite build succeeds
- [x] Manual: start a scan, watch progress advance file-by-file
- [x] Manual: open dashboard against a scan started from another terminal — confirm progress shows
- [x] Manual: cancel mid-scan — confirm partial dim shows ◐ + amber + "partial" label