### PR TITLE
Split prompt hash so non-rules edits don't invalidate carry-forward

### DIFF
--- a/src/quodeq/analysis/_incr_change_detection.py
+++ b/src/quodeq/analysis/_incr_change_detection.py
@@ -5,7 +5,13 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from quodeq.analysis.fingerprint import _hash_file, _hash_prompts, _hash_standards
+from quodeq.analysis.fingerprint import (
+    _RULES_BEARING_PROMPTS,
+    _hash_file,
+    _hash_prompts,
+    _hash_prompts_map,
+    _hash_standards,
+)
 
 _GIT_DIFF_TIMEOUT_S = 10
 
@@ -59,9 +65,27 @@ def detect_changed_files(
 
     prev_prompts = prev_fingerprint.get("prompts_checksum")
     if prev_prompts is not None:
-        current_prompts = _hash_prompts()
-        if current_prompts != prev_prompts:
-            return ChangeDetectionResult(full_reanalysis=True, reason="prompts changed")
+        # New format: per-file dict. Only rules-bearing prompts (those that
+        # define what counts as a violation) trigger full re-analysis.
+        # Framing or runner-specific instruction changes flow into the next
+        # run's prompt naturally without invalidating prior carry-forward.
+        if isinstance(prev_prompts, dict):
+            current_prompts_map = _hash_prompts_map()
+            for fname in _RULES_BEARING_PROMPTS:
+                if prev_prompts.get(fname) != current_prompts_map.get(fname):
+                    return ChangeDetectionResult(
+                        full_reanalysis=True, reason=f"prompts changed ({fname})",
+                    )
+        else:
+            # Legacy single-string format: any change to any prompt
+            # triggers, matching pre-split behavior. Once this dim runs
+            # again under the new code, its fingerprint upgrades to the
+            # selective per-file format.
+            current_prompts = _hash_prompts()
+            if current_prompts != prev_prompts:
+                return ChangeDetectionResult(
+                    full_reanalysis=True, reason="prompts changed (legacy)",
+                )
 
     prev_commit = prev_fingerprint.get("git_commit")
     file_set = set(files)

--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -63,14 +63,40 @@ def _hash_standards(standards_dir: Path, dimension: str) -> str | None:
     return _hash_file(compiled)
 
 
-def _hash_prompts(prompts_dir: Path | None = None) -> str | None:
-    """SHA-256 over the concatenated *.md prompt files in *prompts_dir*.
+# Prompts in this set, when changed, force a full re-analysis because they
+# carry the rules that classify a finding (what counts as a violation, what
+# doesn't). Other prompt files are framing/scaffolding — a change to those
+# still flows into the next run's prompts naturally, but doesn't invalidate
+# carry-forward findings produced under the same rules.
+_RULES_BEARING_PROMPTS: frozenset[str] = frozenset({"evaluation_rules.md"})
 
-    A change to any prompt template (notably ``evaluation_rules.md``) shifts
-    LLM behavior even when source files and standards are byte-identical.
-    Mixing the prompt directory's content into the fingerprint forces
-    re-analysis after a prompt update — otherwise carry-forward keeps
-    serving findings produced under the old rules.
+
+def _hash_prompts_map(prompts_dir: Path | None = None) -> dict[str, str]:
+    """Per-file SHA-256 of every *.md prompt under *prompts_dir*.
+
+    Stored in fingerprints so future runs can decide selectively whether a
+    prompt change is the kind that should invalidate carry-forward (a
+    rules-bearing file in ``_RULES_BEARING_PROMPTS``) versus the kind that
+    shouldn't (framing, runner-specific instructions).
+    """
+    if prompts_dir is None:
+        prompts_dir = default_paths().prompts_dir
+    if prompts_dir is None or not prompts_dir.is_dir():
+        return {}
+    out: dict[str, str] = {}
+    for path in sorted(prompts_dir.glob("*.md")):
+        h = _hash_file(path)
+        if h:
+            out[path.name] = h
+    return out
+
+
+def _hash_prompts(prompts_dir: Path | None = None) -> str | None:
+    """Legacy single-string hash of all prompts concatenated.
+
+    Retained so fingerprints written before the per-file split can still
+    be compared against the current prompt state (back-compat read path).
+    New fingerprints use ``_hash_prompts_map``.
     """
     if prompts_dir is None:
         prompts_dir = default_paths().prompts_dir
@@ -93,12 +119,14 @@ def build_fingerprint(src: Path, files: list[str], dimension: str, standards_dir
         h = _hash_file(src / f)
         if h:
             file_hashes[f] = h
+    prompts_map = _hash_prompts_map() or None
     return {
         "dimension": dimension,
         "git_commit": _get_git_commit(src),
         "file_hashes": file_hashes,
         "standards_checksum": _hash_standards(standards_dir, dimension) if standards_dir else None,
-        "prompts_checksum": _hash_prompts(),
+        # Per-file map; readers handle the legacy single-string format too.
+        "prompts_checksum": prompts_map,
         "analyzed_files": sorted(analyzed_files) if analyzed_files else [],
         "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
     }

--- a/tests/engine/test_incremental.py
+++ b/tests/engine/test_incremental.py
@@ -57,6 +57,93 @@ class TestDetectChangedFiles:
         assert result.full_reanalysis is False
 
 
+class TestDetectPromptsChanged:
+    """Selective prompt invalidation: only rules-bearing files trigger
+    full re-analysis. Framing/runner-prompt changes carry forward.
+    """
+
+    def _make_fingerprint(self, prompts_checksum):
+        return {
+            "dimension": "security",
+            "git_commit": "abc",
+            "file_hashes": {},
+            "standards_checksum": None,
+            "prompts_checksum": prompts_checksum,
+            "timestamp": "2026-01-01",
+        }
+
+    def test_rules_file_change_triggers_full(self, tmp_path, monkeypatch):
+        # evaluation_rules.md is the rules-bearing file → any change
+        # invalidates carry-forward.
+        from quodeq.analysis import _incr_change_detection as mod
+        monkeypatch.setattr(mod, "_hash_prompts_map", lambda: {
+            "evaluation_rules.md": "NEW",
+            "api_prompt.md": "same",
+        })
+        prev = self._make_fingerprint({
+            "evaluation_rules.md": "OLD",
+            "api_prompt.md": "same",
+        })
+        result = detect_changed_files(
+            src=tmp_path, files=[], prev_fingerprint=prev,
+            standards_dir=None, dimension="security",
+        )
+        assert result.full_reanalysis is True
+        assert "evaluation_rules.md" in result.reason
+
+    def test_non_rules_file_change_does_not_trigger(self, tmp_path, monkeypatch):
+        # api_prompt.md is framing — a change shouldn't force full re-analysis,
+        # so prior findings carry forward.
+        from quodeq.analysis import _incr_change_detection as mod
+        monkeypatch.setattr(mod, "_hash_prompts_map", lambda: {
+            "evaluation_rules.md": "same",
+            "api_prompt.md": "NEW",
+            "cli_subagent_prompt.md": "NEW",
+        })
+        prev = self._make_fingerprint({
+            "evaluation_rules.md": "same",
+            "api_prompt.md": "OLD",
+            "cli_subagent_prompt.md": "OLD",
+        })
+        result = detect_changed_files(
+            src=tmp_path, files=[], prev_fingerprint=prev,
+            standards_dir=None, dimension="security",
+        )
+        assert result.full_reanalysis is False
+
+    def test_legacy_string_format_still_triggers(self, tmp_path, monkeypatch):
+        # Pre-split fingerprints stored a single concatenated hash. The reader
+        # falls back to comparing legacy hashes to keep the conservative
+        # behavior until the next run upgrades the fingerprint format.
+        from quodeq.analysis import _incr_change_detection as mod
+        monkeypatch.setattr(mod, "_hash_prompts", lambda: "NEW_LEGACY_HASH")
+        prev = self._make_fingerprint("OLD_LEGACY_HASH")
+        result = detect_changed_files(
+            src=tmp_path, files=[], prev_fingerprint=prev,
+            standards_dir=None, dimension="security",
+        )
+        assert result.full_reanalysis is True
+        assert "legacy" in result.reason
+
+    def test_legacy_string_format_unchanged_does_not_trigger(self, tmp_path, monkeypatch):
+        from quodeq.analysis import _incr_change_detection as mod
+        monkeypatch.setattr(mod, "_hash_prompts", lambda: "SAME_HASH")
+        prev = self._make_fingerprint("SAME_HASH")
+        result = detect_changed_files(
+            src=tmp_path, files=[], prev_fingerprint=prev,
+            standards_dir=None, dimension="security",
+        )
+        assert result.full_reanalysis is False
+
+    def test_missing_prompts_checksum_does_not_trigger(self, tmp_path):
+        prev = self._make_fingerprint(None)
+        result = detect_changed_files(
+            src=tmp_path, files=[], prev_fingerprint=prev,
+            standards_dir=None, dimension="security",
+        )
+        assert result.full_reanalysis is False
+
+
 class TestFindDependents:
     def test_finds_files_that_import_changed_file(self, tmp_path):
         (tmp_path / "auth.py").write_text("")


### PR DESCRIPTION
## Summary

Today every \`*.md\` file under \`prompts/\` contributes to a single concatenated \`prompts_checksum\`. Any byte change to any prompt — even a runner-only tweak like the trailing example collapse in #305 — invalidates every dim's fingerprint and forces a full re-analysis on the next run. Combined with the autoscale + salvage in #306 that's now a survivable but painful multi-hour restart.

This PR splits the hashing model:
- \`prompts_checksum\` is now a per-file map: \`{filename: hash, ...}\`.
- Only files in \`_RULES_BEARING_PROMPTS = {"evaluation_rules.md"}\` invalidate carry-forward when they change. That's the one file whose contents define *what counts as a violation* — the others are framing or runner-specific scaffolding that flows into the next run's prompt naturally without making prior findings stale.

## Motivation

#305 modified two prompt files: \`evaluation_rules.md\` (added new \"NOT a violation\" cases — substantive rules change) and \`api_prompt.md\` (collapsed trailing example — pure framing). With today's binary hash, both had to invalidate; with this PR, only the rules change would have. A future runner-only tweak won't trigger the catch-up loop at all.

## Backward compatibility

Pre-split fingerprints store \`prompts_checksum\` as a single concatenated string. The reader detects the legacy format and falls back to the conservative full-hash comparison — same behavior as before — until that fingerprint's run executes again and upgrades to the new dict format.

## Test plan

- [x] \`uv run pytest tests/analysis tests/services tests/engine tests/api\` — 1537 passed (5 new)
- [x] Manual: complete a normal run (this writes new dict-format fingerprints), then push a PR that touches only \`api_prompt.md\` or one of the \`cli_*\` prompts, then start a new run — verify no \"prompts changed\" full reanalysis fires
- [x] Manual: same setup but touch \`evaluation_rules.md\` — verify full reanalysis still fires (rules-bearing file)