### PR TITLE
Scan progress: per-dim estimates, pool autoscale, and partial-work salvage

### DIFF
--- a/src/quodeq/analysis/_dim_estimates.py
+++ b/src/quodeq/analysis/_dim_estimates.py
@@ -1,0 +1,139 @@
+"""Compute per-dim file count estimates before any dim runs.
+
+The dashboard uses these to render an accurate run total upfront, instead
+of waiting for each dim to start and reveal its post-filter queue size
+one at a time. The estimate matches what the queue will hold once the
+dim actually runs, so the header total stays stable as dims transition
+from pending → running.
+
+Each estimate carries a short *reason* tag so the UI can flag inflated
+counts that aren't really "this much code" but "catching up from a
+previous run that died early":
+
+  - "full"             — non-incremental run; estimate = full source list
+  - "diff"             — diff filter active; estimate = filter intersection
+  - "incremental"      — normal incremental; estimate = changed + dependents
+  - "first-run"        — no prev fingerprint; estimate = full source list
+  - "standards-changed" — standards file changed; full re-analysis
+  - "prompts-changed"  — prompt files changed; full re-analysis
+  - "catching-up"      — most files were fingerprinted but never analyzed
+                          last time (pool timed out / cancelled), so they
+                          get re-swept this run
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from quodeq.analysis._incr_change_detection import detect_changed_files
+from quodeq.analysis._incremental_phases import _list_all_source_files
+from quodeq.analysis._types import RunConfig
+from quodeq.analysis.fingerprint import find_previous_fingerprint
+from quodeq.analysis.incremental import ClassificationInput, classify_files
+
+DIM_ESTIMATES_FILENAME = "dim_estimates.json"
+
+# Below this fraction, the previous run is considered to have died early and
+# this dim is "catching up" (most files re-swept via the not_analyzed branch).
+_CATCHING_UP_PREV_ANALYZED_RATIO = 0.5
+
+
+def _classify_full_reanalysis_reason(detection_reason: str) -> str:
+    if "standards" in detection_reason:
+        return "standards-changed"
+    if "prompts" in detection_reason:
+        return "prompts-changed"
+    if "no previous fingerprint" in detection_reason:
+        return "first-run"
+    return "first-run"
+
+
+def compute_dim_estimates(
+    config: RunConfig, dimensions: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Estimate per-dim file count + reason, before any dim runs.
+
+    Returns ``{dim_id: {"count": int, "reason": str}}``. See module docstring
+    for the reason vocabulary.
+    """
+    estimates: dict[str, dict[str, Any]] = {}
+    evidence_dir = config.work_dir or config.src
+    file_filter = config.options.incremental_file_filter
+    for dim_id in dimensions:
+        files = _list_all_source_files(config, dim_id)
+        if not files:
+            estimates[dim_id] = {"count": 0, "reason": "empty"}
+            continue
+        if config.options.incremental:
+            prev_fp, _ = find_previous_fingerprint(evidence_dir, dim_id)
+            detection = detect_changed_files(
+                config.src, files, prev_fp, config.standards_dir, dim_id,
+            )
+            classification = classify_files(
+                inputs=ClassificationInput(
+                    src=config.src, files=files, prev_fingerprint=prev_fp,
+                    standards_dir=config.standards_dir, dimension=dim_id,
+                    language=config.language,
+                ),
+            )
+            count = len(classification.to_analyze)
+            if detection.full_reanalysis:
+                reason = _classify_full_reanalysis_reason(detection.reason)
+            else:
+                prev_analyzed = len(prev_fp.get("analyzed_files", [])) if prev_fp else 0
+                prev_files = len(prev_fp.get("file_hashes", {})) if prev_fp else 0
+                if (
+                    prev_files > 0
+                    and prev_analyzed < prev_files * _CATCHING_UP_PREV_ANALYZED_RATIO
+                ):
+                    reason = "catching-up"
+                else:
+                    reason = "incremental"
+            estimates[dim_id] = {"count": count, "reason": reason}
+        elif file_filter is not None:
+            count = sum(1 for f in files if f in file_filter)
+            estimates[dim_id] = {"count": count, "reason": "diff"}
+        else:
+            estimates[dim_id] = {"count": len(files), "reason": "full"}
+    return estimates
+
+
+def write_dim_estimates(
+    run_dir: Path, estimates: dict[str, dict[str, Any]],
+) -> None:
+    """Persist per-dim estimates next to status.json. Best-effort."""
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps(estimates, indent=2), encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return per-dim estimates from disk, or {} if missing/corrupt.
+
+    Each value is normalised to ``{"count": int, "reason": str}``.
+    """
+    path = run_dir / DIM_ESTIMATES_FILENAME
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError):
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for k, v in data.items():
+        # Current format: {"count": int, "reason": str}.
+        if isinstance(v, dict) and isinstance(v.get("count"), int):
+            out[k] = {"count": v["count"], "reason": str(v.get("reason", ""))}
+        # Legacy format: a bare int. Older runs predate the reason tag.
+        elif isinstance(v, int):
+            out[k] = {"count": v, "reason": ""}
+    return out

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timezone
 
+from quodeq.analysis._dim_estimates import compute_dim_estimates, write_dim_estimates
 from quodeq.analysis._incremental_context import load_analysis_context as _load_ctx
 from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
 from quodeq.analysis._types import RunConfig, _AnalysisContext
@@ -63,6 +64,20 @@ def _run_dry_run(
     return result
 
 
+def _persist_dim_estimates(config: RunConfig, dimensions: list[str]) -> None:
+    """Compute and persist per-dim file estimates so the dashboard total
+    is accurate before any dim starts. Best-effort: a failure here must
+    not break the run — the UI will fall back to the project-wide ceiling.
+    """
+    if not config.work_dir:
+        return  # dev mode (no run_dir) — nothing for the dashboard to read
+    try:
+        estimates = compute_dim_estimates(config, dimensions)
+    except (OSError, ValueError, KeyError, RuntimeError):
+        return
+    write_dim_estimates(config.work_dir.parent, estimates)
+
+
 def _run_dimensions(
     config: RunConfig,
     on_dimension_done: "Callable[[str, Evidence], None] | None" = None,
@@ -72,6 +87,7 @@ def _run_dimensions(
         return _run_dry_run(config, on_dimension_done=on_dimension_done)
 
     dimensions, ctx = load_analysis_context(config)
+    _persist_dim_estimates(config, dimensions)
 
     # Diff mode always per-dimension — consolidated/incremental loops are
     # incompatible with evidence-only runs (no prior fingerprint, no

--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -124,13 +124,41 @@ def load_fingerprint(evidence_dir: Path, dimension: str) -> dict | None:
         return None
 
 
+def _queue_taken_files(evidence_dir: Path, dimension: str) -> set[str]:
+    """Read files that were dispatched to agents from a dim's queue.json.
+
+    Returns the union of files appearing in any taken batch. Empty set if the
+    queue is missing or unreadable. Used to salvage analyzed_files from runs
+    that crashed or were cancelled before the fingerprint was finalized.
+    """
+    path = evidence_dir / f"{dimension}_queue.json"
+    if not path.is_file():
+        return set()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return set()
+    taken = data.get("taken") if isinstance(data, dict) else None
+    if not isinstance(taken, list):
+        return set()
+    out: set[str] = set()
+    for entry in taken:
+        files = entry.get("files") if isinstance(entry, dict) else None
+        if isinstance(files, list):
+            out.update(f for f in files if isinstance(f, str))
+    return out
+
+
 def find_previous_fingerprint(
     evidence_dir: Path, dimension: str,
 ) -> tuple[dict | None, Path | None]:
     """Find the fingerprint and evidence dir from the most recent previous run.
 
     Walks the run history to find the latest run (other than the current one)
-    that has a fingerprint for the given dimension.
+    that has a fingerprint for the given dimension. Crash/cancel salvage:
+    when the previous run died before finalising, its `analyzed_files` set
+    is stale — we union in whatever files the queue actually dispatched so
+    the catch-up loop doesn't keep re-sweeping work that already happened.
     """
     paths_info = resolve_evidence_paths(evidence_dir)
     if not paths_info:
@@ -141,12 +169,18 @@ def find_previous_fingerprint(
         if run_info.run_id == current_run_id:
             continue
         run_dir = reports_base / project_uuid / run_info.run_id
-        # Only carry forward from runs that completed (have a scored report)
-        eval_report = run_dir / "evaluation" / f"{dimension}.json"
-        if not eval_report.is_file():
-            continue
         prev_evidence = run_dir / "evidence"
         fp = load_fingerprint(prev_evidence, dimension)
-        if fp:
-            return fp, prev_evidence
+        if not fp:
+            continue
+        # Augment analyzed_files with anything the queue dispatched. For
+        # cleanly finalised runs this is a no-op (queue.taken ⊆ analyzed_files
+        # already). For crashed/cancelled runs it salvages partial work.
+        queue_analyzed = _queue_taken_files(prev_evidence, dimension)
+        if queue_analyzed:
+            current_analyzed = set(fp.get("analyzed_files") or [])
+            merged = current_analyzed | queue_analyzed
+            if merged != current_analyzed:
+                fp["analyzed_files"] = sorted(merged)
+        return fp, prev_evidence
     return None, None

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -10,11 +10,41 @@ from quodeq.analysis._types import RunConfig
 from quodeq.analysis.subprocess import AnalysisConfig, count_files_from_stream
 from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.logging import log_info
 from quodeq.shared.utils import get_ai_cmd
 
 _MAX_FILES_PER_AGENT = 30
 _MAX_FILES_PER_AGENT_CAP = 50
 _NON_SCOUT_PROVIDERS = tuple(os.environ.get("QUODEQ_NON_SCOUT_PROVIDERS", "codex,gemini").split(","))
+
+# Auto-scale the pool budget so large queues don't get killed mid-run.
+# A fixed 600s cap chokes any dim with a queue larger than ~80 files
+# (observed throughput ≈ 7-12 s/file with 8 agents); the surviving
+# pending files keep haunting the next run via the not_analyzed sweep
+# and the dim never converges. The user's explicit pool_budget is a
+# FLOOR — we only ever extend it upward, never shrink it.
+_SECONDS_PER_FILE_AUTOSCALE = 12
+# Hard upper bound so a runaway queue can't lock up the run for days.
+_MAX_AUTO_POOL_BUDGET = 7200  # 2 hours
+# Pool budget = 0 means "unlimited"; respect that and never scale it.
+_UNLIMITED_BUDGET = 0
+
+
+def _resolve_pool_budget(user_budget: int | None, queue_size: int) -> int:
+    """Compute the effective pool budget for a queue of *queue_size* files.
+
+    The user's `pool_budget` (or `_DEFAULT_POOL_BUDGET` if unset) is treated
+    as a floor. For large queues we extend it to give each file a fair
+    slice of wallclock time, capped at `_MAX_AUTO_POOL_BUDGET`. A user-set
+    budget of 0 means "unlimited" and is preserved verbatim.
+    """
+    base = user_budget if user_budget is not None else _DEFAULT_POOL_BUDGET
+    if base == _UNLIMITED_BUDGET:
+        return _UNLIMITED_BUDGET
+    if queue_size <= 0:
+        return base
+    needed = queue_size * _SECONDS_PER_FILE_AUTOSCALE
+    return min(_MAX_AUTO_POOL_BUDGET, max(base, needed))
 
 
 def _compute_files_per_agent(total_files: int) -> int:
@@ -48,6 +78,14 @@ def _launch_pool(
     """Create and run a SubagentPool, returning its results."""
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
     subagent_model = config.options.subagent_model or _default_subagent_model() or config.options.ai_model
+    queue_size = len(params.all_files) if params.all_files is not None else 0
+    pool_budget = _resolve_pool_budget(config.options.pool_budget, queue_size)
+    base_user_budget = config.options.pool_budget if config.options.pool_budget is not None else _DEFAULT_POOL_BUDGET
+    if pool_budget != base_user_budget and pool_budget != _UNLIMITED_BUDGET:
+        log_info(
+            f"  [{dim_id}] Pool budget auto-scaled: {base_user_budget}s → {pool_budget}s"
+            f" for {queue_size} files"
+        )
     base_ac = AnalysisConfig(
         analysis_budget=config.options.analysis_budget,
         compiled_dir=compiled_dir,
@@ -55,7 +93,7 @@ def _launch_pool(
         max_duration=config.options.max_duration,
         ai_model=subagent_model,
         max_files_per_agent=params.max_files_per_agent,
-        pool_budget=config.options.pool_budget if config.options.pool_budget is not None else _DEFAULT_POOL_BUDGET,
+        pool_budget=pool_budget,
     )
     n_agents = config.options.max_subagents
 

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -104,6 +104,17 @@ def _prepare_findings_and_queue(
     queue_path = dc.evidence_dir / f"{dc.dim_id}_queue.json"
     files_per_agent = _compute_files_per_agent(len(dc.files))
     FileQueue(queue_path, dc.files, max_files_per_agent=files_per_agent)
+    # Persist a fingerprint *now* — before any agent runs — so a crash or
+    # cancel mid-dim doesn't void the file_hashes / standards baseline.
+    # `analyzed_files` carries forward whatever the previous run analyzed
+    # (it'll be augmented by queue.taken on read in find_previous_fingerprint).
+    prev_fp_for_seed, _ = find_previous_fingerprint(dc.evidence_dir, dc.dim_id)
+    seed_analyzed = set(prev_fp_for_seed.get("analyzed_files", [])) if prev_fp_for_seed else set()
+    initial_fp = build_fingerprint(
+        config.src, dc.files, dc.dim_id, config.standards_dir,
+        analyzed_files=seed_analyzed or None,
+    )
+    save_fingerprint(initial_fp, dc.evidence_dir)
     log_info(f"  [{dc.idx}/{dc.ctx.total}] {dc.dim_id} -- {len(dc.files)} files queued, {len(inline_findings)} inline findings")
 
     return _PoolExecutionParams(

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -125,18 +125,30 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
 
     @app.delete("/api/evaluations/<job_id>")
     def cancel_or_delete_evaluation(job_id: str) -> Response | tuple[Response, int]:
-        """DELETE on a running job cancels it. DELETE on a finished job removes it from history."""
+        """DELETE on a running job cancels it. DELETE on a finished job removes it from history.
+
+        Query: ``?discard=true`` on a running job also wipes the in-flight
+        dim queue + fingerprint snapshots so the next run treats the work
+        as never-happened (forces a full rescan for any dim that didn't
+        finish scoring on its own).
+        """
         snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if snapshot is None:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
         if snapshot.status == "running":
-            _logger.info("cancel_evaluation: job_id=%s, remote_addr=%s", job_id, request.remote_addr)
-            ok = provider.cancel_evaluation(job_id, reports_dir=_reports_dir())
+            discard = request.args.get("discard", "").lower() == "true"
+            _logger.info(
+                "cancel_evaluation: job_id=%s, discard=%s, remote_addr=%s",
+                job_id, discard, request.remote_addr,
+            )
+            ok = provider.cancel_evaluation(
+                job_id, reports_dir=_reports_dir(), discard_partial=discard,
+            )
             if not ok:
                 body, status = error_response("Could not cancel job", HTTPStatus.CONFLICT, "CONFLICT")
                 return jsonify(body), status
-            return jsonify({"ok": True, "action": "cancelled"})
+            return jsonify({"ok": True, "action": "cancelled", "discarded": discard})
         _logger.info("delete_evaluation: job_id=%s, remote_addr=%s", job_id, request.remote_addr)
         ok = provider.delete_evaluation(job_id, reports_dir=_reports_dir())
         if not ok:

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -86,8 +86,18 @@ class EvaluationActions(Protocol):
         """Return current status of an evaluation job."""
         ...
 
-    def cancel_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
-        """Cancel a running evaluation job. Return True on success."""
+    def cancel_evaluation(
+        self, job_id: str, reports_dir: str | None = None,
+        *, discard_partial: bool = False,
+    ) -> bool:
+        """Cancel a running evaluation job. Return True on success.
+
+        When ``discard_partial`` is True, any in-flight dim's
+        ``<dim>_queue.json`` and ``<dim>_fingerprint.json`` are deleted so
+        the next run cannot resume from this run's partial state. Dims that
+        already produced ``evaluation/<dim>.json`` are preserved — only
+        unfinished ones are wiped.
+        """
         ...
 
     def list_evaluations(

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -228,7 +228,10 @@ class FsEvaluationMixin:
         reports_root = Path(reports_dir) if reports_dir else None
         return self._jobs.get_job(job_id, reports_root=reports_root)
 
-    def cancel_evaluation(self, job_id: str, reports_dir: str | None = None) -> bool:
+    def cancel_evaluation(
+        self, job_id: str, reports_dir: str | None = None,
+        *, discard_partial: bool = False,
+    ) -> bool:
         """Cancel a running evaluation job and score any completed dimensions.
 
         Uses ``self.get_evaluation_status`` rather than a bare
@@ -239,6 +242,10 @@ class FsEvaluationMixin:
         ``_score_completed_evidence`` is idempotent (skips dimensions whose
         report file already exists), so double-firing with the route-level
         scoring in ``_evaluation_routes`` is a no-op.
+
+        When ``discard_partial`` is True we also wipe queue + fingerprint
+        files for any dim that didn't complete scoring — the next run sees
+        no salvageable state and starts fresh for those dims.
         """
         reports_root = Path(reports_dir) if reports_dir else None
         job = self.get_evaluation_status(job_id, reports_dir=reports_dir)
@@ -248,6 +255,11 @@ class FsEvaluationMixin:
                 "outputProject": job.output_project,
                 "outputRunId": job.output_run_id,
             })
+            if discard_partial:
+                _discard_partial_dim_state(reports_dir, {
+                    "outputProject": job.output_project,
+                    "outputRunId": job.output_run_id,
+                })
         return ok
 
     def score_failed_evaluation(self, job_id: str, reports_dir: str) -> bool:
@@ -276,6 +288,42 @@ class FsEvaluationMixin:
         if states:
             jobs = [j for j in jobs if j.status in states]
         return jobs[:limit] if limit > 0 else jobs
+
+
+def _discard_partial_dim_state(reports_dir: str, job: dict) -> None:
+    """Wipe queue + fingerprint files for any dim that didn't finish scoring.
+
+    Invoked when the user opts to discard collected findings on cancel.
+    Dims with ``evaluation/<dim>.json`` (cleanly scored) are preserved —
+    only in-flight ones are reset, so partial work doesn't get accidentally
+    discarded just because the umbrella run was stopped.
+    """
+    project = job.get("outputProject")
+    run_id = job.get("outputRunId")
+    if not project or not run_id:
+        return
+
+    evidence_dir = Path(reports_dir) / project / run_id / "evidence"
+    evaluation_dir = Path(reports_dir) / project / run_id / "evaluation"
+    if not evidence_dir.is_dir():
+        return
+
+    scored_dims: set[str] = set()
+    if evaluation_dir.is_dir():
+        for eval_file in evaluation_dir.glob("*.json"):
+            scored_dims.add(eval_file.stem)
+
+    for queue_path in evidence_dir.glob("*_queue.json"):
+        dim_id = queue_path.name.replace("_queue.json", "")
+        if dim_id in scored_dims:
+            continue
+        for victim in (queue_path, evidence_dir / f"{dim_id}_fingerprint.json"):
+            try:
+                victim.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                _logger.warning("Could not discard %s: %s", victim, exc)
 
 
 def _score_completed_evidence(reports_dir: str, job: dict) -> None:

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -6,7 +6,8 @@ the in-memory JobManager state.
 
 Sources:
 - ``status.json``                 — phase, current_dimension, started_at, dimensions
-- ``scan.json``                   — total_files (project-wide upper bound for pending dims)
+- ``dim_estimates.json``          — per-dim file count predicted before any dim runs
+- ``scan.json``                   — total_files (project-wide fallback for pending dims)
 - ``<dim>_queue.json``            — taken / pending counts (precise once dim has started)
 - ``<dim>_evidence.jsonl``        — violation / compliance counters
 - ``<dim>_agent-*.stream`` mtime  — per-dim active-agents heuristic
@@ -32,6 +33,7 @@ class _DimProgress:
     elapsed_s: float | None = None
     budget_s: int | None = None
     active_agents: int = 0
+    estimate_reason: str | None = None  # see _dim_estimates module docstring
 
 
 @dataclass
@@ -60,6 +62,23 @@ def _project_total_files(run_dir: Path) -> int:
         return 0
     raw = scan.get("total_files")
     return int(raw) if isinstance(raw, int) else 0
+
+
+def _read_dim_estimates(run_dir: Path) -> dict[str, dict]:
+    """Per-dim file estimates written before any dim ran. Returns {} when absent.
+
+    Each value is ``{"count": int, "reason": str}`` (see _dim_estimates module).
+    """
+    raw = _read_json(run_dir / "dim_estimates.json") or {}
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, dict] = {}
+    for k, v in raw.items():
+        if isinstance(v, dict) and isinstance(v.get("count"), int):
+            out[k] = {"count": v["count"], "reason": str(v.get("reason", ""))}
+        elif isinstance(v, int):
+            out[k] = {"count": v, "reason": ""}
+    return out
 
 
 def _count_jsonl_findings(jsonl_path: Path) -> tuple[int, int]:
@@ -219,6 +238,7 @@ def build_scan_progress(
         total_elapsed_s = None
 
     project_files = _project_total_files(run_dir)
+    dim_estimates = _read_dim_estimates(run_dir)
     dim_ids = list(status.get("dimensions") or [])
     evidence_dir = run_dir / "evidence"
 
@@ -246,9 +266,18 @@ def build_scan_progress(
             pending = len(queue.get("pending") or [])
             files = {"taken": taken, "total": taken + pending}
         elif d_state == "pending":
-            files = {"taken": 0, "total": project_files}
+            # Pending dims report 0 until the precomputed estimate lands.
+            # The UI uses "any pending dim with total=0" as the signal to
+            # keep the header in "preparing…" — better to show nothing
+            # than the project-wide ceiling, which is misleading once
+            # incremental filters are applied.
+            estimate = dim_estimates.get(dim_id)
+            files = {"taken": 0, "total": estimate["count"] if estimate else 0}
         else:
             files = {"taken": 0, "total": 0}
+
+        estimate_meta = dim_estimates.get(dim_id)
+        estimate_reason = estimate_meta["reason"] if estimate_meta else None
 
         v, c = _count_jsonl_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
@@ -264,6 +293,7 @@ def build_scan_progress(
             elapsed_s=elapsed,
             budget_s=budget,
             active_agents=active,
+            estimate_reason=estimate_reason,
         ))
 
     return _ScanProgress(

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -152,10 +152,12 @@ export function getEvaluationProgress(jobId) {
 
 /**
  * @param {string} jobId
+ * @param {{discard?: boolean}} [opts]
  * @returns {Promise<Object>}
  */
-export function cancelEvaluation(jobId) {
-  return request(`/evaluations/${encodeURIComponent(jobId)}`, { method: 'DELETE' });
+export function cancelEvaluation(jobId, opts = {}) {
+  const qs = opts.discard ? '?discard=true' : '';
+  return request(`/evaluations/${encodeURIComponent(jobId)}${qs}`, { method: 'DELETE' });
 }
 
 /**

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -30,12 +30,25 @@ function lastRelevantLog(logs) {
   return null;
 }
 
-function DimRow({ dim, fallbackTotal }) {
+// Reasons surfaced as a badge so an unusually large estimate isn't a mystery.
+const ESTIMATE_REASON_LABEL = {
+  'catching-up': 'catching up',
+  'first-run': 'first run',
+  'standards-changed': 'standards changed',
+  'prompts-changed': 'prompts changed',
+};
+
+function DimRow({ dim }) {
   const taken = dim.files?.taken ?? 0;
   const isPending = dim.state === 'pending';
-  // Pending dims don't have a real queue yet. Use the running/done dims'
-  // queue total as a better estimate than the project-wide upper bound.
-  const total = isPending && fallbackTotal ? fallbackTotal : (dim.files?.total ?? 0);
+  // Backend supplies accurate per-dim totals: a precomputed estimate for
+  // pending dims, the live queue size for running/done. A 0 here means
+  // estimates haven't landed yet — render nothing rather than a guess.
+  const total = dim.files?.total ?? 0;
+  const reasonLabel = ESTIMATE_REASON_LABEL[dim.estimateReason];
+  const reasonBadge = reasonLabel
+    ? <> · <span className="scan-progress__dim-reason">{reasonLabel}</span></>
+    : null;
   // When the dimension reports `done`, force the bar to 100% even if
   // `files.taken < files.total` (incremental skips, dismissed files, etc.).
   // Backend `done` is the source of truth — count drift shouldn't make a
@@ -57,8 +70,8 @@ function DimRow({ dim, fallbackTotal }) {
   let meta;
   if (isPending) {
     meta = total > 0
-      ? <span className="scan-progress__dim-meta-projected">0 / {total}</span>
-      : null;
+      ? <span className="scan-progress__dim-meta-projected">0 / {total}{reasonBadge}</span>
+      : <span className="scan-progress__dim-meta-projected">estimating…</span>;
   } else if (isDone) {
     meta = (
       <>
@@ -87,6 +100,7 @@ function DimRow({ dim, fallbackTotal }) {
     meta = (
       <>
         {`${taken} / ${total}`}
+        {reasonBadge}
         {dim.activeAgents > 0 && <> · {dim.activeAgents} agents</>}
         {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
         {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
@@ -240,17 +254,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       {detailOpen && dims.length > 0 && (
         <div className="scan-progress__expanded" id={`scan-progress-detail-${jobId}`}>
           <div className="scan-progress__expanded-label">Per-dimension</div>
-          {(() => {
-            // Best estimate for pending dims: the largest queue total observed
-            // among dims that have actually started (running or done). Falls
-            // back to whatever total the backend gave (project-wide ceiling).
-            const observed = dims
-              .filter((d) => d.state !== 'pending')
-              .map((d) => d.files?.total ?? 0)
-              .filter((n) => n > 0);
-            const fallbackTotal = observed.length > 0 ? Math.max(...observed) : 0;
-            return dims.map((d) => <DimRow key={d.id} dim={d} fallbackTotal={fallbackTotal} />);
-          })()}
+          {dims.map((d) => <DimRow key={d.id} dim={d} />)}
         </div>
       )}
       {consoleOpen && <ConsoleLogViewer logs={job.logs} />}

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -1,22 +1,16 @@
 /**
  * Math helpers for the live evaluation header.
  *
- * The header tracks ONE dimension at a time — the currently-running one.
- * Multi-dim incremental scans have wildly different cache hit rates per
- * dim, so summing taken/total across dims produces a moving total that
- * jumps as each dim reveals its real (post-filter) queue size. Showing
- * the running dim's progress directly avoids that whiplash; the
- * per-dimension breakdown lives under the DETAILS toggle.
+ * The header sums every dimension's file counts. Per-dim totals come from
+ * the backend: pending dims carry a precomputed estimate (written before
+ * any dim runs), running/done dims carry their actual queue total. This
+ * keeps the header total stable from t=0 — no jumps as new dims start
+ * and reveal their post-filter queue size.
  *
- * Dim selection (in order):
- *   1. `progress.currentDimension` matches a dim → that one
- *   2. Else first dim where `state === 'running'` (race coverage)
- *   3. Else last dim where `state === 'done'` (so completed runs read 100%
- *      instead of 0/0)
- *   4. Else all zeros (setup phase / nothing started yet)
- *
- * `dimFileEstimate` is unchanged and still drives the per-dim row's
- * pending-dim projection inside the DETAILS panel.
+ * Until every pending dim has an estimate, the header reads "preparing…"
+ * rather than printing a misleading partial sum. This covers the brief
+ * window between status.json (state=running) and dim_estimates.json
+ * landing on disk.
  */
 
 export function pct(taken, total) {
@@ -45,28 +39,25 @@ export function computeOverallProgress(progress) {
     return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
   }
 
-  const currentId = progress?.currentDimension;
-  let dim = null;
-  if (currentId) {
-    dim = dims.find((d) => d?.id === currentId) || null;
-  }
-  if (!dim) {
-    dim = dims.find((d) => d?.state === 'running') || null;
-  }
-  if (!dim) {
-    // Walk from the end so we pick the most recently completed dim.
-    for (let i = dims.length - 1; i >= 0; i--) {
-      if (dims[i]?.state === 'done') {
-        dim = dims[i];
-        break;
-      }
-    }
-  }
-  if (!dim) {
+  // "preparing…" only when *nothing* is known yet — i.e. no dim has
+  // started AND no pending dim has an estimate. Once any dim is
+  // running/done or has a total, we show what we know rather than
+  // contradicting an obviously-running run with a "preparing" label.
+  const anyDimStarted = dims.some((d) => d?.state === 'running' || d?.state === 'done');
+  const anyTotalKnown = dims.some((d) => (d?.files?.total ?? 0) > 0);
+  if (!anyDimStarted && !anyTotalKnown) {
     return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
   }
 
-  const takenFiles = dim.files?.taken ?? 0;
-  const totalFiles = dim.files?.total ?? 0;
+  // Sum across dims using whatever total each one carries. Pending dims
+  // with no estimate (total=0) contribute nothing — they'll join the
+  // header sum once their estimate or queue lands.
+  let takenFiles = 0;
+  let totalFiles = 0;
+  for (const d of dims) {
+    takenFiles += d?.files?.taken ?? 0;
+    totalFiles += d?.files?.total ?? 0;
+  }
+
   return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles) };
 }

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -75,9 +75,23 @@ test('computeOverallProgress: returns zeros when dimensions array is empty', () 
   assert.equal(r.overallPct, 0);
 });
 
+test('computeOverallProgress: setup phase (no per-dim totals yet) → zeros', () => {
+  // Backend hasn't written estimates yet and no dim has started — every
+  // dim's files.total is 0. Header stays in "preparing…".
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { id: 'a', state: 'pending', files: { taken: 0, total: 0 } },
+      { id: 'b', state: 'pending', files: { taken: 0, total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.takenFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
 test('computeOverallProgress: handles missing files object on a dim', () => {
-  // No currentDimension, no done dim, only pending → header shows zeros.
-  // Pending dims never drive the header on their own (per the new contract).
   const r = computeOverallProgress({
     projectFiles: 50,
     dimensions: [{ id: 'x', state: 'pending' }],
@@ -88,70 +102,49 @@ test('computeOverallProgress: handles missing files object on a dim', () => {
 });
 
 // ---------------------------------------------------------------------------
-// computeOverallProgress — current-dim headline
+// computeOverallProgress — whole-run aggregation with backend estimates
 // ---------------------------------------------------------------------------
 
-test('computeOverallProgress: tracks the running dim by id', () => {
-  // currentDimension picks security; reliability is also running but ignored.
-  const progress = {
-    projectFiles: 1682,
-    currentDimension: 'security',
-    dimensions: [
-      { id: 'security',    state: 'running', files: { taken: 55, total: 2035 } },
-      { id: 'reliability', state: 'running', files: { taken: 999, total: 999 } },
-      { id: 'performance', state: 'pending', files: { taken: 0,  total: 1682 } },
-    ],
-  };
-  const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 2035);
-  assert.equal(r.takenFiles, 55);
-  assert.equal(r.overallPct, 3);
-});
-
-test('computeOverallProgress: pending dim fallback ceiling does NOT leak into header (regression)', () => {
-  // Reproduces the screenshot bug: 6-dim incremental run with one running
-  // (security, 827 changed files) and five pending. Old aggregation summed
-  // them and produced a misleading total. New contract: header tracks only
-  // security.
+test('computeOverallProgress: trusts per-dim backend totals (incremental run)', () => {
+  // Each pending dim carries its own precomputed estimate (different per
+  // dim because the incremental classifier hits each fingerprint). Header
+  // sums them directly — no observed-max projection needed.
   const progress = {
     projectFiles: 1682,
     currentDimension: 'security',
     dimensions: [
       { id: 'security',        state: 'running', files: { taken: 3, total: 827 } },
-      { id: 'reliability',     state: 'pending', files: { taken: 0, total: 1682 } },
-      { id: 'maintainability', state: 'pending', files: { taken: 0, total: 1682 } },
-      { id: 'performance',     state: 'pending', files: { taken: 0, total: 1682 } },
-      { id: 'usability',       state: 'pending', files: { taken: 0, total: 1682 } },
-      { id: 'flexibility',     state: 'pending', files: { taken: 0, total: 1682 } },
+      { id: 'reliability',     state: 'pending', files: { taken: 0, total: 412 } },
+      { id: 'maintainability', state: 'pending', files: { taken: 0, total: 950 } },
+      { id: 'performance',     state: 'pending', files: { taken: 0, total: 120 } },
+      { id: 'usability',       state: 'pending', files: { taken: 0, total: 60 } },
+      { id: 'flexibility',     state: 'pending', files: { taken: 0, total: 200 } },
     ],
   };
+  const expected = 827 + 412 + 950 + 120 + 60 + 200;
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 827, 'header is just security, not summed');
+  assert.equal(r.totalFiles, expected);
   assert.equal(r.takenFiles, 3);
-  assert.equal(r.overallPct, 0);
+  assert.equal(r.overallPct, pct(3, expected));
 });
 
-test('computeOverallProgress: falls back to first running dim when currentDimension is unset', () => {
-  // Race window between dim transitions: a dim is running but the backend
-  // hasn't set currentDimension yet.
+test('computeOverallProgress: sums actual totals across multiple running/done dims', () => {
   const progress = {
     projectFiles: 1682,
-    currentDimension: null,
+    currentDimension: 'security',
     dimensions: [
-      { id: 'security',    state: 'pending', files: { taken: 0, total: 1682 } },
-      { id: 'reliability', state: 'running', files: { taken: 7, total: 200 } },
+      { id: 'security',    state: 'running', files: { taken: 55,  total: 2035 } },
+      { id: 'reliability', state: 'running', files: { taken: 999, total: 999 } },
+      { id: 'performance', state: 'pending', files: { taken: 0,   total: 800 } },
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 200);
-  assert.equal(r.takenFiles, 7);
-  assert.equal(r.overallPct, 4);
+  assert.equal(r.totalFiles, 2035 + 999 + 800);
+  assert.equal(r.takenFiles, 55 + 999);
+  assert.equal(r.overallPct, pct(1054, 3834));
 });
 
-test('computeOverallProgress: falls back to last done dim when run has finished', () => {
-  // After completion, currentDimension is null and no dim is running.
-  // We surface the last completed dim so the header reads a real 100%
-  // instead of 0/0.
+test('computeOverallProgress: completed run reads 100%', () => {
   const progress = {
     projectFiles: 1682,
     currentDimension: null,
@@ -161,26 +154,9 @@ test('computeOverallProgress: falls back to last done dim when run has finished'
     ],
   };
   const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 200, 'last done dim wins');
-  assert.equal(r.takenFiles, 200);
+  assert.equal(r.totalFiles, 1027);
+  assert.equal(r.takenFiles, 1027);
   assert.equal(r.overallPct, 100);
-});
-
-test('computeOverallProgress: setup phase (all pending) → zeros', () => {
-  // Before any dim has started: no current, no running, no done. The header
-  // shows preparing… per the JSX guard, which expects totalFiles: 0.
-  const progress = {
-    projectFiles: 200,
-    currentDimension: null,
-    dimensions: [
-      { id: 'a', state: 'pending', files: { taken: 0, total: 200 } },
-      { id: 'b', state: 'pending', files: { taken: 0, total: 200 } },
-    ],
-  };
-  const r = computeOverallProgress(progress);
-  assert.equal(r.totalFiles, 0);
-  assert.equal(r.takenFiles, 0);
-  assert.equal(r.overallPct, 0);
 });
 
 test('computeOverallProgress: single-dim run reads the dim directly', () => {
@@ -197,7 +173,7 @@ test('computeOverallProgress: single-dim run reads the dim directly', () => {
   assert.equal(r.overallPct, 24);
 });
 
-test('computeOverallProgress: zero workTotal on running dim yields 0% (avoid div-by-zero)', () => {
+test('computeOverallProgress: running dim with zero total yields 0% (avoid div-by-zero)', () => {
   const progress = {
     projectFiles: 0,
     currentDimension: 'x',
@@ -211,9 +187,7 @@ test('computeOverallProgress: zero workTotal on running dim yields 0% (avoid div
   assert.equal(r.overallPct, 0);
 });
 
-test('computeOverallProgress: currentDimension that does not match any dim falls back gracefully', () => {
-  // Defensive: backend hiccup where currentDimension references a dim that
-  // isn't in the array. Fall through to the running-dim fallback.
+test('computeOverallProgress: ignores currentDimension (whole-run sum)', () => {
   const progress = {
     projectFiles: 200,
     currentDimension: 'ghost',
@@ -225,4 +199,68 @@ test('computeOverallProgress: currentDimension that does not match any dim falls
   assert.equal(r.totalFiles, 100);
   assert.equal(r.takenFiles, 5);
   assert.equal(r.overallPct, 5);
+});
+
+test('computeOverallProgress: running dim is shown even when other pending dims lack estimates', () => {
+  // Once any dim is running, "preparing…" would contradict what's
+  // visibly happening. Pending dims with no estimate just contribute 0
+  // to the header sum and join later when their estimate lands.
+  const progress = {
+    projectFiles: 1682,
+    currentDimension: 'security',
+    dimensions: [
+      { id: 'security',    state: 'running', files: { taken: 10, total: 827 } },
+      { id: 'reliability', state: 'pending', files: { taken: 0,  total: 0 } },
+      { id: 'performance', state: 'pending', files: { taken: 0,  total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 827);
+  assert.equal(r.takenFiles, 10);
+});
+
+test('computeOverallProgress: setup phase shows preparing only when nothing is known', () => {
+  // No dim has started, no dim has a total → still preparing.
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { id: 'a', state: 'pending', files: { taken: 0, total: 0 } },
+      { id: 'b', state: 'pending', files: { taken: 0, total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.overallPct, 0);
+});
+
+test('computeOverallProgress: pending dim with estimate exits preparing', () => {
+  // Backend wrote dim_estimates but no dim has started yet — header
+  // still shows the projected total (no contradiction with reality).
+  const progress = {
+    projectFiles: 200,
+    dimensions: [
+      { id: 'a', state: 'pending', files: { taken: 0, total: 100 } },
+      { id: 'b', state: 'pending', files: { taken: 0, total: 50 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 150);
+  assert.equal(r.takenFiles, 0);
+});
+
+test('computeOverallProgress: completed run with no pending dims still sums', () => {
+  // Edge case: a legacy completed run never had dim_estimates.json, but
+  // all dims are done (real queue totals). The "pending=0 → preparing"
+  // guard only fires for *pending* dims, so done dims aggregate normally.
+  const progress = {
+    projectFiles: 1682,
+    dimensions: [
+      { id: 'security',    state: 'done', files: { taken: 50, total: 50 } },
+      { id: 'reliability', state: 'done', files: { taken: 0,  total: 0 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 50);
+  assert.equal(r.takenFiles, 50);
+  assert.equal(r.overallPct, 100);
 });

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -249,16 +249,18 @@ function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPoll
 
   async function cancelEvaluationJob(jobId) {
     if (!jobId) return;
-    const ok = await confirmDialog({
+    const result = await confirmDialog({
       title: 'Cancel evaluation?',
-      message: 'Stop the running scan. Any findings collected so far will still be saved.',
+      message: 'Stop the running scan. Findings collected so far will be saved for the next incremental run.',
       confirmLabel: 'Cancel evaluation',
       cancelLabel: 'Keep running',
       variant: 'danger',
+      checkboxLabel: 'Discard collected findings',
+      checkboxHint: 'Force a full rescan next time instead of resuming from this run.',
     });
-    if (!ok) return;
+    if (!result || !result.ok) return;
     try {
-      await cancelEvaluation(jobId);
+      await cancelEvaluation(jobId, { discard: result.checked });
       clearJob();
     } catch (err) {
       console.error('Cancel error:', err);

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2884,3 +2884,4 @@
 .scan-progress__budget   { color: var(--color-warn, #d29922); }
 .scan-progress__budget--overrun { color: var(--color-sev-critical-text, #f85149); }
 .scan-progress__partial  { color: var(--color-warn, #d29922); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+.scan-progress__dim-reason { color: var(--color-warn, #d29922); font-style: italic; }

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1121,6 +1121,28 @@
   line-height: 1.5;
   white-space: pre-wrap;
 }
+.qd-confirm-checkbox {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 8px;
+  row-gap: 2px;
+  margin: 0 0 16px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 13px;
+  color: var(--color-text, #e6edf3);
+}
+.qd-confirm-checkbox input[type="checkbox"] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+.qd-confirm-checkbox-label { font-weight: 500; }
+.qd-confirm-checkbox-hint {
+  grid-column: 2;
+  color: var(--color-text-muted, #8b949e);
+  font-size: 12px;
+  line-height: 1.4;
+}
 .qd-confirm-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/quodeq/ui/src/utils/confirmDialog.js
+++ b/src/quodeq/ui/src/utils/confirmDialog.js
@@ -1,12 +1,19 @@
 /**
- * DOM-based confirmation dialog. Returns a Promise that resolves to true
- * (confirm) or false (cancel / clicked-outside). We roll our own instead of
- * using window.confirm because pywebview in frameless mode can suppress
+ * DOM-based confirmation dialog. We roll our own instead of using
+ * window.confirm because pywebview in frameless mode can suppress
  * native dialogs, leaving callers no feedback path.
+ *
+ * Without `checkboxLabel` it resolves to a boolean (cancel/confirm).
+ * With `checkboxLabel` it resolves to `{ ok, checked }` so the caller
+ * can read both the user's confirmation and an opt-in side-effect.
  *
  * Usage:
  *   const ok = await confirmDialog({ title: 'Delete run?', message: '...' });
  *   if (!ok) return;
+ *
+ *   const { ok, checked } = await confirmDialog({
+ *     title: 'Cancel evaluation?', checkboxLabel: 'Discard collected findings',
+ *   });
  */
 const _ALLOWED_VARIANTS = new Set(['default', 'danger']);
 
@@ -16,6 +23,9 @@ export function confirmDialog({
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   variant = 'default', // 'default' | 'danger'
+  checkboxLabel = null,
+  checkboxHint = '',
+  checkboxDefault = false,
 } = {}) {
   return new Promise((resolve) => {
     if (typeof document === 'undefined') {
@@ -39,6 +49,32 @@ export function confirmDialog({
     messageEl.className = 'qd-confirm-message';
     messageEl.textContent = message;
 
+    let checkboxInput = null;
+    if (checkboxLabel) {
+      const wrap = document.createElement('label');
+      wrap.className = 'qd-confirm-checkbox';
+      checkboxInput = document.createElement('input');
+      checkboxInput.type = 'checkbox';
+      checkboxInput.checked = !!checkboxDefault;
+      const labelText = document.createElement('span');
+      labelText.className = 'qd-confirm-checkbox-label';
+      labelText.textContent = checkboxLabel;
+      wrap.appendChild(checkboxInput);
+      wrap.appendChild(labelText);
+      if (checkboxHint) {
+        const hint = document.createElement('span');
+        hint.className = 'qd-confirm-checkbox-hint';
+        hint.textContent = checkboxHint;
+        wrap.appendChild(hint);
+      }
+      dialog.appendChild(titleEl);
+      dialog.appendChild(messageEl);
+      dialog.appendChild(wrap);
+    } else {
+      dialog.appendChild(titleEl);
+      dialog.appendChild(messageEl);
+    }
+
     const actions = document.createElement('div');
     actions.className = 'qd-confirm-actions';
 
@@ -54,15 +90,17 @@ export function confirmDialog({
 
     actions.appendChild(cancelBtn);
     actions.appendChild(confirmBtn);
-    dialog.appendChild(titleEl);
-    dialog.appendChild(messageEl);
     dialog.appendChild(actions);
     overlay.appendChild(dialog);
 
-    function close(result) {
+    function close(ok) {
       overlay.remove();
       document.removeEventListener('keydown', onKey);
-      resolve(result);
+      if (checkboxInput) {
+        resolve({ ok, checked: ok ? checkboxInput.checked : false });
+      } else {
+        resolve(ok);
+      }
     }
     function onKey(e) {
       if (e.key === 'Escape') close(false);

--- a/tests/analysis/test_dim_estimates.py
+++ b/tests/analysis/test_dim_estimates.py
@@ -1,0 +1,196 @@
+"""Tests for quodeq.analysis._dim_estimates — upfront per-dim file estimation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.analysis._dim_estimates import (
+    DIM_ESTIMATES_FILENAME,
+    compute_dim_estimates,
+    read_dim_estimates,
+    write_dim_estimates,
+)
+from quodeq.analysis._incr_change_detection import ChangeDetectionResult
+from quodeq.analysis._types import RunConfig
+from quodeq.analysis.incremental import FileClassification
+
+
+def _make_config(*, incremental: bool = False, file_filter=None) -> RunConfig:
+    """Minimal RunConfig stub. Only fields read by compute_dim_estimates matter."""
+    cfg = RunConfig.__new__(RunConfig)
+    cfg.src = Path("/repo")
+    cfg.standards_dir = None
+    cfg.work_dir = None
+    cfg.language = "python"
+    options = type("O", (), {})()
+    options.incremental = incremental
+    options.incremental_file_filter = file_filter
+    cfg.options = options
+    return cfg
+
+
+class TestComputeDimEstimates:
+    def test_full_run_returns_per_dim_file_count(self) -> None:
+        cfg = _make_config()
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            side_effect=lambda config, dim: {
+                "security": ["a.py", "b.py", "c.py"],
+                "reliability": ["a.py", "b.py"],
+            }[dim],
+        ):
+            estimates = compute_dim_estimates(cfg, ["security", "reliability"])
+        assert estimates == {
+            "security": {"count": 3, "reason": "full"},
+            "reliability": {"count": 2, "reason": "full"},
+        }
+
+    def test_empty_dim_returns_zero_with_empty_reason(self) -> None:
+        cfg = _make_config()
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=[],
+        ):
+            estimates = compute_dim_estimates(cfg, ["security"])
+        assert estimates == {"security": {"count": 0, "reason": "empty"}}
+
+    def test_diff_mode_intersects_filter(self) -> None:
+        cfg = _make_config(file_filter={"a.py", "c.py"})
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=["a.py", "b.py", "c.py", "d.py"],
+        ):
+            estimates = compute_dim_estimates(cfg, ["security"])
+        assert estimates == {"security": {"count": 2, "reason": "diff"}}
+
+    def test_incremental_normal_run(self) -> None:
+        cfg = _make_config(incremental=True)
+        files = ["a.py", "b.py", "c.py", "d.py"]
+        prev_fp = {"file_hashes": {f: "h" for f in files}, "analyzed_files": files}
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=files,
+        ), patch(
+            "quodeq.analysis._dim_estimates.find_previous_fingerprint",
+            return_value=(prev_fp, Path("/prev")),
+        ), patch(
+            "quodeq.analysis._dim_estimates.detect_changed_files",
+            return_value=ChangeDetectionResult(changed={"a.py"}),
+        ), patch(
+            "quodeq.analysis._dim_estimates.classify_files",
+            return_value=FileClassification(to_analyze=["a.py", "b.py"], unchanged={"c.py", "d.py"}),
+        ):
+            estimates = compute_dim_estimates(cfg, ["security"])
+        assert estimates == {"security": {"count": 2, "reason": "incremental"}}
+
+    def test_incremental_first_run_marks_first_run(self) -> None:
+        cfg = _make_config(incremental=True)
+        files = ["a.py", "b.py"]
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=files,
+        ), patch(
+            "quodeq.analysis._dim_estimates.find_previous_fingerprint",
+            return_value=(None, None),
+        ), patch(
+            "quodeq.analysis._dim_estimates.detect_changed_files",
+            return_value=ChangeDetectionResult(full_reanalysis=True, reason="no previous fingerprint"),
+        ), patch(
+            "quodeq.analysis._dim_estimates.classify_files",
+            return_value=FileClassification(to_analyze=files, full_reanalysis=True),
+        ):
+            estimates = compute_dim_estimates(cfg, ["security"])
+        assert estimates == {"security": {"count": 2, "reason": "first-run"}}
+
+    def test_incremental_standards_changed(self) -> None:
+        cfg = _make_config(incremental=True)
+        files = ["a.py", "b.py"]
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=files,
+        ), patch(
+            "quodeq.analysis._dim_estimates.find_previous_fingerprint",
+            return_value=({"file_hashes": {}}, Path("/prev")),
+        ), patch(
+            "quodeq.analysis._dim_estimates.detect_changed_files",
+            return_value=ChangeDetectionResult(full_reanalysis=True, reason="standards changed"),
+        ), patch(
+            "quodeq.analysis._dim_estimates.classify_files",
+            return_value=FileClassification(to_analyze=files, full_reanalysis=True),
+        ):
+            estimates = compute_dim_estimates(cfg, ["security"])
+        assert estimates["security"]["reason"] == "standards-changed"
+
+    def test_incremental_catching_up_when_prior_run_died_early(self) -> None:
+        # Prior run fingerprinted 100 files but only analyzed 20 → < 50%
+        # threshold → marked as catching-up so the UI can flag the inflated
+        # count as catch-up work, not a code growth signal.
+        cfg = _make_config(incremental=True)
+        files = [f"f{i}.py" for i in range(100)]
+        prev_fp = {
+            "file_hashes": {f: "h" for f in files},
+            "analyzed_files": files[:20],
+        }
+        with patch(
+            "quodeq.analysis._dim_estimates._list_all_source_files",
+            return_value=files,
+        ), patch(
+            "quodeq.analysis._dim_estimates.find_previous_fingerprint",
+            return_value=(prev_fp, Path("/prev")),
+        ), patch(
+            "quodeq.analysis._dim_estimates.detect_changed_files",
+            return_value=ChangeDetectionResult(changed=set(files[20:])),
+        ), patch(
+            "quodeq.analysis._dim_estimates.classify_files",
+            return_value=FileClassification(to_analyze=files[20:], unchanged=set(files[:20])),
+        ):
+            estimates = compute_dim_estimates(cfg, ["usability"])
+        assert estimates["usability"]["reason"] == "catching-up"
+        assert estimates["usability"]["count"] == 80
+
+
+class TestPersistence:
+    def test_write_then_read_roundtrip(self, tmp_path: Path) -> None:
+        payload = {
+            "security": {"count": 42, "reason": "incremental"},
+            "usability": {"count": 999, "reason": "catching-up"},
+        }
+        write_dim_estimates(tmp_path, payload)
+        assert read_dim_estimates(tmp_path) == payload
+
+    def test_read_missing_returns_empty(self, tmp_path: Path) -> None:
+        assert read_dim_estimates(tmp_path) == {}
+
+    def test_read_corrupt_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / DIM_ESTIMATES_FILENAME).write_text("not json{", encoding="utf-8")
+        assert read_dim_estimates(tmp_path) == {}
+
+    def test_read_skips_malformed_entries(self, tmp_path: Path) -> None:
+        (tmp_path / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps({
+                "good": {"count": 5, "reason": "incremental"},
+                "missing_count": {"reason": "incremental"},
+                "wrong_count_type": {"count": "oops", "reason": "incremental"},
+                "wrong_value_type": "oops",
+                "legacy_int": 7,
+            }),
+            encoding="utf-8",
+        )
+        # legacy_int is accepted (back-compat); the others are dropped.
+        assert read_dim_estimates(tmp_path) == {
+            "good": {"count": 5, "reason": "incremental"},
+            "legacy_int": {"count": 7, "reason": ""},
+        }
+
+    def test_read_non_dict_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps([1, 2, 3]), encoding="utf-8",
+        )
+        assert read_dim_estimates(tmp_path) == {}
+
+    def test_read_defaults_missing_reason_to_empty_string(self, tmp_path: Path) -> None:
+        (tmp_path / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps({"security": {"count": 5}}), encoding="utf-8",
+        )
+        assert read_dim_estimates(tmp_path) == {"security": {"count": 5, "reason": ""}}

--- a/tests/analysis/test_pool_budget_autoscale.py
+++ b/tests/analysis/test_pool_budget_autoscale.py
@@ -1,0 +1,56 @@
+"""Tests for the pool-budget auto-scaling helper.
+
+The fixed 600s default pool budget chokes on dim queues with hundreds of
+files (observed throughput ≈ 7-12 s/file with 8 agents). When that
+happens, surviving pending files keep haunting the next run via the
+not_analyzed sweep and the dim never converges. The auto-scaler treats
+the user's ``pool_budget`` as a floor and extends it to give each file a
+fair slice of wallclock time, capped at a hard upper bound.
+"""
+from __future__ import annotations
+
+from quodeq.analysis.subagents._pool_launcher import (
+    _MAX_AUTO_POOL_BUDGET,
+    _SECONDS_PER_FILE_AUTOSCALE,
+    _UNLIMITED_BUDGET,
+    _resolve_pool_budget,
+)
+from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+
+
+class TestResolvePoolBudget:
+    def test_small_queue_uses_user_budget_as_floor(self) -> None:
+        # 30 files × 12 s/file = 360s, which is below the default 600s
+        # floor → return the floor unchanged.
+        assert _resolve_pool_budget(None, 30) == _DEFAULT_POOL_BUDGET
+
+    def test_large_queue_extends_budget(self) -> None:
+        # 800 files × 12 s/file = 9600s, capped at 7200s (2h).
+        assert _resolve_pool_budget(None, 800) == _MAX_AUTO_POOL_BUDGET
+
+    def test_medium_queue_scales_proportionally(self) -> None:
+        # 200 files × 12 s/file = 2400s, above the 600s floor and below
+        # the 7200s ceiling → return the proportional value.
+        assert _resolve_pool_budget(None, 200) == 200 * _SECONDS_PER_FILE_AUTOSCALE
+
+    def test_explicit_user_budget_is_floor_not_cap(self) -> None:
+        # User wants at least 1800s; queue would only need 600s → keep 1800.
+        assert _resolve_pool_budget(1800, 30) == 1800
+        # User wants 1800s but queue needs 3600s → extend to 3600.
+        assert _resolve_pool_budget(1800, 300) == 300 * _SECONDS_PER_FILE_AUTOSCALE
+
+    def test_unlimited_budget_is_preserved(self) -> None:
+        # pool_budget=0 means "no cap"; auto-scaling must not turn that
+        # into a finite number, otherwise we'd silently cap users who
+        # asked for unlimited.
+        assert _resolve_pool_budget(_UNLIMITED_BUDGET, 30) == _UNLIMITED_BUDGET
+        assert _resolve_pool_budget(_UNLIMITED_BUDGET, 10000) == _UNLIMITED_BUDGET
+
+    def test_zero_or_negative_queue_returns_base(self) -> None:
+        # Defensive: an empty file list shouldn't produce a 0-second budget.
+        assert _resolve_pool_budget(None, 0) == _DEFAULT_POOL_BUDGET
+        assert _resolve_pool_budget(900, 0) == 900
+
+    def test_runaway_queue_capped_at_max(self) -> None:
+        assert _resolve_pool_budget(None, 100_000) == _MAX_AUTO_POOL_BUDGET
+        assert _resolve_pool_budget(900, 100_000) == _MAX_AUTO_POOL_BUDGET

--- a/tests/engine/test_fingerprint.py
+++ b/tests/engine/test_fingerprint.py
@@ -116,3 +116,136 @@ class TestFindPreviousFingerprint:
         assert fp is not None
         assert fp["file_hashes"]["a.py"] == "abc123"
         assert prev_dir == prev_evidence
+
+    @patch("quodeq.analysis.fingerprint.list_runs")
+    def test_accepts_run_without_evaluation_report(self, mock_list_runs, tmp_path):
+        """Crashed/cancelled runs without evaluation/{dim}.json should still
+        be honoured — the fingerprint they wrote at queue creation is enough
+        to anchor the next run's classifier.
+        """
+        from quodeq.data.fs.report_parser.runs import RunInfo
+
+        reports = tmp_path / "reports"
+        proj = reports / "proj-uuid"
+        prev_run = proj / "run-cancelled"
+        prev_evidence = prev_run / "evidence"
+        prev_evidence.mkdir(parents=True)
+        prev_fp = {
+            "dimension": "usability",
+            "file_hashes": {"a.py": "h1", "b.py": "h2"},
+            "analyzed_files": ["a.py"],
+        }
+        (prev_evidence / "usability_fingerprint.json").write_text(json.dumps(prev_fp))
+        # Note: NO evaluation/usability.json — run never finalised.
+
+        current_evidence = proj / "run-current" / "evidence"
+        current_evidence.mkdir(parents=True)
+        mock_list_runs.return_value = [
+            RunInfo(run_id="run-current", date_iso="2026-03-24T12:00:00Z", date_label=""),
+            RunInfo(run_id="run-cancelled", date_iso="2026-03-24T11:00:00Z", date_label=""),
+        ]
+
+        fp, prev_dir = find_previous_fingerprint(current_evidence, "usability")
+        assert fp is not None
+        assert fp["file_hashes"] == {"a.py": "h1", "b.py": "h2"}
+        assert prev_dir == prev_evidence
+
+    @patch("quodeq.analysis.fingerprint.list_runs")
+    def test_merges_queue_taken_into_analyzed_files(self, mock_list_runs, tmp_path):
+        """Salvage path: when the previous run was cancelled mid-flight, its
+        fingerprint's `analyzed_files` is stale (whatever the START state was).
+        The queue's taken list reflects the actual work done. Merging the two
+        breaks the catch-up loop where every run re-sweeps the same files.
+        """
+        from quodeq.data.fs.report_parser.runs import RunInfo
+
+        reports = tmp_path / "reports"
+        proj = reports / "proj-uuid"
+        prev_run = proj / "run-cancelled"
+        prev_evidence = prev_run / "evidence"
+        prev_evidence.mkdir(parents=True)
+        # Fingerprint snapshot from queue creation: 1 file from prior run.
+        prev_fp = {
+            "dimension": "usability",
+            "file_hashes": {f: "h" for f in ["a.py", "b.py", "c.py", "d.py"]},
+            "analyzed_files": ["a.py"],
+        }
+        (prev_evidence / "usability_fingerprint.json").write_text(json.dumps(prev_fp))
+        # Queue records that agents took 3 more files before the crash.
+        queue = {
+            "taken": [
+                {"files": ["b.py", "c.py"], "agent": "a1", "ts": 1},
+                {"files": ["d.py"], "agent": "a2", "ts": 2},
+            ],
+            "pending": [],
+        }
+        (prev_evidence / "usability_queue.json").write_text(json.dumps(queue))
+
+        current_evidence = proj / "run-current" / "evidence"
+        current_evidence.mkdir(parents=True)
+        mock_list_runs.return_value = [
+            RunInfo(run_id="run-current", date_iso="2026-03-24T12:00:00Z", date_label=""),
+            RunInfo(run_id="run-cancelled", date_iso="2026-03-24T11:00:00Z", date_label=""),
+        ]
+
+        fp, _ = find_previous_fingerprint(current_evidence, "usability")
+        assert fp is not None
+        assert sorted(fp["analyzed_files"]) == ["a.py", "b.py", "c.py", "d.py"]
+
+    @patch("quodeq.analysis.fingerprint.list_runs")
+    def test_queue_merge_is_noop_for_finalized_runs(self, mock_list_runs, tmp_path):
+        """A cleanly-finalised run already has queue.taken folded into
+        analyzed_files; the salvage merge must not duplicate or perturb it.
+        """
+        from quodeq.data.fs.report_parser.runs import RunInfo
+
+        reports = tmp_path / "reports"
+        proj = reports / "proj-uuid"
+        prev_run = proj / "run-old"
+        prev_evidence = prev_run / "evidence"
+        prev_evidence.mkdir(parents=True)
+        prev_fp = {
+            "dimension": "security",
+            "file_hashes": {"a.py": "h"},
+            "analyzed_files": ["a.py", "b.py"],
+        }
+        (prev_evidence / "security_fingerprint.json").write_text(json.dumps(prev_fp))
+        # Queue agrees with fingerprint — typical post-finalisation state.
+        queue = {"taken": [{"files": ["a.py", "b.py"], "agent": "a1", "ts": 1}], "pending": []}
+        (prev_evidence / "security_queue.json").write_text(json.dumps(queue))
+
+        current_evidence = proj / "run-current" / "evidence"
+        current_evidence.mkdir(parents=True)
+        mock_list_runs.return_value = [
+            RunInfo(run_id="run-current", date_iso="2026-03-24T12:00:00Z", date_label=""),
+            RunInfo(run_id="run-old", date_iso="2026-03-24T11:00:00Z", date_label=""),
+        ]
+
+        fp, _ = find_previous_fingerprint(current_evidence, "security")
+        assert fp is not None
+        assert sorted(fp["analyzed_files"]) == ["a.py", "b.py"]
+
+    @patch("quodeq.analysis.fingerprint.list_runs")
+    def test_corrupt_queue_is_ignored(self, mock_list_runs, tmp_path):
+        """Bad JSON in queue.json must not break the lookup."""
+        from quodeq.data.fs.report_parser.runs import RunInfo
+
+        reports = tmp_path / "reports"
+        proj = reports / "proj-uuid"
+        prev_run = proj / "run-old"
+        prev_evidence = prev_run / "evidence"
+        prev_evidence.mkdir(parents=True)
+        prev_fp = {"dimension": "security", "file_hashes": {}, "analyzed_files": ["a.py"]}
+        (prev_evidence / "security_fingerprint.json").write_text(json.dumps(prev_fp))
+        (prev_evidence / "security_queue.json").write_text("{not json")
+
+        current_evidence = proj / "run-current" / "evidence"
+        current_evidence.mkdir(parents=True)
+        mock_list_runs.return_value = [
+            RunInfo(run_id="run-current", date_iso="2026-03-24T12:00:00Z", date_label=""),
+            RunInfo(run_id="run-old", date_iso="2026-03-24T11:00:00Z", date_label=""),
+        ]
+
+        fp, _ = find_previous_fingerprint(current_evidence, "security")
+        assert fp is not None
+        assert fp["analyzed_files"] == ["a.py"]

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -16,6 +16,7 @@ from quodeq.services.evaluation_mixin import (
     FsEvaluationMixin,
     SubprocessDispatcher,
     _build_evaluate_cmd,
+    _discard_partial_dim_state,
     _register_project,
     _score_completed_evidence,
 )
@@ -309,6 +310,96 @@ class TestCancelEvaluation:
         assert call_args.args[0] == "/reports"
         assert call_args.args[1]["outputProject"] == "proj-uuid"
         assert call_args.args[1]["outputRunId"] == "run-42"
+
+
+class TestCancelDiscardPartial:
+    def test_discard_default_off_does_not_clean(self):
+        # Cancel without discard_partial=True must not touch any files.
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        m._jobs.get_job.return_value = JobSnapshot(
+            job_id="j1", status="running",
+            output_project="proj", output_run_id="run1",
+        )
+        with patch("quodeq.services.evaluation_mixin._score_completed_evidence"), \
+             patch("quodeq.services.evaluation_mixin._discard_partial_dim_state") as mock_discard:
+            m.cancel_evaluation("j1", reports_dir="/reports")
+        mock_discard.assert_not_called()
+
+    def test_discard_true_invokes_cleanup(self):
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        m._jobs.get_job.return_value = JobSnapshot(
+            job_id="j1", status="running",
+            output_project="proj", output_run_id="run1",
+        )
+        with patch("quodeq.services.evaluation_mixin._score_completed_evidence"), \
+             patch("quodeq.services.evaluation_mixin._discard_partial_dim_state") as mock_discard:
+            m.cancel_evaluation("j1", reports_dir="/reports", discard_partial=True)
+        mock_discard.assert_called_once()
+        args = mock_discard.call_args.args
+        assert args[0] == "/reports"
+        assert args[1]["outputProject"] == "proj"
+        assert args[1]["outputRunId"] == "run1"
+
+
+class TestDiscardPartialDimState:
+    def _make_run(self, tmp_path: Path, *, dims: list[str], scored: list[str]) -> Path:
+        evidence = tmp_path / "reports" / "proj" / "run1" / "evidence"
+        evaluation = tmp_path / "reports" / "proj" / "run1" / "evaluation"
+        evidence.mkdir(parents=True)
+        evaluation.mkdir(parents=True)
+        for dim in dims:
+            (evidence / f"{dim}_queue.json").write_text("{}")
+            (evidence / f"{dim}_fingerprint.json").write_text("{}")
+        for dim in scored:
+            (evaluation / f"{dim}.json").write_text("{}")
+        return tmp_path / "reports"
+
+    def test_wipes_only_unscored_dim_state(self, tmp_path: Path):
+        # security finished (has eval/security.json) — must be preserved.
+        # usability is in-flight — its queue + fingerprint must be wiped.
+        reports = self._make_run(
+            tmp_path, dims=["security", "usability"], scored=["security"],
+        )
+        _discard_partial_dim_state(
+            str(reports), {"outputProject": "proj", "outputRunId": "run1"},
+        )
+        evidence = reports / "proj" / "run1" / "evidence"
+        assert (evidence / "security_queue.json").exists()
+        assert (evidence / "security_fingerprint.json").exists()
+        assert not (evidence / "usability_queue.json").exists()
+        assert not (evidence / "usability_fingerprint.json").exists()
+
+    def test_no_evaluation_dir_wipes_everything(self, tmp_path: Path):
+        # Run cancelled before any dim could finalise — every queue/fingerprint
+        # is in-flight and gets wiped.
+        evidence = tmp_path / "reports" / "proj" / "run1" / "evidence"
+        evidence.mkdir(parents=True)
+        (evidence / "security_queue.json").write_text("{}")
+        (evidence / "security_fingerprint.json").write_text("{}")
+        (evidence / "usability_queue.json").write_text("{}")
+        (evidence / "usability_fingerprint.json").write_text("{}")
+
+        _discard_partial_dim_state(
+            str(tmp_path / "reports"),
+            {"outputProject": "proj", "outputRunId": "run1"},
+        )
+        assert list(evidence.iterdir()) == []
+
+    def test_missing_evidence_dir_is_silent(self, tmp_path: Path):
+        # A truly empty run dir shouldn't raise.
+        _discard_partial_dim_state(
+            str(tmp_path),
+            {"outputProject": "ghost", "outputRunId": "ghost"},
+        )
+
+    def test_missing_project_or_run_id_is_silent(self, tmp_path: Path):
+        # Defensive: a malformed job dict should noop, not throw.
+        _discard_partial_dim_state(str(tmp_path), {})
+        _discard_partial_dim_state(str(tmp_path), {"outputProject": "p"})
 
 
 class TestScoreFailedEvaluation:

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -1,0 +1,135 @@
+"""Tests for quodeq.services.scan_progress — live progress reader.
+
+Focus: the per-dim total resolution path. Pending dims should prefer the
+precomputed dim_estimates.json over the project-wide scan.json fallback.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.services.scan_progress import build_scan_progress
+
+
+def _write_status(run_dir: Path, *, dimensions: list[str], state: str = "running",
+                  current_dimension: str | None = None) -> None:
+    status = {
+        "schema_version": 1,
+        "job_id": "j1",
+        "state": state,
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "dimensions": dimensions,
+        "phase": "analyzing",
+        "current_dimension": current_dimension,
+    }
+    (run_dir / "status.json").write_text(json.dumps(status), encoding="utf-8")
+
+
+def _make_run(tmp_path: Path) -> Path:
+    """Create a project_dir / run_dir layout with the directories the reader expects."""
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "run-1"
+    (run_dir / "evidence").mkdir(parents=True)
+    return run_dir
+
+
+class TestPendingDimTotals:
+    def test_pending_dim_uses_precomputed_estimate(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security", "reliability"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({
+                "security": {"count": 827, "reason": "incremental"},
+                "reliability": {"count": 412, "reason": "catching-up"},
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        totals = {d.id: d.files["total"] for d in progress.dimensions}
+        reasons = {d.id: d.estimate_reason for d in progress.dimensions}
+        assert totals == {"security": 827, "reliability": 412}
+        assert reasons == {"security": "incremental", "reliability": "catching-up"}
+
+    def test_legacy_int_estimate_format_still_read(self, tmp_path: Path) -> None:
+        # Pre-reason runs persisted bare ints. Reader must still surface the
+        # count so the header total stays accurate; reason is empty.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": 270}), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.dimensions[0].files["total"] == 270
+        assert progress.dimensions[0].estimate_reason == ""
+
+    def test_pending_dim_reports_zero_when_no_estimate_available(self, tmp_path: Path) -> None:
+        # Without dim_estimates.json, pending dims report total=0. The UI
+        # treats that as "estimates not ready yet" and stays in preparing…
+        # rather than printing a misleading project-wide ceiling.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir.parent / "scan.json").write_text(
+            json.dumps({"total_files": 1682}), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.dimensions[0].files["total"] == 0
+
+    def test_running_dim_uses_queue_total_not_estimate(self, tmp_path: Path) -> None:
+        # Once a queue exists, the actual queue size wins — the estimate was
+        # only ever a placeholder for "before the dim ran".
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], current_dimension="security")
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 999, "reason": "incremental"}}),
+            encoding="utf-8",
+        )
+        # Queue says actual = 50 files (3 taken + 47 pending).
+        queue_payload = {
+            "taken": [{"files": ["a.py", "b.py", "c.py"], "agent": "a1", "ts": 1}],
+            "pending": [f"f{i}.py" for i in range(47)],
+        }
+        (run_dir / "evidence" / "security_queue.json").write_text(
+            json.dumps(queue_payload), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.state == "running"
+        assert dim.files == {"taken": 3, "total": 50}
+
+    def test_estimate_zero_is_distinct_from_missing(self, tmp_path: Path) -> None:
+        # An explicit 0 in dim_estimates means "this dim has no work" —
+        # don't fall through to project_files.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 0, "reason": "empty"}}),
+            encoding="utf-8",
+        )
+        (run_dir.parent / "scan.json").write_text(
+            json.dumps({"total_files": 1682}), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.dimensions[0].files["total"] == 0
+
+    def test_corrupt_dim_estimates_does_not_break_reader(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text("{not json", encoding="utf-8")
+        (run_dir.parent / "scan.json").write_text(
+            json.dumps({"total_files": 100}), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        # Corrupt estimates → empty dict → pending dim reports 0 (preparing…).
+        assert progress.dimensions[0].files["total"] == 0


### PR DESCRIPTION
## Summary

Five linked fixes for the scan-progress UX and incremental-run convergence problem we hit on dims with large queues (usability, flexibility):

- **Per-dim file estimates** computed before any dim runs, persisted to `dim_estimates.json`. The dashboard sums these for an accurate run total from t=0 instead of letting the header drift as each dim reveals its post-filter count. Each estimate carries a reason (`incremental`, `catching-up`, `first-run`, `standards-changed`, etc.) which the UI surfaces as a small badge.
- **Header rule relaxed**: shows `preparing…` only when nothing is known yet. Once any dim is running, the header reflects what we know rather than contradicting an obviously-running run.
- **Pool budget auto-scales** with queue size (12 s/file, capped at 2 h). The fixed 600s default was killing every dim with more than ~80 files in its queue, leaving 700+ files pending → next run swept them all back via `not_analyzed` → loop forever. User's `pool_budget` is treated as a floor; `pool_budget=0` (unlimited) preserved verbatim.
- **Crash/cancel salvage**: write an initial fingerprint at queue creation, and have `find_previous_fingerprint` (a) drop the eval-report requirement so cancelled/crashed runs are still consulted, (b) merge `<dim>_queue.json`'s taken set into `analyzed_files` on read. The FileQueue updates queue.json continuously, so a crash, OOM, or manual cancel preserves whatever work was done.
- **Cancel modal** gets an opt-in `Discard collected findings` checkbox. Default cancel keeps work; checked = wipe `<dim>_queue.json` + `<dim>_fingerprint.json` for unfinished dims so the next run starts fresh. Completed dims (with `evaluation/<dim>.json`) are always preserved.

Together (3) and (4) break the catch-up loop where dims like usability/flexibility keep re-sweeping the same 700+ files because their previous run died at the 10-min budget cap before finalising.

## Test plan

- [x] `uv run pytest tests/analysis tests/services tests/engine tests/api` — 1532 passed
- [x] `node --test src/features/evaluation/components/scanProgressTotals.test.js` — 21 passed
- [x] Manual: kick off a fresh run, verify the per-dim header total stays stable from `phase: analyzing` onward (no more jumps as new dims start)
- [x] Manual: cancel a run mid-usability, start another — verify usability's estimate drops dramatically (catch-up loop broken)
- [x] Manual: cancel a run with the new `Discard collected findings` checkbox checked — verify the next run estimates a full rescan for the discarded dims and preserves the scored ones

## Migration / compat notes

- `dim_estimates.json` is new; the reader handles both the new `{count, reason}` shape and a legacy bare-int shape (no migration needed for in-flight runs).
- Pool budget default behaviour changes: a user-set `pool_budget` is now a floor instead of a hard cap. `pool_budget=0` still means unlimited.
- `find_previous_fingerprint` now merges `queue.taken` into `analyzed_files` automatically. For finalised runs this is a no-op (queue.taken ⊆ analyzed_files).