### PR TITLE
fix(ui): tighten compact drawer (icon-rail leak, repo block, power-user controls)

### DIFF
--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -772,8 +772,17 @@
   .topbar-breadcrumb-slot { display: none !important; }
   .topbar-pill,
   .topbar-btn--evaluate,
-  .topbar-btn--theme { display: none !important; }
+  .topbar-btn--theme,
+  .topbar-btn--report { display: none !important; }
   .topbar-actions { gap: var(--term-space-1); }
+  /* Compact view: hide all side-pane triggers. The pane itself is too
+     narrow to be useful below 900px, and without triggers users can't
+     open it (it stays at 0 width as long as no window is registered).
+     Affects ConsoleButton (in ScanProgress + ServerStatusPill). The
+     divider inside ServerStatusPill is hidden too so the pill doesn't
+     end with an orphan vertical rule. */
+  .console-button,
+  .server-status-pill__divider { display: none !important; }
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-brand-text,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-version,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-section-label,

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -783,6 +783,23 @@
      end with an orphan vertical rule. */
   .console-button,
   .server-status-pill__divider { display: none !important; }
+
+  /* Compact drawer: tighten the "current repo" (projects) block. It
+     contains a single NavButton and on the drawer width the surrounding
+     padding + divider make it read as having a lot more space than the
+     page-nav rows below. Targets only the first sidebar-block (the
+     projects one) — page-nav and operate-nav dividers stay intact.
+     Desktop layout is unchanged. */
+  .sidebar.sidebar--expanded.sidebar--pinned .sidebar-block:first-of-type {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+  .sidebar.sidebar--expanded.sidebar--pinned
+    .sidebar-block:first-of-type
+    + .sidebar-block {
+    border-top: 0;
+    padding-top: 0;
+  }
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-brand-text,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-version,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-section-label,

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -784,6 +784,16 @@
   .console-button,
   .server-status-pill__divider { display: none !important; }
 
+  /* Hide the side-pane itself in compact view. Without this, if a user
+     opens Report on desktop, then resizes to mobile, the body grid
+     collapses to 1fr and the side-pane stacks below the dashboard
+     (with no obvious way to close it because triggers are also hidden).
+     With display:none the pane is removed from layout entirely on
+     mobile; the registered window state is preserved in the SidePane
+     context, so resizing back to desktop restores the open Report
+     panel and the topbar Report button works as before. */
+  .side-pane { display: none !important; }
+
   /* Compact drawer: tighten the "current repo" (projects) block. It
      contains a single NavButton and on the drawer width the surrounding
      padding + divider make it read as having a lot more space than the

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -800,6 +800,14 @@
     border-top: 0;
     padding-top: 0;
   }
+  /* Compact drawer: let the whole sidebar scroll vertically if its
+     content exceeds the viewport. The base rule sets overflow:hidden,
+     which on short phones can cut off the footer (Server status / Help).
+     Limited to the pinned drawer; desktop's hover-expanded sidebar fits
+     by design and shouldn't show a scrollbar. */
+  .sidebar.sidebar--expanded.sidebar--pinned {
+    overflow-y: auto;
+  }
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-brand-text,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-version,
   .sidebar.sidebar--expanded.sidebar--pinned .sidebar-section-label,
@@ -830,12 +838,21 @@
     padding: 0;
   }
   .sidebar:not(.sidebar--expanded):hover { width: 100% !important; }
-  .sidebar-header {
+  .sidebar:not(.sidebar--expanded) .sidebar-header {
     border-bottom: 0;
     border-right: 1px solid var(--color-border);
     padding: var(--term-space-2) var(--term-space-3);
   }
-  .sidebar-nav {
+  /* The next blocks (.sidebar-nav, .sidebar-nav-item, .sidebar-bottom/
+     footer/controls) describe the LEGACY horizontal icon-rail layout
+     for narrow viewports where the sidebar isn't the expanded drawer.
+     They MUST be scoped to .sidebar:not(.sidebar--expanded) — without
+     the scope they leak into the expanded mobile drawer (the "burger"
+     menu) and force its nav rows to flex-direction: row + overflow-x:
+     auto, which causes the drawer to look broken (items in horizontal
+     scroll, weird spacing). The expanded drawer keeps its own column
+     layout from the .sidebar.sidebar--expanded rules below. */
+  .sidebar:not(.sidebar--expanded) .sidebar-nav {
     flex-direction: row;
     flex-wrap: nowrap;
     gap: 0;
@@ -844,15 +861,15 @@
     flex: 1;
     min-width: 0;
   }
-  .sidebar-nav-item {
+  .sidebar:not(.sidebar--expanded) .sidebar-nav-item {
     flex-shrink: 0;
     padding: var(--term-space-2);
   }
   /* Horizontal nav: icon-only, keep badges. */
-  .sidebar-nav-item > span:not(.sidebar-nav-badge) {
+  .sidebar:not(.sidebar--expanded) .sidebar-nav-item > span:not(.sidebar-nav-badge) {
     display: none !important;
   }
-  .sidebar-nav-item {
+  .sidebar:not(.sidebar--expanded) .sidebar-nav-item {
     gap: 0;
     padding: var(--term-space-2) !important;
     width: 40px !important;
@@ -862,9 +879,9 @@
     justify-content: center;
   }
   /* Bottom-of-sidebar controls (help, theme toggle) inline into the row. */
-  .sidebar-bottom,
-  .sidebar-footer,
-  .sidebar-controls {
+  .sidebar:not(.sidebar--expanded) .sidebar-bottom,
+  .sidebar:not(.sidebar--expanded) .sidebar-footer,
+  .sidebar:not(.sidebar--expanded) .sidebar-controls {
     border-top: 0;
     padding: 0 var(--term-space-2);
     flex-direction: row;


### PR DESCRIPTION
## Summary

Three related fixes to the burger / pinned sidebar experience at ≤900px widths.

### 1. Stop legacy icon-rail rules from leaking into the expanded drawer (the "everything off" fix)

In \`terminal.css\` there's a block of mobile rules for \`.sidebar-nav\`, \`.sidebar-nav-item\`, \`.sidebar-bottom/footer/controls\` that flips the sidebar into a **horizontal icon rail** (flex-direction: row, overflow-x: auto, items forced to 40px width). These rules were unscoped, so they also applied to the expanded burger drawer — even though \`.sidebar.sidebar--expanded\` is trying to render a vertical column. Symptoms the user reported:

- Inner horizontal scroll inside the page-nav block (overview / violations / map / history scrolling separately).
- "Everything off" — items with mismatched widths, oddly grouped scroll regions, footer rows cramped horizontally.

Scoped every legacy icon-rail rule to \`.sidebar:not(.sidebar--expanded)\`. The expanded drawer now keeps the column layout from \`.sidebar.sidebar--expanded\` rules intact.

### 2. Tighten the projects (repo) block in the pinned drawer

The projects NavButton lives in its own \`.sidebar-block\` separated from page-nav by a divider. Desktop reads as a deliberate "current context" separator; in the drawer it reads as the projects row having "a lot more space than the rest" (user wording). Targets only the first \`.sidebar-block\` in the pinned drawer:

- Zero its top/bottom padding.
- Drop \`border-top\` + top padding on the next block.

OPERATE / EVALUATE-ANALYZE-ETC dividers later in the sidebar are untouched.

### 3. Hide power-user controls in the topbar / page body

Side-pane triggers are useless at compact widths because the pane is too narrow. Hidden alongside the existing \`.topbar-pill\` / \`.topbar-btn--evaluate\` / \`.topbar-btn--theme\`:

- \`.topbar-btn--report\` (Report toolbar button)
- \`.console-button\` (Console toggle in ScanProgress + ServerStatusPill)
- \`.server-status-pill__divider\` (orphan vertical rule inside the pill)

### Bonus: drawer scrolls when content overflows

\`.sidebar.sidebar--expanded.sidebar--pinned\` now has \`overflow-y: auto\` so the footer (Server status, Help) doesn't get cut off on short phones.

## Test plan

- [x] \`cd src/quodeq/ui && npm run test:ui\` — **158 / 158 passed**.
- [x] Manual: resize below 900px / mobile viewport. Open the burger drawer:
  - Sidebar items render in a single vertical column (no inner horizontal scroll).
  - \`quodeq\` repo row sits flush with the header; page nav (overview / violations / map / history) starts directly after with no extra gap.
  - Scrolling the drawer reveals all groups + footer (Server / Help) on short viewports.
  - Topbar shows back + title + burger only.
  - Settings → Server pill ends with the "Running" indicator (no Console button, no orphan divider).
  - During an active evaluation: ScanProgress card has no Console button.
- [x] Manual: resize above 900px. Desktop layout intact.

## Files

- \`src/quodeq/ui/src/styles/terminal.css\` — scope existing icon-rail rules to \`.sidebar:not(.sidebar--expanded)\`, add tightening rules for the pinned drawer, hide power-user controls.