### PR TITLE
fix(ui): polish live evaluation screen layout and behaviour

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import usePretextHeight from '../../../hooks/usePretextHeight.js';
 
 /**
@@ -8,9 +8,44 @@ import usePretextHeight from '../../../hooks/usePretextHeight.js';
  * outside the scroll content) pins the scroll to the bottom; manual
  * scrolling away from the bottom turns it off so the user can read past
  * output without being yanked back down.
+ *
+ * Logs from the runner can carry SGR escape sequences (colourised level
+ * tokens, etc.). We render the visible terminal output, not the raw
+ * bytes, so we strip both real ESC-prefixed CSI sequences and the bare
+ * `[0;34m`-style remnants that show up when the ESC byte was lost in
+ * transport. Consecutive identical lines are also collapsed — the runner
+ * sometimes emits the same status both via a coloured logger and a plain
+ * stdout echo, which doubled every row in the live view.
  */
 
 const SCROLL_BOTTOM_TOLERANCE = 8;
+// Real ANSI: \x1b[ ... <letter>. Bare CSI fallback: [0;34m, [0m, etc.
+const ANSI_ESC_RE = /\x1b\[[\d;?]*[A-Za-z]/g;
+const ANSI_BARE_RE = /\[(?:\d+(?:;\d+)*)?m/g;
+
+function cleanLine(text) {
+  if (text == null) return '';
+  return String(text)
+    .replace(ANSI_ESC_RE, '')
+    .replace(ANSI_BARE_RE, '')
+    // Collapse runs of inner whitespace introduced where escape codes
+    // hugged a token (e.g. "[0m   [performance]" → "   [performance]").
+    .replace(/[ \t]{2,}/g, ' ')
+    .trimEnd();
+}
+
+function dedupeConsecutive(lines) {
+  if (!lines || lines.length === 0) return lines;
+  const out = [];
+  let prev = null;
+  for (const line of lines) {
+    const key = line.trim();
+    if (key && key === prev) continue;
+    out.push(line);
+    prev = key;
+  }
+  return out;
+}
 
 function LogLine({ text }) {
   const ref = useRef(null);
@@ -45,6 +80,11 @@ export default function ConsoleLogViewer({ logs }) {
   const lastLogCount = useRef(0);
   const programmaticScroll = useRef(false);
 
+  const cleanedLogs = useMemo(
+    () => dedupeConsecutive((logs ?? []).map(cleanLine)),
+    [logs],
+  );
+
   const scrollToBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -54,12 +94,12 @@ export default function ConsoleLogViewer({ logs }) {
   }, []);
 
   useEffect(() => {
-    const count = logs?.length || 0;
+    const count = cleanedLogs.length;
     if (count !== lastLogCount.current) {
       lastLogCount.current = count;
       if (follow) scrollToBottom();
     }
-  }, [logs?.length, follow, scrollToBottom]);
+  }, [cleanedLogs.length, follow, scrollToBottom]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -85,10 +125,10 @@ export default function ConsoleLogViewer({ logs }) {
   return (
     <div className="console-shell">
       <div className="console-scroll" ref={scrollRef}>
-        {!logs || logs.length === 0 ? (
+        {cleanedLogs.length === 0 ? (
           <div className="console-log-empty">Waiting for output\u2026</div>
         ) : (
-          logs.map((line, i) => <LogLine key={i} text={line} />)
+          cleanedLogs.map((line, i) => <LogLine key={i} text={line} />)
         )}
       </div>
       <FollowToggle active={follow} onToggle={handleToggle} />

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -50,12 +50,15 @@ function ActiveProviderBadge({ storage = localStorage }) {
   );
 }
 
-function EvaluateHeader({ isRunning }) {
+function EvaluateHeader() {
+  // Page title stays steady ("evaluate"); the live "in progress / failed /
+  // done" state is carried by the JobHeader card title below to avoid
+  // doubling the same status on screen.
   return (
     <header className="evaluate-header evaluate-header--terminal">
       <div className="evaluate-header__left">
         <TermHeader
-          name={`evaluate${isRunning ? ' · running' : ''}`}
+          name="evaluate"
           sub="run a comprehensive code quality evaluation on any repository"
         />
       </div>
@@ -105,7 +108,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
   return (
     <section className="evaluate-screen">
-      <EvaluateHeader isRunning={job?.status === 'running'} />
+      <EvaluateHeader />
 
       <div className="evaluate-content">
         {!job && selectedProject && (

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -80,7 +80,7 @@ function JobMeta({ job, projectName }) {
         </div>
       )}
       {isExternal ? <ExternalRunBadge /> : <JobProviderBadge />}
-      <div className="job-meta-item">
+      <div className="job-meta-item job-meta-item--id">
         <span className="job-meta-label">Job ID</span>
         <div className="job-meta-id-row">
           <code className="job-meta-code job-meta-code--muted">{job.jobId}</code>

--- a/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/LiveViolationsFeed.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { parseFileRef } from '../../../utils/formatters.js';
@@ -8,6 +8,25 @@ const ANIM_MAX_DELAY_MS = 400;
 
 function severityOrder(s) {
   return s === 'critical' ? 0 : s === 'major' ? 1 : 2;
+}
+
+/**
+ * Track the most recent activity timestamp per dimension so we can sort
+ * "latest active first". The ref persists across renders; we update it
+ * whenever a dim's violation count changes.
+ */
+function useDimensionActivity(liveViolations) {
+  const lastActivityRef = useRef({});
+  const prevCountsRef = useRef({});
+  const now = Date.now();
+  for (const [dim, vs] of Object.entries(liveViolations || {})) {
+    const len = (vs || []).length;
+    if (prevCountsRef.current[dim] !== len) {
+      prevCountsRef.current[dim] = len;
+      lastActivityRef.current[dim] = now;
+    }
+  }
+  return lastActivityRef.current;
 }
 
 function ViolationDetail({ v }) {
@@ -79,15 +98,14 @@ function ViolationLiveRow({ violation, index }) {
   );
 }
 
-function DimensionGroup({ dim, violations, defaultOpen }) {
-  const [open, setOpen] = useState(defaultOpen);
+function DimensionGroup({ dim, violations, open, onToggle }) {
   const count = violations.length;
   return (
     <div className={`vlive-dimension-group${open ? '' : ' vlive-dimension-group--collapsed'}`}>
       <button
         type="button"
         className="vlive-dimension-label"
-        onClick={() => setOpen((v) => !v)}
+        onClick={onToggle}
         aria-expanded={open}
       >
         <span className={`vlive-dimension-caret${open ? ' vlive-dimension-caret--open' : ''}`} aria-hidden="true">▸</span>
@@ -102,16 +120,34 @@ function DimensionGroup({ dim, violations, defaultOpen }) {
 }
 
 export default function LiveViolationsFeed({ liveViolations }) {
+  // Per-dim activity timestamps power "latest active dimension on top".
+  const lastActivity = useDimensionActivity(liveViolations);
+
   const orderedDims = useMemo(() => {
-    const entries = Object.entries(liveViolations ?? {})
+    return Object.entries(liveViolations ?? {})
       .map(([dim, vs]) => ({
         dim,
         violations: [...(vs ?? [])].sort((a, b) => severityOrder(a.severity) - severityOrder(b.severity)),
       }))
       .filter(({ violations }) => violations.length > 0)
-      .sort((a, b) => b.violations.length - a.violations.length);
-    return entries;
+      .sort((a, b) => (lastActivity[b.dim] ?? 0) - (lastActivity[a.dim] ?? 0));
+    // lastActivity is a ref's current value — it's intentionally not in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveViolations]);
+
+  // Single-open-at-a-time accordion. The topmost (most recently active) dim
+  // auto-expands; whenever the topmost changes — i.e. a new dimension starts
+  // producing violations — the previous one collapses and the new one opens.
+  // The user can still click any header to switch which one is open.
+  const [openDim, setOpenDim] = useState(null);
+  const topDim = orderedDims[0]?.dim;
+  const prevTopRef = useRef(null);
+  useEffect(() => {
+    if (topDim && prevTopRef.current !== topDim) {
+      prevTopRef.current = topDim;
+      setOpenDim(topDim);
+    }
+  }, [topDim]);
 
   const totalCount = orderedDims.reduce((sum, d) => sum + d.violations.length, 0);
   if (!totalCount) return null;
@@ -121,12 +157,13 @@ export default function LiveViolationsFeed({ liveViolations }) {
       <div className="vlive-counter">
         {totalCount} violation{totalCount !== 1 ? 's' : ''} found across {orderedDims.length} dimension{orderedDims.length !== 1 ? 's' : ''}
       </div>
-      {orderedDims.map(({ dim, violations }, idx) => (
+      {orderedDims.map(({ dim, violations }) => (
         <DimensionGroup
           key={dim}
           dim={dim}
           violations={violations}
-          defaultOpen={idx === 0}
+          open={openDim === dim}
+          onToggle={() => setOpenDim((cur) => (cur === dim ? null : dim))}
         />
       ))}
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -40,17 +40,19 @@ function DimRow({ dim, fallbackTotal }) {
   // Pending dims don't have a real queue yet. Use the running/done dims'
   // queue total as a better estimate than the project-wide upper bound.
   const total = isPending && fallbackTotal ? fallbackTotal : (dim.files?.total ?? 0);
-  const p = pct(taken, total);
+  // When the dimension reports `done`, force the bar to 100% even if
+  // `files.taken < files.total` (incremental skips, dismissed files, etc.).
+  // Backend `done` is the source of truth — count drift shouldn't make a
+  // green dimension look red.
   const isDone = dim.state === 'done';
   const isRunning = dim.state === 'running';
-
-  const isPartial = isDone && total > 0 && taken < total;
+  const p = isDone ? 100 : pct(taken, total);
 
   let icon = '○';
   let iconClass = '';
   if (isDone) {
-    icon = isPartial ? '◐' : '✓';
-    iconClass = isPartial ? 'scan-progress__dim-icon--partial' : 'scan-progress__dim-icon--done';
+    icon = '✓';
+    iconClass = 'scan-progress__dim-icon--done';
   } else if (isRunning) {
     icon = '▶';
     iconClass = 'scan-progress__dim-icon--running';
@@ -64,20 +66,17 @@ function DimRow({ dim, fallbackTotal }) {
   } else if (isDone) {
     meta = (
       <>
-        {isPartial ? (
-          <>
-            {`${taken} / ${total}`} · <span className="scan-progress__partial">partial</span>
-          </>
-        ) : (
-          total > 0 ? `${total} files` : ''
-        )}
+        {total > 0 ? `${taken} files` : ''}
         {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
         {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
         {dim.elapsedS != null && <> · {formatClock(dim.elapsedS)}</>}
       </>
     );
   } else {
-    let budgetPart;
+    // Only show a clock segment when we actually have a number to print.
+    // Without this guard, a running dim with no elapsed time yields a
+    // dangling "· —" tail.
+    let budgetPart = null;
     if (dim.budgetS) {
       const overrun = dim.elapsedS != null && dim.elapsedS > dim.budgetS;
       const cls = overrun ? 'scan-progress__budget scan-progress__budget--overrun' : 'scan-progress__budget';
@@ -86,7 +85,7 @@ function DimRow({ dim, fallbackTotal }) {
           {formatClock(dim.elapsedS)} / {formatClock(dim.budgetS)} budget
         </span>
       );
-    } else {
+    } else if (dim.elapsedS != null) {
       budgetPart = <span className="scan-progress__budget">{formatClock(dim.elapsedS)}</span>;
     }
     meta = (
@@ -95,15 +94,12 @@ function DimRow({ dim, fallbackTotal }) {
         {dim.activeAgents > 0 && <> · {dim.activeAgents} agents</>}
         {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
         {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
-        {' · '}
-        {budgetPart}
+        {budgetPart && <> · {budgetPart}</>}
       </>
     );
   }
 
-  const fillClass = isDone
-    ? (isPartial ? 'scan-progress__bar-fill--partial' : 'scan-progress__bar-fill--done')
-    : '';
+  const fillClass = isDone ? 'scan-progress__bar-fill--done' : '';
 
   return (
     <div className={`scan-progress__dim${isPending ? ' scan-progress__dim--pending' : ''}`}>
@@ -200,12 +196,6 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       try { localStorage.setItem(CONSOLE_DOT_DISMISSED_KEY, '1'); } catch { /* ignore */ }
     }
   }
-  function rowKey(e) {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      toggleDetail();
-    }
-  }
 
   // Failed / lost: show the error message inline above the progress bar.
   const errorBanner = isFailed
@@ -217,16 +207,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   return (
     <div className="scan-progress">
       {errorBanner}
-      <div
-        className="scan-progress__row"
-        role="button"
-        tabIndex={0}
-        onClick={toggleDetail}
-        onKeyDown={rowKey}
-        aria-expanded={detailOpen}
-        aria-controls={`scan-progress-detail-${jobId}`}
-        aria-label={detailOpen ? 'Hide per-dimension detail' : 'Show per-dimension detail'}
-      >
+      <div className="scan-progress__row">
         <div className="scan-progress__bar-wrap">
           <div className="scan-progress__bar">
             <div className="scan-progress__bar-fill" style={{ width: `${overallPct}%` }} />
@@ -241,8 +222,26 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
             )}
           </div>
         </div>
-        <span className={`scan-progress__caret${detailOpen ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
-        <ConsoleButton open={consoleOpen} showDot={showDot} onToggle={toggleConsole} />
+        <div className="scan-progress__actions">
+          <button
+            type="button"
+            className={`scan-progress__detail-toggle${detailOpen ? ' scan-progress__detail-toggle--open' : ''}`}
+            onClick={toggleDetail}
+            aria-expanded={detailOpen}
+            aria-controls={`scan-progress-detail-${jobId}`}
+            title={detailOpen ? 'Hide per-dimension detail' : 'Show per-dimension detail'}
+          >
+            <span className="scan-progress__detail-label">
+              {/* Ghost label reserves the width of the longest label so the
+                  button (and therefore the progress bar to its left) doesn't
+                  reflow when toggling between "details" and "hide". */}
+              <span className="scan-progress__detail-label-ghost" aria-hidden="true">details</span>
+              <span className="scan-progress__detail-label-active">{detailOpen ? 'hide' : 'details'}</span>
+            </span>
+            <span className={`scan-progress__caret${detailOpen ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
+          </button>
+          <ConsoleButton open={consoleOpen} showDot={showDot} onToggle={toggleConsole} />
+        </div>
       </div>
       {detailOpen && dims.length > 0 && (
         <div className="scan-progress__expanded" id={`scan-progress-detail-${jobId}`}>

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -41,8 +41,16 @@ async function pollSingleDimension(dim, project, runId, refs, setLiveViolations,
 
 function handleJobUpdate(updated, refs, setJob, callbacks) {
   setJob((prev) => ({ ...updated, repo: prev?.repo }));
-  if (updated.dimensions?.length && !refs.requestedDimensions.length) {
+  // Track the latest known dimension list so external (CLI-launched) runs
+  // surface every dimension in the live feed. Local runs already have it
+  // populated via parseDimensions(payload); for external runs the list
+  // arrives via the polled job. Write through to both the persistent ref
+  // and the local closure copy so a polling restart doesn't lose it.
+  if (updated.dimensions?.length) {
     refs.requestedDimensions = updated.dimensions;
+    if (refs.requestedDimensionsRef) {
+      refs.requestedDimensionsRef.current = updated.dimensions;
+    }
   }
   if (updated.phase === 'analyzing' && updated.currentDimension) {
     refs.partialDimensions.add(updated.currentDimension);
@@ -118,6 +126,7 @@ function createJobPoller(refs, setters, startDimensionPolling, getEvaluation) {
     const localRefs = {
       requestedDimensions: requestedDimensionsRef.current,
       partialDimensions: partialDimensionsRef.current,
+      requestedDimensionsRef,
       dimPollingStarted: false,
     };
     const callbacks = {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -271,11 +271,14 @@
   50% { opacity: 0.55; }
 }
 
-/* Meta grid */
+/* Meta grid — flex with wrap. Each item is sized to its content; the
+   Job ID item gets `flex: 1` so the long UUID + copy row absorbs the
+   leftover horizontal space rather than leaving a dead gap. */
 .job-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 12px 28px;
   margin-bottom: 20px;
   padding: 16px;
   background: var(--color-bg);
@@ -288,10 +291,15 @@
   flex-direction: column;
   gap: 4px;
   min-width: 0;
+  flex: 0 0 auto;
+}
+
+.job-meta-item--id {
+  flex: 1 1 220px;
 }
 
 .job-meta-item--full {
-  grid-column: 1 / -1;
+  flex: 0 0 100%;
 }
 
 .job-meta-label {
@@ -2623,43 +2631,78 @@
   border-bottom: 1px solid var(--color-border-soft, var(--color-border));
 }
 
-.scan-progress {
-  /* Negative margin so the hover bg can extend visually past the row's
-     content while the row itself still sits at the panel's 24px inset. */
-  margin: 0 -10px;
-}
-
 .scan-progress__row {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   width: 100%;
-  padding: 9px 10px;
-  background: transparent;
-  border: 0;
-  border-radius: 4px;
-  text-align: left;
-  font: inherit;
-  color: inherit;
-  cursor: pointer;
-  transition: background 0.15s, box-shadow 0.15s;
+  padding: 12px 8px;
 }
-.scan-progress__row:hover {
-  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+
+.scan-progress__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
-.scan-progress__row:hover .scan-progress__caret {
-  color: var(--color-accent);
-  transform: translateX(2px);
-}
-.scan-progress__row:hover .scan-progress__bar {
-  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface-alt));
-}
-.scan-progress__row:focus-visible {
-  outline: 1px solid var(--color-accent);
-  outline-offset: -1px;
-}
+
 .scan-progress__caret { transition: transform 0.18s, color 0.15s; }
+
+/* Detail toggle: a real button next to the console toggle. Same visual
+   language as .scan-progress__console-btn (ghost border, accent on
+   hover, accent fill when open) so the two read as a paired cluster. */
+.scan-progress__detail-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.scan-progress__detail-toggle:hover {
+  color: var(--color-accent);
+  background: var(--color-surface-alt);
+  border-color: var(--color-border);
+}
+.scan-progress__detail-toggle:focus-visible {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 1px;
+}
+.scan-progress__detail-toggle--open {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+}
+.scan-progress__detail-toggle--open:hover {
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+}
+/* Stack the active label on top of an invisible ghost label sized to the
+   longest possible text ("details") so the button — and therefore the
+   1fr progress bar to its left — does not reflow when toggling. */
+.scan-progress__detail-label {
+  display: inline-grid;
+  line-height: 1;
+}
+.scan-progress__detail-label-ghost,
+.scan-progress__detail-label-active {
+  grid-area: 1 / 1;
+}
+.scan-progress__detail-label-ghost {
+  visibility: hidden;
+  pointer-events: none;
+}
+.scan-progress__detail-label-active {
+  text-align: center;
+}
 
 .scan-progress__error {
   padding: 8px 10px;
@@ -2718,9 +2761,9 @@
 }
 
 .scan-progress__bar {
-  height: 4px;
+  height: 6px;
   background: var(--color-surface-alt);
-  border-radius: 2px;
+  border-radius: 3px;
   overflow: hidden;
 }
 .scan-progress__bar-fill {
@@ -2751,22 +2794,27 @@
 }
 
 .scan-progress__caret {
-  color: var(--color-text-dim, var(--color-text-muted));
-  font-size: 10px;
+  font-size: 11px;
+  line-height: 1;
   user-select: none;
   transition: transform 0.18s;
 }
 .scan-progress__caret--open {
   transform: rotate(90deg);
-  color: var(--color-text-muted);
 }
 
 .scan-progress__expanded {
   border-top: 1px solid var(--color-border-soft, var(--color-border));
-  padding: 10px 10px 12px;
+  padding: 14px 8px;
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+/* Console sits as a sibling of __row inside .scan-progress; give it a
+   bit of breathing room so it doesn't butt up against the row above. */
+.scan-progress > .console-shell {
+  margin-top: 8px;
 }
 
 .scan-progress__expanded-label {
@@ -2777,12 +2825,19 @@
   margin-bottom: 2px;
 }
 
+/* Dim row: [icon | name | progress bar (flex) | meta]. The meta column
+   is `auto` — grid sizes it to the widest meta string across all rows,
+   keeping numbers vertically aligned (tabular-nums) without the ch-based
+   over-allocation that previously squashed the bar. */
 .scan-progress__dim {
   display: grid;
-  grid-template-columns: 14px 130px 1fr 240px;
-  gap: 12px;
+  grid-template-columns: 14px 110px minmax(0, 1fr) auto;
+  gap: 14px;
   align-items: center;
+  font-family: var(--term-font-mono, ui-monospace, Menlo, monospace);
   font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  padding: 8px 4px;
 }
 .scan-progress__dim--pending { color: var(--color-text-dim, var(--color-text-muted)); }
 
@@ -2790,14 +2845,20 @@
   font-size: 11px;
   color: var(--color-text-dim, var(--color-text-muted));
   text-align: center;
+  line-height: 1;
 }
 .scan-progress__dim-icon--done    { color: var(--color-success, #56d364); }
 .scan-progress__dim-icon--running { color: var(--color-accent); }
-.scan-progress__dim-icon--partial { color: var(--color-warn, #d29922); }
+/* `partial` is no longer applied at runtime (done = green). Kept defined
+   so any stray markup doesn't fall back to default browser styling. */
+.scan-progress__dim-icon--partial { color: var(--color-success, #56d364); }
 
 .scan-progress__dim-name {
   color: var(--color-text);
   text-transform: lowercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .scan-progress__dim--pending .scan-progress__dim-name { color: var(--color-text-dim, var(--color-text-muted)); }
 
@@ -2806,6 +2867,9 @@
   color: var(--color-text-muted);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .scan-progress__dim-meta-pending {
   color: var(--color-text-dim, var(--color-text-muted));

--- a/uv.lock
+++ b/uv.lock
@@ -1291,7 +1291,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
## Summary

Cleans up several inconsistencies on the live evaluation screen, especially when a run is launched from an external terminal (e.g. `quodeq evaluate ...` while the dashboard is open).

**Visibility & ordering**
- External runs now surface every dimension in the live feed (the requested-dimensions ref was only seeded on the first poll cycle and dropped on restart).
- `LiveViolationsFeed` orders dimensions by most-recent activity and uses a single-open accordion that auto-expands the topmost group — live findings are no longer hidden at the bottom.

**Status correctness**
- Completed dimensions always render at 100 % with a green fill regardless of file-count drift (incremental skips, dismissed files).
- Running rows with no elapsed clock no longer trail a dangling `· —`.

**Layout & affordance**
- The negative-margin hack on `.scan-progress` is removed; the per-dimension and console blocks now align with the rest of the card content.
- Bars are taller (4 → 6 px) with more vertical padding.
- The dim-row meta column switches from `26ch` to `auto` so the bar absorbs the leftover width.
- The expand-detail caret is replaced with an explicit `DETAILS` / `HIDE` pill button paired with the console toggle. A ghost label reserves the wider \"details\" footprint so the bar doesn't reflow when the label toggles.
- `SOURCE` / `JOB ID` row switches from a 4-column grid to flex with the Job ID item taking leftover space — no more dead gap on the right.
- Page header drops the redundant `· running` suffix; the card title carries live status.

**Console output**
- `ConsoleLogViewer` strips ANSI escape sequences (both real ESC-prefixed and bare CSI remnants like `[0;34m`), collapses the double-spaces they leave behind, and dedupes consecutive identical lines that arrive from paired coloured/plain log streams.

**Lockfile**
- `uv.lock` synced to `1.0.7` (the `pyproject.toml` bump is already on develop in #287).

## Test plan

- [x] `npm run test` (100 / 100 passed)
- [x] `npm run test:ui` (8 / 8 passed)
- [x] `npm run build` (clean)
- [x] DOM probe: button width identical in `details` and `hide` states (76.27 px in both); bar holds at 707.73 px → no reflow on toggle
- [x] Smoke test on a real external `quodeq evaluate` run with the dashboard open
- [x] Smoke test on a local in-dashboard scan