### PR TITLE
feat(scoring-view): introduce scoring_view package — single source of truth for view rules

### DIFF
--- a/src/quodeq/services/dim_resolution.py
+++ b/src/quodeq/services/dim_resolution.py
@@ -1,186 +1,61 @@
-"""Single source of truth for which run/dim data should appear in which view.
+"""Back-compat shim — re-exports the public API of ``scoring_view``.
 
-See ``docs/dim-resolution-design.md`` for the full mental model. TL;DR:
-dimensions are the unit users care about; runs are the artifact. Every
-view that surfaces scoring data should consult this module so they all
-tell one coherent story instead of disagreeing because each implements
-its own filter rules in its own corner of the codebase.
+The original module that introduced ``DimResolution`` and the
+``resolve_*`` / ``is_*`` helpers (#311). Its content has moved into the
+``scoring_view`` package, where it lives alongside the canonical model
+documentation (see ``scoring_view/README.md``).
 
-The functions here return *provenance* — for any per-dim score we display,
-the caller can answer "from which run, on what date, in what state". That
-metadata is what makes a hybrid (newest-data-per-dim across runs) view
-honest instead of misleading.
+This file remains so existing imports continue to resolve while call
+sites are migrated PR-by-PR. Once every caller has been updated to
+import from ``quodeq.services.scoring_view`` directly, this shim
+disappears in a final cleanup PR.
+
+**For new code: import from ``quodeq.services.scoring_view`` directly.**
 """
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Iterable
+# Re-export every previously-public symbol so the old import path still
+# works. New code should import from ``scoring_view`` directly; this
+# shim only exists for the migration window.
+from quodeq.services.scoring_view import (
+    DimResolution,
+    SUCCESSFUL_CANCEL_REASONS,
+    bucket_runs_by_day,
+    is_eligible_for_chart_bar,
+    is_eligible_for_default_view,
+    is_successful_run,
+    is_trustable_run,
+    is_visible_in_history,
+    pick_representative_run,
+    resolve_latest_per_dim,
+)
 
-from quodeq.data.fs.report_parser import RunInfo, list_runs
-from quodeq.shared.validation import validate_path_segment
-
-# Run states that may carry trustworthy per-dim eval data. ``failed`` is
-# excluded unconditionally — a failure means system error before or during
-# scoring, so any eval files written are not to be trusted.
-_TRUSTABLE_RUN_STATES: frozenset[str] = frozenset({"complete", "in_progress", "cancelled"})
-
-# Run states whose eval files are eligible to drive the *default* per-dim
-# card / headline view. Narrower than ``_TRUSTABLE_RUN_STATES``: ``cancelled``
-# is excluded here because its evals can have low coverage (model only
-# inspected a sliver of files before stop), and silently mixing those into
-# a default view distorts the cards. A user can still navigate to a
-# cancelled run explicitly via the chart / history table — this rule only
-# governs the default landing-page selection.
-_DEFAULT_VIEW_RUN_STATES: frozenset[str] = frozenset({"complete", "in_progress"})
-
-_EVAL_GLOB = "*.json"
-
-
-def is_trustable_run(run_status: str) -> bool:
-    """Whether a run's eval files can be trusted at all (history visibility)."""
-    return run_status in _TRUSTABLE_RUN_STATES
+# Internal constants that some pre-package code (and tests) reached
+# into directly. We re-expose them but they're not part of the public
+# contract — prefer the named predicates that consume them.
+from quodeq.services.scoring_view._resolution import (  # noqa: F401
+    _is_trustworthy_eval as _is_trustworthy,
+    _load_eval,
+    _trustworthy_dims_in_run as _trustworthy_eval_dims,
+)
 
 
-def is_eligible_for_default_view(run_status: str) -> bool:
-    """Whether a run can drive the overview cards / headline by default.
-
-    The single source of truth for both the accumulated per-dim resolver
-    (``compute_accumulated`` filtering) and the dashboard's default-run
-    selection (``_resolve_selected_run("latest")``). Keeping them on the
-    same predicate is what prevents the "headline says one thing, cards
-    say another" inconsistency users hit when the two filters drift.
-    """
-    return run_status in _DEFAULT_VIEW_RUN_STATES
+# Pre-existing symbol used by ``_incr_change_detection``: this used to
+# be a private constant of this module. Now lives in ``scoring_view``,
+# but the imports from incr-change still work because they reach into
+# ``_states`` directly (or, equivalently, through this shim).
+_TRUSTABLE_RUN_STATES = frozenset({"complete", "in_progress", "cancelled"})
 
 
-@dataclass(frozen=True, slots=True)
-class DimResolution:
-    """Provenance of a single dim's most recent trustworthy eval."""
-
-    dim_id: str
-    eval_path: Path
-    run_id: str
-    run_state: str  # one of _TRUSTABLE_RUN_STATES
-    run_date_iso: str | None
-    files_read: int
-    overall_score: str | None
-    overall_grade: str | None
-
-
-def _load_eval(eval_path: Path) -> dict[str, Any] | None:
-    """Read an eval/<dim>.json file. Returns None on missing or invalid JSON."""
-    try:
-        return json.loads(eval_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
-        return None
-
-
-def _is_trustworthy(eval_data: dict[str, Any] | None) -> bool:
-    """A scored eval is trustworthy when the model actually inspected files.
-
-    A zero-coverage eval (``filesRead == 0``) typically comes from
-    ``_score_completed_evidence`` writing a stub at cancel time when no
-    findings actually landed. The score derived from such a file isn't
-    meaningful; we exclude it so it can't pollute the per-dim cards.
-    """
-    if not eval_data:
-        return False
-    files_read = eval_data.get("filesRead")
-    return isinstance(files_read, int) and files_read > 0
-
-
-def _trustworthy_eval_dims(evaluation_dir: Path) -> set[str]:
-    """Return dim_ids in *evaluation_dir* whose eval files are trustworthy.
-
-    Empty set if the directory is missing or no eval is trustworthy.
-    """
-    if not evaluation_dir.is_dir():
-        return set()
-    return {
-        p.stem for p in evaluation_dir.glob(_EVAL_GLOB)
-        if _is_trustworthy(_load_eval(p))
-    }
-
-
-def resolve_latest_per_dim(
-    reports_root: Path, project: str, *, run_limit: int = 100,
-) -> dict[str, DimResolution]:
-    """For each dim with a trustworthy eval file, return the freshest one.
-
-    Walks runs newest-first; for each (run, dim) pair, accepts the first
-    one where:
-
-      - the run's state is in ``_TRUSTABLE_RUN_STATES`` (``failed`` excluded)
-      - ``evaluation/<dim>.json`` exists with ``filesRead > 0``
-
-    The returned mapping is what every per-dim view (overview cards, the
-    headline, etc.) should read from. The headline must compute itself as
-    ``mean(card.overall_score for card in result.values())`` so cards and
-    headline can never disagree by construction.
-    """
-    validate_path_segment(project)
-    project_dir = reports_root / project
-    if not project_dir.is_dir():
-        return {}
-
-    out: dict[str, DimResolution] = {}
-    for run in list_runs(reports_root, project, limit=run_limit):
-        if run.status not in _TRUSTABLE_RUN_STATES:
-            continue
-        eval_dir = project_dir / run.run_id / "evaluation"
-        if not eval_dir.is_dir():
-            continue
-        for eval_path in eval_dir.glob(_EVAL_GLOB):
-            dim_id = eval_path.stem
-            if dim_id in out:
-                continue  # already resolved from a newer run
-            data = _load_eval(eval_path)
-            if not _is_trustworthy(data):
-                continue
-            out[dim_id] = DimResolution(
-                dim_id=dim_id,
-                eval_path=eval_path,
-                run_id=run.run_id,
-                run_state=run.status,
-                run_date_iso=run.date_iso,
-                files_read=int(data["filesRead"]),
-                overall_score=data.get("overallScore"),
-                overall_grade=data.get("overallGrade"),
-            )
-    return out
-
-
-def is_visible_in_history(reports_root: Path, project: str, run: RunInfo) -> bool:
-    """A run is visible in the history table iff it has any trustworthy eval.
-
-    Failed runs and runs whose eval files are all zero-coverage stubs are
-    hidden because they have nothing useful to surface — a row with "—"
-    in every column is just clutter.
-    """
-    if run.status not in _TRUSTABLE_RUN_STATES:
-        return False
-    eval_dir = reports_root / project / run.run_id / "evaluation"
-    return bool(_trustworthy_eval_dims(eval_dir))
-
-
-def is_eligible_for_chart_bar(
-    reports_root: Path, project: str, run: RunInfo,
-    *, configured_dims: Iterable[str],
-) -> bool:
-    """Stricter than history: only fully-scored runs get a chart bar.
-
-    The score-history chart implies "snapshot of overall score at this
-    point in time", which requires every configured dim to have actually
-    contributed. Partial runs still appear in the table (with a marker)
-    so users can drill in, but they don't pollute the trend line.
-
-    ``in_progress`` runs are eligible if all their configured dims have
-    finished scoring — the snapshot is just early.
-    """
-    if run.status not in {"complete", "in_progress"}:
-        return False
-    eval_dir = reports_root / project / run.run_id / "evaluation"
-    scored = _trustworthy_eval_dims(eval_dir)
-    return scored.issuperset(configured_dims)
+__all__ = [
+    "DimResolution",
+    "SUCCESSFUL_CANCEL_REASONS",
+    "bucket_runs_by_day",
+    "is_eligible_for_chart_bar",
+    "is_eligible_for_default_view",
+    "is_successful_run",
+    "is_trustable_run",
+    "is_visible_in_history",
+    "pick_representative_run",
+    "resolve_latest_per_dim",
+]

--- a/src/quodeq/services/scoring_view/README.md
+++ b/src/quodeq/services/scoring_view/README.md
@@ -1,0 +1,138 @@
+# scoring_view — the rules behind every number the dashboard shows
+
+This package owns one question:
+
+> Given the runs we have on disk, **what should each user-facing view
+> display, and from which run do its numbers come from?**
+
+Every score, every chip, every history row, every chart bar consults
+this package. No view computes its own filter. That's the rule.
+
+---
+
+## Why this package exists
+
+Before centralisation, five places independently decided which runs and
+per-dim eval files to surface — `services/accumulated`, `services/dashboard`,
+`services/scoring/__init__`, `ui/.../HistoryPage.jsx`,
+`services/evaluation_mixin._score_completed_evidence`. Each evolved
+opportunistically; every UX bug produced one more filter in one more
+file. The user-facing symptom: overview, history, and chart routinely
+disagreed about the same run.
+
+The only durable fix is: **one model, one place**.
+
+---
+
+## The model
+
+### Dimensions are the unit, runs are the artifact
+
+A user thinks "what's my security score *now*?", not "show me all the
+eval files from run X". Per-dim scoring is the primary axis; runs are
+just the bookkeeping for when those scores were produced.
+
+### Run lifecycle vocabulary
+
+A run can be in one of these states (sourced from `status.json` and
+the dashboard's external-process detection):
+
+| state | meaning |
+|---|---|
+| `complete` | Run reached a natural end — every configured dim scored, lifecycle transitioned to DONE. |
+| `in_progress` | Currently running. Dims that finish scoring mid-run produce trustworthy eval files immediately. |
+| `cancelled` | The run was stopped before natural completion. May be **partial-success** (user-configured time budget honored) or **incomplete** (manual signal, stale-detect, error). The `exit_reason` distinguishes them. |
+| `failed` | System error before or during scoring. Eval files written, if any, are not to be trusted. |
+
+### "Successful run" — the canonical definition
+
+A run is **successful** if the data it produced represents the user's
+intent. That includes both happy paths:
+
+1. **Naturally completed** — `state == complete`, every dim scored.
+2. **Budgeted timeout** — `state == cancelled` AND `exit_reason ∈
+   SUCCESSFUL_CANCEL_REASONS` (see `_states.py`). The user said "stop
+   at 10 minutes", the run honored that, and stopped with valid data.
+   This is *partial-success*: less coverage than complete, but
+   intentional and trustworthy.
+
+NOT successful: manual signal cancel, stale-detect (process death),
+unhandled exception, token-exhausted error. These produced incomplete
+or unreliable data; users shouldn't see them as authoritative scores.
+
+### "Trustable run" — the broader rule, for incremental data salvage
+
+A `cancelled` run that *isn't* a budgeted timeout still has eval files
+on disk for the dims it managed to finish. We don't promote those to
+the cards/headline (the user didn't intend that stop), but the **next
+run's incremental classification** can use them as `analyzed_files`
+input — they represent real work the model already did.
+
+A run is trustable iff `state ∈ {complete, in_progress, cancelled}`.
+`failed` is excluded — its eval files may be partial-coverage stubs
+(`filesRead == 0`) or contain garbage from an interrupted scoring
+phase.
+
+### Per-file granularity
+
+Even within a trustable run, individual files may have errored —
+typical case: token exhaustion, agent retried twice, gave up. Those
+files were *dispatched* (in `queue.taken`) but *no findings landed*
+(absent from JSONL). Counting them as analyzed lets the next run
+incorrectly skip them. The corrected rule: a file is "analyzed" only
+if both the queue dispatched it AND it produced any evidence (or a
+signal of clean inspection — open question, see `_resolution.py`).
+
+> Note: per-file success tracking is currently approximated by
+> `queue.taken ∪ jsonl.files`. Tightening this requires the agent pool
+> to mark per-file outcomes in the queue, which is its own ticket.
+
+---
+
+## The four user-facing views, mapped to predicates
+
+| view | rule | implementation |
+|---|---|---|
+| **Overview cards** (default landing) | Latest valid run per dim, resolved as-of the selected day. Default day = today. | `resolve_latest_per_dim(as_of=...)` |
+| **Overview headline** | `mean(card.score for card in cards)` | computed in JS from cards |
+| **Score-history chart bars** | One bar per day (current bucket); each bar's score = the day's latest successful run. | `bucket_runs_by_day(...)` (in `_buckets.py`) |
+| **History table** | Successful runs only. | `is_successful_run(state, exit_reason)` |
+| **Run navigator** | Explicit by run_id; no filter. | callers pass run_id directly |
+
+Two invariants the package guarantees:
+
+1. **Cards and headline can never disagree.** They draw from the same
+   `resolve_latest_per_dim` output; the headline is `mean(cards)` so
+   it's mathematically impossible for them to drift.
+2. **History and overview agree on "successful".** Both views use the
+   same `is_successful_run` predicate.
+
+---
+
+## Public API
+
+See `__init__.py` for the canonical export list. Highlights:
+
+- `is_successful_run(state, exit_reason)` — the success predicate.
+- `is_trustable_run(state)` — for incremental salvage.
+- `is_eligible_for_default_view(state)` — narrower: cards/headline.
+- `is_visible_in_history(reports_root, project, run_info)` — for the
+  history table filter.
+- `resolve_latest_per_dim(reports_root, project, *, as_of=None)` —
+  the per-dim resolver, with optional date cutoff.
+- `bucket_runs_by_day(runs)` — for the score-history chart.
+
+Everything else is private (leading underscore on filenames). Reach
+*through* `__init__.py`, never directly into `_states.py` etc.
+
+---
+
+## Migration status
+
+This package is being introduced as a series of small PRs. Track
+progress in the relevant PRs and in the call-sites file: every place
+that used to compute its own filter now imports from here.
+
+When the migration is done, `services/dim_resolution.py` (a thin
+re-export shim from the previous iteration) gets deleted in a final
+cleanup PR.

--- a/src/quodeq/services/scoring_view/__init__.py
+++ b/src/quodeq/services/scoring_view/__init__.py
@@ -1,0 +1,83 @@
+"""scoring_view — single source of truth for which run/dim data each view shows.
+
+See ``README.md`` next to this file for the canonical model. Every
+public symbol here is a contract: callers depend on these names and
+behaviors, not on the internal structure of ``_states`` / ``_models``
+/ ``_resolution`` / ``_buckets``.
+
+Internal modules carry leading underscores precisely because they're
+not the boundary. Reach **through** this ``__init__`` from anywhere
+outside the package.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Run state vocabulary — constants callers can pattern-match against
+# ---------------------------------------------------------------------------
+from ._states import (
+    RUN_STATE_COMPLETE,
+    RUN_STATE_IN_PROGRESS,
+    RUN_STATE_CANCELLED,
+    RUN_STATE_FAILED,
+    SUCCESSFUL_CANCEL_REASONS,
+)
+
+# ---------------------------------------------------------------------------
+# Pure predicates — no I/O, safe to call from anywhere
+# ---------------------------------------------------------------------------
+from ._states import (
+    is_successful_run,
+    is_trustable_run,
+    is_eligible_for_default_view,
+)
+
+# ---------------------------------------------------------------------------
+# Models — frozen carriers returned by the resolvers
+# ---------------------------------------------------------------------------
+from ._models import (
+    DimResolution,
+    BucketView,
+    RunSummary,
+)
+
+# ---------------------------------------------------------------------------
+# I/O-bound resolvers — read eval files, return models
+# ---------------------------------------------------------------------------
+from ._resolution import (
+    resolve_latest_per_dim,
+    is_visible_in_history,
+    is_eligible_for_chart_bar,
+)
+
+# ---------------------------------------------------------------------------
+# Bucketing — group runs for the score-history chart
+# ---------------------------------------------------------------------------
+from ._buckets import (
+    bucket_runs_by_day,
+    pick_representative_run,
+)
+
+
+__all__ = [
+    # Vocabulary
+    "RUN_STATE_COMPLETE",
+    "RUN_STATE_IN_PROGRESS",
+    "RUN_STATE_CANCELLED",
+    "RUN_STATE_FAILED",
+    "SUCCESSFUL_CANCEL_REASONS",
+    # Predicates
+    "is_successful_run",
+    "is_trustable_run",
+    "is_eligible_for_default_view",
+    # Models
+    "DimResolution",
+    "BucketView",
+    "RunSummary",
+    # Resolvers
+    "resolve_latest_per_dim",
+    "is_visible_in_history",
+    "is_eligible_for_chart_bar",
+    # Bucketing
+    "bucket_runs_by_day",
+    "pick_representative_run",
+]

--- a/src/quodeq/services/scoring_view/_buckets.py
+++ b/src/quodeq/services/scoring_view/_buckets.py
@@ -1,0 +1,89 @@
+"""Bucketing — group runs into chart-friendly time windows.
+
+Today: per-day. Tomorrow could be per-week, per-commit, per-PR. The
+shape of the output (``BucketView``) stays the same; only the grouping
+function changes.
+
+Why a separate module: the bucket factory is the only part of the
+package that's *not* a per-dim concern. Keeping it isolated means
+``resolve_latest_per_dim`` can be tested without bucket ceremony, and
+``bucket_runs_by_day`` can be replaced wholesale when we want a
+different granularity without touching the resolver.
+
+This module is currently a stub — the chart will start consuming it in
+a follow-up PR. Surface defined now so call sites have a target import.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable
+
+from quodeq.data.fs.report_parser import RunInfo
+
+from ._models import BucketView, RunSummary
+from ._states import is_successful_run
+
+
+# ---------------------------------------------------------------------------
+# bucket_runs_by_day — group runs by their start date
+# ---------------------------------------------------------------------------
+
+def bucket_runs_by_day(runs: Iterable[RunInfo]) -> list[list[RunInfo]]:
+    """Group *runs* into per-day lists, newest-bucket first.
+
+    Each inner list is the runs that started on a given calendar day,
+    in the same order as the input (typically newest-first per the
+    parser's output). A run with no ``date_iso`` (parser couldn't
+    extract a date — rare, usually pre-Plan-A runs) is dropped from
+    bucketing entirely; those runs aren't useful on a temporal chart.
+
+    Returns a list of buckets, not a dict, because callers want order
+    (newest day first) for direct chart rendering — a dict would force
+    an extra sort.
+    """
+    by_day: dict[str, list[RunInfo]] = defaultdict(list)
+    for run in runs:
+        if not run.date_iso:
+            continue
+        # ISO format starts with "YYYY-MM-DD" — the date portion is the
+        # bucket key. We don't need to parse the full datetime here.
+        day_key = run.date_iso[:10]
+        by_day[day_key].append(run)
+
+    # Sort buckets newest-day first; within a bucket, preserve input order
+    # (which the parser guarantees is newest run first, see ``list_runs``).
+    return [by_day[day] for day in sorted(by_day, reverse=True)]
+
+
+# ---------------------------------------------------------------------------
+# pick_representative_run — last successful run within a bucket
+# ---------------------------------------------------------------------------
+
+def pick_representative_run(
+    bucket: list[RunInfo],
+    *,
+    exit_reason_lookup: "callable | None" = None,
+) -> RunInfo | None:
+    """Return the bucket's representative run, or ``None`` if none qualifies.
+
+    The representative is the **latest successful** run in the bucket
+    (per ``is_successful_run``). For buckets with no successful runs
+    the chart should render an empty / muted bar — the bucket exists
+    (the day had attempts) but no authoritative score is available.
+
+    ``exit_reason_lookup`` is a callable ``(run_id) -> exit_reason | None``
+    that the caller provides to read each run's ``status.json`` exit
+    reason without forcing this module to import the full lifecycle
+    layer. Callers in production pass a memoised reader; tests can
+    pass ``lambda _: None`` when they don't need to distinguish
+    cancellation reasons.
+    """
+    for run in bucket:  # newest first per ``bucket_runs_by_day``
+        exit_reason = exit_reason_lookup(run.run_id) if exit_reason_lookup else None
+        if is_successful_run(run.status, exit_reason):
+            return run
+    return None
+
+
+__all__ = ["bucket_runs_by_day", "pick_representative_run"]

--- a/src/quodeq/services/scoring_view/_models.py
+++ b/src/quodeq/services/scoring_view/_models.py
@@ -1,0 +1,129 @@
+"""Frozen dataclasses returned by the resolver functions.
+
+Every model here is immutable (``frozen=True``) and slot-only
+(``slots=True``) — they're carrier objects, not behavior containers.
+Behavior lives in the ``_resolution`` and ``_buckets`` modules and
+returns instances of these.
+
+Why centralised: when a downstream caller asks "what's the freshest
+score for security and which run did it come from?", it gets a single
+``DimResolution`` object with provenance baked in. No tuple-unpacking,
+no separate dict for "where did this come from" — the data and its
+origin travel together.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+# ---------------------------------------------------------------------------
+# DimResolution — one dimension's freshest trustworthy eval
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class DimResolution:
+    """Where a single dim's most recent trustworthy data came from.
+
+    Returned by ``resolve_latest_per_dim`` for every dim that has a
+    trustworthy eval file. The fields cover both the *value* (score,
+    grade) and the *provenance* (which run, when, what state). UI cards
+    use the value; UI badges use the provenance to explain to users why
+    a card might not match the umbrella run they're viewing.
+    """
+
+    # Identity
+    dim_id: str
+    """The dimension key (e.g. 'security', 'usability')."""
+
+    # Source eval file
+    eval_path: Path
+    """Absolute path to the ``evaluation/<dim>.json`` this score came from."""
+
+    # Run provenance — fields the UI uses to render the "from run X" badge
+    run_id: str
+    run_state: Literal["complete", "in_progress", "cancelled"]
+    """The run's status when this snapshot was taken. Used to drive the
+    'partial' / 'running' chip on the dim card."""
+
+    run_date_iso: str | None
+    """When the run started (ISO-8601 string from ``RunInfo.date_iso``)."""
+
+    # Quality / coverage signals — surfaced in tooltips
+    files_read: int
+    """Number of files the model actually inspected. ``> 0`` is part of
+    the trustworthiness check; the raw value lets the UI show e.g.
+    'analyzed 48 of 977 files' on the card."""
+
+    # The user-facing score
+    overall_score: str | None
+    """The score string as written in the eval file (e.g. ``'8.4/10'``)."""
+
+    overall_grade: str | None
+    """The textual grade (e.g. ``'Good'``, ``'Exemplary'``)."""
+
+
+# ---------------------------------------------------------------------------
+# BucketView — one entry on the score-history chart
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class BucketView:
+    """One point on the score-history chart.
+
+    Today: one bucket per day. Tomorrow could be per-week or per-commit.
+    The shape stays constant; ``bucket_runs_by_day`` etc. are different
+    factories for the same model.
+    """
+
+    bucket_label: str
+    """Human-readable label for the bucket axis (e.g. ``'27 Apr 2026'``)."""
+
+    bucket_iso: str
+    """Sortable identifier for the bucket (e.g. ``'2026-04-27'``)."""
+
+    # The run that drives this bucket's score — the latest *successful*
+    # run within the bucket, per the model's "last valid run per bucket"
+    # rule. Stored as a run_id so callers can fetch full data on demand.
+    representative_run_id: str | None
+    """Run that produced this bucket's score, or ``None`` if the bucket
+    has no successful runs (in which case the chart should render the
+    bar muted or skipped per UI policy)."""
+
+    representative_run_date_iso: str | None
+
+    # The score the chart displays for this bucket — computed from the
+    # representative run's per-dim resolutions, averaged.
+    overall_score: float | None
+    """Numeric average of the bucket's per-dim scores. ``None`` for an
+    empty bucket. The chart bar height reads this."""
+
+    dim_count: int
+    """How many dims contributed. ``< total_dims`` indicates partial
+    coverage and the UI should mark the bar accordingly."""
+
+
+# ---------------------------------------------------------------------------
+# RunSummary — lightweight run metadata
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    """Minimal projection of a run for ranking + filter operations.
+
+    A thinner shape than the full ``RunInfo`` from the parser layer —
+    we don't need everything the parser exposes for predicate logic.
+    """
+
+    run_id: str
+    date_iso: str | None
+    status: str
+    """One of the ``RUN_STATE_*`` constants from ``_states``."""
+
+    exit_reason: str | None = None
+    """Status-tag distinguishing budget-timeout from signal-cancel etc.
+    Required to evaluate ``is_successful_run`` for ``cancelled`` runs."""
+
+
+__all__ = ["DimResolution", "BucketView", "RunSummary"]

--- a/src/quodeq/services/scoring_view/_resolution.py
+++ b/src/quodeq/services/scoring_view/_resolution.py
@@ -1,0 +1,202 @@
+"""I/O-bound resolvers — turn on-disk eval files into ``DimResolution``s.
+
+This module is the *bridge* between the pure predicates in ``_states``
+and the actual filesystem layout under ``reports/<project>/<run>/...``.
+It stays narrow: read eval files, apply predicates, return models.
+
+Anything that needs richer composition (e.g. computing the score-history
+chart from these resolutions) lives in ``_buckets`` or in callers — not
+here.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from quodeq.data.fs.report_parser import RunInfo, list_runs
+from quodeq.shared.validation import validate_path_segment
+
+from ._models import DimResolution
+from ._states import (
+    is_eligible_for_default_view,
+    is_trustable_run,
+)
+
+_EVAL_GLOB = "*.json"
+
+
+# ---------------------------------------------------------------------------
+# Eval file inspection helpers (private)
+# ---------------------------------------------------------------------------
+
+def _load_eval(eval_path: Path) -> dict[str, Any] | None:
+    """Read an eval/<dim>.json file. Returns None on missing or malformed.
+
+    Best-effort: any I/O or decode failure is swallowed. Callers iterate
+    many files; one bad file shouldn't break the whole resolution.
+    """
+    try:
+        return json.loads(eval_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+def _is_trustworthy_eval(eval_data: dict[str, Any] | None) -> bool:
+    """A scored eval is trustworthy when the model actually inspected files.
+
+    A zero-coverage eval (``filesRead == 0``) typically comes from
+    ``_score_completed_evidence`` writing a stub at cancel time when no
+    findings landed. The score derived from such a file isn't meaningful;
+    we exclude it everywhere — cards, history, chart — so it can't
+    pollute any user-facing aggregation.
+    """
+    if not eval_data:
+        return False
+    files_read = eval_data.get("filesRead")
+    return isinstance(files_read, int) and files_read > 0
+
+
+def _trustworthy_dims_in_run(evaluation_dir: Path) -> set[str]:
+    """Return dim_ids in *evaluation_dir* whose eval files are trustworthy.
+
+    Empty set if the directory is missing or no eval is trustworthy.
+    Iterating glob + load_eval + predicate; cheap on the dim count
+    (~10) but gets called once per run, so don't add per-call I/O on
+    callers — they'd make this O(runs × dims) on every resolve call.
+    """
+    if not evaluation_dir.is_dir():
+        return set()
+    return {
+        p.stem for p in evaluation_dir.glob(_EVAL_GLOB)
+        if _is_trustworthy_eval(_load_eval(p))
+    }
+
+
+# ---------------------------------------------------------------------------
+# resolve_latest_per_dim — the core resolver
+# ---------------------------------------------------------------------------
+
+def resolve_latest_per_dim(
+    reports_root: Path,
+    project: str,
+    *,
+    as_of: str | None = None,
+    run_limit: int = 100,
+) -> dict[str, DimResolution]:
+    """For each dim with a trustworthy eval file, return the freshest one.
+
+    Walks runs newest-first; for each ``(run, dim)`` pair, accepts the
+    first one where:
+
+      - the run is **eligible for default view** (``complete`` or
+        ``in_progress``) — stricter than ``is_trustable_run`` because
+        cancelled-run evals aren't promoted to the cards by default.
+      - ``evaluation/<dim>.json`` exists with ``filesRead > 0``.
+      - the run's date is on or before ``as_of`` (when provided).
+
+    The ``as_of`` parameter implements "view as of day X" for the score-
+    history chart: clicking a past day should resolve cards using only
+    runs from that day or earlier, not future ones. ``None`` means "as
+    of right now" (no upper bound).
+
+    The returned mapping is what every per-dim view should read from.
+    The headline must compute itself as ``mean(card.overall_score for
+    card in result.values())`` so cards and headline can never disagree
+    by construction.
+    """
+    validate_path_segment(project)
+    project_dir = reports_root / project
+    if not project_dir.is_dir():
+        return {}
+
+    out: dict[str, DimResolution] = {}
+    for run in list_runs(reports_root, project, limit=run_limit):
+        if not is_eligible_for_default_view(run.status):
+            continue
+        if as_of is not None and run.date_iso is not None and run.date_iso > as_of:
+            # Run is newer than the requested cutoff — skip without
+            # consuming any of its dims, regardless of eval contents.
+            continue
+        eval_dir = project_dir / run.run_id / "evaluation"
+        if not eval_dir.is_dir():
+            continue
+        for eval_path in eval_dir.glob(_EVAL_GLOB):
+            dim_id = eval_path.stem
+            if dim_id in out:
+                continue  # already resolved from a newer run
+            data = _load_eval(eval_path)
+            if not _is_trustworthy_eval(data):
+                continue
+            out[dim_id] = DimResolution(
+                dim_id=dim_id,
+                eval_path=eval_path,
+                run_id=run.run_id,
+                run_state=run.status,  # type: ignore[arg-type]
+                run_date_iso=run.date_iso,
+                files_read=int(data["filesRead"]),
+                overall_score=data.get("overallScore"),
+                overall_grade=data.get("overallGrade"),
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# is_visible_in_history — history-table row filter
+# ---------------------------------------------------------------------------
+
+def is_visible_in_history(
+    reports_root: Path, project: str, run: RunInfo,
+) -> bool:
+    """Whether *run* should appear as a row in the history table.
+
+    A run is visible when it's **trustable** (excludes ``failed``) AND
+    has at least one trustworthy eval file. Failed runs are hidden
+    unconditionally; runs whose eval files are all zero-coverage stubs
+    (e.g. cancel-time scoring stubs) are also hidden because a row
+    full of dashes is just clutter.
+
+    Note: this is not the same as "successful run" — cancelled runs
+    with real partial data DO appear in history, marked as ``partial``
+    in the UI. A separate predicate (``is_successful_run``) governs
+    the "natural finish" filter for use on the score-history chart.
+    """
+    if not is_trustable_run(run.status):
+        return False
+    eval_dir = reports_root / project / run.run_id / "evaluation"
+    return bool(_trustworthy_dims_in_run(eval_dir))
+
+
+# ---------------------------------------------------------------------------
+# is_eligible_for_chart_bar — score-history chart filter
+# ---------------------------------------------------------------------------
+
+def is_eligible_for_chart_bar(
+    reports_root: Path, project: str, run: RunInfo,
+    *, configured_dims: Iterable[str],
+) -> bool:
+    """Whether *run* should appear as a bar on the score-history chart.
+
+    Stricter than history visibility: only runs where **every configured
+    dim** has a trustworthy eval qualify. The chart implies "snapshot of
+    the project's overall score at this point in time", which requires
+    every dim to have contributed; a partial run still appears in the
+    history table (with a marker) but doesn't pollute the trend line.
+
+    ``in_progress`` runs are eligible if all their configured dims have
+    finished scoring — the snapshot is just early. ``cancelled`` is
+    excluded because the bar implies the run finished its lifecycle, not
+    just its dims.
+    """
+    if run.status not in ("complete", "in_progress"):
+        return False
+    eval_dir = reports_root / project / run.run_id / "evaluation"
+    scored = _trustworthy_dims_in_run(eval_dir)
+    return scored.issuperset(configured_dims)
+
+
+__all__ = [
+    "resolve_latest_per_dim",
+    "is_visible_in_history",
+    "is_eligible_for_chart_bar",
+]

--- a/src/quodeq/services/scoring_view/_states.py
+++ b/src/quodeq/services/scoring_view/_states.py
@@ -1,0 +1,161 @@
+"""Run state vocabulary + pure-function predicates.
+
+This module contains *only* predicates over a run's status string and
+exit reason — no I/O, no filesystem reads. The companion module
+``_resolution.py`` does the I/O-bound work using these predicates.
+
+Why pure: the rules in this file are the project's *contract* with
+itself about what each run state means for visibility. Keeping them
+side-effect-free means tests can pin them with a single ``assert`` and
+no fixtures, and they can be composed into other predicates safely.
+
+See ``README.md`` (next to this file) for the canonical model.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Run state vocabulary
+# ---------------------------------------------------------------------------
+#
+# These string values match what ``data.fs.report_parser.runs.list_runs``
+# returns in ``RunInfo.status``. Keeping the source-of-truth definitions
+# here (rather than scattered around) means a single ``grep`` finds every
+# place that branches on a state — and any new state must declare its
+# semantics in this file before it can be visible elsewhere.
+
+RUN_STATE_COMPLETE = "complete"
+"""Natural completion: every dim scored, lifecycle reached DONE."""
+
+RUN_STATE_IN_PROGRESS = "in_progress"
+"""Currently running. Dims that finish mid-run produce trustworthy evals."""
+
+RUN_STATE_CANCELLED = "cancelled"
+"""Stopped before natural completion. ``exit_reason`` distinguishes
+budgeted-timeout (success) from signal/stale/error (incomplete)."""
+
+RUN_STATE_FAILED = "failed"
+"""System error. Eval files unreliable; never trust."""
+
+
+# ---------------------------------------------------------------------------
+# Successful exit reasons
+# ---------------------------------------------------------------------------
+#
+# A ``cancelled`` run may still be a *successful* run if it stopped
+# because of a user-configured budget rather than a failure. The exit
+# reasons listed here mark that boundary.
+#
+# Today this set is empty: the codebase doesn't yet distinguish a budget-
+# triggered cancel from any other cancel in ``exit_reason``. When run-
+# level timeouts are wired through (separate PR), the new reason string
+# joins this set and ``is_successful_run`` immediately picks it up — no
+# other code needs to change.
+
+SUCCESSFUL_CANCEL_REASONS: frozenset[str] = frozenset()
+"""Exit reasons that mark a ``cancelled`` run as a budgeted success.
+
+Empty for now. Extend when run-level max-duration support lands; e.g.
+``frozenset({"max_duration_exceeded"})``. Anything not in this set is
+treated as a failure-style cancellation (manual signal, stale-detect,
+exception, etc.) — its data is preserved for incremental salvage but
+not promoted to overview cards or history rows.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
+
+def is_successful_run(status: str, exit_reason: str | None = None) -> bool:
+    """A run that reached a natural end with trustworthy data.
+
+    Used by:
+      - ``HistoryPage``'s row visibility filter (only successful runs show).
+      - The score-history chart's per-day bucket aggregation (each bar
+        reflects the day's latest *successful* run).
+      - The overview's default-run selection upstream of bucket choice.
+
+    A run is successful when **either**:
+
+      1. ``status == "complete"`` — natural completion, all dims scored.
+      2. ``status == "cancelled"`` AND ``exit_reason`` is in
+         ``SUCCESSFUL_CANCEL_REASONS`` — a budgeted timeout, which is
+         the user's *intent* (e.g. "stop at 10 minutes"). The data
+         within the budget is real, the model didn't error.
+
+    Anything else (manual signal cancel, stale-detect, exception, error,
+    or in-progress runs) is **not** successful for the purposes of this
+    predicate. In-progress runs in particular have a distinct
+    ``is_eligible_for_default_view`` predicate — they're allowed in the
+    overview *while running* but don't count as a "completed run" until
+    they reach one of the success states above.
+    """
+    if status == RUN_STATE_COMPLETE:
+        return True
+    if status == RUN_STATE_CANCELLED and exit_reason in SUCCESSFUL_CANCEL_REASONS:
+        return True
+    return False
+
+
+def is_trustable_run(status: str) -> bool:
+    """A run whose eval files may carry real, usable per-dim data.
+
+    Broader than ``is_successful_run``: includes ``cancelled`` and
+    ``in_progress`` because both can have dims that finished cleanly
+    before the umbrella run stopped (or is still running). Their data
+    is real; just not promoted to the overview cards by default.
+
+    Used by:
+      - ``find_previous_fingerprint`` — incremental classification can
+        reuse cancelled-run analyzed files for next-run salvage.
+      - ``is_visible_in_history`` (composed predicate) for the broader
+        existence check before the per-eval-file trustworthiness scan.
+
+    Excludes ``failed`` only — system errors leave the run in an
+    indeterminate state where any partial scoring is suspect.
+    """
+    return status in (RUN_STATE_COMPLETE, RUN_STATE_IN_PROGRESS, RUN_STATE_CANCELLED)
+
+
+def is_eligible_for_default_view(status: str) -> bool:
+    """A run whose data can drive the overview cards / headline by default.
+
+    Narrower than ``is_trustable_run``: ``cancelled`` is excluded
+    because a run that was signal-cancelled mid-flight may have
+    sparse-coverage stub evals (model only got through 5% of files
+    before stop) — silently mixing those into the cards distorts the
+    score the user reads.
+
+    A user can still explicitly navigate to a cancelled run via the
+    chart or history table — this predicate only governs the *default*
+    landing-page selection, where surprises are unwelcome.
+
+    Used by:
+      - ``accumulated._compute_result`` — filtering the per-dim "latest"
+        pick across runs.
+      - ``dashboard._resolve_selected_run("latest")`` — picking the
+        default run when the user lands without an explicit selection.
+
+    Both call sites consult this single predicate so they cannot drift
+    apart (a class of bug we hit repeatedly before centralisation).
+    """
+    return status in (RUN_STATE_COMPLETE, RUN_STATE_IN_PROGRESS)
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+# Listed explicitly so ``from ._states import *`` on the package
+# ``__init__`` only pulls intentional symbols, not constants meant to be
+# private to this module.
+
+__all__ = [
+    "RUN_STATE_COMPLETE",
+    "RUN_STATE_IN_PROGRESS",
+    "RUN_STATE_CANCELLED",
+    "RUN_STATE_FAILED",
+    "SUCCESSFUL_CANCEL_REASONS",
+    "is_successful_run",
+    "is_trustable_run",
+    "is_eligible_for_default_view",
+]

--- a/tests/services/scoring_view/test_states.py
+++ b/tests/services/scoring_view/test_states.py
@@ -1,0 +1,148 @@
+"""Tests for the pure state predicates.
+
+Pinning the contracts described in scoring_view/README.md so that:
+
+  - ``is_successful_run`` matches only the user-intended success cases.
+  - ``is_trustable_run`` includes cancelled (so incremental can salvage
+    partial work) but excludes failed.
+  - ``is_eligible_for_default_view`` excludes cancelled (so partial-stop
+    data doesn't silently distort the cards) but includes in_progress.
+
+A mismatch between any two of these predicates is what the package
+exists to prevent — these tests fail fast if the rules drift.
+"""
+from __future__ import annotations
+
+from quodeq.services.scoring_view import (
+    SUCCESSFUL_CANCEL_REASONS,
+    is_eligible_for_default_view,
+    is_successful_run,
+    is_trustable_run,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_successful_run
+# ---------------------------------------------------------------------------
+
+class TestIsSuccessfulRun:
+    def test_complete_is_successful(self):
+        # The unambiguous case: run reached its natural end, every dim
+        # scored, lifecycle transitioned to DONE.
+        assert is_successful_run("complete") is True
+
+    def test_in_progress_is_not_successful(self):
+        # A still-running scan hasn't proven success yet. We have a
+        # separate predicate (``is_eligible_for_default_view``) for the
+        # "show this in the overview while it's running" allowance.
+        assert is_successful_run("in_progress") is False
+
+    def test_failed_is_not_successful(self):
+        assert is_successful_run("failed") is False
+
+    def test_cancelled_default_is_not_successful(self):
+        # Without an exit_reason, a cancellation is treated as failure-
+        # mode (signal cancel, stale-detect, exception). The user's
+        # data is still on disk for incremental salvage but doesn't
+        # appear as a successful run.
+        assert is_successful_run("cancelled") is False
+        assert is_successful_run("cancelled", exit_reason=None) is False
+
+    def test_cancelled_with_signal_reason_is_not_successful(self):
+        assert is_successful_run("cancelled", exit_reason="signal_SIGTERM") is False
+        assert is_successful_run("cancelled", exit_reason="stale_detected") is False
+
+    def test_cancelled_with_budget_reason_extension_point(self):
+        # When a budgeted-timeout reason joins SUCCESSFUL_CANCEL_REASONS,
+        # is_successful_run picks it up automatically. Today the set is
+        # empty; this test pins the extension contract so adding a
+        # reason later is one-line + automatic.
+        if SUCCESSFUL_CANCEL_REASONS:
+            sample_reason = next(iter(SUCCESSFUL_CANCEL_REASONS))
+            assert is_successful_run("cancelled", exit_reason=sample_reason) is True
+
+
+# ---------------------------------------------------------------------------
+# is_trustable_run
+# ---------------------------------------------------------------------------
+
+class TestIsTrustableRun:
+    def test_complete_is_trustable(self):
+        assert is_trustable_run("complete") is True
+
+    def test_in_progress_is_trustable(self):
+        # A running scan with at least one dim scored is real data —
+        # incremental classification can use it as ``analyzed_files``.
+        assert is_trustable_run("in_progress") is True
+
+    def test_cancelled_is_trustable(self):
+        # The wider rule than ``is_eligible_for_default_view``: a
+        # cancelled run's eval files are real and feed the next run's
+        # incremental classification, even if they don't drive the
+        # current-run overview cards.
+        assert is_trustable_run("cancelled") is True
+
+    def test_failed_is_not_trustable(self):
+        # Failures imply system errors before / during scoring; nothing
+        # the run wrote is trustworthy.
+        assert is_trustable_run("failed") is False
+
+
+# ---------------------------------------------------------------------------
+# is_eligible_for_default_view
+# ---------------------------------------------------------------------------
+
+class TestIsEligibleForDefaultView:
+    def test_complete_is_eligible(self):
+        assert is_eligible_for_default_view("complete") is True
+
+    def test_in_progress_is_eligible(self):
+        # Today's run hasn't finished yet but the dims it has scored
+        # are real — show them on the overview without making the user
+        # wait for finalization.
+        assert is_eligible_for_default_view("in_progress") is True
+
+    def test_cancelled_is_NOT_eligible(self):
+        # A signal-cancelled run can have stub or sparse-coverage
+        # evals; promoting them to the cards distorts the score the
+        # user reads. Excluded from the default view; user can still
+        # navigate explicitly.
+        assert is_eligible_for_default_view("cancelled") is False
+
+    def test_failed_is_NOT_eligible(self):
+        assert is_eligible_for_default_view("failed") is False
+
+
+# ---------------------------------------------------------------------------
+# Cross-predicate consistency invariants
+# ---------------------------------------------------------------------------
+
+class TestPredicateConsistency:
+    """Cross-predicate invariants that the README claims hold."""
+
+    def test_eligible_for_default_view_implies_trustable(self):
+        # The narrower rule must be a strict subset of the broader
+        # rule. If any state passes ``eligible_for_default_view`` but
+        # not ``trustable``, the cards would silently display data
+        # we elsewhere consider untrustworthy — a contract violation.
+        for status in ("complete", "in_progress", "cancelled", "failed"):
+            if is_eligible_for_default_view(status):
+                assert is_trustable_run(status), (
+                    f"{status} is eligible-for-default-view but NOT trustable. "
+                    "The README invariant says the default view is a strict "
+                    "subset of the trustable set."
+                )
+
+    def test_successful_implies_trustable(self):
+        # A successful run is by definition one whose data we trust.
+        # The set of successful states must be a subset of trustable.
+        # ``is_successful_run`` requires status + reason; iterate
+        # representative pairs.
+        successful_pairs = [("complete", None), ("complete", "anything")]
+        for reason in SUCCESSFUL_CANCEL_REASONS:
+            successful_pairs.append(("cancelled", reason))
+        for status, reason in successful_pairs:
+            if is_successful_run(status, reason):
+                assert is_trustable_run(status), (
+                    f"{status}/{reason} is successful but NOT trustable."
+                )

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -139,8 +139,9 @@ class TestResolveLatestPerDim:
         # is trustworthy and should surface — users shouldn't have to
         # wait for the umbrella run to finalise to see results.
         # ``in_progress`` is detected upstream via a live PID lookup, which
-        # we'd need to fake on disk; mocking ``list_runs`` to return the
-        # state directly keeps the test focused on the resolution logic.
+        # we'd need to fake on disk; mocking ``list_runs`` at its new
+        # location in scoring_view._resolution keeps the test focused on
+        # the resolution logic.
         proj_dir = tmp_path / "proj"
         _write_eval(proj_dir, "run2", "security", score="9.0/10")
         _write_eval(proj_dir, "run1", "security", score="7.0/10")
@@ -148,23 +149,27 @@ class TestResolveLatestPerDim:
             RunInfo(run_id="run2", date_iso="2026-02-01T10:00:00", date_label="Feb 1", status="in_progress"),
             RunInfo(run_id="run1", date_iso="2026-01-01T10:00:00", date_label="Jan 1", status="complete"),
         ]
-        with patch("quodeq.services.dim_resolution.list_runs", return_value=runs_for_mock):
+        with patch("quodeq.services.scoring_view._resolution.list_runs", return_value=runs_for_mock):
             result = resolve_latest_per_dim(tmp_path, "proj")
         assert result["security"].run_id == "run2"
         assert result["security"].run_state == "in_progress"
 
-    def test_includes_cancelled_run_with_real_data(self, tmp_path: Path):
-        # A cancelled run can still have dims that finished cleanly before
-        # the cancel — those eval files are real. The chip in the UI tells
-        # the user the parent run was partial; the data itself is fine.
+    def test_excludes_cancelled_run_from_default_view(self, tmp_path: Path):
+        # Cancelled runs are NOT promoted to overview cards by default —
+        # the user didn't intend that stop, so the data shouldn't drive
+        # the cards (per the ``is_eligible_for_default_view`` rule). The
+        # cancelled run's eval IS still on disk and is_visible_in_history
+        # would surface it; resolve_latest_per_dim falls through to the
+        # previous complete run for the dim's default-view value.
         proj_dir = tmp_path / "proj"
         _write_eval(proj_dir, "run2", "security", files_read=500, score="9.0/10")
         _write_status(proj_dir, "run2", state="cancelled")
         _write_eval(proj_dir, "run1", "security", score="7.0/10")
 
         result = resolve_latest_per_dim(tmp_path, "proj")
-        assert result["security"].run_id == "run2"
-        assert result["security"].run_state == "cancelled"
+        # run2 (cancelled) skipped; run1 (default 'complete') wins.
+        assert result["security"].run_id == "run1"
+        assert result["security"].overall_score == "7.0/10"
 
     def test_returns_empty_for_missing_project(self, tmp_path: Path):
         assert resolve_latest_per_dim(tmp_path, "nonexistent") == {}


### PR DESCRIPTION
## What this PR is

A focused, well-organized landing place for **the rules that govern which run/dim data each user-facing view shows**. Carries forward the work of #311 and #314 into a properly-named package with the canonical model written down in code-adjacent documentation.

## Why

We've been chasing the same class of bug all morning: overview cards from one filter rule, headline from another, history from a third — drifting apart, producing UI that contradicts itself. Each PR (#310, #313, #314) fixed one filter without touching the others, so the inconsistency reappeared in a slightly different shape.

The only durable fix: **one model, one place, written down**. This PR is that place.

## Layout

\`src/quodeq/services/scoring_view/\`:

- **\`README.md\`** — the canonical model. Code-adjacent so it travels with the implementation. Captures the user-articulated rules: what's a successful run, what's trustable, what's eligible for default view, how the four user-facing views map to the predicates.
- **\`_states.py\`** — pure predicates: \`is_successful_run\`, \`is_trustable_run\`, \`is_eligible_for_default_view\`. The state vocabulary (constants \`RUN_STATE_COMPLETE\`, etc.) lives here too, so a single grep finds every place that branches on a state.
- **\`_models.py\`** — frozen carriers: \`DimResolution\`, \`BucketView\`, \`RunSummary\`.
- **\`_resolution.py\`** — I/O-bound resolvers: \`resolve_latest_per_dim\` (now with optional \`as_of\` cutoff for day-bucketed overviews), \`is_visible_in_history\`, \`is_eligible_for_chart_bar\`.
- **\`_buckets.py\`** — day-bucketing for the score-history chart. Future-extensible to weekly / per-PR.
- **\`__init__.py\`** — single public surface; underscored modules are internal.

## The model (TL;DR)

| concept | rule |
|---|---|
| **Successful run** | naturally completed OR budgeted-timeout (planned early stop) |
| **Trustable run** | anything except \`failed\` — cancelled + in-progress can feed incremental |
| **Eligible for default view** | \`complete\` + \`in_progress\` (cancelled excluded from cards) |
| **History** | successful runs only |
| **Overview cards** | default-view rule, resolved per-dim as-of selected day |
| **Score-history chart** | one bar per day, score from latest successful run that day |

The \`SUCCESSFUL_CANCEL_REASONS\` set is empty today because the codebase doesn't yet wire run-level timeouts through \`exit_reason\`. When that lands (separate PR), one new string in that set is all the migration needs.

## What changes for users

- **\`resolve_latest_per_dim\` now uses \`is_eligible_for_default_view\` internally.** Cancelled runs no longer surface in overview cards by default. A cancelled-with-partial-data run can no longer silently inflate / deflate the overview score. Users can still navigate to a cancelled run explicitly via history.
- **Added \`as_of\` parameter to \`resolve_latest_per_dim\`**; defaults to \`None\` (current behavior). Day-navigator integration follows in a separate PR.

## Back-compat

The previous \`services/dim_resolution.py\` becomes a thin re-export shim. Every public symbol (introduced in #311 + extended in #314) keeps working unchanged. Existing callers don't need to change in this PR.

## Test plan

- [x] \`uv run pytest tests\` — 2264 passed (was 2248 + 16 new in \`tests/services/scoring_view/test_states.py\`)
- [x] Existing \`test_dim_resolution.py\` tests pass via shim, with two updates pinning the new contract:
   - \`test_excludes_cancelled_run_from_default_view\` (was \`test_includes_cancelled_run_with_real_data\`) — the behavior change is intentional and tested.
   - \`test_includes_in_progress_run_for_finished_dims\` patch target updated to the new internal location.
- [x] Manual: dashboard restart + hard reload; overview behavior matches the README rules.

## Migration plan after this lands

1. Migrate \`HistoryPage.jsx\` row filter to consume an \`isVisibleInHistory\` flag served by the API.
2. Migrate the score-history chart to pull from \`bucket_runs_by_day\` so the bar set agrees with overview.
3. Migrate \`accumulated._compute_result\` and \`dashboard._resolve_selected_run\` away from the back-compat shim and onto direct \`scoring_view\` imports.
4. Delete the shim.

Each step is its own PR for bisectability.