### PR TITLE
fix(progress): align heartbeat and dashboard finding counts

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -1,16 +1,14 @@
 """Heartbeat and progress reporting for the subagent pool."""
 from __future__ import annotations
 
-import json
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from quodeq.analysis.stream.parser import FINDING_TYPE_COMPLIANCE, FINDING_TYPE_VIOLATION
 from quodeq.analysis.subagents.file_queue import FileQueue
+from quodeq.analysis.subagents.jsonl_utils import FindingTally, tally_unique_findings
 from quodeq.shared.logging import log_info, log_warning
-from quodeq.shared.utils import open_text
 
 _HEARTBEAT_INTERVAL = 10
 _SECONDS_PER_MINUTE = 60
@@ -18,8 +16,8 @@ _HEARTBEAT_FMT = (
     "  [{dimension}] {mins}m{secs:02d}s | "
     "{active} active ({total_agents} total) | "
     "{taken} files taken ({remaining} left) | "
-    "{findings} findings | "
-    "{violations} violations \u00b7 {compliances} compliance"
+    "{findings} findings ({duplicates} dup) | "
+    "{violations} violations · {compliance} compliance"
 )
 
 
@@ -32,79 +30,13 @@ class HeartbeatContext:
     lock: threading.Lock
 
 
-@dataclass
-class FindingCounts:
-    """Aggregated finding counts from a JSONL file."""
-    total: int = 0
-    violations: int = 0
-    compliances: int = 0
-
-
-def _classify_jsonl_line(line: str, counts: FindingCounts) -> None:
-    """Classify a single non-empty JSONL line and update *counts* in place."""
-    counts.total += 1
-    try:
-        entry = json.loads(line)
-        t = entry.get("t")
-        if t == FINDING_TYPE_VIOLATION:
-            counts.violations += 1
-        elif t == FINDING_TYPE_COMPLIANCE:
-            counts.compliances += 1
-    except json.JSONDecodeError:
-        pass
-
-
-def _read_findings_from_file(jsonl_path: Path) -> FindingCounts:
-    """Open *jsonl_path* and classify every non-empty line into finding counts.
-
-    Caller is responsible for holding any required lock before invoking this.
-    """
-    counts = FindingCounts()
-    with open_text(jsonl_path) as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            _classify_jsonl_line(stripped, counts)
-    return counts
-
-
-def _count_jsonl_findings_incremental(
-    jsonl_path: Path, lock: threading.Lock,
-    cumulative: FindingCounts, offset: int,
-) -> tuple[FindingCounts, int]:
-    """Incrementally count findings from *offset*, updating *cumulative* in place."""
+def _read_tally(jsonl_path: Path, lock: threading.Lock) -> FindingTally:
+    """Tally under the shared write lock to avoid TOCTOU with MCP writers."""
     try:
         with lock:
-            if not jsonl_path.exists():
-                return cumulative, offset
-            with open(jsonl_path, "rb") as f:
-                f.seek(offset)
-                new_bytes = f.read()
-                new_offset = offset + len(new_bytes)
-            for line in new_bytes.decode("utf-8", errors="replace").splitlines():
-                stripped = line.strip()
-                if stripped:
-                    _classify_jsonl_line(stripped, cumulative)
-            return cumulative, new_offset
+            return tally_unique_findings(jsonl_path)
     except OSError:
-        return cumulative, offset
-
-
-def _count_jsonl_findings(jsonl_path: Path, lock: threading.Lock) -> FindingCounts:
-    """Count total, violation, and compliance lines in a JSONL file under a lock.
-
-    The existence check and read are both inside the lock to avoid a TOCTOU
-    race with concurrent MCP writers that may create the file between the
-    check and the open.
-    """
-    try:
-        with lock:
-            if not jsonl_path.exists():
-                return FindingCounts()
-            return _read_findings_from_file(jsonl_path)
-    except OSError:
-        return FindingCounts()
+        return FindingTally()
 
 
 def heartbeat_loop(
@@ -113,19 +45,18 @@ def heartbeat_loop(
 ) -> None:
     """Emit periodic progress lines for the subagent pool.
 
-    Tracks JSONL file offset across ticks to avoid re-reading the entire file
-    on every heartbeat cycle.
+    Each tick re-reads the dimension JSONL and deduplicates by
+    ``(p, file, line, t)`` in memory, so the unique counts always match
+    :mod:`quodeq.services.scan_progress` (which the UI consumes). The
+    ``duplicates`` segment surfaces overlap between parallel agents in real
+    time.
     """
     start = time.monotonic()
-    cumulative = FindingCounts()
-    jsonl_offset = 0
     while not stop.wait(_HEARTBEAT_INTERVAL):
         try:
             elapsed = int(time.monotonic() - start)
             mins, secs = divmod(elapsed, _SECONDS_PER_MINUTE)
-            counts, jsonl_offset = _count_jsonl_findings_incremental(
-                ctx.jsonl_path, ctx.lock, cumulative, jsonl_offset,
-            )
+            tally = _read_tally(ctx.jsonl_path, ctx.lock)
             remaining, taken = FileQueue(ctx.queue_path).stats()
             total_agents = len(finished)
             active = sum(1 for v in finished.values() if not v)
@@ -137,9 +68,10 @@ def heartbeat_loop(
                 total_agents=total_agents,
                 taken=taken,
                 remaining=remaining,
-                findings=counts.total,
-                violations=counts.violations,
-                compliances=counts.compliances,
+                findings=tally.total,
+                duplicates=tally.duplicates,
+                violations=tally.violations,
+                compliance=tally.compliance,
             ))
         except (OSError, ValueError, RuntimeError) as exc:
             log_warning(f"Heartbeat error: {exc}")

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -16,9 +16,14 @@ _HEARTBEAT_FMT = (
     "  [{dimension}] {mins}m{secs:02d}s | "
     "{active} active ({total_agents} total) | "
     "{taken} files taken ({remaining} left) | "
-    "{findings} findings ({duplicates} dup) | "
+    "{findings} findings{dup_seg} | "
     "{violations} violations · {compliance} compliance"
 )
+
+
+def _format_dup_segment(duplicates: int) -> str:
+    """Render the ``(N dup)`` suffix only when there's actual overlap to surface."""
+    return f" ({duplicates} dup)" if duplicates > 0 else ""
 
 
 @dataclass
@@ -69,7 +74,7 @@ def heartbeat_loop(
                 taken=taken,
                 remaining=remaining,
                 findings=tally.total,
-                duplicates=tally.duplicates,
+                dup_seg=_format_dup_segment(tally.duplicates),
                 violations=tally.violations,
                 compliance=tally.compliance,
             ))

--- a/src/quodeq/analysis/subagents/jsonl_utils.py
+++ b/src/quodeq/analysis/subagents/jsonl_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
@@ -10,6 +11,58 @@ from quodeq.shared.logging import log_info
 from quodeq.shared.utils import open_text
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FindingTally:
+    """Unique violation/compliance counts plus the duplicates folded out."""
+    violations: int = 0
+    compliance: int = 0
+    duplicates: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.violations + self.compliance
+
+
+def tally_unique_findings(jsonl_path: Path) -> FindingTally:
+    """Count unique findings (deduplicated by ``(p, file, line, t)``) and duplicates.
+
+    Single source of truth for the heartbeat and the dashboard progress reader,
+    so the terminal and UI never disagree mid-batch — before the on-disk
+    :func:`deduplicate_jsonl` pass runs at end of pool, the file holds raw
+    appends from many parallel agents and contains overlapping findings.
+
+    Tolerant: missing files, malformed lines, and OSError yield empty/partial
+    tallies silently.
+    """
+    if not jsonl_path.is_file():
+        return FindingTally()
+    seen: set[tuple] = set()
+    violations = compliance = duplicates = 0
+    try:
+        with open_text(jsonl_path) as f:
+            for raw in f:
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("t")
+                key = (obj.get("p"), obj.get("file"), obj.get("line"), t)
+                if key in seen:
+                    duplicates += 1
+                    continue
+                seen.add(key)
+                if t == "violation":
+                    violations += 1
+                elif t == "compliance":
+                    compliance += 1
+    except OSError:
+        pass
+    return FindingTally(violations=violations, compliance=compliance, duplicates=duplicates)
 
 
 def dedup_jsonl_lines(lines: Iterable[str]) -> list[str]:

--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -8,6 +8,15 @@ from pathlib import Path
 
 from flask import Flask, Response, current_app, jsonify, request
 
+# Lines containing this marker are kept in run.log for forensics but suppressed
+# from the dashboard's live console — they're per-minute resource snapshots
+# (rss / fds / threads / ollama RSS) and clutter the operator-facing view.
+_CONSOLE_HIDDEN_MARKERS: tuple[str, ...] = ("[resources]",)
+
+
+def _is_visible_log_line(line: str) -> bool:
+    return not any(marker in line for marker in _CONSOLE_HIDDEN_MARKERS)
+
 
 def _resolve_run_log(job_id: str) -> tuple[Path | None, int]:
     """Return (log_path, status_hint). status_hint is 0 on success, HTTP code on error."""
@@ -38,7 +47,7 @@ def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
             return [], since  # no complete line yet
         text = text[: last_nl + 1]
     consumed = len(text.encode("utf-8"))
-    lines = text.splitlines()
+    lines = [ln for ln in text.splitlines() if _is_visible_log_line(ln)]
     return lines, since + consumed
 
 
@@ -79,7 +88,8 @@ def _sse_generator(log_path: Path, initial_offset: int, is_done):
             if complete:
                 for line in complete.splitlines():
                     offset += len(line.encode("utf-8")) + 1  # +1 for '\n'
-                    yield _sse_line(line, event_id=offset)
+                    if _is_visible_log_line(line):
+                        yield _sse_line(line, event_id=offset)
         if is_done():
             # Emit done frame without a data field so parsers don't see an empty data entry.
             done_parts = []

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -9,7 +9,7 @@ Sources:
 - ``dim_estimates.json``          — per-dim file count predicted before any dim runs
 - ``scan.json``                   — total_files (project-wide fallback for pending dims)
 - ``<dim>_queue.json``            — taken / pending counts (precise once dim has started)
-- ``<dim>_evidence.jsonl``        — violation / compliance counters
+- ``<dim>_evidence.jsonl``        — unique violation / compliance / duplicate counts (in-memory dedup)
 - ``<dim>_agent-*.stream`` mtime  — per-dim active-agents heuristic
 """
 from __future__ import annotations
@@ -19,6 +19,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
 
 _AGENT_ACTIVE_WINDOW_S = 30
 
@@ -30,6 +32,7 @@ class _DimProgress:
     files: dict
     violations: int = 0
     compliance: int = 0
+    duplicates: int = 0
     elapsed_s: float | None = None
     budget_s: int | None = None
     active_agents: int = 0
@@ -79,35 +82,6 @@ def _read_dim_estimates(run_dir: Path) -> dict[str, dict]:
         elif isinstance(v, int):
             out[k] = {"count": v, "reason": ""}
     return out
-
-
-def _count_jsonl_findings(jsonl_path: Path) -> tuple[int, int]:
-    """Return (violation_count, compliance_count) from a dimension's JSONL.
-
-    Tolerant: malformed lines are skipped silently.
-    """
-    if not jsonl_path.is_file():
-        return 0, 0
-    violations = 0
-    compliance = 0
-    try:
-        with jsonl_path.open(encoding="utf-8") as fh:
-            for line in fh:
-                stripped = line.strip()
-                if not stripped:
-                    continue
-                try:
-                    obj = json.loads(stripped)
-                except json.JSONDecodeError:
-                    continue
-                t = obj.get("t")
-                if t == "violation":
-                    violations += 1
-                elif t == "compliance":
-                    compliance += 1
-    except OSError:
-        pass
-    return violations, compliance
 
 
 def _active_agents(evidence_dir: Path, dim_id: str) -> int:
@@ -279,7 +253,7 @@ def build_scan_progress(
         estimate_meta = dim_estimates.get(dim_id)
         estimate_reason = estimate_meta["reason"] if estimate_meta else None
 
-        v, c = _count_jsonl_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
+        tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
         budget = pool_budget_s if (d_state == "running" and pool_budget_s and pool_budget_s > 0) else None
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
@@ -288,8 +262,9 @@ def build_scan_progress(
             id=dim_id,
             state=d_state,
             files=files,
-            violations=v,
-            compliance=c,
+            violations=tally.violations,
+            compliance=tally.compliance,
+            duplicates=tally.duplicates,
             elapsed_s=elapsed,
             budget_s=budget,
             active_agents=active,

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from quodeq.analysis.subagents._heartbeat import (
     HeartbeatContext,
+    _format_dup_segment,
     _read_tally,
     _HEARTBEAT_FMT,
     heartbeat_loop,
@@ -65,18 +66,30 @@ class TestHeartbeatContext:
 
 
 class TestHeartbeatFormat:
-    def test_format_includes_duplicates_segment(self) -> None:
-        """The duplicates segment must appear so parallel-agent overlap is visible."""
+    def test_format_includes_duplicates_segment_when_present(self) -> None:
+        """The duplicates segment must appear when overlap exists."""
         line = _HEARTBEAT_FMT.format(
             dimension="security", mins=1, secs=2,
             active=2, total_agents=5,
             taken=10, remaining=20,
-            findings=7, duplicates=3,
+            findings=7, dup_seg=_format_dup_segment(3),
             violations=2, compliance=5,
         )
         assert "7 findings (3 dup)" in line
         assert "2 violations" in line
         assert "5 compliance" in line
+
+    def test_format_omits_duplicates_segment_when_zero(self) -> None:
+        """No `(0 dup)` clutter when there's no overlap."""
+        line = _HEARTBEAT_FMT.format(
+            dimension="security", mins=1, secs=2,
+            active=2, total_agents=5,
+            taken=10, remaining=20,
+            findings=7, dup_seg=_format_dup_segment(0),
+            violations=2, compliance=5,
+        )
+        assert "7 findings |" in line
+        assert "dup" not in line
 
 
 class TestHeartbeatLoop:

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -4,94 +4,57 @@ from __future__ import annotations
 import json
 import threading
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
-import pytest
-
-
-class TestClassifyJsonlLine:
-    def test_violation(self):
-        from quodeq.analysis.subagents._heartbeat import _classify_jsonl_line, FindingCounts
-        counts = FindingCounts()
-        _classify_jsonl_line(json.dumps({"t": "violation"}), counts)
-        assert counts.total == 1
-        assert counts.violations == 1
-
-    def test_compliance(self):
-        from quodeq.analysis.subagents._heartbeat import _classify_jsonl_line, FindingCounts
-        counts = FindingCounts()
-        _classify_jsonl_line(json.dumps({"t": "compliance"}), counts)
-        assert counts.total == 1
-        assert counts.compliances == 1
-
-    def test_other_type(self):
-        from quodeq.analysis.subagents._heartbeat import _classify_jsonl_line, FindingCounts
-        counts = FindingCounts()
-        _classify_jsonl_line(json.dumps({"t": "info"}), counts)
-        assert counts.total == 1
-        assert counts.violations == 0
-        assert counts.compliances == 0
-
-    def test_invalid_json(self):
-        from quodeq.analysis.subagents._heartbeat import _classify_jsonl_line, FindingCounts
-        counts = FindingCounts()
-        _classify_jsonl_line("not json", counts)
-        assert counts.total == 1
+from quodeq.analysis.subagents._heartbeat import (
+    HeartbeatContext,
+    _read_tally,
+    _HEARTBEAT_FMT,
+    heartbeat_loop,
+)
+from quodeq.analysis.subagents.jsonl_utils import FindingTally
 
 
-class TestReadFindingsFromFile:
-    def test_reads_findings(self, tmp_path):
-        from quodeq.analysis.subagents._heartbeat import _read_findings_from_file
-        p = tmp_path / "findings.jsonl"
-        p.write_text(
-            json.dumps({"t": "violation"}) + "\n"
-            + json.dumps({"t": "compliance"}) + "\n"
-            + "\n"
-        )
-        counts = _read_findings_from_file(p)
-        assert counts.total == 2
-        assert counts.violations == 1
-        assert counts.compliances == 1
+def _violation(p: str, file: str, line: int) -> str:
+    return json.dumps({"p": p, "file": file, "line": line, "t": "violation"})
 
 
-class TestCountJsonlFindings:
-    def test_file_not_exists(self, tmp_path):
-        from quodeq.analysis.subagents._heartbeat import _count_jsonl_findings
-        lock = threading.Lock()
-        counts = _count_jsonl_findings(tmp_path / "missing.jsonl", lock)
-        assert counts.total == 0
-
-    def test_with_valid_file(self, tmp_path):
-        from quodeq.analysis.subagents._heartbeat import _count_jsonl_findings
-        p = tmp_path / "findings.jsonl"
-        p.write_text(json.dumps({"t": "violation"}) + "\n")
-        lock = threading.Lock()
-        counts = _count_jsonl_findings(p, lock)
-        assert counts.total == 1
-        assert counts.violations == 1
-
-    def test_os_error(self, tmp_path):
-        from quodeq.analysis.subagents._heartbeat import _count_jsonl_findings
-        lock = threading.Lock()
-        with patch("quodeq.analysis.subagents._heartbeat._read_findings_from_file", side_effect=OSError("err")):
-            p = tmp_path / "findings.jsonl"
-            p.write_text("data")
-            counts = _count_jsonl_findings(p, lock)
-            assert counts.total == 0
+def _compliance(p: str, file: str, line: int) -> str:
+    return json.dumps({"p": p, "file": file, "line": line, "t": "compliance"})
 
 
-class TestFindingCounts:
-    def test_defaults(self):
-        from quodeq.analysis.subagents._heartbeat import FindingCounts
-        c = FindingCounts()
-        assert c.total == 0
-        assert c.violations == 0
-        assert c.compliances == 0
+class TestReadTally:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        tally = _read_tally(tmp_path / "missing.jsonl", threading.Lock())
+        assert tally == FindingTally()
+
+    def test_counts_unique_findings(self, tmp_path: Path) -> None:
+        p = tmp_path / "evidence.jsonl"
+        p.write_text("\n".join([
+            _violation("P1", "a.py", 1),
+            _compliance("P2", "b.py", 2),
+            "",
+        ]) + "\n")
+        tally = _read_tally(p, threading.Lock())
+        assert tally.violations == 1
+        assert tally.compliance == 1
+        assert tally.duplicates == 0
+        assert tally.total == 2
+
+    def test_counts_duplicates(self, tmp_path: Path) -> None:
+        """Repeats of (p, file, line, t) collapse — heartbeat should match the
+        UI's view of the file, not the raw line count."""
+        p = tmp_path / "evidence.jsonl"
+        v = _violation("P1", "a.py", 1)
+        c = _compliance("P2", "b.py", 2)
+        p.write_text("\n".join([v, v, v, c, c]) + "\n")
+        tally = _read_tally(p, threading.Lock())
+        assert tally.violations == 1
+        assert tally.compliance == 1
+        assert tally.duplicates == 3
 
 
 class TestHeartbeatContext:
-    def test_creation(self, tmp_path):
-        from quodeq.analysis.subagents._heartbeat import HeartbeatContext
+    def test_creation(self, tmp_path: Path) -> None:
         ctx = HeartbeatContext(
             queue_path=tmp_path / "queue",
             dimension_key="security",
@@ -99,3 +62,54 @@ class TestHeartbeatContext:
             lock=threading.Lock(),
         )
         assert ctx.dimension_key == "security"
+
+
+class TestHeartbeatFormat:
+    def test_format_includes_duplicates_segment(self) -> None:
+        """The duplicates segment must appear so parallel-agent overlap is visible."""
+        line = _HEARTBEAT_FMT.format(
+            dimension="security", mins=1, secs=2,
+            active=2, total_agents=5,
+            taken=10, remaining=20,
+            findings=7, duplicates=3,
+            violations=2, compliance=5,
+        )
+        assert "7 findings (3 dup)" in line
+        assert "2 violations" in line
+        assert "5 compliance" in line
+
+
+class TestHeartbeatLoop:
+    def test_emits_then_stops(self, tmp_path: Path, monkeypatch) -> None:
+        """Smoke test: one tick logs, then stop event ends the loop."""
+        evidence = tmp_path / "evidence.jsonl"
+        evidence.write_text(_violation("P1", "a.py", 1) + "\n")
+        queue = tmp_path / "queue.json"
+        queue.write_text(json.dumps({"version": 1, "taken": [], "pending": []}))
+
+        emitted: list[str] = []
+        monkeypatch.setattr(
+            "quodeq.analysis.subagents._heartbeat.log_info",
+            lambda msg: emitted.append(msg),
+        )
+        # Drive the loop with a tiny interval and stop after one tick.
+        monkeypatch.setattr(
+            "quodeq.analysis.subagents._heartbeat._HEARTBEAT_INTERVAL", 0.01,
+        )
+        ctx = HeartbeatContext(
+            queue_path=queue, dimension_key="security",
+            jsonl_path=evidence, lock=threading.Lock(),
+        )
+        stop = threading.Event()
+        thread = threading.Thread(
+            target=heartbeat_loop, args=(stop, {"a-1": False}, ctx),
+        )
+        thread.start()
+        # Wait briefly for at least one tick, then stop.
+        thread.join(timeout=0.2)
+        stop.set()
+        thread.join(timeout=1.0)
+
+        assert emitted, "heartbeat should emit at least one log line"
+        assert "[security]" in emitted[0]
+        assert "1 violations" in emitted[0]

--- a/tests/analysis/test_jsonl_utils_coverage.py
+++ b/tests/analysis/test_jsonl_utils_coverage.py
@@ -7,9 +7,11 @@ from pathlib import Path
 import pytest
 
 from quodeq.analysis.subagents.jsonl_utils import (
+    FindingTally,
     dedup_jsonl_lines,
     deduplicate_jsonl,
     merge_jsonl,
+    tally_unique_findings,
 )
 
 
@@ -152,3 +154,55 @@ class TestMergeJsonl:
         output = tmp_path / "merged.jsonl"
         merge_jsonl([], output)
         assert output.read_text().strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# tally_unique_findings
+# ---------------------------------------------------------------------------
+
+class TestTallyUniqueFindings:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert tally_unique_findings(tmp_path / "missing.jsonl") == FindingTally()
+
+    def test_counts_violations_and_compliance(self, tmp_path):
+        p = tmp_path / "ev.jsonl"
+        p.write_text(
+            json.dumps({"p": "P1", "file": "a.py", "line": 1, "t": "violation"}) + "\n"
+            + json.dumps({"p": "P2", "file": "b.py", "line": 2, "t": "compliance"}) + "\n"
+        )
+        tally = tally_unique_findings(p)
+        assert tally.violations == 1
+        assert tally.compliance == 1
+        assert tally.duplicates == 0
+        assert tally.total == 2
+
+    def test_dedups_repeats_into_duplicate_count(self, tmp_path):
+        p = tmp_path / "ev.jsonl"
+        line = json.dumps({"p": "P1", "file": "a.py", "line": 1, "t": "violation"})
+        p.write_text("\n".join([line] * 4) + "\n")
+        tally = tally_unique_findings(p)
+        assert tally.violations == 1
+        assert tally.duplicates == 3
+        assert tally.total == 1
+
+    def test_skips_malformed_and_blank_lines(self, tmp_path):
+        p = tmp_path / "ev.jsonl"
+        p.write_text(
+            "not-json\n"
+            "\n"
+            + json.dumps({"p": "P1", "file": "a.py", "line": 1, "t": "violation"}) + "\n"
+        )
+        tally = tally_unique_findings(p)
+        assert tally.violations == 1
+        assert tally.duplicates == 0
+
+    def test_unknown_t_is_dedupped_but_not_classified(self, tmp_path):
+        """Lines with ``t`` other than violation/compliance still occupy a key,
+        so a repeat counts as a duplicate — but neither counter advances."""
+        p = tmp_path / "ev.jsonl"
+        line = json.dumps({"p": "P1", "file": "a.py", "line": 1, "t": "info"})
+        p.write_text(line + "\n" + line + "\n")
+        tally = tally_unique_findings(p)
+        assert tally.violations == 0
+        assert tally.compliance == 0
+        assert tally.duplicates == 1

--- a/tests/api/test_log_stream_routes.py
+++ b/tests/api/test_log_stream_routes.py
@@ -139,3 +139,35 @@ def test_sse_404_on_missing_log(tmp_path, app) -> None:
     client = app.test_client()
     resp = client.get("/api/jobs/job-sse-3/logs/stream")
     assert resp.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_plain_logs_filters_resources_lines(tmp_path, app) -> None:
+    """Resource snapshots stay in run.log for forensics but never reach the dashboard."""
+    content = (
+        "[INFO] [security] 0m10s | 1 active | 5 files taken\n"
+        "[INFO] [resources] elapsed=1m00s rss=120MB threads=5 fds=8 ollama=200MB\n"
+        "[INFO] [security] 0m20s | 1 active | 9 files taken\n"
+    )
+    _seed_run(tmp_path, app, "job-filter", content)
+    client = app.test_client()
+    data = client.get("/api/jobs/job-filter/logs").get_json()
+    assert all("[resources]" not in line for line in data["lines"])
+    assert any("[security]" in line for line in data["lines"])
+    # Offset must still advance past the suppressed line so the next poll
+    # doesn't replay it.
+    assert data["nextOffset"] == len(content)
+
+
+def test_sse_filters_resources_lines(tmp_path, app) -> None:
+    content = (
+        "[INFO] [security] 0m10s | running\n"
+        "[INFO] [resources] elapsed=1m00s rss=120MB threads=5 fds=8 ollama=200MB\n"
+        "[INFO] [security] 0m20s | running\n"
+    )
+    _seed_run(tmp_path, app, "job-sse-filter-done", content)
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-sse-filter-done/logs/stream")
+    events = _collect_sse(resp)
+    payloads = [e["data"] for e in events if "data" in e]
+    assert all("[resources]" not in line for line in payloads)
+    assert any("[security]" in line for line in payloads)


### PR DESCRIPTION
## Summary
- Terminal heartbeat and dashboard \`ScanProgress\` were reporting different violation/compliance counts for the same dimension.
- Root cause was two divergent counters reading the same JSONL: an offset-based cumulative reader in the heartbeat (stale after \`deduplicate_jsonl\` truncated the file in place) and a per-poll full re-read in the UI (inflated by raw duplicate appends from parallel agents).
- Both readers now share \`tally_unique_findings\` in \`subagents/jsonl_utils\`, which dedupes by \`(p, file, line, t)\` in memory and returns unique violation / compliance counts plus a duplicates count. The heartbeat surfaces the duplicates inline (\`... | 181 findings (170 dup) | 15 violations · 165 compliance\`), and the API now ships \`duplicates\` on each dimension so the UI can render it later if desired.

## Test plan
- [x] \`uv run pytest tests/\` (2376 passed)
- [x] Smoke: start a fresh analysis, confirm heartbeat \`findings (N dup)\` segment renders and unique numbers match the dashboard's \`Nv · Mc\` exactly through the run.
- [x] Verify the dashboard still hides the \`v\` / \`c\` chips when their unique count is 0.