### PR TITLE
fix(report-viewer): make download actually save the file

### DIFF
--- a/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
+++ b/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
@@ -14,15 +14,20 @@ function todayISO() {
 }
 
 function downloadMarkdown(title, markdown) {
-  const blob = new Blob([markdown], { type: 'text/markdown' });
+  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = `${slugify(title)}-${todayISO()}.md`;
+  a.rel = 'noopener';
   document.body.appendChild(a);
   a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
+  // Defer cleanup so the browser has time to start the download before
+  // we revoke the blob URL — synchronous cleanup races and can drop the file.
+  setTimeout(() => {
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, 0);
 }
 
 class RenderBoundary extends React.Component {

--- a/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
+++ b/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
@@ -14,14 +14,24 @@ function todayISO() {
 }
 
 function downloadMarkdown(title, markdown) {
-  // Prepend a UTF-8 BOM so text viewers (especially the ones pywebview hands
-  // the file off to on macOS) detect the encoding correctly. Without it,
-  // characters like —, ·, ✓ render as mojibake.
+  const filename = `${slugify(title)}-${todayISO()}.md`;
+
+  // Inside pywebview, blob-URL downloads get handed off to the OS as a
+  // viewer instead of saved to disk. Use the Python-side native Save dialog
+  // when it's available.
+  const pyApi = typeof window !== 'undefined' && window.pywebview && window.pywebview.api;
+  if (pyApi && typeof pyApi.save_file === 'function') {
+    pyApi.save_file(markdown, filename);
+    return;
+  }
+
+  // Browser path: anchor-driven blob download. UTF-8 BOM so text viewers
+  // detect encoding correctly if the file ends up displayed instead of saved.
   const blob = new Blob(['﻿', markdown], { type: 'text/markdown;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${slugify(title)}-${todayISO()}.md`;
+  a.download = filename;
   a.rel = 'noopener';
   document.body.appendChild(a);
   a.click();

--- a/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
+++ b/src/quodeq/ui/src/features/report-viewer/ReportPane.jsx
@@ -14,7 +14,10 @@ function todayISO() {
 }
 
 function downloadMarkdown(title, markdown) {
-  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+  // Prepend a UTF-8 BOM so text viewers (especially the ones pywebview hands
+  // the file off to on macOS) detect the encoding correctly. Without it,
+  // characters like —, ·, ✓ render as mojibake.
+  const blob = new Blob(['﻿', markdown], { type: 'text/markdown;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;


### PR DESCRIPTION
## Summary

Follow-up to #302. The Report viewer's `↓` download button didn't reliably produce a file in two situations — both fixed here.

## Fixes

1. **Synchronous blob-URL revoke race (`fe359691`)**
   `URL.revokeObjectURL(url)` was called immediately after `a.click()`, so the browser sometimes revoked the blob before it had a chance to start the download. Now revokes via `setTimeout(..., 0)` so the click has time to kick off. Also adds `charset=utf-8` to the MIME type and `rel="noopener"` to the anchor as small hardening.

2. **UTF-8 BOM on the file (`9fe0246a`)**
   Some text viewers default to Latin-1 and render `—`, `·`, `✓` as mojibake (`â€"`, `Â·`, …). Prepending the UTF-8 BOM makes any modern viewer detect the encoding correctly.

3. **pywebview native save dialog (`bb4aaa5a`)**
   In pywebview, `<a download>` blob downloads get handed off to the OS as a viewer rather than saved to disk. The Python side already exposes `pywebview.api.save_file(content, filename)` (in `_webview_window.py`); this commit makes the JS prefer that path when `window.pywebview.api.save_file` is present. Browser fallback is unchanged.

## Test plan

- [x] `cd src/quodeq/ui && npx vitest run` — 25 / 25 pass.
- [x] In a regular browser (`npm --prefix src/quodeq/ui run dev`), click `↓` in the Report pane → `.md` lands in the Downloads folder; opens in a viewer with em-dashes, dots, and check marks rendered correctly.
- [x] In pywebview (`uv run quodeq dashboard --dev`), click `↓` → native macOS Save dialog opens; chosen file is UTF-8 with no mojibake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)