### PR TITLE
SSE live updates for evaluation dashboard (Plan 2)

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -234,41 +234,54 @@ def run_events_generator(
     *,
     last_event_id: int = 0,
     tick_seconds: float | None = None,
+    heartbeat_seconds: float | None = None,
 ) -> Iterator[str]:
     """Yield SSE frames observing run_dir.
 
     tick_seconds overrides QUODEQ_SSE_TICK_MS for tests (use 0.0 to drain
     immediately without sleeping).
+    heartbeat_seconds overrides the 15s :keepalive interval for tests.
+
+    The try/finally is defensive: today no per-stream resources persist
+    between ticks (every helper opens and closes its own DB / file handle),
+    so cleanup is a no-op. The block exists so a future change that adds
+    a longer-lived resource has a place to release it.
     """
     sleep_s = tick_seconds if tick_seconds is not None else (_TICK_MS / 1000.0)
+    heartbeat_s = heartbeat_seconds if heartbeat_seconds is not None else _HEARTBEAT_S
     state = WatcherState(last_event_id=last_event_id)
     last_emit_at = time.monotonic()
     yield ":keepalive\n\n"
 
-    while True:
-        events, state = compute_tick(run_dir, state)
-        terminal_state = ""
-        for event_type, payload, event_id in events:
-            yield sse_line(payload, event=event_type, event_id=event_id)
-            last_emit_at = time.monotonic()
-            if event_type == "status":
-                done, terminal = _is_terminal(payload)
-                if done:
-                    terminal_state = terminal
+    try:
+        while True:
+            events, state = compute_tick(run_dir, state)
+            terminal_state = ""
+            for event_type, payload, event_id in events:
+                yield sse_line(payload, event=event_type, event_id=event_id)
+                last_emit_at = time.monotonic()
+                if event_type == "status":
+                    done, terminal = _is_terminal(payload)
+                    if done:
+                        terminal_state = terminal
 
-        if terminal_state:
-            yield sse_line(
-                json.dumps({"state": terminal_state}, separators=(",", ":")),
-                event="done",
-            )
-            return
+            if terminal_state:
+                yield sse_line(
+                    json.dumps({"state": terminal_state}, separators=(",", ":")),
+                    event="done",
+                )
+                return
 
-        if time.monotonic() - last_emit_at >= _HEARTBEAT_S:
-            yield ":keepalive\n\n"
-            last_emit_at = time.monotonic()
+            if time.monotonic() - last_emit_at >= heartbeat_s:
+                yield ":keepalive\n\n"
+                last_emit_at = time.monotonic()
 
-        if sleep_s > 0:
-            time.sleep(sleep_s)
-        else:
-            # tick_seconds=0.0 means "drain once and exit" for tests.
-            return
+            if sleep_s > 0:
+                time.sleep(sleep_s)
+            else:
+                # tick_seconds=0.0 means "drain once and exit" for tests.
+                return
+    finally:
+        # Reserved for future cleanup of long-lived per-stream resources.
+        # Currently a no-op because each tick opens and closes its own handles.
+        pass

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -10,6 +10,7 @@ Reconnect via Last-Event-ID is supported by SQLite's autoincrement findings.id.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -36,3 +37,15 @@ def serialize_finding_event(judgment_dict: dict[str, Any]) -> str:
     converted via _judgment_as_dict (see Task 3).
     """
     return json.dumps(judgment_dict, separators=(",", ":"))
+
+
+@dataclass
+class WatcherState:
+    """Mutable per-stream state. Tracks what has been emitted to one client.
+
+    last_event_id advances only on `event: finding` (matches SSE Last-Event-ID
+    semantics — status and dimension events are idempotent on reconnect).
+    """
+    last_event_id: int = 0
+    last_status_mtime: float | None = None
+    emitted_dimensions: frozenset[str] = field(default_factory=frozenset)

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -204,3 +204,71 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
         emitted_dimensions=frozenset(state.emitted_dimensions | set(new_dims)),
     )
     return events, new_state
+
+
+import os
+import time
+from typing import Iterator
+
+from quodeq.api._sse_log_helpers import sse_line
+
+_TICK_MS = int(os.environ.get("QUODEQ_SSE_TICK_MS", "250"))
+_HEARTBEAT_S = 15.0
+_TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
+
+
+def _is_terminal(status_payload: str) -> tuple[bool, str]:
+    """Check whether the JSON status payload represents a terminal state."""
+    try:
+        data = json.loads(status_payload)
+    except ValueError:
+        return False, ""
+    state = data.get("state") if isinstance(data, dict) else None
+    if isinstance(state, str) and state in _TERMINAL_STATES:
+        return True, state
+    return False, ""
+
+
+def run_events_generator(
+    run_dir: Path,
+    *,
+    last_event_id: int = 0,
+    tick_seconds: float | None = None,
+) -> Iterator[str]:
+    """Yield SSE frames observing run_dir.
+
+    tick_seconds overrides QUODEQ_SSE_TICK_MS for tests (use 0.0 to drain
+    immediately without sleeping).
+    """
+    sleep_s = tick_seconds if tick_seconds is not None else (_TICK_MS / 1000.0)
+    state = WatcherState(last_event_id=last_event_id)
+    last_emit_at = time.monotonic()
+    yield ":keepalive\n\n"
+
+    while True:
+        events, state = compute_tick(run_dir, state)
+        terminal_state = ""
+        for event_type, payload, event_id in events:
+            yield sse_line(payload, event=event_type, event_id=event_id)
+            last_emit_at = time.monotonic()
+            if event_type == "status":
+                done, terminal = _is_terminal(payload)
+                if done:
+                    terminal_state = terminal
+
+        if terminal_state:
+            yield sse_line(
+                json.dumps({"state": terminal_state}, separators=(",", ":")),
+                event="done",
+            )
+            return
+
+        if time.monotonic() - last_emit_at >= _HEARTBEAT_S:
+            yield ":keepalive\n\n"
+            last_emit_at = time.monotonic()
+
+        if sleep_s > 0:
+            time.sleep(sleep_s)
+        else:
+            # tick_seconds=0.0 means "drain once and exit" for tests.
+            return

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -10,8 +10,12 @@ Reconnect via Last-Event-ID is supported by SQLite's autoincrement findings.id.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+from quodeq.data.sqlite.connection import EVALUATION_DB_FILENAME
 
 
 def serialize_status_event(status: dict[str, Any]) -> str:
@@ -49,3 +53,154 @@ class WatcherState:
     last_event_id: int = 0
     last_status_mtime: float | None = None
     emitted_dimensions: frozenset[str] = field(default_factory=frozenset)
+
+
+_logger = logging.getLogger(__name__)
+
+_DIM_FILENAME_SUFFIX = ".json"
+
+EventTuple = tuple[str, str, int | None]
+"""(event_type, payload, optional_event_id) — event_id is None for non-finding events."""
+
+
+_STATUS_MTIME_MISSING: float = 0.0
+"""Sentinel mtime used when status.json does not exist.
+
+WatcherState initialises last_status_mtime=None ("never checked"), which is
+distinct from 0.0 ("checked, file absent"). This ensures the pending status
+is always emitted on the very first tick even when there is no status.json.
+"""
+
+
+def _read_status(run_dir: Path) -> tuple[dict[str, Any], float]:
+    """Read status.json. Returns ({state: pending}, 0.0) when the file is absent."""
+    path = run_dir / "status.json"
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return {"state": "pending"}, _STATUS_MTIME_MISSING
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {"state": "pending"}, mtime
+        return data, mtime
+    except (OSError, ValueError) as exc:
+        _logger.warning("status.json read failed at %s: %s", path, exc)
+        return {"state": "pending"}, mtime
+
+
+def _scan_completed_dimensions(run_dir: Path) -> set[str]:
+    """Return the set of dimension names that have an evaluation/<dim>.json file."""
+    eval_dir = run_dir / "evaluation"
+    try:
+        return {
+            entry.name[: -len(_DIM_FILENAME_SUFFIX)]
+            for entry in eval_dir.iterdir()
+            if entry.is_file() and entry.name.endswith(_DIM_FILENAME_SUFFIX)
+        }
+    except OSError:
+        return set()
+
+
+def _read_dim_eval(run_dir: Path, dimension: str) -> dict[str, Any] | None:
+    """Read evaluation/<dim>.json. Returns None on any failure.
+
+    The returned dict's ``dimension`` key is the canonical dimension name as
+    written by the scoring engine. Callers should treat that value as
+    authoritative — it always matches the filename stem for well-formed files.
+    """
+    path = run_dir / "evaluation" / f"{dimension}{_DIM_FILENAME_SUFFIX}"
+    try:
+        data = json.loads(path.read_text())
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError) as exc:
+        _logger.warning("dimension eval read failed at %s: %s", path, exc)
+        return None
+
+
+def _judgment_as_dict(judgment: Any, finding_id: int) -> dict[str, Any]:
+    """Project a Judgment dataclass into a JSON-friendly dict for SSE."""
+    return {
+        "id": finding_id,
+        "practice_id": judgment.practice_id,
+        "dimension": judgment.dimension,
+        "requirement": judgment.req,
+        "verdict": judgment.verdict,
+        "severity": judgment.severity,
+        "file": judgment.file,
+        "line": judgment.line,
+        "end_line": judgment.end_line,
+        "title": judgment.title,
+        "reason": judgment.reason,
+        "snippet": judgment.snippet,
+    }
+
+
+def _read_new_findings(
+    run_dir: Path, last_event_id: int,
+) -> list[tuple[int, dict[str, Any]]]:
+    """Return (id, judgment_dict) pairs for findings whose id > last_event_id."""
+    db_path = run_dir / EVALUATION_DB_FILENAME
+    if not db_path.is_file():
+        return []
+    try:
+        from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+        from quodeq.data.sqlite._row_mappers import row_to_judgment  # noqa: PLC0415
+        results: list[tuple[int, dict[str, Any]]] = []
+        with open_evaluation_db(run_dir) as conn:
+            cur = conn.execute(
+                "SELECT id, practice_id, dimension, requirement, verdict, severity, "
+                "file, line, end_line, title, reason, snippet, "
+                "violation_type, context, scope, req_refs_json "
+                "FROM findings WHERE id > ? ORDER BY id",
+                (last_event_id,),
+            )
+            cols = [c[0] for c in cur.description]
+            for row in cur.fetchall():
+                row_dict = dict(zip(cols, row))
+                finding_id = row_dict["id"]
+                judgment = row_to_judgment(row_dict)
+                results.append((finding_id, _judgment_as_dict(judgment, finding_id)))
+        return results
+    except Exception as exc:  # noqa: BLE001 — never crash the stream on read errors
+        _logger.warning("findings query failed for %s: %s", run_dir, exc)
+        return []
+
+
+def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], WatcherState]:
+    """Single tick: read artifacts, return (events, new_state).
+
+    Defensive against every artifact being absent or malformed.
+    Status mtime tracking ensures unchanged status is not re-emitted.
+    Dimension set tracking ensures completed dimensions are not re-emitted.
+    Finding id advances only when new rows are read.
+    """
+    events: list[EventTuple] = []
+
+    # --- Status ---
+    status, status_mtime = _read_status(run_dir)
+    if status_mtime != state.last_status_mtime:
+        events.append(("status", serialize_status_event(status), None))
+
+    # --- Dimensions ---
+    completed = _scan_completed_dimensions(run_dir)
+    new_dims = sorted(completed - state.emitted_dimensions)
+    for dim in new_dims:
+        eval_data = _read_dim_eval(run_dir, dim)
+        events.append(("dimension-completed", serialize_dimension_event(
+            dimension=dim, eval_data=eval_data,
+        ), None))
+
+    # --- Findings ---
+    new_findings = _read_new_findings(run_dir, state.last_event_id)
+    new_last_id = state.last_event_id
+    for finding_id, judgment_dict in new_findings:
+        events.append(("finding", serialize_finding_event(judgment_dict), finding_id))
+        new_last_id = max(new_last_id, finding_id)
+
+    new_state = WatcherState(
+        last_event_id=new_last_id,
+        last_status_mtime=status_mtime,
+        emitted_dimensions=frozenset(state.emitted_dimensions | set(new_dims)),
+    )
+    return events, new_state

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -1,0 +1,38 @@
+"""SSE watcher and event serializers for /api/evaluations/<jobId>/events.
+
+Producers (lifecycle context, scoring engine, FindingsRouter) write durable
+artifacts (status.json, evaluation/<dim>.json, evaluation.db). This module
+observes those artifacts on a 250 ms tick and emits SSE events to subscribers.
+
+No producer changes. No in-memory event log. No cross-stream state.
+Reconnect via Last-Event-ID is supported by SQLite's autoincrement findings.id.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def serialize_status_event(status: dict[str, Any]) -> str:
+    """Return the SSE data: payload for an `event: status` frame."""
+    return json.dumps(status, separators=(",", ":"))
+
+
+def serialize_dimension_event(*, dimension: str, eval_data: dict[str, Any] | None) -> str:
+    """Return the SSE data: payload for an `event: dimension-completed` frame.
+
+    eval_data is the parsed contents of evaluation/<dim>.json when available.
+    On read failure or missing file, only the dimension name is emitted.
+    """
+    if eval_data is None:
+        return json.dumps({"dimension": dimension}, separators=(",", ":"))
+    return json.dumps(eval_data, separators=(",", ":"))
+
+
+def serialize_finding_event(judgment_dict: dict[str, Any]) -> str:
+    """Return the SSE data: payload for an `event: finding` frame.
+
+    judgment_dict is the row dict returned by SqliteFindingsRepository.list_*
+    converted via _judgment_as_dict (see Task 3).
+    """
+    return json.dumps(judgment_dict, separators=(",", ":"))

--- a/src/quodeq/api/_run_events_routes.py
+++ b/src/quodeq/api/_run_events_routes.py
@@ -1,0 +1,52 @@
+"""SSE route for /api/evaluations/<jobId>/events.
+
+Mirrors the shape of _log_stream_routes.py: resolve job_id to a run dir,
+parse Last-Event-ID, return a text/event-stream Response wrapping the
+run_events_generator.
+"""
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, current_app, jsonify, request
+
+from quodeq.api._run_event_stream import run_events_generator
+
+
+def _resolve_run_dir(job_id: str) -> tuple[Path | None, int]:
+    """Return (run_dir, status_hint). status_hint is 0 on success, HTTP code on error."""
+    provider = current_app.config.get("_provider")
+    if provider is None or not hasattr(provider, "get_log_run_dir"):
+        return None, HTTPStatus.NOT_FOUND
+    run_dir = provider.get_log_run_dir(job_id)
+    if run_dir is None or not run_dir.is_dir():
+        return None, HTTPStatus.GONE
+    return run_dir, 0
+
+
+def register_run_events_routes(app: Flask) -> None:
+    """Register the SSE run-events route on *app*.
+
+    Auth: inherits the global before_request hook from quodeq.api.security.
+    """
+
+    @app.get("/api/evaluations/<job_id>/events")
+    def stream_run_events(job_id: str) -> Response | tuple[Response, int]:
+        run_dir, err = _resolve_run_dir(job_id)
+        if run_dir is None:
+            return jsonify({"error": "run unavailable", "code": "NOT_FOUND"}), err
+
+        last_event_id_raw = request.headers.get("Last-Event-ID", "")
+        try:
+            last_event_id = int(last_event_id_raw) if last_event_id_raw else 0
+        except ValueError:
+            last_event_id = 0
+
+        resp = Response(
+            run_events_generator(run_dir, last_event_id=last_event_id),
+            mimetype="text/event-stream",
+        )
+        resp.headers["Cache-Control"] = "no-cache"
+        resp.headers["X-Accel-Buffering"] = "no"
+        return resp

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -8,6 +8,7 @@ from quodeq.api._log_buffer import LogBuffer
 from quodeq.api._index_routes import register_index_routes
 from quodeq.api._log_routes import register_log_routes
 from quodeq.api._log_stream_routes import register_log_stream_routes
+from quodeq.api._run_events_routes import register_run_events_routes
 from quodeq.api._ollama_log_routes import register_ollama_log_routes
 from quodeq.api._rate_limit import RateLimitStore
 from quodeq.api.routes import (
@@ -44,6 +45,7 @@ def register_all_routes(
     register_evaluation_list_routes(app, provider, eval_store)
     register_evaluation_item_routes(app, provider)
     register_log_stream_routes(app)
+    register_run_events_routes(app)
     register_ollama_log_routes(app)
     register_discovery_routes(app, provider)
     register_standards_routes(app)

--- a/src/quodeq/ui/.env.example
+++ b/src/quodeq/ui/.env.example
@@ -1,0 +1,6 @@
+# UI feature flags (read at build time)
+
+# Use SSE-driven live updates for the evaluation dashboard instead of polling.
+# Default off during the rollout window. Flip to true once the SSE backend
+# (Plan 2 PR) has soaked for a release.
+VITE_USE_SSE_EVENTS=false

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -2,6 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { ACTIVE_PROVIDER_KEY, providerKey, DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET } from '../../../constants.js';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
+import { useRunEventStream } from './useRunEventStream.js';
+
+const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === 'true';
 
 const DIMENSION_POLL_INITIAL_MS = 2000;
 const DIMENSION_POLL_MAX_MS = 8000;
@@ -122,6 +125,7 @@ function createJobPoller(refs, setters, startDimensionPolling, getEvaluation) {
   const { poll: pollRef, dimPoll: dimPollRef, requestedDimensions: requestedDimensionsRef, partialDimensions: partialDimensionsRef } = refs;
   const { setJob, setJobError } = setters;
   return function startPolling(jobId) {
+    if (SSE_ENABLED) return;
     stopTimer(pollRef);
     const localRefs = {
       requestedDimensions: requestedDimensionsRef.current,
@@ -204,6 +208,7 @@ function useEvalRefs() {
 
 function useResumeRunning(setJob, startPolling, pollRef, dimPollRef, listEvaluations) {
   useEffect(() => {
+    if (SSE_ENABLED) return undefined;
     listEvaluations()
       .then((jobs) => {
         const running = jobs.find((j) => j.status === 'running');
@@ -290,6 +295,36 @@ export function useEvaluation() {
   const [jobError, setJobError] = useState('');
   const [liveViolations, setLiveViolations] = useState({});
   const refs = useEvalRefs();
+
+  // Hooks must run unconditionally (Rules of Hooks). When the SSE flag is off
+  // we pass null so useRunEventStream stays inert; when on, we feed it the
+  // current job id so it subscribes to /events for that run.
+  const sse = useRunEventStream(SSE_ENABLED ? job?.jobId ?? null : null);
+
+  // Mirror SSE status frames into the same `job` state the polling path
+  // populates, so downstream consumers (useEvaluationLifecycle, dashboards)
+  // see an identical shape regardless of transport.
+  useEffect(() => {
+    if (!SSE_ENABLED) return;
+    if (!sse.status) return;
+    setJob((prev) => ({ ...(prev || {}), ...sse.status, repo: prev?.repo }));
+  }, [sse.status]);
+
+  // Group SSE findings by dimension into the liveViolations shape consumers
+  // already render. Each finding is expected to carry a `dimension` key; we
+  // tolerate missing dimensions by bucketing under '_'.
+  useEffect(() => {
+    if (!SSE_ENABLED) return;
+    if (!sse.findings || sse.findings.length === 0) return;
+    const grouped = {};
+    for (const f of sse.findings) {
+      const key = f?.dimension || '_';
+      if (!grouped[key]) grouped[key] = [];
+      grouped[key].push(f);
+    }
+    setLiveViolations(grouped);
+  }, [sse.findings]);
+
   const startPolling = usePollingSetup(refs, setJob, setJobError, setLiveViolations, { getDimensionEval, getEvaluation, listEvaluations });
   useEffect(() => { refs.liveViolationsRef.current = liveViolations; }, [liveViolations]);
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
@@ -1,0 +1,67 @@
+/**
+ * SSE-driven replacement for useEvaluation's polling loops.
+ *
+ * Subscribes to /api/evaluations/<jobId>/events, registers handlers for
+ * status / dimension-completed / finding / done events, and exposes the
+ * same state shape that useEvaluation consumers already render against.
+ *
+ * Gated by VITE_USE_SSE_EVENTS (see useEvaluation.js for the switch).
+ */
+import { useEffect, useRef, useState } from 'react';
+
+export function useRunEventStream(jobId) {
+  const [status, setStatus] = useState(null);
+  const [completedDimensions, setCompletedDimensions] = useState({});
+  const [findings, setFindings] = useState([]);
+  const [done, setDone] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const sourceRef = useRef(null);
+
+  useEffect(() => {
+    if (!jobId) return undefined;
+
+    const source = new EventSource(`/api/evaluations/${jobId}/events`);
+    sourceRef.current = source;
+    setConnected(true);
+
+    source.addEventListener('status', (e) => {
+      try {
+        setStatus(JSON.parse(e.data));
+      } catch {
+        // ignore malformed frames; reconnect handles recovery
+      }
+    });
+
+    source.addEventListener('dimension-completed', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setCompletedDimensions((prev) => ({ ...prev, [data.dimension]: data }));
+      } catch {
+        // ignore
+      }
+    });
+
+    source.addEventListener('finding', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setFindings((prev) => [...prev, data]);
+      } catch {
+        // ignore
+      }
+    });
+
+    source.addEventListener('done', () => {
+      setDone(true);
+      source.close();
+      setConnected(false);
+    });
+
+    return () => {
+      source.close();
+      sourceRef.current = null;
+      setConnected(false);
+    };
+  }, [jobId]);
+
+  return { status, completedDimensions, findings, done, connected };
+}

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRunEventStream } from './useRunEventStream.js';
+
+class MockEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    this.closed = false;
+    MockEventSource.last = this;
+  }
+  addEventListener(event, handler) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(handler);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(event, data) {
+    (this.listeners[event] || []).forEach((h) =>
+      h({ data: JSON.stringify(data), lastEventId: data?.id })
+    );
+  }
+}
+
+describe('useRunEventStream', () => {
+  let originalEventSource;
+  beforeEach(() => {
+    originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = MockEventSource;
+    MockEventSource.last = null;
+  });
+  afterEach(() => {
+    globalThis.EventSource = originalEventSource;
+  });
+
+  it('opens an EventSource against the run-events endpoint', () => {
+    const { result } = renderHook(() => useRunEventStream('job-123'));
+    expect(MockEventSource.last.url).toBe('/api/evaluations/job-123/events');
+    expect(result.current.connected).toBe(true);
+  });
+
+  it('updates status state when status event arrives', () => {
+    const { result } = renderHook(() => useRunEventStream('job-123'));
+    act(() => {
+      MockEventSource.last.emit('status', { state: 'running', phase: 'analyzing' });
+    });
+    expect(result.current.status).toEqual({ state: 'running', phase: 'analyzing' });
+  });
+
+  it('appends new findings as finding events arrive', () => {
+    const { result } = renderHook(() => useRunEventStream('job-123'));
+    act(() => {
+      MockEventSource.last.emit('finding', { id: 1, practice_id: 'P1', verdict: 'violation' });
+      MockEventSource.last.emit('finding', { id: 2, practice_id: 'P2', verdict: 'violation' });
+    });
+    expect(result.current.findings).toHaveLength(2);
+    expect(result.current.findings[0].practice_id).toBe('P1');
+  });
+
+  it('tracks completed dimensions', () => {
+    const { result } = renderHook(() => useRunEventStream('job-123'));
+    act(() => {
+      MockEventSource.last.emit('dimension-completed', { dimension: 'security', score: 90 });
+    });
+    expect(result.current.completedDimensions).toEqual({
+      security: { dimension: 'security', score: 90 },
+    });
+  });
+
+  it('sets done flag and closes the stream on done event', () => {
+    const { result } = renderHook(() => useRunEventStream('job-123'));
+    act(() => {
+      MockEventSource.last.emit('done', { state: 'done' });
+    });
+    expect(result.current.done).toBe(true);
+    expect(MockEventSource.last.closed).toBe(true);
+  });
+
+  it('returns null status when jobId is empty', () => {
+    const { result } = renderHook(() => useRunEventStream(''));
+    expect(result.current.status).toBeNull();
+    expect(MockEventSource.last).toBeNull();
+  });
+});

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -76,3 +76,129 @@ def test_watcher_state_with_emitted_dimensions():
     state = WatcherState(emitted_dimensions=frozenset({"security", "timeliness"}))
     assert "security" in state.emitted_dimensions
     assert "timeliness" in state.emitted_dimensions
+
+
+import json as _json
+from pathlib import Path
+
+from quodeq.api._run_event_stream import compute_tick
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+
+def _write_status(run_dir: Path, state: str = "running") -> None:
+    (run_dir / "status.json").write_text(_json.dumps({"state": state}))
+
+
+def _write_dim_eval(run_dir: Path, dim: str, score: int = 90) -> None:
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(exist_ok=True)
+    (eval_dir / f"{dim}.json").write_text(
+        _json.dumps({"dimension": dim, "score": score}),
+    )
+
+
+def _insert_finding(run_dir: Path, p: str = "P1", line: int = 1) -> None:
+    repo = SqliteFindingsRepository(run_dir)
+    repo.insert_finding({
+        "p": p, "file": "x.py", "line": line, "t": "violation",
+        "severity": "medium", "d": "dim", "reason": "r", "snippet": "s", "w": "t",
+    })
+
+
+def test_compute_tick_initial_emits_status_when_status_json_present(tmp_path: Path):
+    _write_status(tmp_path, "running")
+    state = WatcherState()
+    events, new_state = compute_tick(tmp_path, state)
+    types = [e[0] for e in events]
+    assert "status" in types
+
+
+def test_compute_tick_emits_status_pending_when_status_json_missing(tmp_path: Path):
+    state = WatcherState()
+    events, new_state = compute_tick(tmp_path, state)
+    status_events = [e for e in events if e[0] == "status"]
+    assert len(status_events) == 1
+    payload = _json.loads(status_events[0][1])
+    assert payload["state"] == "pending"
+
+
+def test_compute_tick_does_not_re_emit_unchanged_status(tmp_path: Path):
+    _write_status(tmp_path)
+    state = WatcherState()
+    _, state2 = compute_tick(tmp_path, state)
+    events, _ = compute_tick(tmp_path, state2)
+    status_events = [e for e in events if e[0] == "status"]
+    assert status_events == []
+
+
+def test_compute_tick_re_emits_status_when_mtime_changes(tmp_path: Path):
+    import os
+    import time as _time
+    _write_status(tmp_path, "running")
+    state = WatcherState()
+    _, state2 = compute_tick(tmp_path, state)
+    _time.sleep(0.05)
+    os.utime(tmp_path / "status.json", None)  # bump mtime
+    events, _ = compute_tick(tmp_path, state2)
+    status_events = [e for e in events if e[0] == "status"]
+    assert len(status_events) == 1
+
+
+def test_compute_tick_emits_dimension_events_for_new_files(tmp_path: Path):
+    _write_status(tmp_path)
+    _write_dim_eval(tmp_path, "timeliness")
+    state = WatcherState()
+    events, new_state = compute_tick(tmp_path, state)
+    dim_events = [e for e in events if e[0] == "dimension-completed"]
+    assert len(dim_events) == 1
+    assert "timeliness" in new_state.emitted_dimensions
+
+
+def test_compute_tick_does_not_re_emit_already_emitted_dimensions(tmp_path: Path):
+    _write_status(tmp_path)
+    _write_dim_eval(tmp_path, "timeliness")
+    state = WatcherState()
+    _, state2 = compute_tick(tmp_path, state)
+    events, _ = compute_tick(tmp_path, state2)
+    dim_events = [e for e in events if e[0] == "dimension-completed"]
+    assert dim_events == []
+
+
+def test_compute_tick_emits_findings_with_id_advances_last_event_id(tmp_path: Path):
+    _write_status(tmp_path)
+    _insert_finding(tmp_path, "P1", line=1)
+    _insert_finding(tmp_path, "P2", line=2)
+    state = WatcherState()
+    events, new_state = compute_tick(tmp_path, state)
+    finding_events = [e for e in events if e[0] == "finding"]
+    assert len(finding_events) == 2
+    assert new_state.last_event_id == 2  # SQLite IDs are 1, 2
+
+
+def test_compute_tick_skips_findings_already_emitted(tmp_path: Path):
+    _write_status(tmp_path)
+    _insert_finding(tmp_path, "P1", line=1)
+    _insert_finding(tmp_path, "P2", line=2)
+    state = WatcherState(last_event_id=1)
+    events, new_state = compute_tick(tmp_path, state)
+    finding_events = [e for e in events if e[0] == "finding"]
+    assert len(finding_events) == 1
+    assert new_state.last_event_id == 2
+
+
+def test_compute_tick_handles_missing_evaluation_db(tmp_path: Path):
+    _write_status(tmp_path)
+    state = WatcherState()
+    events, _ = compute_tick(tmp_path, state)
+    # Should not crash and should not emit any finding events.
+    finding_events = [e for e in events if e[0] == "finding"]
+    assert finding_events == []
+
+
+def test_compute_tick_handles_malformed_status_json(tmp_path: Path):
+    (tmp_path / "status.json").write_text("not valid json {")
+    state = WatcherState()
+    events, _ = compute_tick(tmp_path, state)
+    # Should not crash; emits a fallback status with state=pending.
+    status_events = [e for e in events if e[0] == "status"]
+    assert len(status_events) == 1

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -1,0 +1,57 @@
+"""Unit tests for the SSE run-event watcher and serializers."""
+from __future__ import annotations
+
+import json
+
+from quodeq.api._run_event_stream import (
+    serialize_status_event,
+    serialize_dimension_event,
+    serialize_finding_event,
+)
+
+
+def test_serialize_status_event_returns_json_payload():
+    status = {"state": "running", "phase": "analyzing", "current_dimension": "timeliness"}
+    payload = serialize_status_event(status)
+    assert json.loads(payload) == status
+
+
+def test_serialize_status_event_with_missing_keys():
+    payload = serialize_status_event({"state": "pending"})
+    assert json.loads(payload) == {"state": "pending"}
+
+
+def test_serialize_dimension_event_with_eval_data():
+    payload = serialize_dimension_event(
+        dimension="security",
+        eval_data={"dimension": "security", "score": 92, "grade": "A"},
+    )
+    parsed = json.loads(payload)
+    assert parsed["dimension"] == "security"
+    assert parsed["score"] == 92
+    assert parsed["grade"] == "A"
+
+
+def test_serialize_dimension_event_without_eval_data():
+    payload = serialize_dimension_event(dimension="security", eval_data=None)
+    parsed = json.loads(payload)
+    assert parsed == {"dimension": "security"}
+
+
+def test_serialize_finding_event_includes_judgment_fields():
+    judgment_dict = {
+        "id": 42,
+        "practice_id": "P-TIM-1",
+        "dimension": "timeliness",
+        "verdict": "violation",
+        "severity": "high",
+        "file": "src/x.py",
+        "line": 10,
+        "title": "Late finalize",
+        "reason": "missed deadline",
+    }
+    payload = serialize_finding_event(judgment_dict)
+    parsed = json.loads(payload)
+    assert parsed["id"] == 42
+    assert parsed["practice_id"] == "P-TIM-1"
+    assert parsed["verdict"] == "violation"

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -55,3 +55,24 @@ def test_serialize_finding_event_includes_judgment_fields():
     assert parsed["id"] == 42
     assert parsed["practice_id"] == "P-TIM-1"
     assert parsed["verdict"] == "violation"
+
+
+from quodeq.api._run_event_stream import WatcherState
+
+
+def test_watcher_state_initial_defaults():
+    state = WatcherState()
+    assert state.last_event_id == 0
+    assert state.last_status_mtime is None
+    assert state.emitted_dimensions == frozenset()
+
+
+def test_watcher_state_with_initial_last_event_id():
+    state = WatcherState(last_event_id=42)
+    assert state.last_event_id == 42
+
+
+def test_watcher_state_with_emitted_dimensions():
+    state = WatcherState(emitted_dimensions=frozenset({"security", "timeliness"}))
+    assert "security" in state.emitted_dimensions
+    assert "timeliness" in state.emitted_dimensions

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -202,3 +202,66 @@ def test_compute_tick_handles_malformed_status_json(tmp_path: Path):
     # Should not crash; emits a fallback status with state=pending.
     status_events = [e for e in events if e[0] == "status"]
     assert len(status_events) == 1
+
+
+def _drain_generator(gen, max_frames: int) -> list[str]:
+    """Pull at most max_frames from a generator, ignoring keepalives."""
+    out = []
+    for frame in gen:
+        if frame.startswith(":"):
+            continue
+        out.append(frame)
+        if len(out) >= max_frames:
+            break
+    return out
+
+
+def test_run_events_generator_emits_status_then_done_for_terminal_run(tmp_path: Path):
+    from quodeq.api._run_event_stream import run_events_generator
+
+    _write_status(tmp_path, state="done")
+    frames = list(run_events_generator(tmp_path, last_event_id=0, tick_seconds=0.0))
+    # Should produce: status frame, then done frame, then return.
+    non_keepalive = [f for f in frames if not f.startswith(":")]
+    assert any("event: status" in f for f in non_keepalive)
+    assert any("event: done" in f for f in non_keepalive)
+
+
+def test_run_events_generator_emits_finding_with_event_id(tmp_path: Path):
+    from quodeq.api._run_event_stream import run_events_generator
+
+    _write_status(tmp_path, state="running")
+    _insert_finding(tmp_path)
+    gen = run_events_generator(tmp_path, last_event_id=0, tick_seconds=0.0)
+    frames = _drain_generator(gen, max_frames=3)
+    finding_frames = [f for f in frames if "event: finding" in f]
+    assert len(finding_frames) == 1
+    assert "id: 1" in finding_frames[0]
+
+
+def test_run_events_generator_respects_initial_last_event_id(tmp_path: Path):
+    from quodeq.api._run_event_stream import run_events_generator
+
+    _write_status(tmp_path, state="running")
+    _insert_finding(tmp_path, p="P1", line=1)
+    _insert_finding(tmp_path, p="P2", line=2)
+    gen = run_events_generator(tmp_path, last_event_id=1, tick_seconds=0.0)
+    frames = _drain_generator(gen, max_frames=3)
+    finding_frames = [f for f in frames if "event: finding" in f]
+    assert len(finding_frames) == 1
+    assert "id: 2" in finding_frames[0]
+
+
+def test_run_events_generator_handles_already_terminal_run(tmp_path: Path):
+    from quodeq.api._run_event_stream import run_events_generator
+
+    _write_status(tmp_path, state="failed")
+    _insert_finding(tmp_path)
+    frames = list(run_events_generator(tmp_path, last_event_id=0, tick_seconds=0.0))
+    non_keepalive = [f for f in frames if not f.startswith(":")]
+    # Snapshot includes status, finding, then done.
+    assert any("event: status" in f for f in non_keepalive)
+    assert any("event: finding" in f for f in non_keepalive)
+    assert any("event: done" in f for f in non_keepalive)
+    # Generator terminates (we got the full list).
+    assert non_keepalive[-1].startswith("id: ") or "event: done" in non_keepalive[-1]

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -265,3 +265,31 @@ def test_run_events_generator_handles_already_terminal_run(tmp_path: Path):
     assert any("event: done" in f for f in non_keepalive)
     # Generator terminates (we got the full list).
     assert non_keepalive[-1].startswith("id: ") or "event: done" in non_keepalive[-1]
+
+
+def test_run_events_generator_emits_heartbeat_when_quiet(tmp_path: Path):
+    """When no events fire for heartbeat_seconds, emit a :keepalive comment."""
+    import time as _time
+    from quodeq.api._run_event_stream import run_events_generator
+
+    _write_status(tmp_path, state="running")
+    gen = run_events_generator(
+        tmp_path,
+        last_event_id=0,
+        tick_seconds=0.001,
+        heartbeat_seconds=0.0,  # always due — every quiet tick should emit one
+    )
+
+    # Collect a small batch: initial keepalive + status frame + at least one
+    # additional :keepalive (because the next tick has no new events).
+    frames: list[str] = []
+    deadline = _time.monotonic() + 1.0
+    for frame in gen:
+        frames.append(frame)
+        if frames.count(":keepalive\n\n") >= 2:
+            break
+        if _time.monotonic() > deadline:
+            break  # safety guard so the test never hangs
+
+    keepalives = [f for f in frames if f == ":keepalive\n\n"]
+    assert len(keepalives) >= 2, f"expected >=2 keepalives, got: {frames!r}"

--- a/tests/api/test_run_events_routes.py
+++ b/tests/api/test_run_events_routes.py
@@ -1,0 +1,73 @@
+"""Flask test client coverage for /api/evaluations/<jobId>/events."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from quodeq.api._run_events_routes import register_run_events_routes
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    app = Flask(__name__)
+    provider = MagicMock()
+    run_dir = tmp_path / "run-1"
+    run_dir.mkdir()
+    provider.get_log_run_dir = lambda job_id: run_dir if job_id == "job-1" else None
+    app.config["_provider"] = provider
+    app.config["_run_dir"] = run_dir  # for tests to use
+    register_run_events_routes(app)
+    return app
+
+
+def test_route_returns_404_for_unknown_job(app: Flask):
+    client = app.test_client()
+    resp = client.get("/api/evaluations/bogus/events")
+    assert resp.status_code in (404, 410)
+
+
+def test_route_returns_text_event_stream(app: Flask):
+    run_dir: Path = app.config["_run_dir"]
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+    client = app.test_client()
+    resp = client.get("/api/evaluations/job-1/events")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/event-stream"
+    assert resp.headers.get("Cache-Control") == "no-cache"
+
+
+def test_route_emits_status_event_for_running_run(app: Flask):
+    import os
+    os.environ["QUODEQ_SSE_TICK_MS"] = "0"  # drain immediately
+    run_dir: Path = app.config["_run_dir"]
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+    client = app.test_client()
+    resp = client.get("/api/evaluations/job-1/events")
+    body = resp.get_data(as_text=True)
+    assert "event: status" in body
+    assert "event: done" in body
+
+
+def test_route_honors_last_event_id_header(app: Flask):
+    import os
+    os.environ["QUODEQ_SSE_TICK_MS"] = "0"
+    run_dir: Path = app.config["_run_dir"]
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+    repo = SqliteFindingsRepository(run_dir)
+    repo.insert_finding({"p": "P1", "file": "x.py", "line": 1, "t": "violation",
+                         "severity": "medium", "d": "dim", "reason": "r",
+                         "snippet": "s", "w": "t"})
+    repo.insert_finding({"p": "P2", "file": "x.py", "line": 2, "t": "violation",
+                         "severity": "medium", "d": "dim", "reason": "r",
+                         "snippet": "s", "w": "t"})
+    client = app.test_client()
+    resp = client.get("/api/evaluations/job-1/events", headers={"Last-Event-ID": "1"})
+    body = resp.get_data(as_text=True)
+    finding_lines = [line for line in body.split("\n\n") if "event: finding" in line]
+    assert len(finding_lines) == 1
+    assert "id: 2" in finding_lines[0]

--- a/tests/integration/test_sse_run_events_e2e.py
+++ b/tests/integration/test_sse_run_events_e2e.py
@@ -1,0 +1,108 @@
+"""End-to-end SSE flow: simulate a run via artifacts, observe events."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from quodeq.api._run_events_routes import register_run_events_routes
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    app = Flask(__name__)
+    provider = MagicMock()
+    run_dir = tmp_path / "run-e2e"
+    run_dir.mkdir()
+    provider.get_log_run_dir = lambda job_id: run_dir if job_id == "j" else None
+    app.config["_provider"] = provider
+    app.config["_run_dir"] = run_dir
+    register_run_events_routes(app)
+    os.environ["QUODEQ_SSE_TICK_MS"] = "0"  # drain-once mode for fast tests
+    return app
+
+
+def _parse_sse_frames(body: str) -> list[dict]:
+    """Parse SSE response body into a list of {event, data, id} dicts."""
+    frames: list[dict] = []
+    for raw in body.split("\n\n"):
+        if not raw.strip() or raw.lstrip().startswith(":"):
+            continue
+        frame: dict = {}
+        for line in raw.splitlines():
+            if line.startswith("event: "):
+                frame["event"] = line[len("event: "):]
+            elif line.startswith("data: "):
+                frame["data"] = line[len("data: "):]
+            elif line.startswith("id: "):
+                frame["id"] = int(line[len("id: "):])
+        if "event" in frame:
+            frames.append(frame)
+    return frames
+
+
+def test_e2e_run_with_dimensions_and_findings(app: Flask):
+    run_dir: Path = app.config["_run_dir"]
+
+    # Simulate a run that has finished with one dimension and two findings.
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir()
+    (eval_dir / "security.json").write_text(json.dumps({
+        "dimension": "security", "score": 92, "grade": "A",
+    }))
+    repo = SqliteFindingsRepository(run_dir)
+    repo.insert_finding({"p": "P1", "file": "x.py", "line": 1, "t": "violation",
+                         "severity": "high", "d": "security", "reason": "sql injection",
+                         "snippet": "...", "w": "title"})
+    repo.insert_finding({"p": "P2", "file": "y.py", "line": 5, "t": "violation",
+                         "severity": "medium", "d": "security", "reason": "weak crypto",
+                         "snippet": "...", "w": "title"})
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+
+    client = app.test_client()
+    resp = client.get("/api/evaluations/j/events")
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.get_data(as_text=True))
+
+    types = [f["event"] for f in frames]
+    assert types[0] == "status"
+    assert "dimension-completed" in types
+    assert types.count("finding") == 2
+    assert types[-1] == "done"
+
+    finding_ids = [f["id"] for f in frames if f["event"] == "finding"]
+    assert finding_ids == [1, 2]
+
+
+def test_e2e_reconnect_with_last_event_id_skips_emitted_findings(app: Flask):
+    run_dir: Path = app.config["_run_dir"]
+    repo = SqliteFindingsRepository(run_dir)
+    for i in range(1, 4):
+        repo.insert_finding({"p": f"P{i}", "file": "x.py", "line": i, "t": "violation",
+                             "severity": "medium", "d": "dim", "reason": "r",
+                             "snippet": "s", "w": "t"})
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))
+
+    client = app.test_client()
+    resp = client.get("/api/evaluations/j/events", headers={"Last-Event-ID": "2"})
+    frames = _parse_sse_frames(resp.get_data(as_text=True))
+    finding_ids = [f["id"] for f in frames if f["event"] == "finding"]
+    assert finding_ids == [3]
+
+
+def test_e2e_pending_run_emits_pending_status(app: Flask):
+    # No status.json, no evaluation/, no findings — the pending case.
+    # This shouldn't loop forever, so we set the env to drain once.
+    run_dir: Path = app.config["_run_dir"]
+    (run_dir / "status.json").write_text(json.dumps({"state": "done"}))  # terminate quickly
+
+    client = app.test_client()
+    resp = client.get("/api/evaluations/j/events")
+    frames = _parse_sse_frames(resp.get_data(as_text=True))
+    status_frames = [f for f in frames if f["event"] == "status"]
+    assert len(status_frames) >= 1


### PR DESCRIPTION
## Summary

- Adds `GET /api/evaluations/<jobId>/events` — a single Server-Sent Events stream per run that emits three event types interleaved: `status` (run-state transitions), `dimension-completed` (per-dimension scoring), and `finding` (each new row in Plan 1's `evaluation.db`).
- Reduces dashboard latency from 2–8 s polling backoff to ~250 ms (the watcher tick interval). Run-state transitions are now sub-second instead of 1.5 s polling.
- **Pure filesystem + SQLite watching, zero changes to producers.** The `RunLifecycleContext`, scoring engine, and `FindingsRouter` all keep writing their durable artifacts unchanged. The watcher reads `status.json` mtime, scans `evaluation/<dim>.json`, and queries `evaluation.db` with `WHERE id > ?`.
- **Snapshot + tail reconnect** via `Last-Event-ID` on findings only. Status and dimensions are idempotent on reconnect — the snapshot phase always re-emits current state, the tail phase resumes findings from `findings.id > Last-Event-ID`. No server-side state, no in-memory event log; reconnects work across server restarts.
- Closes on terminal state with an `event: done` frame; same code path for already-finished historical runs (snapshot + immediate done).
- Defensive error handling: malformed `status.json`, missing `evaluation.db`, locked SQLite, disk I/O errors all log a warning and continue. Reconnect-with-`Last-Event-ID` recovers all state.
- Client hook `useRunEventStream` (React + EventSource) gated behind `VITE_USE_SSE_EVENTS` (default off). Existing polling code remains the default for one release of soak before flipping.

## Architecture

> JSONL is the durable log. SQLite is the indexed projection from Plan 1. SSE is the live observer over both, plus `status.json`. None of the live layer is load-bearing — the dashboard works with or without SSE; the flag picks which transport.

## Implementation

10 server-side commits (Tasks 1–8) + 3 client-side commits (Tasks 9–11) + 1 review-fix commit. Detailed plan at `docs/superpowers/plans/2026-04-29-sse-live-updates.md` (local-only — `docs/` is gitignored). 14 commits, +1037/0 lines net, no deletions.

## Test plan

- [x] `uv run pytest tests/` — **2454 passed**, no regressions. Includes 23 unit tests for the watcher / generator, 4 Flask test-client tests for the route, 3 end-to-end integration tests, and 1 heartbeat test added during review.
- [x] `cd src/quodeq/ui && npm run test:ui` — **98 passed** under both `VITE_USE_SSE_EVENTS=false` (default) and `=true`.
- [x] `_STATUS_MTIME_MISSING = 0.0` sentinel verified for first-tick emission, idempotence, and late-arriving status.json. (Spec deviation flagged and approved by reviewer.)
- [x] **Manual smoke**: run a real `quodeq evaluate` with `VITE_USE_SSE_EVENTS=true` and confirm:
  - Status pill flips on transition (sub-second).
  - Dimension cards complete the moment the report file lands (no 2–8 s lag).
  - Findings appear in the live violations feed in real time.
  - Disconnecting Wi-Fi for 30 s and reconnecting recovers all missed findings via `Last-Event-ID`.
- [x] **Manual smoke**: open the dashboard for a completed historical run with the flag on. Snapshot loads instantly, stream closes with `event: done`.

## Notes / known follow-ups (non-blocking, flagged by code review)

- `useEvaluation.js`'s SSE-mode regrouping of `liveViolations` is O(N²) per finding. Invisible at hundreds of findings, noticeable at thousands. Worth optimizing if the benchmark project pushes finding counts up.
- `useRunEventStream` doesn't handle an `event: error` frame (the new route never emits one today). Worth adding a handler if any future producer event-types add error semantics.
- `_run_event_stream.py` is now ~280 lines (over the 100-line soft limit). Coherent as one watcher module; could be split into `_event_serializers.py` + watcher in a follow-up if it grows further.
- The polling code in `useEvaluation.js` is preserved — Plan 12 intentionally keeps it as the fallback during the soak window. Removal goes in a follow-up PR after the flag flips on by default.