### PR TITLE
feat(context): path-role classifier downweights non-prod findings (slice 2)

### DIFF
--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from quodeq.analysis.prompts._template import load_template
 from quodeq.analysis.prompts.builder import _load_evaluation_rules
 from quodeq.config.prompt_templates import render_template
+from quodeq.context.path_role import Role, path_role
 
 _log = logging.getLogger(__name__)
 
@@ -40,6 +41,18 @@ def _read_file_safe(path: Path) -> str | None:
         return None
 
 
+def _role_label(display_path: str) -> str:
+    """Return a `(role: <role>)` suffix for non-prod paths, empty otherwise.
+
+    Tells the LLM the surrounding code's purpose so it can tone down findings
+    that don't matter outside production code (e.g. brittle test fixtures).
+    """
+    role = path_role(display_path)
+    if role is Role.PROD:
+        return ""
+    return f" (role: {role.value})"
+
+
 def _build_files_block(source_files: list[Path], repo_root: Path | None = None) -> str:
     """Build the source files block for the prompt."""
     parts: list[str] = []
@@ -49,7 +62,7 @@ def _build_files_block(source_files: list[Path], repo_root: Path | None = None) 
             continue
         display_path = str(path.relative_to(repo_root)) if repo_root else path.name
         numbered = "\n".join(f"{i+1:4d} | {line}" for i, line in enumerate(content.splitlines()))
-        parts.append(f"### {display_path}\n```\n{numbered}\n```")
+        parts.append(f"### {display_path}{_role_label(display_path)}\n```\n{numbered}\n```")
     return "\n\n".join(parts)
 
 

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -17,11 +17,32 @@ if sys.platform != "win32":
 
 from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
+from quodeq.context.path_role import NON_PROD_ROLES, path_role
 from quodeq.data.ports.findings import FindingsRepository
 from quodeq.shared._env import sqlite_disabled
 
 _logger = logging.getLogger(__name__)
 _FINDING_SCHEMA_VERSION = 1
+_NON_PROD_DOWNWEIGHT = 50  # confidence applied to violations on non-prod paths
+                           # when the LLM didn't already lower it.
+
+
+def _apply_path_role_downweight(finding: dict[str, object]) -> None:
+    """Lower a finding's confidence to 50 when it lives on a non-prod path.
+
+    Skipped when the LLM emitted an explicit confidence below the default of
+    100 (we trust the model's own self-doubt over a coarse path heuristic)
+    and for compliance findings (downweighting "this code is fine" makes
+    no sense).
+    """
+    if finding.get("t") != "violation":
+        return
+    role = path_role(finding.get("file"))
+    if role not in NON_PROD_ROLES:
+        return
+    existing = finding.get("confidence")
+    if existing is None or existing == 100:
+        finding["confidence"] = _NON_PROD_DOWNWEIGHT
 
 
 @dataclass
@@ -144,6 +165,7 @@ class FindingsRouter:
         finding.update({k: v for k, v in args.items() if v is not None})
         self._enrich(args, finding)
         enrich_code(finding, self._work_dir, self._read_file)
+        _apply_path_role_downweight(finding)
 
         line = json.dumps(finding) + "\n"
         _locked_write(self._fh, line)

--- a/src/quodeq/context/__init__.py
+++ b/src/quodeq/context/__init__.py
@@ -1,0 +1,10 @@
+"""Context-enrichment services that downweight false-positive findings.
+
+The package exposes services (path-role classifier, project-shape detector,
+precedent corpus) that wrap quodeq's existing dimension scanners. Each
+service emits a confidence multiplier on top of the LLM's verdict; nothing
+is suppressed.
+"""
+from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
+
+__all__ = ["NON_PROD_ROLES", "Role", "path_role"]

--- a/src/quodeq/context/path_role.py
+++ b/src/quodeq/context/path_role.py
@@ -1,0 +1,156 @@
+"""Classify a file path into a role (prod, test, fixture, packaging, ...).
+
+The role is a coarse signal the rest of the pipeline uses to downweight
+findings in non-production paths. Rules are language-agnostic globs so the
+classifier behaves the same for Python, JS/TS, Go, Rust, Swift, Java, etc.
+
+Matching is glob-style with three wildcards:
+
+* ``**`` matches any number of path segments (including none).
+* ``*``  matches any character except ``/``.
+* ``?``  matches a single character except ``/``.
+
+The first matching pattern wins, so more specific patterns are listed
+first (e.g. ``tests/fixtures/**`` before ``tests/**``).
+"""
+from __future__ import annotations
+
+import re
+from enum import Enum
+from functools import lru_cache
+
+
+class Role(str, Enum):
+    """Coarse classification of a file's purpose in the project."""
+
+    PROD = "prod"
+    TEST = "test"
+    TEST_FIXTURE = "test_fixture"
+    BUILD = "build"
+    PACKAGING = "packaging"
+    TOOL = "tool"
+    DOC = "doc"
+    CONFIG = "config"
+
+
+NON_PROD_ROLES: frozenset[Role] = frozenset({
+    Role.TEST, Role.TEST_FIXTURE, Role.BUILD, Role.PACKAGING,
+    Role.TOOL, Role.DOC, Role.CONFIG,
+})
+
+
+_DEFAULT_RULES: tuple[tuple[str, Role], ...] = (
+    # Fixtures must come before tests/** so they classify as TEST_FIXTURE.
+    ("tests/fixtures/**", Role.TEST_FIXTURE),
+    ("**/fixtures/**", Role.TEST_FIXTURE),
+    ("**/__fixtures__/**", Role.TEST_FIXTURE),
+    ("**/testdata/**", Role.TEST_FIXTURE),
+    # Test code (multiple language conventions).
+    ("tests/**", Role.TEST),
+    ("test/**", Role.TEST),
+    ("**/__tests__/**", Role.TEST),
+    ("**/spec/**", Role.TEST),
+    ("**/specs/**", Role.TEST),
+    ("**/test_*.py", Role.TEST),
+    ("**/*_test.py", Role.TEST),
+    ("**/*_test.go", Role.TEST),
+    ("**/*.test.js", Role.TEST),
+    ("**/*.test.jsx", Role.TEST),
+    ("**/*.test.ts", Role.TEST),
+    ("**/*.test.tsx", Role.TEST),
+    ("**/*.spec.js", Role.TEST),
+    ("**/*.spec.jsx", Role.TEST),
+    ("**/*.spec.ts", Role.TEST),
+    ("**/*.spec.tsx", Role.TEST),
+    ("**/*Test.java", Role.TEST),
+    ("**/*Tests.java", Role.TEST),
+    ("**/*Spec.kt", Role.TEST),
+    ("**/*Tests.swift", Role.TEST),
+    # Packaging / CI.
+    ("packaging/**", Role.PACKAGING),
+    ("**/Dockerfile", Role.PACKAGING),
+    ("**/Dockerfile.*", Role.PACKAGING),
+    (".github/**", Role.PACKAGING),
+    (".gitlab/**", Role.PACKAGING),
+    # Build output / artifacts.
+    ("build/**", Role.BUILD),
+    ("dist/**", Role.BUILD),
+    ("target/**", Role.BUILD),
+    ("out/**", Role.BUILD),
+    # Tools / scripts.
+    ("tools/**", Role.TOOL),
+    ("scripts/**", Role.TOOL),
+    ("bin/**", Role.TOOL),
+    # Docs.
+    ("docs/**", Role.DOC),
+    ("doc/**", Role.DOC),
+    ("**/*.md", Role.DOC),
+    ("**/*.rst", Role.DOC),
+    # Config (catch-all by extension).
+    ("**/*.toml", Role.CONFIG),
+    ("**/*.yaml", Role.CONFIG),
+    ("**/*.yml", Role.CONFIG),
+    ("**/*.ini", Role.CONFIG),
+    ("**/*.cfg", Role.CONFIG),
+    ("**/*.json", Role.CONFIG),
+)
+
+
+@lru_cache(maxsize=None)
+def _compile(pattern: str) -> re.Pattern[str]:
+    """Translate a path glob to an anchored regex.
+
+    Cached because every project re-uses the same default rule set across
+    thousands of findings; recompiling per call would be wasteful.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                # `**/` — zero or more directory segments.
+                if i + 2 < n and pattern[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                else:
+                    out.append(".*")
+                    i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c in r".+()[]{}|^$\\":
+            out.append("\\" + c)
+            i += 1
+        else:
+            out.append(c)
+            i += 1
+    return re.compile("^" + "".join(out) + "$")
+
+
+def _normalize(file_path: str) -> str:
+    p = file_path.replace("\\", "/")
+    if p.startswith("./"):
+        p = p[2:]
+    return p.lstrip("/")
+
+
+def path_role(file_path: str | None) -> Role:
+    """Classify *file_path* against the default rule table.
+
+    Empty / falsy paths fall through as ``PROD`` (the safe default: do not
+    downweight when we have no evidence). The first matching rule wins.
+    """
+    if not file_path:
+        return Role.PROD
+    norm = _normalize(file_path)
+    if not norm:
+        return Role.PROD
+    for pattern, role in _DEFAULT_RULES:
+        if _compile(pattern).match(norm):
+            return role
+    return Role.PROD

--- a/src/quodeq/core/finding_builder.py
+++ b/src/quodeq/core/finding_builder.py
@@ -31,6 +31,7 @@ class FindingSpec:
     context: str | None = None
     scope: str | None = None
     include_severity: bool = True
+    confidence: int = 100
 
 
 def build_finding_base(spec: FindingSpec) -> Finding:
@@ -59,6 +60,7 @@ def build_finding_base(spec: FindingSpec) -> Finding:
         req_refs=req_refs,
         context=spec.context if spec.context else None,
         scope=spec.scope if spec.scope else None,
+        confidence=spec.confidence,
     )
 
 

--- a/src/quodeq/core/types/finding.py
+++ b/src/quodeq/core/types/finding.py
@@ -41,3 +41,7 @@ class Finding:
     dimension: str | None = None
     violation_type: str | None = None
     scope: str | None = None
+    # 0..100. Default 100 means "scanner is fully sure this is real".
+    # Lower values flag noise (path role, project shape, precedent) the
+    # context-enricher pipeline downweights post-LLM.
+    confidence: int = 100

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -82,8 +82,20 @@ def _build_finding_entry(obj: dict, dimension: str, req_refs_lookup: dict[str, l
         req_refs=req_refs,
         context=obj.get("context"),
         scope=obj.get("scope"),
+        confidence=_coerce_confidence(obj.get("confidence")),
     ))
     return replace(entry, dimension=obj.get("d", dimension), violation_type=obj.get("vt"))
+
+
+def _coerce_confidence(value: object, default: int = 100) -> int:
+    """Clamp a JSONL confidence to [0, 100]; missing/non-int → *default*."""
+    if value is None:
+        return default
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, min(100, coerced))
 
 
 # ---------------------------------------------------------------------------

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -9,6 +9,7 @@ import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { ComplianceCard } from './EvalCards.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge } from '../../../components/terminal/index.js';
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
+import LowConfidenceGroup, { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
@@ -141,6 +142,21 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
   const showCompliance = !activeFilter || activeFilter === 'all' || activeFilter === 'compliance';
   const showViolations = activeFilter !== 'compliance';
 
+  const { lowConfidenceViolations, highConfidenceBySeverity } = useMemo(() => {
+    const low = [];
+    const high = {};
+    for (const sev of SEVERITY_ORDER) {
+      const bucket = file.violationsBySeverity?.[sev] || [];
+      const highBucket = [];
+      for (const v of bucket) {
+        if (isLowConfidence(v)) low.push(v);
+        else highBucket.push(v);
+      }
+      high[sev] = highBucket;
+    }
+    return { lowConfidenceViolations: low, highConfidenceBySeverity: high };
+  }, [file.violationsBySeverity]);
+
   const reportSpec = useMemo(() => {
     if (!file?.file) return null;
     const buildMarkdown = () => buildFileReport(file);
@@ -191,8 +207,15 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
 
       {showViolations && SEVERITY_ORDER.map((sev) => {
         if (activeFilter && activeFilter !== 'all' && activeFilter !== sev) return null;
-        return <SeverityGroup key={sev} sev={sev} violations={file.violationsBySeverity?.[sev] || []} />;
+        return <SeverityGroup key={sev} sev={sev} violations={highConfidenceBySeverity[sev] || []} />;
       })}
+
+      {showViolations && (!activeFilter || activeFilter === 'all') && (
+        <LowConfidenceGroup
+          violations={lowConfidenceViolations}
+          renderViolation={(v, idx) => <ViolationCard key={`lc-${idx}`} v={v} index={idx} />}
+        />
+      )}
 
       {showCompliance && totalCompliance > 0 && (
         <div>

--- a/src/quodeq/ui/src/features/violations/components/LowConfidenceGroup.jsx
+++ b/src/quodeq/ui/src/features/violations/components/LowConfidenceGroup.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+const LOW_CONFIDENCE_THRESHOLD = 50;
+
+export function isLowConfidence(violation) {
+  return typeof violation?.confidence === 'number' && violation.confidence < LOW_CONFIDENCE_THRESHOLD;
+}
+
+export default function LowConfidenceGroup({ violations, renderViolation }) {
+  const [expanded, setExpanded] = useState(false);
+  if (!violations || violations.length === 0) return null;
+  const count = violations.length;
+  return (
+    <div className="low-confidence-group">
+      <button
+        type="button"
+        className="violation-group-header low-confidence-group-header"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span className="violation-group-title">Low confidence</span>
+        <span className="violation-group-count">{count}</span>
+        <span className="low-confidence-group-hint">
+          {expanded ? 'Hide' : 'Show'} likely false positives
+        </span>
+      </button>
+      {expanded && (
+        <div className="vlive-violations-group">
+          {violations.map((v, idx) => renderViolation(v, idx))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -302,6 +302,30 @@
   font-variant-numeric: tabular-nums;
 }
 
+.low-confidence-group {
+  margin-top: var(--space-5);
+}
+
+.low-confidence-group-header {
+  background: none;
+  border: none;
+  padding: 0;
+  width: 100%;
+  cursor: pointer;
+  color: var(--color-text-subtle);
+  text-align: left;
+}
+
+.low-confidence-group-header:hover .violation-group-title {
+  color: var(--color-text);
+}
+
+.low-confidence-group-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
+  font-style: italic;
+}
+
 /* --- File Picker Dialog --- */
 .dialog-backdrop {
   position: fixed;

--- a/src/quodeq/ui/src/utils/explorerUtils.js
+++ b/src/quodeq/ui/src/utils/explorerUtils.js
@@ -78,6 +78,7 @@ function aggregateViolationEntry(bucket, dimension, entry) {
     title: entry.title || '',
     reason: entry.reason || '',
     severity,
+    confidence: typeof entry.confidence === 'number' ? entry.confidence : 100,
     ...(entry.cwe ? { cwe: entry.cwe } : {}),
   });
 

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -85,3 +85,29 @@ class TestAssembleApiPrompt:
         )
         assert isinstance(prompt, str)
         assert len(prompt) > 0
+
+    def test_labels_test_file_with_role(self, tmp_path, standards_text):
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_main.py").write_text("def test_x():\n    assert True\n")
+        prompt = assemble_api_prompt(
+            source_files=[tests_dir / "test_main.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+            repo_root=tmp_path,
+        )
+        assert "tests/test_main.py (role: test)" in prompt
+
+    def test_omits_role_label_for_prod_files(self, tmp_path, standards_text):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "server.py").write_text("def hello():\n    pass\n")
+        prompt = assemble_api_prompt(
+            source_files=[src / "server.py"],
+            standards_text=standards_text,
+            dimension="maintainability",
+            repo_name="test-repo",
+            repo_root=tmp_path,
+        )
+        assert "(role:" not in prompt

--- a/tests/context/test_path_role.py
+++ b/tests/context/test_path_role.py
@@ -1,0 +1,88 @@
+import pytest
+
+from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
+
+
+@pytest.mark.parametrize("path", [
+    "src/quodeq/api/server.py",
+    "lib/main.go",
+    "app/components/Button.tsx",
+    "internal/auth/oauth.go",
+    "src/index.js",
+])
+def test_production_paths_default_to_prod(path):
+    assert path_role(path) is Role.PROD
+
+
+@pytest.mark.parametrize("path", [
+    "tests/test_server.py",
+    "tests/api/test_routes.py",
+    "src/__tests__/Button.test.jsx",
+    "internal/auth/oauth_test.go",
+    "components/Button.test.tsx",
+    "components/Button.spec.ts",
+    "src/MyClassTest.java",
+    "src/MyClassSpec.kt",
+])
+def test_test_paths_classified_as_test(path):
+    assert path_role(path) is Role.TEST
+
+
+@pytest.mark.parametrize("path", [
+    "tests/fixtures/sample.json",
+    "tests/fixtures/nested/data.txt",
+    "internal/parser/testdata/golden.txt",
+    "src/__fixtures__/users.json",
+    "src/components/__tests__/__fixtures__/data.json",
+])
+def test_fixture_paths_classified_as_test_fixture(path):
+    assert path_role(path) is Role.TEST_FIXTURE
+
+
+def test_fixture_pattern_wins_over_tests_pattern():
+    """`tests/fixtures/**` is listed before `tests/**`, so fixtures don't get
+    misclassified as TEST."""
+    assert path_role("tests/fixtures/foo.json") is Role.TEST_FIXTURE
+
+
+@pytest.mark.parametrize("path,expected", [
+    ("packaging/macos/launcher.sh", Role.PACKAGING),
+    ("Dockerfile", Role.PACKAGING),
+    ("docker/Dockerfile.dev", Role.PACKAGING),
+    (".github/workflows/ci.yml", Role.PACKAGING),
+    ("scripts/release.sh", Role.TOOL),
+    ("tools/codegen.py", Role.TOOL),
+    ("docs/architecture.md", Role.DOC),
+    ("README.md", Role.DOC),
+    ("pyproject.toml", Role.CONFIG),
+    ("config.yaml", Role.CONFIG),
+    ("dist/bundle.js", Role.BUILD),
+    ("build/output.bin", Role.BUILD),
+])
+def test_special_directories(path, expected):
+    assert path_role(path) is expected
+
+
+def test_none_returns_prod():
+    assert path_role(None) is Role.PROD
+
+
+def test_empty_string_returns_prod():
+    assert path_role("") is Role.PROD
+
+
+def test_windows_separators_are_normalized():
+    assert path_role("tests\\fixtures\\sample.json") is Role.TEST_FIXTURE
+    assert path_role("src\\index.js") is Role.PROD
+
+
+def test_leading_slash_is_stripped():
+    assert path_role("/tests/test_foo.py") is Role.TEST
+
+
+def test_non_prod_roles_set_excludes_prod():
+    assert Role.PROD not in NON_PROD_ROLES
+    # Every other role is in the set.
+    for role in Role:
+        if role is not Role.PROD:
+            assert role in NON_PROD_ROLES

--- a/tests/engine/test_mcp_findings_router.py
+++ b/tests/engine/test_mcp_findings_router.py
@@ -67,6 +67,53 @@ class TestFindingsRouter:
         written = json.loads(findings_file.read_text().strip())
         assert "req_refs" not in written
 
+    def test_violation_on_test_file_gets_downweighted(self, tmp_path: Path) -> None:
+        findings_file = tmp_path / "findings.jsonl"
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(fh)
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Slow", "file": "tests/test_server.py", "line": 10,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert written["confidence"] == 50
+
+    def test_violation_on_prod_path_keeps_full_confidence(self, tmp_path: Path) -> None:
+        findings_file = tmp_path / "findings.jsonl"
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(fh)
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Slow", "file": "src/server.py", "line": 10,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert "confidence" not in written  # default 100 stays implicit
+
+    def test_llm_emitted_low_confidence_is_preserved(self, tmp_path: Path) -> None:
+        """If the LLM already lowered confidence, the path-role downweight
+        does not overwrite it."""
+        findings_file = tmp_path / "findings.jsonl"
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(fh)
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Slow", "file": "tests/test_server.py", "line": 10,
+                "confidence": 25,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert written["confidence"] == 25
+
+    def test_compliance_finding_is_not_downweighted(self, tmp_path: Path) -> None:
+        findings_file = tmp_path / "findings.jsonl"
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(fh)
+            router.receive({
+                "p": "P1", "t": "compliance", "d": "perf",
+                "w": "OK", "file": "tests/test_server.py", "line": 10,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert "confidence" not in written
+
 
 class TestGetNextFiles:
     def test_tools_list_includes_get_next_files(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Slice 2 of the [context-enricher plan](https://github.com/quodeq/quodeq/pull/360). Adds a glob-driven path-role classifier that downweights findings on non-production paths so they cluster in a collapsible \"Low confidence\" group instead of polluting the main severity list.

- New \`quodeq.context\` package with \`path_role(file) -> Role\`. Roles: \`{prod, test, test_fixture, build, packaging, tool, doc, config}\`. Rules are language-agnostic globs; \`tests/fixtures/**\` wins over \`tests/**\` etc.
- \`FindingsRouter.receive\` applies a 0.5x downweight (confidence -> 50) on non-prod violations only when the LLM didn't already lower confidence. Compliance findings are unaffected.
- \`assemble_api_prompt\` suffixes non-prod files with \`(role: <role>)\` so the LLM can self-tone-down.
- \`Finding\` dataclass gains \`confidence: int = 100\`; \`violations_parsing\` carries it from JSONL through camelCase to the UI.
- \`FileDetailPage\` partitions violations into per-severity (high-confidence) groups + a single collapsible \`<LowConfidenceGroup>\` at the bottom.

## Test plan

- [x] \`tests/context/test_path_role.py\` -- 36 cases covering prod/test/fixture/packaging/doc/config classification + Windows separators + leading-slash normalization.
- [x] \`tests/engine/test_mcp_findings_router.py\` -- 4 new cases: violation-on-test downweighted, violation-on-prod unchanged, LLM-emitted low confidence preserved, compliance not downweighted.
- [x] \`tests/analysis/test_api_prompt.py\` -- prompt includes \`(role: test)\` for test files, omits role suffix for prod files.
- [x] Full Python suite green (2507 passed).
- [x] UI Node tests green (134 passed).
- [x] Manual: re-run a small slice of the flexibility audit on quodeq itself, verify discipline-corpus findings (e.g. \`tests/fixtures/**\`) cluster in the low-confidence group.

## What does not change

- No suppression rules. Every finding still surfaces.
- Schema: confidence column landed in slice 1 (PR #360); this slice just produces non-100 values.
- Subagent prompt path is unchanged (\`api_prompt_assembly\` only). Subagent path was out of scope; can follow if/when needed.