### PR TITLE
Show cancelled-but-partial runs in history with a 'partial' chip

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -11,7 +11,12 @@ import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js'
 import { TermHeader } from '../../../components/terminal/index.js';
 import FittedText from '../../../components/FittedText.jsx';
 
-const HIDDEN_STATUSES = new Set(['cancelled', 'failed']);
+// Only outright failures are hidden. Cancelled runs may still have written
+// per-dim evaluation files (the dashboard's overview reads them and shows
+// scores), so hiding them here would create a confusing mismatch where the
+// overview shows scores from a run that history claims doesn't exist.
+const HIDDEN_STATUSES = new Set(['failed']);
+const PARTIAL_STATUSES = new Set(['cancelled']);
 
 function formatDateParts(dateISO, fallbackLabel) {
   if (!dateISO) return { date: fallbackLabel || '', time: '' };
@@ -122,7 +127,7 @@ function HistoryRow({ className = '', onClick, cells, onDelete }) {
   );
 }
 
-function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick, onDeleteRun }) {
+function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onDeleteRun }) {
   return (
     <section className="history-evaluations panel">
       <div className="history-evaluations__header">
@@ -145,16 +150,29 @@ function EvaluationsTable({ visible, selectedRunId, deltas, onRunClick, onDelete
           const runScore = parseFloat(entry.runNumericAverage ?? entry.numericAverage);
           const grade = gradeLabel(entry.runOverallGrade || entry.overallGrade) || '—';
           const isSelected = entry.runId === selectedRunId;
+          const isPartial = PARTIAL_STATUSES.has(statusByRunId.get(entry.runId));
           return (
             <HistoryRow
               key={entry.runId}
-              className={isSelected ? 'history-row--selected' : ''}
+              className={`${isSelected ? 'history-row--selected' : ''}${isPartial ? ' history-row--partial' : ''}`.trim()}
               onClick={() => onRunClick(entry.runId, entry.dateLabel)}
               onDelete={onDeleteRun ? () => onDeleteRun(entry.runId, entry.dateLabel || date) : undefined}
               cells={{
                 date,
                 time: <span className="history-row__muted">{time}</span>,
-                grade: <span className={`chip small ${scoreColorClass(runScore)}`}>{grade}</span>,
+                grade: (
+                  <>
+                    <span className={`chip small ${scoreColorClass(runScore)}`}>{grade}</span>
+                    {isPartial && (
+                      <span
+                        className="chip small history-row__partial-chip"
+                        title="Run was cancelled — some dimensions completed, others didn't"
+                      >
+                        partial
+                      </span>
+                    )}
+                  </>
+                ),
                 score: <strong>{Number.isNaN(runScore) ? '—' : trimTrailingZero(runScore)}</strong>,
                 delta: <DeltaText delta={deltas[i]} />,
                 dims: (
@@ -223,6 +241,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
         visible={visible}
         selectedRunId={selectedRunId}
         deltas={deltas}
+        statusByRunId={statusByRunId}
         onRunClick={onRunClick}
         onDeleteRun={onDeleteRun}
       />

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -994,6 +994,22 @@
 .history-table .history-row--selected {
   background: var(--color-surface-alt) !important;
 }
+/* Cancelled-but-partial runs: same row treatment, with a yellow "partial"
+   chip in the grade column so reviewers can tell at a glance the scores
+   come from an incomplete run (not all dims may have run). */
+.history-row__partial-chip {
+  margin-left: 6px;
+  background: transparent;
+  border: 1px solid var(--color-warn, #d29922);
+  color: var(--color-warn, #d29922);
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+}
+.history-table .history-row--partial .history-row__col--score strong,
+.history-table .history-row--partial .history-row__col--delta {
+  opacity: 0.7;
+}
 
 /* Monospace + theme-correct text colour inside every data row, overriding
    the inherited Plus Jakarta from `.panel`. */


### PR DESCRIPTION
## Summary

The dashboard's **overview** reads \`evaluation/{dim}.json\` files from any run — cancelled or done — and surfaces the per-dim scores in the gauge cards. **History** was hiding cancelled runs entirely. Result: users saw a "latest 8.0" in the overview that matched no row in history, because the run that produced those scores had been silently filtered out.

This PR drops \`cancelled\` from \`HIDDEN_STATUSES\`; only outright \`failed\` runs stay hidden. Cancelled rows render with a small yellow \`partial\` chip next to the grade and slightly-dimmed score/delta columns, so it's visually clear the numbers come from an incomplete run that may not have run every dimension.

\`\`\`
DATE          TIME      GRADE         SCORE   Δ      DIMENSIONS CHANGED
Apr 27 2026   06:47 AM  [B] [partial] 8.0     —      flexibility 7.0, security 9.2, …
Apr 25 2026   10:43 PM  [B]           8.0     +0.7   flexibility 7.0, maintainability 8.1, …
\`\`\`

## Out of scope

The overview itself has a separate inconsistency where the **headline overall** (computed from \`accumulated.summary.numericAverage\`) doesn't agree with the **weighted average of the per-dim cards** (e.g. headline 8.0 but cards average ~8.9). That's a deeper accumulator/scoring refactor and deserves its own PR — surgical fix here, principled fix there.

## Test plan

- [x] \`node --test src/features/evaluation/components/scanProgressTotals.test.js\` — 21 passed
- [x] Manual: a project with a recent cancelled run that has at least one \`evaluation/{dim}.json\` shows the row with a yellow \`partial\` chip
- [x] Manual: a \`failed\` run is still hidden
- [x] Manual: clicking a partial row navigates into the run dashboard like any other row