### PR TITLE
feat(dim-resolution): one shared trust predicate for accumulated + dashboard (phase 2)

### DIFF
--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -11,6 +11,7 @@ from quodeq.services.ports import RunInfo, list_runs
 from quodeq.core.types import DimensionResult
 from quodeq.shared.utils import _env_int
 from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services.dim_resolution import is_eligible_for_default_view
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.services._fs_projects import find_children as _find_children
 
@@ -78,12 +79,12 @@ def _compute_result(
     If every run on file is partial (fresh project, all attempts crashed),
     fall back to all runs so the dashboard isn't blank.
 
-    Interim solution: this filter duplicates the trust rule that lives in
-    ``services.dim_resolution._TRUSTABLE_RUN_STATES``; phase 2 of #311 will
-    migrate this call site to ``resolve_latest_per_dim`` and remove the
-    duplication.
+    The eligibility predicate is the shared
+    ``dim_resolution.is_eligible_for_default_view`` rule, used by both this
+    call site and ``dashboard._resolve_selected_run`` so the headline and
+    cards always read from the same set of runs.
     """
-    complete_run_infos = [r for r in all_run_infos if r.status in ("complete", "in_progress")]
+    complete_run_infos = [r for r in all_run_infos if is_eligible_for_default_view(r.status)]
     if not complete_run_infos:
         complete_run_infos = all_run_infos
     runs = [r.run_id for r in complete_run_infos]

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -20,6 +20,7 @@ from quodeq.services.ports import (
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services.dim_resolution import is_eligible_for_default_view
 
 
 @dataclass
@@ -164,18 +165,26 @@ def _build_dashboard_result(
 def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     """Return the selected RunInfo and its index in *runs*, raising FileNotFoundError if absent.
 
-    For ``run == _LATEST_RUN``, prefer the most recent fully-completed run so
-    the per-dim cards in the dashboard reflect one coherent run that agrees
-    with the accumulated headline. If every run on file is cancelled or
-    in-progress (e.g. fresh project, all attempts crashed), fall back to
-    ``runs[0]`` rather than refusing to render. Users can still navigate to
-    a specific partial run via the score-history chart.
+    For ``run == _LATEST_RUN``, prefer the most recent run that's eligible
+    to drive the default view (``complete`` or ``in_progress``). The
+    eligibility predicate is the shared
+    ``dim_resolution.is_eligible_for_default_view`` rule, used by both this
+    call site and ``accumulated._compute_result``. Keeping them on the
+    same predicate is what prevents the "headline says one thing, cards
+    say another" inconsistency users hit when the two filters drift.
+
+    If every run is cancelled (fresh project / repeated crashes), fall
+    back to ``runs[0]`` rather than refusing to render. Users can still
+    navigate to a specific partial run via the score-history chart.
 
     Note: run IDs are opaque UUIDs (no sensitive data), safe to include in
     error messages.
     """
     if run == _LATEST_RUN:
-        selected_run = next((r for r in runs if r.status == "complete"), runs[0])
+        selected_run = next(
+            (r for r in runs if is_eligible_for_default_view(r.status)),
+            runs[0],
+        )
     else:
         selected_run = next((item for item in runs if item.run_id == run), None)
     if not selected_run:

--- a/src/quodeq/services/dim_resolution.py
+++ b/src/quodeq/services/dim_resolution.py
@@ -26,7 +26,33 @@ from quodeq.shared.validation import validate_path_segment
 # scoring, so any eval files written are not to be trusted.
 _TRUSTABLE_RUN_STATES: frozenset[str] = frozenset({"complete", "in_progress", "cancelled"})
 
+# Run states whose eval files are eligible to drive the *default* per-dim
+# card / headline view. Narrower than ``_TRUSTABLE_RUN_STATES``: ``cancelled``
+# is excluded here because its evals can have low coverage (model only
+# inspected a sliver of files before stop), and silently mixing those into
+# a default view distorts the cards. A user can still navigate to a
+# cancelled run explicitly via the chart / history table — this rule only
+# governs the default landing-page selection.
+_DEFAULT_VIEW_RUN_STATES: frozenset[str] = frozenset({"complete", "in_progress"})
+
 _EVAL_GLOB = "*.json"
+
+
+def is_trustable_run(run_status: str) -> bool:
+    """Whether a run's eval files can be trusted at all (history visibility)."""
+    return run_status in _TRUSTABLE_RUN_STATES
+
+
+def is_eligible_for_default_view(run_status: str) -> bool:
+    """Whether a run can drive the overview cards / headline by default.
+
+    The single source of truth for both the accumulated per-dim resolver
+    (``compute_accumulated`` filtering) and the dashboard's default-run
+    selection (``_resolve_selected_run("latest")``). Keeping them on the
+    same predicate is what prevents the "headline says one thing, cards
+    say another" inconsistency users hit when the two filters drift.
+    """
+    return run_status in _DEFAULT_VIEW_RUN_STATES
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -24,6 +24,8 @@ from quodeq.data.fs.report_parser import RunInfo
 from quodeq.services.dim_resolution import (
     DimResolution,
     is_eligible_for_chart_bar,
+    is_eligible_for_default_view,
+    is_trustable_run,
     is_visible_in_history,
     resolve_latest_per_dim,
 )
@@ -235,6 +237,34 @@ class TestIsVisibleInHistory:
 # ---------------------------------------------------------------------------
 # is_eligible_for_chart_bar
 # ---------------------------------------------------------------------------
+
+class TestSharedTrustPredicates:
+    """Pin the two run-state predicates that are the shared source of truth
+    for ``accumulated._compute_result`` and ``dashboard._resolve_selected_run``.
+    Drift between these two predicates is what produces the "headline says
+    one thing, cards say another" class of bug.
+    """
+
+    def test_is_trustable_run_includes_complete_in_progress_cancelled(self):
+        # The broader rule — used by history visibility. Cancelled is in
+        # because a cancelled run can still have dims that finished cleanly.
+        assert is_trustable_run("complete") is True
+        assert is_trustable_run("in_progress") is True
+        assert is_trustable_run("cancelled") is True
+
+    def test_is_trustable_run_excludes_failed(self):
+        assert is_trustable_run("failed") is False
+
+    def test_is_eligible_for_default_view_includes_complete_in_progress(self):
+        # The narrower rule — used by overview cards / headline. Cancelled
+        # is OUT because partial-coverage stub evals can distort the cards.
+        assert is_eligible_for_default_view("complete") is True
+        assert is_eligible_for_default_view("in_progress") is True
+
+    def test_is_eligible_for_default_view_excludes_cancelled_and_failed(self):
+        assert is_eligible_for_default_view("cancelled") is False
+        assert is_eligible_for_default_view("failed") is False
+
 
 class TestIsEligibleForChartBar:
     def _run(self, run_id: str, status: str = "complete") -> RunInfo:


### PR DESCRIPTION
## What this PR is

Phase 2 of the dim-resolution centralisation kicked off in #311. The inconsistency we kept hitting all morning — overview cards from one filter rule, headline from another, the two drifting — was structurally caused by \`accumulated._compute_result\` and \`dashboard._resolve_selected_run\` each owning their own copy of the "which runs drive the default view" predicate. Each patch (#310, #313) fixed one filter without touching the other, so the mismatch reappeared in a slightly different shape every time.

This PR makes both call sites consult **one named predicate** in \`dim_resolution\`. They cannot drift again.

## API

\`\`\`python
# services/dim_resolution.py
def is_trustable_run(run_status: str) -> bool: ...
    # complete | in_progress | cancelled
    # broader rule — used by history visibility

def is_eligible_for_default_view(run_status: str) -> bool: ...
    # complete | in_progress (cancelled excluded)
    # narrower rule — used by overview cards / headline
\`\`\`

## Migration

- \`accumulated._compute_result\` → \`is_eligible_for_default_view(r.status)\`
- \`dashboard._resolve_selected_run(\"latest\")\` → same

Both used to inline \`status in (\"complete\", ...)\` with subtly different sets. Now they're the same call.

## Verified against in-flight run \`278ce91e\`

\`\`\`
dashboard.selectedRun         = 278ce91e  ← today's in-progress run, no longer skipped
dashboard.summary.numericAverage = 9.1    ← (9.2+8.4+9.6+9.2+9.2)/5, today's 5 finished dims
accumulated.summary.numericAverage = 8.8  ← cross-run: today's 5 + flexibility from older
\`\`\`

The two numbers still differ — that's correct, they answer different questions (single-run vs cross-run aggregation). What used to be wrong was the dashboard headline showing yesterday's complete-run score (8.0) while the cards already showed today's data; now both come from today's run.

## Test plan

- [x] \`uv run pytest tests\` — 2248 passed (+4 new for the shared predicates)
- [x] Manual: open dashboard fresh on a project with an in-progress run; default view shows today's run with all the dims that have already finished, headline matches the cards.
- [x] Manual: cancelled-only project still renders (fallback to runs[0]).

## Out of scope

The deeper refactor (use \`resolve_latest_per_dim\` directly to *build* the cards, with the headline computed in JS as \`mean(cards)\`) is the next step in this thread. That's the structural change that removes the cross-vs-single-run distinction entirely. Tracking as phase 3+.