### PR TITLE
fix(ui): correct headline file count on live scan progress

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -177,9 +177,21 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   if (!jobId) return null;
 
   const dims = progress?.dimensions || [];
-  const totalFiles = dims.reduce((acc, d) => acc + (d.files?.total ?? 0), 0);
-  const takenFiles = dims.reduce((acc, d) => acc + (d.files?.taken ?? 0), 0);
-  const overallPct = pct(takenFiles, totalFiles);
+  // Per-dim file totals are *not* comparable across dims at runtime:
+  // running dims expose the post-filter queue size while pending dims
+  // fall back to the project-wide ceiling (see scan_progress.py:248-249).
+  // Summing them inflates the headline by ~N× the project file count.
+  // Use the run's project_files for a stable, intuitive denominator and
+  // derive the numerator from the overall work-unit ratio so the
+  // displayed `taken / total` matches the overall percentage.
+  const projectFiles = progress?.projectFiles ?? 0;
+  const workTotal = dims.reduce((acc, d) => acc + (d.files?.total ?? 0), 0);
+  const workTaken = dims.reduce((acc, d) => acc + (d.files?.taken ?? 0), 0);
+  const overallPct = pct(workTaken, workTotal);
+  const totalFiles = projectFiles;
+  const takenFiles = projectFiles > 0 && workTotal > 0
+    ? Math.round((workTaken / workTotal) * projectFiles)
+    : 0;
   const inlineLabel = progress?.currentDimension
     ? <>running <span className="scan-progress__dim-active">{progress.currentDimension}</span></>
     : progress?.phase

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { getEvaluationProgress } from '../../../api/index.js';
 import ConsoleLogViewer from './ConsoleLogViewer.jsx';
 import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
+import { pct, computeOverallProgress } from './scanProgressTotals.js';
 
 const POLL_INTERVAL_MS = 2000;
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
@@ -13,11 +14,6 @@ function formatClock(s) {
   const m = Math.floor(total / 60);
   const sec = total % 60;
   return `${m}:${String(sec).padStart(2, '0')}`;
-}
-
-function pct(taken, total) {
-  if (!total || total <= 0) return 0;
-  return Math.min(100, Math.round((taken / total) * 100));
 }
 
 function isStatusLine(line) {
@@ -177,21 +173,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   if (!jobId) return null;
 
   const dims = progress?.dimensions || [];
-  // Per-dim file totals are *not* comparable across dims at runtime:
-  // running dims expose the post-filter queue size while pending dims
-  // fall back to the project-wide ceiling (see scan_progress.py:248-249).
-  // Summing them inflates the headline by ~N× the project file count.
-  // Use the run's project_files for a stable, intuitive denominator and
-  // derive the numerator from the overall work-unit ratio so the
-  // displayed `taken / total` matches the overall percentage.
-  const projectFiles = progress?.projectFiles ?? 0;
-  const workTotal = dims.reduce((acc, d) => acc + (d.files?.total ?? 0), 0);
-  const workTaken = dims.reduce((acc, d) => acc + (d.files?.taken ?? 0), 0);
-  const overallPct = pct(workTaken, workTotal);
-  const totalFiles = projectFiles;
-  const takenFiles = projectFiles > 0 && workTotal > 0
-    ? Math.round((workTaken / workTotal) * projectFiles)
-    : 0;
+  const { totalFiles, takenFiles, overallPct } = computeOverallProgress(progress);
   const inlineLabel = progress?.currentDimension
     ? <>running <span className="scan-progress__dim-active">{progress.currentDimension}</span></>
     : progress?.phase

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -1,0 +1,57 @@
+/**
+ * Math helpers for the live evaluation header.
+ *
+ * The header shows the *aggregated* work across every dim: 2 dims × 100
+ * files of analysis = "0 / 200 files" at start. That matches what the
+ * dashboard is actually doing — analyse each file once per dim.
+ *
+ * Per-dim totals from `/api/evaluations/<jobId>/progress` are NOT
+ * uniform at runtime, though: running/done dims report their post-filter
+ * queue size while a pending dim falls back to the project-wide ceiling
+ * (see `services/scan_progress.py`). Summing them as-is inflates the
+ * headline by ~N× project_files in mixed states.
+ *
+ * `computeOverallProgress` substitutes a pending-dim's project-ceiling
+ * total with the largest *observed* (running or done) queue total — the
+ * same fallback the per-dim row uses — so every dim contributes a
+ * consistent estimate. Once any dim has started, the fallback is the
+ * actual filtered queue size; before that, it falls back to
+ * `progress.projectFiles` as a last resort.
+ */
+
+export function pct(taken, total) {
+  if (!total || total <= 0) return 0;
+  return Math.min(100, Math.round((taken / total) * 100));
+}
+
+/**
+ * Best estimate of a single-dim's file count: the largest queue total
+ * observed among running/done dims. Falls back to `progress.projectFiles`
+ * before any dim has started. Returns 0 if nothing is known.
+ */
+export function dimFileEstimate(progress) {
+  const dims = progress?.dimensions || [];
+  const observed = dims
+    .filter((d) => d?.state !== 'pending')
+    .map((d) => d?.files?.total ?? 0)
+    .filter((n) => n > 0);
+  if (observed.length > 0) return Math.max(...observed);
+  return progress?.projectFiles ?? 0;
+}
+
+export function computeOverallProgress(progress) {
+  const dims = progress?.dimensions || [];
+  const dimEstimate = dimFileEstimate(progress);
+
+  const totalFiles = dims.reduce((acc, d) => {
+    // Pending dims expose the project-wide ceiling, not the post-filter
+    // queue they'll actually scan. Swap in the fallback estimate so each
+    // pending dim contributes a comparable number to the aggregate.
+    if (d?.state === 'pending') return acc + dimEstimate;
+    return acc + (d?.files?.total ?? 0);
+  }, 0);
+  const takenFiles = dims.reduce((acc, d) => acc + (d?.files?.taken ?? 0), 0);
+  const overallPct = pct(takenFiles, totalFiles);
+
+  return { totalFiles, takenFiles, overallPct };
+}

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pct, computeOverallProgress, dimFileEstimate } from './scanProgressTotals.js';
+
+// ---------------------------------------------------------------------------
+// pct
+// ---------------------------------------------------------------------------
+
+test('pct: returns 0 when total is 0', () => {
+  assert.equal(pct(0, 0), 0);
+  assert.equal(pct(5, 0), 0);
+});
+
+test('pct: returns 0 when total is undefined or negative', () => {
+  assert.equal(pct(5, undefined), 0);
+  assert.equal(pct(5, -1), 0);
+});
+
+test('pct: rounds to nearest integer', () => {
+  assert.equal(pct(1, 3), 33);
+  assert.equal(pct(2, 3), 67);
+  assert.equal(pct(1, 100), 1);
+});
+
+test('pct: caps at 100 when taken > total', () => {
+  assert.equal(pct(150, 100), 100);
+});
+
+// ---------------------------------------------------------------------------
+// dimFileEstimate
+// ---------------------------------------------------------------------------
+
+test('dimFileEstimate: returns max of running/done queue totals', () => {
+  const r = dimFileEstimate({
+    projectFiles: 1682,
+    dimensions: [
+      { state: 'running', files: { taken: 3, total: 827 } },
+      { state: 'done',    files: { taken: 600, total: 600 } },
+      { state: 'pending', files: { taken: 0, total: 1682 } },
+    ],
+  });
+  assert.equal(r, 827);
+});
+
+test('dimFileEstimate: falls back to projectFiles when no dim has started', () => {
+  const r = dimFileEstimate({
+    projectFiles: 1682,
+    dimensions: [
+      { state: 'pending', files: { taken: 0, total: 1682 } },
+      { state: 'pending', files: { taken: 0, total: 1682 } },
+    ],
+  });
+  assert.equal(r, 1682);
+});
+
+test('dimFileEstimate: returns 0 when nothing is known', () => {
+  assert.equal(dimFileEstimate(null), 0);
+  assert.equal(dimFileEstimate({}), 0);
+  assert.equal(dimFileEstimate({ dimensions: [] }), 0);
+});
+
+// ---------------------------------------------------------------------------
+// computeOverallProgress — empty and edge cases
+// ---------------------------------------------------------------------------
+
+test('computeOverallProgress: returns zeros when progress is null', () => {
+  const r = computeOverallProgress(null);
+  assert.deepEqual(r, { totalFiles: 0, takenFiles: 0, overallPct: 0 });
+});
+
+test('computeOverallProgress: returns zeros when dimensions array is empty', () => {
+  const r = computeOverallProgress({ projectFiles: 100, dimensions: [] });
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: handles missing files object on a dim', () => {
+  const r = computeOverallProgress({
+    projectFiles: 50,
+    dimensions: [{ id: 'x', state: 'pending' }],
+  });
+  // Pending dim with no observed sibling → fallback estimate is projectFiles.
+  assert.equal(r.totalFiles, 50);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+// ---------------------------------------------------------------------------
+// computeOverallProgress — aggregated headline
+// ---------------------------------------------------------------------------
+
+test('computeOverallProgress: 2 dims × 100 files reads "X / 200" (aggregated)', () => {
+  // Header is the aggregated work across dims, not the project file
+  // count. Two dims that each scan 100 files = 200 work units.
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { state: 'running', files: { taken: 50, total: 100 } },
+      { state: 'pending', files: { taken: 0,  total: 100 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 200);
+  assert.equal(r.takenFiles, 50);
+  assert.equal(r.overallPct, 25);
+});
+
+test('computeOverallProgress: 6-dim run does NOT use project-ceiling for pending dims (regression)', () => {
+  // Reproduces the bug from the screenshot. Without the fallback
+  // substitution, pending dims would each contribute the project-wide
+  // ceiling (1682) and the headline becomes "3 / 9237 files". With the
+  // substitution, every dim contributes the post-filter queue size (827)
+  // observed on the running dim, and the headline becomes the coherent
+  // aggregated "3 / 4962 files".
+  const progress = {
+    projectFiles: 1682,
+    dimensions: [
+      { id: 'security',        state: 'running', files: { taken: 3, total: 827 } },
+      { id: 'reliability',     state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'maintainability', state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'performance',     state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'usability',       state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'flexibility',     state: 'pending', files: { taken: 0, total: 1682 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 4962, 'pending dims contribute 827 each, not 1682');
+  assert.equal(r.takenFiles, 3);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: pending dims before any has started fall back to projectFiles', () => {
+  // Every dim is pending — no observed running/done queue total exists,
+  // so the only sensible fallback is projectFiles (the upper bound).
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { state: 'pending', files: { taken: 0, total: 200 } },
+      { state: 'pending', files: { taken: 0, total: 200 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 400);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: single-dim run keeps the per-dim count intact', () => {
+  const progress = {
+    projectFiles: 500,
+    dimensions: [
+      { state: 'running', files: { taken: 120, total: 500 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 500);
+  assert.equal(r.takenFiles, 120);
+  assert.equal(r.overallPct, 24);
+});
+
+test('computeOverallProgress: all dims done → 100% and full aggregated count', () => {
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { state: 'done', files: { taken: 200, total: 200 } },
+      { state: 'done', files: { taken: 200, total: 200 } },
+      { state: 'done', files: { taken: 200, total: 200 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 600);
+  assert.equal(r.takenFiles, 600);
+  assert.equal(r.overallPct, 100);
+});
+
+test('computeOverallProgress: zero workTotal yields 0% (avoid div-by-zero)', () => {
+  const progress = {
+    projectFiles: 0,
+    dimensions: [
+      { state: 'pending', files: { taken: 0, total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: mixed running queues contribute their own totals', () => {
+  // Two running dims with different post-filter queues — each contributes
+  // its actual queue total to the aggregate; only pending dims get the
+  // fallback estimate (which here is the larger of the two running totals).
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { state: 'running', files: { taken: 30, total: 100 } },
+      { state: 'running', files: { taken: 80, total: 150 } },
+      { state: 'pending', files: { taken: 0,  total: 200 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  // 100 (running) + 150 (running) + 150 (pending → fallback = max observed)
+  assert.equal(r.totalFiles, 400);
+  assert.equal(r.takenFiles, 110);
+  assert.equal(r.overallPct, 28);
+});


### PR DESCRIPTION
## Bug

The live evaluation header reads `{taken} / {total} files`. Both numbers came from `dims.reduce((a, d) => a + (d.files?.total ?? 0), 0)`, which sums per-dim totals that are **not** comparable across dim states:

- **Running / done** dims expose the post-filter queue total (e.g. `827`)
- **Pending** dims fall back to the project-wide ceiling (e.g. `1682`) — see `scan_progress.py:248-249`

For a 6-dim run on an 828-file project this produced `3 / 10092 files` while every per-dim row read `… / 827`. The percentage and the file ratio drift apart.

## Fix

The header is meant to show the **aggregated** work across every dim — each file × dim is one unit of analysis, exactly what every per-dim badge counts. The right total is the **sum of every dim's queue**, but with pending dims contributing the *observed* queue size (not the project ceiling). The same `fallbackTotal` already used by the per-dim row is reused here.

```js
// pending dims contribute dimEstimate (max observed running/done queue,
// or projectFiles before any has started) instead of the project ceiling
const totalFiles = dims.reduce((acc, d) => {
  if (d?.state === 'pending') return acc + dimEstimate;
  return acc + (d?.files?.total ?? 0);
}, 0);
const takenFiles = dims.reduce((acc, d) => acc + (d?.files?.taken ?? 0), 0);
const overallPct = pct(takenFiles, totalFiles);
```

Result for the screenshot scenario (6 dims, 828 files, security running): `36 / 4962 file-analyses · 1%` — coherent aggregated math, every per-dim badge sums into the headline.

The math moved into a sibling helper `scanProgressTotals.js` so it can be unit tested.

## On hidden dimensions

Confirmed orthogonal to this bug: `status.json["dimensions"]` only contains dims selected when the run was launched, so dims hidden via the eye-closed toggle never enter the progress payload. The inflation came from pending sibling dims **inside the same run** falling back to the project ceiling, not from hidden dims.

## Tests

New `scanProgressTotals.test.js` (14 tests):

- `pct` edge cases — div-by-zero, undefined/negative totals, rounding, cap at 100
- `dimFileEstimate` fallback chain — running/done observed → `projectFiles` → 0
- `computeOverallProgress`:
  - regression: 6-dim run does **not** use project-ceiling for pending dims (the screenshot scenario)
  - 2 dims × 100 files reads `X / 200` (aggregated)
  - pending-only run falls back to `projectFiles`
  - single-dim run keeps the per-dim count intact
  - all dims done → 100% and full aggregated count
  - mixed running queues — each running dim contributes its own total
  - empty / null / missing-data inputs

## Verification

- [x] `npm run test` — **117 / 117** passed
- [x] `npm run test:ui` — 8 / 8 passed
- [x] `npm run build` — clean
- [x] Live smoke test: 6-dim run on 828-file project reads `36 / 4962 files · 1%` (was `36 / 10092`)