### PR TITLE
fix(analysis): widen finding highlight to the full violation span

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -56,23 +56,34 @@ class _Finding(BaseModel):
     end_line: int | None = Field(
         default=None,
         description=(
-            "Last line of the offending span. Omit unless the violation is structural "
-            "(long function, nesting depth, file length). The server reads the actual source "
-            "to render the snippet; setting this widens the rendered window."
+            "Last line of the offending span. Set this whenever the violation "
+            "spans more than one line — both for structural issues (long "
+            "function, nesting depth) and for multi-line expressions or "
+            "blocks. Omit only when the issue is genuinely a single line. "
+            "The server reads the actual source to render the highlighted "
+            "snippet from line..end_line; getting end_line right is what "
+            "makes the highlight readable."
         ),
     )
     severity: _Severity = Field(default=_Severity.minor)
     w: str = Field(description="Short title of the finding")
     snippet: str = Field(
         description=(
-            "Exact text of the offending line, verbatim from the source file. "
-            "Required. If you cannot quote the line, drop the finding."
+            "Offending code copied VERBATIM from the source file — exact "
+            "characters, no paraphrase, no summarisation. One or a few "
+            "contiguous lines: quote enough that the issue is self-evident, "
+            "no padding. The number of lines in `snippet` must match the "
+            "span from `line` to `end_line` (so end_line - line + 1 == "
+            "snippet line count). Required. If you cannot quote the code, "
+            "drop the finding."
         ),
         min_length=1,
     )
     reason: str = Field(
         description=(
-            "One sentence: what the quoted line does wrong AS WRITTEN. "
+            "1–3 sentences: state what the quoted code does wrong AS WRITTEN, "
+            "and name the concrete impact (what breaks, who is affected, or "
+            "what attack/failure it enables). "
             "No hedging ('could', 'might', 'should consider', 'if X were larger')."
         ),
         min_length=1,
@@ -145,7 +156,7 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
         model=config.model,
         response_model=_Findings,
         messages=[
-            {"role": "system", "content": "You are a code quality evaluator. Quote the offending line into `snippet`. Empty `findings` is a valid answer."},
+            {"role": "system", "content": "You are a code quality evaluator. Quote the offending code into `snippet` VERBATIM from the source — one or a few contiguous lines, exact characters, no paraphrase. Set `end_line` to match the last line of the snippet. In `reason`, state what the code does wrong and the concrete impact in 1–3 sentences. Empty `findings` is a valid answer."},
             {"role": "user", "content": prompt},
         ],
         temperature=config.temperature,
@@ -180,6 +191,26 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
 # Enrichment and path resolution
 # ---------------------------------------------------------------------------
 
+def _infer_end_line(findings: list[dict]) -> None:
+    """Derive end_line from snippet line count when the model omits it.
+
+    Small local models often skip end_line, which collapses the dashboard
+    highlight to a single line even when the model quoted several lines into
+    snippet. If snippet has N>1 lines and end_line is unset, assume the span
+    runs from line to line+N-1.
+    """
+    for f in findings:
+        if f.get("end_line"):
+            continue
+        snippet = f.get("snippet") or ""
+        line = f.get("line") or 0
+        if line <= 0 or not snippet:
+            continue
+        n = snippet.count("\n") + 1
+        if n > 1:
+            f["end_line"] = line + n - 1
+
+
 def _enrich_findings(
     findings: list[dict],
     compiled_dir: Path | None,
@@ -187,6 +218,7 @@ def _enrich_findings(
     work_dir: Path | None,
 ) -> list[dict]:
     """Enrich findings through FindingsRouter (same as MCP path)."""
+    _infer_end_line(findings)
     if not compiled_dir:
         return findings
     try:

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -22,10 +22,10 @@ Each finding must be a JSON object with these fields:
     "line": integer - line number
     "severity": string - "critical", "major", or "minor"
     "w": string - short title of the finding
-    "reason": string - why this is a violation or compliance
+    "reason": string - 1–3 sentences: what the quoted code does wrong AS WRITTEN, plus the concrete impact
+    "snippet": string - offending code copied VERBATIM from the source (one or a few contiguous lines, exact characters)
   Optional:
     "end_line": integer - last line if multi-line
-    "snippet": string - code snippet
     "scope": string - "file", "class", or "module"
 """
 

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -10,7 +10,7 @@ NOT a violation: literal inside a constant/enum definition; long function that o
 
 ## Evidence
 
-Quote the specific problem expression in `snippet`. Code must be visible in source.
+Quote the specific problem expression in `snippet` — VERBATIM from the source, exact characters, no paraphrase. Set `end_line` so that `end_line - line + 1` equals the number of lines in `snippet`. Code must be visible in source.
 
 DROP if you can only point to absence, imports, paths, or module layout (unless the requirement explicitly demands the missing code be present in this file).
 
@@ -33,7 +33,7 @@ Test files contain `eval(x)`, secrets, path-traversal payloads on purpose. A rea
 ## Self-check (every finding, including minor)
 
 1. **Evidence** — Quote the problem line. Only "missing"/"absent" → drop.
-2. **Concrete** — State the problem in one sentence about the quoted code.
+2. **Concrete** — State the problem in 1–3 sentences about the quoted code, and name the concrete impact (what breaks, who is affected, or what attack/failure it enables).
 3. **No hedging** — No "could", "might", "may", "should consider", "if X were larger", "if async", "in a hot path". Describe what the line does wrong AS WRITTEN.
 4. **Impact** — Name the observable consequence. "Could be slow under load" without a profile is speculation.
 


### PR DESCRIPTION
## Summary

- Small local models (Ollama) collapsed the dashboard highlight to a single line because they followed the schema literally and never set `end_line` — the field description told them to omit it unless the violation was structural. Flipped that guidance: set `end_line` whenever the violation spans more than one line.
- Tightened `snippet` to require **verbatim** source text (exact characters, no paraphrase) so the snippet's line count is a reliable proxy for the offending span.
- Added `_infer_end_line()` safety net in the API runner: when a model omits `end_line` but quotes a multi-line snippet, derive `end_line = line + (snippet line count - 1)` before MCP enrichment runs. This widens the highlight even when the model forgets.
- `reason` now asks for **1–3 sentences with concrete impact** instead of one sentence — small models were producing detail text that read as a single hedge-free clause.

The MCP enrichment pipeline always overwrites `snippet` with file-extracted text from `line`→`end_line` and adds 5 lines of context above/below, so the rendered dashboard snippet is still source-faithful — this PR just makes sure `end_line` matches reality.

No CWE changes: per-rule mappings in `flexibility.json` are correct; CWE-1061 dominates flexibility findings because MITRE only tags 5 CWEs as flexibility-related and 1061 fits encapsulation/abstraction issues.

## Test plan

- [x] `pytest tests/analysis/ tests/data/` — 436 passed
- [x] Re-run a flexibility scan with Ollama and confirm the dashboard highlight now spans the actual violation
- [x] Re-run with a large API model (Sonnet/Opus) to confirm no regression in highlight width or reason quality