### PR TITLE
fix(side-pane): pywebview-drag-region on topbar; smooth inner-splitter

### DIFF
--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -108,7 +108,7 @@ export default function TopBar({
 }) {
   const { isOpen: paneOpen, closeAll } = useSidePane();
   return (
-    <header className="topbar">
+    <header className="topbar pywebview-drag-region">
       {/* Compact-mode back button. Hidden entirely at the root of the
           nav stack — showing a disabled arrow adds visual noise without
           giving the user anything to click. */}

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -46,29 +46,55 @@ export function SidePane() {
     window.addEventListener('pointerup', onUp);
   }, [paneWidth, setPaneWidth]);
 
-  // Internal between-window resizer.
+  // Internal between-window resizer. Mutates the two adjacent slot
+  // elements' inline flex grow factors directly during the drag (no
+  // setState — same trick as the outer drag with --side-pane-width)
+  // so the markdown bodies don't re-render every pointer move. Commits
+  // the final ratio to React state on release.
   const containerRef = useRef(null);
   const onInnerDividerPointerDown = useCallback((index) => (e) => {
     e.preventDefault();
-    const startY = e.clientY;
-    const startRatio = ratios[index] ?? 0.5;
     const container = containerRef.current;
     if (!container) return;
     const slots = container.querySelectorAll('.side-pane-window-slot');
     const aEl = slots[index];
     const bEl = slots[index + 1];
-    const span = (aEl?.offsetHeight ?? 0) + (bEl?.offsetHeight ?? 0);
+    if (!aEl || !bEl) return;
+    const startY = e.clientY;
+    const startRatio = ratios[index] ?? 0.5;
+    const span = aEl.offsetHeight + bEl.offsetHeight;
     if (span <= 0) return;
+    // Combined weight of these two slots stays constant during this drag —
+    // we just split it differently. Capture it once.
+    const aStartFlex = parseFloat(aEl.style.flexGrow) || 1;
+    const bStartFlex = parseFloat(bEl.style.flexGrow) || 1;
+    const combinedFlex = aStartFlex + bStartFlex;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+    let pendingRatio = startRatio;
+    let rafId = null;
+    const apply = () => {
+      rafId = null;
+      aEl.style.flex = `${combinedFlex * pendingRatio} 1 0`;
+      bEl.style.flex = `${combinedFlex * (1 - pendingRatio)} 1 0`;
+    };
     const onMove = (ev) => {
       const delta = ev.clientY - startY;
-      const next = Math.min(1 - MIN_WINDOW_RATIO, Math.max(MIN_WINDOW_RATIO, startRatio + delta / span));
-      setRatios((prev) => {
-        const out = [...prev];
-        out[index] = next;
-        return out;
-      });
+      pendingRatio = Math.min(1 - MIN_WINDOW_RATIO, Math.max(MIN_WINDOW_RATIO, startRatio + delta / span));
+      if (rafId == null) rafId = requestAnimationFrame(apply);
     };
     const onUp = () => {
+      if (rafId != null) cancelAnimationFrame(rafId);
+      apply();
+      setRatios((prev) => {
+        const out = [...prev];
+        out[index] = pendingRatio;
+        return out;
+      });
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
     };

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1641,21 +1641,10 @@
   font-family: var(--term-font-mono);
   font-size: 13px;
 }
-/* Frameless pywebview window: let the topbar act as the OS-style title bar.
-   Drag anywhere on it to move the window; interactive controls inside opt
-   out of the drag region so they remain clickable. */
-.in-webview .topbar {
-  -webkit-app-region: drag;
-  app-region: drag;
-}
-.in-webview .topbar button,
-.in-webview .topbar a,
-.in-webview .topbar input,
-.in-webview .topbar select,
-.in-webview .topbar [role="button"] {
-  -webkit-app-region: no-drag;
-  app-region: no-drag;
-}
+/* Frameless pywebview window: the topbar acts as the OS-style title bar.
+   The drag itself is wired via the `pywebview-drag-region` class on the
+   <header> (pywebview's native API — works on its WKWebView, unlike
+   the Chromium-only -webkit-app-region). */
 /* --------------------------------------------------------------
    TopBar breadcrumb zone. Desktop shows the full NavBreadcrumb
    chain; mobile swaps it for a back button on the left, the


### PR DESCRIPTION
## Summary
Follow-up to #323. The previous PR landed with the wrong drag-region mechanism (`-webkit-app-region`) and the splitter still felt scratchy.

- **Topbar drag**: `-webkit-app-region` is Chromium-only and ignored by pywebview's WKWebView, so after #323 the topbar wasn't draggable at all. Replace it with pywebview's native marker — the `pywebview-drag-region` CSS class on the `<header>`. Buttons inside continue to work because pywebview excludes interactive elements automatically.
- **Inner splitter smoothness**: the between-windows resizer was calling `setRatios` on every `pointermove`, triggering a full React re-render of every window's body (markdown included) each frame. Switch to direct DOM writes on the two adjacent slot elements via `requestAnimationFrame`; commit the final ratio to React state on release. Same pattern the outer pane-width drag already used; resize is now CSS-only during the drag.

## Test plan
- [x] In the pywebview app: drag the topbar (anywhere except a button) → window moves smoothly.
- [x] Topbar buttons remain clickable.
- [x] Open two windows in the side pane, grab the horizontal splitter between them → drag is smooth, no flicker, markdown bodies stay paint-stable.
- [x] Release the splitter → final ratio sticks; subsequent re-renders show the same split.
- [x] Outer pane-width gutter still works as before.