### PR TITLE
fix(loops): retry scoring callback after broken-pipe to persist evaluation/<dim>.json

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -119,15 +119,28 @@ def run_incremental_loop(
                 if on_dimension_done:
                     on_dimension_done(dimension, ev)
             except BrokenPipeError:
-                # Stdout pipe to parent died (the most likely cause of the
-                # silent-skip bug observed in production: log_success or the
-                # dashboard's scoring callback writes to a closed parent
-                # pipe). Keep result, log the trail, continue to next dim
-                # instead of letting it bubble out and lifecycle quietly
-                # converting it to state=done.
+                # Stdout pipe to parent died mid-callback. Silence stdout/
+                # stderr, then retry the callback once: scoring callbacks like
+                # ``_score_dimension`` write evaluation/<dim>.json to disk and
+                # are idempotent (overwrite). The previous "result kept"
+                # message was misleading \u2014 only the in-memory Evidence stayed,
+                # the persistent file write was lost with the exception.
                 _silence_broken_stdout()
                 result.setdefault(dimension, ev)
-                log_warning(f"[loop] {dimension} \u2014 callback broken pipe, result kept, continuing loop")
+                if on_dimension_done:
+                    try:
+                        on_dimension_done(dimension, ev)
+                        log_warning(
+                            f"[loop] {dimension} \u2014 callback broken pipe, "
+                            f"retried after silencing stdout, result persisted",
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        log_warning(
+                            f"[loop] {dimension} \u2014 callback retry after broken pipe raised "
+                            f"{type(exc).__name__}: {exc} \u2014 result NOT persisted, continuing loop",
+                        )
+                else:
+                    log_warning(f"[loop] {dimension} \u2014 callback broken pipe, no retry needed, continuing loop")
             except Exception as exc:  # noqa: BLE001
                 log_warning(
                     f"[loop] {dimension} \u2014 callback raised "
@@ -198,11 +211,25 @@ def run_per_dimension_loop(
             if on_dimension_done:
                 on_dimension_done(dimension, ev)
         except BrokenPipeError:
-            # Stdout pipe to parent died (this is the most likely cause of
-            # the silent-skip bug observed in production). Keep result, log
-            # the trail, continue to next dim instead of bubbling out.
+            # Stdout pipe to parent died mid-callback. Silence stdout/stderr,
+            # then retry the callback once so the scoring side effects
+            # (evaluation/<dim>.json) actually land on disk. See the matching
+            # block in run_incremental_loop for rationale.
             _silence_broken_stdout()
-            log_warning(f"[loop] {dimension} — callback broken pipe, result kept, continuing loop")
+            if on_dimension_done:
+                try:
+                    on_dimension_done(dimension, ev)
+                    log_warning(
+                        f"[loop] {dimension} — callback broken pipe, "
+                        f"retried after silencing stdout, result persisted",
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    log_warning(
+                        f"[loop] {dimension} — callback retry after broken pipe raised "
+                        f"{type(exc).__name__}: {exc} — result NOT persisted, continuing loop",
+                    )
+            else:
+                log_warning(f"[loop] {dimension} — callback broken pipe, no retry needed, continuing loop")
         except Exception as exc:  # noqa: BLE001
             log_warning(
                 f"[loop] {dimension} — callback raised "

--- a/tests/analysis/test_loops_safety.py
+++ b/tests/analysis/test_loops_safety.py
@@ -69,7 +69,12 @@ class _FakeEvidence:
 class TestPerDimLoopSafety:
     def test_callback_broken_pipe_does_not_drop_subsequent_dims(self):
         """The bug we observed: scoring callback writes to closed pipe,
-        BrokenPipeError propagates, loop terminates early."""
+        BrokenPipeError propagates, loop terminates early.
+
+        Post-fix the callback is retried once after stdout/stderr are silenced,
+        so usability appears twice in callback_calls (the second invocation
+        is the retry that persists the side effects).
+        """
         cfg = _config()
         seen_dims: list[str] = []
 
@@ -78,9 +83,11 @@ class TestPerDimLoopSafety:
             return _FakeEvidence()
 
         callback_calls: list[str] = []
+        usability_raise_count = {"n": 0}
         def on_done(dim, _ev):
             callback_calls.append(dim)
-            if dim == "usability":  # exact bug: usability's callback dies
+            if dim == "usability" and usability_raise_count["n"] == 0:
+                usability_raise_count["n"] += 1
                 raise BrokenPipeError("parent pipe closed")
 
         result = run_per_dimension_loop(
@@ -91,8 +98,8 @@ class TestPerDimLoopSafety:
         assert seen_dims == ["security", "usability", "flexibility"]
         # Result still includes usability (we kept the evidence).
         assert set(result) == {"security", "usability", "flexibility"}
-        # Callback fired for all three (loop didn't bail early).
-        assert callback_calls == ["security", "usability", "flexibility"]
+        # Callback fired for all three, and usability was retried once.
+        assert callback_calls == ["security", "usability", "usability", "flexibility"]
 
     def test_callback_generic_exception_does_not_drop_subsequent_dims(self):
         cfg = _config()
@@ -187,9 +194,10 @@ class TestIncrementalLoopSafety:
         assert seen == ["security", "usability", "flexibility"]
         # All three results captured (we keep the evidence even when callback fails).
         assert set(result) == {"security", "usability", "flexibility"}
-        # on_done fired for security and flexibility; usability's loop body
-        # bailed out of the try at log_result_fn so on_done didn't fire for it.
-        assert "usability" not in callback_calls
+        # log_result_fn raised before on_done was reached for usability, so the
+        # retry path invokes on_done for usability after silencing — meaning
+        # usability now DOES appear in callback_calls (the persistence retry).
+        assert callback_calls == ["security", "usability", "flexibility"]
 
     def test_unexpected_exception_in_runner_logs_and_continues(self):
         cfg = _config()
@@ -229,6 +237,92 @@ class TestIncrementalLoopSafety:
 
 
 # ---------------------------------------------------------------------------
+# Retry-after-broken-pipe persistence semantics
+# ---------------------------------------------------------------------------
+
+class TestCallbackRetryPersistsSideEffects:
+    """Pin down the per-dim run f061b58e bug: security's queue completed,
+    the scoring callback raised BrokenPipeError mid-run, the loop swallowed
+    it with a misleading "result kept" message but evaluation/security.json
+    was never written.
+
+    Post-fix: when a callback raises BrokenPipeError, stdout is silenced and
+    the callback is retried once so persistent side effects (the on-disk
+    report) actually land.
+    """
+
+    def test_per_dim_retry_persists_when_only_first_call_raises(self):
+        cfg = _config()
+        # Imitate _score_dimension's contract: on success, write a sentinel
+        # file. On the first call for the dim, raise BrokenPipeError before
+        # the write. On retry, the write succeeds.
+        written: list[str] = []
+        attempts: dict[str, int] = {}
+
+        def scoring_callback(dim, _ev):
+            attempts[dim] = attempts.get(dim, 0) + 1
+            if dim == "security" and attempts[dim] == 1:
+                raise BrokenPipeError("parent pipe closed mid-write")
+            written.append(dim)
+
+        run_per_dimension_loop(
+            cfg, ["security", "reliability"], _ctx(2),
+            process_fn=lambda *a, **k: _FakeEvidence(),
+            on_dimension_done=scoring_callback,
+        )
+        # security was retried once; reliability ran straight through.
+        assert attempts == {"security": 2, "reliability": 1}
+        # Both files written — the bug was that security's write was lost.
+        assert written == ["security", "reliability"]
+
+    def test_per_dim_retry_failure_logs_not_persisted_warning(self):
+        cfg = _config()
+
+        def always_raises(_dim, _ev):
+            raise BrokenPipeError("permanently broken")
+
+        with patch("quodeq.analysis._loops.log_warning") as mock_warn:
+            run_per_dimension_loop(
+                cfg, ["security"], _ctx(1),
+                process_fn=lambda *a, **k: _FakeEvidence(),
+                on_dimension_done=always_raises,
+            )
+        warn_messages = [c.args[0] for c in mock_warn.call_args_list]
+        assert any("retry after broken pipe raised" in m for m in warn_messages), warn_messages
+        assert any("NOT persisted" in m for m in warn_messages), warn_messages
+
+    def test_incremental_retry_persists_when_only_first_call_raises(self):
+        cfg = _config()
+        written: list[str] = []
+        attempts: dict[str, int] = {}
+
+        def fake_runner(_c, dim, _i, _ctx):
+            return _FakeEvidence()
+
+        # log_result_fn raises BrokenPipeError before on_dimension_done is
+        # reached on the original try; the retry path then invokes
+        # on_dimension_done with stdout silenced.
+        def log_result(_ev, dim, _i, _t):
+            if dim == "security":
+                raise BrokenPipeError("dashboard pipe closed")
+
+        def scoring_callback(dim, _ev):
+            attempts[dim] = attempts.get(dim, 0) + 1
+            written.append(dim)
+
+        with patch("quodeq.analysis._loops.run_dimension_incremental", side_effect=fake_runner):
+            run_incremental_loop(
+                cfg, ["security", "reliability"], _ctx(2),
+                process_fn=MagicMock(),
+                log_result_fn=log_result,
+                on_dimension_done=scoring_callback,
+            )
+
+        assert attempts == {"security": 1, "reliability": 1}
+        assert written == ["security", "reliability"]
+
+
+# ---------------------------------------------------------------------------
 # Regression test: the exact production bug shape
 # ---------------------------------------------------------------------------
 
@@ -249,12 +343,15 @@ class TestProductionBugRegression:
             attempted.append(dim)
             return _FakeEvidence(files_read=979 if dim == "usability" else 22)
 
+        usability_first_call = {"done": False}
         def scoring_callback(dim, _ev):
             # In production, this callback writes evaluation/{dim}.json AND
             # logs to stdout — the latter dies once the dashboard parent pipe
-            # closes.
+            # closes. Post-fix the loop retries the callback after silencing
+            # stdout, so the second call succeeds and persists the write.
             scored.append(dim)
-            if dim == "usability":
+            if dim == "usability" and not usability_first_call["done"]:
+                usability_first_call["done"] = True
                 raise BrokenPipeError("Broken pipe")
 
         with patch("quodeq.analysis._loops.run_dimension_incremental", side_effect=fake_runner):
@@ -272,11 +369,11 @@ class TestProductionBugRegression:
             "security", "reliability", "maintainability", "performance",
             "usability", "flexibility",
         ]
-        # Scoring callback fired for first 4 + usability (raised) + flexibility
-        # (post-fix continues despite usability's failure).
+        # Scoring callback fired for first 4, then usability twice (initial raise
+        # + retry that persists), then flexibility.
         assert scored == [
             "security", "reliability", "maintainability", "performance",
-            "usability", "flexibility",
+            "usability", "usability", "flexibility",
         ]
         # All six in result — the evidence was captured even though usability's
         # callback raised.


### PR DESCRIPTION
## Summary

When a per-dimension scoring callback raised `BrokenPipeError` mid-call (parent dashboard pipe closed), the loop swallowed it with a misleading "result kept, continuing loop" log — but only the in-memory `Evidence` was kept; the persistent side effects (`write_dimension_report` → `evaluation/<dim>.json`) were lost. Subsequent dimensions completed normally, but the affected dimension stayed stuck in the running ▶ state in the UI forever, since the dim-state classifier (`scan_progress._dim_state`) keys off the on-disk evaluation file.

**Fix**: after `_silence_broken_stdout()` swaps stdout/stderr to `/dev/null`, retry `on_dimension_done(dim, ev)` once. The callback is idempotent (`score_evidence` is pure, `write_dimension_report` overwrites), so the second invocation lands the file with all prints harmlessly silenced. Replaces the misleading "result kept" log with either "retried after silencing stdout, result persisted" or "retry after broken pipe raised X, result NOT persisted" depending on outcome.

## Reproduced from

Run `ext-061b58ea-7f3f-4e95-89e3-4050b62c74c9`: security finished analysis at 14:33 (queue, evidence.jsonl, fingerprint all on disk) but `evaluation/security.json` was never written — `run.log` line 589 shows `[loop] security — callback broken pipe, result kept, continuing loop`. Reliability and maintainability completed normally afterwards because each callback runs against fresh stream state.

## Changes

- `src/quodeq/analysis/_loops.py` — retry `on_dimension_done` once after `_silence_broken_stdout()` in both `run_incremental_loop` and `run_per_dimension_loop` BrokenPipeError handlers.
- `tests/analysis/test_loops_safety.py` — new `TestCallbackRetryPersistsSideEffects` class (3 tests: per-dim retry success, retry-also-fails warning, incremental retry success). Updated 2 existing safety tests + the production regression to expect the retry call.

## Test plan

- [x] `pytest tests/analysis/test_loops_safety.py -v` → 11/11 pass
- [x] `pytest tests/analysis/` → 372/372 pass
- [x] Manual: trigger a real dashboard-restart-mid-scan to confirm `evaluation/<dim>.json` lands when the parent pipe closes