### PR TITLE
fix(incremental): split finding-format prompt out of rules-bearing file

### DIFF
--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 
 from quodeq.analysis.prompts._template import load_template
+from quodeq.analysis.prompts.builder import _load_evaluation_rules
 from quodeq.config.prompt_templates import render_template
 
 _log = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ def assemble_api_prompt(
 ) -> str:
     """Assemble a complete evaluation prompt for the API runner."""
     template = load_template(template_name="api_prompt.md")
-    rules = load_template(template_name="evaluation_rules.md")
+    rules = _load_evaluation_rules()
     files_block = _build_files_block(source_files, repo_root=repo_root)
     return render_template(template, {
         "DIMENSION": dimension,

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -23,11 +23,25 @@ _TPL_EVALUATION_RULES = "EVALUATION_RULES"
 
 
 def _load_evaluation_rules() -> str:
-    """Load shared evaluation rules from evaluation_rules.md."""
-    try:
-        return load_template(template_name="evaluation_rules.md")
-    except (OSError, FileNotFoundError):
-        return ""
+    """Load shared evaluation rules + reporting format.
+
+    Concatenates two prompt files into the same template slot. They are
+    kept apart on disk so the incremental cache can treat them
+    differently:
+
+    - evaluation_rules.md is rules-bearing (in ``_RULES_BEARING_PROMPTS``)
+      — anything that decides what counts as a violation. Edits force a
+      full re-analysis.
+    - finding_format.md is reporting/quoting/phrasing discipline. Edits
+      do NOT invalidate carry-forward.
+    """
+    parts: list[str] = []
+    for name in ("evaluation_rules.md", "finding_format.md"):
+        try:
+            parts.append(load_template(template_name=name))
+        except (OSError, FileNotFoundError):
+            continue
+    return "\n\n".join(p for p in parts if p)
 
 
 def render_previous_findings_section(findings: list[dict]) -> str:

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -10,7 +10,7 @@ NOT a violation: literal inside a constant/enum definition; long function that o
 
 ## Evidence
 
-Quote the specific problem expression in `snippet` — VERBATIM from the source, exact characters, no paraphrase. Set `end_line` so that `end_line - line + 1` equals the number of lines in `snippet`. Code must be visible in source.
+Code must be visible in source.
 
 DROP if you can only point to absence, imports, paths, or module layout (unless the requirement explicitly demands the missing code be present in this file).
 
@@ -33,7 +33,7 @@ Test files contain `eval(x)`, secrets, path-traversal payloads on purpose. A rea
 ## Self-check (every finding, including minor)
 
 1. **Evidence** — Quote the problem line. Only "missing"/"absent" → drop.
-2. **Concrete** — State the problem in 1–3 sentences about the quoted code, and name the concrete impact (what breaks, who is affected, or what attack/failure it enables).
+2. **Concrete** — State the problem about the quoted code and name the concrete impact (what breaks, who is affected, or what attack/failure it enables).
 3. **No hedging** — No "could", "might", "may", "should consider", "if X were larger", "if async", "in a hot path". Describe what the line does wrong AS WRITTEN.
 4. **Impact** — Name the observable consequence. "Could be slow under load" without a profile is speculation.
 

--- a/src/quodeq/data/prompts/finding_format.md
+++ b/src/quodeq/data/prompts/finding_format.md
@@ -1,0 +1,7 @@
+## How to quote evidence
+
+Quote the specific problem expression in `snippet` — VERBATIM from the source, exact characters, no paraphrase. Set `end_line` so that `end_line - line + 1` equals the number of lines in `snippet`.
+
+## How to phrase the finding
+
+State the problem in 1–3 sentences about the quoted code.


### PR DESCRIPTION
## Summary

- Split `evaluation_rules.md` into two files so quoting/phrasing edits don't invalidate the incremental cache.
- New `finding_format.md` holds reporting discipline (`snippet` VERBATIM + `end_line` arithmetic, "in 1–3 sentences" length).
- `evaluation_rules.md` keeps only what defines a violation (look-for / NOT-a-violation / drop rules / severity / test-files / self-check decision logic). It stays the sole entry in `_RULES_BEARING_PROMPTS`.
- Both files are concatenated into the same `EVALUATION_RULES` template slot — the agent sees identical prompt content; only the cache contract changes.

## Motivation

#315 tweaked `evaluation_rules.md` to widen the finding highlight span (`snippet` VERBATIM, `end_line` discipline, "1–3 sentences"). All three are presentation/phrasing — a finding produced under the old rules would still be a valid finding under the new ones, just slightly less well-described. But because `evaluation_rules.md` is rules-bearing, the next CI run forced a full re-analysis of all 989 files across all 6 dimensions. That overnight run is still going (~6h of work that was meant to be incremental).

This is the same trick PR #307 used at the prompt-set level (split rules-bearing `evaluation_rules.md` from framing prompts), one level deeper: split rules-bearing content from formatting content within the file itself.

## Effect

- Edits to `finding_format.md` no longer fire `full_reanalysis=True` with reason `prompts changed (...)`.
- Edits to `evaluation_rules.md` still do — the contract for genuine rules changes is unchanged.
- The currently running analysis still completes its full pass (its fingerprint was written under the old single-file model). The next run on top of these changes will write fingerprints with `finding_format.md` recorded separately, and from then on carry-forward is selective.

## Test plan

- [x] `uv run pytest tests/analysis tests/engine tests/api -q` — 974 passed
- [x] Verified concatenated content includes both `## Look for` (rules) and `## How to quote evidence` (format), with `VERBATIM` and `DROP speculative` both present.
- [x] Diff against the pre-split file confirms no semantic content lost.
- [x] Manual on next CI run: edit only `finding_format.md` and verify no "prompts changed" full reanalysis fires.
- [x] Manual on next CI run: edit `evaluation_rules.md` and verify full reanalysis still fires.