### PR TITLE
fix: cap unbounded reads/lists in API + SSE paths

### DIFF
--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -22,13 +22,22 @@ from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
 
 _logger = logging.getLogger(__name__)
 
+# Cap on /api/evaluations ?limit= so a client cannot ask the server to materialize
+# an unbounded list. limit=0 still means "no client cap" but we clamp the actual
+# value the provider sees. 1000 is well above any realistic dashboard query.
+_EVALUATIONS_LIST_HARD_CAP = 1000
+
 
 def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_rate_store: object | None = None) -> None:
     """Register evaluation listing and creation routes."""
 
     @app.get("/api/evaluations")
     def list_evaluations() -> Response:
-        limit = request.args.get("limit", 0, type=int)
+        raw_limit = request.args.get("limit", 0, type=int)
+        if raw_limit <= 0 or raw_limit > _EVALUATIONS_LIST_HARD_CAP:
+            limit = _EVALUATIONS_LIST_HARD_CAP
+        else:
+            limit = raw_limit
         state_arg = request.args.get("state", "").strip()
         states = {s for s in (v.strip() for v in state_arg.split(",")) if s} or None
         items = provider.list_evaluations(limit=limit, reports_dir=_reports_dir(), states=states)

--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -1,6 +1,7 @@
 """Log-stream routes — SSE live stream + plain JSON fallback for /api/jobs/<id>/logs."""
 from __future__ import annotations
 
+import os
 from http import HTTPStatus
 from pathlib import Path
 
@@ -12,6 +13,22 @@ from quodeq.api._sse_log_helpers import sse_tail_generator as _sse_tail_generato
 # from the dashboard's live console — they're per-minute resource snapshots
 # (rss / fds / threads / ollama RSS) and clutter the operator-facing view.
 _CONSOLE_HIDDEN_MARKERS: tuple[str, ...] = ("[resources]",)
+
+# Per-poll byte cap: a single tail read will not pull more than this many bytes
+# into memory in one shot. The remaining bytes will be served on the next poll.
+# Caps a runaway log file from blowing out RAM on read.
+_DEFAULT_TAIL_MAX_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+
+def _tail_max_bytes() -> int:
+    raw = os.environ.get("QUODEQ_LOG_TAIL_MAX_BYTES")
+    if not raw:
+        return _DEFAULT_TAIL_MAX_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TAIL_MAX_BYTES
+    return value if value > 0 else _DEFAULT_TAIL_MAX_BYTES
 
 
 def _is_visible_log_line(line: str) -> bool:
@@ -39,7 +56,7 @@ def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
     """
     with open(log_path, "rb") as fh:
         fh.seek(since)
-        raw = fh.read()
+        raw = fh.read(_tail_max_bytes())
     text = raw.decode("utf-8", errors="replace")
     if not text.endswith("\n"):
         last_nl = text.rfind("\n")

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -11,11 +11,31 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from quodeq.data.sqlite.connection import EVALUATION_DB_FILENAME
+
+_DEFAULT_FINDINGS_BATCH = 500
+"""Per-tick cap on findings pulled from SQLite for the SSE stream.
+
+Bounds the initial-snapshot burst (and any post-disconnect catch-up) so a run
+with tens of thousands of findings cannot OOM the API process. Subsequent
+ticks resume from the highest id returned via the SSE Last-Event-ID mechanism.
+"""
+
+
+def _findings_batch_size() -> int:
+    raw = os.environ.get("QUODEQ_SSE_FINDINGS_BATCH")
+    if not raw:
+        return _DEFAULT_FINDINGS_BATCH
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_FINDINGS_BATCH
+    return value if value > 0 else _DEFAULT_FINDINGS_BATCH
 
 
 def serialize_status_event(status: dict[str, Any]) -> str:
@@ -139,7 +159,11 @@ def _judgment_as_dict(judgment: Any, finding_id: int) -> dict[str, Any]:
 def _read_new_findings(
     run_dir: Path, last_event_id: int,
 ) -> list[tuple[int, dict[str, Any]]]:
-    """Return (id, judgment_dict) pairs for findings whose id > last_event_id."""
+    """Return (id, judgment_dict) pairs for findings whose id > last_event_id.
+
+    Caps the result at ``_findings_batch_size()`` rows per call. Subsequent
+    ticks pick up the remainder via the highest id returned.
+    """
     db_path = run_dir / EVALUATION_DB_FILENAME
     if not db_path.is_file():
         return []
@@ -152,8 +176,8 @@ def _read_new_findings(
                 "SELECT id, practice_id, dimension, requirement, verdict, severity, "
                 "file, line, end_line, title, reason, snippet, "
                 "violation_type, context, scope, req_refs_json "
-                "FROM findings WHERE id > ? ORDER BY id",
-                (last_event_id,),
+                "FROM findings WHERE id > ? ORDER BY id LIMIT ?",
+                (last_event_id, _findings_batch_size()),
             )
             cols = [c[0] for c in cur.description]
             for row in cur.fetchall():

--- a/src/quodeq/api/_sse_log_helpers.py
+++ b/src/quodeq/api/_sse_log_helpers.py
@@ -8,6 +8,21 @@ from pathlib import Path
 _POLL_MS = int(os.environ.get("QUODEQ_LOG_STREAM_POLL_MS", "100"))
 _MAX_WAIT_S = int(os.environ.get("QUODEQ_LOG_STREAM_MAX_WAIT_S", "10"))
 
+# Per-tick byte cap on the SSE tail read. Caps a runaway log file from blowing
+# out RAM in a single read; remaining bytes are served on the next tick.
+_DEFAULT_TAIL_MAX_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+
+def _tail_max_bytes() -> int:
+    raw = os.environ.get("QUODEQ_LOG_TAIL_MAX_BYTES")
+    if not raw:
+        return _DEFAULT_TAIL_MAX_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_TAIL_MAX_BYTES
+    return value if value > 0 else _DEFAULT_TAIL_MAX_BYTES
+
 
 def sse_line(data: str, event: str | None = None, event_id: int | None = None) -> str:
     parts = []
@@ -51,7 +66,7 @@ def sse_tail_generator(
             continue
         with open(log_path, "rb") as fh:
             fh.seek(offset)
-            raw = fh.read()
+            raw = fh.read(_tail_max_bytes())
         text = raw.decode("utf-8", errors="replace")
         if text:
             complete = text if text.endswith("\n") else text[: text.rfind("\n") + 1]

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -10,6 +10,7 @@ from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
 
 _DEFAULT_DISMISSED_LIMIT = 500
+_MAX_DISMISSED_LIMIT = 5000
 
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
@@ -32,10 +33,15 @@ def register_findings_routes(app: Flask) -> None:
         project = request.args.get("project", "")
         if not project:
             return jsonify([])
-        limit = request.args.get("limit", _DEFAULT_DISMISSED_LIMIT, type=int)
-        offset = request.args.get("offset", 0, type=int)
-        items = load_dismissed(_project_dir(_eval_dir(), project))
-        return jsonify(items[offset:offset + limit])
+        raw_limit = request.args.get("limit", _DEFAULT_DISMISSED_LIMIT, type=int)
+        limit = max(1, min(raw_limit, _MAX_DISMISSED_LIMIT))
+        offset = max(0, request.args.get("offset", 0, type=int))
+        items = load_dismissed(
+            _project_dir(_eval_dir(), project),
+            offset=offset,
+            limit=limit,
+        )
+        return jsonify(items)
 
     @app.post("/api/findings/dismiss")
     def dismiss() -> tuple[Response, int]:

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -63,15 +63,32 @@ def _key(entry: dict) -> tuple:
     return (entry.get("req", ""), entry.get("file", ""), entry.get("line", 0))
 
 
-def load_dismissed(project_dir: Path) -> list[dict]:
-    """Load dismissed findings for a project. Returns empty list if none."""
+def load_dismissed(
+    project_dir: Path,
+    *,
+    offset: int = 0,
+    limit: int | None = None,
+) -> list[dict]:
+    """Load dismissed findings for a project. Returns empty list if none.
+
+    *offset* and *limit* let API callers slice the result without first
+    materializing the full list. The on-disk file is still read in full
+    (it's a small per-project JSON), but the returned slice is bounded.
+    """
     path = _dismissed_path(project_dir)
     if not path.exists():
         return []
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        items = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return []
+    if not isinstance(items, list):
+        return []
+    if offset <= 0 and limit is None:
+        return items
+    start = max(0, offset)
+    end = start + limit if limit is not None and limit >= 0 else None
+    return items[start:end]
 
 
 def dismiss_finding(project_dir: Path, finding: dict) -> None:

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
@@ -21,8 +21,23 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { evaluationKeys } from "../../../api/queryKeys.js";
 
+// Cap the per-job findings array so a long-running scan with tens of thousands
+// of findings does not grow the React Query cache without bound. The dashboard
+// renders aggregated counts and the most-recent slice; older entries are still
+// reachable through the scored evaluation/<dim>.json artifacts on disk.
+const MAX_FINDINGS_IN_CACHE = 5000;
+
 function isSseEnabled() {
   return import.meta.env?.VITE_USE_SSE_EVENTS === "true";
+}
+
+function appendBoundedFinding(prev, data) {
+  if (prev.length >= MAX_FINDINGS_IN_CACHE) {
+    const trimmed = prev.slice(prev.length - MAX_FINDINGS_IN_CACHE + 1);
+    trimmed.push(data);
+    return trimmed;
+  }
+  return [...prev, data];
 }
 
 export function useRunEventStream(jobId) {
@@ -65,7 +80,7 @@ export function useRunEventStream(jobId) {
         const data = JSON.parse(e.data);
         writeCache(
           evaluationKeys.findings(jobId),
-          (prev = []) => [...prev, data],
+          (prev = []) => appendBoundedFinding(prev, data),
         );
       } catch {
         // ignore


### PR DESCRIPTION
## Summary

Five DoS / OOM hardening fixes from the bucket-D triage of the **performance** dimension audit (229 violations). Each replaces an unbounded read or query with a size-capped equivalent that paginates via existing resume mechanisms.

| File | Fix |
|---|---|
| \`api/_log_stream_routes.py\` | \`_read_tail\` caps \`fh.read\` at \`QUODEQ_LOG_TAIL_MAX_BYTES\` (default 1 MiB) |
| \`api/_sse_log_helpers.py\` | \`sse_tail_generator\` applies the same cap; downstream \`splitlines()\` now bounded |
| \`api/_evaluation_routes.py\` | \`?limit=\` clamped to 1000 (was unbounded) |
| \`api/_run_event_stream.py\` | findings query gains \`LIMIT ?\` (default 500, env \`QUODEQ_SSE_FINDINGS_BATCH\`); SSE Last-Event-ID resumes |
| \`api/routes_findings.py\` + \`services/dismissed.py\` | \`load_dismissed\` accepts \`offset/limit\`; route clamps limit to 5000 |
| \`ui/.../useRunEventStream.js\` | \`appendBoundedFinding\` caps React Query findings cache at 5000 |

All defaults preserved. Behaviour unchanged unless the new env vars are set or the per-call payload would have exceeded the cap.

## Triage context

Of the 229 performance violations:
- **217 dismissed** as scanner noise — bounded-by-design domain data (≤6 dimensions, ≤7 principles, ≤100 runs), test fixtures/files, build/packaging scripts, single-process desktop \"blocks thread\" complaints, well-behaved UI render patterns.
- **3 dismissed as confirmed false positives** — \`_run_scores.py:20\` is already LRU-bounded by \`make_lru_dimension_fetcher\`; \`pageStateCache.js:20\` is bounded by enum-sized namespace count; \`galaxyViewLayout.js:38\` O(N³) with N≤30 = sub-millisecond.
- **9 reqs (5 distinct fixes) shipped here** — the actual server-facing DoS/OOM vectors.

Audit trail in \`~/.quodeq/evaluations/d33f1fd0-.../dismissed.json\` (228 flexibility + 229 performance = 457 total entries with per-finding rationale).

## Test plan

- [x] \`pytest -q\` — 2456 tests pass
- [x] \`npm test\` — 134 UI tests pass
- [x] Spot-check log-tail endpoints with a synthetic 100MB log file
- [x] Spot-check \`/api/evaluations?limit=999999\` returns at most 1000 items