### PR TITLE
fix(analysis): tighten api-runner schema to ground model findings

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -52,10 +52,31 @@ class _Finding(BaseModel):
     req: str = Field(description="Requirement ID (e.g. P-TIM-1, S-CON-3)")
     t: _FindingType = Field(description="violation or compliance")
     file: str = Field(description="File path relative to repo root")
-    line: int = Field(default=0, description="Line number")
+    line: int = Field(description="1-indexed line number of the offending expression. MUST be > 0.", gt=0)
+    end_line: int | None = Field(
+        default=None,
+        description=(
+            "Last line of the offending span. Omit unless the violation is structural "
+            "(long function, nesting depth, file length). The server reads the actual source "
+            "to render the snippet; setting this widens the rendered window."
+        ),
+    )
     severity: _Severity = Field(default=_Severity.minor)
     w: str = Field(description="Short title of the finding")
-    reason: str = Field(default="", description="Why this is a violation or compliance")
+    snippet: str = Field(
+        description=(
+            "Exact text of the offending line, verbatim from the source file. "
+            "Required. If you cannot quote the line, drop the finding."
+        ),
+        min_length=1,
+    )
+    reason: str = Field(
+        description=(
+            "One sentence: what the quoted line does wrong AS WRITTEN. "
+            "No hedging ('could', 'might', 'should consider', 'if X were larger')."
+        ),
+        min_length=1,
+    )
 
 
 class _Findings(BaseModel):
@@ -124,7 +145,7 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
         model=config.model,
         response_model=_Findings,
         messages=[
-            {"role": "system", "content": "You are a code quality evaluator."},
+            {"role": "system", "content": "You are a code quality evaluator. Quote the offending line into `snippet`. Empty `findings` is a valid answer."},
             {"role": "user", "content": prompt},
         ],
         temperature=config.temperature,

--- a/src/quodeq/data/prompts/api_prompt.md
+++ b/src/quodeq/data/prompts/api_prompt.md
@@ -15,13 +15,10 @@ You MUST evaluate EVERY principle group — not just the first ones.
 
 ## Your Task
 
-Evaluate the source files against EACH principle group in the checklist above.
+Evaluate the source files against EACH principle group in the checklist above. Clean code returns `{"findings": []}`.
 
 {{EVALUATION_RULES}}
 
 {{FINDING_SCHEMA}}
 
-Respond with ONLY this JSON format — no other text:
-{"findings": [{"req": "M-MOD-1", "t": "violation", "file": "src/app.py", "line": 10, "severity": "major", "w": "Multiple responsibilities", "reason": "Module handles both IO and logic"}]}
-
-If no issues found: {"findings": []}
+Respond with ONLY this JSON.

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -6,7 +6,7 @@ Report BOTH violations AND compliance. Scoring is a ratio. For every principle w
 
 Report each occurrence separately. 5 misplaced methods = 5 findings.
 
-NOT a violation: literal inside a constant/enum definition; long function that only registers routes; duplicated test setup; code that IS the remediation for the issue.
+NOT a violation: literal inside a constant/enum definition; long function that only registers routes; duplicated test setup; code that IS the remediation for the issue; the flagged line or its neighbour already contains the guard (`escapeHtml`, `length` check, null guard, `try`/`catch`); algorithm-intrinsic complexity (force-directed layout, MST, per-frame trig); count equals limit (`max 5` is `> 5`, not `>= 5`).
 
 ## Evidence
 

--- a/tests/analysis/test_api_integration.py
+++ b/tests/analysis/test_api_integration.py
@@ -39,6 +39,7 @@ def _mock_findings_model():
             line=2,
             severity=_Severity.critical,
             w="Hardcoded password",
+            snippet='password = "admin123"',
             reason="Password stored as plaintext string literal",
         ),
     ])

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -21,7 +21,9 @@ def _make_findings(*findings_data):
     for req, t, file, line, severity, w in findings_data:
         findings.append(_Finding(
             req=req, t=_FindingType(t), file=file, line=line,
-            severity=_Severity(severity), w=w, reason=f"Test reason for {req}",
+            severity=_Severity(severity), w=w,
+            snippet=f"line for {req}",
+            reason=f"Test reason for {req}",
         ))
     return _Findings(findings=findings)
 

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -29,7 +29,7 @@ from quodeq.analysis._api_runner import (
 
 class TestSalvagePartialFindings:
     def test_extracts_valid_findings_from_malformed_json(self):
-        raw = '{"findings": [{"req":"S-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"test","reason":"bad"}, BROKEN'
+        raw = '{"findings": [{"req":"S-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"test","snippet":"x = 1","reason":"bad"}, BROKEN'
         result = _salvage_partial_findings(raw)
         assert len(result) >= 1
         assert result[0]["req"] == "S-1"
@@ -39,16 +39,19 @@ class TestSalvagePartialFindings:
         assert result == []
 
     def test_skips_invalid_objects(self):
-        # Missing required 'req' field
-        raw = '{"req":"X-1","t":"violation","file":"a.py","w":"ok"} {"not_a_finding": true}'
+        # First object is well-formed and valid; second lacks required fields and must be dropped.
+        raw = (
+            '{"req":"X-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"ok","snippet":"x = 1","reason":"r"} '
+            '{"not_a_finding": true}'
+        )
         result = _salvage_partial_findings(raw)
-        # First one should parse, second should not
-        assert len(result) >= 1
+        assert len(result) == 1
+        assert result[0]["req"] == "X-1"
 
     def test_handles_multiple_valid_objects(self):
         raw = (
-            '{"req":"A-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"one","reason":"r"} '
-            '{"req":"B-2","t":"compliance","file":"b.py","line":2,"severity":"major","w":"two","reason":"r"}'
+            '{"req":"A-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"one","snippet":"x = 1","reason":"r"} '
+            '{"req":"B-2","t":"compliance","file":"b.py","line":2,"severity":"major","w":"two","snippet":"y = 2","reason":"r"}'
         )
         result = _salvage_partial_findings(raw)
         assert len(result) == 2
@@ -151,7 +154,7 @@ class TestCallApi:
         )
         mock_client = MagicMock()
         # Simulate instructor validation failure with valid JSON in the error message
-        error_msg = 'Validation failed: {"req":"X-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"test","reason":"bad"}'
+        error_msg = 'Validation failed: {"req":"X-1","t":"violation","file":"a.py","line":1,"severity":"minor","w":"test","snippet":"x = 1","reason":"bad"}'
         mock_client.chat.completions.create.side_effect = Exception(error_msg)
 
         with patch("quodeq.analysis._api_runner.instructor") as mock_inst, \
@@ -243,7 +246,7 @@ class TestRunApiAnalysisAppend:
 
         config = ApiRunnerConfig(model="m", api_base="http://localhost/v1")
         findings = _Findings(findings=[
-            _Finding(req="NEW-1", t=_FindingType.violation, file="a.py", w="new"),
+            _Finding(req="NEW-1", t=_FindingType.violation, file="a.py", line=1, w="new", snippet="x = 1", reason="placeholder"),
         ])
 
         mock_client = MagicMock()
@@ -264,7 +267,7 @@ class TestRunApiAnalysisAppend:
         jsonl = tmp_path / "evidence.jsonl"
         config = ApiRunnerConfig(model="m", api_base="http://localhost/v1")
         findings = _Findings(findings=[
-            _Finding(req="X-1", t=_FindingType.violation, file="a.py", w="test"),
+            _Finding(req="X-1", t=_FindingType.violation, file="a.py", line=1, w="test", snippet="x = 1", reason="placeholder"),
         ])
 
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary

Small models (Gemma-class) were emitting speculative, hedged, or self-contradictory findings (e.g. "5 exceeds 5", "257 lines exceeds 300", XSS flagged on already-escaped HTML, demands for type annotations on plain `.js`) because the response schema let them. This tightens the schema and adds the minimum prompt signal needed to drop the most common false-positive classes — almost all the leverage is in the schema, not the prose.

- `_Finding`: require non-empty `snippet` and `reason`, require `line > 0`, add optional `end_line` for structural violations (parity with the MCP path's `report_finding`). `enrich_code` already consumes `end_line` to widen the rendered window — no downstream changes needed.
- `api_prompt.md`: collapsed trailing example/instructions into a single "clean code returns `[]`" reminder.
- `evaluation_rules.md`: extended the existing "NOT a violation" line with guard-recognition (`escapeHtml`, length check, null guard, `try`/`catch`), algorithm-intrinsic complexity (force-directed, MST, per-frame trig), and count-equals-limit cases.
- System prompt: one sentence — quote into `snippet`, empty `findings` is a valid answer.
- Tests: fixtures updated to construct valid `_Finding` under the new contract.

Net per-call prompt overhead: ~+50 tokens. Schema does the heavy lifting.

## Test plan

- [x] `pytest tests/analysis/` — 341 passing
- [x] full `pytest` — 2254 passing
- [x] Re-run analyzer on `src/quodeq/ui/src/features/map` with the same model/config that produced the 122-item baseline; compare findings count and false-positive categories