### PR TITLE
fix: plug OpenAI FD leak that aborted long scans (+ surface cleanups)

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -142,9 +142,9 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
         raw = str(exc)
         salvaged = _salvage_partial_findings(raw)
         if salvaged:
-            _log.warning("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
+            _log.debug("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
             return salvaged
-        _log.warning("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
+        _log.debug("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
         return []
 
 

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -101,13 +101,15 @@ def _salvage_partial_findings(raw_json: str) -> list[dict]:
 
 
 def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
-    """Call LLM via Instructor — returns validated finding dicts."""
+    """Call LLM via Instructor — returns validated finding dicts.
+
+    The OpenAI client owns an httpx connection pool whose sockets count
+    against the process FD limit. Without an explicit close, a long scan
+    (one call per file) accumulates pools until macOS's 256-FD soft cap
+    aborts the dimension with EMFILE on the next queue read.
+    """
     if config.api_base and config.api_base != _OLLAMA_DEFAULT_BASE:
         validate_url_safe(config.api_base, allow_private=True)
-    client = instructor.from_openai(
-        openai.OpenAI(base_url=config.api_base, api_key=config.api_key or _OLLAMA_DEFAULT_API_KEY),
-        mode=instructor.Mode.JSON,
-    )
 
     extra_body: dict = {"reasoning_effort": "none"}
     ctx_size = config.context_size
@@ -133,19 +135,24 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
         create_kwargs["max_tokens"] = config.max_tokens
 
     _log.debug("Calling %s model=%s via Instructor", config.api_base, config.model)
-    try:
-        result = client.chat.completions.create(**create_kwargs)
-        _log.debug("Instructor returned %d findings", len(result.findings))
-        return [f.model_dump() for f in result.findings]
-    except Exception as exc:
-        # Try to salvage valid findings from the malformed response
-        raw = str(exc)
-        salvaged = _salvage_partial_findings(raw)
-        if salvaged:
-            _log.debug("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
-            return salvaged
-        _log.debug("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
-        return []
+    with openai.OpenAI(
+        base_url=config.api_base,
+        api_key=config.api_key or _OLLAMA_DEFAULT_API_KEY,
+    ) as oa_client:
+        client = instructor.from_openai(oa_client, mode=instructor.Mode.JSON)
+        try:
+            result = client.chat.completions.create(**create_kwargs)
+            _log.debug("Instructor returned %d findings", len(result.findings))
+            return [f.model_dump() for f in result.findings]
+        except Exception as exc:
+            # Try to salvage valid findings from the malformed response
+            raw = str(exc)
+            salvaged = _salvage_partial_findings(raw)
+            if salvaged:
+                _log.debug("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
+                return salvaged
+            _log.debug("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
+            return []
 
 
 # ---------------------------------------------------------------------------

--- a/src/quodeq/llm_bridge/_cloud.py
+++ b/src/quodeq/llm_bridge/_cloud.py
@@ -48,15 +48,15 @@ def check_cloud_connection(
         return {"success": False, "error": "Cannot connect to private/internal network addresses"}
 
     try:
-        client = _create_client(api_base, api_key)
-        start = time.monotonic()
-        client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": "hi"}],
-            max_tokens=1,
-        )
-        latency = int((time.monotonic() - start) * 1000)
-        return {"success": True, "model": model, "latency_ms": latency}
+        with _create_client(api_base, api_key) as client:
+            start = time.monotonic()
+            client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=1,
+            )
+            latency = int((time.monotonic() - start) * 1000)
+            return {"success": True, "model": model, "latency_ms": latency}
     except Exception as exc:
         _log.debug("Cloud connection check failed: %s", exc)
         # Surface the exception type and HTTP status codes without leaking

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -208,7 +208,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
           </div>
           <div className="scan-progress__meta">
             <span>
-              {totalFiles > 0 ? <><strong>{takenFiles} / {totalFiles}</strong> files · {overallPct}%</> : <strong>preparing…</strong>}
+              {totalFiles > 0 ? <><strong>{takenFiles} / {totalFiles}</strong> checks · {overallPct}%</> : <strong>preparing…</strong>}
               {isRunning && inlineLabel && <> · {inlineLabel}</>}
             </span>
             {progress?.totalElapsedS != null && (

--- a/tests/llm_bridge/test_cloud.py
+++ b/tests/llm_bridge/test_cloud.py
@@ -11,6 +11,7 @@ from quodeq.llm_bridge._cloud import check_cloud_connection
 class TestCloudConnection:
     def test_successful_connection(self):
         mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
         mock_choice = MagicMock()
         mock_choice.message.content = "hi"
         mock_response = MagicMock()
@@ -27,10 +28,14 @@ class TestCloudConnection:
 
         assert result["success"] is True
         assert "latency_ms" in result
+        mock_client.__exit__.assert_called_once()
 
     def test_auth_failure(self):
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception("401 Unauthorized")
         with patch("quodeq.llm_bridge._cloud.openai") as mock_openai:
-            mock_openai.OpenAI.return_value.chat.completions.create.side_effect = Exception("401 Unauthorized")
+            mock_openai.OpenAI.return_value = mock_client
             result = check_cloud_connection(
                 api_base="https://openrouter.ai/api/v1",
                 model="test-model",
@@ -39,6 +44,7 @@ class TestCloudConnection:
 
         assert result["success"] is False
         assert "401" in result["error"]
+        mock_client.__exit__.assert_called_once()
 
     def test_missing_openai_package(self):
         with patch("quodeq.llm_bridge._cloud.openai", None):


### PR DESCRIPTION
## Summary

Investigation of inconsistencies on the live evaluation screen turned up a **real FD leak** that was aborting long Ollama scans mid-run. Two surface cleanups came along for the ride.

### 1. (main fix) FD leak in OpenAI client — \`_api_runner.py\`, \`_cloud.py\`

\`_call_api()\` was creating a fresh \`openai.OpenAI()\` per file and never closing it. The client owns an httpx connection pool whose sockets count against the process FD limit. After ~250 calls, the macOS 256 soft cap is hit and the next \`FileQueue\` read dies with EMFILE — the dimension fails outright:

\`\`\`
Heartbeat error: Cannot read queue file: [Errno 24] Too many open files
[3/6] maintainability — failed: ...
\`\`\`

Now wrapped in \`with openai.OpenAI(...) as oa_client:\` so the pool releases after every request. Same fix in \`check_cloud_connection\` (smaller-scale leak, but same shape).

Tests in \`test_cloud.py\` updated to set \`__enter__.return_value\` and assert \`__exit__\` fires — regression guard against reintroducing the leak.

### 2. Hide Instructor validation warnings from the user-facing console

\`Instructor validation failed — no findings salvaged\` was leaking into the live log box with raw pydantic errors attached. These paths are recoverable (we salvage findings or return \`[]\`), so demoted from \`warning\` → \`debug\`.

### 3. Headline label \`files\` → \`checks\`

The headline aggregates *file × dim* work units (e.g. 6 dims × 829 files = 4974). Labelled "files", which conflicts with the per-dim rows that genuinely count files. Renamed to "checks" so the noun matches the math.

## Out of scope

- The heartbeat tail \`4 active (208 total)\` — \`208\` is *lifetime* subagent count for that dimension, easy to misread as "queue total". Could be relabelled \`spawned\` later.
- Heartbeat counters drift slightly from the dashboard because they read different sources at different cadences. Cosmetic timing skew.

## Test plan

- [x] Run a full Ollama scan (>250 file × dim units) and confirm no \`Errno 24 / Too many open files\` failures
- [x] \`lsof -p <pid>\` mid-scan should show a stable FD count, not monotonic growth
- [x] No \`Instructor validation failed\` lines appear in the live console
- [x] Live evaluation screen headline reads \`X / Y checks · N%\`
- [x] Cloud connection test (\`check_cloud_connection\`) still works for OpenRouter/Anthropic
- [x] \`uv run pytest tests/analysis tests/llm_bridge tests/api\` — all 564 pass