### PR TITLE
Per-run resource sampler — RSS / FDs / threads / ollama every 60s

### DIFF
--- a/src/quodeq/shared/resource_sampler.py
+++ b/src/quodeq/shared/resource_sampler.py
@@ -1,0 +1,134 @@
+"""Periodic resource snapshots written to the run log.
+
+The run process has died silently in the field at sustained load — no
+stack trace, no crash report, no jetsam entry, just a clean stop on the
+heartbeat thread at the same instant Ollama saw all sockets close. With
+no in-process trail it's impossible to tell whether the death was OOM,
+FD exhaustion, segfault, or external SIGKILL.
+
+This sampler runs alongside the heartbeat and writes one line per
+interval to the run log, capturing the obvious dimensions:
+
+    [resources] elapsed=12m05s rss=523MB threads=11 fds=87 ollama=15384MB
+
+The next death gives us the trajectory of those numbers leading up to
+the silence. No new dependencies — uses ``ps`` and stdlib only.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+import time
+
+from quodeq.shared.logging import log_info
+
+_DEFAULT_INTERVAL_S = 60.0
+_PS_TIMEOUT_S = 2.0
+_KB_PER_MB = 1024
+_UNKNOWN = -1
+
+
+def _self_rss_mb() -> int:
+    """Resident set size of the current process in MB. Returns -1 on failure."""
+    return _ps_rss_mb(os.getpid())
+
+
+def _ollama_rss_mb() -> int:
+    """RSS of the first ``ollama`` process (if any) in MB. 0 if not running."""
+    try:
+        out = subprocess.run(
+            ["pgrep", "-x", "ollama"], capture_output=True, text=True,
+            timeout=_PS_TIMEOUT_S, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return _UNKNOWN
+    if out.returncode != 0:
+        return 0  # ollama not running — explicit zero, not unknown
+    pids = [p for p in out.stdout.split() if p.isdigit()]
+    if not pids:
+        return 0
+    return _ps_rss_mb(int(pids[0]))
+
+
+def _ps_rss_mb(pid: int) -> int:
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)], capture_output=True, text=True,
+            timeout=_PS_TIMEOUT_S, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return _UNKNOWN
+    raw = out.stdout.strip()
+    if not raw.isdigit():
+        return _UNKNOWN
+    return int(raw) // _KB_PER_MB
+
+
+def _fd_count() -> int:
+    """Open file descriptor count for this process. Returns -1 on failure."""
+    for path in (f"/proc/{os.getpid()}/fd", "/dev/fd"):
+        try:
+            return len(os.listdir(path))
+        except OSError:
+            continue
+    return _UNKNOWN
+
+
+def _format(elapsed_s: float, rss_mb: int, threads: int, fds: int, ollama_mb: int) -> str:
+    mins, secs = divmod(int(elapsed_s), 60)
+    return (
+        f"[resources] elapsed={mins}m{secs:02d}s "
+        f"rss={rss_mb}MB threads={threads} fds={fds} ollama={ollama_mb}MB"
+    )
+
+
+class ResourceSampler:
+    """Background thread that logs a resource snapshot every *interval*.
+
+    Daemon thread so a hard-kill of the process doesn't block exit. The
+    sampler is best-effort: any error inside the loop is swallowed, never
+    raised, and the next tick tries again.
+    """
+
+    def __init__(self, *, interval_s: float = _DEFAULT_INTERVAL_S) -> None:
+        self._interval = interval_s
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started_at: float | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return  # idempotent
+        self._stop.clear()
+        self._started_at = time.monotonic()
+        self._thread = threading.Thread(
+            target=self._loop, name="quodeq-resource-sampler", daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, *, timeout: float = 2.0) -> None:
+        self._stop.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+        self._thread = None
+
+    def sample_once(self) -> str:
+        """Compute and return a snapshot line without logging it. Useful for tests."""
+        elapsed = time.monotonic() - (self._started_at or time.monotonic())
+        return _format(
+            elapsed,
+            _self_rss_mb(),
+            threading.active_count(),
+            _fd_count(),
+            _ollama_rss_mb(),
+        )
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                log_info(self.sample_once())
+            except (OSError, ValueError):
+                pass  # best-effort: never let observability kill the run
+            self._stop.wait(self._interval)

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -25,6 +25,7 @@ from types import TracebackType
 from typing import Any
 
 from quodeq.shared import cancellation
+from quodeq.shared.resource_sampler import ResourceSampler
 from quodeq.shared.run_heartbeat import HeartbeatThread
 from quodeq.shared.run_status import (
     RunState,
@@ -65,6 +66,7 @@ class RunLifecycleContext:
         self._phase: str | None = None
         self._current_dimension: str | None = None
         self._heartbeat = HeartbeatThread(run_dir, interval=heartbeat_interval)
+        self._resources = ResourceSampler()
         self._previous_handlers: dict[int, Any] = {}
         self._atexit_registered = False
 
@@ -78,6 +80,7 @@ class RunLifecycleContext:
         self._atexit_registered = True
         self._transition(RunState.RUNNING)
         self._heartbeat.start()
+        self._resources.start()
         return self
 
     def __exit__(
@@ -87,6 +90,7 @@ class RunLifecycleContext:
         traceback: TracebackType | None,
     ) -> bool:
         self._heartbeat.stop()
+        self._resources.stop()
         if exc_type is None:
             # No exception — pipeline is expected to have transitioned to finalizing.
             if self._current_state not in TERMINAL_STATES:
@@ -158,6 +162,7 @@ class RunLifecycleContext:
             cancellation.request_cancel()
             # Avoid using the transition-validating path — we may be mid-state.
             self._heartbeat.stop()
+            self._resources.stop()
             write_status(
                 self._run_dir,
                 state=RunState.CANCELLED,
@@ -196,6 +201,7 @@ class RunLifecycleContext:
             return
         # We exited without a terminal state — write cancelled.
         self._heartbeat.stop()
+        self._resources.stop()
         write_status(
             self._run_dir,
             state=RunState.CANCELLED,

--- a/tests/shared/test_resource_sampler.py
+++ b/tests/shared/test_resource_sampler.py
@@ -1,0 +1,110 @@
+"""Tests for the per-run resource sampler.
+
+The sampler is purely observability — its only job is to never raise
+into the lifecycle and to produce a parseable line each tick. We test
+the snapshot format, start/stop idempotency, and graceful degradation
+when ``ps``/``pgrep`` aren't available (CI sandboxes, weird platforms).
+"""
+from __future__ import annotations
+
+import re
+import time
+from unittest.mock import patch
+
+from quodeq.shared.resource_sampler import (
+    ResourceSampler,
+    _format,
+    _ollama_rss_mb,
+    _self_rss_mb,
+)
+
+
+class TestSnapshotFormat:
+    def test_format_includes_all_fields(self) -> None:
+        line = _format(elapsed_s=125, rss_mb=512, threads=8, fds=42, ollama_mb=15384)
+        assert line == "[resources] elapsed=2m05s rss=512MB threads=8 fds=42 ollama=15384MB"
+
+    def test_format_handles_zero_elapsed(self) -> None:
+        line = _format(elapsed_s=0, rss_mb=0, threads=1, fds=0, ollama_mb=0)
+        assert "elapsed=0m00s" in line
+
+    def test_sample_once_matches_format(self) -> None:
+        sampler = ResourceSampler()
+        sampler.start()
+        try:
+            line = sampler.sample_once()
+        finally:
+            sampler.stop()
+        # Shape: [resources] elapsed=<m>m<ss>s rss=<n>MB threads=<n> fds=<n> ollama=<n>MB
+        assert re.match(
+            r"^\[resources\] elapsed=\d+m\d{2}s rss=-?\d+MB threads=\d+ fds=-?\d+ ollama=-?\d+MB$",
+            line,
+        )
+
+
+class TestStartStop:
+    def test_start_is_idempotent(self) -> None:
+        sampler = ResourceSampler(interval_s=999)  # never ticks during test
+        sampler.start()
+        first = sampler._thread
+        sampler.start()  # double-start must not spawn a second thread
+        assert sampler._thread is first
+        sampler.stop()
+
+    def test_stop_without_start_is_safe(self) -> None:
+        ResourceSampler().stop()  # must not raise
+
+    def test_thread_dies_after_stop(self) -> None:
+        sampler = ResourceSampler(interval_s=0.05)
+        sampler.start()
+        thread = sampler._thread
+        time.sleep(0.1)  # let it tick at least once
+        sampler.stop(timeout=1.0)
+        assert thread is not None
+        assert not thread.is_alive()
+
+
+class TestErrorTolerance:
+    def test_loop_swallows_log_errors(self) -> None:
+        # Observability must never kill the run — even if log_info itself
+        # blows up (write to a closed FD, e.g.), the thread keeps going.
+        sampler = ResourceSampler(interval_s=0.05)
+        with patch(
+            "quodeq.shared.resource_sampler.log_info",
+            side_effect=OSError("disk full"),
+        ):
+            sampler.start()
+            time.sleep(0.15)  # multiple ticks, each raising
+            assert sampler._thread is not None and sampler._thread.is_alive()
+            sampler.stop()
+
+    def test_self_rss_returns_int_not_raises(self) -> None:
+        # Real ps call against the test process — should always succeed.
+        rss = _self_rss_mb()
+        assert isinstance(rss, int)
+        assert rss > 0  # we exist; we have memory
+
+    def test_self_rss_returns_unknown_when_ps_missing(self) -> None:
+        with patch(
+            "quodeq.shared.resource_sampler.subprocess.run",
+            side_effect=OSError("no ps"),
+        ):
+            assert _self_rss_mb() == -1
+
+    def test_ollama_rss_returns_zero_when_not_running(self) -> None:
+        # pgrep returncode != 0 means not found — distinct from "couldn't ask".
+        class _R:
+            returncode = 1
+            stdout = ""
+        with patch(
+            "quodeq.shared.resource_sampler.subprocess.run",
+            return_value=_R(),
+        ):
+            assert _ollama_rss_mb() == 0
+
+    def test_ollama_rss_returns_unknown_on_pgrep_error(self) -> None:
+        with patch(
+            "quodeq.shared.resource_sampler.subprocess.run",
+            side_effect=OSError("no pgrep"),
+        ):
+            assert _ollama_rss_mb() == -1


### PR DESCRIPTION
## Summary

Runs have been dying silently at sustained load (~40-60min in, 150-270 accumulated agent spawns) with no on-disk forensic trail. Confirmed:
- ulimit is unlimited (FDs ruled out)
- no jetsam OOM kill events in macOS unified log
- no Python crash reports in \`~/Library/Logs/DiagnosticReports\`
- no system sleep/wake events around death times
- the Python process simply stops writing at the same instant Ollama sees all sockets close

So the next thing to do is **add a trail**. ResourceSampler runs alongside the heartbeat thread and writes one line per minute into \`run.log\`:

\`\`\`
[resources] elapsed=42m00s rss=890MB threads=10 fds=98 ollama=18500MB
\`\`\`

When the next death happens we read backwards from the silence and immediately see whether RSS was climbing, FDs leaking, threads piling, or Ollama eating the box. No new dependencies — \`ps\` + \`pgrep\` + stdlib only.

## Test plan

- [x] \`uv run pytest tests/shared tests/analysis tests/services tests/engine tests/api\` — 1661 passed
- [x] Manual: kick off any run; \`tail -f run.log | grep '\[resources\]'\` shows lines every 60s
- [x] Manual: kill ollama mid-run; sampler should log \`ollama=0MB\` from then on without disrupting the run
- [x] Manual: when the next \`stale_detected\` death happens, inspect the last few \`[resources]\` lines in \`run.log\` to identify the leaking dimension