### PR TITLE
perf(side-pane): defer body mount, memo render, contain slot paint

### DIFF
--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -35,6 +35,10 @@
   display: flex;
   min-height: 0;
   overflow: hidden;
+  /* Isolate the slot's layout + paint from siblings: while one slot
+     resizes (between-window splitter drag) the browser doesn't have
+     to relayout / repaint the markdown body of the adjacent slots. */
+  contain: layout paint;
 }
 .side-pane-window {
   display: flex;
@@ -42,6 +46,7 @@
   width: 100%;
   min-height: 0;
   overflow: hidden;
+  contain: layout paint;
 }
 
 /* ── Window header ───────────────────────────────────── */
@@ -93,10 +98,36 @@
 /* ── Window body ─────────────────────────────────────── */
 .side-pane-window__body {
   flex: 1 1 auto;
-  overflow-y: auto;
+  /* Reserve scrollbar space always so an inter-window resize doesn't
+     toggle the scrollbar in/out and trigger a content reflow. */
+  overflow-y: scroll;
   padding: 12px 16px;
   line-height: 1.55;
 }
+.side-pane-window__error {
+  color: var(--color-danger, #fca5a5);
+  font-style: italic;
+}
+
+/* Skeleton shown while the slide-in animation runs, before the heavy
+   body content (markdown) mounts. Matches the deferred-mount pattern
+   from the original ReportPane. */
+.side-pane-window__body-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-top: 4px;
+}
+.side-pane-window__body-skeleton > span {
+  display: block;
+  height: 12px;
+  border-radius: 4px;
+  background: var(--color-surface-alt);
+  opacity: 0.6;
+}
+.side-pane-window__body-skeleton > span:nth-child(1) { width: 55%; height: 18px; }
+.side-pane-window__body-skeleton > span:nth-child(2) { width: 90%; }
+.side-pane-window__body-skeleton > span:nth-child(3) { width: 75%; }
 
 /* ── Markdown content (.side-pane-md) ──────────────── */
 .side-pane-md h1,

--- a/src/quodeq/ui/src/features/side-pane/SidePane.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { SidePane } from './SidePane.jsx';
 import { SidePaneProvider } from './SidePaneProvider.jsx';
@@ -31,12 +31,14 @@ describe('SidePane', () => {
     expect(screen.queryByRole('complementary', { name: /side pane/i })).toBeNull();
   });
 
-  it('renders one window with its title and body when one is added', () => {
+  it('renders one window with its title immediately and the body once the slide-in defer finishes', async () => {
     render(<SidePaneProvider><Adder /><SidePane /></SidePaneProvider>);
     fireEvent.click(screen.getByText('add-a'));
     expect(screen.getByRole('complementary', { name: /side pane/i })).toBeInTheDocument();
     expect(screen.getByText('Alpha')).toBeInTheDocument();
-    expect(screen.getByText('body:alpha')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('body:alpha')).toBeInTheDocument();
+    });
   });
 
   it('renders multiple windows in registration order with a horizontal resizer between them', () => {

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
@@ -1,6 +1,9 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const COPY_FEEDBACK_MS = 1500;
+// Defer mounting the body until the slide-in animation finishes (~220ms).
+// Otherwise the heavy markdown render happens mid-animation and stutters.
+const SLIDE_MS = 220;
 
 function slugify(s) {
   return (s || 'window').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'window';
@@ -27,15 +30,41 @@ function triggerDownload({ filename, body }) {
   setTimeout(() => { a.remove(); URL.revokeObjectURL(url); }, 0);
 }
 
+class RenderBoundary extends React.Component {
+  state = { failed: false };
+  static getDerivedStateFromError() { return { failed: true }; }
+  componentDidCatch() { /* swallow — header still works */ }
+  componentDidUpdate(prev) {
+    if (prev.contentKey !== this.props.contentKey && this.state.failed) {
+      this.setState({ failed: false });
+    }
+  }
+  render() {
+    if (this.state.failed) {
+      return <p className="side-pane-window__error">Failed to render report.</p>;
+    }
+    return this.props.children;
+  }
+}
+
 export function SidePaneWindow({ spec, onClose }) {
   const bodyRef = useRef(null);
   const [justCopied, setJustCopied] = useState(false);
+  const [bodyReady, setBodyReady] = useState(false);
 
   useEffect(() => {
     if (bodyRef.current) bodyRef.current.scrollTop = 0;
   }, [spec.id]);
 
   useEffect(() => { setJustCopied(false); }, [spec.id]);
+
+  // Defer the body mount on each fresh window; the skeleton holds the slot
+  // while the parent's slide-in finishes.
+  useEffect(() => {
+    setBodyReady(false);
+    const t = setTimeout(() => setBodyReady(true), SLIDE_MS);
+    return () => clearTimeout(t);
+  }, [spec.id]);
 
   useEffect(() => {
     if (!justCopied) return undefined;
@@ -55,6 +84,12 @@ export function SidePaneWindow({ spec, onClose }) {
   }, [spec]);
 
   const onClickClose = useCallback(() => onClose(spec.id), [onClose, spec.id]);
+
+  // Memoise the rendered body keyed on spec identity. Prevents the heavy
+  // markdown subtree from re-running through React reconciliation every
+  // time the parent (SidePane) re-renders for unrelated reasons — e.g.
+  // a sibling window resize updating the inline flex weights of the slots.
+  const body = useMemo(() => spec.render(), [spec]);
 
   return (
     <section className="side-pane-window" aria-label={spec.title}>
@@ -89,7 +124,13 @@ export function SidePaneWindow({ spec, onClose }) {
         </div>
       </header>
       <div className="side-pane-window__body" ref={bodyRef}>
-        {spec.render()}
+        {bodyReady ? (
+          <RenderBoundary contentKey={spec.id}>{body}</RenderBoundary>
+        ) : (
+          <div className="side-pane-window__body-skeleton" aria-hidden="true">
+            <span /><span /><span />
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { SidePaneWindow } from './SidePaneWindow.jsx';
 
@@ -19,10 +19,12 @@ function makeSpec(overrides = {}) {
 }
 
 describe('SidePaneWindow', () => {
-  it('renders the title and body', () => {
+  it('renders the title immediately and the body once the slide-in defer finishes', async () => {
     render(<SidePaneWindow spec={makeSpec()} onClose={() => {}} />);
     expect(screen.getByText('My Window')).toBeInTheDocument();
-    expect(screen.getByText('body content')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('body content')).toBeInTheDocument();
+    });
   });
 
   it('Close button calls onClose with the window id', () => {


### PR DESCRIPTION
## Summary
The inner-window splitter felt choppy because every pointer-move triggered a full React reconciliation of the markdown subtree in both adjacent windows. Three compounding changes plus restoration of two patterns lost in the rewrite:

- **Defer body mount by 220ms** with a skeleton placeholder. Same pattern the original `ReportPane` had via `SLIDE_MS` — opening a fresh window no longer pays the markdown render cost mid-animation.
- **`useMemo` around `spec.render()`** in `SidePaneWindow`, keyed on spec identity. The markdown subtree no longer re-runs reconciliation when the parent re-renders for unrelated reasons (e.g. when the inner-splitter drag commits its final ratio to React state).
- **CSS `contain: layout paint`** on `.side-pane-window-slot` and `.side-pane-window`, plus `overflow-y: scroll` on the body so the scrollbar doesn't toggle in/out on micro-resizes. The browser can now skip relayout/repaint of sibling slots when one slot's flex changes during the drag.
- Restore the **`RenderBoundary`** that wrapped the body in the original `ReportPane` (was lost in the rewrite).

## Test plan
- [x] Open one window in the side pane → brief skeleton, then markdown appears.
- [x] Open two windows → inter-window splitter drag is smooth, no FPS drop.
- [x] Switch between windows by removing/adding from different pages → each shows its skeleton briefly before its body mounts.
- [x] Outer pane-width gutter still works as before.
- [x] All vitest tests pass (40/40 locally).