### PR TITLE
fix(history): clean up in-progress row + correct delta alignment

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -37,11 +37,17 @@ function trimTrailingZero(n) {
   return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed;
 }
 
-function computeDeltas(trend) {
-  return trend.map((entry, i) => {
-    if (i >= trend.length - 1) return null;
+function computeDeltas(rows) {
+  // Aligns 1:1 with `rows` (which may include in-progress stubs at the
+  // front). In-progress entries have no score, so their delta is null and
+  // we compare each completed row against the next completed one.
+  return rows.map((entry, i) => {
+    if (entry.status === 'in_progress') return null;
+    let nextIdx = i + 1;
+    while (nextIdx < rows.length && rows[nextIdx].status === 'in_progress') nextIdx++;
+    if (nextIdx >= rows.length) return null;
     const curr = parseFloat(entry.numericAverage);
-    const prev = parseFloat(trend[i + 1].numericAverage);
+    const prev = parseFloat(rows[nextIdx].numericAverage);
     if (Number.isNaN(curr) || Number.isNaN(prev)) return null;
     return Math.round((curr - prev) * 10) / 10;
   });
@@ -146,6 +152,30 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
           }}
         />
         {visible.map((entry, i) => {
+          const isInProgress = entry.status === 'in_progress';
+          if (isInProgress) {
+            const { date } = formatDateParts(new Date().toISOString());
+            return (
+              <HistoryRow
+                key={entry.runId}
+                className="history-row--in-progress"
+                onClick={() => onRunClick(entry.runId)}
+                cells={{
+                  date,
+                  time: (
+                    <span className="history-row__running">
+                      <span className="history-row__running-dot" aria-hidden="true" />
+                      running
+                    </span>
+                  ),
+                  grade: <span className="history-row__muted">—</span>,
+                  score: <span className="history-row__muted">—</span>,
+                  delta: <span className="history-delta history-delta--muted">—</span>,
+                  dims: <span className="history-row__muted">in progress</span>,
+                }}
+              />
+            );
+          }
           const { date, time } = formatDateParts(entry.dateISO, entry.dateLabel);
           const runScore = parseFloat(entry.runNumericAverage ?? entry.numericAverage);
           const grade = gradeLabel(entry.runOverallGrade || entry.overallGrade) || '—';
@@ -193,7 +223,6 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
   const { trend, selectedRunId, availableRuns } = data;
   const { onRunClick, onRunChange, onDeleteRun } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
-  const deltas = useMemo(() => computeDeltas(trend), [trend]);
   const inProgressStubs = useMemo(() => buildInProgressStubs(availableRuns, trend), [availableRuns, trend]);
   const statusByRunId = useMemo(() => {
     const map = new Map();
@@ -208,6 +237,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
     const combined = [...inProgressStubs, ...trend];
     return combined.filter((entry) => !isHiddenStatus(entry.runId));
   }, [inProgressStubs, trend, statusByRunId]);  // eslint-disable-line react-hooks/exhaustive-deps
+  const deltas = useMemo(() => computeDeltas(visible), [visible]);
 
   return (
     <div className="history-page history-page--terminal">

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1011,6 +1011,39 @@
   opacity: 0.7;
 }
 
+/* In-progress evaluation row: pulsing dot in TIME, "running" chip in GRADE.
+   Lets reviewers tell at a glance which row is a live run vs a finalized one,
+   without showing the (ugly) raw run UUID that we used to fall back to when
+   no dateISO was available yet. */
+.history-table .history-row--in-progress {
+  background: color-mix(in srgb, var(--color-warn, #d29922) 6%, transparent);
+}
+.history-row__running {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-warn, #d29922);
+  text-transform: lowercase;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+.history-row__running-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-warn, #d29922);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 50%, transparent);
+  animation: history-row-running-pulse 1.4s ease-out infinite;
+}
+@keyframes history-row-running-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 55%, transparent); }
+  70%  { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-warn, #d29922) 0%,  transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-warn, #d29922) 0%,  transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .history-row__running-dot { animation: none; }
+}
+
 /* Monospace + theme-correct text colour inside every data row, overriding
    the inherited Plus Jakarta from `.panel`. */
 .history-row,


### PR DESCRIPTION
## Summary

The in-progress row in the EVALUATIONS table had two issues:

1. **Ugly UUID in DATE column.** When no `dateISO` was available yet (true for runs that haven't written a started-at timestamp), the date cell fell back to `entry.dateLabel`, which the API stamps as the run UUID. Result: `1e5e3765-6df8-…`.
2. **Wrong delta in Δ column.** `deltas[i]` was computed from `trend`, but `visible[i]` is `[...inProgressStubs, ...trend]`. With one stub, `visible[0]` is the in-progress row but `deltas[0]` was the *latest two completed runs*' delta — so the in-progress row stole the next row's number. Independent bug from the styling.

## Before / after

Before:
```
1e5e3765-6df8-…    [chip --]    —    +1    —
```

After:
```
Apr 28, 2026   ● running   —   —   —   in progress
```

The TIME column shows a pulsing amber dot + "running" text. GRADE/SCORE/Δ all read `—`. DIMENSIONS reads "in progress". Click navigation to the run still works.

## Changes

- [src/quodeq/ui/src/features/history/components/HistoryPage.jsx](src/quodeq/ui/src/features/history/components/HistoryPage.jsx)
  - `computeDeltas(rows)` now takes the rendered `rows` (i.e. `visible`) instead of `trend`. In-progress entries return `null`. Deltas array is 1:1 with rendered rows — fixes the misalignment everywhere, not just the in-progress row.
  - In-progress rows get a dedicated render path with today's date and a "● running" indicator. No chip in GRADE — the column is 44px wide, too narrow for "RUNNING" without overflow; the TIME indicator carries the signal alone.
- [src/quodeq/ui/src/styles/terminal.css](src/quodeq/ui/src/styles/terminal.css)
  - `.history-row--in-progress` faint amber row tint (`color-mix` with `--color-warn`).
  - `.history-row__running` + `.history-row__running-dot` for the pulsing indicator. `prefers-reduced-motion` disables the pulse.

## Test plan

- [x] `npm run test:ui` (vitest) — 25/25 passed
- [x] Live verified in dashboard preview: today's date renders, amber dot pulses, no overflow.
- [x] Delta regression check on completed rows: Apr 27 (9) → +1, Apr 25 (8) → +0.7, Apr 24 (7.3) → +0.3 — all consistent with the score column.
- [x] Manual: a run that finishes during the user's session — the in-progress row should disappear and be replaced by a proper completed row (no full reload required, since the data flows through existing `availableRuns` + `trend`).