### PR TITLE
style(explorer): terminal-polish dimension overview

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/TopOffendingFilesTable.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/TopOffendingFilesTable.jsx
@@ -1,10 +1,13 @@
-// Props: { files, onFileClick, pageSize = 20 }
-// Table of top offending files by violation count with pagination.
+// Props: { files, onFileClick }
+// Terminal-styled list of top offending files by violation count.
 // onFileClick is called with the file object when a row is clicked.
+//
+// Off-screen rows skip layout/paint via CSS `content-visibility: auto` on
+// `.offending-file-row`, so the full list renders without a "Show all"
+// pagination control.
 
-import { memo, useState } from 'react';
-
-const DEFAULT_PAGE_SIZE = 20;
+import { memo } from 'react';
+import { SevBadge } from '../../../components/terminal/index.js';
 
 function basenameOf(filepath) {
   if (!filepath) return '';
@@ -12,53 +15,37 @@ function basenameOf(filepath) {
   return idx >= 0 ? filepath.slice(idx + 1) : filepath;
 }
 
-const TopOffendingFilesTable = memo(function TopOffendingFilesTable({ files, onFileClick, pageSize = DEFAULT_PAGE_SIZE }) {
-  const [showAll, setShowAll] = useState(false);
-  const displayFiles = showAll ? (files || []) : (files || []).slice(0, pageSize);
-  const hasMore = (files || []).length > pageSize;
-
+const TopOffendingFilesTable = memo(function TopOffendingFilesTable({ files, onFileClick }) {
+  const list = files || [];
   return (
-    <>
-      <ul className="offending-file-list">
-        {displayFiles.map((f, idx) => (
-          <li
-            key={idx}
-            className={`offending-file-row${onFileClick ? ' offending-file-row--clickable' : ''}`}
-            onClick={onFileClick ? () => onFileClick(f) : undefined}
-            role={onFileClick ? 'button' : undefined}
-            tabIndex={onFileClick ? 0 : undefined}
-            onKeyDown={onFileClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onFileClick(f); } } : undefined}
-            title={f.file}
-          >
-            <div className="offending-file-info">
-              <span className="offending-file-name">{basenameOf(f.file)}</span>
-              <span className="offending-file-path">{f.file}</span>
-              {f.dimensionsStr && (
-                <span className="offending-file-dims">{f.dimensionsStr}</span>
-              )}
-            </div>
-            <strong className="offending-file-total">{f.total}</strong>
-            <span className="offending-file-tags">
-              {f.critical > 0 && (
-                <span className="severity-tag critical">{f.critical} critical</span>
-              )}
-              {f.major > 0 && (
-                <span className="severity-tag major">{f.major} major</span>
-              )}
-              {f.minor > 0 && (
-                <span className="severity-tag minor">{f.minor} minor</span>
-              )}
-            </span>
-            {onFileClick && <span className="offending-file-chevron">›</span>}
-          </li>
-        ))}
-      </ul>
-      {hasMore && (
-        <button className="offending-show-more" onClick={() => setShowAll(v => !v)}>
-          {showAll ? 'Show less' : `Show all ${files.length} files`}
-        </button>
-      )}
-    </>
+    <ul className="offending-file-list">
+      {list.map((f, idx) => (
+        <li
+          key={idx}
+          className={`offending-file-row${onFileClick ? ' offending-file-row--clickable' : ''}`}
+          onClick={onFileClick ? () => onFileClick(f) : undefined}
+          role={onFileClick ? 'button' : undefined}
+          tabIndex={onFileClick ? 0 : undefined}
+          onKeyDown={onFileClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onFileClick(f); } } : undefined}
+          title={f.file}
+        >
+          <div className="offending-file-info">
+            <span className="offending-file-name">{basenameOf(f.file)}</span>
+            <span className="offending-file-path">{f.file}</span>
+            {f.dimensionsStr && (
+              <span className="offending-file-dims">{f.dimensionsStr}</span>
+            )}
+          </div>
+          <strong className="offending-file-total">{f.total}</strong>
+          <span className="offending-file-tags">
+            {f.critical > 0 && <SevBadge level="critical" count={f.critical} format="count-abbr" />}
+            {f.major > 0 && <SevBadge level="major" count={f.major} format="count-abbr" />}
+            {f.minor > 0 && <SevBadge level="minor" count={f.minor} format="count-abbr" />}
+          </span>
+          {onFileClick && <span className="offending-file-chevron">›</span>}
+        </li>
+      ))}
+    </ul>
   );
 });
 

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -1,5 +1,6 @@
 import { SectionLabel } from '../../../components/terminal/index.js';
 import { extractDimensionHistory } from '../../../components/DimensionSparkline.jsx';
+import { scoreGradeColorVar } from '../../../utils/formatters.js';
 
 const MAX = 16;
 
@@ -34,40 +35,39 @@ export default function DimensionScoreHistoryPanel({ trend = [], dimension }) {
   );
 }
 
+// Fixed visible scale matches the inline DimensionSparkline so bar heights
+// read consistently across both surfaces. The top of the chart always
+// represents 10/10 (the "100%" reference).
+const SCALE_MIN = 4;
+const SCALE_MAX = 10;
+
 function DimensionHistoryChart({ scores }) {
-  // Bar+line chart auto-scaled to the data range so bars fill the panel.
   const W = 480;
   const H = 180;
   const PAD_X = 10;
+  const PAD_TOP = 10;
+  const PAD_BOT = 6;
   const GAP = 12;
   const barW = (W - PAD_X * 2 - GAP * (scores.length - 1)) / scores.length;
-  const lo = Math.min(...scores);
-  const hi = Math.max(...scores);
-  const range = Math.max(hi - lo, 0.5); // avoid divide-by-zero when all equal
-  const padding = range * 0.15;
-  const yMin = Math.max(0, lo - padding);
-  const yMax = Math.min(10, hi + padding);
-  const yFor = (v) => H - 6 - ((Math.max(yMin, Math.min(v, yMax)) - yMin) / (yMax - yMin)) * (H - 16);
+  const yFor = (v) => {
+    const clipped = Math.max(SCALE_MIN, Math.min(SCALE_MAX, v));
+    const ratio = (clipped - SCALE_MIN) / (SCALE_MAX - SCALE_MIN);
+    return H - PAD_BOT - ratio * (H - PAD_TOP - PAD_BOT);
+  };
   const xFor = (i) => PAD_X + i * (barW + GAP);
-  const last = scores.length - 1;
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H }}>
+    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: '100%', minHeight: H, display: 'block' }}>
       {[0.25, 0.5, 0.75].map((p) => (
         <line key={p} x1="0" y1={H * p} x2={W} y2={H * p}
               stroke="var(--color-border)" strokeDasharray="2 3" strokeWidth="0.5" />
       ))}
+      {/* 100% reference at the top of the plot area */}
+      <line x1="0" y1={PAD_TOP} x2={W} y2={PAD_TOP}
+            stroke="var(--color-border)" strokeWidth="0.6" />
       {scores.map((v, i) => {
         const y = yFor(v);
-        const fill = i === last ? 'var(--color-accent)' : i >= scores.length - 3 ? '#c8b08c' : '#d8c8b0';
-        return <rect key={i} x={xFor(i)} y={y} width={barW} height={H - 6 - y} fill={fill} />;
+        return <rect key={i} x={xFor(i)} y={y} width={barW} height={H - PAD_BOT - y} fill={scoreGradeColorVar(v)} />;
       })}
-      <polyline
-        fill="none"
-        stroke="var(--color-accent)"
-        strokeWidth="1.8"
-        points={scores.map((v, i) => `${xFor(i) + barW / 2},${yFor(v)}`).join(' ')}
-      />
-      <circle cx={xFor(last) + barW / 2} cy={yFor(scores[last])} r="3" fill="var(--color-text)" />
     </svg>
   );
 }

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -35,13 +35,19 @@ export default function DimensionScoreHistoryPanel({ trend = [], dimension }) {
 }
 
 function DimensionHistoryChart({ scores }) {
-  // Simple SVG bar+line chart, scaled 0..10. Latest is rightmost & highlighted.
+  // Bar+line chart auto-scaled to the data range so bars fill the panel.
   const W = 480;
   const H = 180;
   const PAD_X = 10;
   const GAP = 12;
   const barW = (W - PAD_X * 2 - GAP * (scores.length - 1)) / scores.length;
-  const yFor = (v) => H - 6 - (Math.max(0, Math.min(v, 10)) / 10) * (H - 16);
+  const lo = Math.min(...scores);
+  const hi = Math.max(...scores);
+  const range = Math.max(hi - lo, 0.5); // avoid divide-by-zero when all equal
+  const padding = range * 0.15;
+  const yMin = Math.max(0, lo - padding);
+  const yMax = Math.min(10, hi + padding);
+  const yFor = (v) => H - 6 - ((Math.max(yMin, Math.min(v, yMax)) - yMin) / (yMax - yMin)) * (H - 16);
   const xFor = (i) => PAD_X + i * (barW + GAP);
   const last = scores.length - 1;
   return (

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -25,6 +25,37 @@ function buildRadialPrinciples(principleGrades) {
   });
 }
 
+/**
+ * Enrich each principleGrade with the per-principle counts that
+ * DimensionGaugeCard expects: total violations, compliance count, and a
+ * severity histogram. The data comes from the same evalData we already
+ * have — no extra API call.
+ */
+function buildEnrichedPrinciples(principleGrades, allViolations, complianceByPrinciple) {
+  const violationsByPrinciple = new Map();
+  for (const v of allViolations || []) {
+    const key = v.principle;
+    if (!key) continue;
+    if (!violationsByPrinciple.has(key)) violationsByPrinciple.set(key, []);
+    violationsByPrinciple.get(key).push(v);
+  }
+  return (principleGrades || []).map((pg) => {
+    const vs = violationsByPrinciple.get(pg.principle) || [];
+    const severity = { critical: 0, major: 0, minor: 0 };
+    for (const v of vs) {
+      const s = (v.severity || 'minor').toLowerCase();
+      if (severity[s] !== undefined) severity[s]++;
+    }
+    const compliance = complianceByPrinciple?.get?.(pg.principle) || [];
+    return {
+      ...pg,
+      violationCount: vs.length,
+      complianceCount: compliance.length,
+      severity,
+    };
+  });
+}
+
 export default function ExplorerPage({
   project,
   dimension,
@@ -84,6 +115,7 @@ export default function ExplorerPage({
 
   const dim = String(d.evalData.dimension || '').toLowerCase();
   const radialPrinciples = buildRadialPrinciples(d.principleGrades);
+  const enrichedPrinciples = buildEnrichedPrinciples(d.principleGrades, d.allViolations, d.complianceByPrinciple);
   const onPrincipleClick = (name) => onNavigate?.('evalprinciple', { evalPrincipal: buildEvalPrincipal(name) });
 
   const overallScoreNum = parseFloat(d.overallGrade?.score);
@@ -128,7 +160,7 @@ export default function ExplorerPage({
         </div>
 
         <div className="qd-top-right">
-          <section className="panel" aria-label="Principles radial">
+          <section className="run-history-panel--terminal panel" aria-label="Principles radial">
             <div className="run-history-panel__header">
               <SectionLabel>principles_radial · {radialPrinciples.length}</SectionLabel>
               <span className="run-history-panel__stats">SCALE 0–10</span>
@@ -143,19 +175,21 @@ export default function ExplorerPage({
         </div>
       </div>
 
-      <div className="qd-section-banner">
-        <SectionLabel>{`principles · ${radialPrinciples.length}`}</SectionLabel>
-      </div>
-      <PrinciplesCardsRow
-        principles={d.principleGrades || []}
-        onPrincipleClick={onPrincipleClick}
-      />
+      <section className="qd-cards-panel" aria-label="Principles">
+        <div className="qd-cards-panel__head">
+          <SectionLabel>{`principles · ${radialPrinciples.length}`}</SectionLabel>
+        </div>
+        <PrinciplesCardsRow
+          principles={enrichedPrinciples}
+          onPrincipleClick={onPrincipleClick}
+        />
+      </section>
 
-      <div className="qd-section-banner">
-        <SectionLabel>{`violations_by_file · ${d.topFiles.length}`}</SectionLabel>
-        <span className="run-history-panel__stats">SORTED BY SEVERITY</span>
-      </div>
-      <section className="panel wide-panel offending-panel">
+      <section className="qd-cards-panel offending-panel" aria-label="Violations by file">
+        <div className="qd-cards-panel__head">
+          <SectionLabel>{`violations_by_file · ${d.topFiles.length}`}</SectionLabel>
+          <span className="run-history-panel__stats">SORTED BY SEVERITY</span>
+        </div>
         <TopOffendingFilesTable
           files={d.topFiles}
           onFileClick={(f) => onNavigate?.('file', { file: f })}

--- a/src/quodeq/ui/src/features/explorer/components/PrinciplesRadial.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrinciplesRadial.jsx
@@ -12,11 +12,14 @@
  *   - 3+ plotted: a filled <polyline> (with implicit-close fill) connecting
  *     plotted vertices in axis order; insufficient axes produce stroke gaps.
  */
+import { scoreGradeColorVar } from '../../../utils/formatters.js';
 const RING_LEVELS = [0.2, 0.4, 0.6, 0.8, 1.0]; // fraction of max
-const LABEL_OFFSET = 16;     // svg units beyond the outer ring
-const SUB_OFFSET   = 28;     // sub-label offset (score below name)
+const LABEL_OFFSET = 18;     // svg units beyond the outer ring (name baseline)
 const VERT_RADIUS = 3.2;
 const INSUF_RADIUS = 3.0;
+// Horizontal padding around the plot so long principle names don't clip.
+const VIEWBOX_PAD_X = 140;
+const VIEWBOX_PAD_Y = 24;
 
 function axisAngles(n) {
   // First axis at 12 o'clock, then clockwise.
@@ -31,11 +34,25 @@ function ringPoints(angles, r) {
   return angles.map((a) => polar(a, r).join(',')).join(' ');
 }
 
+// Greedy word-wrap so long principle names break onto a second line instead of
+// running off the SVG. `maxChars` is a coarse character budget per line.
+function wrapLines(words, maxChars) {
+  const lines = [];
+  let current = '';
+  for (const w of words) {
+    if (!current) { current = w; continue; }
+    if (current.length + 1 + w.length <= maxChars) current = `${current} ${w}`;
+    else { lines.push(current); current = w; }
+  }
+  if (current) lines.push(current);
+  return lines.length ? lines : [''];
+}
+
 export default function PrinciplesRadial({
   principles = [],
   scaleMax = 10,
   size = 400,
-  outerRadius = 160,
+  outerRadius = 200,
   onPrincipleClick,
 }) {
   const n = principles.length;
@@ -57,7 +74,7 @@ export default function PrinciplesRadial({
   const showPolyline = plotted.length >= 2;
 
   const half = size / 2;
-  const viewBox = `${-half} ${-half - 10} ${size} ${size + 20}`;
+  const viewBox = `${-half - VIEWBOX_PAD_X} ${-half - VIEWBOX_PAD_Y} ${size + VIEWBOX_PAD_X * 2} ${size + VIEWBOX_PAD_Y * 2}`;
 
   const handleClick = (name) => () => onPrincipleClick && onPrincipleClick(name);
   const handleKey = (name) => (e) => {
@@ -138,12 +155,16 @@ export default function PrinciplesRadial({
           />
         );
       })}
-      {/* Labels */}
+      {/* Labels — name and score share an anchor point on a label ring just
+          outside the plot. Score is always rendered on the line below the name
+          via a tspan(dy), so the two never collide regardless of axis angle. */}
       {principles.map((p, i) => {
         const [x, y] = polar(angles[i], outerRadius + LABEL_OFFSET);
-        const [sx, sy] = polar(angles[i], outerRadius + SUB_OFFSET);
         const isInsuf = !p.hasEvidence;
-        const anchor = Math.cos(angles[i]) > 0.2 ? 'start' : Math.cos(angles[i]) < -0.2 ? 'end' : 'middle';
+        const cosA = Math.cos(angles[i]);
+        const anchor = cosA > 0.2 ? 'start' : cosA < -0.2 ? 'end' : 'middle';
+        const words = p.name.toUpperCase().split(/\s+/);
+        const lines = wrapLines(words, 14);
         return (
           <g
             key={`lab-${i}`}
@@ -159,15 +180,17 @@ export default function PrinciplesRadial({
               y={y}
               textAnchor={anchor}
             >
-              {p.name.toUpperCase()}
-            </text>
-            <text
-              className={`qd-radial__lab-sub${isInsuf ? ' qd-radial__lab-sub--insuf' : ''}`}
-              x={sx}
-              y={sy}
-              textAnchor={anchor}
-            >
-              {isInsuf ? 'insufficient' : p.score?.toFixed(1)}
+              {lines.map((line, li) => (
+                <tspan key={li} x={x} dy={li === 0 ? 0 : '1.15em'}>{line}</tspan>
+              ))}
+              <tspan
+                className={`qd-radial__lab-sub${isInsuf ? ' qd-radial__lab-sub--insuf' : ''}`}
+                x={x}
+                dy="1.25em"
+                style={isInsuf ? undefined : { fill: scoreGradeColorVar(p.score) }}
+              >
+                {isInsuf ? 'insufficient' : p.score?.toFixed(1)}
+              </tspan>
             </text>
           </g>
         );

--- a/src/quodeq/ui/src/features/explorer/components/PrinciplesRadial.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrinciplesRadial.jsx
@@ -50,7 +50,10 @@ export default function PrinciplesRadial({
     return polar(p.angle, r);
   });
 
-  const polylineFill = plotted.length >= 3 ? 'rgba(181,84,58,0.16)' : 'none';
+  const polylineFill = plotted.length >= 3
+    ? 'color-mix(in srgb, var(--color-accent) 18%, transparent)'
+    : 'none';
+  const isClosed = plotted.length >= 3 && plotted.length === principles.length;
   const showPolyline = plotted.length >= 2;
 
   const half = size / 2;
@@ -96,7 +99,9 @@ export default function PrinciplesRadial({
         <polyline
           className="qd-radial__poly"
           fill={polylineFill}
-          points={points.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(' ')}
+          points={(isClosed ? [...points, points[0]] : points)
+            .map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`)
+            .join(' ')}
         />
       )}
       {/* Plotted vertices */}

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -582,7 +582,11 @@
 .dimensions-grid {
   display: grid;
   gap: var(--space-3);
-  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  /* Cards stretch to share whatever width is left so the row stays full
+     before wrapping. They wrap to a new row only once each track would fall
+     below the 180px min — no half-empty rows just because a fixed max didn't
+     divide cleanly. */
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .dimension-card {
@@ -1447,18 +1451,25 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  font-family: var(--term-font-mono);
 }
 
 .offending-file-row {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  transition: background 0.12s, border-color 0.12s;
+  gap: var(--term-space-3);
+  padding: 10px var(--term-space-2);
+  border-bottom: var(--term-divider);
+  transition: background-color 0.12s;
+  /* Off-screen rows skip layout/paint natively. Same trick used by
+     `.vdetail-row` in evaluation.css. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 56px;
+}
+
+.offending-file-row:last-child {
+  border-bottom: 0;
 }
 
 .offending-file-row--clickable {
@@ -1466,8 +1477,13 @@
 }
 
 .offending-file-row--clickable:hover {
-  background: color-mix(in srgb, var(--color-accent) 7%, transparent);
-  border-color: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  background: var(--color-surface-alt);
+}
+
+.offending-file-row--clickable:focus-visible {
+  outline: 0;
+  background: var(--color-surface-alt);
+  box-shadow: inset 2px 0 0 var(--color-accent);
 }
 
 .offending-file-row--clickable:hover .offending-file-chevron {
@@ -1483,11 +1499,13 @@
 }
 
 .offending-file-total {
-  font-size: 0.88rem;
+  font-family: var(--term-font-mono);
+  font-size: 13px;
   font-weight: 700;
   color: var(--color-text);
   min-width: 22px;
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .offending-file-info {
@@ -1499,10 +1517,11 @@
 }
 
 .offending-file-name {
-  font-size: 0.95rem;
-  font-weight: var(--weight-semibold, 600);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--text-sm);
+  font-weight: 400;
   color: var(--color-text);
-  letter-spacing: -0.005em;
+  letter-spacing: 0.02em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1512,8 +1531,9 @@
 
 .offending-file-path {
   min-width: 0;
-  font-size: 0.75rem;
-  color: var(--color-text-subtle);
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1521,8 +1541,11 @@
 }
 
 .offending-file-dims {
-  font-size: 0.72rem;
-  color: var(--color-text-muted);
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1534,29 +1557,11 @@
 
 .offending-file-chevron {
   flex-shrink: 0;
-  font-size: 1.1rem;
-  color: var(--color-accent);
-  opacity: 0.3;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--color-text-muted);
+  opacity: 0.5;
   transition: opacity 0.12s, transform 0.12s;
-}
-
-.offending-show-more {
-  display: block;
-  width: 100%;
-  margin-top: 8px;
-  padding: 6px 0;
-  background: none;
-  border: none;
-  color: var(--color-accent);
-  font-size: var(--text-sm);
-  cursor: pointer;
-  text-align: center;
-  opacity: 0.75;
-  transition: opacity 0.12s;
-}
-
-.offending-show-more:hover {
-  opacity: 1;
 }
 
 /* Diff summary section */

--- a/src/quodeq/ui/src/styles/dim-gauge-card.css
+++ b/src/quodeq/ui/src/styles/dim-gauge-card.css
@@ -39,10 +39,11 @@
 /* header row: name + trend */
 .dim-gauge-card__head {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--space-1);
   flex-wrap: nowrap;
+  min-height: 2.5em;
 }
 .dim-gauge-card__name {
   font-size: var(--text-sm);
@@ -51,9 +52,12 @@
   letter-spacing: 0.02em;
   min-width: 0;
   flex: 1 1 auto;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.25;
+  word-break: break-word;
 }
 .dim-gauge-card__head .trend-badge {
   flex: 0 0 auto;

--- a/src/quodeq/ui/src/styles/explorer-redesign.css
+++ b/src/quodeq/ui/src/styles/explorer-redesign.css
@@ -9,51 +9,66 @@
   align-items: stretch;
 }
 .qd-top-left { display: flex; flex-direction: column; gap: var(--space-3, 12px); }
+/* Let the score-history panel consume the remaining height in the left column
+   so its bars fill the gap when the radial on the right is taller. */
+.qd-top-left > .run-history-panel--terminal {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.qd-top-left > .run-history-panel--terminal > svg,
+.qd-top-left > .run-history-panel--terminal > .qd-history-empty {
+  flex: 1;
+  min-height: 0;
+}
 .qd-top-right { display: flex; }
 .qd-top-right > .panel { flex: 1; display: flex; flex-direction: column; }
 .qd-top-right > .panel .qd-radial { flex: 1; align-items: center; }
 
-/* 2x2 stats */
+/* 2x2 stats — each cell is a bordered card to match the overview's cards strip,
+   sized down to fit four panels in the dimension-detail's left column. */
 .qd-stats-2x2 {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: var(--space-3, 12px);
 }
-
-/* Section banner (mirrors QUALITY_DIMENSIONS strip) */
-.qd-section-banner {
-  background: var(--color-surface-alt);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 8px 14px;
-  margin: var(--space-3, 12px) 0 var(--space-2, 8px);
+.qd-stats-2x2 .term-stat {
+  border: var(--term-border);
+  border-radius: var(--term-radius);
+  padding: var(--term-space-3) var(--term-space-3) 18px;
+  background: var(--color-surface);
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  min-height: 0;
-}
-.qd-section-banner .term-section-label {
-  padding: 0;
+  flex-direction: column;
+  gap: var(--term-space-1);
 }
 
-/* Cards row */
+/* Cards-panel rhythm: sit below the top grid with the same gap as the grid. */
+.qd-cards-panel {
+  margin-top: var(--space-3, 12px);
+}
+
+/* Cards row — cards stretch to share leftover width so the row stays full
+   before wrapping. Wrap only when each track would fall below 180px; this
+   avoids the half-empty trailing row a fixed-max + center produced. */
 .qd-cards-row {
   display: grid;
-  grid-template-columns: repeat(var(--qd-cards-count, 5), 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: var(--space-3, 12px);
 }
 
 /* Radial container */
 .qd-radial { display: flex; justify-content: center; align-items: center; padding: 6px 0 4px; }
-.qd-radial__svg { display: block; max-width: 360px; }
-.qd-radial__ring { stroke: var(--color-border); stroke-width: 0.6; }
-.qd-radial__axis { stroke: var(--color-rule, var(--primitive-sand-300, #d4ccc0)); stroke-width: 0.5; stroke-dasharray: 2 3; }
+.qd-radial__svg { display: block; max-width: 640px; width: 100%; overflow: visible; }
+.qd-radial__ring { stroke: var(--color-text-muted); stroke-width: 0.8; opacity: 0.55; }
+.qd-radial__axis { stroke: var(--color-text-muted); stroke-width: 0.9; stroke-dasharray: 2 3; opacity: 0.75; }
 .qd-radial__poly { stroke: var(--color-accent); stroke-width: 1.4; stroke-linejoin: round; }
 .qd-radial__vert { fill: var(--color-accent); }
 .qd-radial__vert--insuf { stroke: var(--color-text-subtle); stroke-width: 1; stroke-dasharray: 1.5 1.5; }
-.qd-radial__lab { font: 10px ui-monospace, monospace; fill: var(--color-text); letter-spacing: 0.05em; }
-.qd-radial__lab-sub { font: 10px ui-monospace, monospace; fill: var(--color-text-muted); }
-.qd-radial__lab--insuf, .qd-radial__lab-sub--insuf { fill: var(--color-text-subtle); }
+.qd-radial__lab { font: 500 13px ui-monospace, monospace; fill: var(--color-text); letter-spacing: 0.04em; }
+.qd-radial__lab-sub { font: 600 14px ui-monospace, monospace; fill: var(--color-text); letter-spacing: 0.02em; }
+.qd-radial__lab--insuf { fill: var(--color-text-subtle); }
+.qd-radial__lab-sub--insuf { fill: var(--color-text-subtle); font: 500 11px ui-monospace, monospace; letter-spacing: 0.04em; }
 .qd-radial__label-group { cursor: pointer; }
 .qd-radial__label-group--insuf { cursor: default; }
 .qd-radial__label-group:hover .qd-radial__lab { fill: var(--color-accent); }
@@ -64,4 +79,15 @@
   color: var(--color-text-subtle);
   text-align: center;
   padding: 36px 0;
+}
+
+/* Narrow viewports: stack the top grid (radial drops below score history) and
+   keep at least two principle cards per row so they don't collapse to a list. */
+@media (max-width: 760px) {
+  .qd-top-grid {
+    grid-template-columns: 1fr;
+  }
+  .qd-cards-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/src/quodeq/ui/src/styles/explorer-redesign.css
+++ b/src/quodeq/ui/src/styles/explorer-redesign.css
@@ -25,11 +25,15 @@
   background: var(--color-surface-alt);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 10px 14px;
-  margin: var(--space-4, 16px) 0 var(--space-2, 8px);
+  padding: 8px 14px;
+  margin: var(--space-3, 12px) 0 var(--space-2, 8px);
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  min-height: 0;
+}
+.qd-section-banner .term-section-label {
+  padding: 0;
 }
 
 /* Cards row */

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -936,7 +936,8 @@
 .run-history-panel--terminal,
 .dim-score-panel--terminal,
 .top-findings,
-.quality-dimensions {
+.quality-dimensions,
+.qd-cards-panel {
   border: 1px solid var(--color-border) !important;
   border-radius: var(--term-radius) !important;
   box-shadow: none !important;
@@ -950,6 +951,7 @@
 .run-history-panel--terminal .run-history-panel__header,
 .top-findings__head,
 .quality-dimensions__head,
+.qd-cards-panel__head,
 .dim-score-panel--terminal .dim-score-panel__header {
   display: flex;
   align-items: baseline;
@@ -967,7 +969,8 @@
 }
 .run-history-panel--terminal .run-history-panel__header .term-section-label,
 .top-findings__head .term-section-label,
-.quality-dimensions__head .term-section-label {
+.quality-dimensions__head .term-section-label,
+.qd-cards-panel__head .term-section-label {
   padding: 0;
 }
 
@@ -975,6 +978,7 @@
 .run-history-panel--terminal > *:not(.run-history-panel__header),
 .top-findings > *:not(.top-findings__head),
 .quality-dimensions > *:not(.quality-dimensions__head),
+.qd-cards-panel > *:not(.qd-cards-panel__head),
 .dim-score-panel--terminal > *:not(.dim-score-panel__header) {
   padding: var(--term-space-3);
 }


### PR DESCRIPTION
Re-applies the work from #347, which merged into a feature branch (`feat/standard-detail-redesign`) that had already been merged & deleted via #346 — so its commits never made it onto `develop`. This PR cherry-picks both commits onto `develop` directly.

## Summary
- **VIOLATIONS_BY_FILE** — monospace + terminal palette; severity tags use `count-abbr` SevBadges (`3 CRIT`, `2 MAJ`) to match `DimensionGaugeCard`. Drop the "Show all / Show less" pagination control; rows are natively lazy via `content-visibility: auto` (same trick as `.vdetail-row` on the principle detail).
- **SCORE_HISTORY** — drop the cyan trend polyline + endpoint dot. Every bar uses `scoreGradeColorVar(v)`, so the latest run shows its real grade instead of being painted accent. Also picks up the autoscale + section-banner slimming from the orphan commit.
- **PRINCIPLES_RADIAL** — close radial stroke (orphan commit) plus polish: heavier dashed reference lines, lighter principle labels (font-weight 500), larger score sublabel rendered in its grade color via inline `style.fill`.

## Test plan
- [x] Open a dimension overview with mixed-severity findings — confirm `VIOLATIONS_BY_FILE` rows render in mono, severity tags appear as `N CRIT` / `N MAJ` / `N MIN`, and there's no "Show all" button.
- [x] Scroll a long file list and confirm rows below the fold are paint-skipped but appear correctly when scrolled in.
- [x] Open a dimension whose latest score is critical — confirm the last `SCORE_HISTORY` bar is in its grade color (not cyan), and there is no overlay line.
- [x] Confirm radial sublabel scores show in their grade color and the dashed axis lines remain visible behind the filled polygon.