### PR TITLE
feat(context): project-shape detector downweights hosted-service findings (slice 3)

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -22,6 +22,7 @@ import openai
 from pydantic import BaseModel, Field
 
 from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
+from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements
 from quodeq.engine._ref_utils import load_compiled_refs
 from quodeq.shared.url_validation import validate_url_safe
@@ -224,11 +225,13 @@ def _enrich_findings(
     try:
         compiled_refs = load_compiled_refs(compiled_dir, dimension) or {}
         compiled_reqs = load_compiled_requirements(compiled_dir, dimension) or {}
+        project_shape = detect_shape(work_dir) if work_dir is not None else None
         ctx = CompiledContext(
             compiled_refs=compiled_refs,
             compiled_reqs=compiled_reqs,
             dimension=dimension,
             work_dir=work_dir,
+            project_shape=project_shape,
         )
 
         buf = io.StringIO()

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -12,6 +12,7 @@ from quodeq.analysis.prompts._template import load_template
 from quodeq.analysis.prompts.builder import _load_evaluation_rules
 from quodeq.config.prompt_templates import render_template
 from quodeq.context.path_role import Role, path_role
+from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
 
 _log = logging.getLogger(__name__)
 
@@ -66,6 +67,44 @@ def _build_files_block(source_files: list[Path], repo_root: Path | None = None) 
     return "\n\n".join(parts)
 
 
+def _format_shape_block(shape: ProjectShape) -> str:
+    """Render a project-shape briefing for the LLM, or empty when unknown.
+
+    Skipped for ``UNKNOWN`` deployments: the heuristics didn't fire and we
+    don't want to plant a wrong assumption in the model's head.
+    """
+    if shape.deployment is Deployment.UNKNOWN:
+        return ""
+    parts: list[str] = [f"deployment={shape.deployment.value}",
+                        f"single_user={'true' if shape.is_single_user else 'false'}"]
+    if shape.runtime_langs:
+        parts.append(f"runtime={'+'.join(shape.runtime_langs)}")
+    if shape.web_frameworks:
+        parts.append(f"web_frameworks={'+'.join(shape.web_frameworks)}")
+    if shape.ui_lang:
+        parts.append(f"ui={shape.ui_lang}")
+    summary = ", ".join(parts)
+
+    note = ""
+    if shape.deployment is Deployment.DESKTOP and shape.is_single_user:
+        note = (
+            " This is a single-user desktop tool, not a hosted multi-tenant"
+            " service. Treat findings about thread blocking, distributed"
+            " state, concurrent callers, and rate limiting with skepticism."
+        )
+    elif shape.deployment is Deployment.LIBRARY:
+        note = (
+            " This is a library, not an end-user application. API stability"
+            " and backwards compatibility matter more than user-facing UX."
+        )
+    elif shape.deployment is Deployment.CLI and shape.is_single_user:
+        note = (
+            " This is a single-user CLI, not a hosted service. Concurrent"
+            " caller and multi-tenant findings rarely apply."
+        )
+    return f"## Project Shape\n\n**{summary}**.{note}"
+
+
 def assemble_api_prompt(
     *,
     source_files: list[Path],
@@ -73,15 +112,25 @@ def assemble_api_prompt(
     dimension: str,
     repo_name: str,
     repo_root: Path | None = None,
+    project_shape: ProjectShape | None = None,
 ) -> str:
-    """Assemble a complete evaluation prompt for the API runner."""
+    """Assemble a complete evaluation prompt for the API runner.
+
+    *project_shape* is computed from *repo_root* when not supplied; pass an
+    explicit shape to skip detection (e.g. when a cached shape is being
+    reused across dimensions).
+    """
     template = load_template(template_name="api_prompt.md")
     rules = _load_evaluation_rules()
     files_block = _build_files_block(source_files, repo_root=repo_root)
+    if project_shape is None and repo_root is not None:
+        project_shape = detect_shape(repo_root)
+    shape_block = _format_shape_block(project_shape) if project_shape else ""
     return render_template(template, {
         "DIMENSION": dimension,
         "REPO_NAME": repo_name,
         "STANDARDS_TEXT": standards_text,
+        "PROJECT_SHAPE": shape_block,
         "EVALUATION_RULES": rules,
         "FINDING_SCHEMA": _FINDING_SCHEMA,
         "FILES_BLOCK": files_block,

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -17,6 +17,7 @@ from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.mcp.args import ServerArgs, parse_args
 from quodeq.analysis.mcp.dispatch import read_message, dispatch as _dispatch
 from quodeq.engine._ref_utils import load_compiled_refs as _load_compiled_refs
+from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements as _load_compiled_requirements
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 
@@ -41,12 +42,16 @@ def _build_compiled_context(sa: ServerArgs) -> CompiledContext:
             for req_id in dim_reqs:
                 req_to_dim[req_id] = dim
 
+    work_dir = Path(sa.work_dir) if sa.work_dir else None
+    project_shape = detect_shape(work_dir) if work_dir is not None else None
+
     return CompiledContext(
         compiled_refs=compiled_refs or {},
         compiled_reqs=compiled_reqs or {},
         req_to_dim=req_to_dim,
         dimension=sa.dimension,
-        work_dir=Path(sa.work_dir) if sa.work_dir else None,
+        work_dir=work_dir,
+        project_shape=project_shape,
     )
 
 

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -18,6 +18,7 @@ if sys.platform != "win32":
 from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
+from quodeq.context.project_shape import Deployment, ProjectShape
 from quodeq.data.ports.findings import FindingsRepository
 from quodeq.shared._env import sqlite_disabled
 
@@ -25,6 +26,20 @@ _logger = logging.getLogger(__name__)
 _FINDING_SCHEMA_VERSION = 1
 _NON_PROD_DOWNWEIGHT = 50  # confidence applied to violations on non-prod paths
                            # when the LLM didn't already lower it.
+_SHAPE_DOWNWEIGHT = 40  # confidence applied when the finding clearly assumes
+                        # a hosted multi-tenant service but the project shape
+                        # says single-user desktop / CLI / library.
+
+_HOSTED_SERVICE_KEYWORDS: tuple[str, ...] = (
+    "concurrent caller", "concurrent callers", "concurrent request",
+    "concurrent requests", "thread block", "blocks the thread",
+    "blocks thread", "blocks the event loop", "blocks the request thread",
+    "distributed state", "distributed system", "distributed lock",
+    "multi-tenant", "multitenant", "tenant isolation",
+    "rate limit", "rate-limit", "rate limiting",
+    "ddos", "denial of service", "denial-of-service",
+    "horizontal scaling", "horizontal scale",
+)
 
 
 def _apply_path_role_downweight(finding: dict[str, object]) -> None:
@@ -45,6 +60,45 @@ def _apply_path_role_downweight(finding: dict[str, object]) -> None:
         finding["confidence"] = _NON_PROD_DOWNWEIGHT
 
 
+def _shape_irrelevant_to_hosted_service(shape: ProjectShape | None) -> bool:
+    """True when the project clearly isn't a hosted multi-tenant service."""
+    if shape is None:
+        return False
+    if shape.deployment in (Deployment.DESKTOP, Deployment.LIBRARY):
+        return True
+    if shape.deployment is Deployment.CLI and shape.is_single_user:
+        return True
+    return False
+
+
+def _apply_shape_downweight(
+    finding: dict[str, object], shape: ProjectShape | None,
+) -> None:
+    """Downweight findings that clearly assume a hosted service when the
+    project is desktop / CLI / library.
+
+    Matches keywords inside the finding's reason / title. The keyword list
+    is generic across languages; it isn't tied to any one framework or
+    project. Like the path-role downweight, this only fires when the LLM
+    didn't already lower confidence.
+    """
+    if finding.get("t") != "violation":
+        return
+    if not _shape_irrelevant_to_hosted_service(shape):
+        return
+    haystack_parts: list[str] = []
+    for key in ("reason", "w", "title"):
+        val = finding.get(key)
+        if isinstance(val, str):
+            haystack_parts.append(val.lower())
+    haystack = " ".join(haystack_parts)
+    if not any(kw in haystack for kw in _HOSTED_SERVICE_KEYWORDS):
+        return
+    existing = finding.get("confidence")
+    if existing is None or existing == 100:
+        finding["confidence"] = _SHAPE_DOWNWEIGHT
+
+
 @dataclass
 class CompiledContext:
     """Grouped compiled-standards data for finding enrichment."""
@@ -53,6 +107,7 @@ class CompiledContext:
     req_to_dim: dict[str, str] = field(default_factory=dict)
     dimension: str | None = None
     work_dir: Path | None = None
+    project_shape: ProjectShape | None = None
 
 
 @runtime_checkable
@@ -129,6 +184,7 @@ class FindingsRouter:
         self._req_to_dim = ctx.req_to_dim
         self._seen: DeduplicationStore = seen_store if seen_store is not None else set()
         self._work_dir = ctx.work_dir
+        self._project_shape = ctx.project_shape
         self._read_file = file_reader or _default_read_file
         self._findings_repo = findings_repo
         self.counter = 0
@@ -166,6 +222,7 @@ class FindingsRouter:
         self._enrich(args, finding)
         enrich_code(finding, self._work_dir, self._read_file)
         _apply_path_role_downweight(finding)
+        _apply_shape_downweight(finding, self._project_shape)
 
         line = json.dumps(finding) + "\n"
         _locked_write(self._fh, line)

--- a/src/quodeq/context/__init__.py
+++ b/src/quodeq/context/__init__.py
@@ -6,5 +6,13 @@ service emits a confidence multiplier on top of the LLM's verdict; nothing
 is suppressed.
 """
 from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
+from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
 
-__all__ = ["NON_PROD_ROLES", "Role", "path_role"]
+__all__ = [
+    "Deployment",
+    "NON_PROD_ROLES",
+    "ProjectShape",
+    "Role",
+    "detect_shape",
+    "path_role",
+]

--- a/src/quodeq/context/project_shape.py
+++ b/src/quodeq/context/project_shape.py
@@ -1,0 +1,286 @@
+"""Detect a project's deployment shape from its manifest files.
+
+Reads ``pyproject.toml``, ``package.json``, ``Cargo.toml``, ``go.mod`` and
+similar at the repo root and produces a :class:`ProjectShape`. Detection is
+language-agnostic: every check is a manifest pattern, never a code-level
+assumption.
+
+The shape is the single biggest source of false positives in the current
+audit corpus (~40%) because the scanner defaults to "hosted multi-tenant
+web service" assumptions on what is in fact a desktop / CLI / library.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from pathlib import Path
+
+
+class Deployment(str, Enum):
+    DESKTOP = "desktop"
+    CLI = "cli"
+    WEB_SERVICE = "web_service"
+    LIBRARY = "library"
+    MOBILE = "mobile"
+    EMBEDDED = "embedded"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class ProjectShape:
+    """Coarse classification of what a repository ships.
+
+    Fields are populated best-effort from manifests; absent signals leave
+    fields as their defaults (``UNKNOWN`` / empty list / ``None``). The
+    finding pipeline reads ``deployment`` and ``is_single_user`` to decide
+    whether hosted-service findings (concurrent callers, distributed state,
+    blocking the request thread) deserve their default confidence.
+    """
+
+    deployment: Deployment = Deployment.UNKNOWN
+    runtime_langs: list[str] = field(default_factory=list)
+    web_frameworks: list[str] = field(default_factory=list)
+    ui_lang: str | None = None
+    is_single_user: bool = True
+
+    def to_dict(self) -> dict[str, object]:
+        d = asdict(self)
+        d["deployment"] = self.deployment.value
+        return d
+
+
+_PY_WEB_FRAMEWORKS = (
+    "flask", "fastapi", "django", "starlette", "aiohttp",
+    "sanic", "tornado", "bottle", "falcon", "pyramid",
+)
+_PY_DESKTOP_HINTS = (
+    "pyinstaller", "pywebview", "tkinter", "pyside6", "pyqt5", "pyqt6",
+    "kivy", "wxpython", "toga", "dearpygui",
+)
+
+_JS_WEB_FRAMEWORKS = (
+    "express", "fastify", "next", "nestjs", "@nestjs/core", "koa",
+    "hapi", "@hapi/hapi", "restify", "hono",
+)
+_JS_DESKTOP_HINTS = (
+    "electron", "@electron/remote", "tauri", "@tauri-apps/api",
+    "neutralinojs", "nodegui",
+)
+_JS_MOBILE_HINTS = (
+    "react-native", "expo", "@ionic/core", "nativescript",
+)
+_JS_UI_LIBS = ("react", "vue", "svelte", "preact", "@angular/core", "solid-js")
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _read_toml(path: Path) -> dict[str, object] | None:
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+
+def _read_json(path: Path) -> dict[str, object] | None:
+    text = _read_text(path)
+    if text is None:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _flat_dep_names(*sources: object) -> list[str]:
+    out: list[str] = []
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        for key in src:
+            out.append(str(key).lower())
+    return out
+
+
+def _matches_any(haystack: list[str], needles: tuple[str, ...]) -> list[str]:
+    needle_set = {n.lower() for n in needles}
+    return [n for n in haystack if n in needle_set]
+
+
+def _python_signals(repo: Path) -> tuple[Deployment | None, list[str], list[str]]:
+    """Return ``(deployment_hint, web_frameworks, desktop_hints)`` from pyproject.
+
+    A deployment hint is only set when the manifest is unambiguous; the
+    caller fuses signals across all manifests before settling on a verdict.
+    """
+    pyproject = _read_toml(repo / "pyproject.toml")
+    if pyproject is None:
+        return None, [], []
+    project_raw = pyproject.get("project") or {}
+    project = project_raw if isinstance(project_raw, dict) else {}
+    deps_list = project.get("dependencies") or []
+    optional_deps = project.get("optional-dependencies") or {}
+    optional_flat: list[str] = []
+    if isinstance(optional_deps, dict):
+        for group in optional_deps.values():
+            if isinstance(group, list):
+                optional_flat.extend(group)
+    raw = list(deps_list) + optional_flat
+    names = [_strip_dep_spec(d).lower() for d in raw if isinstance(d, str)]
+    web = _matches_any(names, _PY_WEB_FRAMEWORKS)
+    desktop = _matches_any(names, _PY_DESKTOP_HINTS)
+    if web and not desktop:
+        return Deployment.WEB_SERVICE, web, desktop
+    if desktop and not web:
+        return Deployment.DESKTOP, web, desktop
+    return None, web, desktop
+
+
+_DEP_SPEC_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
+
+
+def _strip_dep_spec(spec: str) -> str:
+    """Reduce a PEP 508 spec like ``flask>=3.0`` to its bare name."""
+    m = _DEP_SPEC_RE.match(spec.strip())
+    return m.group(1) if m else spec.strip()
+
+
+def _node_signals(
+    repo: Path,
+) -> tuple[Deployment | None, list[str], list[str], str | None]:
+    pkg = _read_json(repo / "package.json")
+    if pkg is None:
+        return None, [], [], None
+    deps = _flat_dep_names(
+        pkg.get("dependencies"),
+        pkg.get("devDependencies"),
+        pkg.get("peerDependencies"),
+    )
+    web = _matches_any(deps, _JS_WEB_FRAMEWORKS)
+    desktop = _matches_any(deps, _JS_DESKTOP_HINTS)
+    mobile = _matches_any(deps, _JS_MOBILE_HINTS)
+    ui = next((u for u in _JS_UI_LIBS if u.lower() in deps), None)
+    if mobile:
+        return Deployment.MOBILE, web, desktop, ui
+    if desktop:
+        return Deployment.DESKTOP, web, desktop, ui
+    if web:
+        return Deployment.WEB_SERVICE, web, desktop, ui
+    return None, web, desktop, ui
+
+
+def _rust_signals(repo: Path) -> Deployment | None:
+    cargo = _read_toml(repo / "Cargo.toml")
+    if cargo is None:
+        return None
+    package_raw = cargo.get("package") or {}
+    package = package_raw if isinstance(package_raw, dict) else {}
+    has_lib = (repo / "src" / "lib.rs").exists() or "lib" in cargo
+    has_bin = (repo / "src" / "main.rs").exists() or bool(cargo.get("bin"))
+    publish = package.get("publish")
+    # Cargo's publish defaults to True; explicit False means private/CLI.
+    publishable = publish is not False
+    if has_lib and not has_bin and publishable:
+        return Deployment.LIBRARY
+    if has_bin and not has_lib:
+        return Deployment.CLI
+    return None
+
+
+_GO_WEB_IMPORTS = (
+    "net/http", "github.com/gin-gonic/gin", "github.com/gorilla/mux",
+    "github.com/labstack/echo", "github.com/gofiber/fiber",
+)
+
+
+def _go_signals(repo: Path) -> Deployment | None:
+    if not (repo / "go.mod").exists():
+        return None
+    main_go = repo / "main.go"
+    if main_go.exists():
+        text = _read_text(main_go) or ""
+        if any(imp in text for imp in _GO_WEB_IMPORTS):
+            return Deployment.WEB_SERVICE
+        return Deployment.CLI
+    return None
+
+
+_LANG_MARKERS: tuple[tuple[str, str], ...] = (
+    ("python", "pyproject.toml"),
+    ("python", "setup.py"),
+    ("javascript", "package.json"),
+    ("rust", "Cargo.toml"),
+    ("go", "go.mod"),
+    ("java", "pom.xml"),
+    ("kotlin", "build.gradle.kts"),
+    ("swift", "Package.swift"),
+    ("ruby", "Gemfile"),
+    ("dart", "pubspec.yaml"),
+    ("php", "composer.json"),
+)
+
+
+def _detect_runtime_langs(repo: Path) -> list[str]:
+    seen: list[str] = []
+    for lang, marker in _LANG_MARKERS:
+        if (repo / marker).exists() and lang not in seen:
+            seen.append(lang)
+    return seen
+
+
+def detect_shape(repo_path: Path) -> ProjectShape:
+    """Detect a :class:`ProjectShape` from manifests at *repo_path*.
+
+    Falls back to ``Deployment.UNKNOWN`` whenever signals are absent or
+    contradictory; callers must treat ``UNKNOWN`` as a no-op (no downweight,
+    no prompt enrichment).
+    """
+    repo = Path(repo_path)
+    if not repo.is_dir():
+        return ProjectShape()
+
+    py_dep, py_web, _ = _python_signals(repo)
+    js_dep, js_web, _, ui_lang = _node_signals(repo)
+    rust_dep = _rust_signals(repo)
+    go_dep = _go_signals(repo)
+
+    # Priority: explicit desktop/mobile signals beat web signals beat library
+    # beat cli, since desktop hints come from very specific dep names while
+    # web hints can show up in dev dependencies of desktop apps.
+    deployment = Deployment.UNKNOWN
+    for candidate in (py_dep, js_dep, rust_dep, go_dep):
+        if candidate is None:
+            continue
+        if candidate is Deployment.DESKTOP:
+            deployment = Deployment.DESKTOP
+            break
+        if candidate is Deployment.MOBILE:
+            deployment = Deployment.MOBILE
+            break
+    else:
+        for candidate in (py_dep, js_dep, rust_dep, go_dep):
+            if candidate is None:
+                continue
+            if deployment is Deployment.UNKNOWN:
+                deployment = candidate
+
+    web_frameworks = sorted({*py_web, *js_web})
+    runtime_langs = _detect_runtime_langs(repo)
+    is_single_user = deployment is not Deployment.WEB_SERVICE
+
+    return ProjectShape(
+        deployment=deployment,
+        runtime_langs=runtime_langs,
+        web_frameworks=web_frameworks,
+        ui_lang=ui_lang,
+        is_single_user=is_single_user,
+    )

--- a/src/quodeq/data/prompts/api_prompt.md
+++ b/src/quodeq/data/prompts/api_prompt.md
@@ -9,6 +9,8 @@ You MUST evaluate EVERY principle group — not just the first ones.
 
 {{STANDARDS_TEXT}}
 
+{{PROJECT_SHAPE}}
+
 ## Source Files
 
 {{FILES_BLOCK}}

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -111,3 +111,39 @@ class TestAssembleApiPrompt:
             repo_root=tmp_path,
         )
         assert "(role:" not in prompt
+
+    def test_includes_project_shape_when_detected(self, tmp_path, standards_text):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0.1.0"\ndependencies = ["pywebview"]\n'
+        )
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "main.py").write_text("def main():\n    pass\n")
+        prompt = assemble_api_prompt(
+            source_files=[src / "main.py"],
+            standards_text=standards_text,
+            dimension="performance",
+            repo_name="test-repo",
+            repo_root=tmp_path,
+        )
+        assert "## Project Shape" in prompt
+        assert "deployment=desktop" in prompt
+        assert "single_user=true" in prompt
+        # The desktop note should warn the LLM about hosted-service findings.
+        assert "thread blocking" in prompt
+
+    def test_omits_project_shape_when_unknown(self, tmp_path, standards_text):
+        """No manifests at the root means no shape briefing — we don't want
+        to plant a wrong assumption in the LLM's head."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "main.py").write_text("def main():\n    pass\n")
+        prompt = assemble_api_prompt(
+            source_files=[src / "main.py"],
+            standards_text=standards_text,
+            dimension="performance",
+            repo_name="test-repo",
+            repo_root=tmp_path,
+        )
+        assert "## Project Shape" not in prompt
+        assert "{{PROJECT_SHAPE}}" not in prompt

--- a/tests/context/test_project_shape.py
+++ b/tests/context/test_project_shape.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+
+import pytest
+
+from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def test_unknown_when_no_manifests(tmp_path: Path) -> None:
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.UNKNOWN
+    assert shape.is_single_user is True
+    assert shape.web_frameworks == []
+    assert shape.runtime_langs == []
+
+
+def test_missing_repo_returns_unknown(tmp_path: Path) -> None:
+    shape = detect_shape(tmp_path / "does-not-exist")
+    assert shape.deployment is Deployment.UNKNOWN
+
+
+def test_pyproject_with_flask_is_web_service(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", """
+[project]
+name = "x"
+version = "0.1.0"
+dependencies = ["flask>=3.0", "click"]
+""")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.WEB_SERVICE
+    assert "flask" in shape.web_frameworks
+    assert shape.is_single_user is False
+
+
+def test_pyproject_with_pyinstaller_is_desktop(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", """
+[project]
+name = "x"
+version = "0.1.0"
+dependencies = ["pywebview>=5.0", "click"]
+""")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.DESKTOP
+    assert shape.is_single_user is True
+
+
+def test_desktop_wins_when_pyproject_has_both(tmp_path: Path) -> None:
+    """Desktop framework dep beats a web framework dep in optional-dependencies.
+
+    Real example: a desktop app may pull in flask only as a dev dep for a
+    docs server. Optional dependencies should not flip the deployment.
+    """
+    _write(tmp_path / "pyproject.toml", """
+[project]
+name = "x"
+version = "0.1.0"
+dependencies = ["pywebview>=5.0"]
+
+[project.optional-dependencies]
+dev = ["flask"]
+""")
+    shape = detect_shape(tmp_path)
+    # Both signals present -> Python returns None (ambiguous), falling back
+    # to UNKNOWN unless something else votes. Desktop hint at the *project*
+    # priority pass wins below — but here pyproject is ambiguous, no other
+    # manifests exist, so verdict is UNKNOWN.
+    assert shape.deployment is Deployment.UNKNOWN
+
+
+def test_package_json_express_is_web_service(tmp_path: Path) -> None:
+    _write(tmp_path / "package.json", '{"dependencies": {"express": "^4.0.0"}}')
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.WEB_SERVICE
+    assert "express" in shape.web_frameworks
+    assert shape.is_single_user is False
+
+
+def test_package_json_electron_is_desktop(tmp_path: Path) -> None:
+    _write(tmp_path / "package.json",
+           '{"dependencies": {"electron": "^28.0.0", "react": "^18.0.0"}}')
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.DESKTOP
+    assert shape.ui_lang == "react"
+    assert shape.is_single_user is True
+
+
+def test_package_json_react_native_is_mobile(tmp_path: Path) -> None:
+    _write(tmp_path / "package.json", '{"dependencies": {"react-native": "0.73"}}')
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.MOBILE
+
+
+def test_cargo_lib_only_publishable_is_library(tmp_path: Path) -> None:
+    _write(tmp_path / "Cargo.toml", """
+[package]
+name = "x"
+version = "0.1.0"
+""")
+    _write(tmp_path / "src" / "lib.rs", "// lib")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.LIBRARY
+
+
+def test_cargo_bin_only_is_cli(tmp_path: Path) -> None:
+    _write(tmp_path / "Cargo.toml", """
+[package]
+name = "x"
+version = "0.1.0"
+""")
+    _write(tmp_path / "src" / "main.rs", "fn main() {}")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.CLI
+
+
+def test_go_with_main_no_web_imports_is_cli(tmp_path: Path) -> None:
+    _write(tmp_path / "go.mod", "module example.com/x\n\ngo 1.22\n")
+    _write(tmp_path / "main.go", "package main\n\nfunc main() {}\n")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.CLI
+
+
+def test_go_with_net_http_is_web_service(tmp_path: Path) -> None:
+    _write(tmp_path / "go.mod", "module example.com/x\n\ngo 1.22\n")
+    _write(tmp_path / "main.go",
+           'package main\nimport "net/http"\nfunc main() { http.ListenAndServe(":8080", nil) }\n')
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.WEB_SERVICE
+
+
+def test_desktop_python_beats_cli_go_when_both_present(tmp_path: Path) -> None:
+    """Multi-language repos: desktop hints from any manifest beat cli."""
+    _write(tmp_path / "pyproject.toml", """
+[project]
+name = "x"
+version = "0.1.0"
+dependencies = ["pywebview"]
+""")
+    _write(tmp_path / "go.mod", "module example.com/x\n\ngo 1.22\n")
+    _write(tmp_path / "main.go", "package main\nfunc main() {}\n")
+    shape = detect_shape(tmp_path)
+    assert shape.deployment is Deployment.DESKTOP
+    assert "python" in shape.runtime_langs
+    assert "go" in shape.runtime_langs
+
+
+def test_to_dict_serializes_enum_value() -> None:
+    shape = ProjectShape(deployment=Deployment.DESKTOP, is_single_user=True)
+    d = shape.to_dict()
+    assert d["deployment"] == "desktop"
+    assert d["is_single_user"] is True
+
+
+def test_runtime_langs_detected_from_markers(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[project]\nname = 'x'\nversion='0.1.0'\n")
+    _write(tmp_path / "Gemfile", "source 'https://rubygems.org'")
+    shape = detect_shape(tmp_path)
+    assert "python" in shape.runtime_langs
+    assert "ruby" in shape.runtime_langs
+
+
+def test_unknown_deployment_is_single_user() -> None:
+    """Default for ambiguous projects: assume single-user (libraries, CLIs,
+    or bare repos without manifests). Only web_service flips the flag."""
+    shape = ProjectShape()
+    assert shape.deployment is Deployment.UNKNOWN
+    assert shape.is_single_user is True

--- a/tests/engine/test_mcp_findings_router.py
+++ b/tests/engine/test_mcp_findings_router.py
@@ -114,6 +114,57 @@ class TestFindingsRouter:
         written = json.loads(findings_file.read_text().strip())
         assert "confidence" not in written
 
+    def test_shape_downweights_hosted_service_finding_on_desktop_app(self, tmp_path: Path) -> None:
+        from quodeq.context.project_shape import Deployment, ProjectShape
+        findings_file = tmp_path / "findings.jsonl"
+        shape = ProjectShape(deployment=Deployment.DESKTOP, is_single_user=True)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(project_shape=shape),
+            )
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Concurrent callers can corrupt shared state",
+                "reason": "Multiple concurrent callers will race.",
+                "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert written["confidence"] == 40
+
+    def test_shape_does_not_downweight_unrelated_finding(self, tmp_path: Path) -> None:
+        from quodeq.context.project_shape import Deployment, ProjectShape
+        findings_file = tmp_path / "findings.jsonl"
+        shape = ProjectShape(deployment=Deployment.DESKTOP, is_single_user=True)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(project_shape=shape),
+            )
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Quadratic loop", "reason": "Nested for-loops over the same list.",
+                "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert "confidence" not in written
+
+    def test_shape_does_not_downweight_for_web_service(self, tmp_path: Path) -> None:
+        from quodeq.context.project_shape import Deployment, ProjectShape
+        findings_file = tmp_path / "findings.jsonl"
+        shape = ProjectShape(deployment=Deployment.WEB_SERVICE, is_single_user=False)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(project_shape=shape),
+            )
+            router.receive({
+                "p": "P1", "t": "violation", "d": "perf",
+                "w": "Concurrent callers can corrupt shared state",
+                "reason": "Multiple concurrent callers will race.",
+                "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        # Web service: the hosted-service finding stays at full confidence.
+        assert "confidence" not in written
+
 
 class TestGetNextFiles:
     def test_tools_list_includes_get_next_files(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Slice 3 of the context-enricher plan, building on slices 1 (#360) and 2 (#361). Adds a manifest-driven \`ProjectShape\` so the LLM and the post-LLM pipeline both know whether a project is a desktop tool, a CLI, a library, or a hosted web service.

This targets the **single largest noise category** in the audit corpus: ~40% of dismissed false positives were the scanner assuming hosted multi-tenant service when the codebase was a desktop tool.

### What lands

- New \`quodeq.context.project_shape\` with \`detect_shape(repo) -> ProjectShape\`. Reads \`pyproject.toml\`, \`package.json\`, \`Cargo.toml\`, \`go.mod\` + \`main.go\`. Fields: \`deployment\`, \`runtime_langs\`, \`web_frameworks\`, \`ui_lang\`, \`is_single_user\`. Language-agnostic, no per-framework code paths.
- API prompt assembly injects \`## Project Shape\` when shape is known (e.g. \`deployment=desktop, single_user=true\`). For desktop / library / single-user CLI a brief note tells the LLM to be skeptical about thread-blocking, distributed-state, and concurrent-caller findings. UNKNOWN deployments emit no block, so the model isn't pushed toward a wrong assumption.
- FindingsRouter post-LLM downweight: when shape is hosted-service-irrelevant AND the finding's reason/title hits one of \`concurrent caller, distributed state, multi-tenant, rate limit, ddos, horizontal scaling, ...\`, confidence drops to 40. Skipped for compliance findings and when the LLM already lowered confidence.

### Out of scope (deferred)

- Persistence to \`<project_dir>/context.json\` with mtime-based refresh. Manifests parse in ms, so recomputing per evaluation is fine. Will revisit if/when Slice 5 (online-project shallow cache) needs to share this surface.

## Test plan

- [x] \`tests/context/test_project_shape.py\` -- 16 cases: pyproject (flask -> web, pywebview -> desktop, ambiguous -> unknown), package.json (express -> web, electron -> desktop, react-native -> mobile), Cargo (lib-only -> library, bin-only -> cli), go.mod (net/http -> web, no web import -> cli), multi-language priority (desktop python beats cli go).
- [x] \`tests/analysis/test_api_prompt.py\` -- prompt includes \`## Project Shape\` for detected pyproject + pywebview, omits the block when shape is UNKNOWN.
- [x] \`tests/engine/test_mcp_findings_router.py\` -- desktop+single_user downweights hosted-service finding to 40, doesn't downweight unrelated findings, doesn't downweight on web service.
- [x] Full Python suite green (2528 passed).
- [x] UI Node tests green (134 passed).
- [x] mypy clean on \`quodeq.context\`.
- [x] Manual: re-run a small slice of the performance/reliability audit on quodeq itself, verify thread-blocking / distributed-state findings drop into the low-confidence group.

## Notes for review

The hosted-service keyword list in \`router.py\` is intentionally narrow. The bias is **recall over precision**: better to miss a few real hosted-service issues on a desktop project (they still show up at full confidence, just without downweight) than to over-aggressively suppress real bugs. The list can grow once we observe miscalibration on the next self-audit.