### PR TITLE
feat(ui): move "Add project" to Projects tab

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -7,6 +7,7 @@ const FileDetailPage = lazy(() => import('./features/explorer/components/FileDet
 const PrincipleDetailPage = lazy(() => import('./features/explorer/components/PrincipleDetailPage.jsx'));
 const FindingDetailPage = lazy(() => import('./features/explorer/components/FindingDetailPage.jsx'));
 const ProjectsPage = lazy(() => import('./features/dashboard/components/ProjectsPage.jsx'));
+const AddProjectModal = lazy(() => import('./features/dashboard/components/AddProjectModal.jsx'));
 const HistoryPage = lazy(() => import('./features/history/components/HistoryPage.jsx'));
 const EvaluateScreen = lazy(() => import('./features/evaluation/components/EvaluateScreen.jsx'));
 const SettingsPage = lazy(() => import('./features/settings/components/SettingsPage.jsx'));
@@ -30,7 +31,10 @@ import { EvalLogProvider } from './features/evaluation/eval-log/EvalLogProvider.
 import { ServerLogProvider } from './features/settings/server-log/ServerLogProvider.jsx';
 import { OllamaLogProvider } from './features/settings/ollama-log/OllamaLogProvider.jsx';
 
-const NO_PROJECT_TABS = ['evaluate', 'standards', 'settings', 'help'];
+// Tabs that are reachable with zero projects. `projects` is in here so a
+// fresh-install user can land on Projects and add their first one without
+// hitting the "no analyzed projects yet" wall.
+const NO_PROJECT_TABS = ['projects', 'evaluate', 'standards', 'settings', 'help'];
 
 /**
  * Returns whether the app is currently rendering dark, taking the saved
@@ -59,7 +63,7 @@ function useEffectiveDark(themeMode) {
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
  * @returns {JSX.Element}
  */
-function EvaluateCase({ serverHealth, evaluation, selectedProject, projects }) {
+function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects }) {
   const { connected, setConnected } = serverHealth;
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
@@ -69,7 +73,7 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject, projects }) {
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
         context={{ selectedProject, projectInfo }}
-        actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation }}
+        actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects }}
       />
     </>
   );
@@ -243,7 +247,7 @@ const ROUTE_RENDERERS = {
       trend={props.dashboardData.dashboard?.trend || []}
     />
   ),
-  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} />,
+  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} onGoToProjects={() => props.navigation.navTab('projects')} />,
   file: (params) => <FileDetailPage file={params.file} />,
   evalprinciple: renderEvalPrincipleDetail,
   'eval-principle-detail': renderEvalPrincipleDetail,
@@ -260,7 +264,7 @@ const ROUTE_RENDERERS = {
     />
   ),
   settings: (params, props) => <SettingsCase settings={props.settings} />,
-  projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject }} />,
+  projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject, onAddProject: props.navigation.onAddProject }} />,
   standards: () => <StandardsPage />,
   help: () => <HelpPage />,
 };
@@ -275,7 +279,19 @@ function MainContent({ activePage, props }) {
     const projects = props.navigation?.projects;
     if (!projects || projects.length === 0) {
       if (!props.navigation?.projectsLoaded) return <LoadingScreen />;
-      return <section className="empty-state"><h2>No analyzed projects yet</h2><p>Run an evaluation to get started.</p></section>;
+      return (
+        <section className="empty-state">
+          <h2>No analyzed projects yet</h2>
+          <p>Add a project to get started.</p>
+          <button
+            type="button"
+            className="empty-state__cta"
+            onClick={() => props.navigation.navTab('projects')}
+          >
+            Go to Projects
+          </button>
+        </section>
+      );
     }
   }
   const renderer = ROUTE_RENDERERS[page];
@@ -310,6 +326,7 @@ export default function App() {
   const APP_VERSION = state.serverVersion;
   const selectedProjectInfo = state.projects?.find((p) => (p.id || p.name) === state.selectedProject) || null;
   const [sidebarPinned, setSidebarPinned] = useState(false);
+  const [isAddProjectOpen, setIsAddProjectOpen] = useState(false);
   const sidebarProvider = (typeof localStorage !== 'undefined' && localStorage.getItem(ACTIVE_PROVIDER_KEY)) || null;
   const sidebarModel = sidebarProvider && typeof localStorage !== 'undefined'
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
@@ -356,6 +373,7 @@ export default function App() {
       historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
       currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,
       prefetchHandlers: state.prefetchHandlers,
+      onAddProject: () => setIsAddProjectOpen(true),
     },
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },
@@ -444,6 +462,14 @@ export default function App() {
               <div className="tab-fade" key={activeTab}>
                 <MainContent activePage={activePage} props={contentProps} />
               </div>
+              <AddProjectModal
+                open={isAddProjectOpen}
+                onClose={() => setIsAddProjectOpen(false)}
+                onStart={(payload) => {
+                  state.evalLifecycle.handleStartEvaluation(payload);
+                  navTab('evaluate');
+                }}
+              />
             </Suspense>
           }
             />

--- a/src/quodeq/ui/src/features/dashboard/components/AddProjectModal.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AddProjectModal.jsx
@@ -1,0 +1,52 @@
+/**
+ * AddProjectModal — wraps the existing EvaluationForm in a modal overlay.
+ *
+ * Used from ProjectsPage so "Add project" is the entry point on the Projects
+ * tab. After the form's onStart fires, the modal closes and the parent
+ * navigates to the Evaluate tab where EvaluationStatus takes over.
+ */
+import { useEffect } from 'react';
+import EvaluationForm from '../../evaluation/components/EvaluationForm.jsx';
+
+export default function AddProjectModal({ open, onClose, onStart }) {
+  useEffect(() => {
+    if (!open) return undefined;
+    function onKey(e) { if (e.key === 'Escape') onClose(); }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  function handleStart(payload) {
+    onStart(payload);
+    onClose();
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onClose} role="presentation">
+      <div
+        className="add-project-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-project-modal-title"
+      >
+        <div className="add-project-modal__header">
+          <h2 id="add-project-modal-title" className="add-project-modal__title">Add project</h2>
+          <button
+            type="button"
+            className="modal-close-btn"
+            onClick={onClose}
+            aria-label="Close add-project dialog"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="add-project-modal__body">
+          <EvaluationForm onStart={handleStart} disabled={false} selectedProject={null} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -245,20 +245,50 @@ function useRelocateDialog(onRelocate) {
   return { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate };
 }
 
+function EmptyProjectsCTA({ onAddProject }) {
+  return (
+    <div className="projects-empty projects-empty--cta">
+      <h3 className="projects-empty__title">Add your first project</h3>
+      <p className="projects-empty__hint">
+        Point quodeq at a local repository or paste a Git URL to get started.
+      </p>
+      <button
+        type="button"
+        className="projects-empty__cta-btn"
+        onClick={onAddProject}
+      >
+        + Add project
+      </button>
+    </div>
+  );
+}
+
 export default function ProjectsPage({ projects = [], selectedProject, actions }) {
-  const { onSelect, onDelete, onExport, onRelocate } = actions;
+  const { onSelect, onDelete, onExport, onRelocate, onAddProject } = actions;
   const { children, roots } = useMemo(() => computeProjectTree(projects), [projects]);
   const [confirming, setConfirming] = useState(null);
   const relocateActions = useRelocateDialog(onRelocate);
 
   return (
     <section className="projects-page projects-page--terminal">
-      <TermHeader
-        name="repositories"
-        sub={`${projects.length} ${projects.length === 1 ? 'repository' : 'repositories'} evaluated`}
-      />
+      <div className="projects-page__header">
+        <TermHeader
+          name="repositories"
+          sub={`${projects.length} ${projects.length === 1 ? 'repository' : 'repositories'} evaluated`}
+        />
+        {projects.length > 0 && onAddProject && (
+          <button
+            type="button"
+            className="projects-page__add-btn"
+            onClick={onAddProject}
+            aria-label="Add project"
+          >
+            + Add project
+          </button>
+        )}
+      </div>
       {projects.length === 0 ? (
-        <div className="projects-empty"><p>No projects yet. Run an evaluation to get started.</p></div>
+        <EmptyProjectsCTA onAddProject={onAddProject} />
       ) : (
         <div className="projects-cards">
           {roots.map((p) => (

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import EvaluationForm from './EvaluationForm.jsx';
 import EvaluationStatus from './EvaluationStatus.jsx';
 import ReEvaluateCard from './ReEvaluateCard.jsx';
 import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
@@ -89,10 +88,30 @@ function ErrorToast({ message, onDismiss }) {
   );
 }
 
+function NoProjectSelected({ onGoToProjects }) {
+  return (
+    <div className="panel evaluate-panel evaluate-no-project">
+      <SectionLabel>no_project_selected</SectionLabel>
+      <p className="evaluate-no-project__hint">
+        Add or pick a project from Projects to run an evaluation.
+      </p>
+      {onGoToProjects && (
+        <button
+          type="button"
+          className="evaluate-no-project__cta"
+          onClick={onGoToProjects}
+        >
+          Go to Projects
+        </button>
+      )}
+    </div>
+  );
+}
+
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
   const { selectedProject, projectInfo } = context;
-  const { onStart: onStartEvaluation, onDismiss, onCancel } = actions;
+  const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects } = actions;
   const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
 
@@ -115,11 +134,8 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
           <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={wrappedOnStart} disabled={false} />
         )}
 
-        {!job && (
-          <div className="panel evaluate-panel">
-            <SectionLabel>{selectedProject ? 'evaluate_new_repository' : 'evaluate_repository'}</SectionLabel>
-            <EvaluationForm onStart={wrappedOnStart} disabled={false} selectedProject={projectInfo} />
-          </div>
+        {!job && !selectedProject && (
+          <NoProjectSelected onGoToProjects={onGoToProjects} />
         )}
 
         <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} hasEvaluations={!!selectedProject} />

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2607,6 +2607,129 @@
   padding: var(--space-6);
 }
 
+/* ── Projects page header (with "+ Add project" button) ── */
+
+.projects-page__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.projects-page__add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.1s;
+}
+
+.projects-page__add-btn:hover {
+  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
+}
+
+/* ── Empty-projects centered CTA ── */
+
+.projects-empty--cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--space-12) var(--space-6);
+  gap: var(--space-3);
+}
+
+.projects-empty__title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.projects-empty__hint {
+  margin: 0;
+  max-width: 420px;
+  color: var(--color-text-muted);
+}
+
+.projects-empty__cta-btn {
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-6);
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.projects-empty__cta-btn:hover {
+  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
+}
+
+/* ── Add Project modal panel (uses .modal-overlay from standards.css) ── */
+
+.add-project-modal {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-6);
+  width: 100%;
+  max-width: 720px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 16px 48px color-mix(in srgb, #000 24%, transparent);
+}
+
+.add-project-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.add-project-modal__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.add-project-modal__body {
+  margin: 0;
+}
+
+/* ── Global empty-state CTA (used on overview/violations/map when no projects) ── */
+
+.empty-state__cta {
+  margin-top: var(--space-4);
+  padding: var(--space-2) var(--space-5);
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.empty-state__cta:hover {
+  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
+}
+
 /* ── Project card footer / delete ── */
 
 .project-card-footer {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -58,6 +58,37 @@
   padding: 24px;
 }
 
+/* ── No-project-selected state on the Evaluate tab ── */
+
+.evaluate-no-project {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.evaluate-no-project__hint {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.evaluate-no-project__cta {
+  padding: 8px 16px;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.evaluate-no-project__cta:hover {
+  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
+}
+
 
 .form-group {
   display: flex;


### PR DESCRIPTION
## Summary

Splits project-management (a noun) from evaluation (a verb). The Evaluation tab today does both: it has a "create new project + run first scan" form alongside the "re-evaluate existing project" card, which forces new users into a single-flow funnel and conflates two distinct concerns.

## What changes

| Tab | Before | After |
|---|---|---|
| Projects | Lists projects | Lists projects **+ adds them** |
| Evaluation | New-project form + Re-evaluate + Status | Re-evaluate + Status |

| File | Change |
|---|---|
| \`features/dashboard/components/AddProjectModal.jsx\` | **New**: modal wrapping the existing \`EvaluationForm\`. After submit, closes and navigates to Evaluate. |
| \`features/dashboard/components/ProjectsPage.jsx\` | Empty state becomes a centered "Add your first project" CTA. With projects, header gains a "+ Add project" button. |
| \`features/evaluation/components/EvaluateScreen.jsx\` | When no project is selected, drops the inline form and shows a "Go to Projects" pointer. Re-evaluate path unchanged. |
| \`App.jsx\` | \`'projects'\` added to \`NO_PROJECT_TABS\` so fresh-install users can reach the tab to add their first project. Modal state lives at the App root. Global empty-state button points to Projects. |
| \`styles/dashboard.css\`, \`styles/evaluation.css\` | New classes for the empty CTA, header "+" button, modal panel, and "go to Projects" empty-state. |

## What does NOT change

- \`EvaluationForm\` component itself: same props, same \`onStart\` contract.
- Backend: \`/api/evaluations\` route, job lifecycle, project storage all untouched.
- Re-evaluate UX on the Evaluation tab.
- Sidebar nav: no new tabs added.

## Context

This is **slice 0** of a multi-slice plan to reduce false-positive noise in quality audits. Across six dimension audits (1,269 findings, 1.6% real bugs), the dominant noise sources are deployment-shape mismatches and language/framework-model errors — addressable via confidence-scored findings, project-shape detection, and a precedent corpus of dismissal rationales.

This PR is pure UI restructure with no dependencies on the rest of the plan, so it can ship independently.

## Test plan

- [x] \`npm test\` — 134 UI tests pass
- [x] \`pytest -q\` — 2456 Python tests pass
- [x] \`npx vite build\` — production build succeeds
- [x] Spot-check: fresh install (zero projects) lands on Projects with the empty-state CTA
- [x] Spot-check: existing user sees "+ Add project" in the Projects header
- [x] Spot-check: clicking "+ Add project" opens the modal, submitting auto-navigates to Evaluate
- [x] Spot-check: visiting Evaluate without a project selected shows the "Go to Projects" pointer