### PR TITLE
feat(ui): open fix plans in the side pane with a topbar trigger

### DIFF
--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -10,30 +10,38 @@
  * Stateless; the parent passes the data it has.
  */
 import { useSidePane } from '../features/side-pane/index.js';
-import { FileTextIcon } from './CopyButton.jsx';
+import { FileTextIcon, SparkleIcon } from './CopyButton.jsx';
 
-function ReportToolbarButton() {
+function SidePaneSpecButton({ type, label, icon, modifier }) {
   const ctx = useSidePane();
-  const spec = ctx.getRegisteredSpec ? ctx.getRegisteredSpec('report') : null;
+  const spec = ctx.getRegisteredSpec ? ctx.getRegisteredSpec(type) : null;
   if (!spec) return null;
   const inDock = ctx.hasWindow(spec.id);
   const atCap = ctx.windows.length >= ctx.MAX_WINDOWS && !inDock;
   return (
     <button
       type="button"
-      className={`topbar-btn topbar-btn--report${inDock ? ' topbar-btn--report--open' : ''}`}
+      className={`topbar-btn topbar-btn--${modifier}${inDock ? ` topbar-btn--${modifier}--open` : ''}`}
       aria-pressed={inDock}
       disabled={atCap}
-      title={atCap ? 'Close a window to open another' : (inDock ? 'Close report' : 'Open report')}
+      title={atCap ? 'Close a window to open another' : (inDock ? `Close ${label.toLowerCase()}` : `Open ${label.toLowerCase()}`)}
       onClick={() => {
         if (inDock) ctx.removeWindow(spec.id);
         else ctx.addWindow(spec);
       }}
     >
-      <FileTextIcon />
-      <span>Report</span>
+      {icon}
+      <span>{label}</span>
     </button>
   );
+}
+
+function ReportToolbarButton() {
+  return <SidePaneSpecButton type="report" label="Report" icon={<FileTextIcon />} modifier="report" />;
+}
+
+function FixPlanToolbarButton() {
+  return <SidePaneSpecButton type="fixplan" label="Fix plan" icon={<SparkleIcon />} modifier="fixplan" />;
 }
 
 function Dot({ ok }) {
@@ -152,6 +160,7 @@ export default function TopBar({
             {effectiveDark ? <SunIcon /> : <MoonIcon />}
           </button>
         )}
+        <FixPlanToolbarButton />
         <ReportToolbarButton />
         {onEvaluate && (
           <button

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -1,13 +1,11 @@
 import { useMemo } from 'react';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
-import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import ScoreCircle from '../../../components/ScoreCircle.jsx';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
 import { SectionLabel } from '../../../components/terminal/index.js';
 
 const HERO_SCORE_CIRCLE_SIZE = 120;
-import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { buildRunReport } from '../../../utils/reportBuilder.js';
 import { formatRunId, complianceRatio } from '../../../utils/formatters.js';
@@ -86,19 +84,6 @@ function RunHeroSection({ dashboard, selectedRunId, stats }) {
     <section className="acc-eval-panel panel">
       <div className="acc-eval-top">
         <span className="acc-eval-date">{dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId)}</span>
-        {(dashboard?.dimensions || []).some((d) => (d.violations?.length || 0) > 0) && (
-          <CopyButton
-            label="Full fix plan"
-            className="fix-plan-btn-header"
-            icon={<SparkleIcon />}
-            onClick={() => {
-              const allViolations = (dashboard.dimensions || []).flatMap(
-                (d) => (d.violations || []).map((v) => ({ ...v, dimension: d.dimension }))
-              );
-              copyToClipboard(buildDimensionPlanFromViolations(dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId), allViolations));
-            }}
-          />
-        )}
       </div>
       <div className="acc-eval-golden">
         <div className="acc-eval-circle-col">
@@ -153,6 +138,28 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, projectName
     };
   }, [dashboard, runSummary, selectedRunId, projectName]);
   useRegisterWindowSpec('report', reportSpec);
+
+  const fixPlanSpec = useMemo(() => {
+    const dims = dashboard?.dimensions || [];
+    const hasViolations = dims.some((d) => (d.violations?.length || 0) > 0);
+    if (!hasViolations) return null;
+    const runId = dashboard?.selectedRun?.runId || selectedRunId || 'current';
+    const dateLabel = dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId) || 'run';
+    const filenameLabel = (dateLabel || runId).replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    const buildMarkdown = () => {
+      const allViolations = dims.flatMap((d) => (d.violations || []).map((v) => ({ ...v, dimension: d.dimension })));
+      return buildDimensionPlanFromViolations(dateLabel, allViolations);
+    };
+    return {
+      id: `fixplan:run:${runId}`,
+      type: 'fixplan',
+      title: `${dateLabel} fix plan`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `run-${filenameLabel}-fix-plan.md`, body: buildMarkdown() }),
+    };
+  }, [dashboard, selectedRunId]);
+  useRegisterWindowSpec('fixplan', fixPlanSpec);
 
   // Per-dimension deltas from the trend entry (same source the history rows use)
   const trendDeltas = useMemo(() => {

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -1,11 +1,11 @@
 import { useRef } from 'react';
 import { parseFileRef } from '../../../utils/formatters.js';
-import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
+import { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
-import { copyToClipboard } from '../../../utils/clipboard.js';
 import SevBadge from '../../../components/terminal/SevBadge.jsx';
 import usePretextHeight from '../../../hooks/usePretextHeight.js';
+import { useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
@@ -79,7 +79,8 @@ function ViolationDetail({ item }) {
   );
 }
 
-export function EvalViolationCard({ v, principle, buildViolationPlanText, index, onDismiss }) {
+export function EvalViolationCard({ v, principle, index, onDismiss }) {
+  const { addWindow } = useSidePane();
   const { filename, ref, display } = useFileInfo(v.file, v.line, v.endLine);
   return (
     <div
@@ -90,12 +91,14 @@ export function EvalViolationCard({ v, principle, buildViolationPlanText, index,
         <SevBadge level={v.severity} format="long" />
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
-        <CopyButton
-          label="Fix plan"
+        <button
+          type="button"
           className="fix-plan-btn"
-          icon={<SparkleIcon />}
-          onClick={() => copyToClipboard(buildViolationPlanText(v))}
-        />
+          onClick={() => { const spec = violationFixPlanSpec(v, v.principle || principle); if (spec) addWindow(spec); }}
+        >
+          <SparkleIcon />
+          Fix plan
+        </button>
         {onDismiss && (
           <button
             type="button"

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,9 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import ViolationsByPrincipleTable from '../../dashboard/components/ViolationsByPrincipleTable.jsx';
-import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
 import { gradeColorClass, complianceRatio } from '../../../utils/formatters.js';
-import { copyToClipboard } from '../../../utils/clipboard.js';
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
 import { buildDimensionReport } from '../../../utils/reportBuilder.js';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
@@ -12,7 +10,7 @@ import { useExplorerData, buildEvalPrincipalFn } from './explorerDataHooks.js';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 
 function DimensionOverview({ data, stats, onNavigate }) {
-  const { evalData, runId, dateLabel, allViolations } = data;
+  const { evalData, runId, dateLabel } = data;
   const { overallGrade, severityCounts, totalCompliant, topFiles, uniquePrinciples, principleGrades } = stats;
   const scoreDisplay = overallGrade?.score?.replace('/10', '') || '—';
   const sevBadges = (severityCounts.critical || severityCounts.major || severityCounts.minor) ? (
@@ -30,16 +28,6 @@ function DimensionOverview({ data, stats, onNavigate }) {
           name={`${evalData.dimension}.overview`}
           sub={dateLabel || runId || null}
         />
-        <div className="dimension-overview__actions">
-          {allViolations.length > 0 && (
-            <CopyButton
-              label="Full fix plan"
-              className="fix-plan-btn-header"
-              icon={<SparkleIcon />}
-              onClick={() => copyToClipboard(buildDimensionPlanFromViolations(evalData.dimension, allViolations))}
-            />
-          )}
-        </div>
       </div>
       <StatStrip bordered>
         <Stat label="SCORE"      value={scoreDisplay}                                      hint={overallGrade?.grade || null} />
@@ -173,6 +161,21 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, sev
   }, [d.evalData, d.principleGrades, filteredViolations, d.overallGrade, dateLabel, runId]);
   useRegisterWindowSpec('report', reportSpec);
 
+  const fixPlanSpec = useMemo(() => {
+    if (!d.evalData || filteredViolations.length === 0) return null;
+    const dim = (d.evalData.dimension || 'unknown').toLowerCase();
+    const buildMarkdown = () => buildDimensionPlanFromViolations(d.evalData.dimension, filteredViolations);
+    return {
+      id: `fixplan:dimension:${dim}:${runId ?? 'current'}`,
+      type: 'fixplan',
+      title: `${dim} fix plan`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `${dim}-fix-plan.md`, body: buildMarkdown() }),
+    };
+  }, [d.evalData, filteredViolations, runId]);
+  useRegisterWindowSpec('fixplan', fixPlanSpec);
+
   if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
   if (d.error) return <div className="inline-error">Failed to load evaluation data. Please try again or check the console for details.</div>;
   if (!d.evalData) return <div className="empty-state"><h2>No data found</h2></div>;
@@ -180,7 +183,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, sev
   return (
     <>
       <DimensionOverview
-        data={{ evalData: d.evalData, runId, dateLabel, allViolations: filteredViolations }}
+        data={{ evalData: d.evalData, runId, dateLabel }}
         stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: filteredTopFiles, uniquePrinciples: d.uniquePrinciples, principleGrades: d.principleGrades }}
         onNavigate={onNavigate}
       />

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -10,7 +10,7 @@ import { useExplorerData, buildEvalPrincipalFn } from './explorerDataHooks.js';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 
 function DimensionOverview({ data, stats, onNavigate }) {
-  const { evalData, runId, dateLabel } = data;
+  const { evalData, runId, dateLabel, allViolations } = data;
   const { overallGrade, severityCounts, totalCompliant, topFiles, uniquePrinciples, principleGrades } = stats;
   const scoreDisplay = overallGrade?.score?.replace('/10', '') || '—';
   const sevBadges = (severityCounts.critical || severityCounts.major || severityCounts.minor) ? (
@@ -183,7 +183,7 @@ export default function ExplorerPage({ project, dimension, runId, dateLabel, sev
   return (
     <>
       <DimensionOverview
-        data={{ evalData: d.evalData, runId, dateLabel }}
+        data={{ evalData: d.evalData, runId, dateLabel, allViolations: filteredViolations }}
         stats={{ overallGrade: d.overallGrade, severityCounts: d.severityCounts, totalCompliant: d.totalCompliant, topFiles: filteredTopFiles, uniquePrinciples: d.uniquePrinciples, principleGrades: d.principleGrades }}
         onNavigate={onNavigate}
       />

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -1,24 +1,18 @@
 import { memo, useMemo } from 'react';
-import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { buildFileReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER, parseFileRef } from '../../../utils/formatters.js';
-import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
+import { SparkleIcon } from '../../../components/CopyButton.jsx';
 import FileCopyBtn from '../../../components/FileCopyBtn.jsx';
 import ContextBlock from '../../../components/ContextBlock.jsx';
 import { ComplianceCard } from './EvalCards.jsx';
-import { copyToClipboard } from '../../../utils/clipboard.js';
-import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
+import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
 
-function buildViolationPlanText(v) {
-  const title = [v.dimension, v.principle].filter(Boolean).join(' / ') || 'Violation';
-  return buildSingleViolationPlanText(v, title);
-}
-
 function ViolationCard({ v, index }) {
+  const { addWindow } = useSidePane();
   const { filePath, line } = parseFileRef(v.file, v.line);
   const filename = filePath ? filePath.split('/').pop() : null;
   const range = (v.endLine && v.endLine !== line) ? `${line}-${v.endLine}` : line;
@@ -34,12 +28,14 @@ function ViolationCard({ v, index }) {
         {filename && (
           <FileCopyBtn display={display} copyText={ref} />
         )}
-        <CopyButton
-          label="Fix plan"
+        <button
+          type="button"
           className="fix-plan-btn"
-          icon={<SparkleIcon />}
-          onClick={() => copyToClipboard(buildViolationPlanText(v))}
-        />
+          onClick={() => { const spec = violationFixPlanSpec(v); if (spec) addWindow(spec); }}
+        >
+          <SparkleIcon />
+          Fix plan
+        </button>
       </div>
       <div className="vlive-detail">
         {(v.title || v.reason) && (
@@ -143,18 +139,27 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
   }, [file]);
   useRegisterWindowSpec('report', reportSpec);
 
+  const fixPlanSpec = useMemo(() => {
+    if (!file?.file || (file.total || 0) === 0) return null;
+    const buildMarkdown = () => buildFilePlanText(file);
+    const filenameLabel = file.file.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    return {
+      id: `fixplan:file:${file.file}`,
+      type: 'fixplan',
+      title: `${file.file.split('/').pop()} fix plan`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `file-${filenameLabel}-fix-plan.md`, body: buildMarkdown() }),
+    };
+  }, [file]);
+  useRegisterWindowSpec('fixplan', fixPlanSpec);
+
   return (
     <>
       <section className="panel file-detail-summary-panel">
         <h3 className="file-detail-title">{file.file}</h3>
         <div className="file-detail-stats-row">
           <FileSeverityStats file={file} totalViolations={totalViolations} totalCompliance={totalCompliance} dimensionsCount={dimensionsCount} />
-          <CopyButton
-            label="Full fix plan"
-            className="fix-plan-btn-header"
-            icon={<SparkleIcon />}
-            onClick={() => copyToClipboard(buildFilePlanText(file))}
-          />
         </div>
       </section>
 

--- a/src/quodeq/ui/src/features/explorer/components/FindingDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FindingDetailPage.jsx
@@ -9,13 +9,8 @@
  * summary. If the user wants the principle's full list, there's already the
  * PrincipleDetailPage route.
  */
-import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { TermHeader, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 import { EvalViolationCard } from './EvalCards.jsx';
-
-function buildPlanText(v, principle) {
-  return buildSingleViolationPlanText(v, principle, { reqRefs: v?.reqRefs, reqFallback: v?.req || undefined });
-}
 
 export default function FindingDetailPage({ finding, principle, dimension, onDismiss }) {
   if (!finding) {
@@ -48,7 +43,6 @@ export default function FindingDetailPage({ finding, principle, dimension, onDis
         <EvalViolationCard
           v={finding}
           principle={principle || finding.principle}
-          buildViolationPlanText={(v) => buildPlanText(v, principle || finding.principle)}
           index={0}
           onDismiss={onDismiss}
         />

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -1,10 +1,7 @@
 import { memo, useState, useCallback, useMemo } from 'react';
-import { buildSingleViolationPlanText } from '../../../utils/planBuilder.js';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { buildPrincipleReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeColorClass } from '../../../utils/formatters.js';
-import CopyButton, { SparkleIcon } from '../../../components/CopyButton.jsx';
-import { copyToClipboard } from '../../../utils/clipboard.js';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
@@ -16,7 +13,7 @@ import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 // "Show all" pagination is needed. Rows render naturally inside the app's
 // existing scroll container.
 
-function ViolationListSection({ violationsBySeverity, principle, buildViolationPlanText, onDismiss }) {
+function ViolationListSection({ violationsBySeverity, principle, onDismiss }) {
   return EVAL_SEVERITY_ORDER.map((sev) => {
     const vs = violationsBySeverity[sev];
     if (!vs || vs.length === 0) return null;
@@ -29,7 +26,6 @@ function ViolationListSection({ violationsBySeverity, principle, buildViolationP
               key={`${v.file || 'nofile'}:${v.line ?? 'noline'}:${idx}`}
               v={v}
               principle={principle}
-              buildViolationPlanText={buildViolationPlanText}
               index={idx}
               onDismiss={onDismiss}
             />
@@ -59,10 +55,6 @@ function ComplianceListSection({ compliance, principle }) {
   );
 }
 
-function buildViolationPlanText(v, principle) {
-  return buildSingleViolationPlanText(v, principle, { reqRefs: v.reqRefs, reqFallback: v.req || undefined });
-}
-
 function SevBadgeRow({ sevCounts }) {
   if (!(sevCounts.critical || sevCounts.major || sevCounts.minor)) return null;
   return (
@@ -74,7 +66,7 @@ function SevBadgeRow({ sevCounts }) {
   );
 }
 
-function PrincipleHeader({ data, onCopyPlan }) {
+function PrincipleHeader({ data }) {
   const { principle, score, grade, violations, compliance, sevCounts } = data;
   const scoreDisplay = score ? String(score).replace('/10', '') : '—';
   const ratioDisplay = (compliance.length > 0 && violations.length > 0)
@@ -92,14 +84,6 @@ function PrincipleHeader({ data, onCopyPlan }) {
               : <span className={`chip small ${gradeColorClass(grade)}`}>{grade || '—'}</span>
           }
         />
-        {violations.length > 0 && (
-          <CopyButton
-            label="Full fix plan"
-            className="fix-plan-btn-header"
-            icon={<SparkleIcon />}
-            onClick={onCopyPlan}
-          />
-        )}
       </div>
       <StatStrip bordered>
         <Stat label="SCORE" value={scoreDisplay} />
@@ -227,11 +211,25 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
   }, [principle, dimension, runId, score, grade, liveScore, liveGrade, filteredViolations, displayedBySeverity, compliance, principleData]);
   useRegisterWindowSpec('report', reportSpec);
 
+  const fixPlanSpec = useMemo(() => {
+    if (!principle || filteredViolations.length === 0) return null;
+    const buildMarkdown = () => buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData);
+    const slug = `${(dimension || 'dim')}-${principle}`.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    return {
+      id: `fixplan:principle:${dimension || 'dim'}:${principle}:${runId || 'current'}`,
+      type: 'fixplan',
+      title: `${principle} fix plan`,
+      render: () => <ReportContent markdown={buildMarkdown()} />,
+      copy: () => buildMarkdown(),
+      download: () => ({ filename: `principle-${slug}-fix-plan.md`, body: buildMarkdown() }),
+    };
+  }, [principle, dimension, runId, violations, violationsBySeverity, principleData, filteredViolations.length]);
+  useRegisterWindowSpec('fixplan', fixPlanSpec);
+
   return (
     <>
       <PrincipleHeader
         data={{ principle, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts }}
-        onCopyPlan={() => copyToClipboard(buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData))}
       />
       <PrincipleContext principleData={principleData} />
       {filteredViolations.length > 0 && (
@@ -240,7 +238,6 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
       <ViolationListSection
         violationsBySeverity={displayedBySeverity}
         principle={principle}
-        buildViolationPlanText={(v) => buildViolationPlanText(v, principle)}
         onDismiss={handleDismiss}
       />
       <ComplianceListSection compliance={compliance} principle={principle} />

--- a/src/quodeq/ui/src/features/side-pane/index.js
+++ b/src/quodeq/ui/src/features/side-pane/index.js
@@ -3,3 +3,4 @@ export { SidePaneProvider } from './SidePaneProvider.jsx';
 export { useSidePane } from './SidePaneContext.jsx';
 export { useRegisterWindowSpec } from './useRegisterWindowSpec.js';
 export { ReportContent } from './reportContent.jsx';
+export { violationFixPlanSpec } from './violationFixPlanSpec.jsx';

--- a/src/quodeq/ui/src/features/side-pane/reportContent.jsx
+++ b/src/quodeq/ui/src/features/side-pane/reportContent.jsx
@@ -13,9 +13,9 @@ const components = {
   ),
 };
 
-export function ReportContent({ markdown }) {
+export function ReportContent({ markdown, emptyMessage = 'No content yet.' }) {
   if (!markdown || !markdown.trim()) {
-    return <p className="side-pane-md side-pane-md--empty">No content for this report yet.</p>;
+    return <p className="side-pane-md side-pane-md--empty">{emptyMessage}</p>;
   }
   return (
     <div className="side-pane-md">

--- a/src/quodeq/ui/src/features/side-pane/violationFixPlanSpec.jsx
+++ b/src/quodeq/ui/src/features/side-pane/violationFixPlanSpec.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ReportContent } from './reportContent.jsx';
+import { buildSingleViolationPlanText } from '../../utils/planBuilder.js';
+
+function slugify(s) {
+  return (s || 'violation').replace(/[^a-z0-9-]+/gi, '-').toLowerCase().replace(/^-|-$/g, '') || 'violation';
+}
+
+/**
+ * Build a side-pane window spec for a single violation's fix plan.
+ *
+ * @param {Object} v   Violation object (severity, principle, file, line, ...).
+ * @param {string} [titleOverride]  Title shown in the window header. Defaults
+ *                                  to "<dimension> / <principle>" or the
+ *                                  principle name when no dimension is set.
+ */
+export function violationFixPlanSpec(v, titleOverride) {
+  if (!v) return null;
+  const heading = titleOverride
+    || [v.dimension, v.principle].filter(Boolean).join(' / ')
+    || 'Violation';
+  const buildMarkdown = () => buildSingleViolationPlanText(v, heading, {
+    reqRefs: v.reqRefs,
+    reqFallback: v.req || undefined,
+  });
+  const fileRef = v.file ? `${v.file}${v.line != null ? `:${v.line}` : ''}` : 'unknown';
+  const slug = slugify(`${v.principle || 'violation'}-${fileRef}`);
+  return {
+    id: `fixplan:violation:${slug}`,
+    type: 'fixplan-violation',
+    title: `${heading} fix plan`,
+    render: () => <ReportContent markdown={buildMarkdown()} />,
+    copy: () => buildMarkdown(),
+    download: () => ({ filename: `violation-${slug}-fix-plan.md`, body: buildMarkdown() }),
+  };
+}

--- a/src/quodeq/ui/src/features/side-pane/violationFixPlanSpec.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/violationFixPlanSpec.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { violationFixPlanSpec } from './violationFixPlanSpec.jsx';
+
+describe('violationFixPlanSpec', () => {
+  it('returns null for missing violation', () => {
+    expect(violationFixPlanSpec(null)).toBeNull();
+    expect(violationFixPlanSpec(undefined)).toBeNull();
+  });
+
+  it('builds a spec with id, title, copy, download, and render', () => {
+    const v = {
+      severity: 'critical',
+      principle: 'SRP',
+      dimension: 'maintainability',
+      file: 'src/foo.js',
+      line: 12,
+      title: 'God object',
+      reason: 'Class does too much',
+    };
+    const spec = violationFixPlanSpec(v);
+    expect(spec).not.toBeNull();
+    expect(spec.id).toMatch(/^fixplan:violation:/);
+    expect(spec.type).toBe('fixplan-violation');
+    expect(spec.title).toMatch(/fix plan/i);
+    expect(typeof spec.copy).toBe('function');
+    expect(typeof spec.download).toBe('function');
+    const dl = spec.download();
+    expect(dl.filename).toMatch(/\.md$/);
+    expect(dl.body).toEqual(spec.copy());
+  });
+
+  it('uses titleOverride when provided', () => {
+    const spec = violationFixPlanSpec({ principle: 'SRP', dimension: 'maintainability' }, 'Custom title');
+    expect(spec.title).toMatch(/^Custom title/);
+  });
+
+  it('renders ReportContent with markdown body', () => {
+    const spec = violationFixPlanSpec({ principle: 'SRP', file: 'a.js', title: 'x' });
+    const { container } = render(<>{spec.render()}</>);
+    expect(container.querySelector('.side-pane-md')).not.toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -773,7 +773,8 @@
   .topbar-pill,
   .topbar-btn--evaluate,
   .topbar-btn--theme,
-  .topbar-btn--report { display: none !important; }
+  .topbar-btn--report,
+  .topbar-btn--fixplan { display: none !important; }
   .topbar-actions { gap: var(--term-space-1); }
   /* Compact view: hide all side-pane triggers. The pane itself is too
      narrow to be useful below 900px, and without triggers users can't
@@ -1908,15 +1909,19 @@
   background: var(--color-surface-alt);
   border-color: var(--color-text-muted);
 }
-/* Report button: neutral by default (same shape as Evaluate, no accent
-   tint), accent treatment only on hover or when the report pane is open. */
+/* Report and Fix-plan toolbar buttons: neutral by default (same shape as
+   Evaluate, no accent tint), accent treatment only on hover or when the
+   pane is open. */
 .topbar-btn--report:hover,
-.topbar-btn--report--open {
+.topbar-btn--report--open,
+.topbar-btn--fixplan:hover,
+.topbar-btn--fixplan--open {
   background: color-mix(in srgb, var(--color-accent) 10%, transparent);
   border-color: var(--color-accent);
   color: var(--color-accent);
 }
-.topbar-btn--report:focus-visible {
+.topbar-btn--report:focus-visible,
+.topbar-btn--fixplan:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- Topbar gains a **Fix plan** button (next to Report); appears whenever a page registers a \`fixplan\` side-pane spec.
- Pages that previously had an inline "Full fix plan" CopyButton now register the spec instead — the inline button is gone, the toolbar covers it.
- Per-violation **Fix plan** buttons (in \`EvalViolationCard\` and the \`FileDetailPage\` violation rows) now open the violation's plan in a fresh side-pane window with copy/download/close, instead of copying to clipboard.

Pages affected: Run detail, history-run detail, dimension/standard detail (Explorer), principle detail, file detail.

## Implementation notes
- Added \`violationFixPlanSpec(v, titleOverride)\` helper in \`features/side-pane\` so per-violation specs are built consistently.
- \`ReportContent\` empty-state copy is now generic ("No content yet."); accepts \`emptyMessage\` prop for overrides.
- The compact-drawer CSS breakpoint hides both \`.topbar-btn--report\` and \`.topbar-btn--fixplan\` (mobile/burger view).
- \`SidePaneWindow\` is type-agnostic — fixplan, fixplan-violation, and report specs all use the same window chrome.

## Test plan
- [x] \`npm test\` — 134 node tests passing
- [x] \`npx vitest run\` — 162 component tests passing (4 new for \`violationFixPlanSpec\`)
- [x] \`npx vite build\` — clean
- [x] Manual: on each detail page (run, history-run, dimension, principle, file), confirm the Fix plan toolbar button opens the slider with copy/download/close. On per-violation rows, confirm the inline Fix plan button opens a fresh side-pane window.
- [x] Manual: confirm the toolbar Fix plan button is hidden in compact (≤900px) view.