### PR TITLE
fix(scan-progress): header tracks running dim, not summed totals

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -1,22 +1,22 @@
 /**
  * Math helpers for the live evaluation header.
  *
- * The header shows the *aggregated* work across every dim: 2 dims × 100
- * files of analysis = "0 / 200 files" at start. That matches what the
- * dashboard is actually doing — analyse each file once per dim.
+ * The header tracks ONE dimension at a time — the currently-running one.
+ * Multi-dim incremental scans have wildly different cache hit rates per
+ * dim, so summing taken/total across dims produces a moving total that
+ * jumps as each dim reveals its real (post-filter) queue size. Showing
+ * the running dim's progress directly avoids that whiplash; the
+ * per-dimension breakdown lives under the DETAILS toggle.
  *
- * Per-dim totals from `/api/evaluations/<jobId>/progress` are NOT
- * uniform at runtime, though: running/done dims report their post-filter
- * queue size while a pending dim falls back to the project-wide ceiling
- * (see `services/scan_progress.py`). Summing them as-is inflates the
- * headline by ~N× project_files in mixed states.
+ * Dim selection (in order):
+ *   1. `progress.currentDimension` matches a dim → that one
+ *   2. Else first dim where `state === 'running'` (race coverage)
+ *   3. Else last dim where `state === 'done'` (so completed runs read 100%
+ *      instead of 0/0)
+ *   4. Else all zeros (setup phase / nothing started yet)
  *
- * `computeOverallProgress` substitutes a pending-dim's project-ceiling
- * total with the largest *observed* (running or done) queue total — the
- * same fallback the per-dim row uses — so every dim contributes a
- * consistent estimate. Once any dim has started, the fallback is the
- * actual filtered queue size; before that, it falls back to
- * `progress.projectFiles` as a last resort.
+ * `dimFileEstimate` is unchanged and still drives the per-dim row's
+ * pending-dim projection inside the DETAILS panel.
  */
 
 export function pct(taken, total) {
@@ -41,17 +41,32 @@ export function dimFileEstimate(progress) {
 
 export function computeOverallProgress(progress) {
   const dims = progress?.dimensions || [];
-  const dimEstimate = dimFileEstimate(progress);
+  if (dims.length === 0) {
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
+  }
 
-  const totalFiles = dims.reduce((acc, d) => {
-    // Pending dims expose the project-wide ceiling, not the post-filter
-    // queue they'll actually scan. Swap in the fallback estimate so each
-    // pending dim contributes a comparable number to the aggregate.
-    if (d?.state === 'pending') return acc + dimEstimate;
-    return acc + (d?.files?.total ?? 0);
-  }, 0);
-  const takenFiles = dims.reduce((acc, d) => acc + (d?.files?.taken ?? 0), 0);
-  const overallPct = pct(takenFiles, totalFiles);
+  const currentId = progress?.currentDimension;
+  let dim = null;
+  if (currentId) {
+    dim = dims.find((d) => d?.id === currentId) || null;
+  }
+  if (!dim) {
+    dim = dims.find((d) => d?.state === 'running') || null;
+  }
+  if (!dim) {
+    // Walk from the end so we pick the most recently completed dim.
+    for (let i = dims.length - 1; i >= 0; i--) {
+      if (dims[i]?.state === 'done') {
+        dim = dims[i];
+        break;
+      }
+    }
+  }
+  if (!dim) {
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
+  }
 
-  return { totalFiles, takenFiles, overallPct };
+  const takenFiles = dim.files?.taken ?? 0;
+  const totalFiles = dim.files?.total ?? 0;
+  return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles) };
 }

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -76,45 +76,46 @@ test('computeOverallProgress: returns zeros when dimensions array is empty', () 
 });
 
 test('computeOverallProgress: handles missing files object on a dim', () => {
+  // No currentDimension, no done dim, only pending → header shows zeros.
+  // Pending dims never drive the header on their own (per the new contract).
   const r = computeOverallProgress({
     projectFiles: 50,
     dimensions: [{ id: 'x', state: 'pending' }],
   });
-  // Pending dim with no observed sibling → fallback estimate is projectFiles.
-  assert.equal(r.totalFiles, 50);
+  assert.equal(r.totalFiles, 0);
   assert.equal(r.takenFiles, 0);
   assert.equal(r.overallPct, 0);
 });
 
 // ---------------------------------------------------------------------------
-// computeOverallProgress — aggregated headline
+// computeOverallProgress — current-dim headline
 // ---------------------------------------------------------------------------
 
-test('computeOverallProgress: 2 dims × 100 files reads "X / 200" (aggregated)', () => {
-  // Header is the aggregated work across dims, not the project file
-  // count. Two dims that each scan 100 files = 200 work units.
+test('computeOverallProgress: tracks the running dim by id', () => {
+  // currentDimension picks security; reliability is also running but ignored.
   const progress = {
-    projectFiles: 100,
+    projectFiles: 1682,
+    currentDimension: 'security',
     dimensions: [
-      { state: 'running', files: { taken: 50, total: 100 } },
-      { state: 'pending', files: { taken: 0,  total: 100 } },
+      { id: 'security',    state: 'running', files: { taken: 55, total: 2035 } },
+      { id: 'reliability', state: 'running', files: { taken: 999, total: 999 } },
+      { id: 'performance', state: 'pending', files: { taken: 0,  total: 1682 } },
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 200);
-  assert.equal(r.takenFiles, 50);
-  assert.equal(r.overallPct, 25);
+  assert.equal(r.totalFiles, 2035);
+  assert.equal(r.takenFiles, 55);
+  assert.equal(r.overallPct, 3);
 });
 
-test('computeOverallProgress: 6-dim run does NOT use project-ceiling for pending dims (regression)', () => {
-  // Reproduces the bug from the screenshot. Without the fallback
-  // substitution, pending dims would each contribute the project-wide
-  // ceiling (1682) and the headline becomes "3 / 9237 files". With the
-  // substitution, every dim contributes the post-filter queue size (827)
-  // observed on the running dim, and the headline becomes the coherent
-  // aggregated "3 / 4962 files".
+test('computeOverallProgress: pending dim fallback ceiling does NOT leak into header (regression)', () => {
+  // Reproduces the screenshot bug: 6-dim incremental run with one running
+  // (security, 827 changed files) and five pending. Old aggregation summed
+  // them and produced a misleading total. New contract: header tracks only
+  // security.
   const progress = {
     projectFiles: 1682,
+    currentDimension: 'security',
     dimensions: [
       { id: 'security',        state: 'running', files: { taken: 3, total: 827 } },
       { id: 'reliability',     state: 'pending', files: { taken: 0, total: 1682 } },
@@ -125,60 +126,55 @@ test('computeOverallProgress: 6-dim run does NOT use project-ceiling for pending
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 4962, 'pending dims contribute 827 each, not 1682');
+  assert.equal(r.totalFiles, 827, 'header is just security, not summed');
   assert.equal(r.takenFiles, 3);
   assert.equal(r.overallPct, 0);
 });
 
-test('computeOverallProgress: pending dims before any has started fall back to projectFiles', () => {
-  // Every dim is pending — no observed running/done queue total exists,
-  // so the only sensible fallback is projectFiles (the upper bound).
+test('computeOverallProgress: falls back to first running dim when currentDimension is unset', () => {
+  // Race window between dim transitions: a dim is running but the backend
+  // hasn't set currentDimension yet.
   const progress = {
-    projectFiles: 200,
+    projectFiles: 1682,
+    currentDimension: null,
     dimensions: [
-      { state: 'pending', files: { taken: 0, total: 200 } },
-      { state: 'pending', files: { taken: 0, total: 200 } },
+      { id: 'security',    state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'reliability', state: 'running', files: { taken: 7, total: 200 } },
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 400);
-  assert.equal(r.takenFiles, 0);
-  assert.equal(r.overallPct, 0);
+  assert.equal(r.totalFiles, 200);
+  assert.equal(r.takenFiles, 7);
+  assert.equal(r.overallPct, 4);
 });
 
-test('computeOverallProgress: single-dim run keeps the per-dim count intact', () => {
+test('computeOverallProgress: falls back to last done dim when run has finished', () => {
+  // After completion, currentDimension is null and no dim is running.
+  // We surface the last completed dim so the header reads a real 100%
+  // instead of 0/0.
   const progress = {
-    projectFiles: 500,
+    projectFiles: 1682,
+    currentDimension: null,
     dimensions: [
-      { state: 'running', files: { taken: 120, total: 500 } },
+      { id: 'security',    state: 'done', files: { taken: 827, total: 827 } },
+      { id: 'reliability', state: 'done', files: { taken: 200, total: 200 } },
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 500);
-  assert.equal(r.takenFiles, 120);
-  assert.equal(r.overallPct, 24);
-});
-
-test('computeOverallProgress: all dims done → 100% and full aggregated count', () => {
-  const progress = {
-    projectFiles: 200,
-    dimensions: [
-      { state: 'done', files: { taken: 200, total: 200 } },
-      { state: 'done', files: { taken: 200, total: 200 } },
-      { state: 'done', files: { taken: 200, total: 200 } },
-    ],
-  };
-  const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 600);
-  assert.equal(r.takenFiles, 600);
+  assert.equal(r.totalFiles, 200, 'last done dim wins');
+  assert.equal(r.takenFiles, 200);
   assert.equal(r.overallPct, 100);
 });
 
-test('computeOverallProgress: zero workTotal yields 0% (avoid div-by-zero)', () => {
+test('computeOverallProgress: setup phase (all pending) → zeros', () => {
+  // Before any dim has started: no current, no running, no done. The header
+  // shows preparing… per the JSX guard, which expects totalFiles: 0.
   const progress = {
-    projectFiles: 0,
+    projectFiles: 200,
+    currentDimension: null,
     dimensions: [
-      { state: 'pending', files: { taken: 0, total: 0 } },
+      { id: 'a', state: 'pending', files: { taken: 0, total: 200 } },
+      { id: 'b', state: 'pending', files: { taken: 0, total: 200 } },
     ],
   };
   const r = computeOverallProgress(progress);
@@ -187,21 +183,46 @@ test('computeOverallProgress: zero workTotal yields 0% (avoid div-by-zero)', () 
   assert.equal(r.overallPct, 0);
 });
 
-test('computeOverallProgress: mixed running queues contribute their own totals', () => {
-  // Two running dims with different post-filter queues — each contributes
-  // its actual queue total to the aggregate; only pending dims get the
-  // fallback estimate (which here is the larger of the two running totals).
+test('computeOverallProgress: single-dim run reads the dim directly', () => {
   const progress = {
-    projectFiles: 200,
+    projectFiles: 500,
+    currentDimension: 'security',
     dimensions: [
-      { state: 'running', files: { taken: 30, total: 100 } },
-      { state: 'running', files: { taken: 80, total: 150 } },
-      { state: 'pending', files: { taken: 0,  total: 200 } },
+      { id: 'security', state: 'running', files: { taken: 120, total: 500 } },
     ],
   };
   const r = computeOverallProgress(progress);
-  // 100 (running) + 150 (running) + 150 (pending → fallback = max observed)
-  assert.equal(r.totalFiles, 400);
-  assert.equal(r.takenFiles, 110);
-  assert.equal(r.overallPct, 28);
+  assert.equal(r.totalFiles, 500);
+  assert.equal(r.takenFiles, 120);
+  assert.equal(r.overallPct, 24);
+});
+
+test('computeOverallProgress: zero workTotal on running dim yields 0% (avoid div-by-zero)', () => {
+  const progress = {
+    projectFiles: 0,
+    currentDimension: 'x',
+    dimensions: [
+      { id: 'x', state: 'running', files: { taken: 0, total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: currentDimension that does not match any dim falls back gracefully', () => {
+  // Defensive: backend hiccup where currentDimension references a dim that
+  // isn't in the array. Fall through to the running-dim fallback.
+  const progress = {
+    projectFiles: 200,
+    currentDimension: 'ghost',
+    dimensions: [
+      { id: 'security', state: 'running', files: { taken: 5, total: 100 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 100);
+  assert.equal(r.takenFiles, 5);
+  assert.equal(r.overallPct, 5);
 });


### PR DESCRIPTION
## Summary

- Live evaluation header progress bar now tracks the **currently-running** dimension only, instead of summing `taken/total` across every dim.
- Multi-dim incremental scans no longer show a misleading aggregated total that jumped each time a new dim revealed its real (post-filter) queue size.
- `pct` and `dimFileEstimate` (driving the per-dim DETAILS rows) are unchanged. No backend or JSX changes — `ScanProgress.jsx` consumes the same `{ totalFiles, takenFiles, overallPct }` shape.

## Why

Per-dim incremental cache rates differ wildly: one dim might carry-forward 940 files, another 0. Summing the per-dim queues produced a header total that grew/shrank as each dim started and revealed its real size — visually, the bar could appear to jump backward mid-run.

## Behaviour change

Header dim selection (in order):
1. \`progress.currentDimension\` matches a dim → that one
2. Else first dim with \`state === 'running'\` (race coverage between dim transitions)
3. Else last dim with \`state === 'done'\` (post-completion, so the bar reads a real 100% instead of 0/0)
4. Else all zeros → JSX shows \"preparing…\" via the existing guard

DETAILS / per-dim breakdown is unchanged.

## Test Plan

- [x] Unit: 9 tests in \`scanProgressTotals.test.js\` cover all four selection rules + a defensive \"ghost currentDimension\" case + div-by-zero
- [x] Full UI suite: 118/118 pass
- [x] Manual smoke test on a multi-dim incremental run: confirm bar resets between dims and reads 100% on the last completed dim post-run

## Out of scope

- Showing carry-forward / cached files in the bar
- \`dimFileEstimate\` / pending-dim projection for DETAILS rows
- Backend changes — \`currentDimension\` is already exposed by \`services/scan_progress.py\`