### PR TITLE
feat(findings): add per-finding confidence field to data model

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -153,6 +153,7 @@ def _judgment_as_dict(judgment: Any, finding_id: int) -> dict[str, Any]:
         "title": judgment.title,
         "reason": judgment.reason,
         "snippet": judgment.snippet,
+        "confidence": getattr(judgment, "confidence", 100),
     }
 
 
@@ -175,7 +176,7 @@ def _read_new_findings(
             cur = conn.execute(
                 "SELECT id, practice_id, dimension, requirement, verdict, severity, "
                 "file, line, end_line, title, reason, snippet, "
-                "violation_type, context, scope, req_refs_json "
+                "violation_type, context, scope, req_refs_json, confidence "
                 "FROM findings WHERE id > ? ORDER BY id LIMIT ?",
                 (last_event_id, _findings_batch_size()),
             )

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -14,6 +14,17 @@ from quodeq.shared.utils import open_text
 _logger = logging.getLogger(__name__)
 
 
+def _jsonl_confidence(value: object, default: int = 100) -> int:
+    """Clamp a JSONL confidence value to [0, 100]; missing/non-int → *default*."""
+    if value is None:
+        return default
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, min(100, coerced))
+
+
 def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
     """Parse a single JSONL evidence line into a Judgment and optional LLM ref selection."""
     line = line.strip()
@@ -37,6 +48,7 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
         violation_type=obj.get("vt", ""), reason=obj.get("reason", ""),
         req=obj.get("req"), title=obj.get("w", ""),
         context=obj.get("context", ""), scope=obj.get("scope", ""),
+        confidence=_jsonl_confidence(obj.get("confidence")),
     )
     pre_resolved = obj.get("req_refs")
     if isinstance(pre_resolved, list) and pre_resolved:
@@ -55,6 +67,12 @@ def judgment_to_dict(j: Judgment) -> dict:
         val = getattr(j, key, None)
         if val:
             d[key] = val
+    # Carry confidence forward only when it's not the default 100. Keeps the
+    # PrincipleEvidence dicts compact for the common case where every finding
+    # has full confidence; producers writing < 100 surface in the output.
+    confidence = getattr(j, "confidence", 100)
+    if confidence != 100:
+        d["confidence"] = confidence
     return d
 
 

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -39,6 +39,10 @@ class Judgment:
     title: str = ""
     context: str = ""
     scope: str = ""
+    # 0-100 confidence score the scanner attaches to this finding. 100 means
+    # "no reason to doubt." Subsequent slices of the context-enricher plan
+    # populate values < 100 to downweight known false-positive patterns.
+    confidence: int = 100
 
     def __post_init__(self) -> None:
         if not self.practice_id:

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -14,6 +14,18 @@ def _current_version(conn: sqlite3.Connection) -> int:
     return conn.execute("PRAGMA user_version").fetchone()[0]
 
 
+# Incremental upgrades from version N to N+1. Each function takes a connection
+# already at version N; the caller bumps PRAGMA user_version to N+1 afterwards.
+def _upgrade_v1_to_v2(conn: sqlite3.Connection) -> None:
+    """Add per-finding confidence column (default 100 = full confidence)."""
+    conn.execute("ALTER TABLE findings ADD COLUMN confidence INTEGER NOT NULL DEFAULT 100")
+
+
+_UPGRADES = {
+    1: _upgrade_v1_to_v2,
+}
+
+
 def apply_evaluation_schema(conn: sqlite3.Connection) -> None:
     version = _current_version(conn)
     if version == SCHEMA_VERSION:
@@ -23,8 +35,18 @@ def apply_evaluation_schema(conn: sqlite3.Connection) -> None:
             f"evaluation.db has schema version {version}, "
             f"this binary supports {SCHEMA_VERSION}",
         )
-    if version != 0:
-        raise SchemaVersionError(
-            f"unexpected evaluation.db schema version {version} (expected 0 or {SCHEMA_VERSION})",
-        )
-    conn.executescript(EVALUATION_DDL)
+    if version == 0:
+        # Fresh DB: apply the latest DDL (its leading PRAGMA sets user_version).
+        conn.executescript(EVALUATION_DDL)
+        return
+    # Incremental upgrade path: walk N -> N+1 -> ... -> SCHEMA_VERSION.
+    while version < SCHEMA_VERSION:
+        upgrade = _UPGRADES.get(version)
+        if upgrade is None:
+            raise SchemaVersionError(
+                f"missing upgrade path from schema version {version} "
+                f"(target: {SCHEMA_VERSION})",
+            )
+        upgrade(conn)
+        version += 1
+        conn.execute(f"PRAGMA user_version = {version}")

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -16,6 +16,21 @@ def _dedup_key(practice_id: str, file: str, line: int, verdict: str) -> str:
     return f"{practice_id}|{file}|{line}|{verdict}"
 
 
+def _coerce_confidence(value: Any, default: int = 100) -> int:
+    """Clamp *value* to [0, 100]; fall back to *default* for missing/non-int."""
+    if value is None:
+        return default
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if coerced < 0:
+        return 0
+    if coerced > 100:
+        return 100
+    return coerced
+
+
 def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
     """Translate a FindingsRouter wire dict into a row dict ready for SQL bind."""
     practice_id = finding.get("p", "")
@@ -41,6 +56,7 @@ def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
         "scope": finding.get("scope", "") or "",
         "req_refs_json": json.dumps(refs) if refs is not None else None,
         "dedup_key": _dedup_key(practice_id, file, line, verdict),
+        "confidence": _coerce_confidence(finding.get("confidence")),
     }
 
 
@@ -64,6 +80,7 @@ def judgment_to_row(j: Judgment) -> dict[str, Any]:
         "scope": j.scope,
         "req_refs_json": json.dumps(j.req_refs) if j.req_refs is not None else None,
         "dedup_key": _dedup_key(j.practice_id, j.file, j.line, j.verdict),
+        "confidence": _coerce_confidence(getattr(j, "confidence", 100)),
     }
 
 
@@ -87,4 +104,5 @@ def row_to_judgment(row: dict[str, Any]) -> Judgment:
         title=row.get("title", ""),
         context=row.get("context", ""),
         scope=row.get("scope", ""),
+        confidence=_coerce_confidence(row.get("confidence")),
     )

--- a/src/quodeq/data/sqlite/_schema.py
+++ b/src/quodeq/data/sqlite/_schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 EVALUATION_DDL = """
-PRAGMA user_version = 1;
+PRAGMA user_version = 2;
 
 CREATE TABLE findings (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -23,6 +23,10 @@ CREATE TABLE findings (
     scope           TEXT NOT NULL DEFAULT '',
     req_refs_json   TEXT,
     dedup_key       TEXT NOT NULL UNIQUE,
+    -- per-finding confidence in [0, 100]; default 100 means "scanner is fully
+    -- sure this is real." Slice 1 of the context-enricher plan adds this column;
+    -- subsequent slices write < 100 to downweight false-positive patterns.
+    confidence      INTEGER NOT NULL DEFAULT 100,
     created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -70,4 +74,4 @@ CREATE TABLE run_meta (
 );
 """
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -15,18 +15,18 @@ _INSERT_SQL = """
 INSERT OR IGNORE INTO findings (
     schema_version, practice_id, dimension, requirement, verdict, severity,
     file, line, end_line, title, reason, snippet,
-    violation_type, context, scope, req_refs_json, dedup_key
+    violation_type, context, scope, req_refs_json, dedup_key, confidence
 ) VALUES (
     :schema_version, :practice_id, :dimension, :requirement, :verdict, :severity,
     :file, :line, :end_line, :title, :reason, :snippet,
-    :violation_type, :context, :scope, :req_refs_json, :dedup_key
+    :violation_type, :context, :scope, :req_refs_json, :dedup_key, :confidence
 )
 """
 
 _SELECT_COLUMNS = (
     "id, practice_id, dimension, requirement, verdict, severity, "
     "file, line, end_line, title, reason, snippet, "
-    "violation_type, context, scope, req_refs_json"
+    "violation_type, context, scope, req_refs_json, confidence"
 )
 
 

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -4,13 +4,14 @@ from quodeq.data.sqlite._migrations import (
     apply_evaluation_schema,
     SchemaVersionError,
 )
+from quodeq.data.sqlite._schema import SCHEMA_VERSION
 
 
 def test_apply_evaluation_schema_on_fresh_db_sets_version():
     conn = sqlite3.connect(":memory:")
     apply_evaluation_schema(conn)
     cur = conn.execute("PRAGMA user_version")
-    assert cur.fetchone()[0] == 1
+    assert cur.fetchone()[0] == SCHEMA_VERSION
 
 
 def test_apply_evaluation_schema_creates_findings_and_fts():
@@ -31,11 +32,64 @@ def test_apply_evaluation_schema_idempotent_on_same_version():
     # second apply must not fail and must not duplicate
     apply_evaluation_schema(conn)
     cur = conn.execute("PRAGMA user_version")
-    assert cur.fetchone()[0] == 1
+    assert cur.fetchone()[0] == SCHEMA_VERSION
 
 
 def test_apply_evaluation_schema_rejects_newer_version():
     conn = sqlite3.connect(":memory:")
     conn.execute("PRAGMA user_version = 99")
+    with pytest.raises(SchemaVersionError):
+        apply_evaluation_schema(conn)
+
+
+def _build_v1_db() -> sqlite3.Connection:
+    """Recreate the schema as it existed at SCHEMA_VERSION=1, before the
+    confidence column was added. Used to verify the v1 → v2 upgrade path."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        PRAGMA user_version = 1;
+        CREATE TABLE findings (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            schema_version  INTEGER NOT NULL DEFAULT 1,
+            practice_id     TEXT NOT NULL,
+            dimension       TEXT NOT NULL DEFAULT '',
+            requirement     TEXT,
+            verdict         TEXT NOT NULL CHECK (verdict IN ('violation','compliance','dismissed')),
+            severity        TEXT NOT NULL CHECK (severity IN ('critical','high','medium','low','minor')),
+            file            TEXT NOT NULL DEFAULT '',
+            line            INTEGER NOT NULL DEFAULT 0,
+            end_line        INTEGER NOT NULL DEFAULT 0,
+            title           TEXT NOT NULL DEFAULT '',
+            reason          TEXT NOT NULL DEFAULT '',
+            snippet         TEXT NOT NULL DEFAULT '',
+            violation_type  TEXT NOT NULL DEFAULT '',
+            context         TEXT NOT NULL DEFAULT '',
+            scope           TEXT NOT NULL DEFAULT '',
+            req_refs_json   TEXT,
+            dedup_key       TEXT NOT NULL UNIQUE,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+    return conn
+
+
+def test_apply_evaluation_schema_upgrades_v1_to_current():
+    conn = _build_v1_db()
+    # Existing rows in v1 must survive the upgrade and inherit the default 100.
+    conn.execute(
+        "INSERT INTO findings (practice_id, verdict, severity, dedup_key) "
+        "VALUES ('P-1', 'violation', 'medium', 'k1')",
+    )
+    apply_evaluation_schema(conn)
+    cur = conn.execute("PRAGMA user_version")
+    assert cur.fetchone()[0] == SCHEMA_VERSION
+    cur = conn.execute("SELECT confidence FROM findings WHERE practice_id='P-1'")
+    assert cur.fetchone()[0] == 100
+
+
+def test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path():
+    conn = sqlite3.connect(":memory:")
+    # Set user_version to a non-zero value with no upgrade path defined.
+    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 100}")
     with pytest.raises(SchemaVersionError):
         apply_evaluation_schema(conn)

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -72,3 +72,51 @@ def test_judgment_to_row_uses_long_names():
     assert row["practice_id"] == "P1"
     assert row["requirement"] == "R1"
     assert row["dedup_key"] == "P1|f.py|3|violation"
+
+
+def test_finding_dict_to_row_defaults_confidence_to_100_when_missing():
+    finding = {"p": "P1", "t": "violation", "severity": "medium"}
+    row = finding_dict_to_row(finding)
+    assert row["confidence"] == 100
+
+
+def test_finding_dict_to_row_clamps_confidence_to_valid_range():
+    assert finding_dict_to_row({"p": "P1", "t": "violation", "severity": "medium",
+                                 "confidence": -50})["confidence"] == 0
+    assert finding_dict_to_row({"p": "P1", "t": "violation", "severity": "medium",
+                                 "confidence": 200})["confidence"] == 100
+    assert finding_dict_to_row({"p": "P1", "t": "violation", "severity": "medium",
+                                 "confidence": 73})["confidence"] == 73
+
+
+def test_finding_dict_to_row_treats_non_int_confidence_as_default():
+    row = finding_dict_to_row(
+        {"p": "P1", "t": "violation", "severity": "medium", "confidence": "abc"},
+    )
+    assert row["confidence"] == 100
+
+
+def test_judgment_to_row_propagates_confidence():
+    j = Judgment(
+        practice_id="P1", verdict="violation", severity="medium", confidence=42,
+    )
+    row = judgment_to_row(j)
+    assert row["confidence"] == 42
+
+
+def test_row_to_judgment_defaults_confidence_to_100_for_legacy_rows():
+    # Older rows from before slice 1 lack the confidence column entirely.
+    legacy_row = {
+        "practice_id": "P1", "verdict": "violation", "severity": "medium",
+        "file": "f.py", "line": 1,
+    }
+    j = row_to_judgment(legacy_row)
+    assert j.confidence == 100
+
+
+def test_row_to_judgment_preserves_explicit_confidence():
+    row = {
+        "practice_id": "P1", "verdict": "violation", "severity": "medium",
+        "file": "f.py", "line": 1, "confidence": 30,
+    }
+    assert row_to_judgment(row).confidence == 30

--- a/tests/data/sqlite/test_schema.py
+++ b/tests/data/sqlite/test_schema.py
@@ -12,5 +12,9 @@ def test_evaluation_ddl_includes_fts5():
     assert "content='findings'" in _schema.EVALUATION_DDL
 
 
-def test_evaluation_ddl_sets_user_version_1():
-    assert "PRAGMA user_version = 1" in _schema.EVALUATION_DDL
+def test_evaluation_ddl_sets_user_version_to_schema_version():
+    assert f"PRAGMA user_version = {_schema.SCHEMA_VERSION}" in _schema.EVALUATION_DDL
+
+
+def test_evaluation_ddl_includes_confidence_column():
+    assert "confidence" in _schema.EVALUATION_DDL


### PR DESCRIPTION
## Summary

Slice 1 of the context-enricher plan. Adds a per-finding \`confidence: int (0-100)\` field that flows through every layer (SQLite, JSONL, Judgment dataclass, SSE) with a default of \`100\` so existing scans behave identically.

This is the foundation slice. Nothing produces non-100 confidence yet; the plumbing is in place so Slice 2 (path-role classifier) can wire its output into a live pipeline without re-plumbing.

## Backend changes

| File | Change |
|---|---|
| \`data/sqlite/_schema.py\` | Bumped to \`user_version = 2\`. \`findings\` gains \`confidence INTEGER NOT NULL DEFAULT 100\`. |
| \`data/sqlite/_migrations.py\` | New \`_UPGRADES\` dict supports incremental N→N+1 upgrades. \`_upgrade_v1_to_v2\` runs \`ALTER TABLE ADD COLUMN\`. |
| \`core/evidence/model.py\` | \`Judgment\` dataclass: \`confidence: int = 100\`. |
| \`data/sqlite/_row_mappers.py\` | All three mappers (\`finding_dict_to_row\`, \`judgment_to_row\`, \`row_to_judgment\`) carry confidence with \`_coerce_confidence\` clamping to [0, 100] and defaulting on missing/non-int input. |
| \`data/sqlite/findings_repository.py\` | \`_INSERT_SQL\` + \`_SELECT_COLUMNS\` include the new column. |
| \`core/evidence/_jsonl.py\` | \`parse_jsonl_line\` reads optional \`confidence\`; \`judgment_to_dict\` emits the key only when != 100. |
| \`api/_run_event_stream.py\` | SSE \`_judgment_as_dict\` + the live findings SELECT include confidence. |

## Tests added (9 new, total 2465 pass)

- \`test_apply_evaluation_schema_upgrades_v1_to_current\` — inserts a row into a synthetic v1 DB, runs the upgrade, confirms confidence=100 inherited via the column default.
- \`test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path\`.
- 6 row_mapper tests covering missing field, clamping, non-int input, legacy rows, explicit propagation, and Judgment round-trip.
- \`test_evaluation_ddl_includes_confidence_column\`.

## Scope decision: UI shell deferred to Slice 2

The plan doc proposed a \`LowConfidenceGroup\` shell + sort utility in this slice. On reflection, both would be **unreachable code** until Slices 2-4 actually populate non-100 confidences — exactly the \"don't add abstractions beyond what the task requires\" pattern the codebase guidelines warn against.

The cleaner shape: ship the backend foundation here (this PR), then build the UI at the top of Slice 2 where real low-confidence findings exist to validate the UX against. Documented in the commit message so it's traceable later.

## Risk

Schema migration. Existing on-disk \`evaluation.db\` files at \`user_version=1\` get upgraded on first read via \`ALTER TABLE ADD COLUMN ... DEFAULT 100\`. The migration only adds a column with a default, so it's safe to roll back: rolling back the binary doesn't drop the column, and \`SELECT\` from old code keeps working since it never named it.

## Test plan

- [x] \`pytest -q\` — 2465 tests pass
- [x] All 9 new tests pass individually and in suite
- [x] Spot-check on a real \`evaluation.db\` from a previous run: open via the new code, confirm \`PRAGMA user_version\` is 2 and \`SELECT confidence FROM findings\` returns 100s