### PR TITLE
fix(topbar): reorder controls and standardize button heights

### DIFF
--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -69,7 +69,7 @@ function BackIcon() {
 
 function MoonIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
     </svg>
   );
@@ -77,7 +77,7 @@ function MoonIcon() {
 
 function SunIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <circle cx="12" cy="12" r="4" />
       <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
     </svg>
@@ -129,6 +129,21 @@ export default function TopBar({
       <div className="topbar-spacer" />
 
       <div className="topbar-actions">
+        <FixPlanToolbarButton />
+        <ReportToolbarButton />
+
+        {onToggleTheme && (
+          <button
+            type="button"
+            className="topbar-btn topbar-btn--icon topbar-btn--theme"
+            onClick={onToggleTheme}
+            aria-label={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
+            title={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
+          >
+            {effectiveDark ? <SunIcon /> : <MoonIcon />}
+          </button>
+        )}
+
         {(provider || model) && (
           onProviderClick ? (
             <button
@@ -150,19 +165,6 @@ export default function TopBar({
           )
         )}
 
-        {onToggleTheme && (
-          <button
-            type="button"
-            className="topbar-btn topbar-btn--icon topbar-btn--theme"
-            onClick={onToggleTheme}
-            aria-label={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
-            title={effectiveDark ? 'Switch to light theme' : 'Switch to dark theme'}
-          >
-            {effectiveDark ? <SunIcon /> : <MoonIcon />}
-          </button>
-        )}
-        <FixPlanToolbarButton />
-        <ReportToolbarButton />
         {onEvaluate && (
           <button
             type="button"

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1793,6 +1793,8 @@
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
+  min-height: 28px;
+  box-sizing: border-box;
   border: 1px solid var(--color-border);
   border-radius: var(--term-radius);
   font-size: 12px;
@@ -1844,12 +1846,20 @@
   font-family: inherit;
   font-size: 12px;
   font-weight: 500;
+  /* Same line-height as .topbar-pill so the inner content box matches —
+     keeps row heights identical across pill / button / icon-button. */
+  line-height: 1.4;
+  /* Lock all topbar controls to the same outer height regardless of
+     content (text vs icon). 28px = 12px font * 1.4 line-height + 4px+4px
+     padding + 2x 1px border, rounded. */
+  min-height: 28px;
   padding: 4px 10px;
   background: transparent;
   color: var(--color-text);
   border: 1px solid var(--color-border);
   border-radius: var(--term-radius);
   cursor: pointer;
+  box-sizing: border-box;
   transition: background 0.14s ease, border-color 0.14s ease, color 0.14s ease, box-shadow 0.14s ease, transform 0.14s ease;
 }
 .topbar-btn:hover {


### PR DESCRIPTION
## Order
Now: Fix plan, Report, theme toggle, provider pill, Evaluate.
- Two side-pane triggers go first (most-frequent actions on detail pages).
- Provider pill sits next to its primary action (Evaluate) so they read as one group.

## Heights
All five controls now share an explicit `min-height: 28px` and matching `line-height: 1.4`, so pill / button / icon-button / Evaluate all align on the same baseline regardless of content (text vs icon).

The theme icon is scaled to 12px to match the Fix-plan and Report icons; previously it was 14px which made the icon-only button look slightly chunkier.

Evaluate keeps its accent border treatment as the primary call-to-action.