### PR TITLE
fix(ui): disable placeholderData on History tabs

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -4,7 +4,20 @@ import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
 import { projectKeys } from "../../../api/queryKeys.js";
 
-export function useDashboard({ selectedProject, selectedRun }) {
+/**
+ * @param {{
+ *   selectedProject: string,
+ *   selectedRun: string,
+ *   keepPlaceholder?: boolean,
+ * }} opts
+ *
+ * keepPlaceholder (default true): when switching runs, keep the previous
+ * run's data on screen during the background fetch. Great for Overview
+ * navigation where consecutive runs are similar. Set false in contexts
+ * where stale data is misleading (e.g. History run details, where users
+ * compare specific runs and the flash of previous data confuses them).
+ */
+export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = true }) {
   const { getDashboard } = useApi();
   const queryClient = useQueryClient();
 
@@ -16,7 +29,8 @@ export function useDashboard({ selectedProject, selectedRun }) {
     // Keep showing the previous run's data while a new run loads — instant
     // perceived navigation. isFetching toggles true during the background
     // fetch, which the page reads to show a subtle indicator.
-    placeholderData: (prev) => prev,
+    // Disabled when keepPlaceholder=false (History run details).
+    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
   });
 
   const {
@@ -25,7 +39,7 @@ export function useDashboard({ selectedProject, selectedRun }) {
     loading: scoresLoading,
     error: scoresError,
     availableRuns,
-  } = useProjectScores({ selectedProject, selectedRun });
+  } = useProjectScores({ selectedProject, selectedRun, keepPlaceholder });
 
   const dashboardWithTrend = useMemo(() => {
     if (!dashboardQuery.data) return null;

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -97,8 +97,19 @@ export function useAppState() {
     selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject,
   } = projectBundle;
   const settings = useAppSettings();
-  const effectiveRun = activePage.page === 'history-run' ? historySelectedRun : selectedRun;
-  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard } = useDashboard({ selectedProject, selectedRun: effectiveRun });
+  const isHistoryRun = activePage.page === 'history-run';
+  const isHistoryTab = activePage.page === 'history';
+  const effectiveRun = isHistoryRun ? historySelectedRun : selectedRun;
+  // History views (the History tab and its run-detail page) show specific
+  // past runs in a comparison-oriented mental model — flashing the previous
+  // run's data via placeholderData is confusing. Overview navigation, by
+  // contrast, benefits from the instant swap because consecutive runs are
+  // usually nearly identical.
+  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard } = useDashboard({
+    selectedProject,
+    selectedRun: effectiveRun,
+    keepPlaceholder: !isHistoryRun && !isHistoryTab,
+  });
   const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
     dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
     ...computeDerivedState(accumulated, dashboard, selectedProject, projects),

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -12,7 +12,16 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getProjectScores } from "../api/index.js";
 import { projectKeys } from "../api/queryKeys.js";
 
-export function useProjectScores({ selectedProject, selectedRun }) {
+/**
+ * @param {{
+ *   selectedProject: string,
+ *   selectedRun: string,
+ *   keepPlaceholder?: boolean,
+ * }} opts
+ *
+ * keepPlaceholder (default true): see useDashboard for rationale.
+ */
+export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true }) {
   const queryClient = useQueryClient();
   const asOf = selectedRun && selectedRun !== "latest" ? selectedRun : null;
 
@@ -22,7 +31,7 @@ export function useProjectScores({ selectedProject, selectedRun }) {
     enabled: !!selectedProject,
     staleTime: 60_000,
     // Keep prior scores visible while switching runs — see useDashboard for rationale.
-    placeholderData: (prev) => prev,
+    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
   });
 
   const latestQuery = useQuery({
@@ -30,6 +39,8 @@ export function useProjectScores({ selectedProject, selectedRun }) {
     queryFn: () => getProjectScores(selectedProject),
     enabled: !!selectedProject,
     staleTime: 60_000,
+    // Latest scores are project-wide (no per-run swap), so prev-data
+    // flashing isn't a concern — keep placeholder unconditionally.
     placeholderData: (prev) => prev,
   });
 


### PR DESCRIPTION
## Summary

PR #337 shipped \`placeholderData\` so switching between runs on the **Overview** tab keeps the previous run's data visible during the fetch — instant perceived navigation, no full-screen loader flash. This is great for Overview where you're scanning trends and consecutive runs are mostly the same.

On the **History** tab and **History run detail** page it's the wrong default. Users there are deliberately comparing specific runs, and the brief flash of the previous run's content reads as glitchy / misleading rather than smooth. The user reported "selecting looks not really great" on History.

## Fix

Add a \`keepPlaceholder\` option to \`useDashboard\` / \`useProjectScores\` (default \`true\`). \`useAppState\` passes \`false\` when \`activePage.page\` is \`'history'\` or \`'history-run'\`, so those views fall back to the standard loading state on a run switch.

The shared run-dimension cache from #337 still applies, so the load itself is fast (~280ms warm vs 750ms before #337) — this PR only changes **what the user sees during that load**, not the load duration.

## Why \`latestQuery\` keeps placeholderData unconditionally

\`useProjectScores\`'s \`latestQuery\` is project-wide (no per-run swap), so it never produces a confusing flash of "wrong run" data. Keeping placeholder there avoids re-renders when the user switches runs at the project level, but doesn't trade off any clarity.

## Test plan

- [x] \`cd src/quodeq/ui && npm run test:ui\` — **158 / 158 passed**.
- [x] **Manual smoke**: navigate Overview → click between runs → expect instant swap with subtle dim (current behavior, unchanged).
- [x] **Manual smoke**: navigate to History tab → click between runs → expect a clean loading state (no flash of previous run's data).
- [x] **Manual smoke**: navigate to a specific run from History → expect a clean loading state.

## Files

- \`src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js\` — add \`keepPlaceholder\` parameter
- \`src/quodeq/ui/src/hooks/useProjectScores.js\` — add \`keepPlaceholder\` parameter (only the run-scoped query opts out; latest stays cached)
- \`src/quodeq/ui/src/hooks/useAppState.js\` — derive \`isHistoryRun\` / \`isHistoryTab\` and pass \`keepPlaceholder: !isHistoryRun && !isHistoryTab\`