### PR TITLE
fix(findings): stop silently capping dismissed list at 500

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -9,7 +9,6 @@ from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_f
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
 
-_DEFAULT_DISMISSED_LIMIT = 500
 _MAX_DISMISSED_LIMIT = 5000
 
 
@@ -33,7 +32,9 @@ def register_findings_routes(app: Flask) -> None:
         project = request.args.get("project", "")
         if not project:
             return jsonify([])
-        raw_limit = request.args.get("limit", _DEFAULT_DISMISSED_LIMIT, type=int)
+        # No limit param → return everything (capped at the hard maximum).
+        # An explicit limit is clamped to [1, _MAX_DISMISSED_LIMIT].
+        raw_limit = request.args.get("limit", _MAX_DISMISSED_LIMIT, type=int)
         limit = max(1, min(raw_limit, _MAX_DISMISSED_LIMIT))
         offset = max(0, request.args.get("offset", 0, type=int))
         items = load_dismissed(

--- a/src/quodeq/ui/src/api/findings.js
+++ b/src/quodeq/ui/src/api/findings.js
@@ -4,13 +4,21 @@
 
 import { request } from './request.js';
 
+// The dismissed list is per-project user data: a single response with all
+// entries is fine for any realistic project (a few thousand at most). Ask
+// for the server-side hard cap to avoid the API's default page size.
+const DISMISSED_REQUEST_LIMIT = 5000;
+
 /**
  * List dismissed findings for a project.
  * @param {string} projectId - Project identifier
  * @returns {Promise<Array>} Dismissed findings array
  */
 export async function listDismissedFindings(projectId) {
-  return request(`/findings/dismissed?project=${encodeURIComponent(projectId)}`);
+  return request(
+    `/findings/dismissed?project=${encodeURIComponent(projectId)}`
+    + `&limit=${DISMISSED_REQUEST_LIMIT}`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

The dismissed-findings view in the dashboard was capped at 500 entries even when the user had many more (1,197 in my case after running the five-dimension quality audits). The UI showed \`dismissed (500)\` and silently truncated the rest.

## Cause

The \`/api/findings/dismissed\` Flask route used \`_DEFAULT_DISMISSED_LIMIT = 500\` when no \`?limit=\` was supplied, and the UI never passed one.

## Fix

| File | Change |
|---|---|
| \`api/routes_findings.py\` | When no \`limit\` query param is supplied, return everything up to \`_MAX_DISMISSED_LIMIT\` (5000). Explicit limits still clamped. |
| \`ui/.../api/findings.js\` | UI passes \`?limit=5000\` (the server hard cap) so the dismissed view loads the full list regardless of server-side defaults. |

## Test plan

- [x] \`pytest tests/api/test_routes_findings.py\` — 5 tests pass
- [x] \`pytest\` — full suite (2456) passes
- [x] Spot-check: dashboard "dismissed" tab shows the full count (>500 entries) for a project with many dismissals