### PR TITLE
perf(side-pane): suppress body layout during resize via content-visibility

### DIFF
--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -104,6 +104,15 @@
   padding: 12px 16px;
   line-height: 1.55;
 }
+
+/* While a divider is being dragged, skip layout + paint of the body
+   subtrees entirely — the per-pointermove cost of re-flowing markdown
+   text is what makes resize chunky on heavy reports. The bodies stay
+   the right size (their flex slot still takes space); only the content
+   inside is suppressed until pointerup clears the flag. */
+.side-pane[data-resizing] .side-pane-window__body {
+  content-visibility: hidden;
+}
 .side-pane-window__error {
   color: var(--color-danger, #fca5a5);
   font-style: italic;

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -16,6 +16,18 @@ export function SidePane() {
     setRatios(Array(Math.max(0, windows.length - 1)).fill(0.5));
   }, [windows.length]);
 
+  // While dragging either divider, set data-resizing on the aside so CSS
+  // can mask the markdown bodies (content-visibility: hidden) — the text
+  // layout pass per pointermove is the actual perf killer with multi-window
+  // multi-paragraph reports.
+  const containerRef = useRef(null);
+  const setResizingFlag = useCallback((on) => {
+    const el = containerRef.current;
+    if (!el) return;
+    if (on) el.dataset.resizing = 'true';
+    else delete el.dataset.resizing;
+  }, []);
+
   // Outer pane (left-edge) drag — resizes the whole dock width.
   const [isDragging, setIsDragging] = useState(false);
   const onOuterDividerPointerDown = useCallback((e) => {
@@ -24,6 +36,7 @@ export function SidePane() {
     const startWidth = paneWidth;
     const viewport = window.innerWidth;
     setIsDragging(true);
+    setResizingFlag(true);
     const prevCursor = document.body.style.cursor;
     const prevSelect = document.body.style.userSelect;
     document.body.style.cursor = 'col-resize';
@@ -37,6 +50,7 @@ export function SidePane() {
       const delta = startX - ev.clientX;
       setPaneWidth(clampSidePaneWidth(startWidth + delta, window.innerWidth));
       setIsDragging(false);
+      setResizingFlag(false);
       document.body.style.cursor = prevCursor;
       document.body.style.userSelect = prevSelect;
       window.removeEventListener('pointermove', onMove);
@@ -44,14 +58,13 @@ export function SidePane() {
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
-  }, [paneWidth, setPaneWidth]);
+  }, [paneWidth, setPaneWidth, setResizingFlag]);
 
   // Internal between-window resizer. Mutates the two adjacent slot
   // elements' inline flex grow factors directly during the drag (no
   // setState — same trick as the outer drag with --side-pane-width)
   // so the markdown bodies don't re-render every pointer move. Commits
   // the final ratio to React state on release.
-  const containerRef = useRef(null);
   const onInnerDividerPointerDown = useCallback((index) => (e) => {
     e.preventDefault();
     const container = containerRef.current;
@@ -69,6 +82,7 @@ export function SidePane() {
     const aStartFlex = parseFloat(aEl.style.flexGrow) || 1;
     const bStartFlex = parseFloat(bEl.style.flexGrow) || 1;
     const combinedFlex = aStartFlex + bStartFlex;
+    setResizingFlag(true);
     const prevCursor = document.body.style.cursor;
     const prevSelect = document.body.style.userSelect;
     document.body.style.cursor = 'row-resize';
@@ -93,6 +107,7 @@ export function SidePane() {
         out[index] = pendingRatio;
         return out;
       });
+      setResizingFlag(false);
       document.body.style.cursor = prevCursor;
       document.body.style.userSelect = prevSelect;
       window.removeEventListener('pointermove', onMove);
@@ -100,7 +115,7 @@ export function SidePane() {
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
-  }, [ratios]);
+  }, [ratios, setResizingFlag]);
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
Even after #326 the side-pane resize was still chunky on heavy reports. The remaining cost was the browser re-flowing markdown text inside every visible window's body on each `pointermove`. With multi-paragraph reports that's tens of milliseconds per frame — easily enough to drop FPS.

This PR sidesteps it: while a divider is being dragged, the body subtree gets `content-visibility: hidden`, which tells the browser to skip layout AND paint of that subtree until the flag is cleared. The body element still occupies its flex slot, so the resize preview itself is unchanged — only the inner markdown layout pass is suppressed.

- Both pointer-down handlers (outer gutter + inner between-windows) set `data-resizing` on the `.side-pane` `<aside>` via a containerRef.
- Pointer-up clears the flag.
- CSS rule keys off the attribute: `.side-pane[data-resizing] .side-pane-window__body { content-visibility: hidden; }`.

## Test plan
- [x] Open the dock with a heavy markdown report. Drag the outer gutter — smooth, no FPS drop. The body content disappears during the drag and snaps back on release.
- [x] Open two windows. Drag the splitter between them — same: smooth, bodies hidden during, snap back on release.
- [x] Outer drag still resizes the pane width.
- [x] Inner drag still rebalances the two adjacent windows.
- [x] No regression in the 40 vitest tests.