### PR TITLE
perf(side-pane): smooth splitter drag + UX polish

### DIFF
--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -13,7 +13,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-markdown": "^9.1.0",
-        "recharts": "3.7.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0"
@@ -3952,15 +3952,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
-      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
       "workspaces": [
         "www"
       ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -17,7 +17,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-markdown": "^9.1.0",
-    "recharts": "3.7.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0"

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -12,15 +12,6 @@
 import { useSidePane } from '../features/side-pane/index.js';
 import { FileTextIcon } from './CopyButton.jsx';
 
-function CloseIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <line x1="18" y1="6" x2="6" y2="18" />
-      <line x1="6" y1="6" x2="18" y2="18" />
-    </svg>
-  );
-}
-
 function ReportToolbarButton() {
   const ctx = useSidePane();
   const spec = ctx.getRegisteredSpec ? ctx.getRegisteredSpec('report') : null;
@@ -106,7 +97,6 @@ export default function TopBar({
   effectiveDark = false,
   onToggleTheme,
 }) {
-  const { isOpen: paneOpen, closeAll } = useSidePane();
   return (
     <header className="topbar pywebview-drag-region">
       {/* Compact-mode back button. Hidden entirely at the root of the
@@ -163,17 +153,6 @@ export default function TopBar({
           </button>
         )}
         <ReportToolbarButton />
-        {paneOpen && (
-          <button
-            type="button"
-            className="topbar-btn topbar-btn--icon topbar-btn--close-pane"
-            onClick={closeAll}
-            aria-label="Close all side-pane windows"
-            title="Close all"
-          >
-            <CloseIcon />
-          </button>
-        )}
         {onEvaluate && (
           <button
             type="button"

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -198,7 +198,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
     return {
       id: `report:overview:${reportProjectName}`,
       type: 'report',
-      title: `Code Quality Report — ${reportProjectName}`,
+      title: `${reportProjectName} report`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `code-quality-report-${reportProjectName}.md`, body: buildMarkdown() }),

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -153,8 +153,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, sev
 
   const reportSpec = useMemo(() => {
     if (!d.evalData) return null;
-    const dim = d.evalData.dimension || 'Unknown';
-    const dimTitle = dim.charAt(0).toUpperCase() + dim.slice(1);
+    const dim = (d.evalData.dimension || 'unknown').toLowerCase();
     const buildMarkdown = () => buildDimensionReport({
       evalData: d.evalData,
       principleGrades: d.principleGrades || [],
@@ -166,7 +165,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, sev
     return {
       id: `report:dimension:${dim}:${runId ?? 'current'}`,
       type: 'report',
-      title: `${dimTitle} Report`,
+      title: `${dim} report`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `${dim}-report.md`, body: buildMarkdown() }),

--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -105,14 +105,6 @@
   line-height: 1.55;
 }
 
-/* While a divider is being dragged, skip layout + paint of the body
-   subtrees entirely — the per-pointermove cost of re-flowing markdown
-   text is what makes resize chunky on heavy reports. The bodies stay
-   the right size (their flex slot still takes space); only the content
-   inside is suppressed until pointerup clears the flag. */
-.side-pane[data-resizing] .side-pane-window__body {
-  content-visibility: hidden;
-}
 .side-pane-window__error {
   color: var(--color-danger, #fca5a5);
   font-style: italic;
@@ -139,6 +131,11 @@
 .side-pane-window__body-skeleton > span:nth-child(3) { width: 75%; }
 
 /* ── Markdown content (.side-pane-md) ──────────────── */
+.side-pane-md {
+  /* Scope reflow of the markdown subtree to itself so width changes from
+     a divider drag can't propagate layout work into siblings. */
+  contain: layout;
+}
 .side-pane-md h1,
 .side-pane-md h2 {
   border-bottom: 1px solid var(--color-border);
@@ -153,13 +150,25 @@
   border-radius: 3px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.9em;
+  /* Long unbroken paths inside inline <code> (e.g. file refs in tables)
+     would otherwise paint past their container in WKWebView. Force a
+     break at any character if needed. */
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  /* `min-width: 0` lets the inline-code box actually shrink below the
+     intrinsic width of its content inside table-layout:fixed cells. */
+  min-width: 0;
 }
 .side-pane-md pre {
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: 6px;
   padding: 12px;
-  overflow-x: auto;
+  /* `scroll` + `scrollbar-gutter: stable` avoids the auto-scrollbar toggle
+     that fires extra layout passes per pointermove when the column width
+     changes. WKWebView is especially expensive at scrollbar-driven layout. */
+  overflow-x: scroll;
+  scrollbar-gutter: stable;
 }
 .side-pane-md pre > code {
   background: none;
@@ -167,12 +176,16 @@
   border-radius: 0;
 }
 .side-pane-md .md-table-wrap {
-  overflow-x: auto;
+  overflow-x: scroll;
+  scrollbar-gutter: stable;
   margin: 12px 0;
 }
 .side-pane-md table {
   border-collapse: collapse;
   width: 100%;
+  /* `fixed` locks column widths from the first row so the browser doesn't
+     re-measure every cell to redistribute widths on each pointermove. */
+  table-layout: fixed;
   font-size: 0.9em;
 }
 .side-pane-md th,
@@ -180,6 +193,18 @@
   border: 1px solid var(--color-border);
   padding: 6px 10px;
   text-align: left;
+  /* With table-layout: fixed, long unbroken strings (e.g. deep file paths)
+     would otherwise overflow into the next column. Allow breaks anywhere
+     so paths wrap inside their cell. Also applied to descendants because
+     inline elements like <code> are treated as a single unbreakable token
+     unless given the same hint. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.side-pane-md th *,
+.side-pane-md td * {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .side-pane-md tr:nth-child(even) td {
   background: rgba(255, 255, 255, 0.02);

--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -13,6 +13,9 @@
 }
 
 /* ── Left-edge resize gutter (between main column and pane) ─────────── */
+/* The full 8px area is the drag hit zone; the visible rail is a subtle 1px
+   seam in the middle of that zone, thickening to 3px on hover/drag. Same
+   pattern the old ReportPane used. */
 .side-pane__divider {
   position: absolute;
   top: 0;
@@ -21,13 +24,22 @@
   height: 100%;
   cursor: col-resize;
   z-index: 1;
-  background: var(--color-surface-alt);
-  opacity: 0.5;
-  transition: opacity 120ms ease;
+  background: transparent;
 }
-.side-pane__divider:hover,
-.side-pane__divider--dragging {
-  opacity: 0.85;
+.side-pane__divider::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1px;
+  height: 100%;
+  background: var(--color-border);
+  transition: background 120ms ease, width 120ms ease;
+}
+.side-pane__divider:hover::after,
+.side-pane__divider--dragging::after {
+  width: 3px;
 }
 
 /* ── Window slot ─────────────────────────────────────── */
@@ -103,6 +115,42 @@
   overflow-y: scroll;
   padding: 12px 16px;
   line-height: 1.55;
+  /* Thinner scrollbars across the whole side-pane subtree (≈half of the
+     macOS default). `scrollbar-width: thin` is the standard CSS hook;
+     ::-webkit-scrollbar gives fine control on WKWebView. */
+  scrollbar-width: thin;
+}
+.side-pane-window__body::-webkit-scrollbar,
+.side-pane-md pre::-webkit-scrollbar,
+.side-pane-md .md-table-wrap::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+/* Grow the scrollbar when the user hovers the scrollable element so it's
+   easier to grab. WebKit doesn't transition scrollbar width, so this is
+   an instant snap, but visually it just feels like the macOS overlay
+   scrollbar swelling on touch. */
+.side-pane-window__body:hover::-webkit-scrollbar,
+.side-pane-md pre:hover::-webkit-scrollbar,
+.side-pane-md .md-table-wrap:hover::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+.side-pane-window__body::-webkit-scrollbar-track,
+.side-pane-md pre::-webkit-scrollbar-track,
+.side-pane-md .md-table-wrap::-webkit-scrollbar-track {
+  background: transparent;
+}
+.side-pane-window__body::-webkit-scrollbar-thumb,
+.side-pane-md pre::-webkit-scrollbar-thumb,
+.side-pane-md .md-table-wrap::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-text) 22%, transparent);
+  border-radius: 4px;
+}
+.side-pane-window__body::-webkit-scrollbar-thumb:hover,
+.side-pane-md pre::-webkit-scrollbar-thumb:hover,
+.side-pane-md .md-table-wrap::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--color-text) 38%, transparent);
 }
 
 .side-pane-window__error {

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -16,19 +16,23 @@ export function SidePane() {
     setRatios(Array(Math.max(0, windows.length - 1)).fill(0.5));
   }, [windows.length]);
 
-  // While dragging either divider, set data-resizing on the aside so CSS
-  // can mask the markdown bodies (content-visibility: hidden) — the text
-  // layout pass per pointermove is the actual perf killer with multi-window
-  // multi-paragraph reports.
+  // While dragging either divider, set data-pane-resizing on the document
+  // root. The flag is read by a CSS rule on .app-shell__body that suppresses
+  // its `transition: grid-template-columns 220ms ease` — without that, every
+  // pointermove kicks off a fresh 220ms animation of the column width, so
+  // the pane edge lags the cursor and the heavy main column reflows mid-
+  // animation many times per drag step.
   const containerRef = useRef(null);
   const setResizingFlag = useCallback((on) => {
-    const el = containerRef.current;
-    if (!el) return;
-    if (on) el.dataset.resizing = 'true';
-    else delete el.dataset.resizing;
+    const root = document.documentElement;
+    if (on) root.dataset.paneResizing = 'true';
+    else delete root.dataset.paneResizing;
   }, []);
 
   // Outer pane (left-edge) drag — resizes the whole dock width.
+  // pointermove can fire 100+ times/sec on a 120Hz trackpad. Coalesce
+  // multiple events into one CSS-var write per frame via rAF — same
+  // pattern the inner divider uses for its flex writes.
   const [isDragging, setIsDragging] = useState(false);
   const onOuterDividerPointerDown = useCallback((e) => {
     e.preventDefault();
@@ -41,14 +45,25 @@ export function SidePane() {
     const prevSelect = document.body.style.userSelect;
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
+    let pendingNext = startWidth;
+    let rafId = null;
+    const apply = () => {
+      rafId = null;
+      document.documentElement.style.setProperty('--side-pane-width', `${pendingNext}px`);
+    };
     const onMove = (ev) => {
       const delta = startX - ev.clientX;
-      const next = clampSidePaneWidth(startWidth + delta, viewport);
-      document.documentElement.style.setProperty('--side-pane-width', `${next}px`);
+      pendingNext = clampSidePaneWidth(startWidth + delta, viewport);
+      if (rafId == null) rafId = requestAnimationFrame(apply);
     };
     const onUp = (ev) => {
+      if (rafId != null) cancelAnimationFrame(rafId);
       const delta = startX - ev.clientX;
-      setPaneWidth(clampSidePaneWidth(startWidth + delta, window.innerWidth));
+      const finalWidth = clampSidePaneWidth(startWidth + delta, window.innerWidth);
+      // Write final value to the var immediately so the column doesn't
+      // jump on the next React commit; setPaneWidth then persists state.
+      document.documentElement.style.setProperty('--side-pane-width', `${finalWidth}px`);
+      setPaneWidth(finalWidth);
       setIsDragging(false);
       setResizingFlag(false);
       document.body.style.cursor = prevCursor;

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
@@ -6,6 +6,27 @@ const STORAGE_KEY = 'quodeq.sidePaneWidth';
 const LEGACY_STORAGE_KEY = 'quodeq.reportPaneWidth';
 const DEFAULT_WIDTH_PX = 560;
 const MAX_WINDOWS = 3;
+const NOTICE_DISMISS_MS = 4000;
+const AT_CAP_MESSAGE = `Up to ${MAX_WINDOWS} panels can be open at once — close one first.`;
+
+function SidePaneToast({ notice, onDismiss }) {
+  useEffect(() => {
+    if (!notice) return undefined;
+    const t = setTimeout(onDismiss, NOTICE_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [notice, onDismiss]);
+  if (!notice) return null;
+  return (
+    <div
+      className="job-error-toast side-pane-toast"
+      onClick={onDismiss}
+      role="status"
+      aria-live="polite"
+    >
+      {notice.message}
+    </div>
+  );
+}
 
 function readStoredWidth() {
   try {
@@ -38,6 +59,10 @@ function writeStoredWidth(px) {
 export function SidePaneProvider({ children }) {
   const [windows, setWindows] = useState([]);
   const [paneWidth, setPaneWidthState] = useState(readStoredWidth);
+  // Transient notice surfaced as a toast (e.g. "max panels open"). The `key`
+  // forces a fresh mount when the same message is shown twice in a row, so
+  // the auto-dismiss timer resets and the slide-in animation replays.
+  const [notice, setNotice] = useState(null);
 
   const isOpen = windows.length > 0;
 
@@ -46,14 +71,21 @@ export function SidePaneProvider({ children }) {
     [windows],
   );
 
+  const showAtCapNotice = useCallback(() => {
+    setNotice({ message: AT_CAP_MESSAGE, key: Date.now() });
+  }, []);
+
+  const clearNotice = useCallback(() => setNotice(null), []);
+
   const addWindow = useCallback((spec) => {
     if (!spec || !spec.id) return;
-    setWindows((prev) => {
-      if (prev.some((w) => w.id === spec.id)) return prev;
-      if (prev.length >= MAX_WINDOWS) return prev;
-      return [...prev, spec];
-    });
-  }, []);
+    if (windows.some((w) => w.id === spec.id)) return;
+    if (windows.length >= MAX_WINDOWS) {
+      showAtCapNotice();
+      return;
+    }
+    setWindows((prev) => [...prev, spec]);
+  }, [windows, showAtCapNotice]);
 
   const removeWindow = useCallback((id) => {
     setWindows((prev) => prev.filter((w) => w.id !== id));
@@ -61,14 +93,16 @@ export function SidePaneProvider({ children }) {
 
   const toggleWindow = useCallback((spec) => {
     if (!spec || !spec.id) return;
-    setWindows((prev) => {
-      if (prev.some((w) => w.id === spec.id)) {
-        return prev.filter((w) => w.id !== spec.id);
-      }
-      if (prev.length >= MAX_WINDOWS) return prev;
-      return [...prev, spec];
-    });
-  }, []);
+    if (windows.some((w) => w.id === spec.id)) {
+      setWindows((prev) => prev.filter((w) => w.id !== spec.id));
+      return;
+    }
+    if (windows.length >= MAX_WINDOWS) {
+      showAtCapNotice();
+      return;
+    }
+    setWindows((prev) => [...prev, spec]);
+  }, [windows, showAtCapNotice]);
 
   const closeAll = useCallback(() => setWindows([]), []);
 
@@ -137,6 +171,7 @@ export function SidePaneProvider({ children }) {
   return (
     <SidePaneContext.Provider value={value}>
       {children}
+      <SidePaneToast key={notice?.key} notice={notice} onDismiss={clearNotice} />
     </SidePaneContext.Provider>
   );
 }

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.test.jsx
@@ -80,6 +80,16 @@ describe('SidePaneProvider', () => {
     expect(screen.getByTestId('state')).toHaveTextContent('open:a,b,c');
   });
 
+  it('shows an at-cap toast when addWindow is called past MAX_WINDOWS', () => {
+    render(<SidePaneProvider><Probe /></SidePaneProvider>);
+    fireEvent.click(screen.getByText('add-a'));
+    fireEvent.click(screen.getByText('add-b'));
+    fireEvent.click(screen.getByText('add-c'));
+    expect(screen.queryByRole('status')).toBeNull();
+    fireEvent.click(screen.getByText('add-d'));
+    expect(screen.getByRole('status')).toHaveTextContent(/3 panels/i);
+  });
+
   it('hasWindow reflects current dock contents', () => {
     render(<SidePaneProvider><Probe /></SidePaneProvider>);
     expect(screen.getByTestId('has-a')).toHaveTextContent('no');

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1355,6 +1355,17 @@
   min-height: 0;
   transition: grid-template-columns 220ms ease;
 }
+/* While the user is dragging the side-pane divider, the column width
+   tracks the cursor every pointermove via the --side-pane-width CSS var.
+   Letting the 220ms grid transition fire on each move makes the column
+   edge animate behind the cursor and reflows the main column many times
+   per drag step — which feels scratchy. Suppress the transition during
+   the drag so the column snaps to the cursor; the open/close slide-in
+   still uses it because it's only set off while data-pane-resizing is
+   present on the root. */
+:root[data-pane-resizing] .app-shell__body {
+  transition: none;
+}
 .app-shell__body:has(.sidebar.sidebar--expanded:hover),
 .app-shell__body:has(.sidebar.sidebar--expanded.sidebar--pinned) {
   grid-template-columns:
@@ -1368,6 +1379,11 @@
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  /* Isolate the main column's layout + paint from the side-pane subtree
+     and topbar so a pane-divider drag doesn't propagate reflow into the
+     entire document. The column already clips its own overflow, so
+     containment doesn't change visible bounds. */
+  contain: layout paint;
 }
 .app-shell__main-column > .dashboard {
   flex: 1 1 auto;

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -104,8 +104,7 @@ function buildComplianceSection(compliance) {
 }
 
 export function buildDimensionReport({ evalData, principleGrades, allViolations, overallGrade, dateLabel, runId }) {
-  const dim = evalData?.dimension || 'Unknown';
-  const dimTitle = dim.charAt(0).toUpperCase() + dim.slice(1);
+  const dim = (evalData?.dimension || 'unknown').toLowerCase();
   const score = overallGrade?.score || '—';
   const grade = overallGrade?.grade || '—';
   const compliance = evalData?.compliance || [];
@@ -113,7 +112,7 @@ export function buildDimensionReport({ evalData, principleGrades, allViolations,
   const rid = runId ? ` · **Run:** ${runId.slice(0, 8)}` : '';
 
   const lines = [];
-  lines.push(`# ${dimTitle} Report`);
+  lines.push(`# ${dim} report`);
   lines.push('');
   lines.push(`**Date:** ${date}${rid} · **Score:** ${score} ${grade}`);
   lines.push('');
@@ -175,7 +174,7 @@ function buildTopOffendingFiles(accumulatedDimensions) {
   lines.push('| File | Violations | Critical | Major | Minor |');
   lines.push('|------|-----------|----------|-------|-------|');
   for (const [file, stats] of topFiles) {
-    lines.push(`| \`${file}\` | ${stats.count} | ${stats.critical} | ${stats.major} | ${stats.minor} |`);
+    lines.push(`| ${file} | ${stats.count} | ${stats.critical} | ${stats.major} | ${stats.minor} |`);
   }
   lines.push('');
   return lines;
@@ -193,8 +192,7 @@ function buildCritMajorSection(accumulatedDimensions) {
     lines.push(`## Critical & Major Violations (${total})`);
     lines.push('');
     for (const { dimension, violations } of critMajor) {
-      const dimTitle = (dimension || '').charAt(0).toUpperCase() + (dimension || '').slice(1);
-      lines.push(`### ${dimTitle}`);
+      lines.push(`### ${(dimension || '').toLowerCase()}`);
       lines.push('');
       for (const v of violations) lines.push(formatViolationEntry(v));
     }
@@ -231,7 +229,7 @@ export function buildOverviewReport(accumulated, accumulatedDimensions, projectN
   const project = projectName || 'Project';
 
   const lines = [];
-  lines.push(`# Code Quality Report — ${project}`);
+  lines.push(`# ${project} report`);
   lines.push('');
   lines.push(`**Date:** ${date} · **Overall Score:** ${score} ${grade}`);
   lines.push('');


### PR DESCRIPTION
## Summary

Started as: dragging the splitter between the side-pane (multi-window dock) and the main column felt scratchy / laggy in pywebview, while OS window resize on the same content stayed smooth — the ceiling wasn't WKWebView paint cost itself but how the JS-driven splitter triggered layout per pointermove. Picked up some adjacent UX polish along the way.

## Commits

1. **`chore(deps): bump recharts 3.7.0 → 3.8.1`** — bugfixes + new coordinate hooks; pulls in any underlying React batching improvements.
2. **`feat(topbar): drop redundant close-all-side-panes button`** — each side-pane window already has its own ✕ in the header; the topbar global close was duplicating affordances.
3. **`feat(side-pane): show at-cap toast instead of silent no-op`** — at MAX_WINDOWS=3, addWindow / toggleWindow now surface a transient toast ("Up to 3 panels can be open at once — close one first.") instead of silently dropping the click. Reuses the existing `job-error-toast` styling pattern.
4. **`feat(report): lowercase titles, plain-text file paths in tables`** — side-pane window title and markdown H1 are now `{project} report` / `{dim} report` (drops "Code Quality Report — " prefix, lowercase). Top-Offending-Files cells render the path as plain text instead of inline `<code>` so deep paths actually wrap inside `table-layout: fixed` cells in WKWebView.
5. **`perf(side-pane): smooth divider drag and md-viewer reflow`** — the meat:
    - `:root[data-pane-resizing] .app-shell__body { transition: none }` so each pointermove doesn't restart the 220ms grid-template-columns animation that was making the column edge lag the cursor.
    - rAF-coalesce the outer divider's pointermove writes (matches inner divider).
    - `contain: layout paint` on `.app-shell__main-column` and `contain: layout` on `.side-pane-md` to scope reflow.
    - Drop the data-resizing content-visibility hide added in #327 — markdown reflow stays visible during drag, per requested feel.
    - `overflow-x: scroll` + `scrollbar-gutter: stable` on `.side-pane-md pre` and `.md-table-wrap` so the auto-scrollbar doesn't toggle in/out and fire extra layout passes per pointermove.
    - `table-layout: fixed` on `.side-pane-md table` so cells aren't re-measured to redistribute column widths each frame.
    - `overflow-wrap: anywhere` / `word-break: break-all` on td/th + descendants and inline `<code>` so long file paths still wrap inside fixed-layout cells.
6. **`style(side-pane): subtle divider seam and thinner scrollbars`** — replaces the flat translucent divider strip with a 1px seam in the middle of the 8px hit zone (3px on hover/drag, no colour change). Side-pane scrollbars are now 8px, growing to 12px when you hover the scrollable element, with a translucent thumb.

## Test plan

- [x] `vitest run` — 41/41 pass (added one Provider test for the at-cap toast path).
- [x] Manual: outer pane-divider drag in pywebview — feels comparable to OS window resize now.
- [x] Manual: open/close pane slide-in animation still works (transition only suppressed while `data-pane-resizing` is set).
- [x] Manual: inner between-window divider drag unchanged.
- [x] Manual: trying to open a 4th panel surfaces the at-cap toast and auto-dismisses.
- [x] Manual: deep file paths wrap cleanly inside the Top Offending Files table.
- [x] Sanity-check at narrow viewport (`@media (max-width: 900px)` overlay path).
- [x] Sanity-check that no popovers/tooltips visually escape the main column now that it has `contain: paint`.