### PR TITLE
fix(ui): read sidebar version from server health

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -297,7 +297,7 @@ function AppShell({ sidebar, header, content }) {
 export default function App() {
   const { dismissFinding } = useApi();
   const state = useAppState();
-  const APP_VERSION = '1.0.6';
+  const APP_VERSION = state.serverVersion;
   const selectedProjectInfo = state.projects?.find((p) => (p.id || p.name) === state.selectedProject) || null;
   const [sidebarPinned, setSidebarPinned] = useState(false);
   const sidebarProvider = (typeof localStorage !== 'undefined' && localStorage.getItem(ACTIVE_PROVIDER_KEY)) || null;

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -65,7 +65,7 @@ function useProjects({ onNoProjects }) {
 }
 
 function useAppNavigation() {
-  const [serverConnected, setServerConnected] = useServerHealth();
+  const [serverConnected, setServerConnected, serverVersion] = useServerHealth();
   const { navStack, activePage, navPush, navPop, navGoTo, navReset, navTab } = useNavStack();
   const projectBundle = useProjects({ onNoProjects: () => navTab('evaluate') });
   const { selectedRun, setSelectedRun, handleRunChange } = projectBundle;
@@ -75,7 +75,7 @@ function useAppNavigation() {
     if (page === 'history-run' && params.runId) setHistorySelectedRun(params.runId);
     navPush({ page, ...params });
   }
-  return { serverConnected, setServerConnected, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun };
+  return { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPush, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun };
 }
 
 export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRunIndex) {
@@ -90,7 +90,7 @@ export function formatDayLabel(trend, currentOverviewRun, dailyRuns, overviewRun
 
 export function useAppState() {
   const nav = useAppNavigation();
-  const { serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
+  const { serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navReset, navTab, projectBundle, handleNavigate, handleRunChange, historySelectedRun, setHistorySelectedRun } = nav;
   const {
     projects, projectsLoaded, setProjects, selectedProject,
     selectedRun, setSelectedRun, loadProjects, handleProjectChange,
@@ -138,7 +138,7 @@ export function useAppState() {
   const showRunNav = activeTab === TAB_OVERVIEW && showProjectHeader && visibleDailyRuns.length > 0 && navStack.length === 1;
 
   return {
-    serverConnected, setServerConnected, navStack, activePage, navPop, navGoTo, navTab,
+    serverConnected, setServerConnected, serverVersion, navStack, activePage, navPop, navGoTo, navTab,
     projects, projectsLoaded, selectedProject, selectedRun, handleProjectChange, handleNavigate,
     handleDeleteProject, handleExportProject, handleRelocateProject,
     dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, dailyRuns: visibleDailyRuns, overviewRunIndex,

--- a/src/quodeq/ui/src/hooks/useServerHealth.js
+++ b/src/quodeq/ui/src/hooks/useServerHealth.js
@@ -44,13 +44,15 @@ export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER
   // it on each poll resolution. setServerConnected(true) lets the reconnect
   // overlay optimistically clear the disconnected state until the next poll.
   const [connected, setConnected] = useState(true);
+  const [version, setVersion] = useState(null);
 
   useQuery({
     queryKey: systemKeys.health(),
     queryFn: async () => {
       try {
-        await getHealth();
+        const data = await getHealth();
         setConnected(true);
+        if (data?.version) setVersion(data.version);
         return true;
       } catch {
         const currentPort = typeof window !== 'undefined' ? window.location.port : '';
@@ -77,5 +79,5 @@ export function useServerHealth({ altPorts = DEFAULT_ALT_PORTS, baseUrl = SERVER
     setConnected(Boolean(next));
   }, []);
 
-  return [connected, setServerConnected];
+  return [connected, setServerConnected, version];
 }


### PR DESCRIPTION
The sidebar version badge was hardcoded to `1.0.6` in App.jsx while Settings was already reading the live value from `/api/health`. Now both surfaces use the same source.

`useServerHealth` tracks the version from each health poll; `useAppState` exposes it as `serverVersion`; App.jsx threads it into Sidebar in place of the constant. The Sidebar already hides the badge when version is null, so there's no flash before the first health response.