### PR TITLE
TanStack Query migration for the dashboard (Plan 3)

### DIFF
--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
+        "@tanstack/react-query": "^5.100.6",
         "d3-hierarchy": "^3.1.2",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -19,6 +20,7 @@
         "xterm-addon-fit": "^0.8.0"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.100.6",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "4.7.0",
@@ -1450,6 +1452,61 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.100.6.tgz",
+      "integrity": "sha512-2SiNwlOiAdTbqktCSmwlXZH8x8mckSbES2O0bdr3qZNhdQl5DCtImZx0S3HGeNHWTIkzTaHx2Isg+bD4M3WRIg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.100.6.tgz",
+      "integrity": "sha512-sz3ksMKA2t1rx0+Odzb0x1A3pXH/SVf7fzlzd3sKXzwXz8980f5sbOwfQD6+UfTG8G4Y2KaIg9e3sBn+uC4VTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.100.6",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@chenglou/pretext": "^0.0.5",
+    "@tanstack/react-query": "^5.100.6",
     "d3-hierarchy": "^3.1.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -23,6 +24,7 @@
     "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.100.6",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "4.7.0",

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -25,6 +25,7 @@ import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { readVisibleStandardIds } from './utils/visibleStandards.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
 import { SidePane, SidePaneProvider } from './features/side-pane/index.js';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { EvalLogProvider } from './features/evaluation/eval-log/EvalLogProvider.jsx';
 import { ServerLogProvider } from './features/settings/server-log/ServerLogProvider.jsx';
 import { OllamaLogProvider } from './features/settings/ollama-log/OllamaLogProvider.jsx';
@@ -364,6 +365,7 @@ export default function App() {
           : null);
 
   return (
+    <>
     <SidePaneProvider>
       <EvalLogProvider>
         <ServerLogProvider>
@@ -438,5 +440,7 @@ export default function App() {
         </ServerLogProvider>
       </EvalLogProvider>
     </SidePaneProvider>
+    {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </>
   );
 }

--- a/src/quodeq/ui/src/api/queryClient.js
+++ b/src/quodeq/ui/src/api/queryClient.js
@@ -1,0 +1,25 @@
+/**
+ * Singleton QueryClient for the dashboard.
+ *
+ * Defaults match the Plan 3 spec:
+ * - staleTime: 30s — most server data is fresh enough on reload.
+ * - gcTime: 5min (library default) — kept long enough for screen-back navigation.
+ * - retry: 1 — fail fast on real errors.
+ * - refetchOnWindowFocus / refetchOnReconnect: true — natural recovery.
+ *
+ * Per-query overrides live at each useQuery call site (refetchInterval
+ * for polling-driven sources; staleTime: Infinity when SSE owns updates).
+ */
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      retry: 1,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+    },
+  },
+});

--- a/src/quodeq/ui/src/api/queryClient.test.jsx
+++ b/src/quodeq/ui/src/api/queryClient.test.jsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { queryClient } from "./queryClient";
+
+describe("queryClient", () => {
+  it("is a QueryClient instance", () => {
+    expect(typeof queryClient.getQueryData).toBe("function");
+    expect(typeof queryClient.setQueryData).toBe("function");
+    expect(typeof queryClient.invalidateQueries).toBe("function");
+  });
+
+  it("defaults staleTime to 30s", () => {
+    expect(queryClient.getDefaultOptions().queries.staleTime).toBe(30_000);
+  });
+
+  it("defaults retry to 1", () => {
+    expect(queryClient.getDefaultOptions().queries.retry).toBe(1);
+  });
+
+  it("defaults refetchOnWindowFocus to true", () => {
+    expect(queryClient.getDefaultOptions().queries.refetchOnWindowFocus).toBe(true);
+  });
+
+  it("defaults refetchOnReconnect to true", () => {
+    expect(queryClient.getDefaultOptions().queries.refetchOnReconnect).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -1,0 +1,33 @@
+/**
+ * Typed query-key factories.
+ *
+ * Convention: [scope, id, ...subkey]. Pass the scope-prefix to
+ * queryClient.invalidateQueries() to refetch the whole subtree.
+ *
+ *   evaluationKeys.evaluation('job-1')   // ['evaluation', 'job-1']         (subtree)
+ *   evaluationKeys.status('job-1')       // ['evaluation', 'job-1', 'status']
+ *   projectKeys.project('p1')            // ['project', 'p1']               (subtree)
+ *   projectKeys.scores('p1', 'r1')       // ['project', 'p1', 'scores', 'r1']
+ *   systemKeys.health()                  // ['system', 'health']
+ */
+export const evaluationKeys = {
+  all: () => ["evaluation"],
+  evaluation: (jobId) => ["evaluation", jobId],
+  status: (jobId) => ["evaluation", jobId, "status"],
+  findings: (jobId) => ["evaluation", jobId, "findings"],
+  dimensions: (jobId) => ["evaluation", jobId, "dimensions"],
+};
+
+export const projectKeys = {
+  all: () => ["project"],
+  project: (projectId) => ["project", projectId],
+  scores: (projectId, asOf) => ["project", projectId, "scores", asOf || "latest"],
+  dashboard: (projectId, run) => ["project", projectId, "dashboard", run || "latest"],
+  runs: (projectId) => ["project", projectId, "runs"],
+};
+
+export const systemKeys = {
+  all: () => ["system"],
+  health: () => ["system", "health"],
+  ollama: () => ["system", "ollama"],
+};

--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -31,3 +31,17 @@ export const systemKeys = {
   health: () => ["system", "health"],
   ollama: () => ["system", "ollama"],
 };
+
+export const standardsKeys = {
+  all: () => ["standards"],
+  list: () => ["standards", "list"],
+  library: () => ["standards", "library"],
+  cwes: () => ["standards", "cwes"],
+};
+
+export const settingsKeys = {
+  all: () => ["settings"],
+  aiClients: () => ["settings", "aiClients"],
+  knownModels: (providerId) => ["settings", "knownModels", providerId],
+  ollamaModels: () => ["settings", "ollamaModels"],
+};

--- a/src/quodeq/ui/src/api/queryKeys.test.jsx
+++ b/src/quodeq/ui/src/api/queryKeys.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { evaluationKeys, projectKeys, systemKeys } from "./queryKeys";
+
+describe("query key factories", () => {
+  it("evaluationKeys.evaluation returns the run-scope prefix", () => {
+    expect(evaluationKeys.evaluation("job-1")).toEqual(["evaluation", "job-1"]);
+  });
+
+  it("evaluationKeys.status appends 'status' subkey", () => {
+    expect(evaluationKeys.status("job-1")).toEqual(["evaluation", "job-1", "status"]);
+  });
+
+  it("evaluationKeys.findings appends 'findings'", () => {
+    expect(evaluationKeys.findings("job-1")).toEqual(["evaluation", "job-1", "findings"]);
+  });
+
+  it("evaluationKeys.dimensions appends 'dimensions'", () => {
+    expect(evaluationKeys.dimensions("job-1")).toEqual(["evaluation", "job-1", "dimensions"]);
+  });
+
+  it("projectKeys.project returns project-scope prefix", () => {
+    expect(projectKeys.project("p1")).toEqual(["project", "p1"]);
+  });
+
+  it("projectKeys.scores includes asOf when provided", () => {
+    expect(projectKeys.scores("p1", "run-1")).toEqual(["project", "p1", "scores", "run-1"]);
+  });
+
+  it("projectKeys.scores omits asOf when null", () => {
+    expect(projectKeys.scores("p1", null)).toEqual(["project", "p1", "scores", "latest"]);
+  });
+
+  it("projectKeys.dashboard includes run when provided", () => {
+    expect(projectKeys.dashboard("p1", "run-1")).toEqual(["project", "p1", "dashboard", "run-1"]);
+  });
+
+  it("projectKeys.dashboard uses 'latest' when run is null", () => {
+    expect(projectKeys.dashboard("p1", null)).toEqual(["project", "p1", "dashboard", "latest"]);
+  });
+
+  it("systemKeys.health is the global health key", () => {
+    expect(systemKeys.health()).toEqual(["system", "health"]);
+  });
+
+  it("systemKeys.ollama is the global ollama key", () => {
+    expect(systemKeys.ollama()).toEqual(["system", "ollama"]);
+  });
+});

--- a/src/quodeq/ui/src/api/queryKeys.test.jsx
+++ b/src/quodeq/ui/src/api/queryKeys.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { evaluationKeys, projectKeys, systemKeys } from "./queryKeys";
+import { evaluationKeys, projectKeys, systemKeys, standardsKeys, settingsKeys } from "./queryKeys";
 
 describe("query key factories", () => {
   it("evaluationKeys.evaluation returns the run-scope prefix", () => {
@@ -44,5 +44,29 @@ describe("query key factories", () => {
 
   it("systemKeys.ollama is the global ollama key", () => {
     expect(systemKeys.ollama()).toEqual(["system", "ollama"]);
+  });
+
+  it("standardsKeys.list points to the standards list", () => {
+    expect(standardsKeys.list()).toEqual(["standards", "list"]);
+  });
+
+  it("standardsKeys.library points to the standards library", () => {
+    expect(standardsKeys.library()).toEqual(["standards", "library"]);
+  });
+
+  it("standardsKeys.cwes points to the CWE list", () => {
+    expect(standardsKeys.cwes()).toEqual(["standards", "cwes"]);
+  });
+
+  it("settingsKeys.aiClients points to the AI client list", () => {
+    expect(settingsKeys.aiClients()).toEqual(["settings", "aiClients"]);
+  });
+
+  it("settingsKeys.knownModels embeds the providerId", () => {
+    expect(settingsKeys.knownModels("openai")).toEqual(["settings", "knownModels", "openai"]);
+  });
+
+  it("settingsKeys.ollamaModels is the local Ollama model list key", () => {
+    expect(settingsKeys.ollamaModels()).toEqual(["settings", "ollamaModels"]);
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,117 +1,57 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useApi } from '../../../api/ApiContext.jsx';
-import { useProjectScores, clearScoresCache } from '../../../hooks/useProjectScores.js';
-
-const REFRESH_DEBOUNCE_MS = 300;
-
-// Run data cache — only for the per-run dashboard view (dimensions/summary).
-// The unified scores endpoint handles accumulated + rescore + trend.
-// Shared mutable state; use clearDashboardCache() for test resets.
-const MAX_RUN_CACHE_SIZE = 100;
-const _runCache = new Map();
-function _runCacheKey(project, run) { return `${project}\0${run || 'latest'}`; }
-
-export function clearDashboardCache(project) {
-  clearScoresCache(project);
-  if (project) {
-    for (const key of [..._runCache.keys()]) {
-      if (key.startsWith(project + '\0')) _runCache.delete(key);
-    }
-  } else {
-    _runCache.clear();
-  }
-}
-
-function fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError, getDashboard) {
-  if (!selectedProject) { setDashboard(null); setError(null); return; }
-
-  const cacheKey = _runCacheKey(selectedProject, selectedRun);
-  const cached = _runCache.get(cacheKey);
-  if (cached) {
-    setDashboard(cached);
-    setLoading(false);
-    return undefined;
-  }
-
-  let active = true;
-  setError(null);
-
-  getDashboard(selectedProject, selectedRun)
-    .then((payload) => {
-      if (!active) return;
-      if (_runCache.size >= MAX_RUN_CACHE_SIZE) _runCache.delete(_runCache.keys().next().value);
-      _runCache.set(cacheKey, payload);
-      if (active) setDashboard(payload);
-    })
-    .catch(() => { if (active) setError('Failed to load dashboard data. Check your connection and try refreshing.'); })
-    .finally(() => { if (active) setLoading(false); });
-
-  return () => { active = false; };
-}
-
-function syncProjectState(prevProjectRef, prevRunRef, selectedProject, selectedRun, setDashboard, setError) {
-  if (prevProjectRef.current !== selectedProject) {
-    prevProjectRef.current = selectedProject;
-    prevRunRef.current = selectedRun;
-    setDashboard(null);
-    setError(null);
-  } else if (prevRunRef.current !== selectedRun) {
-    prevRunRef.current = selectedRun;
-    const dashKey = _runCacheKey(selectedProject, selectedRun);
-    const cachedDash = _runCache.get(dashKey);
-    if (cachedDash) setDashboard(cachedDash);
-  }
-}
-
-function useDebouncedRefresh(selectedProject, refreshScores, setRefreshKey) {
-  const refreshTimerRef = useRef(null);
-  const refreshDashboard = useCallback(() => {
-    clearDashboardCache(selectedProject);
-    refreshScores();
-    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), REFRESH_DEBOUNCE_MS);
-  }, [selectedProject, refreshScores, setRefreshKey]);
-
-  useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
-  return refreshDashboard;
-}
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useApi } from "../../../api/ApiContext.jsx";
+import { useProjectScores } from "../../../hooks/useProjectScores.js";
+import { projectKeys } from "../../../api/queryKeys.js";
 
 export function useDashboard({ selectedProject, selectedRun }) {
   const { getDashboard } = useApi();
-  const [dashboard, setDashboard] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const queryClient = useQueryClient();
 
-  const { scores, latestScores, loading: scoresLoading, error: scoresError, availableRuns, refreshScores } = useProjectScores({ selectedProject, selectedRun });
+  const dashboardQuery = useQuery({
+    queryKey: projectKeys.dashboard(selectedProject || "_none_", selectedRun),
+    queryFn: () => getDashboard(selectedProject, selectedRun),
+    enabled: !!selectedProject,
+    staleTime: 60_000,
+  });
 
-  const prevProjectRef = useRef(selectedProject);
-  const prevRunRef = useRef(selectedRun);
-  syncProjectState(prevProjectRef, prevRunRef, selectedProject, selectedRun, setDashboard, setError);
-
-  useEffect(() => {
-    setLoading(true);
-    return fetchDashboardEffect(selectedProject, selectedRun, setDashboard, setLoading, setError, getDashboard);
-  }, [selectedProject, selectedRun, refreshKey, getDashboard]);
+  const {
+    scores,
+    latestScores,
+    loading: scoresLoading,
+    error: scoresError,
+    availableRuns,
+  } = useProjectScores({ selectedProject, selectedRun });
 
   const dashboardWithTrend = useMemo(() => {
-    if (!dashboard) return null;
-    const trend = scores?.trend || latestScores?.trend || dashboard.trend || [];
-    return { ...dashboard, trend };
-  }, [dashboard, scores, latestScores]);
+    if (!dashboardQuery.data) return null;
+    const trend = scores?.trend || latestScores?.trend || dashboardQuery.data.trend || [];
+    return { ...dashboardQuery.data, trend };
+  }, [dashboardQuery.data, scores, latestScores]);
 
-  const accumulated = scores?.accumulated || null;
-  const latestAccumulated = latestScores?.accumulated || null;
-  const refreshDashboard = useDebouncedRefresh(selectedProject, refreshScores, setRefreshKey);
+  const refreshDashboard = useCallback(() => {
+    if (!selectedProject) return;
+    queryClient.invalidateQueries({ queryKey: projectKeys.project(selectedProject) });
+  }, [queryClient, selectedProject]);
 
   return {
     dashboard: dashboardWithTrend,
-    accumulated,
-    latestAccumulated,
+    accumulated: scores?.accumulated || null,
+    latestAccumulated: latestScores?.accumulated || null,
     rescoreLookup: {},
-    loading: loading || scoresLoading,
-    error: error || scoresError,
+    loading: dashboardQuery.isLoading || scoresLoading,
+    error: dashboardQuery.isError
+      ? "Failed to load dashboard data. Check your connection and try refreshing."
+      : (scoresError || null),
     availableRuns,
     refreshDashboard,
   };
+}
+
+// Deprecation shim — kept for backward-compat with any leftover callers.
+export function clearDashboardCache(_project) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "clearDashboardCache is deprecated; use queryClient.invalidateQueries(projectKeys.project(project)).",
+  );
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -47,11 +47,3 @@ export function useDashboard({ selectedProject, selectedRun }) {
     refreshDashboard,
   };
 }
-
-// Deprecation shim — kept for backward-compat with any leftover callers.
-export function clearDashboardCache(_project) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    "clearDashboardCache is deprecated; use queryClient.invalidateQueries(projectKeys.project(project)).",
-  );
-}

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { useDashboard } from "./useDashboard";
+import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
+import { ApiProvider } from "../../../api/ApiContext.jsx";
+
+const fakeApi = {
+  getDashboard: vi.fn(async (project, run) => ({
+    project,
+    run: run || "latest",
+    trend: [],
+    summary: { score: 75 },
+  })),
+};
+
+vi.mock("../../../api/index.js", () => ({
+  getProjectScores: vi.fn(async () => ({
+    accumulated: { score: 90 },
+    trend: [],
+    availableRuns: [],
+  })),
+}));
+
+function wrap(children) {
+  const QC = withQueryClient();
+  return (
+    <QC>
+      <ApiProvider value={fakeApi}>{children}</ApiProvider>
+    </QC>
+  );
+}
+
+describe("useDashboard", () => {
+  it("returns nulls when project is empty", () => {
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "", selectedRun: null }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.accumulated).toBeNull();
+  });
+
+  it("fetches dashboard data for the selected project", async () => {
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => {
+      expect(result.current.dashboard?.summary?.score).toBe(75);
+    });
+  });
+
+  it("merges trend from scores into the dashboard payload", async () => {
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => {
+      expect(Array.isArray(result.current.dashboard?.trend)).toBe(true);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getEvaluationProgress } from '../../../api/index.js';
+import { evaluationKeys } from '../../../api/queryKeys.js';
 import { useEvalLog } from '../eval-log/EvalLogContext.js';
 import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
 import { pct, computeOverallProgress } from './scanProgressTotals.js';
@@ -132,7 +134,6 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   const isFailed = status === 'failed';
   const isLost = status === 'lost';
 
-  const [progress, setProgress] = useState(null);
   const [detailOpen, setDetailOpen] = useState(false);
   const [showDot, setShowDot] = useState(() => {
     if (hasEvaluations) return false;
@@ -140,31 +141,19 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   });
   const evalLog = useEvalLog();
   const consoleOpen = evalLog.activeJobId === jobId;
-  const timerRef = useRef(null);
   const isTerminal = TERMINAL_STATES.has(status);
 
-  useEffect(() => {
-    if (!jobId) return undefined;
-    let stopped = false;
-
-    async function tick() {
-      try {
-        const data = await getEvaluationProgress(jobId);
-        if (!stopped) setProgress(data);
-      } catch {
-        /* progress is best-effort */
-      }
-    }
-
-    tick();
-    if (!isTerminal) {
-      timerRef.current = setInterval(tick, POLL_INTERVAL_MS);
-    }
-    return () => {
-      stopped = true;
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [jobId, isTerminal]);
+  const progressQuery = useQuery({
+    queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
+    queryFn: () => getEvaluationProgress(jobId),
+    enabled: !!jobId,
+    refetchInterval: isTerminal ? false : POLL_INTERVAL_MS,
+    staleTime: 0,
+    retry: false,
+  });
+  // Best-effort: surface the last successful payload, ignore errors silently
+  // (progress is purely informational and should never block the UI).
+  const progress = progressQuery.data ?? null;
 
   useEffect(() => {
     if (evalLog.activeJobId === jobId) {

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -3,13 +3,19 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { EvalLogContext } from '../eval-log/EvalLogContext.js';
 import ScanProgress from './ScanProgress.jsx';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 
 vi.mock('../../../api/index.js', () => ({
   getEvaluationProgress: vi.fn(() => Promise.resolve({ dimensions: [], totalElapsedS: 0 })),
 }));
 
 function withEvalLog(ui, ctx) {
-  return render(<EvalLogContext.Provider value={ctx}>{ui}</EvalLogContext.Provider>);
+  const QC = withQueryClient();
+  return render(
+    <QC>
+      <EvalLogContext.Provider value={ctx}>{ui}</EvalLogContext.Provider>
+    </QC>,
+  );
 }
 
 const baseJob = { jobId: 'job-1', status: 'running', logs: [] };

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -25,10 +25,47 @@ import { useApi } from "../../../api/ApiContext.jsx";
 import { confirmDialog } from "../../../utils/confirmDialog.js";
 import { useRunEventStream } from "./useRunEventStream.js";
 import { evaluationKeys } from "../../../api/queryKeys.js";
+import {
+  ACTIVE_PROVIDER_KEY,
+  providerKey,
+  DEFAULT_MAX_SUBAGENTS,
+  DEFAULT_POOL_BUDGET,
+} from "../../../constants.js";
 
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
 const JOB_POLL_MS = 1500;
 const DIM_POLL_MS = 2000;
+const DEFAULT_OLLAMA_SUBAGENTS = "1";
+const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
+const DEFAULT_OLLAMA_BUDGET = "0";
+const DEFAULT_CLI_BUDGET = String(DEFAULT_POOL_BUDGET);
+
+/**
+ * Merge per-provider Settings (provider, model, subagents, budget, etc.)
+ * from localStorage into the start-evaluation payload. Mirrors the legacy
+ * useEvaluation behavior; throws a user-facing error if no provider/model
+ * is configured.
+ */
+function preparePayload(payload, storage = localStorage) {
+  const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || "";
+  if (!activeProvider) throw new Error("No provider selected. Go to Settings to configure one.");
+  const get = (key) => storage.getItem(providerKey(activeProvider, key));
+  const model = get("model");
+  if (!model) throw new Error("No model selected. Go to Settings and select one.");
+  const isOllama = activeProvider === "ollama";
+  const subagents = parseInt(get("subagents") || (isOllama ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS), 10);
+  const poolBudget = parseInt(get("pool-budget") || (isOllama ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET), 10);
+  const result = {
+    ...payload,
+    aiCmd: activeProvider,
+    aiModel: model,
+    maxSubagents: subagents,
+    poolBudget,
+  };
+  if (get("per-dimension") === "true") result.perDimension = true;
+  if (get("verify") === "false") result.verifyFindings = false;
+  return result;
+}
 
 export function useEvaluation() {
   const api = useApi();
@@ -85,17 +122,30 @@ export function useEvaluation() {
 
   // --- Mutations -------------------------------------------------------
   const startMutation = useMutation({
-    mutationFn: (input) => api.startEvaluation(input),
+    mutationFn: (input) => {
+      // preparePayload throws on missing provider/model — let the error
+      // propagate to onError so jobError gets set with a useful message.
+      const prepared = preparePayload(input);
+      return api.startEvaluation(prepared).then((created) => ({
+        ...created,
+        repo: prepared.repo,
+      }));
+    },
     onSuccess: (created) => {
       setJobError(null);
       setJobId(created.jobId);
       queryClient.setQueryData(evaluationKeys.status(created.jobId), created);
     },
-    onError: (err) => setJobError(err?.message || "Failed to start evaluation."),
+    onError: (err) => {
+      const msg = err?.message || "Failed to start evaluation.";
+      setJobError(
+        msg.startsWith("No ") || msg.startsWith("Select ") ? msg : "Failed to start evaluation",
+      );
+    },
   });
 
   const cancelMutation = useMutation({
-    mutationFn: () => api.cancelEvaluation(jobId),
+    mutationFn: ({ discard } = {}) => api.cancelEvaluation(jobId, { discard }),
     onSuccess: () => {
       if (jobId) {
         queryClient.invalidateQueries({ queryKey: evaluationKeys.evaluation(jobId) });
@@ -109,9 +159,16 @@ export function useEvaluation() {
   );
 
   const cancelEvaluation = useCallback(async () => {
-    const ok = await confirmDialog("Cancel this evaluation?");
-    if (!ok) return;
-    cancelMutation.mutate();
+    const result = await confirmDialog({
+      title: "Cancel evaluation?",
+      message: "The run will stop. Findings collected so far are kept by default.",
+      checkboxLabel: "Discard collected findings",
+      confirmLabel: "Cancel evaluation",
+      cancelLabel: "Keep running",
+      variant: "danger",
+    });
+    if (!result || !result.ok) return;
+    cancelMutation.mutate({ discard: result.checked });
   }, [cancelMutation]);
 
   const clearJob = useCallback(() => {

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -1,339 +1,130 @@
-import { useEffect, useRef, useState } from 'react';
-import { useApi } from '../../../api/ApiContext.jsx';
-import { ACTIVE_PROVIDER_KEY, providerKey, DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET } from '../../../constants.js';
-import { confirmDialog } from '../../../utils/confirmDialog.js';
-import { useRunEventStream } from './useRunEventStream.js';
-
-const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === 'true';
-
-const DIMENSION_POLL_INITIAL_MS = 2000;
-const DIMENSION_POLL_MAX_MS = 8000;
-const JOB_POLL_INITIAL_MS = 1500;
-const MAX_DIM_POLL_FAILURES = 10;
-const POLL_CONCURRENCY = 4;
-const POLL_BACKOFF_FACTOR = 1.5;
-const DEFAULT_OLLAMA_SUBAGENTS = '1';
-const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
-const DEFAULT_OLLAMA_BUDGET = '0';
-const DEFAULT_CLI_BUDGET = String(DEFAULT_POOL_BUDGET);
-
-function stopTimer(ref) {
-  if (ref.current) {
-    clearInterval(ref.current);
-    ref.current = null;
-  }
-}
-
-async function pollSingleDimension(dim, project, runId, refs, setLiveViolations, getDimensionEval) {
-  try {
-    const data = await getDimensionEval(project, runId, dim);
-    refs.dimFailCount[dim] = 0;
-    if (data?.violations) {
-      setLiveViolations(prev => ({ ...prev, [dim]: data.violations }));
-      if (!data.partial) {
-        refs.partialDimensions.delete(dim);
-      }
-    }
-  } catch (err) {
-    console.debug('Dimension poll failed:', dim, err);
-    const fails = (refs.dimFailCount[dim] || 0) + 1;
-    refs.dimFailCount[dim] = fails;
-    if (fails > MAX_DIM_POLL_FAILURES) refs.partialDimensions.delete(dim);
-  }
-}
-
-function handleJobUpdate(updated, refs, setJob, callbacks) {
-  setJob((prev) => ({ ...updated, repo: prev?.repo }));
-  // Track the latest known dimension list so external (CLI-launched) runs
-  // surface every dimension in the live feed. Local runs already have it
-  // populated via parseDimensions(payload); for external runs the list
-  // arrives via the polled job. Write through to both the persistent ref
-  // and the local closure copy so a polling restart doesn't lose it.
-  if (updated.dimensions?.length) {
-    refs.requestedDimensions = updated.dimensions;
-    if (refs.requestedDimensionsRef) {
-      refs.requestedDimensionsRef.current = updated.dimensions;
-    }
-  }
-  if (updated.phase === 'analyzing' && updated.currentDimension) {
-    refs.partialDimensions.add(updated.currentDimension);
-  }
-  const hasOutput = updated.outputProject && updated.outputRunId;
-  const isAnalyzing = updated.phase === 'analyzing' || updated.phase === 'scoring' || updated.status !== 'running';
-  const canPollDims = hasOutput && isAnalyzing;
-  // Seed partialDimensions on reconnect. When the dashboard is restarted
-  // while a scan is running, the CLI-launched job reports phase=analyzing
-  // but currentDimension is often null (the pipeline-level phase setter
-  // does not know which dimension the worker pool is on right now), so
-  // the block above adds nothing to partialDimensions. Without any
-  // dimensions queued, startDimPolling spins with no work and the Live
-  // Violations panel stays empty. If we're analyzing and know the list
-  // of requested dimensions, seed them all — pollSingleDimension will
-  // remove each one from the set as soon as its status comes back
-  // non-partial.
-  if (isAnalyzing
-      && refs.partialDimensions.size === 0
-      && refs.requestedDimensions.length) {
-    for (const dim of refs.requestedDimensions) {
-      refs.partialDimensions.add(dim);
-    }
-  }
-  if (updated.status !== 'running') {
-    callbacks.stopPolling();
-    if (canPollDims && !refs.dimPollingStarted) {
-      refs.dimPollingStarted = true;
-      callbacks.startDimPolling(updated.outputProject, updated.outputRunId);
-    }
-  } else if (canPollDims && !refs.dimPollingStarted) {
-    refs.dimPollingStarted = true;
-    callbacks.startDimPolling(updated.outputProject, updated.outputRunId);
-  }
-}
-
-async function pollPartialDimensions(partialDimensionsRef, project, runId, refs, setLiveViolations, getDimensionEval) {
-  const partial = [...partialDimensionsRef.current];
-  if (!partial.length) return false;
-  let hadErrors = false;
-  for (let i = 0; i < partial.length; i += POLL_CONCURRENCY) {
-    const batch = partial.slice(i, i + POLL_CONCURRENCY);
-    const results = await Promise.allSettled(
-      batch.map((dim) => pollSingleDimension(dim, project, runId, refs, setLiveViolations, getDimensionEval))
-    );
-    if (results.some((r) => r.status === 'rejected')) hadErrors = true;
-  }
-  return hadErrors;
-}
-
-function createDimensionPoller(dimPollRef, dimFailCountRef, partialDimensionsRef, setLiveViolations, getDimensionEval) {
-  return function startDimensionPolling(project, runId) {
-    stopTimer(dimPollRef);
-    dimFailCountRef.current = {};
-    let delay = DIMENSION_POLL_INITIAL_MS;
-    const refs = { dimFailCount: dimFailCountRef.current, partialDimensions: partialDimensionsRef.current };
-    function scheduleNext() {
-      dimPollRef.current = setTimeout(async () => {
-        const anyFailed = await pollPartialDimensions(partialDimensionsRef, project, runId, refs, setLiveViolations, getDimensionEval);
-        delay = anyFailed ? Math.min(delay * POLL_BACKOFF_FACTOR, DIMENSION_POLL_MAX_MS) : DIMENSION_POLL_INITIAL_MS;
-        scheduleNext();
-      }, delay);
-    }
-    scheduleNext();
-  };
-}
-
-function createJobPoller(refs, setters, startDimensionPolling, getEvaluation) {
-  const { poll: pollRef, dimPoll: dimPollRef, requestedDimensions: requestedDimensionsRef, partialDimensions: partialDimensionsRef } = refs;
-  const { setJob, setJobError } = setters;
-  return function startPolling(jobId) {
-    if (SSE_ENABLED) return;
-    stopTimer(pollRef);
-    const localRefs = {
-      requestedDimensions: requestedDimensionsRef.current,
-      partialDimensions: partialDimensionsRef.current,
-      requestedDimensionsRef,
-      dimPollingStarted: false,
-    };
-    const callbacks = {
-      stopPolling: () => stopTimer(pollRef),
-      startDimPolling: startDimensionPolling,
-    };
-    pollRef.current = setInterval(async () => {
-      try {
-        const updated = await getEvaluation(jobId);
-        handleJobUpdate(updated, localRefs, setJob, callbacks);
-      } catch (err) {
-        setJob((prev) => prev ? { ...prev, status: 'lost' } : prev);
-        console.error('Poll error:', err);
-        setJobError('Evaluation polling failed');
-        stopTimer(pollRef);
-        stopTimer(dimPollRef);
-      }
-    }, JOB_POLL_INITIAL_MS);
-  };
-}
-
 /**
- * Build the evaluation payload from provider settings.
- * Throws if the orchestrator model is not configured.
+ * useEvaluation — evaluation lifecycle hook backed by TanStack Query.
+ *
+ * Exposes:
+ *   { job, jobError, liveViolations, startEvaluation, clearJob, cancelEvaluation }
+ *
+ * Data sources:
+ *   - statusQuery: ['evaluation', jobId, 'status'] — fetched via api.getEvaluation
+ *     and updated by useRunEventStream when VITE_USE_SSE_EVENTS=true.
+ *   - findingsQuery: ['evaluation', jobId, 'findings'] — under SSE, populated
+ *     entirely by useRunEventStream's setQueryData writes (queryFn is a no-op).
+ *     Under polling, fetched via per-dimension getDimensionEval calls.
+ *
+ * Mutations:
+ *   - startMutation: api.startEvaluation -> seeds status cache on success.
+ *   - cancelMutation: api.cancelEvaluation -> invalidates the run subtree.
+ *
+ * Out of scope (vs. legacy hook):
+ *   - Auto-resume of CLI-started external runs via listEvaluations on mount.
+ *     Restore in a follow-up if required by user reports.
  */
-function preparePayload(payload, storage = localStorage) {
-  const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  if (!activeProvider) throw new Error('No provider selected. Go to Settings to configure one.');
+import { useCallback, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useApi } from "../../../api/ApiContext.jsx";
+import { confirmDialog } from "../../../utils/confirmDialog.js";
+import { useRunEventStream } from "./useRunEventStream.js";
+import { evaluationKeys } from "../../../api/queryKeys.js";
 
-  const get = (key) => storage.getItem(providerKey(activeProvider, key));
-
-  const model = get('model');
-  if (!model) throw new Error('No model selected. Go to Settings and select one.');
-
-  const defaultSubagents = ['ollama'].includes(activeProvider) ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS;
-  const subagents = parseInt(get('subagents') || defaultSubagents, 10);
-
-  const defaultBudget = ['ollama'].includes(activeProvider) ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET;
-  const poolBudget = parseInt(get('pool-budget') || defaultBudget, 10);
-
-  const result = {
-    ...payload,
-    aiCmd: activeProvider,
-    aiModel: model,
-    maxSubagents: subagents,
-    poolBudget,
-  };
-  if (get('per-dimension') === 'true') result.perDimension = true;
-  if (get('verify') === 'false') result.verifyFindings = false;
-  return result;
-}
-
-function parseDimensions(payload) {
-  const rawDims = payload.dimensions ?? [];
-  return typeof rawDims === 'string' ? rawDims.split(',').map(d => d.trim()).filter(Boolean) : rawDims;
-}
-
-function resetRefs(liveViolationsRef, requestedDimensionsRef, partialDimensionsRef, dimFailCountRef) {
-  liveViolationsRef.current = {};
-  requestedDimensionsRef.current = [];
-  partialDimensionsRef.current = new Set();
-  dimFailCountRef.current = {};
-}
-
-function useEvalRefs() {
-  return {
-    pollRef: useRef(null),
-    dimPollRef: useRef(null),
-    requestedDimensionsRef: useRef([]),
-    liveViolationsRef: useRef({}),
-    partialDimensionsRef: useRef(new Set()),
-    dimFailCountRef: useRef({}),
-  };
-}
-
-function useResumeRunning(setJob, startPolling, pollRef, dimPollRef, listEvaluations) {
-  useEffect(() => {
-    if (SSE_ENABLED) return undefined;
-    listEvaluations()
-      .then((jobs) => {
-        const running = jobs.find((j) => j.status === 'running');
-        if (running) {
-          setJob(running);
-          startPolling(running.jobId);
-        }
-      })
-      .catch((err) => console.warn('Failed to fetch running evaluations:', err));
-    return () => {
-      stopTimer(pollRef);
-      stopTimer(dimPollRef);
-    };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- mount-only: resume any running eval; startPolling is stable (defined outside render cycle via refs)
-}
-
-function useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPolling, { startEvaluation, cancelEvaluation }) {
-  async function startEvaluationJob(payload) {
-    setJobError('');
-    refs.requestedDimensionsRef.current = parseDimensions(payload);
-    refs.liveViolationsRef.current = {};
-    refs.partialDimensionsRef.current = new Set();
-    setLiveViolations({});
-    try {
-      if (Array.isArray(payload.dimensions) && payload.dimensions.length === 0) {
-        throw new Error('Select at least one dimension.');
-      }
-      const prepared = preparePayload(payload);
-      const created = await startEvaluation(prepared);
-      setJob({ ...created, repo: prepared.repo });
-      startPolling(created.jobId);
-    } catch (err) {
-      console.error('Start error:', err);
-      setJobError(err.message?.startsWith('No ') || err.message?.startsWith('Select ') ? err.message : 'Failed to start evaluation');
-    }
-  }
-
-  function clearJob() {
-    stopTimer(refs.pollRef); stopTimer(refs.dimPollRef);
-    setJob(null); setJobError(''); setLiveViolations({});
-    resetRefs(refs.liveViolationsRef, refs.requestedDimensionsRef, refs.partialDimensionsRef, refs.dimFailCountRef);
-  }
-
-  async function cancelEvaluationJob(jobId) {
-    if (!jobId) return;
-    const result = await confirmDialog({
-      title: 'Cancel evaluation?',
-      message: 'Stop the running scan. Findings collected so far will be saved for the next incremental run.',
-      confirmLabel: 'Cancel evaluation',
-      cancelLabel: 'Keep running',
-      variant: 'danger',
-      checkboxLabel: 'Discard collected findings',
-      checkboxHint: 'Force a full rescan next time instead of resuming from this run.',
-    });
-    if (!result || !result.ok) return;
-    try {
-      await cancelEvaluation(jobId, { discard: result.checked });
-      clearJob();
-    } catch (err) {
-      console.error('Cancel error:', err);
-      setJobError('Failed to cancel evaluation');
-    }
-  }
-
-  return { startEvaluationJob, clearJob, cancelEvaluationJob };
-}
-
-function usePollingSetup(refs, setJob, setJobError, setLiveViolations, { getDimensionEval, getEvaluation, listEvaluations }) {
-  const startDimensionPolling = createDimensionPoller(refs.dimPollRef, refs.dimFailCountRef, refs.partialDimensionsRef, setLiveViolations, getDimensionEval);
-  const startPolling = createJobPoller(
-    { poll: refs.pollRef, dimPoll: refs.dimPollRef, requestedDimensions: refs.requestedDimensionsRef, partialDimensions: refs.partialDimensionsRef },
-    { setJob, setJobError },
-    startDimensionPolling,
-    getEvaluation,
-  );
-  useResumeRunning(setJob, startPolling, refs.pollRef, refs.dimPollRef, listEvaluations);
-  return startPolling;
-}
+const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
+const JOB_POLL_MS = 1500;
+const DIM_POLL_MS = 2000;
 
 export function useEvaluation() {
   const api = useApi();
-  const { startEvaluation, getEvaluation, cancelEvaluation, getDimensionEval, listEvaluations } = api;
-  const [job, setJob] = useState(null);
-  const [jobError, setJobError] = useState('');
-  const [liveViolations, setLiveViolations] = useState({});
-  const refs = useEvalRefs();
+  const queryClient = useQueryClient();
+  const [jobId, setJobId] = useState(null);
+  const [jobError, setJobError] = useState(null);
 
-  // Hooks must run unconditionally (Rules of Hooks). When the SSE flag is off
-  // we pass null so useRunEventStream stays inert; when on, we feed it the
-  // current job id so it subscribes to /events for that run.
-  const sse = useRunEventStream(SSE_ENABLED ? job?.jobId ?? null : null);
+  // SSE side-effect — writes status/dimensions/findings into cache.
+  // No-op when VITE_USE_SSE_EVENTS is off; refetchInterval below covers.
+  useRunEventStream(jobId);
 
-  // Mirror SSE status frames into the same `job` state the polling path
-  // populates, so downstream consumers (useEvaluationLifecycle, dashboards)
-  // see an identical shape regardless of transport.
-  useEffect(() => {
-    if (!SSE_ENABLED) return;
-    if (!sse.status) return;
-    setJob((prev) => ({ ...(prev || {}), ...sse.status, repo: prev?.repo }));
-  }, [sse.status]);
+  // --- Status (the "job" object) ---------------------------------------
+  const statusQuery = useQuery({
+    queryKey: jobId ? evaluationKeys.status(jobId) : ["evaluation", "_none_", "status"],
+    queryFn: () => api.getEvaluation(jobId),
+    enabled: !!jobId,
+    staleTime: SSE_ENABLED ? Infinity : 0,
+    refetchInterval: SSE_ENABLED ? false : JOB_POLL_MS,
+  });
 
-  // Group SSE findings by dimension into the liveViolations shape consumers
-  // already render. Each finding is expected to carry a `dimension` key; we
-  // tolerate missing dimensions by bucketing under '_'.
-  useEffect(() => {
-    if (!SSE_ENABLED) return;
-    if (!sse.findings || sse.findings.length === 0) return;
-    const grouped = {};
-    for (const f of sse.findings) {
-      const key = f?.dimension || '_';
-      if (!grouped[key]) grouped[key] = [];
-      grouped[key].push(f);
-    }
-    setLiveViolations(grouped);
-  }, [sse.findings]);
+  const job = statusQuery.data || null;
 
-  const startPolling = usePollingSetup(refs, setJob, setJobError, setLiveViolations, { getDimensionEval, getEvaluation, listEvaluations });
-  useEffect(() => { refs.liveViolationsRef.current = liveViolations; }, [liveViolations]);
+  // --- Findings (a flat list, then grouped into liveViolations) --------
+  // Under SSE the cache is filled by useRunEventStream; queryFn is a no-op.
+  // Under polling, fetch each dimension's eval and flatten violations.
+  const findingsQuery = useQuery({
+    queryKey: jobId ? evaluationKeys.findings(jobId) : ["evaluation", "_none_", "findings"],
+    queryFn: async () => {
+      if (SSE_ENABLED) return [];
+      if (!job?.outputProject || !job?.outputRunId || !job?.dimensions?.length) {
+        return [];
+      }
+      const results = await Promise.all(
+        job.dimensions.map((d) =>
+          api.getDimensionEval(job.outputProject, job.outputRunId, d)
+            .then((data) => (data?.violations || []).map((v) => ({ ...v, dimension: d })))
+            .catch(() => []),
+        ),
+      );
+      return results.flat();
+    },
+    enabled: !!jobId && (SSE_ENABLED || !!job?.outputProject),
+    staleTime: SSE_ENABLED ? Infinity : 0,
+    refetchInterval: SSE_ENABLED ? false : DIM_POLL_MS,
+  });
 
-  const { startEvaluationJob, clearJob, cancelEvaluationJob } = useJobLifecycle(refs, setJob, setJobError, setLiveViolations, startPolling, { startEvaluation, cancelEvaluation });
+  // Group findings into the legacy { [dim]: [violations] } shape.
+  const findings = findingsQuery.data || [];
+  const liveViolations = {};
+  for (const f of findings) {
+    const dim = f.dimension || "_";
+    (liveViolations[dim] ??= []).push(f);
+  }
+
+  // --- Mutations -------------------------------------------------------
+  const startMutation = useMutation({
+    mutationFn: (input) => api.startEvaluation(input),
+    onSuccess: (created) => {
+      setJobError(null);
+      setJobId(created.jobId);
+      queryClient.setQueryData(evaluationKeys.status(created.jobId), created);
+    },
+    onError: (err) => setJobError(err?.message || "Failed to start evaluation."),
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: () => api.cancelEvaluation(jobId),
+    onSuccess: () => {
+      if (jobId) {
+        queryClient.invalidateQueries({ queryKey: evaluationKeys.evaluation(jobId) });
+      }
+    },
+  });
+
+  const startEvaluation = useCallback(
+    (input) => startMutation.mutateAsync(input),
+    [startMutation],
+  );
+
+  const cancelEvaluation = useCallback(async () => {
+    const ok = await confirmDialog("Cancel this evaluation?");
+    if (!ok) return;
+    cancelMutation.mutate();
+  }, [cancelMutation]);
+
+  const clearJob = useCallback(() => {
+    setJobId(null);
+    setJobError(null);
+  }, []);
 
   return {
-    job, jobError, liveViolations,
-    startEvaluation: startEvaluationJob,
+    job,
+    jobError,
+    liveViolations,
+    startEvaluation,
     clearJob,
-    cancelEvaluation: () => cancelEvaluationJob(job?.jobId),
+    cancelEvaluation,
   };
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -172,9 +172,15 @@ export function useEvaluation() {
   }, [cancelMutation]);
 
   const clearJob = useCallback(() => {
+    if (jobId) {
+      // Drop cached entries so a future Start with a different jobId
+      // doesn't carry stale findings/status into view (gcTime would
+      // otherwise hold them for 5 minutes).
+      queryClient.removeQueries({ queryKey: evaluationKeys.evaluation(jobId) });
+    }
     setJobId(null);
     setJobError(null);
-  }, []);
+  }, [jobId, queryClient]);
 
   return {
     job,

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -30,6 +30,9 @@ describe("useEvaluation", () => {
     fakeApi.listEvaluations.mockResolvedValue([]);
     // Default: SSE off — refetchInterval path
     import.meta.env.VITE_USE_SSE_EVENTS = "false";
+    // preparePayload reads localStorage; seed a working provider+model.
+    localStorage.setItem("cc-active-provider", "ollama");
+    localStorage.setItem("cc-ollama-model", "llama3.1");
   });
 
   it("returns the documented public shape", () => {
@@ -82,5 +85,29 @@ describe("useEvaluation", () => {
       wrapper: makeWrapper(),
     });
     expect(result.current.liveViolations).toEqual({});
+  });
+
+  it("startEvaluation merges Settings (provider/model/subagents) from localStorage", async () => {
+    fakeApi.startEvaluation.mockResolvedValue({ jobId: "j3", status: "pending", dimensions: [] });
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: ["security"] });
+    });
+    expect(fakeApi.startEvaluation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repo: "x",
+        aiCmd: "ollama",
+        aiModel: "llama3.1",
+      }),
+    );
+  });
+
+  it("startEvaluation surfaces a useful error when no provider is configured", async () => {
+    localStorage.removeItem("cc-active-provider");
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await expect(
+      result.current.startEvaluation({ repo: "x", dimensions: [] }),
+    ).rejects.toThrow(/provider/i);
+    await waitFor(() => expect(result.current.jobError).toMatch(/provider/i));
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import React from "react";
+import { useEvaluation } from "./useEvaluation";
+import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
+import { ApiProvider } from "../../../api/ApiContext.jsx";
+
+const fakeApi = {
+  getEvaluation: vi.fn(),
+  startEvaluation: vi.fn(),
+  cancelEvaluation: vi.fn(),
+  getDimensionEval: vi.fn(),
+  listEvaluations: vi.fn().mockResolvedValue([]),
+};
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe("useEvaluation", () => {
+  beforeEach(() => {
+    Object.values(fakeApi).forEach((fn) => fn.mockReset?.());
+    fakeApi.listEvaluations.mockResolvedValue([]);
+    // Default: SSE off — refetchInterval path
+    import.meta.env.VITE_USE_SSE_EVENTS = "false";
+  });
+
+  it("returns the documented public shape", () => {
+    const { result } = renderHook(() => useEvaluation(), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current).toHaveProperty("job");
+    expect(result.current).toHaveProperty("jobError");
+    expect(result.current).toHaveProperty("liveViolations");
+    expect(result.current).toHaveProperty("startEvaluation");
+    expect(result.current).toHaveProperty("clearJob");
+    expect(result.current).toHaveProperty("cancelEvaluation");
+  });
+
+  it("startEvaluation seeds the cache with the created job", async () => {
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j1",
+      status: "pending",
+      dimensions: [],
+    });
+    const { result } = renderHook(() => useEvaluation(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    await waitFor(() => {
+      expect(result.current.job?.jobId).toBe("j1");
+    });
+  });
+
+  it("clearJob resets job state", async () => {
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j2",
+      status: "pending",
+      dimensions: [],
+    });
+    const { result } = renderHook(() => useEvaluation(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    act(() => result.current.clearJob());
+    await waitFor(() => expect(result.current.job).toBeNull());
+  });
+
+  it("liveViolations is an empty object when no findings", () => {
+    const { result } = renderHook(() => useEvaluation(), {
+      wrapper: makeWrapper(),
+    });
+    expect(result.current.liveViolations).toEqual({});
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
@@ -1,67 +1,81 @@
 /**
- * SSE-driven replacement for useEvaluation's polling loops.
+ * SSE → cache-update writer.
  *
- * Subscribes to /api/evaluations/<jobId>/events, registers handlers for
- * status / dimension-completed / finding / done events, and exposes the
- * same state shape that useEvaluation consumers already render against.
+ * Subscribes to /api/evaluations/<jobId>/events and writes each event
+ * into the TanStack Query cache via setQueryData. Components consume
+ * the cached data via useQuery, agnostic to whether it arrived via
+ * initial GET, refetchInterval poll, or this SSE handler.
  *
- * Gated by VITE_USE_SSE_EVENTS (see useEvaluation.js for the switch).
+ * Returns nothing — this hook is a side-effect.
+ *
+ * Gated by VITE_USE_SSE_EVENTS (default off). When off, components fall
+ * back to useQuery's refetchInterval polling.
+ *
+ * Each cache write is preceded by a fire-and-forget cancelQueries on
+ * the same key. This prevents an in-flight initial fetch (or poll)
+ * from landing AFTER our setQueryData and overwriting the streamed
+ * value — a real race once a query is mounted in the same render as
+ * the SSE handler.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { evaluationKeys } from "../../../api/queryKeys.js";
+
+function isSseEnabled() {
+  return import.meta.env?.VITE_USE_SSE_EVENTS === "true";
+}
 
 export function useRunEventStream(jobId) {
-  const [status, setStatus] = useState(null);
-  const [completedDimensions, setCompletedDimensions] = useState({});
-  const [findings, setFindings] = useState([]);
-  const [done, setDone] = useState(false);
-  const [connected, setConnected] = useState(false);
-  const sourceRef = useRef(null);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
+    if (!isSseEnabled()) return undefined;
     if (!jobId) return undefined;
 
-    const source = new EventSource(`/api/evaluations/${jobId}/events`);
-    sourceRef.current = source;
-    setConnected(true);
-
-    source.addEventListener('status', (e) => {
-      try {
-        setStatus(JSON.parse(e.data));
-      } catch {
-        // ignore malformed frames; reconnect handles recovery
-      }
-    });
-
-    source.addEventListener('dimension-completed', (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        setCompletedDimensions((prev) => ({ ...prev, [data.dimension]: data }));
-      } catch {
-        // ignore
-      }
-    });
-
-    source.addEventListener('finding', (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        setFindings((prev) => [...prev, data]);
-      } catch {
-        // ignore
-      }
-    });
-
-    source.addEventListener('done', () => {
-      setDone(true);
-      source.close();
-      setConnected(false);
-    });
-
-    return () => {
-      source.close();
-      sourceRef.current = null;
-      setConnected(false);
+    const writeCache = (key, updater) => {
+      queryClient.cancelQueries({ queryKey: key });
+      queryClient.setQueryData(key, updater);
     };
-  }, [jobId]);
 
-  return { status, completedDimensions, findings, done, connected };
+    const source = new EventSource(`/api/evaluations/${jobId}/events`);
+
+    source.addEventListener("status", (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        writeCache(evaluationKeys.status(jobId), data);
+      } catch {
+        // ignore malformed frames; reconnect handles recovery via Last-Event-ID
+      }
+    });
+
+    source.addEventListener("dimension-completed", (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        writeCache(
+          evaluationKeys.dimensions(jobId),
+          (prev = {}) => ({ ...prev, [data.dimension]: data }),
+        );
+      } catch {
+        // ignore
+      }
+    });
+
+    source.addEventListener("finding", (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        writeCache(
+          evaluationKeys.findings(jobId),
+          (prev = []) => [...prev, data],
+        );
+      } catch {
+        // ignore
+      }
+    });
+
+    source.addEventListener("done", () => {
+      source.close();
+    });
+
+    return () => source.close();
+  }, [jobId, queryClient]);
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
@@ -1,85 +1,114 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useRunEventStream } from './useRunEventStream.js';
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { useRunEventStream } from "./useRunEventStream";
+import { evaluationKeys } from "../../../api/queryKeys.js";
+import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
 
 class MockEventSource {
   constructor(url) {
     this.url = url;
     this.listeners = {};
-    this.closed = false;
     MockEventSource.last = this;
   }
   addEventListener(event, handler) {
     if (!this.listeners[event]) this.listeners[event] = [];
     this.listeners[event].push(handler);
   }
-  close() {
-    this.closed = true;
-  }
+  close() { this.closed = true; }
   emit(event, data) {
     (this.listeners[event] || []).forEach((h) =>
-      h({ data: JSON.stringify(data), lastEventId: data?.id })
+      h({ data: JSON.stringify(data), lastEventId: data?.id }),
     );
   }
 }
 
-describe('useRunEventStream', () => {
-  let originalEventSource;
+function renderStreamAndQuery(jobId, key) {
+  const wrapper = withQueryClient();
+  return renderHook(
+    () => {
+      useRunEventStream(jobId);
+      return useQuery({
+        queryKey: key,
+        queryFn: () => null,
+        enabled: !!jobId,
+      });
+    },
+    { wrapper },
+  );
+}
+
+describe("useRunEventStream (cache-writer)", () => {
   beforeEach(() => {
-    originalEventSource = globalThis.EventSource;
-    globalThis.EventSource = MockEventSource;
+    global.EventSource = MockEventSource;
     MockEventSource.last = null;
   });
-  afterEach(() => {
-    globalThis.EventSource = originalEventSource;
+
+  it("opens an EventSource against the events endpoint when SSE is enabled", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    renderStreamAndQuery("job-123", evaluationKeys.status("job-123"));
+    expect(MockEventSource.last.url).toBe("/api/evaluations/job-123/events");
   });
 
-  it('opens an EventSource against the run-events endpoint', () => {
-    const { result } = renderHook(() => useRunEventStream('job-123'));
-    expect(MockEventSource.last.url).toBe('/api/evaluations/job-123/events');
-    expect(result.current.connected).toBe(true);
-  });
-
-  it('updates status state when status event arrives', () => {
-    const { result } = renderHook(() => useRunEventStream('job-123'));
+  it("writes status events into evaluationKeys.status cache slot", async () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { result } = renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     act(() => {
-      MockEventSource.last.emit('status', { state: 'running', phase: 'analyzing' });
+      MockEventSource.last.emit("status", { state: "running", phase: "analyzing" });
     });
-    expect(result.current.status).toEqual({ state: 'running', phase: 'analyzing' });
-  });
-
-  it('appends new findings as finding events arrive', () => {
-    const { result } = renderHook(() => useRunEventStream('job-123'));
-    act(() => {
-      MockEventSource.last.emit('finding', { id: 1, practice_id: 'P1', verdict: 'violation' });
-      MockEventSource.last.emit('finding', { id: 2, practice_id: 'P2', verdict: 'violation' });
-    });
-    expect(result.current.findings).toHaveLength(2);
-    expect(result.current.findings[0].practice_id).toBe('P1');
-  });
-
-  it('tracks completed dimensions', () => {
-    const { result } = renderHook(() => useRunEventStream('job-123'));
-    act(() => {
-      MockEventSource.last.emit('dimension-completed', { dimension: 'security', score: 90 });
-    });
-    expect(result.current.completedDimensions).toEqual({
-      security: { dimension: 'security', score: 90 },
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ state: "running", phase: "analyzing" });
     });
   });
 
-  it('sets done flag and closes the stream on done event', () => {
-    const { result } = renderHook(() => useRunEventStream('job-123'));
+  it("appends finding events into evaluationKeys.findings cache slot", async () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { result } = renderStreamAndQuery("job-1", evaluationKeys.findings("job-1"));
     act(() => {
-      MockEventSource.last.emit('done', { state: 'done' });
+      MockEventSource.last.emit("finding", { id: 1, practice_id: "P1" });
+      MockEventSource.last.emit("finding", { id: 2, practice_id: "P2" });
     });
-    expect(result.current.done).toBe(true);
+    await waitFor(() => {
+      expect(result.current.data).toEqual([
+        { id: 1, practice_id: "P1" },
+        { id: 2, practice_id: "P2" },
+      ]);
+    });
+  });
+
+  it("writes dimension-completed events as a map keyed by dimension", async () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { result } = renderStreamAndQuery("job-1", evaluationKeys.dimensions("job-1"));
+    act(() => {
+      MockEventSource.last.emit("dimension-completed", {
+        dimension: "security", score: 90,
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        security: { dimension: "security", score: 90 },
+      });
+    });
+  });
+
+  it("closes the source on done event", async () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
+    act(() => {
+      MockEventSource.last.emit("done", { state: "done" });
+    });
     expect(MockEventSource.last.closed).toBe(true);
   });
 
-  it('returns null status when jobId is empty', () => {
-    const { result } = renderHook(() => useRunEventStream(''));
-    expect(result.current.status).toBeNull();
+  it("does not open EventSource when jobId is empty", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    renderStreamAndQuery("", evaluationKeys.status(""));
+    expect(MockEventSource.last).toBeNull();
+  });
+
+  it("is a no-op when VITE_USE_SSE_EVENTS is not 'true'", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "false";
+    renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     expect(MockEventSource.last).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { scanPath } from '../../../api/index.js';
+import { projectKeys } from '../../../api/queryKeys.js';
 
 /**
  * Fetch scan data for a project ID or a raw local path.
@@ -7,44 +8,25 @@ import { scanPath } from '../../../api/index.js';
  * Returns { scanData, loading, error }.
  */
 export function useScanData(projectId, localPath) {
-  const [scanData, setScanData] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const target = projectId || localPath || null;
+  const { data, isLoading, error } = useQuery({
+    queryKey: projectId
+      ? [...projectKeys.project(projectId), 'scan']
+      : ['project', 'scan-path', localPath || ''],
+    queryFn: async ({ signal }) => {
+      if (projectId) {
+        const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`, { signal });
+        if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
+        return res.json();
+      }
+      return scanPath(localPath);
+    },
+    enabled: !!target,
+  });
 
-  useEffect(() => {
-    const target = projectId || localPath;
-    if (!target) {
-      setScanData(null);
-      return;
-    }
-
-    const controller = new AbortController();
-    setLoading(true);
-    setError(null);
-
-    const fetchPromise = projectId
-      ? fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`, { signal: controller.signal }).then((res) => {
-          if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
-          return res.json();
-        })
-      : scanPath(localPath);
-
-    fetchPromise
-      .then((data) => {
-        if (!controller.signal.aborted) {
-          setScanData(data);
-          setLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          setError(err.message);
-          setLoading(false);
-        }
-      });
-
-    return () => { controller.abort(); };
-  }, [projectId, localPath]);
-
-  return { scanData, loading, error };
+  return {
+    scanData: data ?? null,
+    loading: !!target && isLoading,
+    error: error ? error.message : null,
+  };
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+
+vi.mock('../../../api/index.js', () => ({
+  scanPath: vi.fn(),
+}));
+
+import { scanPath } from '../../../api/index.js';
+import { useScanData } from './useScanData.js';
+
+describe('useScanData', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    scanPath.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null scanData when neither id nor path given', () => {
+    const { result } = renderHook(() => useScanData(null, null), { wrapper: withQueryClient() });
+    expect(result.current.scanData).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetches /api/projects/<id>/scan when projectId is given', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ branches: ['main'], currentBranch: 'main' }),
+    });
+    const { result } = renderHook(() => useScanData('proj-1'), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current.scanData).toEqual({ branches: ['main'], currentBranch: 'main' });
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/projects/proj-1/scan',
+      expect.objectContaining({ signal: expect.anything() }),
+    );
+  });
+
+  it('falls back to scanPath() when only localPath is given', async () => {
+    scanPath.mockResolvedValue({ branches: ['dev'] });
+    const { result } = renderHook(() => useScanData(null, '/tmp/repo'), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current.scanData).toEqual({ branches: ['dev'] });
+    });
+    expect(scanPath).toHaveBeenCalledWith('/tmp/repo');
+  });
+
+  it('exposes error message when fetch fails', async () => {
+    globalThis.fetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    const { result } = renderHook(() => useScanData('proj-2'), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current.error).toMatch(/500/);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { MIN_SUBAGENTS, MAX_SUBAGENTS, DEFAULT_SUBAGENTS } from '../../../constants.js';
+import { settingsKeys } from '../../../api/queryKeys.js';
 import PowerSelector from '../../evaluation/components/PowerSelector.jsx';
 import { STORAGE_KEY as POWER_KEY } from '../../evaluation/components/powerLevels.js';
 import { TimeLimitSetting, AdvancedAnalysisSettings } from './ProviderSettings.jsx';
@@ -31,7 +33,6 @@ function ModelSuggestInput({ label, value, suggestions, placeholder, onChange, r
 
 export default function CliProviderTab({ providerId, state, update }) {
   const { getKnownModels } = useApi();
-  const [suggestions, setSuggestions] = useState([]);
   const [power, setPower] = useState(() => {
     try { return Number(localStorage.getItem(POWER_KEY)) || DEFAULT_POWER_LEVEL; } catch { return DEFAULT_POWER_LEVEL; }
   });
@@ -41,11 +42,12 @@ export default function CliProviderTab({ providerId, state, update }) {
     try { localStorage.setItem(POWER_KEY, String(level)); } catch { /* */ }
   }
 
-  useEffect(() => {
-    getKnownModels()
-      .then((data) => setSuggestions(data[providerId] || []))
-      .catch(() => setSuggestions([]));
-  }, [providerId]);
+  const { data: knownModels } = useQuery({
+    queryKey: settingsKeys.knownModels(providerId),
+    queryFn: () => getKnownModels(),
+    enabled: !!providerId,
+  });
+  const suggestions = knownModels?.[providerId] || [];
 
   const { fast, balanced, thorough } = useMemo(() => {
     const f = [], b = [], t = [];

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import CliProviderTab from './CliProviderTab.jsx';
+
+const fakeApi = {
+  getKnownModels: vi.fn(),
+};
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('CliProviderTab', () => {
+  beforeEach(() => {
+    fakeApi.getKnownModels.mockReset();
+  });
+
+  it('fetches known models for the active provider on mount', async () => {
+    fakeApi.getKnownModels.mockResolvedValue({
+      'cli-foo': [{ id: 'm1', label: 'M1', tier: 'fast' }],
+    });
+    const Wrapper = makeWrapper();
+    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
+    const update = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <CliProviderTab providerId="cli-foo" state={state} update={update} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      expect(fakeApi.getKnownModels).toHaveBeenCalled();
+    });
+    // datalist is populated with M1 (option value="m1")
+    await waitFor(() => {
+      const datalists = container.querySelectorAll('datalist option');
+      expect([...datalists].some((opt) => opt.value === 'm1')).toBe(true);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.jsx
@@ -1,10 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { MIN_SUBAGENTS, MAX_SUBAGENTS } from '../../../constants.js';
 import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import { useOllamaServerStatus } from '../hooks/useOllamaServerStatus.js';
 import { TimeLimitSetting, AdvancedAnalysisSettings } from './ProviderSettings.jsx';
 import { useOllamaLog } from '../ollama-log/OllamaLogContext.js';
+import { settingsKeys } from '../../../api/queryKeys.js';
 
 function ModelSelector({ value, models, onChange }) {
   const needsModel = !value;
@@ -23,17 +25,17 @@ export default function OllamaTab({ state, update }) {
   const { getOllamaModels, testOllamaConcurrency } = useApi();
   const ollamaLog = useOllamaLog();
   const ollamaStatus = useOllamaServerStatus();
-  const [models, setModels] = useState([]);
-  const [modelsError, setModelsError] = useState(null);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [testError, setTestError] = useState(null);
 
-  useEffect(() => {
-    getOllamaModels()
-      .then((data) => { setModels(data); setModelsError(null); })
-      .catch(() => { setModels([]); setModelsError('Failed to load Ollama models. Check that Ollama is running.'); });
-  }, []);
+  const { data: models = [], error: modelsQueryError } = useQuery({
+    queryKey: settingsKeys.ollamaModels(),
+    queryFn: () => getOllamaModels(),
+  });
+  const modelsError = modelsQueryError
+    ? 'Failed to load Ollama models. Check that Ollama is running.'
+    : null;
 
   const runTest = async () => {
     if (!state.model) return;

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { OllamaLogContext } from '../ollama-log/OllamaLogContext.js';
+import OllamaTab from './OllamaTab.jsx';
+
+const fakeApi = {
+  getOllamaModels: vi.fn(),
+  testOllamaConcurrency: vi.fn(),
+  // useOllamaServerStatus depends on this; return offline by default
+  getOllamaServerStatus: vi.fn().mockResolvedValue({ status: 'offline' }),
+};
+
+const stubOllamaLog = { open: false, openLog: vi.fn(), closeLog: vi.fn() };
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>
+          <OllamaLogContext.Provider value={stubOllamaLog}>{children}</OllamaLogContext.Provider>
+        </ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('OllamaTab', () => {
+  beforeEach(() => {
+    fakeApi.getOllamaModels.mockReset();
+    fakeApi.testOllamaConcurrency.mockReset();
+  });
+
+  it('lists Ollama models returned by getOllamaModels', async () => {
+    fakeApi.getOllamaModels.mockResolvedValue([
+      { name: 'llama3.1' },
+      { name: 'qwen3' },
+    ]);
+    const Wrapper = makeWrapper();
+    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
+    const { container } = render(
+      <Wrapper>
+        <OllamaTab state={state} update={vi.fn()} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      const opts = container.querySelectorAll('select option');
+      expect([...opts].some((o) => o.value === 'llama3.1')).toBe(true);
+      expect([...opts].some((o) => o.value === 'qwen3')).toBe(true);
+    });
+  });
+
+  it('shows the models error when getOllamaModels rejects', async () => {
+    fakeApi.getOllamaModels.mockRejectedValue(new Error('no ollama'));
+    const Wrapper = makeWrapper();
+    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
+    const { findByText } = render(
+      <Wrapper>
+        <OllamaTab state={state} update={vi.fn()} />
+      </Wrapper>,
+    );
+    expect(await findByText(/Failed to load Ollama models/i)).toBeTruthy();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -1,40 +1,33 @@
-import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
 import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import { useServerLog } from '../server-log/ServerLogContext.js';
+import { systemKeys } from '../../../api/queryKeys.js';
 
 const HEALTH_POLL_MS = 10000;
 
-function ping() {
-  return fetch('/api/health?_t=' + Date.now())
-    .then((r) => r.ok ? r.json() : null)
-    .catch(() => null);
+async function ping() {
+  try {
+    const res = await fetch('/api/health?_t=' + Date.now());
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.ok ? data : null;
+  } catch {
+    return null;
+  }
 }
 
-
 export default function ServerSection() {
-  const [health, setHealth] = useState(null);
-  const [status, setStatus] = useState('checking');
-  const healthTimerRef = useRef(null);
-  const cancelledRef = useRef(false);
   const serverLog = useServerLog();
 
-  // Health polling
-  useEffect(() => {
-    cancelledRef.current = false;
+  const { data: health, isLoading } = useQuery({
+    queryKey: [...systemKeys.health(), 'settings-detail'],
+    queryFn: ping,
+    refetchInterval: HEALTH_POLL_MS,
+    refetchOnWindowFocus: false,
+  });
 
-    function tick() {
-      ping().then((d) => {
-        if (cancelledRef.current) return;
-        if (d?.ok) { setHealth(d); setStatus('online'); }
-        else { setHealth(null); setStatus('offline'); }
-        healthTimerRef.current = setTimeout(tick, HEALTH_POLL_MS);
-      });
-    }
-    tick();
-
-    return () => { cancelledRef.current = true; clearTimeout(healthTimerRef.current); };
-  }, []);
+  const status = isLoading && !health ? 'checking' : (health ? 'online' : 'offline');
 
   return (
     <section className="panel settings-section">

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ServerLogContext } from '../server-log/ServerLogContext.js';
+import ServerSection from './ServerSection.jsx';
+
+const stubServerLog = { open: false, openLog: vi.fn(), closeLog: vi.fn() };
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ServerLogContext.Provider value={stubServerLog}>{children}</ServerLogContext.Provider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('ServerSection', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders online and shows server detail when /api/health responds', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, port: 7863, pid: 1234, version: '1.0.6', address: '127.0.0.1' }),
+    });
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getByText('7863')).toBeTruthy();
+      expect(screen.getByText('1234')).toBeTruthy();
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/health'));
+  });
+
+  it('renders offline when /api/health is unreachable', async () => {
+    globalThis.fetch.mockRejectedValue(new Error('net down'));
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Restart/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/hooks/useOllamaServerStatus.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useOllamaServerStatus.js
@@ -1,37 +1,34 @@
-import { useEffect, useRef, useState } from 'react';
+/**
+ * useOllamaServerStatus — TanStack Query poll for Ollama daemon status.
+ *
+ * Polls every 5s and reports { status: 'online' | 'offline', address }.
+ * A fetch rejection is treated as offline.
+ */
+import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { systemKeys } from '../../../api/queryKeys.js';
 
 const POLL_MS = 5000;
 
 export function useOllamaServerStatus() {
   const { getOllamaStatus } = useApi();
-  const [state, setState] = useState(null);
-  const timerRef = useRef(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const { data } = useQuery({
+    queryKey: systemKeys.ollama(),
+    queryFn: async () => {
+      try {
+        const result = await getOllamaStatus();
+        if (result?.running) {
+          return { status: 'online', address: result.address ?? null };
+        }
+        return { status: 'offline', address: null };
+      } catch {
+        return { status: 'offline', address: null };
+      }
+    },
+    refetchInterval: POLL_MS,
+    refetchOnWindowFocus: false,
+  });
 
-    function tick() {
-      getOllamaStatus()
-        .then((data) => {
-          if (cancelled) return;
-          if (data?.running) {
-            setState({ status: 'online', address: data.address ?? null });
-          } else {
-            setState({ status: 'offline', address: null });
-          }
-        })
-        .catch(() => {
-          if (!cancelled) setState({ status: 'offline', address: null });
-        });
-    }
-    tick();
-    timerRef.current = setInterval(tick, POLL_MS);
-    return () => {
-      cancelled = true;
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [getOllamaStatus]);
-
-  return state;
+  return data ?? null;
 }

--- a/src/quodeq/ui/src/features/settings/hooks/useOllamaServerStatus.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useOllamaServerStatus.test.jsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ApiContext } from '../../../api/ApiContext.jsx';
 import { useOllamaServerStatus } from './useOllamaServerStatus.js';
 
@@ -15,16 +16,23 @@ function Probe() {
 }
 
 function renderWithApi(getOllamaStatus) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
   return render(
-    <ApiContext.Provider value={{ getOllamaStatus }}>
-      <Probe />
-    </ApiContext.Provider>
+    <QueryClientProvider client={client}>
+      <ApiContext.Provider value={{ getOllamaStatus }}>
+        <Probe />
+      </ApiContext.Provider>
+    </QueryClientProvider>
   );
 }
 
 describe('useOllamaServerStatus', () => {
-  beforeEach(() => { vi.useFakeTimers(); });
-  afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); });
+  afterEach(() => { vi.restoreAllMocks(); });
 
   it('returns null until the first poll resolves', () => {
     const get = vi.fn(() => new Promise(() => {}));
@@ -36,22 +44,25 @@ describe('useOllamaServerStatus', () => {
   it('returns online status with address when poll succeeds', async () => {
     const get = vi.fn().mockResolvedValue({ running: true, address: 'localhost:11434' });
     renderWithApi(get);
-    await act(async () => { await Promise.resolve(); });
-    expect(screen.getByTestId('status')).toHaveTextContent('online');
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('online');
+    });
     expect(screen.getByTestId('address')).toHaveTextContent('localhost:11434');
   });
 
   it('returns offline status when running=false', async () => {
     const get = vi.fn().mockResolvedValue({ running: false });
     renderWithApi(get);
-    await act(async () => { await Promise.resolve(); });
-    expect(screen.getByTestId('status')).toHaveTextContent('offline');
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('offline');
+    });
   });
 
   it('returns offline when the API call rejects', async () => {
     const get = vi.fn().mockRejectedValue(new Error('boom'));
     renderWithApi(get);
-    await act(async () => { await Promise.resolve(); });
-    expect(screen.getByTestId('status')).toHaveTextContent('offline');
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('offline');
+    });
   });
 });

--- a/src/quodeq/ui/src/features/settings/server-log/ServerLogProvider.test.jsx
+++ b/src/quodeq/ui/src/features/settings/server-log/ServerLogProvider.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SidePaneProvider } from '../../side-pane/index.js';
 import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
 import { ServerLogProvider } from './ServerLogProvider.jsx';
@@ -20,20 +21,26 @@ function Probe() {
 }
 
 function renderWithProviders(ui) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
   return render(
-    <SidePaneProvider>
-      <ServerLogProvider>{ui}</ServerLogProvider>
-    </SidePaneProvider>
+    <QueryClientProvider client={client}>
+      <SidePaneProvider>
+        <ServerLogProvider>{ui}</ServerLogProvider>
+      </SidePaneProvider>
+    </QueryClientProvider>
   );
 }
 
 describe('ServerLogProvider', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ lines: [] }) });
   });
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 

--- a/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.js
+++ b/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.js
@@ -1,4 +1,13 @@
+/**
+ * useServerLogPoll — TanStack Query poll for /api/logs.
+ *
+ * Polls every 2s while `active` is true. The `since` cursor lives in a ref
+ * so the queryKey stays stable (and the refetchInterval ticks regularly);
+ * it is read inside the queryFn and advanced on each successful response.
+ * Toggling `active` resets buffered logs and the cursor.
+ */
 import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 const POLL_MS = 2000;
 const MAX_LINES = 5000;
@@ -14,39 +23,44 @@ export function useServerLogPoll(active) {
   const [logs, setLogs] = useState([]);
   const sinceRef = useRef(-1);
 
+  // Reset when toggling off; on toggle-on the next queryFn picks up since=-1.
   useEffect(() => {
     if (!active) {
       setLogs([]);
       sinceRef.current = -1;
-      return undefined;
+    } else {
+      setLogs([]);
+      sinceRef.current = -1;
     }
-    setLogs([]);
-    sinceRef.current = -1;
-    let cancelled = false;
-    let timer = null;
-
-    function tick() {
-      const url = '/api/logs' + (sinceRef.current >= 0 ? `?since=${sinceRef.current}` : '');
-      fetch(url)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          if (cancelled || !data || !data.lines) return;
-          if (data.lines.length) {
-            const formatted = data.lines.map(format);
-            setLogs((prev) => {
-              const merged = prev.concat(formatted);
-              return merged.length > MAX_LINES ? merged.slice(merged.length - MAX_LINES) : merged;
-            });
-            sinceRef.current = data.lines[data.lines.length - 1].index;
-          }
-          if (!cancelled) timer = setTimeout(tick, POLL_MS);
-        })
-        .catch(() => { if (!cancelled) timer = setTimeout(tick, POLL_MS); });
-    }
-    tick();
-
-    return () => { cancelled = true; if (timer) clearTimeout(timer); };
   }, [active]);
+
+  useQuery({
+    queryKey: ['system', 'serverLog'],
+    enabled: !!active,
+    queryFn: async () => {
+      const since = sinceRef.current;
+      const url = '/api/logs' + (since >= 0 ? `?since=${since}` : '');
+      const r = await fetch(url);
+      if (!r.ok) return null;
+      const data = await r.json();
+      if (!data || !data.lines) return null;
+      if (data.lines.length) {
+        const formatted = data.lines.map(format);
+        setLogs((prev) => {
+          const merged = prev.concat(formatted);
+          return merged.length > MAX_LINES ? merged.slice(merged.length - MAX_LINES) : merged;
+        });
+        sinceRef.current = data.lines[data.lines.length - 1].index;
+      }
+      // Return a tick value so TanStack treats the query as fresh data
+      // (avoids dedupe/stale-cache surprises across re-renders).
+      return { at: Date.now(), count: data.lines.length };
+    },
+    refetchInterval: POLL_MS,
+    refetchOnWindowFocus: false,
+    // Swallow fetch errors silently — original implementation just retried.
+    retry: false,
+  });
 
   return { logs };
 }

--- a/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.test.jsx
+++ b/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useServerLogPoll } from './useServerLogPoll.js';
 
 function Probe({ active }) {
@@ -8,13 +9,25 @@ function Probe({ active }) {
   return <div data-testid="logs">{logs.join('|')}</div>;
 }
 
+function renderProbe(active) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <Probe active={active} />
+    </QueryClientProvider>
+  );
+}
+
 describe('useServerLogPoll', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     globalThis.fetch = vi.fn();
   });
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -26,7 +39,7 @@ describe('useServerLogPoll', () => {
   }
 
   it('does not fetch when inactive', () => {
-    render(<Probe active={false} />);
+    renderProbe(false);
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
@@ -37,20 +50,32 @@ describe('useServerLogPoll', () => {
         { index: 2, timestamp: '2026-04-29T10:00:06.000Z', line: 'second' },
       ],
     });
-    render(<Probe active />);
-    await act(async () => { await Promise.resolve(); });
+    // Subsequent polls return empty so the test stays deterministic.
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lines: [] }),
+    });
+    renderProbe(true);
+    await waitFor(() => {
+      expect(screen.getByTestId('logs')).toHaveTextContent('[10:00:05] first|[10:00:06] second');
+    });
     expect(globalThis.fetch).toHaveBeenCalledWith('/api/logs');
-    expect(screen.getByTestId('logs')).toHaveTextContent('[10:00:05] first|[10:00:06] second');
   });
 
   it('passes since on subsequent polls and accumulates lines', async () => {
     mockFetchOnce({ lines: [{ index: 5, timestamp: '2026-04-29T10:00:05.000Z', line: 'a' }] });
     mockFetchOnce({ lines: [{ index: 7, timestamp: '2026-04-29T10:00:07.000Z', line: 'b' }] });
-    render(<Probe active />);
-    await act(async () => { await Promise.resolve(); });
-    await act(async () => { vi.advanceTimersByTime(2000); await Promise.resolve(); });
-    expect(globalThis.fetch).toHaveBeenLastCalledWith('/api/logs?since=5');
-    expect(screen.getByTestId('logs')).toHaveTextContent('[10:00:05] a|[10:00:07] b');
+    // Padding for any extra polls before assertion.
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lines: [] }),
+    });
+    renderProbe(true);
+    await waitFor(() => {
+      expect(screen.getByTestId('logs')).toHaveTextContent('[10:00:05] a|[10:00:07] b');
+    }, { timeout: 4000 });
+    // The second poll passes since=5 (the cursor advanced after 'a' arrived).
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(2, '/api/logs?since=5');
   });
 
   it('caps the buffer at 5000 lines, dropping from the front', async () => {
@@ -58,25 +83,70 @@ describe('useServerLogPoll', () => {
       index: i, timestamp: '', line: `L${i}`,
     }));
     mockFetchOnce({ lines });
-    render(<Probe active />);
-    await act(async () => { await Promise.resolve(); });
-    const text = screen.getByTestId('logs').textContent;
-    const arr = text.split('|');
-    expect(arr.length).toBe(5000);
-    expect(arr[0]).toBe('L50');
-    expect(arr[arr.length - 1]).toBe('L5049');
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lines: [] }),
+    });
+    renderProbe(true);
+    await waitFor(() => {
+      const text = screen.getByTestId('logs').textContent;
+      const arr = text.split('|');
+      expect(arr.length).toBe(5000);
+      expect(arr[0]).toBe('L50');
+      expect(arr[arr.length - 1]).toBe('L5049');
+    });
   });
 
   it('toggling active off then on resets state', async () => {
     mockFetchOnce({ lines: [{ index: 1, timestamp: '', line: 'old' }] });
-    const { rerender } = render(<Probe active />);
-    await act(async () => { await Promise.resolve(); });
-    expect(screen.getByTestId('logs')).toHaveTextContent('old');
-    await act(async () => { rerender(<Probe active={false} />); });
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lines: [] }),
+    });
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <Probe active />
+      </QueryClientProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('logs')).toHaveTextContent('old');
+    });
+    await act(async () => {
+      rerender(
+        <QueryClientProvider client={client}>
+          <Probe active={false} />
+        </QueryClientProvider>
+      );
+    });
     expect(screen.getByTestId('logs')).toBeEmptyDOMElement();
+
+    globalThis.fetch.mockReset();
     mockFetchOnce({ lines: [{ index: 9, timestamp: '', line: 'new' }] });
-    rerender(<Probe active />);
-    await act(async () => { await Promise.resolve(); });
-    expect(screen.getByTestId('logs')).toHaveTextContent('new');
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lines: [] }),
+    });
+    rerender(
+      <QueryClientProvider client={client}>
+        <Probe active />
+      </QueryClientProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('logs')).toHaveTextContent('new');
+    });
+  });
+
+  it('handles fetch rejection without throwing', async () => {
+    globalThis.fetch.mockRejectedValue(new Error('boom'));
+    renderProbe(true);
+    // Wait long enough for at least one poll; logs should remain empty.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByTestId('logs')).toBeEmptyDOMElement();
   });
 });

--- a/src/quodeq/ui/src/features/standards/components/LibraryBrowser.jsx
+++ b/src/quodeq/ui/src/features/standards/components/LibraryBrowser.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLibrary } from '../hooks/useLibrary.js';
 
 function LibraryCard({ standard, onImport, importing }) {
@@ -37,10 +37,7 @@ function LibraryCard({ standard, onImport, importing }) {
 }
 
 export default function LibraryBrowser({ onClose, onImported }) {
-  const { libraryStandards, loading, error, fetchLibrary, importStandard } = useLibrary();
-
-  useEffect(() => { fetchLibrary(); }, [fetchLibrary]);
-
+  const { libraryStandards, loading, error, importStandard } = useLibrary();
   const [importError, setImportError] = useState(null);
 
   const handleImport = async (file) => {

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { standardsKeys } from '../../../api/queryKeys.js';
 
 const EDITABLE_REF_TYPES = ['cwe', 'book', 'url', 'other'];
 const BUILTIN_REF_TYPES = ['cwe', 'asvs', 'cert', 'cisq', 'wcag22'];
@@ -68,13 +70,19 @@ function CweFilterBar({ searchRef, query, setQuery, filterAbstraction, setFilter
 
 function CweBrowserModal({ onSelect, onClose }) {
   const { listCwes } = useApi();
-  const [cwes, setCwes] = useState([]);
-  const [cweError, setCweError] = useState(null);
   const [query, setQuery] = useState('');
   const [filterAbstraction, setFilterAbstraction] = useState('');
   const searchRef = useRef(null);
 
-  useEffect(() => { listCwes().then((data) => { setCwes(data); setCweError(null); }).catch(() => { setCwes([]); setCweError('Failed to load CWE list. Check your connection and try again.'); }); }, [listCwes]);
+  const { data: cwesData, error: cwesQueryError } = useQuery({
+    queryKey: standardsKeys.cwes(),
+    queryFn: () => listCwes(),
+  });
+  const cwes = cwesData || [];
+  const cweError = cwesQueryError
+    ? 'Failed to load CWE list. Check your connection and try again.'
+    : null;
+
   useEffect(() => { if (searchRef.current) searchRef.current.focus(); }, []);
 
   const filtered = useMemo(() => cwes.filter((c) => {

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.test.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import ReferenceEditor from './ReferenceEditor.jsx';
+
+const fakeApi = {
+  listCwes: vi.fn(),
+};
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('ReferenceEditor / CweBrowserModal', () => {
+  beforeEach(() => {
+    fakeApi.listCwes.mockReset();
+  });
+
+  it('loads CWEs when the browser modal opens', async () => {
+    fakeApi.listCwes.mockResolvedValue([
+      { id: 79, name: 'XSS', abstraction: 'Base' },
+      { id: 89, name: 'SQL Injection', abstraction: 'Base' },
+    ]);
+    const Wrapper = makeWrapper();
+    const refs = [{ type: 'cwe', refId: '', name: '', url: '' }];
+    const onChange = vi.fn();
+    render(
+      <Wrapper>
+        <ReferenceEditor refs={refs} onChange={onChange} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByText('Select CWE...'));
+    await waitFor(() => {
+      expect(fakeApi.listCwes).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('XSS')).toBeTruthy();
+      expect(screen.getByText('SQL Injection')).toBeTruthy();
+    });
+  });
+
+  it('shows the CWE error banner when listCwes rejects', async () => {
+    fakeApi.listCwes.mockRejectedValue(new Error('cwe down'));
+    const Wrapper = makeWrapper();
+    const refs = [{ type: 'cwe', refId: '', name: '', url: '' }];
+    const onChange = vi.fn();
+    render(
+      <Wrapper>
+        <ReferenceEditor refs={refs} onChange={onChange} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByText('Select CWE...'));
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load CWE list/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
@@ -1,31 +1,30 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { listLibrary, importFromLibrary } from '../../../api/index.js';
+import { standardsKeys } from '../../../api/queryKeys.js';
 
 export function useLibrary() {
-  const [libraryStandards, setLibraryStandards] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [importError, setImportError] = useState(null);
 
-  const fetchLibrary = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await listLibrary();
-      setLibraryStandards(data);
-      setError(null);
-    }
-    catch (err) { setError(err.message); }
-    finally { setLoading(false); }
-  }, []);
+  const { data, isLoading, error } = useQuery({
+    queryKey: standardsKeys.library(),
+    queryFn: () => listLibrary(),
+  });
 
   const importStandard = useCallback(async (filePath) => {
     try {
       await importFromLibrary(filePath);
-      setError(null);
+      setImportError(null);
     } catch (err) {
-      setError(err.message || 'Failed to import standard');
+      setImportError(err.message || 'Failed to import standard');
       throw err;
     }
   }, []);
 
-  return { libraryStandards, loading, error, fetchLibrary, importStandard };
+  return {
+    libraryStandards: data || [],
+    loading: isLoading,
+    error: importError || (error ? error.message : null),
+    importStandard,
+  };
 }

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+
+vi.mock('../../../api/index.js', () => ({
+  listLibrary: vi.fn(),
+  importFromLibrary: vi.fn(),
+}));
+
+import { listLibrary, importFromLibrary } from '../../../api/index.js';
+import { useLibrary } from './useLibrary.js';
+
+describe('useLibrary', () => {
+  beforeEach(() => {
+    listLibrary.mockReset();
+    importFromLibrary.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads the library list on mount', async () => {
+    listLibrary.mockResolvedValue([
+      { id: 's1', name: 'Standard 1' },
+      { id: 's2', name: 'Standard 2' },
+    ]);
+    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current.libraryStandards).toHaveLength(2);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes the error message when listLibrary fails', async () => {
+    listLibrary.mockRejectedValue(new Error('library down'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current.error).toBe('library down');
+    });
+  });
+
+  it('importStandard surfaces the import error and re-throws', async () => {
+    listLibrary.mockResolvedValue([]);
+    importFromLibrary.mockRejectedValue(new Error('cannot import'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let thrown = null;
+    await act(async () => {
+      try {
+        await result.current.importStandard('foo.yaml');
+      } catch (err) {
+        thrown = err;
+      }
+    });
+    expect(thrown?.message).toBe('cannot import');
+    expect(result.current.error).toBe('cannot import');
+  });
+});

--- a/src/quodeq/ui/src/features/standards/hooks/useStandards.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandards.js
@@ -1,40 +1,46 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
+import { standardsKeys } from '../../../api/queryKeys.js';
 
 export const STANDARD_TYPES = { BUILTIN: 'builtin', QUODEQ: 'quodeq', COMMUNITY: 'community', CUSTOM: 'custom' };
 
 export function useStandards() {
   const { listStandards, deleteStandard, duplicateStandard } = useApi();
-  const [standards, setStandards] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const queryClient = useQueryClient();
+  const [mutationError, setMutationError] = useState(null);
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: standardsKeys.list(),
+    queryFn: () => listStandards(),
+  });
+
+  const standards = data || [];
 
   const refresh = useCallback(() => {
-    setLoading(true);
-    listStandards()
-      .then((data) => { setStandards(data); setError(null); })
-      .catch((err) => setError(err.message))
-      .finally(() => setLoading(false));
-  }, []);
-
-  useEffect(() => { refresh(); }, [refresh]);
+    queryClient.invalidateQueries({ queryKey: standardsKeys.list() });
+    return refetch();
+  }, [queryClient, refetch]);
 
   const handleDelete = useCallback(async (id) => {
     try {
       await deleteStandard(id);
-      refresh();
+      setMutationError(null);
+      await refresh();
     } catch (err) {
-      setError(err.message || 'Failed to delete standard');
+      setMutationError(err.message || 'Failed to delete standard');
     }
-  }, [refresh]);
+  }, [deleteStandard, refresh]);
+
   const handleDuplicate = useCallback(async (id, newId) => {
     try {
       await duplicateStandard(id, newId);
-      refresh();
+      setMutationError(null);
+      await refresh();
     } catch (err) {
-      setError(err.message || 'Failed to duplicate standard');
+      setMutationError(err.message || 'Failed to duplicate standard');
     }
-  }, [refresh]);
+  }, [duplicateStandard, refresh]);
 
   const grouped = useMemo(() => {
     const g = {
@@ -49,5 +55,15 @@ export function useStandards() {
     return g;
   }, [standards]);
 
-  return { standards, grouped, loading, error, refresh, handleDelete, handleDuplicate };
+  const combinedError = mutationError || (error ? error.message : null);
+
+  return {
+    standards,
+    grouped,
+    loading: isLoading,
+    error: combinedError,
+    refresh,
+    handleDelete,
+    handleDuplicate,
+  };
 }

--- a/src/quodeq/ui/src/features/standards/hooks/useStandards.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useStandards.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { useStandards, STANDARD_TYPES } from './useStandards.js';
+
+const fakeApi = {
+  listStandards: vi.fn(),
+  deleteStandard: vi.fn(),
+  duplicateStandard: vi.fn(),
+};
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('useStandards', () => {
+  beforeEach(() => {
+    Object.values(fakeApi).forEach((fn) => fn.mockReset());
+  });
+
+  it('fetches standards on mount and groups them by type', async () => {
+    fakeApi.listStandards.mockResolvedValue([
+      { id: 'a', name: 'A', type: STANDARD_TYPES.BUILTIN },
+      { id: 'b', name: 'B', type: STANDARD_TYPES.CUSTOM },
+      { id: 'c', name: 'C', type: STANDARD_TYPES.CUSTOM },
+    ]);
+    const { result } = renderHook(() => useStandards(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.standards).toHaveLength(3);
+    });
+    expect(result.current.grouped[STANDARD_TYPES.BUILTIN]).toHaveLength(1);
+    expect(result.current.grouped[STANDARD_TYPES.CUSTOM]).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('exposes the error message when listStandards rejects', async () => {
+    fakeApi.listStandards.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useStandards(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.error).toBe('boom');
+    });
+  });
+
+  it('handleDelete calls deleteStandard and refreshes', async () => {
+    fakeApi.listStandards.mockResolvedValue([{ id: 'a', name: 'A', type: STANDARD_TYPES.CUSTOM }]);
+    fakeApi.deleteStandard.mockResolvedValue({});
+    const { result } = renderHook(() => useStandards(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.standards).toHaveLength(1));
+    await act(async () => {
+      await result.current.handleDelete('a');
+    });
+    expect(fakeApi.deleteStandard).toHaveBeenCalledWith('a');
+    // refresh triggers a refetch
+    expect(fakeApi.listStandards.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handleDelete surfaces the mutation error', async () => {
+    fakeApi.listStandards.mockResolvedValue([]);
+    fakeApi.deleteStandard.mockRejectedValue(new Error('cannot delete'));
+    const { result } = renderHook(() => useStandards(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.handleDelete('a');
+    });
+    expect(result.current.error).toBe('cannot delete');
+  });
+});

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -59,11 +59,3 @@ export function useProjectScores({ selectedProject, selectedRun }) {
     refreshScores,
   };
 }
-
-// Deprecation shim — Task 9 removes its last consumer (useDashboard.js).
-export function clearScoresCache(_project) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    "clearScoresCache is deprecated; use queryClient.invalidateQueries(projectKeys.project(project)).",
-  );
-}

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -1,141 +1,69 @@
 /**
  * useProjectScores -- single hook for all score data.
  *
- * Fetches from the unified /scores endpoint which returns pre-rescored data.
- * No client-side rescore calls. One source of truth consumed by Overview,
- * History, Explorer, etc.
+ * Two queries: scores at a specific run (when asOf is set), plus latest
+ * scores. TanStack Query handles caching, abort, and refresh.
+ *
+ * To force a refresh after a mutation (dismiss/restore), call:
+ *   queryClient.invalidateQueries({ queryKey: projectKeys.project(p) });
  */
-
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { getProjectScores } from '../api/index.js';
-
-const REFRESH_DEBOUNCE_MS = 300;
-
-// Cache by (project, asOf) to avoid refetching on view changes.
-// Cleared by clearScoresCache() when mutations happen (dismiss/restore).
-const MAX_CACHE_SIZE = 100;
-const _cache = new Map();
-function _cacheKey(project, asOf) { return `${project}\0${asOf || 'all'}`; }
-
-export function clearScoresCache(project) {
-  if (project) {
-    for (const key of [..._cache.keys()]) {
-      if (key.startsWith(project + '\0')) _cache.delete(key);
-    }
-  } else {
-    _cache.clear();
-  }
-}
-
-/**
- * @param {{ selectedProject: string, selectedRun: string }} opts
- * @returns {{
- *   scores: { accumulated: Object, trend: Array, availableRuns: Array } | null,
- *   latestScores: { accumulated: Object, trend: Array, availableRuns: Array } | null,
- *   loading: boolean,
- *   error: string | null,
- *   availableRuns: Array,
- *   refreshScores: () => void,
- * }}
- */
-function fetchRunScoresEffect(selectedProject, selectedRun, setScores, setLoading, setError) {
-  if (!selectedProject) { setScores(null); setError(null); return; }
-  const asOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
-  const key = _cacheKey(selectedProject, asOf);
-  const cached = _cache.get(key);
-  if (cached) {
-    setScores(cached);
-    setLoading(false);
-    return;
-  }
-
-  let active = true;
-  setLoading(true);
-  getProjectScores(selectedProject, asOf)
-    .then((data) => {
-      if (!active) return;
-      if (_cache.size >= MAX_CACHE_SIZE) _cache.delete(_cache.keys().next().value);
-      _cache.set(key, data);
-      setScores(data);
-    })
-    .catch(() => { if (active) setError('Failed to load score data. Check your connection and try refreshing.'); })
-    .finally(() => { if (active) setLoading(false); });
-  return () => { active = false; };
-}
-
-function fetchLatestScoresEffect(selectedProject, setLatestScores) {
-  if (!selectedProject) { setLatestScores(null); return; }
-  const key = _cacheKey(selectedProject, null);
-  const cached = _cache.get(key);
-  if (cached) {
-    setLatestScores(cached);
-    return;
-  }
-
-  let active = true;
-  getProjectScores(selectedProject)
-    .then((data) => {
-      if (!active) return;
-      if (_cache.size >= MAX_CACHE_SIZE) _cache.delete(_cache.keys().next().value);
-      _cache.set(key, data);
-      setLatestScores(data);
-    })
-    .catch(() => {}); // non-fatal for latest
-  return () => { active = false; };
-}
-
-function syncScoresOnChange(prevProjectRef, prevRunRef, selectedProject, selectedRun, setScores, setLatestScores, setError) {
-  if (prevProjectRef.current !== selectedProject) {
-    prevProjectRef.current = selectedProject;
-    prevRunRef.current = selectedRun;
-    setScores(null);
-    setLatestScores(null);
-    setError(null);
-  } else if (prevRunRef.current !== selectedRun) {
-    prevRunRef.current = selectedRun;
-    const asOf = selectedRun && selectedRun !== 'latest' ? selectedRun : null;
-    const cached = _cache.get(_cacheKey(selectedProject, asOf));
-    if (cached) setScores(cached);
-  }
-}
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getProjectScores } from "../api/index.js";
+import { projectKeys } from "../api/queryKeys.js";
 
 export function useProjectScores({ selectedProject, selectedRun }) {
-  const [scores, setScores] = useState(null);
-  const [latestScores, setLatestScores] = useState(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const queryClient = useQueryClient();
+  const asOf = selectedRun && selectedRun !== "latest" ? selectedRun : null;
 
-  const prevProjectRef = useRef(selectedProject);
-  const prevRunRef = useRef(selectedRun);
-  syncScoresOnChange(prevProjectRef, prevRunRef, selectedProject, selectedRun, setScores, setLatestScores, setError);
+  const scoresQuery = useQuery({
+    queryKey: projectKeys.scores(selectedProject || "_none_", asOf),
+    queryFn: () => getProjectScores(selectedProject, asOf),
+    enabled: !!selectedProject,
+    staleTime: 60_000,
+  });
 
-  useEffect(() => {
-    return fetchRunScoresEffect(selectedProject, selectedRun, setScores, setLoading, setError);
-  }, [selectedProject, selectedRun, refreshKey]);
-
-  useEffect(() => {
-    return fetchLatestScoresEffect(selectedProject, setLatestScores);
-  }, [selectedProject, refreshKey]);
+  const latestQuery = useQuery({
+    queryKey: projectKeys.scores(selectedProject || "_none_", null),
+    queryFn: () => getProjectScores(selectedProject),
+    enabled: !!selectedProject,
+    staleTime: 60_000,
+  });
 
   const availableRuns = useMemo(() => {
-    // Prefer availableRuns from the scores payload (includes in_progress runs not in trend).
-    // Fall back to deriving from trend entries (which only contain completed runs).
-    const fromPayload = scores?.availableRuns || latestScores?.availableRuns;
+    const fromPayload =
+      scoresQuery.data?.availableRuns || latestQuery.data?.availableRuns;
     if (fromPayload && fromPayload.length > 0) return fromPayload;
-    const trend = scores?.trend || latestScores?.trend || [];
-    if (trend.length === 0) return [];
-    return trend.map((row) => ({ runId: row.runId, dateLabel: row.dateLabel || row.runId, status: 'complete' }));
-  }, [scores, latestScores]);
+    const trend = scoresQuery.data?.trend || latestQuery.data?.trend || [];
+    return trend.map((row) => ({
+      runId: row.runId,
+      dateLabel: row.dateLabel || row.runId,
+      status: "complete",
+    }));
+  }, [scoresQuery.data, latestQuery.data]);
 
-  const refreshTimerRef = useRef(null);
   const refreshScores = useCallback(() => {
-    clearScoresCache(selectedProject);
-    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-    refreshTimerRef.current = setTimeout(() => setRefreshKey((k) => k + 1), REFRESH_DEBOUNCE_MS);
-  }, [selectedProject]);
+    if (!selectedProject) return;
+    queryClient.invalidateQueries({ queryKey: projectKeys.project(selectedProject) });
+  }, [queryClient, selectedProject]);
 
-  useEffect(() => () => { if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current); }, []);
+  return {
+    scores: scoresQuery.data ?? null,
+    latestScores: latestQuery.data ?? null,
+    loading: scoresQuery.isLoading || latestQuery.isLoading,
+    error:
+      (scoresQuery.isError || latestQuery.isError)
+        ? "Failed to load score data. Check your connection and try refreshing."
+        : null,
+    availableRuns,
+    refreshScores,
+  };
+}
 
-  return { scores, latestScores, loading, error, availableRuns, refreshScores };
+// Deprecation shim — Task 9 removes its last consumer (useDashboard.js).
+export function clearScoresCache(_project) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "clearScoresCache is deprecated; use queryClient.invalidateQueries(projectKeys.project(project)).",
+  );
 }

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useProjectScores } from "./useProjectScores";
+import { withQueryClient } from "../test-utils/withQueryClient.jsx";
+
+vi.mock("../api/index.js", () => ({
+  getProjectScores: vi.fn(async (project, asOf) => {
+    if (asOf) {
+      return {
+        accumulated: { score: 80 },
+        trend: [{ runId: asOf }],
+        availableRuns: [],
+      };
+    }
+    return {
+      accumulated: { score: 90 },
+      trend: [],
+      availableRuns: [{ runId: "r1" }],
+    };
+  }),
+}));
+
+describe("useProjectScores", () => {
+  it("returns null when project is empty", () => {
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "", selectedRun: null }),
+      { wrapper: withQueryClient() },
+    );
+    expect(result.current.scores).toBeNull();
+    expect(result.current.latestScores).toBeNull();
+  });
+
+  it("fetches scores for the selected run + latest in parallel", async () => {
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: "r9" }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current.scores?.accumulated?.score).toBe(80);
+      expect(result.current.latestScores?.accumulated?.score).toBe(90);
+    });
+  });
+
+  it("derives availableRuns from the scores payload", async () => {
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current.availableRuns).toEqual([{ runId: "r1" }]);
+    });
+  });
+});

--- a/src/quodeq/ui/src/hooks/useServerHealth.js
+++ b/src/quodeq/ui/src/hooks/useServerHealth.js
@@ -1,59 +1,82 @@
-import { useState, useEffect } from 'react';
+/**
+ * useServerHealth — TanStack Query-based connectivity poll.
+ *
+ * Polls the server every 5s. When the primary endpoint is unreachable,
+ * probes alternate quodeq ports (4180-4183) and redirects if the server
+ * has moved. Otherwise reports disconnected.
+ *
+ * Returns [serverConnected, setServerConnected] for backward compatibility.
+ * setServerConnected(true) lets the reconnect overlay optimistically clear
+ * the disconnected state until the next successful poll.
+ */
+import { useCallback, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { getHealth } from '../api/index.js';
 import { SERVER_BASE_URL } from '../config.js';
+import { systemKeys } from '../api/queryKeys.js';
 
-/**
- * Monitors server connectivity, polling every 5 seconds.
- * When the server is unreachable on the current origin, checks alternate ports
- * and redirects if the server has moved.
- *
- * Returns [serverConnected, setServerConnected].
- */
-// Standard quodeq port range (4180-4183). The server picks the first
-// available port; the client probes alternates when the current one drops.
 const DEFAULT_ALT_PORTS = [4180, 4181, 4182, 4183];
 const HEALTH_CHECK_TIMEOUT_MS = 2000;
 const HEALTH_POLL_INTERVAL_MS = 5000;
 const HEALTH_ENDPOINT = '/api/health';
 
+async function probeAltPort(port, baseUrl) {
+  const ac = new AbortController();
+  const tid = setTimeout(() => ac.abort(), HEALTH_CHECK_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl}:${port}${HEALTH_ENDPOINT}`, { signal: ac.signal });
+    clearTimeout(tid);
+    return res.ok ? port : null;
+  } catch {
+    clearTimeout(tid);
+    return null;
+  }
+}
+
+async function tryFindPort(candidates, baseUrl) {
+  const results = await Promise.allSettled(candidates.map((p) => probeAltPort(p, baseUrl)));
+  const found = results.find((r) => r.status === 'fulfilled' && r.value !== null);
+  return found ? found.value : null;
+}
+
 export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER_BASE_URL } = {}) {
-  const [serverConnected, setServerConnected] = useState(true);
+  // Local override pinned to a specific dataUpdatedAt. setServerConnected(true)
+  // optimistically clears the disconnect overlay; once a fresh poll comes
+  // in (newer dataUpdatedAt) the override is dropped and the query value wins.
+  const [override, setOverride] = useState(null);
 
-  useEffect(() => {
-    let mounted = true;
-
-    async function tryFindPort(candidates) {
-      const results = await Promise.allSettled(
-        candidates.map(async (port) => {
-          const ac = new AbortController();
-          const tid = setTimeout(() => ac.abort(), HEALTH_CHECK_TIMEOUT_MS);
-          try {
-            const res = await fetch(`${baseUrl}:${port}${HEALTH_ENDPOINT}`, { signal: ac.signal });
-            clearTimeout(tid);
-            if (res.ok) return port;
-          } catch { clearTimeout(tid); return null; }
-          return null;
-        })
-      );
-      const found = results.find(r => r.status === 'fulfilled' && r.value !== null);
-      return found ? found.value : null;
-    }
-
-    async function checkHealth() {
+  const { data, dataUpdatedAt } = useQuery({
+    queryKey: systemKeys.health(),
+    queryFn: async () => {
       try {
         await getHealth();
-        if (mounted) setServerConnected(true);
+        return true;
       } catch {
-        const currentPort = window.location.port;
-        const foundPort = await tryFindPort(altPorts.filter(p => String(p) !== currentPort));
-        if (foundPort) { window.location.href = `${baseUrl}:${foundPort}`; return; }
-        if (mounted) setServerConnected(false);
+        const currentPort = typeof window !== 'undefined' ? window.location.port : '';
+        const foundPort = await tryFindPort(
+          altPorts.filter((p) => String(p) !== currentPort),
+          baseUrl,
+        );
+        if (foundPort && typeof window !== 'undefined') {
+          window.location.href = `${baseUrl}:${foundPort}`;
+          // Treat redirect as still-connected to avoid an overlay flash
+          // before the page navigates away.
+          return true;
+        }
+        return false;
       }
-    }
-    checkHealth();
-    const interval = setInterval(checkHealth, HEALTH_POLL_INTERVAL_MS);
-    return () => { mounted = false; clearInterval(interval); };
+    },
+    refetchInterval: HEALTH_POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  const setServerConnected = useCallback((next) => {
+    setOverride({ value: Boolean(next), at: Date.now() });
   }, []);
 
-  return [serverConnected, setServerConnected];
+  // The override wins only while it is newer than the latest poll.
+  const overrideActive = override !== null && override.at > dataUpdatedAt;
+  const effective = overrideActive ? override.value : (data ?? true);
+
+  return [effective, setServerConnected];
 }

--- a/src/quodeq/ui/src/hooks/useServerHealth.js
+++ b/src/quodeq/ui/src/hooks/useServerHealth.js
@@ -40,16 +40,17 @@ async function tryFindPort(candidates, baseUrl) {
 }
 
 export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER_BASE_URL } = {}) {
-  // Local override pinned to a specific dataUpdatedAt. setServerConnected(true)
-  // optimistically clears the disconnect overlay; once a fresh poll comes
-  // in (newer dataUpdatedAt) the override is dropped and the query value wins.
-  const [override, setOverride] = useState(null);
+  // Local state is the source of truth for callers. The query side-effects
+  // it on each poll resolution. setServerConnected(true) lets the reconnect
+  // overlay optimistically clear the disconnected state until the next poll.
+  const [connected, setConnected] = useState(true);
 
-  const { data, dataUpdatedAt } = useQuery({
+  useQuery({
     queryKey: systemKeys.health(),
     queryFn: async () => {
       try {
         await getHealth();
+        setConnected(true);
         return true;
       } catch {
         const currentPort = typeof window !== 'undefined' ? window.location.port : '';
@@ -61,8 +62,10 @@ export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER
           window.location.href = `${baseUrl}:${foundPort}`;
           // Treat redirect as still-connected to avoid an overlay flash
           // before the page navigates away.
+          setConnected(true);
           return true;
         }
+        setConnected(false);
         return false;
       }
     },
@@ -71,12 +74,8 @@ export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER
   });
 
   const setServerConnected = useCallback((next) => {
-    setOverride({ value: Boolean(next), at: Date.now() });
+    setConnected(Boolean(next));
   }, []);
 
-  // The override wins only while it is newer than the latest poll.
-  const overrideActive = override !== null && override.at > dataUpdatedAt;
-  const effective = overrideActive ? override.value : (data ?? true);
-
-  return [effective, setServerConnected];
+  return [connected, setServerConnected];
 }

--- a/src/quodeq/ui/src/hooks/useServerHealth.test.jsx
+++ b/src/quodeq/ui/src/hooks/useServerHealth.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { withQueryClient } from '../test-utils/withQueryClient.jsx';
+
+vi.mock('../api/index.js', () => ({
+  getHealth: vi.fn(),
+}));
+
+import { getHealth } from '../api/index.js';
+import { useServerHealth } from './useServerHealth.js';
+
+describe('useServerHealth', () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports connected when getHealth resolves', async () => {
+    getHealth.mockResolvedValue({ ok: true });
+    const { result } = renderHook(() => useServerHealth(), { wrapper: withQueryClient() });
+    await waitFor(() => {
+      expect(result.current[0]).toBe(true);
+    });
+  });
+
+  it('reports disconnected when getHealth rejects and no alt port responds', async () => {
+    getHealth.mockRejectedValue(new Error('boom'));
+    globalThis.fetch.mockRejectedValue(new Error('also boom'));
+    const { result } = renderHook(
+      () => useServerHealth({ altPorts: [4180], baseUrl: 'http://localhost' }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current[0]).toBe(false);
+    });
+  });
+
+  it('exposes setServerConnected for optimistic reconnect', async () => {
+    getHealth.mockResolvedValue({ ok: true });
+    const { result } = renderHook(() => useServerHealth(), { wrapper: withQueryClient() });
+    await waitFor(() => expect(result.current[0]).toBe(true));
+    act(() => {
+      result.current[1](false);
+    });
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -4,6 +4,8 @@ import App from './App.jsx';
 import './styles/index.css';
 import { resolveDataTheme } from './utils/themeResolver.js';
 import { ApiProvider } from './api/ApiContext.jsx';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './api/queryClient.js';
 
 const LS_THEME = 'cc-theme';
 const LS_THEME_MODE = 'cc-theme-mode';
@@ -81,5 +83,9 @@ window.addEventListener('pywebviewready', markWebview);
 const rootEl = document.getElementById('root');
 if (!rootEl) throw new Error('Root element #root not found in DOM');
 createRoot(rootEl).render(
-  <React.StrictMode><ApiProvider><App /></ApiProvider></React.StrictMode>
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <ApiProvider><App /></ApiProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
 );

--- a/src/quodeq/ui/src/test-utils/withQueryClient.jsx
+++ b/src/quodeq/ui/src/test-utils/withQueryClient.jsx
@@ -1,0 +1,24 @@
+/**
+ * Test wrapper providing a fresh QueryClient per test.
+ *
+ * Usage:
+ *   import { withQueryClient } from '../test-utils/withQueryClient.jsx';
+ *   const { result } = renderHook(() => useFoo(), { wrapper: withQueryClient() });
+ *
+ * The fresh client uses retry: false and gcTime: 0 for determinism —
+ * tests don't share cache state and failing queries fail fast.
+ */
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function withQueryClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}

--- a/src/quodeq/ui/src/test-utils/withQueryClient.test.jsx
+++ b/src/quodeq/ui/src/test-utils/withQueryClient.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { withQueryClient } from "./withQueryClient";
+
+describe("withQueryClient", () => {
+  it("provides a QueryClient that resolves a queryFn", async () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(
+      () => useQuery({ queryKey: ["t"], queryFn: () => Promise.resolve(42) }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.data).toBe(42));
+  });
+
+  it("returns a fresh wrapper each call (no state leak between tests)", () => {
+    const wrapperA = withQueryClient();
+    const wrapperB = withQueryClient();
+    expect(wrapperA).not.toBe(wrapperB);
+  });
+
+  it("disables retries so failing queryFns surface errors immediately", async () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(
+      () => useQuery({
+        queryKey: ["err"],
+        queryFn: () => Promise.reject(new Error("boom")),
+      }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/quodeq/ui/vite.config.js
+++ b/src/quodeq/ui/vite.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
           'vendor-react': ['react', 'react-dom'],
           'vendor-d3': ['d3-hierarchy'],
           'vendor-markdown': ['react-markdown', 'remark-gfm'],
+          'vendor-tanstack-query': ['@tanstack/react-query', '@tanstack/react-query-devtools'],
         },
       },
     },


### PR DESCRIPTION
## Summary

- Adopts `@tanstack/react-query` as the dashboard's server-state cache. Singleton `QueryClient` mounted in `main.jsx` outside `ApiProvider`. Dev-only `<ReactQueryDevtools>` gated on `import.meta.env.DEV` (zero bytes in production).
- All major fetch hooks migrated. Dramatic line-count reductions across the board:
  - `useEvaluation` (339 → ~150 lines, with restored `preparePayload` Settings merge and discard-on-cancel)
  - `useProjectScores` (141 → 67) — manual `_cache: Map` + LRU eviction deleted
  - `useDashboard` (117 → 56) — manual `_runCache` + abort-flag plumbing deleted
  - `useServerHealth`, `useOllamaServerStatus`, `useServerLogPoll` — all converted to `useQuery({ refetchInterval })`
  - 7 component-local fetch sites swept (`useScanData`, `useStandards`, `useLibrary`, `ServerSection`, `CliProviderTab`, `OllamaTab`, `CweBrowserModal`, `ScanProgress`)
- **Plan 2's `useRunEventStream` rewritten as a thin cache writer.** Each SSE event calls `queryClient.setQueryData(...)` instead of holding `useState`. A `cancelQueries(...)` defensive call before each write prevents in-flight `queryFn` resolutions from clobbering live SSE pushes.
- **Cold cutover** — no new feature flag. The existing `VITE_USE_SSE_EVENTS` flag preserves its semantics: `true` → SSE owns updates with `staleTime: Infinity`; `false` → `useQuery` polls via `refetchInterval` matching the legacy cadences (1500 ms job-status, 2000 ms dimensions/findings, 5000 ms health).
- Typed cache key factories (`evaluationKeys`, `projectKeys`, `systemKeys`, `standardsKeys`, `settingsKeys`) prevent stringly-typed bugs and make `invalidateQueries` precise.
- TanStack Query split into its own vendor chunk via `manualChunks` in `vite.config.js`. **Main bundle dropped from 164 kB → 127 kB** (saves 37 kB / 11 kB gzipped); new `vendor-tanstack-query-*.js` chunk is 37 kB / 11 kB gzipped.

## Architecture

> Server state lives in the cache. Initial GETs, `refetchInterval` polls, and SSE pushes are all just ways to populate and update it. Components read with `useQuery`, agnostic to source. Cache invalidation (mutations, refresh callbacks) is precise via `queryKeys.project(p)`-style scope-prefix matching.

## Implementation

23 commits in four phases:

- **Phase 1 — Infrastructure (Tasks 1–5):** install deps, query keys, QueryClient singleton, test wrapper, mount provider + dev-only DevTools.
- **Phase 2 — Big hooks (Tasks 6–9):** `useRunEventStream` (cache writer), `useEvaluation`, `useProjectScores`, `useDashboard`. Includes a regression-fix commit that restored `preparePayload` (Settings merge from localStorage) and the discard-on-cancel checkbox dropped during initial Task 7 implementation.
- **Phase 3 — Polling hooks (Tasks 10–11):** `useServerHealth`, `useOllamaServerStatus`, `useServerLogPoll`.
- **Phase 4 — Sweep + finalize (Tasks 12–13):** 7 component-local fetches converted; vendor chunk split; final smoke. Plus a post-review commit migrating `ScanProgress.jsx`'s missed polling site and adding `removeQueries` cleanup in `clearJob`.

Plan and spec live locally at `docs/superpowers/plans/2026-05-01-tanstack-query-migration.md` and `docs/superpowers/specs/2026-04-30-tanstack-query-migration-design.md` (`docs/` is gitignored).

**Net stats:** 43 files changed, +1786 / −905 lines.

## Test plan

- [x] `cd src/quodeq/ui && npm run test:ui` — **158 passed (32 files)**, no regressions. Includes 11 new tests for the key factories, 5 for `QueryClient` defaults, 3 for the test wrapper, plus targeted tests on every migrated hook.
- [x] `uv run pytest tests/` — **2454 passed**, no regressions (no Python code touched).
- [x] `npm run build` — succeeds; `vendor-tanstack-query-*.js` chunk listed in output at 37 kB / 11 kB gzipped; main `index-*.js` shrunk to 127 kB / 42 kB gzipped (down from 164 kB / 53 kB gzipped).
- [x] DevTools confirmed excluded from production bundle (`grep ReactQueryDevtools dist/...` returns nothing).
- [x] **Manual smoke**: with `VITE_USE_SSE_EVENTS=true npm run dev` — start an evaluation, confirm sub-second updates flow through the cache (status / dimensions / findings). Open React Query DevTools (gear icon, dev only), watch the cache populate.
- [x] **Manual smoke**: with `VITE_USE_SSE_EVENTS=false npm run dev` — same evaluation, confirm `refetchInterval` polling drives updates at the legacy ~1.5–2 s cadence.
- [x] **Manual smoke**: disconnect Wi-Fi for 30 s during an active run, reconnect — both `useQuery` and SSE should recover; no duplicate findings.
- [x] **Manual smoke**: open Settings → Server status / Ollama tab — confirm 5 s polling still works.

## Notes / known follow-ups (non-blocking, flagged by code review)

- **`partialDimensions` filter not reinstated.** Under `VITE_USE_SSE_EVENTS=false`, `useEvaluation` re-fetches all dimensions every 2 s instead of only `partial: true` ones. SSE-on path is unaffected. Worth a follow-up optimization for users on the polling fallback.
- **CLI-started run auto-resume dropped.** The legacy hook called `listEvaluations` on mount to resume external runs. The new hook requires the consumer to provide a `jobId`. Restore in a follow-up if user reports surface.
- ~~`clearScoresCache` / `clearDashboardCache` deprecation shims have no remaining callers. Worth a cleanup commit.~~ **Done in `e94678ff`.**
- **`useStandardDetail`, `useReEvalInfo`, `usePluginDimensions`, `useProjectState`, and a few others were intentionally skipped from the Task 12 sweep** — each has stateful coupling between the fetched value and post-mutation edits/transforms that doesn't fit `useQuery`'s read-only cache model. Documented per-file in the implementation report.
- **`VITE_USE_SSE_EVENTS=true` should be flipped to default in a follow-up release** after one round of soak. With Plan 3 landed, both flag values exercise `useQuery` — the difference is just refetchInterval polling vs SSE-driven cache writes.