### PR TITLE
fix(window-drag): disable easy_drag; mark topbar as drag region

### DIFF
--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -504,8 +504,11 @@ def main() -> None:
     instance = InstanceController(sock_path)
     api = _WindowApi()
 
+    # easy_drag intercepts pointer events on any non-interactive element to
+    # move the window — that breaks our resize splitter (a <div>, not a
+    # <button>). Disable it and let the topbar opt-in via -webkit-app-region.
     window = webview.create_window("quodeq", url, width=_WINDOW_WIDTH, height=_WINDOW_HEIGHT,
-                                    frameless=True, easy_drag=True,
+                                    frameless=True, easy_drag=False,
                                     background_color=_WINDOW_BG_COLOR, hidden=True,
                                     js_api=api)
     api.bind(window, api_pid=api_pid, instance=instance, base_url=url)

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1641,6 +1641,21 @@
   font-family: var(--term-font-mono);
   font-size: 13px;
 }
+/* Frameless pywebview window: let the topbar act as the OS-style title bar.
+   Drag anywhere on it to move the window; interactive controls inside opt
+   out of the drag region so they remain clickable. */
+.in-webview .topbar {
+  -webkit-app-region: drag;
+  app-region: drag;
+}
+.in-webview .topbar button,
+.in-webview .topbar a,
+.in-webview .topbar input,
+.in-webview .topbar select,
+.in-webview .topbar [role="button"] {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
 /* --------------------------------------------------------------
    TopBar breadcrumb zone. Desktop shows the full NavBreadcrumb
    chain; mobile swaps it for a back button on the left, the


### PR DESCRIPTION
## Summary
Follow-up to #322. The previous side-pane PR landed before this fix was queued.

`easy_drag=True` in pywebview makes any pointer-down on a non-interactive element move the whole window. The side-pane resize splitter is a `<div>`, so dragging it dragged the window instead of resizing the pane.

- Disable `easy_drag` in `_webview_window.py`.
- Mark the topbar as the OS-style drag region via `-webkit-app-region: drag` (scoped to `.in-webview` so a regular browser is unaffected).
- Buttons / links / inputs / `[role="button"]` inside the topbar opt out via `app-region: no-drag` so they remain clickable.

## Test plan
- [x] In the pywebview app: drag the topbar (anywhere except a button) → window moves.
- [x] Drag a button in the topbar → button activates, window does not move.
- [x] Open the side pane, grab the left gutter → pane resizes (not the window).
- [x] Open two windows in the dock, grab the horizontal splitter between them → windows resize.
- [x] In a regular browser (`vite` / `npm run dev` directly): no behavior change — `app-region` is a no-op outside pywebview.