### PR TITLE
chore: env overrides for stale constants flagged in flexibility audit

### DIFF
--- a/src/quodeq/analysis/_backfill.py
+++ b/src/quodeq/analysis/_backfill.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json as _json
+import os
 import time
 from copy import copy
 from dataclasses import dataclass
@@ -15,7 +16,23 @@ from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
 from quodeq.shared.logging import log_debug, log_info
 
 
-_MIN_BACKFILL_BUDGET_S = 60
+_DEFAULT_MIN_BACKFILL_BUDGET_S = 60
+
+
+def _min_backfill_budget_s() -> int:
+    """Return the minimum remaining-budget threshold to start a backfill phase.
+
+    Honours QUODEQ_MIN_BACKFILL_BUDGET_S; falls back to the default on any
+    parse error or non-positive value.
+    """
+    raw = os.environ.get("QUODEQ_MIN_BACKFILL_BUDGET_S")
+    if not raw:
+        return _DEFAULT_MIN_BACKFILL_BUDGET_S
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MIN_BACKFILL_BUDGET_S
+    return value if value > 0 else _DEFAULT_MIN_BACKFILL_BUDGET_S
 
 
 @dataclass
@@ -92,7 +109,7 @@ def run_backfill_phase(
         total_budget = pool_budget or _DEFAULT_POOL_BUDGET
         remaining_budget = max(0, total_budget - int(elapsed))
 
-        if remaining_budget < _MIN_BACKFILL_BUDGET_S:
+        if remaining_budget < _min_backfill_budget_s():
             log_info(f"  [{dimension}] Backfill: {len(backfill_candidates)} unevaluated files, but no budget remaining")
             return backfill_taken
         log_info(

--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -4,8 +4,10 @@ Each function handles one JSON-RPC method and returns the response dict.
 """
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
+from quodeq import __version__
 from quodeq.analysis.mcp.jsonrpc_io import _JSONRPC_VERSION, send as _send, ok as _ok
 from quodeq.analysis.mcp.schemas import (
     _DEFAULT_FILE_BATCH_SIZE,
@@ -24,8 +26,20 @@ if TYPE_CHECKING:
 _JSONRPC_METHOD_NOT_FOUND = -32601
 _MCP_DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 _SERVER_NAME = "quodeq-findings"
-_SERVER_VERSION = "1.0.0"
-_MAX_FILE_BATCH_SIZE = 1000
+_SERVER_VERSION = __version__ or "0.0.0"
+_DEFAULT_MAX_FILE_BATCH_SIZE = 1000
+
+
+def _max_file_batch_size() -> int:
+    """Return the per-call file-batch ceiling, honouring QUODEQ_MCP_MAX_BATCH."""
+    raw = os.environ.get("QUODEQ_MCP_MAX_BATCH")
+    if not raw:
+        return _DEFAULT_MAX_FILE_BATCH_SIZE
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_FILE_BATCH_SIZE
+    return value if value > 0 else _DEFAULT_MAX_FILE_BATCH_SIZE
 
 
 def handle_initialize(request_id: object, msg: dict) -> dict:
@@ -78,7 +92,7 @@ def handle_tools_call(
         count = args.get("count", _DEFAULT_FILE_BATCH_SIZE)
         if not isinstance(count, int) or count < 1:
             count = _DEFAULT_FILE_BATCH_SIZE
-        count = min(count, _MAX_FILE_BATCH_SIZE)
+        count = min(count, _max_file_batch_size())
         files = queue.take(count, agent_id=agent_id)
         if not files:
             return _ok(request_id, {

--- a/src/quodeq/api/_ollama_log_routes.py
+++ b/src/quodeq/api/_ollama_log_routes.py
@@ -14,9 +14,14 @@ from quodeq.api._sse_log_helpers import sse_tail_generator
 def _ollama_log_path() -> Path | None:
     """Return the platform's Ollama server log path, or None if not present.
 
-    macOS / Linux: ~/.ollama/logs/server.log
-    Windows: %LOCALAPPDATA%/Ollama/server.log
+    Resolution order:
+      1. ``QUODEQ_OLLAMA_LOG`` env var (explicit override for non-default installs)
+      2. macOS / Linux: ~/.ollama/logs/server.log
+      3. Windows: %LOCALAPPDATA%/Ollama/server.log
     """
+    override = os.environ.get("QUODEQ_OLLAMA_LOG")
+    if override:
+        return Path(override)
     if sys.platform == "win32":
         local_app = os.environ.get("LOCALAPPDATA")
         if not local_app:

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -213,7 +213,7 @@ from typing import Iterator
 from quodeq.api._sse_log_helpers import sse_line
 
 _TICK_MS = int(os.environ.get("QUODEQ_SSE_TICK_MS", "250"))
-_HEARTBEAT_S = 15.0
+_HEARTBEAT_S = float(os.environ.get("QUODEQ_SSE_HEARTBEAT_S", "15"))
 _TERMINAL_STATES = frozenset({"done", "failed", "cancelled"})
 
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -37,7 +37,20 @@ _SKIP_GRADES = {"NA", "N/A", "INSUFFICIENT"}
 # stale dimensions. The full run list is still returned in availableRuns (metadata
 # only, no disk reads) so users can navigate to older runs directly.
 _LATEST_RUN = "latest"
-_MAX_HISTORY_RUNS = 100
+_DEFAULT_MAX_HISTORY_RUNS = 100
+
+
+def _max_history_runs(env: dict[str, str] | None = None) -> int:
+    """Return the history-scan ceiling, honouring QUODEQ_MAX_HISTORY_RUNS."""
+    raw = (env or os.environ).get("QUODEQ_MAX_HISTORY_RUNS")
+    if not raw:
+        return _DEFAULT_MAX_HISTORY_RUNS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_HISTORY_RUNS
+    return value if value > 0 else _DEFAULT_MAX_HISTORY_RUNS
+
 
 _DEFAULT_RUN_DIM_CACHE_MAX = 256
 
@@ -239,13 +252,14 @@ def _compute_dashboard_payload(
         (i for i, r in enumerate(scoreable_runs) if r.run_id == ctx.run.run_id),
         None,
     )
+    max_history = _max_history_runs()
     if selected_in_scoreable is None:
         # Selected run was cancelled/failed (so it's not in scoreable_runs).
         # Treat the entire scoreable history as "older" runs relative to it.
-        history_runs = scoreable_runs[:_MAX_HISTORY_RUNS]
+        history_runs = scoreable_runs[:max_history]
         history_index = len(history_runs)
     else:
-        history_runs = scoreable_runs[:max(_MAX_HISTORY_RUNS, selected_in_scoreable + 1)]
+        history_runs = scoreable_runs[:max(max_history, selected_in_scoreable + 1)]
         history_index = selected_in_scoreable
     get_run_dimensions = _make_run_dimension_fetcher(
         reports_root, project, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,


### PR DESCRIPTION
Re-opening of #352, which was branched from main by mistake (phantom conflicts).

## Summary

Six small adaptability fixes from the bucket-D triage of the flexibility audit. Each replaces a hardcoded constant with an env-var-honouring helper, or unstales a literal that drifted from the source of truth.

| File | Fix |
|---|---|
| \`analysis/mcp/handlers.py\` | \`_SERVER_VERSION\` reads from \`quodeq.__version__\` (was stale \`\"1.0.0\"\`; project is on \`1.0.8\`) |
| \`analysis/mcp/handlers.py\` | \`_MAX_FILE_BATCH_SIZE\` → \`_max_file_batch_size()\` honouring \`QUODEQ_MCP_MAX_BATCH\` |
| \`api/_ollama_log_routes.py\` | \`_ollama_log_path()\` honours \`QUODEQ_OLLAMA_LOG\` before OS-default detection |
| \`api/_run_event_stream.py\` | \`_HEARTBEAT_S\` reads \`QUODEQ_SSE_HEARTBEAT_S\` (matches the existing \`_TICK_MS\` pattern) |
| \`analysis/_backfill.py\` | \`_MIN_BACKFILL_BUDGET_S\` → \`_min_backfill_budget_s()\` honouring \`QUODEQ_MIN_BACKFILL_BUDGET_S\` |
| \`services/dashboard.py\` | \`_MAX_HISTORY_RUNS\` → \`_max_history_runs()\` honouring \`QUODEQ_MAX_HISTORY_RUNS\` |

All defaults preserved. No behaviour change unless the new env vars are set.

## Test plan

- [x] \`pytest\` — 2456 tests pass
- [x] Smoke-tested each new helper with default + env-override + bogus-value inputs
- [x] Spot-check that \`_SERVER_VERSION\` shows \`1.0.8\` in MCP \`initialize\` response