### PR TITLE
fix(ui): drop em-dash from at-cap toast message

### DIFF
--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
@@ -7,7 +7,7 @@ const LEGACY_STORAGE_KEY = 'quodeq.reportPaneWidth';
 const DEFAULT_WIDTH_PX = 560;
 const MAX_WINDOWS = 3;
 const NOTICE_DISMISS_MS = 4000;
-const AT_CAP_MESSAGE = `Up to ${MAX_WINDOWS} panels can be open at once — close one first.`;
+const AT_CAP_MESSAGE = `Up to ${MAX_WINDOWS} panels can be open at once. Close one first.`;
 
 function SidePaneToast({ notice, onDismiss }) {
   useEffect(() => {


### PR DESCRIPTION
Replaces the em-dash with a period in the side-pane at-cap toast (`Up to 3 panels can be open at once. Close one first.`).