### PR TITLE
fix: harden API input validation + path/signal safety

### DIFF
--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -109,20 +109,25 @@ def read_state(path: Path) -> dict:
 
 
 def write_state(state: dict, path: Path) -> None:
-    """Atomic write: temp file in the same directory, then rename."""
+    """Atomic write: temp file in the same directory, then rename.
+
+    Uses try/finally with a sentinel so cleanup runs on any exit path —
+    including SIGINT/SystemExit — without swallowing those signals.
+    """
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=str(parent), suffix=".tmp", prefix=".queue_")
+    cleanup_tmp: str | None = tmp_path
     try:
         with os.fdopen(fd, "w") as f:
             json.dump(state, f)
             f.flush()
             os.fsync(f.fileno())
         os.rename(tmp_path, str(path))
-    except BaseException:
-        # Clean up temp file on any failure
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+        cleanup_tmp = None  # ownership transferred to final path
+    finally:
+        if cleanup_tmp is not None:
+            try:
+                os.unlink(cleanup_tmp)
+            except OSError:
+                pass

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -23,6 +23,16 @@ _MAX_POOL_BUDGET = 3600
 _MAX_CONTEXT_SIZE = 2_000_000
 
 
+def _coerce_int(value: object, default: int) -> int:
+    """Return int(*value*) when convertible, else *default*. Never raises."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _sanitize_url(url: str) -> str:
     """Remove embedded credentials from a URL for safe logging/error messages."""
     return _CREDENTIALS_RE.sub(r"\1***@", url)
@@ -47,9 +57,9 @@ def _validate_ai_cmd(ai_cmd: str | None, env: dict[str, str] | None = None) -> t
 def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
     """Construct and validate EvaluationOptions from the request payload."""
     from quodeq.services.base import EvaluationOptions  # deferred: avoid circular import at module level
-    max_subagents_raw = payload.get("maxSubagents", _DEFAULT_MAX_SUBAGENTS)
-    max_subagents = max(_MIN_SUBAGENTS, min(_MAX_SUBAGENTS, int(max_subagents_raw)))
-    pool_budget_raw = int(payload.get("poolBudget", _DEFAULT_POOL_BUDGET))
+    max_subagents_raw = _coerce_int(payload.get("maxSubagents"), _DEFAULT_MAX_SUBAGENTS)
+    max_subagents = max(_MIN_SUBAGENTS, min(_MAX_SUBAGENTS, max_subagents_raw))
+    pool_budget_raw = _coerce_int(payload.get("poolBudget"), _DEFAULT_POOL_BUDGET)
     pool_budget = 0 if pool_budget_raw == 0 else max(_MIN_POOL_BUDGET, min(_MAX_POOL_BUDGET, pool_budget_raw))
     ai_model = payload.get("aiModel") or None
     subagent_model = payload.get("subagentModel") or ai_model  # default to orchestrator
@@ -65,7 +75,7 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
         pool_budget=pool_budget,
         incremental=bool(payload.get("incremental", False)),
         per_dimension=bool(payload.get("perDimension", False)),
-        context_size=max(0, min(_MAX_CONTEXT_SIZE, int(payload.get("contextSize", 0)))),
+        context_size=max(0, min(_MAX_CONTEXT_SIZE, _coerce_int(payload.get("contextSize"), 0))),
         branch=payload.get("branch") or None,
         scope_path=payload.get("scopePath") or None,
     )

--- a/src/quodeq/api/_rate_limit_factory.py
+++ b/src/quodeq/api/_rate_limit_factory.py
@@ -3,12 +3,39 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
 from quodeq.api._rate_limit_store import InMemoryRateLimitStore, RateLimitStore
 
 _logger = logging.getLogger(__name__)
 
 _KNOWN_BACKENDS = {"memory", "file"}
+_DEFAULT_RATE_LIMIT_FILE = "/tmp/quodeq_rate_limits.json"
+
+
+def _validated_rate_limit_path(raw: str) -> str:
+    """Reject obviously-unsafe rate-limit file paths from the env.
+
+    Falls back to the default if *raw* is empty, relative, or resolves to a
+    location with parent-traversal components. Symlink resolution is
+    deliberately not strict (the file may not exist yet on first run).
+    """
+    if not raw:
+        return _DEFAULT_RATE_LIMIT_FILE
+    try:
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            raise ValueError("path must be absolute")
+        resolved = candidate.resolve(strict=False)
+        if ".." in resolved.parts:
+            raise ValueError("path contains parent-directory traversal")
+    except (OSError, ValueError) as exc:
+        _logger.warning(
+            "Ignoring unsafe QUODEQ_RATE_LIMIT_FILE=%r (%s); using default %s",
+            raw, exc, _DEFAULT_RATE_LIMIT_FILE,
+        )
+        return _DEFAULT_RATE_LIMIT_FILE
+    return str(resolved)
 
 
 def create_rate_limit_store(env: dict[str, str] | None = None) -> RateLimitStore:
@@ -30,7 +57,7 @@ def create_rate_limit_store(env: dict[str, str] | None = None) -> RateLimitStore
 
     if backend == "file":
         from quodeq.api._rate_limit_file_store import FileRateLimitStore
-        path = environ.get("QUODEQ_RATE_LIMIT_FILE", "/tmp/quodeq_rate_limits.json")
+        path = _validated_rate_limit_path(environ.get("QUODEQ_RATE_LIMIT_FILE", ""))
         _logger.info("Using file-based rate-limit store at %s", path)
         return FileRateLimitStore(path)
 

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -42,9 +42,23 @@ def _handle_update_project_path(provider: ActionProvider) -> Response | tuple[Re
     if not new_path:
         body, status = error_response("Path is required", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
         return jsonify(body), status
-    if ".." in new_path or not Path(new_path).is_absolute():
+    try:
+        # Reject literal '..' segments in user input — even if they resolve
+        # to a fine canonical path, accepting them silently transforms what
+        # the user typed into something different. Then resolve and verify
+        # the canonical form is still absolute and traversal-free.
+        if ".." in Path(new_path).parts:
+            raise ValueError("path contains parent-directory segment")
+        candidate = Path(new_path)
+        if not candidate.is_absolute():
+            raise ValueError("path must be absolute")
+        resolved = candidate.resolve(strict=False)
+        if not resolved.is_absolute() or ".." in resolved.parts:
+            raise ValueError("path resolves to a non-canonical location")
+    except (OSError, ValueError):
         body, status = error_response("Invalid path", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
         return jsonify(body), status
+    new_path = str(resolved)
     _logger.info("update_project_path: project=%s, remote_addr=%s", project, request.remote_addr)
     ok = provider.update_project_path(reports_dir(), project, new_path)
     if not ok:

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -12,6 +12,18 @@ _TYPE_CUSTOM = "custom"
 _TYPE_BUILTIN = "builtin"
 
 
+def _require_id(data: dict, source: str) -> str:
+    """Return data['id'], raising ValueError with context if missing/empty.
+
+    Standards are user-uploaded JSON; surfacing the bad payload as a
+    ValueError lets API routes return a 400 instead of a 500 KeyError.
+    """
+    sid = data.get("id")
+    if not isinstance(sid, str) or not sid:
+        raise ValueError(f"{source} missing required 'id' field")
+    return sid
+
+
 def default_read_json(path: Path) -> dict:
     """Read and parse a JSON file from disk."""
     return json.loads(path.read_text())
@@ -30,8 +42,9 @@ def count_principles_and_requirements(data: dict) -> tuple[int, int]:
 
 def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDetail:
     """Construct a StandardDetail from a raw JSON dict."""
+    sid = _require_id(data, "standard")
     return StandardDetail(
-        id=data["id"], name=data.get("name", data["id"]),
+        id=sid, name=data.get("name", sid),
         description=data.get("description", ""),
         weight=data.get("weight", 1.0), source=data.get("source", ""),
         type=data.get("type", type_default), managed=data.get("managed", False),
@@ -53,8 +66,9 @@ def build_builtin_detail(data: dict, standard_id: str, weight: float) -> Standar
 
 def build_custom_meta(data: dict, p_count: int, r_count: int) -> StandardMeta:
     """Build a StandardMeta for a user-created custom standard."""
+    sid = _require_id(data, "custom standard")
     return StandardMeta(
-        id=data["id"], name=data.get("name", data["id"]),
+        id=sid, name=data.get("name", sid),
         description=data.get("description", ""),
         weight=data.get("weight", 1.0), source=data.get("source", ""),
         type=data.get("type", _TYPE_CUSTOM), managed=data.get("managed", False),
@@ -65,8 +79,9 @@ def build_custom_meta(data: dict, p_count: int, r_count: int) -> StandardMeta:
 
 def build_builtin_meta(dim: dict, p_count: int, r_count: int) -> StandardMeta:
     """Build a StandardMeta for a built-in dimension."""
+    did = _require_id(dim, "built-in dimension")
     return StandardMeta(
-        id=dim["id"], name=dim.get("iso_25010") or dim.get("name", dim["id"]),
+        id=did, name=dim.get("iso_25010") or dim.get("name", did),
         description=f'{dim.get("source", "Built-in")} standard',
         weight=dim.get("weight", 1.0), source=dim.get("source", ""),
         type=dim.get("type", _TYPE_BUILTIN), managed=True,
@@ -89,7 +104,23 @@ def is_builtin_id(dimensions_data: dict, standard_id: str) -> bool:
 
 
 def load_cwe_entries(entries: list) -> list[dict]:
-    """Normalize raw CWE entries into a list of slim dicts."""
-    return [{"id": e["id"], "name": e["name"],
-             "abstraction": e.get("abstraction", ""), "dimensions": e.get("dimensions", [])}
-            for e in entries]
+    """Normalize raw CWE entries into a list of slim dicts.
+
+    Entries lacking ``id`` or ``name`` are skipped rather than raising
+    KeyError, since the CWE corpus is third-party data and a single
+    malformed row should not abort the whole load.
+    """
+    out: list[dict] = []
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        eid = e.get("id")
+        ename = e.get("name")
+        if eid is None or ename is None:
+            continue
+        out.append({
+            "id": eid, "name": ename,
+            "abstraction": e.get("abstraction", ""),
+            "dimensions": e.get("dimensions", []),
+        })
+    return out


### PR DESCRIPTION
## Summary

Five fault-tolerance hardenings from the bucket-D triage of the **reliability** dimension audit (355 violations). Each turns a 500-with-stacktrace path into a 400-with-message, or rewrites a technically-correct-but-scanner-flagged defensive pattern.

| File | Fix |
|---|---|
| \`api/_evaluation_helpers.py\` | \`int()\` on raw payload now via \`_coerce_int()\` (non-numeric → default, not 500) |
| \`api/routes_project_list.py\` | path-traversal: reject literal \`..\` segments + verify resolved canonical path |
| \`api/_rate_limit_factory.py\` | \`QUODEQ_RATE_LIMIT_FILE\` validated via \`_validated_rate_limit_path\` |
| \`analysis/subagents/_queue_state.py\` | \`except BaseException...raise\` → try/finally + sentinel (no signal catching) |
| \`services/_standards_io.py\` | \`build_*\` functions use \`_require_id()\` (KeyError → ValueError → 400) |

## Triage context

Of the 355 reliability findings:
- **343 dismissed** as scanner noise — including 169 UI defensive-check complaints (React handles via optional chaining + conditional rendering), 50 \"Maturity / lacks type annotations\" complaints (the UI is intentionally JS, not TS), 31 test fixture corpora, 16 packaging/tooling scripts, 15 test files, 1 Critical that's the deliberately-vulnerable \`eval(userInput)\` test fixture used to verify the analyzer detects it.
- **2 dismissed as confirmed false positives** — \`standards_library.py:24\` urlopen IS wrapped (route layer); \`:63\` data['id'] IS preceded by \`_validate_id\`.
- **10 reqs (5 distinct fixes) shipped here**.

Audit trail in \`~/.quodeq/evaluations/d33f1fd0-.../dismissed.json\` (228 flexibility + 229 performance + 355 reliability = 812 total entries with per-finding rationale).

## Test plan

- [x] \`pytest -q\` — 2456 tests pass
- [x] \`test_routes_project_list.py\` traversal regression test passes
- [x] Spot-check: \`POST /api/evaluations\` with \`{\"maxSubagents\": \"abc\"}\` returns 202 with default, not 500
- [x] Spot-check: \`PATCH /api/projects/x/path\` with \`/foo/../bar\` returns 400