### PR TITLE
fix(salvage-scoring): populate files_read + source_file_count from queue / scan.json

### DIFF
--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -326,11 +326,52 @@ def _discard_partial_dim_state(reports_dir: str, job: dict) -> None:
                 _logger.warning("Could not discard %s: %s", victim, exc)
 
 
+def _read_queue_files_count(queue_path: Path) -> int:
+    """Sum of files dispatched across all batches in a dim's queue.json.
+
+    Used to populate ``files_read`` when scoring residual evidence —
+    without this, ``_score_completed_evidence`` writes eval stubs with
+    ``filesRead: 0``, which the ``scoring_view`` trust rule rejects as
+    untrustworthy. Returning the queue's taken count yields a faithful
+    coverage figure: every file that was actually dispatched to an agent.
+    """
+    try:
+        data = json.loads(queue_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return 0
+    taken = data.get("taken") if isinstance(data, dict) else None
+    if not isinstance(taken, list):
+        return 0
+    total = 0
+    for entry in taken:
+        files = entry.get("files") if isinstance(entry, dict) else None
+        if isinstance(files, list):
+            total += len(files)
+    return total
+
+
+def _read_project_source_file_count(reports_dir: str, project: str) -> int:
+    """Read ``scan.json`` total_files for the project. Returns 0 on failure."""
+    scan_path = Path(reports_dir) / project / "scan.json"
+    try:
+        data = json.loads(scan_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return 0
+    raw = data.get("total_files") if isinstance(data, dict) else None
+    return int(raw) if isinstance(raw, int) else 0
+
+
 def _score_completed_evidence(reports_dir: str, job: dict) -> None:
     """Score any dimensions that have evidence but no evaluation report.
 
     Called after cancellation so completed dimensions are preserved in the
     dashboard even when the overall run was cancelled.
+
+    Populates ``files_read`` from the dim's queue.json (count of dispatched
+    files) and ``source_file_count`` from the project's scan.json. Without
+    these, the scored eval has ``filesRead: 0``, which ``scoring_view``'s
+    trust rule rejects — the user sees the cancelled run's data fall
+    through to an older run's stale value despite real findings on disk.
     """
     project = job.get("outputProject")
     run_id = job.get("outputRunId")
@@ -345,6 +386,7 @@ def _score_completed_evidence(reports_dir: str, job: dict) -> None:
         return
 
     evaluation_dir.mkdir(parents=True, exist_ok=True)
+    source_file_count = _read_project_source_file_count(reports_dir, project)
 
     for jsonl_path in evidence_dir.glob("*_evidence.jsonl"):
         dim_id = jsonl_path.name.replace("_evidence.jsonl", "")
@@ -358,15 +400,19 @@ def _score_completed_evidence(reports_dir: str, job: dict) -> None:
         if not queue_file.exists():
             continue  # verification not completed for this dimension
 
+        files_read = _read_queue_files_count(queue_file)
         try:
             evidence = parse_jsonl_to_evidence(jsonl_path, EvidenceContext(
                 language="", repository="", date_str="",
-                source_file_count=0, files_read=0,
+                source_file_count=source_file_count, files_read=files_read,
             ))
             if evidence is None:
                 continue
             scores = score_evidence(evidence, mode="numerical")
             write_dimension_report(evidence, scores, dim_id, evaluation_dir)
-            _log.info("Scored cancelled dimension '%s' for run %s", dim_id, run_id[:8])
+            _log.info(
+                "Scored cancelled dimension '%s' for run %s (files_read=%d)",
+                dim_id, run_id[:8], files_read,
+            )
         except (OSError, json.JSONDecodeError, ValueError, KeyError) as exc:
             _log.debug("Could not score cancelled dimension '%s': %s", dim_id, exc)

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -17,6 +17,8 @@ from quodeq.services.evaluation_mixin import (
     SubprocessDispatcher,
     _build_evaluate_cmd,
     _discard_partial_dim_state,
+    _read_project_source_file_count,
+    _read_queue_files_count,
     _register_project,
     _score_completed_evidence,
 )
@@ -474,6 +476,138 @@ class TestScoreCompletedEvidence:
             "outputProject": "proj",
             "outputRunId": "run1",
         })
+
+
+# ---------------------------------------------------------------------------
+# _read_queue_files_count + _read_project_source_file_count
+# ---------------------------------------------------------------------------
+
+class TestReadQueueFilesCount:
+    """Pin the contract that salvage scoring uses to populate `files_read`.
+
+    Without this, ``_score_completed_evidence`` writes evals with
+    ``filesRead: 0`` — which the ``scoring_view`` trust rule rejects as
+    untrustworthy stubs, falling the user back to an older run's stale
+    score for that dim despite real findings being on disk.
+    """
+
+    def test_sums_files_across_taken_batches(self, tmp_path: Path):
+        # Real-shape queue: each batch is `{files, agent, ts}`; files_read
+        # is the count of files dispatched across all batches.
+        queue = tmp_path / "q.json"
+        queue.write_text(json.dumps({
+            "taken": [
+                {"files": ["a.py", "b.py", "c.py"], "agent": "a1", "ts": 1},
+                {"files": ["d.py", "e.py"], "agent": "a2", "ts": 2},
+            ],
+            "pending": [],
+        }))
+        assert _read_queue_files_count(queue) == 5
+
+    def test_zero_when_no_taken_entries(self, tmp_path: Path):
+        queue = tmp_path / "q.json"
+        queue.write_text(json.dumps({"taken": [], "pending": ["x.py"]}))
+        assert _read_queue_files_count(queue) == 0
+
+    def test_zero_when_missing_file(self, tmp_path: Path):
+        # Salvage path encounters a non-existent queue (rare but possible
+        # if a dim never reached the queue-creation step) — must not raise.
+        assert _read_queue_files_count(tmp_path / "missing.json") == 0
+
+    def test_zero_when_corrupt_json(self, tmp_path: Path):
+        queue = tmp_path / "q.json"
+        queue.write_text("{not json")
+        assert _read_queue_files_count(queue) == 0
+
+    def test_handles_missing_files_field_in_batch(self, tmp_path: Path):
+        # Defensive: a malformed batch missing `files` shouldn't crash.
+        queue = tmp_path / "q.json"
+        queue.write_text(json.dumps({
+            "taken": [{"agent": "a1", "ts": 1}, {"files": ["x.py"]}],
+            "pending": [],
+        }))
+        assert _read_queue_files_count(queue) == 1
+
+
+class TestReadProjectSourceFileCount:
+    def test_reads_from_scan_json(self, tmp_path: Path):
+        proj_dir = tmp_path / "reports" / "proj"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "scan.json").write_text(json.dumps({"total_files": 1855}))
+        assert _read_project_source_file_count(str(tmp_path / "reports"), "proj") == 1855
+
+    def test_zero_when_scan_missing(self, tmp_path: Path):
+        assert _read_project_source_file_count(str(tmp_path), "ghost") == 0
+
+    def test_zero_when_corrupt_scan(self, tmp_path: Path):
+        proj_dir = tmp_path / "reports" / "proj"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "scan.json").write_text("{nope")
+        assert _read_project_source_file_count(str(tmp_path / "reports"), "proj") == 0
+
+    def test_zero_when_total_files_not_int(self, tmp_path: Path):
+        proj_dir = tmp_path / "reports" / "proj"
+        proj_dir.mkdir(parents=True)
+        (proj_dir / "scan.json").write_text(json.dumps({"total_files": "many"}))
+        assert _read_project_source_file_count(str(tmp_path / "reports"), "proj") == 0
+
+
+class TestScoreCompletedEvidencePopulatesCoverage:
+    """The bug this fixes: salvage-written evals had filesRead=0, so the
+    scoring_view trust rule (filesRead > 0) rejected them as stubs. The
+    user-visible symptom was a real, fully-completed dim's score being
+    silently replaced by an older run's score on the overview cards.
+    """
+
+    def test_files_read_populated_from_queue(self, tmp_path: Path):
+        reports = tmp_path / "reports"
+        proj = reports / "proj"
+        run = proj / "run1"
+        ev_dir = run / "evidence"
+        ev_dir.mkdir(parents=True)
+        # Mark the project's scan with a real total_files.
+        (proj / "scan.json").write_text(json.dumps({"total_files": 1000}))
+        # 7 files dispatched across two agent batches.
+        (ev_dir / "security_queue.json").write_text(json.dumps({
+            "taken": [
+                {"files": ["a.py", "b.py", "c.py", "d.py"], "agent": "a1", "ts": 1},
+                {"files": ["e.py", "f.py", "g.py"], "agent": "a2", "ts": 2},
+            ],
+            "pending": [],
+        }))
+        # Real findings written to JSONL (would normally come from agents).
+        (ev_dir / "security_evidence.jsonl").write_text(
+            '{"req": "S-CON-1", "t": "violation", "file": "a.py", "line": 1, "severity": "minor", "w": "x", "reason": "y"}\n'
+        )
+
+        _score_completed_evidence(str(reports), {
+            "outputProject": "proj",
+            "outputRunId": "run1",
+        })
+
+        eval_path = run / "evaluation" / "security.json"
+        assert eval_path.is_file()
+        eval_data = json.loads(eval_path.read_text())
+        # The fix: filesRead reflects the queue's taken count, not 0.
+        assert eval_data["filesRead"] == 7
+        # And source_file_count comes from scan.json.
+        assert eval_data["sourceFileCount"] == 1000
+
+    def test_files_read_zero_when_no_queue(self, tmp_path: Path):
+        # Edge case: if the queue file is missing entirely (which already
+        # short-circuits the dim earlier in the function), the helper
+        # gracefully returns 0 without crashing the broader walk.
+        reports = tmp_path / "reports"
+        ev_dir = reports / "proj" / "run1" / "evidence"
+        ev_dir.mkdir(parents=True)
+        # No queue file — _score_completed_evidence skips this dim entirely.
+        (ev_dir / "security_evidence.jsonl").write_text('{"f":1}\n')
+        _score_completed_evidence(str(reports), {
+            "outputProject": "proj",
+            "outputRunId": "run1",
+        })
+        eval_path = reports / "proj" / "run1" / "evaluation" / "security.json"
+        assert not eval_path.exists()  # skipped because no queue
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug shape

Today's run \`278ce91e\` (which started before #312 merged, so it ran the old loop code) hit the silent-skip bug exactly as predicted:

- Flexibility's pool ran 981/981 files cleanly.
- 1264 deduplicated findings written to \`flexibility_evidence.jsonl\`.
- \`[flexibility] Coverage: 981/981 files (100%)\` logged.
- Then the dashboard's scoring callback raised \`BrokenPipeError\` (parent pipe closed), the pre-#312 loop didn't catch it, lifecycle silently transitioned to \`done\`, and \`evaluation/flexibility.json\` was never written.

So I tried to recover by manually calling \`_score_completed_evidence\` against the run dir. **It wrote a stub with \`filesRead: 0\`** — which the new \`scoring_view\` trust rule correctly rejects as untrustworthy. Net effect: the overview kept showing flexibility from Apr 25 even though today's data was scored and on disk.

## Why the rule rejects stubs

The trust rule (\`filesRead > 0\`) exists because cancel-time stubs *do* sometimes get written with no real coverage — they shouldn't be promoted to cards. But in this case the data IS real (981 files inspected, 1264 findings); the stub status is purely cosmetic, caused by \`_score_completed_evidence\` not bothering to populate \`files_read\` from anywhere.

## Fix

Two new helpers — \`_read_queue_files_count\` and \`_read_project_source_file_count\` — derive the metadata from disk so the eval is faithful:

\`\`\`
files_read         = sum(len(b['files']) for b in queue['taken'])     # 981
source_file_count  = scan.json's total_files                          # 1855
coveragePct        = computed downstream                               # 52.9
\`\`\`

Re-running salvage with this fix on the production data turns flexibility's stub into a proper eval, and \`resolve_latest_per_dim\` now correctly picks today's flexibility data instead of falling back to Apr 25.

## Test plan

- [x] \`uv run pytest tests\` — 2275 passed (was 2264 + 11 new)
- [x] Helper unit tests pin: corrupt JSON, missing files, malformed batches all return 0 without raising.
- [x] Integration test pins: \`_score_completed_evidence\` writes \`filesRead == queue.taken total\` and \`sourceFileCount == scan.json's total_files\`.
- [x] Verified against on-disk data for run \`278ce91e\`: re-salvage produces a trustworthy eval that \`resolve_latest_per_dim\` accepts.
- [x] Manual: refresh dashboard after merge, flexibility card on overview shows today's score (8.4) not the older run's (7.0).