### PR TITLE
feat(ui): side-pane Report on run, history-run, and file detail pages

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -13,6 +13,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
       <RunOverviewPanel
         dashboard={dashboard}
         selectedRunId={selectedRunId}
+        projectName={projectInfo?.displayName || projectInfo?.name || selectedProject}
         onDimensionClick={onDimensionCardClick}
         onFileClick={onFileClick}
       />

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -9,8 +9,10 @@ import { SectionLabel } from '../../../components/terminal/index.js';
 const HERO_SCORE_CIRCLE_SIZE = 120;
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
+import { buildRunReport } from '../../../utils/reportBuilder.js';
 import { formatRunId, complianceRatio } from '../../../utils/formatters.js';
 import { withDimensionsStr } from '../../../utils/dimensionUtils.js';
+import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import buildRunSummary from '../buildRunSummary.js';
 
 // ---------------------------------------------------------------------------
@@ -127,13 +129,30 @@ function RunFileViolations({ runTopFiles, onFileClick }) {
   );
 }
 
-export default function RunOverviewPanel({ dashboard, selectedRunId, onDimensionClick, onFileClick }) {
+export default function RunOverviewPanel({ dashboard, selectedRunId, projectName, onDimensionClick, onFileClick }) {
   const runSummary = useMemo(() => buildRunSummary(dashboard?.dimensions), [dashboard]);
   const runTopFiles = useMemo(() => withDimensionsStr(buildTopOffendingFiles(dashboard?.dimensions || [])), [dashboard]);
   const runUniquePrinciples = useMemo(() => {
     const violations = (dashboard?.dimensions || []).flatMap((d) => d.violations || []);
     return new Set(violations.map((v) => v.principle).filter(Boolean)).size;
   }, [dashboard]);
+
+  const reportSpec = useMemo(() => {
+    if (!dashboard?.dimensions) return null;
+    const runId = dashboard?.selectedRun?.runId || selectedRunId || 'current';
+    const dateLabel = dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId) || 'run';
+    const buildMarkdown = () => buildRunReport({ dashboard, runSummary, projectName });
+    const filenameLabel = (dateLabel || runId).replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    return {
+      id: `report:run:${runId}`,
+      type: 'report',
+      title: `${dateLabel} report`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `run-${filenameLabel}-report.md`, body: buildMarkdown() }),
+    };
+  }, [dashboard, runSummary, selectedRunId, projectName]);
+  useRegisterWindowSpec('report', reportSpec);
 
   // Per-dimension deltas from the trend entry (same source the history rows use)
   const trendDeltas = useMemo(() => {

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -1,12 +1,14 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
+import { buildFileReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
 import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { ComplianceCard } from './EvalCards.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
+import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
@@ -125,6 +127,21 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
   const totalViolations = file.total || 0;
   const totalCompliance = file.compliance?.length || 0;
   const dimensionsCount = file.dimensionsCount || 0;
+
+  const reportSpec = useMemo(() => {
+    if (!file?.file) return null;
+    const buildMarkdown = () => buildFileReport(file);
+    const filenameLabel = file.file.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    return {
+      id: `report:file:${file.file}`,
+      type: 'report',
+      title: `${file.file.split('/').pop()} report`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `file-${filenameLabel}-report.md`, body: buildMarkdown() }),
+    };
+  }, [file]);
+  useRegisterWindowSpec('report', reportSpec);
 
   return (
     <>

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -1,6 +1,7 @@
 import { memo, useState, useCallback, useMemo } from 'react';
 import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
+import { buildPrincipleReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
 import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
@@ -8,6 +9,7 @@ import { useApi } from '../../../api/ApiContext.jsx';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
+import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 
 // Off-screen rows skip layout/paint via CSS `content-visibility: auto` on
 // `.vdetail-row` (see styles/explorer.css), so no JS virtualizer or
@@ -197,13 +199,33 @@ function usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss) {
 }
 
 const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, severityFilter, onDismiss }) {
-  const { principleData, principle, score, grade } = evalPrincipal;
+  const { principleData, principle, score, grade, dimension, runId } = evalPrincipal;
 
   const {
     violations, compliance, violationsBySeverity,
     liveScore, liveGrade, activeSevFilter, setActiveSevFilter,
     handleDismiss, filteredViolations, liveSevCounts, displayedBySeverity,
   } = usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss);
+
+  const reportSpec = useMemo(() => {
+    if (!principle) return null;
+    const buildMarkdown = () => buildPrincipleReport({
+      principle, dimension,
+      score: liveScore ?? score, grade: liveGrade ?? grade,
+      violations: filteredViolations, violationsBySeverity: displayedBySeverity,
+      compliance, principleData, runId,
+    });
+    const slug = `${(dimension || 'dim')}-${principle}`.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    return {
+      id: `report:principle:${dimension || 'dim'}:${principle}:${runId || 'current'}`,
+      type: 'report',
+      title: `${principle} report`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `principle-${slug}-report.md`, body: buildMarkdown() }),
+    };
+  }, [principle, dimension, runId, score, grade, liveScore, liveGrade, filteredViolations, displayedBySeverity, compliance, principleData]);
+  useRegisterWindowSpec('report', reportSpec);
 
   return (
     <>

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -241,3 +241,81 @@ export function buildOverviewReport(accumulated, accumulatedDimensions, projectN
 
   return lines.join('\n');
 }
+
+export function buildRunReport({ dashboard, runSummary, projectName }) {
+  const dimensions = dashboard?.dimensions || [];
+  const selectedRun = dashboard?.selectedRun || {};
+  const dateLabel = selectedRun.dateLabel || formatDate();
+  const runId = selectedRun.runId || '';
+  const numeric = runSummary?.numericAverage;
+  const score = numeric != null ? `${Math.round(parseFloat(numeric) * 10) / 10}/10` : '—';
+  const grade = runSummary?.overallGrade || '—';
+  const project = projectName || 'Run';
+  const ridSuffix = runId ? ` · **Run:** ${runId.slice(0, 8)}` : '';
+
+  const lines = [];
+  lines.push(`# ${project} run report`);
+  lines.push('');
+  lines.push(`**Date:** ${dateLabel}${ridSuffix} · **Overall Score:** ${score} ${grade}`);
+  lines.push('');
+
+  lines.push(...buildDimensionSummaryTable(dimensions));
+  lines.push(...buildTopOffendingFiles(dimensions));
+  lines.push(...buildCritMajorSection(dimensions));
+  lines.push(...buildOverviewSummarySection(runSummary || {}, dimensions));
+
+  return lines.join('\n');
+}
+
+function buildFileSummarySection(file, totalViolations, totalCompliance) {
+  const lines = [];
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(`- **${totalViolations}** total violations (${file.critical || 0} critical, ${file.major || 0} major, ${file.minor || 0} minor)`);
+  lines.push(`- **${totalCompliance}** compliance findings`);
+  lines.push(`- **${file.dimensionsCount || 0}** dimension${file.dimensionsCount === 1 ? '' : 's'}`);
+  if (totalViolations && totalCompliance) {
+    lines.push(`- **Ratio:** 1:${Math.round(totalCompliance / totalViolations)}`);
+  }
+  lines.push('');
+  return lines;
+}
+
+function buildFileViolationsSection(file) {
+  const lines = [];
+  const allViolations = SEVERITY_ORDER.flatMap((sev) => file.violationsBySeverity?.[sev] || []);
+  lines.push(`## Violations (${allViolations.length})`);
+  lines.push('');
+  if (allViolations.length === 0) {
+    lines.push('No violations found.');
+    lines.push('');
+    return lines;
+  }
+  for (const sev of SEVERITY_ORDER) {
+    const vs = file.violationsBySeverity?.[sev] || [];
+    if (vs.length === 0) continue;
+    lines.push(`### ${sev.charAt(0).toUpperCase() + sev.slice(1)} (${vs.length})`);
+    lines.push('');
+    for (const v of vs) lines.push(formatViolationEntry(v));
+  }
+  return lines;
+}
+
+export function buildFileReport(file) {
+  const filePath = file?.file || 'unknown';
+  const totalViolations = file?.total || 0;
+  const totalCompliance = file?.compliance?.length || 0;
+  const date = formatDate();
+
+  const lines = [];
+  lines.push(`# File report`);
+  lines.push('');
+  lines.push(`**File:** \`${filePath}\` · **Date:** ${date}`);
+  lines.push('');
+
+  lines.push(...buildFileSummarySection(file, totalViolations, totalCompliance));
+  lines.push(...buildFileViolationsSection(file));
+  lines.push(...buildComplianceSection(file?.compliance || []));
+
+  return lines.join('\n');
+}

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -267,6 +267,54 @@ export function buildRunReport({ dashboard, runSummary, projectName }) {
   return lines.join('\n');
 }
 
+export function buildPrincipleReport({ principle, dimension, score, grade, violations, violationsBySeverity, compliance, principleData, runId, dateLabel }) {
+  const violationsList = violations || [];
+  const complianceList = (compliance || []).filter((c) => c.file || c.reason || c.snippet);
+  const date = dateLabel || formatDate();
+  const ridSuffix = runId ? ` · **Run:** ${runId.slice(0, 8)}` : '';
+  const dimSuffix = dimension ? ` · **Dimension:** ${dimension}` : '';
+  const scoreDisplay = score ? `${String(score).replace('/10', '')}/10` : '—';
+
+  const lines = [];
+  lines.push(`# ${principle} report`);
+  lines.push('');
+  lines.push(`**Date:** ${date}${ridSuffix}${dimSuffix} · **Score:** ${scoreDisplay} ${grade || '—'}`);
+  lines.push('');
+
+  if (principleData?.findings) {
+    lines.push('## Findings');
+    lines.push('');
+    lines.push(principleData.findings);
+    lines.push('');
+  }
+  if (principleData?.justification) {
+    lines.push('## Justification');
+    lines.push('');
+    lines.push(principleData.justification);
+    lines.push('');
+  }
+
+  const bySeverity = violationsBySeverity || groupBySeverity(violationsList);
+  lines.push(`## Violations (${violationsList.length})`);
+  lines.push('');
+  if (violationsList.length === 0) {
+    lines.push('No violations found.');
+    lines.push('');
+  } else {
+    for (const sev of SEVERITY_ORDER) {
+      const vs = bySeverity[sev] || [];
+      if (vs.length === 0) continue;
+      lines.push(`### ${sev.charAt(0).toUpperCase() + sev.slice(1)} (${vs.length})`);
+      lines.push('');
+      for (const v of vs) lines.push(formatViolationEntry(v));
+    }
+  }
+
+  lines.push(...buildComplianceSection(complianceList));
+
+  return lines.join('\n');
+}
+
 function buildFileSummarySection(file, totalViolations, totalCompliance) {
   const lines = [];
   lines.push('## Summary');

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -1,0 +1,107 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRunReport, buildFileReport, buildOverviewReport, buildDimensionReport } from './reportBuilder.js';
+
+const dimensions = [
+  {
+    dimension: 'maintainability',
+    overallScore: '7.5/10',
+    overallGrade: 'B',
+    violations: [
+      { file: 'lib/a.sh', severity: 'critical', principle: 'SRP', title: 'Too many responsibilities' },
+      { file: 'lib/b.sh', severity: 'major', principle: 'Modularity', title: 'God object' },
+    ],
+    compliance: [{ principle: 'SRP' }],
+  },
+  {
+    dimension: 'performance',
+    overallScore: '8.0/10',
+    overallGrade: 'B',
+    violations: [
+      { file: 'lib/a.sh', severity: 'minor', principle: 'Speed', title: 'Slow loop' },
+    ],
+    compliance: [],
+  },
+];
+
+const runSummary = {
+  numericAverage: '7.8',
+  overallGrade: 'B',
+  totalViolations: 3,
+  totalCompliance: 1,
+  dimensionCount: 2,
+  severity: { critical: 1, major: 1, minor: 1 },
+};
+
+test('buildRunReport includes title with project name and run header', () => {
+  const dashboard = { dimensions, selectedRun: { runId: 'abc12345', dateLabel: '21 Apr 2025' } };
+  const md = buildRunReport({ dashboard, runSummary, projectName: 'MyApp' });
+  assert.match(md, /^# MyApp run report/);
+  assert.match(md, /\*\*Date:\*\* 21 Apr 2025/);
+  assert.match(md, /\*\*Run:\*\* abc12345/);
+  assert.match(md, /\*\*Overall Score:\*\* 7\.8\/10 B/);
+});
+
+test('buildRunReport includes dimensions table and crit/major section', () => {
+  const dashboard = { dimensions, selectedRun: {} };
+  const md = buildRunReport({ dashboard, runSummary, projectName: 'X' });
+  assert.match(md, /## Dimensions/);
+  assert.match(md, /\| Maintainability \|/);
+  assert.match(md, /## Top Offending Files/);
+  assert.match(md, /## Critical & Major Violations \(2\)/);
+  assert.match(md, /Too many responsibilities/);
+});
+
+test('buildRunReport handles empty dashboard gracefully', () => {
+  const dashboard = { dimensions: [], selectedRun: {} };
+  const md = buildRunReport({ dashboard, runSummary: { totalViolations: 0, totalCompliance: 0 }, projectName: 'X' });
+  assert.match(md, /^# X run report/);
+  assert.match(md, /No critical or major violations found\./);
+});
+
+test('buildFileReport includes file path and totals', () => {
+  const file = {
+    file: 'src/foo/bar.js',
+    total: 3,
+    critical: 1,
+    major: 1,
+    minor: 1,
+    dimensionsCount: 2,
+    compliance: [{ principle: 'Naming' }],
+    violationsBySeverity: {
+      critical: [{ severity: 'critical', principle: 'SRP', title: 'Bad', file: 'src/foo/bar.js', line: 12 }],
+      major: [{ severity: 'major', principle: 'DRY', title: 'Repeat', file: 'src/foo/bar.js' }],
+      minor: [{ severity: 'minor', principle: 'Style', title: 'Format', file: 'src/foo/bar.js' }],
+    },
+  };
+  const md = buildFileReport(file);
+  assert.match(md, /^# File report/);
+  assert.match(md, /\*\*File:\*\* `src\/foo\/bar\.js`/);
+  assert.match(md, /## Summary/);
+  assert.match(md, /\*\*3\*\* total violations \(1 critical, 1 major, 1 minor\)/);
+  assert.match(md, /\*\*1\*\* compliance findings/);
+  assert.match(md, /## Violations \(3\)/);
+  assert.match(md, /### Critical \(1\)/);
+  assert.match(md, /## Compliance Summary \(1\)/);
+});
+
+test('buildFileReport with no violations shows "No violations found"', () => {
+  const file = { file: 'empty.js', total: 0, compliance: [], violationsBySeverity: {}, dimensionsCount: 1 };
+  const md = buildFileReport(file);
+  assert.match(md, /No violations found\./);
+});
+
+test('existing buildOverviewReport and buildDimensionReport still produce output', () => {
+  const acc = { summary: { numericAverage: 8.0, overallGrade: 'B', totalViolations: 3, totalCompliance: 1, severity: { critical: 1, major: 1, minor: 1 } } };
+  const md1 = buildOverviewReport(acc, dimensions, 'MyApp');
+  assert.match(md1, /^# MyApp report/);
+  const md2 = buildDimensionReport({
+    evalData: { dimension: 'performance', compliance: [] },
+    principleGrades: [{ principle: 'Speed', score: '8/10', grade: 'B' }],
+    allViolations: dimensions[1].violations,
+    overallGrade: { score: '8/10', grade: 'B' },
+    dateLabel: '21 Apr 2025',
+    runId: 'abc12345',
+  });
+  assert.match(md2, /^# performance report/);
+});

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildRunReport, buildFileReport, buildOverviewReport, buildDimensionReport } from './reportBuilder.js';
+import { buildRunReport, buildFileReport, buildOverviewReport, buildDimensionReport, buildPrincipleReport } from './reportBuilder.js';
 
 const dimensions = [
   {
@@ -88,6 +88,38 @@ test('buildFileReport includes file path and totals', () => {
 test('buildFileReport with no violations shows "No violations found"', () => {
   const file = { file: 'empty.js', total: 0, compliance: [], violationsBySeverity: {}, dimensionsCount: 1 };
   const md = buildFileReport(file);
+  assert.match(md, /No violations found\./);
+});
+
+test('buildPrincipleReport includes principle, score, findings, and violations', () => {
+  const md = buildPrincipleReport({
+    principle: 'Single Responsibility',
+    dimension: 'maintainability',
+    score: '6/10',
+    grade: 'C',
+    violations: [
+      { severity: 'critical', principle: 'Single Responsibility', title: 'Mega class', file: 'src/big.js', line: 10 },
+    ],
+    compliance: [{ principle: 'Single Responsibility', file: 'src/small.js', reason: 'small and focused' }],
+    principleData: { findings: 'Code lacks separation.', justification: 'Several god objects.' },
+    runId: 'abc12345',
+    dateLabel: '21 Apr 2025',
+  });
+  assert.match(md, /^# Single Responsibility report/);
+  assert.match(md, /\*\*Date:\*\* 21 Apr 2025/);
+  assert.match(md, /\*\*Run:\*\* abc12345/);
+  assert.match(md, /\*\*Dimension:\*\* maintainability/);
+  assert.match(md, /\*\*Score:\*\* 6\/10 C/);
+  assert.match(md, /## Findings/);
+  assert.match(md, /Code lacks separation\./);
+  assert.match(md, /## Justification/);
+  assert.match(md, /## Violations \(1\)/);
+  assert.match(md, /### Critical \(1\)/);
+  assert.match(md, /## Compliance Summary \(1\)/);
+});
+
+test('buildPrincipleReport with no violations shows "No violations found"', () => {
+  const md = buildPrincipleReport({ principle: 'X', violations: [], compliance: [], principleData: null });
   assert.match(md, /No violations found\./);
 });
 


### PR DESCRIPTION
## Summary
- New \`buildRunReport\` and \`buildFileReport\` utilities in \`reportBuilder.js\`.
- \`RunOverviewPanel\` registers a Report side-pane spec (covers both Run detail and History run detail since both routes render this component).
- \`FileDetailPage\` registers a Report side-pane spec.
- Dimension detail already had a Report (via \`ExplorerPage\`) — no change.

The topbar Report button now appears on every detail page, with markdown that mirrors the existing Overview report shape: stats summary, dimensions/violations tables, severity-grouped findings, and compliance.

## Test plan
- [x] \`npm test\` (node:test) — 132 passed including 6 new tests for builders
- [x] \`npx vitest run\` — 158 passed
- [x] \`npx vite build\` — clean
- [x] Manual: open a run detail, history-run detail, dimension detail, and file detail page and verify the Report toolbar button is available, copy/download work, and contents look right