### PR TITLE
fix: harden standard-id path, export filename, tooltip helper

### DIFF
--- a/src/quodeq/services/_standards_queries.py
+++ b/src/quodeq/services/_standards_queries.py
@@ -11,6 +11,7 @@ from quodeq.services._standards_io import (
     count_principles_and_requirements, get_builtin_weight, is_builtin_id,
     load_cwe_entries,
 )
+from quodeq.shared.validation import validate_path_segment
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,12 @@ def list_custom(evaluators_dir: Path, read_json: Callable) -> list[StandardMeta]
 
 def get_standard(standard_id: str, evaluators_dir: Path, compiled_dir: Path,
                  dimensions_file: Path, read_json: Callable) -> StandardDetail:
-    """Return full detail for a single standard, checking custom then built-in."""
+    """Return full detail for a single standard, checking custom then built-in.
+
+    Validates *standard_id* up-front so a path-traversal segment ('../foo')
+    cannot reach the filesystem join below.
+    """
+    validate_path_segment(standard_id)
     custom_path = evaluators_dir / f"{standard_id}.json"
     if custom_path.is_file():
         return build_detail(read_json(custom_path))

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
@@ -14,8 +14,12 @@ export function updateTooltip(el, hovered, animating, cx, cy) {
   if (!el) return;
   if (!hovered || animating) { el.style.display = 'none'; return; }
   const d = hovered.data;
+  // label/value are escaped so this helper stays safe even if a future
+  // caller passes a string from data instead of the current numeric/literal
+  // values. Color is hardcoded by callers (CSS var or rgb()) so it bypasses
+  // escape — but is still wrapped in a fixed style attribute.
   const row = (label, value, color) =>
-    `<div style="display:flex;justify-content:space-between;gap:12px;color:${color || 'var(--color-text-muted)'}"><span>${label}</span><span style="color:${color || 'var(--color-text)'};font-weight:500">${value}</span></div>`;
+    `<div style="display:flex;justify-content:space-between;gap:12px;color:${color || 'var(--color-text-muted)'}"><span>${escapeHtml(String(label))}</span><span style="color:${color || 'var(--color-text)'};font-weight:500">${escapeHtml(String(value))}</span></div>`;
   const rows = [row('Score', d.score.toFixed(1))];
   if (hovered.type === 'dim') rows.push(row('Principles', d.principleCount));
   rows.push(row('Violations', d.violations));

--- a/src/quodeq/ui/src/hooks/useProjectActions.js
+++ b/src/quodeq/ui/src/hooks/useProjectActions.js
@@ -5,6 +5,15 @@
  */
 import { useApi } from '../api/ApiContext.jsx';
 
+// Strip filesystem-unfriendly characters so a project name like
+// "foo/bar" or "..\\evil" can't influence the download path.
+function sanitizeFilename(name) {
+  return String(name || '')
+    .replace(/[/\\:*?"<>|\x00-\x1f]+/g, '_')
+    .replace(/^\.+/, '_')
+    .slice(0, 100) || 'project';
+}
+
 export function useProjectActions({ projects, selectedProject, handleProjectChange, loadProjects }) {
   const { deleteProject, getProjectExportUrl, relocateProject } = useApi();
   async function handleDeleteProject(projectId) {
@@ -20,7 +29,7 @@ export function useProjectActions({ projects, selectedProject, handleProjectChan
 
   function handleExportProject(projectId) {
     const proj = projects.find((p) => (p.id || p.name) === projectId);
-    const filename = `${proj?.name || projectId}.zip`;
+    const filename = `${sanitizeFilename(proj?.name || projectId)}.zip`;
     // PyWebView: native Save dialog, fetches server-side
     if (window.pywebview?.api?.download_url) {
       window.pywebview.api.download_url(`/api/projects/${encodeURIComponent(projectId)}/export`, filename);


### PR DESCRIPTION
## Summary

Three security hardenings from the bucket-D triage of the **security** dimension audit (88 violations).

| File | Fix |
|---|---|
| \`services/_standards_queries.py\` | \`get_standard()\` validates \`standard_id\` via \`validate_path_segment()\` before path join (rejects \`..\`, \`/\`, \`\\\`, null) |
| \`ui/.../useProjectActions.js\` | \`sanitizeFilename()\` strips filesystem-unfriendly chars from project name before pywebview download |
| \`ui/.../galaxyViewEvents.js\` | \`row()\` tooltip helper now \`escapeHtml()\`s both label and value before innerHTML interpolation (defense in depth) |

## Triage context

Of the 88 security findings:
- **29 dismissed as React-escapes-text-content false positives** — \`{var}\` in JSX is auto-escaped; the scanner flagged every text interpolation as if it were \`dangerouslySetInnerHTML\`.
- **6 dismissed as hardcoded subprocess argv** — \`sysctl\`, \`nvidia-smi\`, \`lsof\`, \`git -C\`, \`shutil.which(\"npm\")\` are the canonical Python pattern with no user input on the command line.
- **4 dismissed as SQL f-string with constant interpolation** — \`_SELECT_COLUMNS\` and \`_LIST_COLS\` are module-level string constants; user values still flow through \`?\` placeholders.
- **34 dismissed as internal plumbing in a single-user desktop app** — Ollama localhost URL, Claude/codex permission flags (intentional), env-loader \`~\` expansion, etc. The OS user account is the trust boundary.
- **9 dismissed as test fixtures intended to be detected** — \`eval(userInput)\`, hardcoded \`password = 'hunter2'\`, \`gin.Default()\` debug middleware exist as analyzer-input samples.
- **1 dismissed as user-shown error message** — \`alert(\`Failed to delete: \${err.message}\`)\` is shown to the user, who is the admin of their own machine.
- **5 reqs (3 distinct fixes) shipped here** — the genuine path-traversal / filesystem / innerHTML-helper cases.

Audit trail in \`~/.quodeq/evaluations/d33f1fd0-.../dismissed.json\` (228 flexibility + 229 performance + 355 reliability + 88 security = 900 total entries with per-finding rationale).

## Test plan

- [x] \`pytest -q\` — 2456 tests pass
- [x] \`npm test\` — 134 UI tests pass
- [x] Spot-check: \`GET /api/standards/../foo\` returns 400 (Flask url-converter already blocks; this adds belt-and-braces at the service layer)
- [x] Spot-check: a project named \`foo/bar\` exports as \`foo_bar.zip\`, not into a subdirectory