### PR TITLE
Default overview cards + headline to the latest complete run

### DIFF
--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -66,12 +66,24 @@ def _compute_result(
     reports_root: Path, project: str, all_run_infos: list[RunInfo],
     cache_config: AccumulatedCacheConfig | None,
 ) -> _AccumulatedResult:
-    """Load run data and compute trends, severity, and scores."""
-    runs = [r.run_id for r in all_run_infos]
+    """Load run data and compute trends, severity, and scores.
+
+    Cancelled/failed runs are excluded from the per-dim "latest" pick so the
+    overview cards don't quietly mix partial-run scores (e.g. inflated 9.x
+    from a dim the model only finished a fraction of) with stable scores
+    from older complete runs. The trend chart already excludes them; this
+    aligns the cards with that contract. If every run on file is partial
+    (fresh project, all attempts crashed), fall back to all runs so the
+    dashboard isn't blank.
+    """
+    complete_run_infos = [r for r in all_run_infos if r.status == "complete"]
+    if not complete_run_infos:
+        complete_run_infos = all_run_infos
+    runs = [r.run_id for r in complete_run_infos]
     _cache, _lock, _max = _resolve_cache(cache_config)
     get_run_data = make_lru_dimension_fetcher(reports_root, project, _cache, _lock, _max)
     latest_by_dim, prev_occurrence, prev_run_latest = _read_all_run_data(
-        reports_root, project, all_run_infos, runs, get_run_data,
+        reports_root, project, complete_run_infos, runs, get_run_data,
     )
     all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), reports_root / project)
     dims_with_trend = _compute_accumulated_trends(all_dims, prev_occurrence)

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -164,9 +164,20 @@ def _build_dashboard_result(
 def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     """Return the selected RunInfo and its index in *runs*, raising FileNotFoundError if absent.
 
-    Note: run IDs are opaque UUIDs (no sensitive data), safe to include in error messages.
+    For ``run == _LATEST_RUN``, prefer the most recent fully-completed run so
+    the per-dim cards in the dashboard reflect one coherent run that agrees
+    with the accumulated headline. If every run on file is cancelled or
+    in-progress (e.g. fresh project, all attempts crashed), fall back to
+    ``runs[0]`` rather than refusing to render. Users can still navigate to
+    a specific partial run via the score-history chart.
+
+    Note: run IDs are opaque UUIDs (no sensitive data), safe to include in
+    error messages.
     """
-    selected_run = runs[0] if run == _LATEST_RUN else next((item for item in runs if item.run_id == run), None)
+    if run == _LATEST_RUN:
+        selected_run = next((r for r in runs if r.status == "complete"), runs[0])
+    else:
+        selected_run = next((item for item in runs if item.run_id == run), None)
     if not selected_run:
         raise FileNotFoundError("Run not found")
     selected_index = next((idx for idx, item in enumerate(runs) if item.run_id == selected_run.run_id), None)

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -180,3 +180,37 @@ class TestComputeAccumulated:
         result = compute_accumulated(str(reports_root), "proj", None)
         assert "severity" in result["summary"]
         assert "critical" in result["summary"]["severity"]
+
+    def test_excludes_cancelled_run_from_per_dim_latest(self, tmp_path: Path):
+        # The newer run is cancelled — its per-dim eval files exist but
+        # represent partial work that doesn't agree with the headline. The
+        # accumulated cards should pick from the older complete run instead,
+        # so the headline (averaged from the same dims) matches the cards.
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run2", [_dim("security", "9.5", "A"), _dim("maintainability", "9.5", "A")]),
+            ("run1", [_dim("security", "7.0", "B"), _dim("maintainability", "8.0", "B")]),
+        ])
+        # Mark run2 as cancelled by writing status.json.
+        (reports_root / "proj" / "run2" / "status.json").write_text(
+            json.dumps({"state": "cancelled"}),
+        )
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        scores = {d["dimension"]: d["overallScore"] for d in result["dimensions"]}
+        # Both should fall through to run1 (the latest complete run), not run2.
+        assert scores == {"security": "7.0", "maintainability": "8.0"}
+        assert result["summary"]["numericAverage"] == 7.5  # avg(7.0, 8.0)
+
+    def test_falls_back_when_all_runs_cancelled(self, tmp_path: Path):
+        # If every run is cancelled (fresh project, all attempts crashed), we
+        # still want to render *something* rather than a blank dashboard, so
+        # the filter falls back to all runs.
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run1", [_dim("security", "6.0", "C")]),
+        ])
+        (reports_root / "proj" / "run1" / "status.json").write_text(
+            json.dumps({"state": "cancelled"}),
+        )
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        assert result["dimensions"][0]["overallScore"] == "6.0"

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -127,3 +127,49 @@ class TestBuildDashboard:
         assert result["selectedRun"]["runId"] == "r1"
         assert len(result["dimensions"]) == 1
         assert "trend" in result
+
+    def test_latest_skips_cancelled_runs(self, tmp_path):
+        # ``"latest"`` defaults to the most recent fully-completed run so the
+        # per-dim cards reflect a coherent run that agrees with the headline.
+        # The cancelled run remains reachable via explicit selection.
+        cancelled = RunInfo(run_id="r-newest", date_iso="2024-03-01", date_label="2024-03-01", status="cancelled")
+        complete = RunInfo(run_id="r-older", date_iso="2024-02-01", date_label="2024-02-01", status="complete")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[cancelled, complete]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")
+        assert result["selectedRun"]["runId"] == "r-older"
+
+    def test_latest_falls_back_when_all_cancelled(self, tmp_path):
+        # If every run is cancelled, fall back to the newest one rather than
+        # refusing to render — the dashboard still needs to show something.
+        cancelled1 = RunInfo(run_id="r2", date_iso="2024-03-01", date_label="2024-03-01", status="cancelled")
+        cancelled2 = RunInfo(run_id="r1", date_iso="2024-02-01", date_label="2024-02-01", status="cancelled")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[cancelled1, cancelled2]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")
+        assert result["selectedRun"]["runId"] == "r2"
+
+    def test_explicit_run_selection_overrides_latest_default(self, tmp_path):
+        # Explicit selection by run_id navigates to that run regardless of
+        # state — users can still inspect partial runs from the bar chart.
+        cancelled = RunInfo(run_id="r-cancelled", date_iso="2024-03-01", date_label="2024-03-01", status="cancelled")
+        complete = RunInfo(run_id="r-complete", date_iso="2024-02-01", date_label="2024-02-01", status="complete")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[cancelled, complete]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "r-cancelled")
+        assert result["selectedRun"]["runId"] == "r-cancelled"


### PR DESCRIPTION
## Summary

Opening the dashboard fresh produced a mismatched overview: the **headline** read \`8.0\` (latest done run) while the **per-dim cards** averaged ~\`8.8\` (mix of today's partial-run high scores + Apr 25's flexibility). Clicking any specific bar in the score-history chart fixed it — both views agreed on the explicitly-selected run — but the default landing state lied.

### Why the cards lied

\`compute_accumulated()\` walks every run on disk and picks the most recent \`evaluation/{dim}.json\` per dimension. It happily included today's cancelled-but-partial run (5 dims completed with high scores) for those dims, and fell back to Apr 25's run for flexibility. Meanwhile the trend chart already excluded cancelled runs. The two views were computing on different sets of runs.

### Fix

Two surgical filters that both default to "latest fully-completed run":

- **\`accumulated._compute_result\`** filters to \`status == 'complete'\` before building \`latest_by_dim\`. Falls back to all runs only when nothing complete exists.
- **\`dashboard._resolve_selected_run('latest')\`** defaults to the most recent complete run. Falls back to \`runs[0]\` if all are partial.

Partial runs remain reachable via explicit selection from the score-history bar chart, and #309 already added a yellow \`partial\` chip in history so they're discoverable.

### Verified against real data

\`\`\`
Before fix:
  summary.numericAverage = 8.8
  cards: maint 9.2, perf 8.4, rel 9.6, sec 9.2, usab 9.3 (today's partial),
         flexibility 7.0 (Apr 25)

After fix:
  summary.numericAverage = 8.0
  cards: all from run 7c4c1d11 (Apr 25):
         maint 8.1, perf 8.1, rel 8.2, sec 8.4, usab 7.9, flexibility 7.0
\`\`\`

Headline now matches card average. Same as what user saw after manually clicking the bar.

## Test plan

- [x] \`uv run pytest tests\` — 2214 passed (+5 new)
- [x] Manual: open the dashboard fresh on a project with a recent cancelled run; headline + per-dim cards agree
- [x] Manual: click the most recent (cancelled) bar in score-history; both switch to that run, still consistent with each other
- [x] Manual: project where every run is cancelled (fresh / all-crashed) still renders rather than showing blank