### PR TITLE
fix(analysis): clean scan ignores prior findings instead of re-verifying them

### DIFF
--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -79,18 +79,21 @@ def _prepare_findings_and_queue(
     config: RunConfig, dc: _DimensionContext,
 ) -> _PoolExecutionParams:
     """Load previous findings, partition by fingerprint, and create the file queue."""
-    prev_findings = _load_and_filter_previous(config, dc.dim_id, dc.evidence_dir)
+    # Clean scan (incremental=False) means "ignore everything from before",
+    # not "re-verify everything from before". Skip the loader so prior
+    # findings don't get inlined into prompts as needs_verify entries.
+    if config.options.incremental:
+        prev_findings = _load_and_filter_previous(config, dc.dim_id, dc.evidence_dir)
+    else:
+        prev_findings = []
     carry_forward: list[dict] = []
     needs_verify: list[dict] = []
-    if prev_findings and config.options.incremental:
+    if prev_findings:
         prev_fp, _ = find_previous_fingerprint(dc.evidence_dir, dc.dim_id)
         carry_forward, needs_verify = partition_findings_by_fingerprint(
             prev_findings, prev_fp, config.src,
             standards_dir=config.standards_dir, dimension=dc.dim_id,
         )
-    elif prev_findings:
-        # Clean scan: every previous finding goes back through verification.
-        needs_verify = list(prev_findings)
     if carry_forward:
         written = write_carry_forward_findings(carry_forward, dc.evidence_dir, dc.dim_id)
         log_info(f"  [{dc.idx}/{dc.ctx.total}] {dc.dim_id} -- {written} findings carried forward")

--- a/tests/engine/test_clean_scan_bypass.py
+++ b/tests/engine/test_clean_scan_bypass.py
@@ -1,0 +1,62 @@
+"""Regression tests for clean-scan (incremental=False) prior-findings bypass.
+
+Before this fix, a clean scan still loaded all prior findings from
+<dim>_evidence.jsonl and routed them through inline re-verification,
+making prompts larger and re-checking findings the user wanted ignored.
+
+The bypass: when config.options.incremental is False, _prepare_findings_and_queue
+skips _load_and_filter_previous entirely so no prior findings reach the queue.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from quodeq.analysis.subagents.runner import _prepare_findings_and_queue
+
+
+def _make_dc(tmp_path: Path) -> SimpleNamespace:
+    """Minimal _DimensionContext-shaped object for the call under test."""
+    return SimpleNamespace(
+        dim_id="security",
+        idx=1,
+        ctx=SimpleNamespace(total=1),
+        files=["a.py", "b.py"],
+        evidence_dir=tmp_path,
+    )
+
+
+def _make_config(*, incremental: bool, src: Path) -> SimpleNamespace:
+    """Minimal RunConfig-shaped object exposing the fields _prepare uses."""
+    return SimpleNamespace(
+        options=SimpleNamespace(incremental=incremental, verify_findings=True),
+        src=src,
+        standards_dir=None,
+        work_dir=src,
+    )
+
+
+def test_clean_scan_skips_loading_prior_findings(tmp_path):
+    """incremental=False must NOT call _load_and_filter_previous."""
+    config = _make_config(incremental=False, src=tmp_path)
+    dc = _make_dc(tmp_path)
+    with patch(
+        "quodeq.analysis.subagents.runner._load_and_filter_previous"
+    ) as mock_load:
+        result = _prepare_findings_and_queue(config, dc)
+    mock_load.assert_not_called()
+    assert result.inline_findings == []
+    assert result.mini_verify_findings == []
+
+
+def test_incremental_scan_still_loads_prior_findings(tmp_path):
+    """incremental=True must keep calling _load_and_filter_previous."""
+    config = _make_config(incremental=True, src=tmp_path)
+    dc = _make_dc(tmp_path)
+    with patch(
+        "quodeq.analysis.subagents.runner._load_and_filter_previous",
+        return_value=[],
+    ) as mock_load:
+        _prepare_findings_and_queue(config, dc)
+    mock_load.assert_called_once_with(config, dc.dim_id, dc.evidence_dir)


### PR DESCRIPTION
## Summary

The "Clean scan" toggle (\`incremental=False\`) didn't behave the way users expect. It only changed *how* prior findings were reused — instead of carry-forward by fingerprint, every prior finding was loaded into \`needs_verify\` and inlined into each analysis prompt for re-checking.

A clean scan against a project with 1797 prior findings produced log lines like:

\`\`\`
[performance] 1797 previous findings: 0 files gone, 1797 surviving
[4/6] performance -- 829 files queued, 1797 inline findings
\`\`\`

That's the opposite of what \"clean\" suggests.

## Root cause

In \`runner.py:_prepare_findings_and_queue\`, the \`incremental\` flag only chose between two reuse strategies:

\`\`\`python
if prev_findings and config.options.incremental:
    # carry-forward + partition
elif prev_findings:
    needs_verify = list(prev_findings)   # clean scan re-verified ALL priors
\`\`\`

There was no path that ignored prior findings entirely.

## Fix

Gate the loader on \`incremental\`. When \`False\`, prev_findings stays empty and the partition path no longer fires:

\`\`\`python
if config.options.incremental:
    prev_findings = _load_and_filter_previous(config, dc.dim_id, dc.evidence_dir)
else:
    prev_findings = []
\`\`\`

Default behavior (incremental ON) is untouched — still loads prior findings, still partitions by fingerprint.

## Why this also helps performance

Inline findings get embedded in every analysis prompt for their file. With 1797 priors / 829 files ≈ 2.2 findings per file added to context. On Ollama, that translated into longer per-call latency on a workload that was already 1m+ per call. Skipping them shrinks prompts substantially on clean re-runs.

## Behavior after this PR

| Toggle state                       | Load prior findings? | Carry forward? | Re-verify priors? |
|------------------------------------|----------------------|----------------|-------------------|
| Incremental ON (default)           | yes                  | matched        | mismatched only   |
| Incremental OFF (clean scan)       | **no**               | n/a            | **no**            |

## Test plan

- [x] \`uv run pytest tests/analysis tests/engine tests/api\` — 934 pass
- [x] New regression tests in \`tests/engine/test_clean_scan_bypass.py\` assert \`_load_and_filter_previous\` is **not** called when incremental=False, and **is** called when True
- [x] Manual: run a scan with priors on disk, toggle Clean scan ON, confirm no \`X previous findings: ... surviving\` log lines and no \`X inline findings\` in queue logs
- [x] Manual: run a follow-up scan with Clean scan OFF and confirm prior findings still get loaded and partitioned

## Note

The \"Clean scan\" toggle remains tri-state (\`off\` / \`once\` / \`permanent\`) per PR #294. This PR doesn't change the toggle UI — only what \`incremental=False\` means downstream.