### PR TITLE
fix(overview): include in-progress runs when picking the latest per-dim eval

### DIFF
--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -71,12 +71,19 @@ def _compute_result(
     Cancelled/failed runs are excluded from the per-dim "latest" pick so the
     overview cards don't quietly mix partial-run scores (e.g. inflated 9.x
     from a dim the model only finished a fraction of) with stable scores
-    from older complete runs. The trend chart already excludes them; this
-    aligns the cards with that contract. If every run on file is partial
-    (fresh project, all attempts crashed), fall back to all runs so the
-    dashboard isn't blank.
+    from older complete runs. ``in_progress`` runs ARE included so dims
+    that have already produced a scored evaluation file (eval/<dim>.json)
+    surface in the cards as soon as they finish — users shouldn't have to
+    wait for the umbrella run to finalise before seeing those results.
+    If every run on file is partial (fresh project, all attempts crashed),
+    fall back to all runs so the dashboard isn't blank.
+
+    Interim solution: this filter duplicates the trust rule that lives in
+    ``services.dim_resolution._TRUSTABLE_RUN_STATES``; phase 2 of #311 will
+    migrate this call site to ``resolve_latest_per_dim`` and remove the
+    duplication.
     """
-    complete_run_infos = [r for r in all_run_infos if r.status == "complete"]
+    complete_run_infos = [r for r in all_run_infos if r.status in ("complete", "in_progress")]
     if not complete_run_infos:
         complete_run_infos = all_run_infos
     runs = [r.run_id for r in complete_run_infos]

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -201,6 +201,27 @@ class TestComputeAccumulated:
         assert scores == {"security": "7.0", "maintainability": "8.0"}
         assert result["summary"]["numericAverage"] == 7.5  # avg(7.0, 8.0)
 
+    def test_includes_in_progress_run_for_dims_already_scored(self, tmp_path: Path):
+        # A dim that produced an eval file inside an in-progress run is
+        # trustworthy — its score should surface in the cards immediately,
+        # not wait for the umbrella run to finalise. (Without this, users
+        # see today's freshly-completed dim as "Older run · Apr 25" because
+        # the still-running umbrella excluded today's partial state.)
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run2", [_dim("usability", "9.5", "A")]),
+            ("run1", [_dim("usability", "7.0", "B"), _dim("flexibility", "6.0", "C")]),
+        ])
+        # Mark run2 as still in progress.
+        (reports_root / "proj" / "run2" / "status.json").write_text(
+            json.dumps({"state": "running"}),
+        )
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        scores = {d["dimension"]: d["overallScore"] for d in result["dimensions"]}
+        # usability picked up from in-progress run2 (the freshest score for
+        # that dim); flexibility falls through to run1.
+        assert scores == {"usability": "9.5", "flexibility": "6.0"}
+
     def test_falls_back_when_all_runs_cancelled(self, tmp_path: Path):
         # If every run is cancelled (fresh project, all attempts crashed), we
         # still want to render *something* rather than a blank dashboard, so


### PR DESCRIPTION
## Symptom

A dim that just finished scoring inside a still-running umbrella run shows up immediately in **history** but not in the **overview cards** — the cards fall back to whatever older complete run had that dim, often labelled \"Older run · DD MMM\" right next to a fresher card from the same run dir.

Confirmed against today's in-flight run \`278ce91e\`: usability had just finished with \`evaluation/usability.json\` (score 9.2/10) but the overview card still showed Apr 25's 7.9 because the run was still \`in_progress\`.

## Root cause

#310 widened the per-dim filter in \`accumulated._compute_result\` to exclude cancelled and failed runs (good) but also accidentally excluded \`in_progress\` runs (not so good). The trust rule should be: a dim eval file is trustworthy if its parent run is in any state where the file represents real, scored work — \`complete\`, \`in_progress\`, or \`cancelled\` (with a non-zero coverage check). \`failed\` is excluded.

## Fix

One-line filter widening: \`status in (\"complete\", \"in_progress\")\`. Cancelled stays excluded for now (its partial-coverage evals can be misleading); the more nuanced rule lives in \`services.dim_resolution._TRUSTABLE_RUN_STATES\` from #311.

## Verified against live data

\`\`\`
$ uv run python -c \"...compute_accumulated('/Users/victor/.quodeq/evaluations', '<project>', None)\"
headline: 8.8
  maintainability      score=  9.2/10  fromRun=278ce91e
  performance          score=  8.4/10  fromRun=278ce91e
  reliability          score=  9.6/10  fromRun=278ce91e
  security             score=  9.2/10  fromRun=278ce91e
  usability            score=  9.2/10  fromRun=278ce91e   ← now picked from in-progress run
  flexibility          score=  7.0/10  fromRun=7c4c1d11   ← still pending in current run
\`\`\`

Headline 8.8 matches the weighted average of the cards. No more \"Older run\" labels next to today's freshly-scored siblings.

## Phase 2 of #311 will replace this

The duplicate trust rule (one filter in \`accumulated\`, the canonical one in \`dim_resolution\`) is on the migration backlog. This PR is the immediate user-visible fix; phase 2 of the dim-resolution work removes the duplication.

## Test plan

- [x] \`uv run pytest tests\` — 2244 passed (was 2235 + 1 new test pinning the in-progress inclusion)
- [x] Manual: while a run is in progress and has finished some dims, overview cards show today's freshly-scored dims with provenance from the in-progress run, not last-week's complete run.