### PR TITLE
fix(loops): don't silently skip dims when callback raises BrokenPipeError

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -77,9 +77,12 @@ def run_incremental_loop(
         log_result_fn: Callback to log a completed dimension result.
     """
     result: dict[str, Evidence] = {}
+    log_info(f"[loop] incremental: {len(dimensions)} dim(s) to process: {', '.join(dimensions)}")
     for idx, dimension in enumerate(dimensions, 1):
+        log_info(f"[loop] entering iteration {idx}/{ctx.total} for {dimension}")
         emit_marker("analyzing", dimension=dimension)
         log_info(f"\u2192 [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
+        ev: Evidence | None = None
         try:
             ev = run_dimension_incremental(config, dimension, idx, ctx)
         except BrokenPipeError:
@@ -95,11 +98,47 @@ def run_incremental_loop(
             except BrokenPipeError:
                 _silence_broken_stdout()
                 ev = None
+        except Exception as exc:  # noqa: BLE001
+            # Loop-level diagnostic: an unanticipated exception class would
+            # otherwise propagate up silently and the lifecycle would treat
+            # it as failed without saying which dim. Log + swallow + continue
+            # so subsequent dims still run; the surfaced log line gives us
+            # the trail we need next time this happens.
+            log_warning(
+                f"[loop] {dimension} \u2014 unexpected exception "
+                f"{type(exc).__name__}: {exc} \u2014 skipping dim, continuing loop",
+            )
+            ev = None
+        # log_result_fn / on_dimension_done are caller-provided (e.g., the
+        # dashboard's scoring callback). Wrap them too \u2014 an exception in a
+        # callback shouldn't drop the next iteration on the floor.
         if ev:
-            log_result_fn(ev, dimension, idx, ctx.total)
-            result[dimension] = ev
-            if on_dimension_done:
-                on_dimension_done(dimension, ev)
+            try:
+                log_result_fn(ev, dimension, idx, ctx.total)
+                result[dimension] = ev
+                if on_dimension_done:
+                    on_dimension_done(dimension, ev)
+            except BrokenPipeError:
+                # Stdout pipe to parent died (the most likely cause of the
+                # silent-skip bug observed in production: log_success or the
+                # dashboard's scoring callback writes to a closed parent
+                # pipe). Keep result, log the trail, continue to next dim
+                # instead of letting it bubble out and lifecycle quietly
+                # converting it to state=done.
+                _silence_broken_stdout()
+                result.setdefault(dimension, ev)
+                log_warning(f"[loop] {dimension} \u2014 callback broken pipe, result kept, continuing loop")
+            except Exception as exc:  # noqa: BLE001
+                log_warning(
+                    f"[loop] {dimension} \u2014 callback raised "
+                    f"{type(exc).__name__}: {exc} \u2014 result kept, continuing loop",
+                )
+                result.setdefault(dimension, ev)
+        log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (ev={'set' if ev else 'None'})")
+    log_info(
+        f"[loop] incremental finished: processed {len(result)} of {len(dimensions)} dim(s) "
+        f"({', '.join(result) if result else 'none'})",
+    )
     check_zero_findings(
         result, config.source_file_count,
         incremental_filter_active=config.options.incremental_file_filter is not None
@@ -124,28 +163,56 @@ def run_per_dimension_loop(
     """
     result: dict[str, Evidence] = {}
     skipped_count = 0
+    log_info(f"[loop] per-dimension: {len(dimensions)} dim(s) to process: {', '.join(dimensions)}")
     for idx, dimension in enumerate(dimensions, 1):
+        log_info(f"[loop] entering iteration {idx}/{ctx.total} for {dimension}")
+        ev: Evidence | None = None
         try:
             ev = process_fn(config, dimension, idx, ctx)
         except BrokenPipeError:
-            # Parent closed the pipe mid-run. The current dim is treated as
-            # skipped — its evidence may already be on disk (scoring will
-            # pick that up via _score_completed_evidence on the API side),
-            # but we don't try to recover it here. Silence stdout so the
-            # remaining dims can run without every log call re-raising.
             _silence_broken_stdout()
             skipped_count += 1
+            log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: broken pipe)")
             continue
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 failed: {exc}")
             skipped_count += 1
+            log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: {type(exc).__name__})")
+            continue
+        except Exception as exc:  # noqa: BLE001
+            # Don't let an exotic exception class drop the rest of the loop
+            # silently. Log + count as skipped + continue so we get the trail.
+            log_warning(
+                f"[loop] {dimension} — unexpected exception "
+                f"{type(exc).__name__}: {exc} — skipping dim, continuing loop",
+            )
+            skipped_count += 1
+            log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: unexpected)")
             continue
         if ev is None:
             skipped_count += 1
+            log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: ev=None)")
             continue
-        result[dimension] = ev
-        if on_dimension_done:
-            on_dimension_done(dimension, ev)
+        try:
+            result[dimension] = ev
+            if on_dimension_done:
+                on_dimension_done(dimension, ev)
+        except BrokenPipeError:
+            # Stdout pipe to parent died (this is the most likely cause of
+            # the silent-skip bug observed in production). Keep result, log
+            # the trail, continue to next dim instead of bubbling out.
+            _silence_broken_stdout()
+            log_warning(f"[loop] {dimension} — callback broken pipe, result kept, continuing loop")
+        except Exception as exc:  # noqa: BLE001
+            log_warning(
+                f"[loop] {dimension} — callback raised "
+                f"{type(exc).__name__}: {exc} — result kept, continuing loop",
+            )
+        log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (ev=set)")
+    log_info(
+        f"[loop] per-dimension finished: processed {len(result)} of {len(dimensions)} dim(s) "
+        f"({', '.join(result) if result else 'none'}, {skipped_count} skipped)",
+    )
     check_zero_findings(
         result, config.source_file_count, skipped_count,
         incremental_filter_active=config.options.incremental_file_filter is not None

--- a/tests/analysis/test_loops_safety.py
+++ b/tests/analysis/test_loops_safety.py
@@ -1,0 +1,286 @@
+"""Tests for the safety properties of the dimension loops.
+
+These pin down the guarantee that motivated the diagnostic + widened
+exception trap: a broken pipe (or any unexpected exception) raised by
+the per-dim runner *or* by the result/scoring callback must not drop
+subsequent iterations on the floor. The bug we observed in production:
+usability finished its queue, the dashboard's scoring callback raised
+``BrokenPipeError`` while writing to a closed parent pipe, the
+exception propagated out of the loop, the lifecycle's
+``BrokenPipeError`` handler quietly converted state to ``done`` —
+flexibility never ran, usability's eval file was never written, and
+nothing in the run.log told us where the gap was.
+
+The fix this file pins down: catch broken-pipe / generic exceptions
+from both the dim runner *and* the callback inside the loop, log a
+diagnostic, keep the result, continue iterating.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
+from quodeq.analysis._types import _AnalysisContext
+
+
+def _ctx(total: int) -> _AnalysisContext:
+    """Minimal _AnalysisContext — only `total` is read by the loops."""
+    return _AnalysisContext(
+        dimensions_data=None,
+        date_str="",
+        template="",
+        subagent_template="",
+        total=total,
+    )
+
+
+def _config() -> MagicMock:
+    """Minimal RunConfig stub for the few fields the loops dereference.
+
+    ``skip_scoring=True`` makes ``check_zero_findings`` short-circuit so the
+    safety tests can use a stub Evidence without wiring real principle data.
+    """
+    cfg = MagicMock()
+    cfg.source_file_count = 100
+    cfg.options.incremental_file_filter = None
+    cfg.options.skip_scoring = True
+    return cfg
+
+
+@dataclass
+class _FakeEvidence:
+    files_read: int = 5
+    # check_zero_findings (called after the loop) iterates principles —
+    # an empty dict satisfies it without any findings logic.
+    principles: dict = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.principles is None:
+            object.__setattr__(self, "principles", {})
+
+
+# ---------------------------------------------------------------------------
+# run_per_dimension_loop
+# ---------------------------------------------------------------------------
+
+class TestPerDimLoopSafety:
+    def test_callback_broken_pipe_does_not_drop_subsequent_dims(self):
+        """The bug we observed: scoring callback writes to closed pipe,
+        BrokenPipeError propagates, loop terminates early."""
+        cfg = _config()
+        seen_dims: list[str] = []
+
+        def process_fn(_c, dim, _i, _ctx):
+            seen_dims.append(dim)
+            return _FakeEvidence()
+
+        callback_calls: list[str] = []
+        def on_done(dim, _ev):
+            callback_calls.append(dim)
+            if dim == "usability":  # exact bug: usability's callback dies
+                raise BrokenPipeError("parent pipe closed")
+
+        result = run_per_dimension_loop(
+            cfg, ["security", "usability", "flexibility"], _ctx(3),
+            process_fn=process_fn, on_dimension_done=on_done,
+        )
+        # All three dims iterated despite usability's callback raising.
+        assert seen_dims == ["security", "usability", "flexibility"]
+        # Result still includes usability (we kept the evidence).
+        assert set(result) == {"security", "usability", "flexibility"}
+        # Callback fired for all three (loop didn't bail early).
+        assert callback_calls == ["security", "usability", "flexibility"]
+
+    def test_callback_generic_exception_does_not_drop_subsequent_dims(self):
+        cfg = _config()
+        seen: list[str] = []
+
+        def process_fn(_c, dim, _i, _ctx):
+            seen.append(dim)
+            return _FakeEvidence()
+
+        def on_done(dim, _ev):
+            if dim == "reliability":
+                raise AttributeError("boom")  # arbitrary class loop didn't catch before
+
+        result = run_per_dimension_loop(
+            cfg, ["security", "reliability", "performance"], _ctx(3),
+            process_fn=process_fn, on_dimension_done=on_done,
+        )
+        assert seen == ["security", "reliability", "performance"]
+        assert set(result) == {"security", "reliability", "performance"}
+
+    def test_unexpected_exception_in_runner_logs_and_continues(self):
+        cfg = _config()
+        seen: list[str] = []
+
+        def process_fn(_c, dim, _i, _ctx):
+            seen.append(dim)
+            if dim == "security":
+                raise AttributeError("not in the catch list")  # not OSError/Value/etc.
+            return _FakeEvidence()
+
+        result = run_per_dimension_loop(
+            cfg, ["security", "reliability"], _ctx(2),
+            process_fn=process_fn,
+        )
+        # Both iterations attempted; security skipped, reliability succeeds.
+        assert seen == ["security", "reliability"]
+        assert "security" not in result
+        assert "reliability" in result
+
+    def test_diagnostic_log_lines_are_emitted(self):
+        cfg = _config()
+        with patch("quodeq.analysis._loops.log_info") as mock_log:
+            run_per_dimension_loop(
+                cfg, ["a", "b"], _ctx(2),
+                process_fn=lambda *a, **k: _FakeEvidence(),
+            )
+        messages = [c.args[0] for c in mock_log.call_args_list]
+        # Loop start banner
+        assert any("per-dimension: 2 dim(s) to process: a, b" in m for m in messages)
+        # Per-iteration entry + completion
+        assert any("entering iteration 1/2 for a" in m for m in messages)
+        assert any("completed iteration 1/2 for a" in m for m in messages)
+        assert any("entering iteration 2/2 for b" in m for m in messages)
+        assert any("completed iteration 2/2 for b" in m for m in messages)
+        # Final summary
+        assert any("per-dimension finished: processed 2 of 2 dim(s)" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# run_incremental_loop
+# ---------------------------------------------------------------------------
+
+class TestIncrementalLoopSafety:
+    def test_callback_broken_pipe_does_not_drop_subsequent_dims(self):
+        # Same bug class as per-dim, but on the incremental path which is
+        # what the production run was using when usability + flexibility
+        # got dropped together.
+        cfg = _config()
+        seen: list[str] = []
+        callback_calls: list[str] = []
+
+        def fake_runner(_c, dim, _i, _ctx):
+            seen.append(dim)
+            return _FakeEvidence()
+
+        def log_result(_ev, dim, _i, _t):
+            if dim == "usability":
+                raise BrokenPipeError("dashboard pipe closed")
+
+        def on_done(dim, _ev):
+            callback_calls.append(dim)
+
+        with patch("quodeq.analysis._loops.run_dimension_incremental", side_effect=fake_runner):
+            result = run_incremental_loop(
+                cfg, ["security", "usability", "flexibility"], _ctx(3),
+                process_fn=MagicMock(),  # only used as fallback if the inner runner raises
+                log_result_fn=log_result,
+                on_dimension_done=on_done,
+            )
+
+        # All three iterated — flexibility ran despite usability's callback dying.
+        assert seen == ["security", "usability", "flexibility"]
+        # All three results captured (we keep the evidence even when callback fails).
+        assert set(result) == {"security", "usability", "flexibility"}
+        # on_done fired for security and flexibility; usability's loop body
+        # bailed out of the try at log_result_fn so on_done didn't fire for it.
+        assert "usability" not in callback_calls
+
+    def test_unexpected_exception_in_runner_logs_and_continues(self):
+        cfg = _config()
+        seen: list[str] = []
+
+        def fake_runner(_c, dim, _i, _ctx):
+            seen.append(dim)
+            if dim == "reliability":
+                raise AttributeError("not in catch list")
+            return _FakeEvidence()
+
+        with patch("quodeq.analysis._loops.run_dimension_incremental", side_effect=fake_runner):
+            result = run_incremental_loop(
+                cfg, ["security", "reliability", "maintainability"], _ctx(3),
+                process_fn=MagicMock(),
+                log_result_fn=lambda *a: None,
+            )
+        assert seen == ["security", "reliability", "maintainability"]
+        assert set(result) == {"security", "maintainability"}
+
+    def test_diagnostic_log_lines_are_emitted(self):
+        cfg = _config()
+        with patch("quodeq.analysis._loops.run_dimension_incremental", return_value=_FakeEvidence()), \
+             patch("quodeq.analysis._loops.log_info") as mock_log:
+            run_incremental_loop(
+                cfg, ["security", "flexibility"], _ctx(2),
+                process_fn=MagicMock(),
+                log_result_fn=lambda *a: None,
+            )
+        messages = [c.args[0] for c in mock_log.call_args_list]
+        assert any("incremental: 2 dim(s) to process: security, flexibility" in m for m in messages)
+        assert any("entering iteration 1/2 for security" in m for m in messages)
+        assert any("completed iteration 1/2 for security" in m for m in messages)
+        assert any("entering iteration 2/2 for flexibility" in m for m in messages)
+        assert any("completed iteration 2/2 for flexibility" in m for m in messages)
+        assert any("incremental finished: processed 2 of 2 dim(s)" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Regression test: the exact production bug shape
+# ---------------------------------------------------------------------------
+
+class TestProductionBugRegression:
+    """Pins down the run f7768d55 incident: usability's queue completed,
+    the scoring callback raised BrokenPipeError, the loop bailed before
+    flexibility could iterate, and the lifecycle promoted the half-done
+    state to ``done`` — both usability's eval and flexibility entirely
+    were silently lost.
+    """
+
+    def test_usability_callback_dying_does_not_skip_flexibility(self):
+        cfg = _config()
+        attempted: list[str] = []
+        scored: list[str] = []
+
+        def fake_runner(_c, dim, _i, _ctx):
+            attempted.append(dim)
+            return _FakeEvidence(files_read=979 if dim == "usability" else 22)
+
+        def scoring_callback(dim, _ev):
+            # In production, this callback writes evaluation/{dim}.json AND
+            # logs to stdout — the latter dies once the dashboard parent pipe
+            # closes.
+            scored.append(dim)
+            if dim == "usability":
+                raise BrokenPipeError("Broken pipe")
+
+        with patch("quodeq.analysis._loops.run_dimension_incremental", side_effect=fake_runner):
+            result = run_incremental_loop(
+                cfg,
+                ["security", "reliability", "maintainability", "performance", "usability", "flexibility"],
+                _ctx(6),
+                process_fn=MagicMock(),
+                log_result_fn=lambda *a: None,
+                on_dimension_done=scoring_callback,
+            )
+
+        # All six dims attempted, including flexibility which was the missing one in prod.
+        assert attempted == [
+            "security", "reliability", "maintainability", "performance",
+            "usability", "flexibility",
+        ]
+        # Scoring callback fired for first 4 + usability (raised) + flexibility
+        # (post-fix continues despite usability's failure).
+        assert scored == [
+            "security", "reliability", "maintainability", "performance",
+            "usability", "flexibility",
+        ]
+        # All six in result — the evidence was captured even though usability's
+        # callback raised.
+        assert set(result) == {
+            "security", "reliability", "maintainability", "performance",
+            "usability", "flexibility",
+        }


### PR DESCRIPTION
## Production incident (run \`f7768d55\`)

A 6-dim incremental scan finished in \`state=done\` after only running 5 dims:

- **Evaluate panel**: 5 green checks (security, reliability, maintainability, performance, usability) + flexibility \`○\` pending.
- **History**: today's row lists only 4 dims under "dimensions changed" (usability missing) → its eval file was never written.
- **Overview**: usability card shows "Older run · 25 Apr 2026" → today's data not picked up.
- **run.log**: shows \`[5/6] Analyzing usability\` followed by usability completing its queue (\`Coverage: 979/979 files (100%)\`), then nothing. No \`[6/6]\` log, no \`Analyzing flexibility\`, no error trace.

## Forensics (what we ruled out)

- \`ulimit -n\` is unlimited → not FD exhaustion.
- macOS unified log shows no jetsam/OOM kill events for the run's PID.
- \`~/Library/Logs/DiagnosticReports\` shows no Python crash reports.
- No system sleep/wake events between scan start and end.
- Resource sampler (#308) shows RSS 164→201MB stable, FDs flat at 10-11, threads flat at 8 — **not a memory leak**.
- \`status.json\` shows clean \`state=done\` with \`exit_reason=null\` — no exception bubbled to the lifecycle.

## What actually happened

The loop's \`try\` only wraps \`run_dimension_incremental\`, not \`log_result_fn\` / \`on_dimension_done\`. The dashboard's scoring callback writes \`evaluation/<dim>.json\` AND emits a status line to stdout — the latter dies with \`BrokenPipeError\` if the parent pipe is closed (e.g. dashboard restart, \`pywebview\` window closed). The exception propagates out of the loop body, terminates the for loop, propagates to the lifecycle context — whose \`BrokenPipeError\` handler **silently transitions to \`done\`** on the assumption "the analysis itself already ran." It hadn't.

## The fix

Both \`run_incremental_loop\` and \`run_per_dimension_loop\`:

1. **Wrap callbacks in their own try/except.** \`BrokenPipeError\` → silence stdout, keep the dim's result, continue iterating. Generic exception → log + keep result + continue.
2. **Widen the runner-side trap** to catch unexpected exception classes (previously only \`OSError\` / \`KeyError\` / \`ValueError\` / \`RuntimeError\`). Log + count as skipped + continue.
3. **Add diagnostic log lines** at iteration entry, completion, and loop end. Next time something drops a dim we'll see the exact spot in \`run.log\` instead of staring at a blank after the last successful iteration.

## Test plan

- [x] \`uv run pytest tests\` — 2243 passed (was 2235 + 8 new)
- [x] Regression test pins the exact production shape: usability's \`on_dimension_done\` raising \`BrokenPipeError\` must not skip flexibility.
- [x] Manual: kick off a fresh 6-dim run; \`run.log\` shows \`[loop] entering iteration N/6\` and \`[loop] completed iteration N/6\` for every dim plus a final \`[loop] incremental finished: processed 6 of 6\` summary.
- [x] Manual: artificially close the dashboard parent pipe mid-run (e.g. restart \`uv run quodeq dashboard --dev\`) — run continues and finishes with all 6 dims rather than silent done-with-5.

## Out of scope

- The dim_resolution refactor (#311 + phases 2-4) is the longer-term cleanup of the visibility logic; this PR is the immediate "stop dropping iterations" hardening.