### PR TITLE
Fix: dashboard 500 when cancelled runs sit above selected run

### DIFF
--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -213,15 +213,31 @@ def _compute_dashboard_payload(
     # Exclude cancelled/failed runs — they produce misleading points on the
     # history chart. They remain visible in availableRuns for the UI.
     scoreable_runs = [r for r in runs if r.status not in ("cancelled", "failed")]
-    history_runs = scoreable_runs[:max(_MAX_HISTORY_RUNS, ctx.index + 1)]
+    # Re-find the selected run's index inside scoreable_runs. ctx.index is
+    # the index in the full unfiltered run list, which can exceed
+    # len(history_runs) when cancelled/failed runs sit above the selected
+    # run. Passing the wrong index to collect_stale_dimensions /
+    # _collect_previous_scores caused IndexError on history_runs[newer_idx].
+    selected_in_scoreable = next(
+        (i for i, r in enumerate(scoreable_runs) if r.run_id == ctx.run.run_id),
+        None,
+    )
+    if selected_in_scoreable is None:
+        # Selected run was cancelled/failed (so it's not in scoreable_runs).
+        # Treat the entire scoreable history as "older" runs relative to it.
+        history_runs = scoreable_runs[:_MAX_HISTORY_RUNS]
+        history_index = len(history_runs)
+    else:
+        history_runs = scoreable_runs[:max(_MAX_HISTORY_RUNS, selected_in_scoreable + 1)]
+        history_index = selected_in_scoreable
     get_run_dimensions = _make_run_dimension_fetcher(
         reports_root, project, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
     )
     previous_by_dimension = _collect_previous_scores(
-        history_runs, ctx.index, selected_dim_names, get_run_dimensions,
+        history_runs, history_index, selected_dim_names, get_run_dimensions,
     )
     stale_dimensions, stale_previous_by_dimension = collect_stale_dimensions(
-        history_runs, ctx.index, selected_dim_names, get_run_dimensions,
+        history_runs, history_index, selected_dim_names, get_run_dimensions,
     )
     return _DashboardPayload(
         selected_summary=ctx.summary,

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -173,3 +173,31 @@ class TestBuildDashboard:
         ):
             result = build_dashboard(str(tmp_path), "proj", "r-cancelled")
         assert result["selectedRun"]["runId"] == "r-cancelled"
+
+    def test_does_not_crash_when_cancelled_runs_precede_selected(self, tmp_path):
+        # Regression: build_dashboard formerly raised IndexError when the
+        # selected complete run had cancelled/failed runs above it in the
+        # full list, because ctx.index (full-list index) was passed to
+        # collect_stale_dimensions / _collect_previous_scores along with
+        # `history_runs` (filtered list of scoreable runs only). When
+        # ctx.index >= len(history_runs), `history_runs[newer_idx]` blew up.
+        cancelled_top = [
+            RunInfo(run_id=f"c{i}", date_iso="2024-03-01", date_label="2024-03-01", status="cancelled")
+            for i in range(5)
+        ]
+        selected = RunInfo(run_id="r-selected", date_iso="2024-02-15", date_label="2024-02-15", status="complete")
+        complete_below = [
+            RunInfo(run_id=f"c-below-{i}", date_iso="2024-02-01", date_label="2024-02-01", status="complete")
+            for i in range(2)
+        ]
+        runs = cancelled_top + [selected] + complete_below
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=runs),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            # Must not raise.
+            result = build_dashboard(str(tmp_path), "proj", "r-selected")
+        assert result["selectedRun"]["runId"] == "r-selected"


### PR DESCRIPTION
## Summary

- Selecting a complete run that has ≥1 cancelled/failed run above it in the history list returns HTTP 500 from \`GET /api/projects/<p>/dashboard?run=<id>\`. The UI shows a generic \"Failed to load dashboard data\". User reproduced this picking April 21 in their dashboard while April 25–27 had cancelled runs above it.
- Root cause: \`_compute_dashboard_payload\` (\`services/dashboard.py\`) computes \`history_runs\` by filtering out cancelled/failed runs from \`runs\`, but passes \`ctx.index\` — the index in the **full unfiltered** list — to \`collect_stale_dimensions\` / \`_collect_previous_scores\` along with the **filtered** \`history_runs\`. When the selected run had cancelled runs above it, \`ctx.index >= len(history_runs)\`, and \`collect_stale_dimensions\`'s \`range(selected_index)\` loop overflowed on \`history_runs[newer_idx]\` with \`IndexError\`. \`_collect_previous_scores\` silently returned empty for the same reason.
- Bug dates to commit \`75fcc3a1\` from 2026-03-16. **Not introduced by Plans 1, 2, or 3** — it's pre-existing and just got hit now because of the user's particular run-history shape.

## Fix

In \`_compute_dashboard_payload\`:
- Re-find the selected run's index inside \`scoreable_runs\`.
- Use that index both to bound the prefix slice and as \`selected_index\` for the two helper calls.
- If the selected run is itself cancelled/failed (and thus not in \`scoreable_runs\`), treat the entire scoreable history as older context for the lookup.

## Test plan

- [x] New regression test \`test_does_not_crash_when_cancelled_runs_precede_selected\` reproduces the IndexError on \`develop\` and passes after the fix. Constructs a runs list of \`[5×cancelled, selected_complete, 2×complete_below]\` and asserts \`build_dashboard\` returns successfully.
- [x] Full Python suite: **2455 / 2455 passed**.
- [x] Manual: restart the running dashboard server, navigate to the previously-failing run (e.g., a complete run with cancelled runs above it), confirm the dashboard loads.