### PR TITLE
Centralize per-dim/per-run visibility logic (phase 1: module + tests)

### DIFF
--- a/src/quodeq/services/dim_resolution.py
+++ b/src/quodeq/services/dim_resolution.py
@@ -1,0 +1,160 @@
+"""Single source of truth for which run/dim data should appear in which view.
+
+See ``docs/dim-resolution-design.md`` for the full mental model. TL;DR:
+dimensions are the unit users care about; runs are the artifact. Every
+view that surfaces scoring data should consult this module so they all
+tell one coherent story instead of disagreeing because each implements
+its own filter rules in its own corner of the codebase.
+
+The functions here return *provenance* — for any per-dim score we display,
+the caller can answer "from which run, on what date, in what state". That
+metadata is what makes a hybrid (newest-data-per-dim across runs) view
+honest instead of misleading.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from quodeq.data.fs.report_parser import RunInfo, list_runs
+from quodeq.shared.validation import validate_path_segment
+
+# Run states that may carry trustworthy per-dim eval data. ``failed`` is
+# excluded unconditionally — a failure means system error before or during
+# scoring, so any eval files written are not to be trusted.
+_TRUSTABLE_RUN_STATES: frozenset[str] = frozenset({"complete", "in_progress", "cancelled"})
+
+_EVAL_GLOB = "*.json"
+
+
+@dataclass(frozen=True, slots=True)
+class DimResolution:
+    """Provenance of a single dim's most recent trustworthy eval."""
+
+    dim_id: str
+    eval_path: Path
+    run_id: str
+    run_state: str  # one of _TRUSTABLE_RUN_STATES
+    run_date_iso: str | None
+    files_read: int
+    overall_score: str | None
+    overall_grade: str | None
+
+
+def _load_eval(eval_path: Path) -> dict[str, Any] | None:
+    """Read an eval/<dim>.json file. Returns None on missing or invalid JSON."""
+    try:
+        return json.loads(eval_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _is_trustworthy(eval_data: dict[str, Any] | None) -> bool:
+    """A scored eval is trustworthy when the model actually inspected files.
+
+    A zero-coverage eval (``filesRead == 0``) typically comes from
+    ``_score_completed_evidence`` writing a stub at cancel time when no
+    findings actually landed. The score derived from such a file isn't
+    meaningful; we exclude it so it can't pollute the per-dim cards.
+    """
+    if not eval_data:
+        return False
+    files_read = eval_data.get("filesRead")
+    return isinstance(files_read, int) and files_read > 0
+
+
+def _trustworthy_eval_dims(evaluation_dir: Path) -> set[str]:
+    """Return dim_ids in *evaluation_dir* whose eval files are trustworthy.
+
+    Empty set if the directory is missing or no eval is trustworthy.
+    """
+    if not evaluation_dir.is_dir():
+        return set()
+    return {
+        p.stem for p in evaluation_dir.glob(_EVAL_GLOB)
+        if _is_trustworthy(_load_eval(p))
+    }
+
+
+def resolve_latest_per_dim(
+    reports_root: Path, project: str, *, run_limit: int = 100,
+) -> dict[str, DimResolution]:
+    """For each dim with a trustworthy eval file, return the freshest one.
+
+    Walks runs newest-first; for each (run, dim) pair, accepts the first
+    one where:
+
+      - the run's state is in ``_TRUSTABLE_RUN_STATES`` (``failed`` excluded)
+      - ``evaluation/<dim>.json`` exists with ``filesRead > 0``
+
+    The returned mapping is what every per-dim view (overview cards, the
+    headline, etc.) should read from. The headline must compute itself as
+    ``mean(card.overall_score for card in result.values())`` so cards and
+    headline can never disagree by construction.
+    """
+    validate_path_segment(project)
+    project_dir = reports_root / project
+    if not project_dir.is_dir():
+        return {}
+
+    out: dict[str, DimResolution] = {}
+    for run in list_runs(reports_root, project, limit=run_limit):
+        if run.status not in _TRUSTABLE_RUN_STATES:
+            continue
+        eval_dir = project_dir / run.run_id / "evaluation"
+        if not eval_dir.is_dir():
+            continue
+        for eval_path in eval_dir.glob(_EVAL_GLOB):
+            dim_id = eval_path.stem
+            if dim_id in out:
+                continue  # already resolved from a newer run
+            data = _load_eval(eval_path)
+            if not _is_trustworthy(data):
+                continue
+            out[dim_id] = DimResolution(
+                dim_id=dim_id,
+                eval_path=eval_path,
+                run_id=run.run_id,
+                run_state=run.status,
+                run_date_iso=run.date_iso,
+                files_read=int(data["filesRead"]),
+                overall_score=data.get("overallScore"),
+                overall_grade=data.get("overallGrade"),
+            )
+    return out
+
+
+def is_visible_in_history(reports_root: Path, project: str, run: RunInfo) -> bool:
+    """A run is visible in the history table iff it has any trustworthy eval.
+
+    Failed runs and runs whose eval files are all zero-coverage stubs are
+    hidden because they have nothing useful to surface — a row with "—"
+    in every column is just clutter.
+    """
+    if run.status not in _TRUSTABLE_RUN_STATES:
+        return False
+    eval_dir = reports_root / project / run.run_id / "evaluation"
+    return bool(_trustworthy_eval_dims(eval_dir))
+
+
+def is_eligible_for_chart_bar(
+    reports_root: Path, project: str, run: RunInfo,
+    *, configured_dims: Iterable[str],
+) -> bool:
+    """Stricter than history: only fully-scored runs get a chart bar.
+
+    The score-history chart implies "snapshot of overall score at this
+    point in time", which requires every configured dim to have actually
+    contributed. Partial runs still appear in the table (with a marker)
+    so users can drill in, but they don't pollute the trend line.
+
+    ``in_progress`` runs are eligible if all their configured dims have
+    finished scoring — the snapshot is just early.
+    """
+    if run.status not in {"complete", "in_progress"}:
+        return False
+    eval_dir = reports_root / project / run.run_id / "evaluation"
+    scored = _trustworthy_eval_dims(eval_dir)
+    return scored.issuperset(configured_dims)

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -1,0 +1,302 @@
+"""Tests for the central dim_resolution module.
+
+This module is the single source of truth for which run/dim data should
+appear in which view. The tests pin down its three guarantees:
+
+  1. resolve_latest_per_dim returns the freshest *trustworthy* eval per
+     dim, with full provenance, and never picks from failed runs or
+     zero-coverage stubs.
+  2. is_visible_in_history accepts any non-failed run that has at least
+     one trustworthy eval — partial work is discoverable.
+  3. is_eligible_for_chart_bar is stricter — only runs where every
+     configured dim has a trustworthy eval qualify.
+
+Together these make the migration in later phases safe: each call site
+can replace its local filter with a documented predicate from this module.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from quodeq.data.fs.report_parser import RunInfo
+from quodeq.services.dim_resolution import (
+    DimResolution,
+    is_eligible_for_chart_bar,
+    is_visible_in_history,
+    resolve_latest_per_dim,
+)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+# Each test gets a unique date per run_id so list_runs can sort newest-first.
+_RUN_DATES = {
+    "run1": "2026-01-01T10:00:00",
+    "run2": "2026-02-01T10:00:00",
+    "run3": "2026-03-01T10:00:00",
+    "r1":   "2026-01-01T10:00:00",
+    "r2":   "2026-02-01T10:00:00",
+}
+
+
+def _ensure_run_dir(project_dir: Path, run_id: str) -> Path:
+    """Create a run dir with the manifest.json that ``list_runs`` needs to
+    register the run as a project entry."""
+    run_dir = project_dir / run_id
+    evidence = run_dir / "evidence"
+    evidence.mkdir(parents=True, exist_ok=True)
+    (evidence / "manifest.json").write_text("{}")
+    return run_dir
+
+
+def _write_eval(
+    project_dir: Path, run_id: str, dim_id: str,
+    *, files_read: int = 100, score: str = "8.0/10", grade: str = "Good",
+) -> None:
+    _ensure_run_dir(project_dir, run_id)
+    eval_dir = project_dir / run_id / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / f"{dim_id}.json").write_text(json.dumps({
+        "dimension": dim_id,
+        "date": _RUN_DATES.get(run_id, "2026-01-01T10:00:00"),
+        "filesRead": files_read,
+        "overallScore": score,
+        "overallGrade": grade,
+    }))
+
+
+def _write_status(project_dir: Path, run_id: str, *, state: str) -> None:
+    run_dir = project_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "status.json").write_text(json.dumps({"state": state}))
+
+
+# ---------------------------------------------------------------------------
+# resolve_latest_per_dim
+# ---------------------------------------------------------------------------
+
+class TestResolveLatestPerDim:
+    def test_picks_newest_complete_run_per_dim(self, tmp_path: Path):
+        # Two complete runs, run2 newer; the newer run's score wins for
+        # every dim it contains.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", score="9.0/10")
+        _write_eval(proj_dir, "run1", "security", score="6.0/10")
+        # No status.json → defaults to "complete" via the run parser.
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        assert "security" in result
+        assert result["security"].overall_score == "9.0/10"
+        assert result["security"].run_id == "run2"
+        assert result["security"].run_state == "complete"
+
+    def test_falls_through_to_older_run_when_newest_lacks_dim(self, tmp_path: Path):
+        # A common scenario: today's run only finished some dims; older
+        # complete run carries the rest. Result is a hybrid view, but each
+        # card carries provenance so the user knows where it came from.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", score="9.0/10")
+        _write_eval(proj_dir, "run1", "security", score="6.0/10")
+        _write_eval(proj_dir, "run1", "flexibility", score="5.0/10")
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        assert result["security"].run_id == "run2"
+        assert result["flexibility"].run_id == "run1"
+
+    def test_excludes_failed_run(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", score="9.0/10")
+        _write_status(proj_dir, "run2", state="failed")
+        _write_eval(proj_dir, "run1", "security", score="7.0/10")
+        # run1 has no status.json → defaults to "complete".
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        # The freshest trustworthy is run1 — failed run skipped entirely.
+        assert result["security"].run_id == "run1"
+        assert result["security"].overall_score == "7.0/10"
+
+    def test_excludes_zero_coverage_eval(self, tmp_path: Path):
+        # _score_completed_evidence sometimes writes a stub eval at cancel
+        # time with filesRead=0 because no findings landed. That stub's
+        # score is meaningless and must not be picked over real data.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", files_read=0, score="9.5/10")
+        _write_status(proj_dir, "run2", state="cancelled")
+        _write_eval(proj_dir, "run1", "security", files_read=500, score="7.0/10")
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        assert result["security"].run_id == "run1"
+        assert result["security"].files_read == 500
+
+    def test_includes_in_progress_run_for_finished_dims(self, tmp_path: Path):
+        # If a dim has finished scoring inside a running scan, its data
+        # is trustworthy and should surface — users shouldn't have to
+        # wait for the umbrella run to finalise to see results.
+        # ``in_progress`` is detected upstream via a live PID lookup, which
+        # we'd need to fake on disk; mocking ``list_runs`` to return the
+        # state directly keeps the test focused on the resolution logic.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", score="9.0/10")
+        _write_eval(proj_dir, "run1", "security", score="7.0/10")
+        runs_for_mock = [
+            RunInfo(run_id="run2", date_iso="2026-02-01T10:00:00", date_label="Feb 1", status="in_progress"),
+            RunInfo(run_id="run1", date_iso="2026-01-01T10:00:00", date_label="Jan 1", status="complete"),
+        ]
+        with patch("quodeq.services.dim_resolution.list_runs", return_value=runs_for_mock):
+            result = resolve_latest_per_dim(tmp_path, "proj")
+        assert result["security"].run_id == "run2"
+        assert result["security"].run_state == "in_progress"
+
+    def test_includes_cancelled_run_with_real_data(self, tmp_path: Path):
+        # A cancelled run can still have dims that finished cleanly before
+        # the cancel — those eval files are real. The chip in the UI tells
+        # the user the parent run was partial; the data itself is fine.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run2", "security", files_read=500, score="9.0/10")
+        _write_status(proj_dir, "run2", state="cancelled")
+        _write_eval(proj_dir, "run1", "security", score="7.0/10")
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        assert result["security"].run_id == "run2"
+        assert result["security"].run_state == "cancelled"
+
+    def test_returns_empty_for_missing_project(self, tmp_path: Path):
+        assert resolve_latest_per_dim(tmp_path, "nonexistent") == {}
+
+    def test_returns_empty_when_no_trustworthy_evals(self, tmp_path: Path):
+        # Run exists but every eval is zero-coverage — nothing to surface.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run1", "security", files_read=0)
+        assert resolve_latest_per_dim(tmp_path, "proj") == {}
+
+    def test_returns_provenance_with_path_run_state_and_score(self, tmp_path: Path):
+        # Round-trip check on the DimResolution shape itself.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "run1", "security", score="8.4/10", grade="Good")
+
+        result = resolve_latest_per_dim(tmp_path, "proj")
+        res = result["security"]
+        assert isinstance(res, DimResolution)
+        assert res.dim_id == "security"
+        assert res.eval_path == proj_dir / "run1" / "evaluation" / "security.json"
+        assert res.run_id == "run1"
+        assert res.run_state == "complete"
+        assert res.files_read == 100
+        assert res.overall_score == "8.4/10"
+        assert res.overall_grade == "Good"
+
+
+# ---------------------------------------------------------------------------
+# is_visible_in_history
+# ---------------------------------------------------------------------------
+
+class TestIsVisibleInHistory:
+    def _run(self, run_id: str, status: str = "complete") -> RunInfo:
+        return RunInfo(run_id=run_id, date_iso="2026-04-27", date_label="Apr 27", status=status)
+
+    def test_visible_when_run_has_trustworthy_eval(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1")) is True
+
+    def test_hidden_when_failed(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1", "failed")) is False
+
+    def test_hidden_when_no_evals(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        (proj_dir / "r1").mkdir(parents=True)
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1", "cancelled")) is False
+
+    def test_hidden_when_only_zero_coverage_evals(self, tmp_path: Path):
+        # Cancelled run with stub eval files — nothing useful to show.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security", files_read=0)
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1", "cancelled")) is False
+
+    def test_visible_when_cancelled_with_partial_real_data(self, tmp_path: Path):
+        # Cancelled run that completed at least one dim cleanly — surface
+        # it in history with the partial chip the UI already supports.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security", files_read=500)
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1", "cancelled")) is True
+
+    def test_visible_when_in_progress_with_partial_data(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security", files_read=500)
+        assert is_visible_in_history(tmp_path, "proj", self._run("r1", "in_progress")) is True
+
+
+# ---------------------------------------------------------------------------
+# is_eligible_for_chart_bar
+# ---------------------------------------------------------------------------
+
+class TestIsEligibleForChartBar:
+    def _run(self, run_id: str, status: str = "complete") -> RunInfo:
+        return RunInfo(run_id=run_id, date_iso="2026-04-27", date_label="Apr 27", status=status)
+
+    def test_complete_with_all_dims_eligible(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        _write_eval(proj_dir, "r1", "reliability")
+        run = self._run("r1")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security", "reliability"],
+        ) is True
+
+    def test_complete_missing_a_dim_not_eligible(self, tmp_path: Path):
+        # Snapshot semantics: every configured dim must have contributed
+        # for the bar to mean what the chart claims it means.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        run = self._run("r1")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security", "reliability"],
+        ) is False
+
+    def test_in_progress_with_all_dims_eligible(self, tmp_path: Path):
+        # A snapshot's a snapshot — if every configured dim is scored,
+        # the bar is meaningful regardless of the umbrella run state.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        _write_eval(proj_dir, "r1", "reliability")
+        run = self._run("r1", "in_progress")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security", "reliability"],
+        ) is True
+
+    def test_cancelled_never_eligible(self, tmp_path: Path):
+        # Even if a cancelled run happens to have all dims scored, treat
+        # it as untrustworthy for the chart — the bar implies the run
+        # finished its lifecycle, not just its dims.
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        _write_eval(proj_dir, "r1", "reliability")
+        run = self._run("r1", "cancelled")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security", "reliability"],
+        ) is False
+
+    def test_failed_never_eligible(self, tmp_path: Path):
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        run = self._run("r1", "failed")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security"],
+        ) is False
+
+    def test_zero_coverage_eval_does_not_count_toward_coverage(self, tmp_path: Path):
+        # A stub eval (filesRead=0) is the same as a missing eval for the
+        # purposes of "did this dim contribute to the snapshot".
+        proj_dir = tmp_path / "proj"
+        _write_eval(proj_dir, "r1", "security")
+        _write_eval(proj_dir, "r1", "reliability", files_read=0)
+        run = self._run("r1")
+        assert is_eligible_for_chart_bar(
+            tmp_path, "proj", run, configured_dims=["security", "reliability"],
+        ) is False


### PR DESCRIPTION
## Why

Five places independently decide which runs and per-dim eval files to surface — \`accumulated\`, dashboard's \`_resolve_selected_run\`, the trend-chart filter, history's \`HIDDEN_STATUSES\`, and \`_score_completed_evidence\`. Each evolved opportunistically; every UX bug in this area produced one more filter in one more file. The contract is implicit, untested, and inconsistent — overview, history, and chart routinely disagree about the same run (most recently in #310 / #309 / the chart-selection bug observed today).

This is **phase 1** of standardising that contract. Purely additive — new module + tests, zero existing code touched.

## Mental model

**Dimensions are the unit users care about; runs are the artifact.** A user thinks "what's my security score now?", not "show me run X." Run state is *trust metadata*, not a hard visibility gate.

### Run states

| State | Eval files trustworthy? |
|---|---|
| \`complete\` | Yes |
| \`in_progress\` | Yes for finished dims; pending dims absent |
| \`cancelled\` | Yes for dims that produced an eval with \`filesRead > 0\` |
| \`failed\` | No — exclude entirely |

A \`(run, dim)\` eval file is **trustworthy** iff:
- Run state ∈ \`{complete, in_progress, cancelled}\`, AND
- \`evaluation/<dim>.json\` exists with \`filesRead > 0\`

\`failed\` runs and zero-coverage stubs (which cancel-time scoring sometimes writes) are excluded everywhere.

### Five user-facing questions, three primitives

| # | Question | Answer |
|---|---|---|
| 1 | Freshest trustworthy score per dim? (overview cards) | \`resolve_latest_per_dim()\` |
| 2 | Overall project score? (overview headline) | \`mean(card.score)\` from #1 — never drifts |
| 3 | Which runs are score-history bars? | \`is_eligible_for_chart_bar(run)\` |
| 4 | Which runs in history? | \`is_visible_in_history(run)\` |
| 5 | Explicit run navigation | by \`run_id\`, no filter |

## What's in this PR

- \`src/quodeq/services/dim_resolution.py\` — the three primitives + \`DimResolution\` provenance dataclass.
- \`tests/services/test_dim_resolution.py\` — 21 tests pinning the three guarantees, including the untrustworthy-stub regression.

Nothing else changes. Existing call sites still use their local filters until phase 2.

## Phases 2-4 (separate PRs after this lands)

2. Migrate \`accumulated._compute_result\` and \`dashboard._resolve_selected_run\` to call \`resolve_latest_per_dim\`. Drop their local filters.
3. Migrate \`HistoryPage.jsx\` and the chart bar predicate. Add a regression test for the chart-selection inconsistency observed today (chart highlights one bar, cards show data from a different one).
4. UI: surface provenance on each card (which run, what date, what state). Headline computed in JS as mean-of-cards.

## Test plan

- [x] \`uv run pytest tests\` — 2235 passed (was 2214 + 21 new)
- [x] Code review of the design choices in the module docstrings (the doc lives only in the PR + module headers; \`docs/\` is gitignored per the project convention from \`bdda9e45\`)