### PR TITLE
feat(context): project-local precedent corpus downweights re-emitted findings (slice 4)

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -22,6 +22,7 @@ import openai
 from pydantic import BaseModel, Field
 
 from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
+from quodeq.context.precedent import load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements
 from quodeq.engine._ref_utils import load_compiled_refs
@@ -217,6 +218,7 @@ def _enrich_findings(
     compiled_dir: Path | None,
     dimension: str | None,
     work_dir: Path | None,
+    project_dir: Path | None = None,
 ) -> list[dict]:
     """Enrich findings through FindingsRouter (same as MCP path)."""
     _infer_end_line(findings)
@@ -226,12 +228,14 @@ def _enrich_findings(
         compiled_refs = load_compiled_refs(compiled_dir, dimension) or {}
         compiled_reqs = load_compiled_requirements(compiled_dir, dimension) or {}
         project_shape = detect_shape(work_dir) if work_dir is not None else None
+        precedents = load_precedent_fingerprints(project_dir) if project_dir else set()
         ctx = CompiledContext(
             compiled_refs=compiled_refs,
             compiled_reqs=compiled_reqs,
             dimension=dimension,
             work_dir=work_dir,
             project_shape=project_shape,
+            precedent_fingerprints=precedents,
         )
 
         buf = io.StringIO()
@@ -279,7 +283,11 @@ def run_api_analysis(
     if source_file_paths:
         findings = _resolve_file_paths(findings, source_file_paths)
 
-    findings = _enrich_findings(findings, compiled_dir, dimension, work_dir)
+    # jsonl_file is `<project_dir>/<run_id>/evidence/<dim>_evidence.jsonl`,
+    # so the project directory is its great-grandparent. Used by the
+    # context-enricher pipeline to load prior dismissals as precedents.
+    project_dir = jsonl_file.parent.parent.parent if jsonl_file else None
+    findings = _enrich_findings(findings, compiled_dir, dimension, work_dir, project_dir)
 
     _log.debug("Received %d findings from API", len(findings))
 

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -17,6 +17,7 @@ from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.mcp.args import ServerArgs, parse_args
 from quodeq.analysis.mcp.dispatch import read_message, dispatch as _dispatch
 from quodeq.engine._ref_utils import load_compiled_refs as _load_compiled_refs
+from quodeq.context.precedent import load_precedent_fingerprints
 from quodeq.context.project_shape import detect_shape
 from quodeq.core.standards.refs import load_compiled_requirements as _load_compiled_requirements
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
@@ -96,11 +97,16 @@ def _build_router(findings_fh, findings_path: Path, ctx: CompiledContext) -> Fin
     """Construct a FindingsRouter wired to dual-write into the run's evaluation.db.
 
     The findings_path is `<run_dir>/evidence/<dim>_evidence.jsonl`, so the run
-    directory is its grandparent. SqliteFindingsRepository creates / opens
-    `<run_dir>/evaluation.db` lazily on first insert.
+    directory is its grandparent and the project directory its great-
+    grandparent. SqliteFindingsRepository creates / opens
+    `<run_dir>/evaluation.db` lazily on first insert. We also load the
+    project's prior dismissals from `<project_dir>/dismissed.json` so the
+    router can downweight findings the user has already judged.
     """
     run_dir = Path(findings_path).parent.parent
+    project_dir = run_dir.parent
     repo = SqliteFindingsRepository(run_dir)
+    ctx.precedent_fingerprints = load_precedent_fingerprints(project_dir)
     return FindingsRouter(findings_fh, context=ctx, findings_repo=repo)
 
 

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -18,6 +18,7 @@ if sys.platform != "win32":
 from quodeq.analysis.mcp.enrichment import enrich_code
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
+from quodeq.context.precedent import fingerprint as _precedent_fingerprint
 from quodeq.context.project_shape import Deployment, ProjectShape
 from quodeq.data.ports.findings import FindingsRepository
 from quodeq.shared._env import sqlite_disabled
@@ -29,6 +30,9 @@ _NON_PROD_DOWNWEIGHT = 50  # confidence applied to violations on non-prod paths
 _SHAPE_DOWNWEIGHT = 40  # confidence applied when the finding clearly assumes
                         # a hosted multi-tenant service but the project shape
                         # says single-user desktop / CLI / library.
+_PRECEDENT_DOWNWEIGHT = 25  # confidence applied when the finding fingerprint
+                            # matches a prior dismissal in this project — the
+                            # user has already judged the same code before.
 
 _HOSTED_SERVICE_KEYWORDS: tuple[str, ...] = (
     "concurrent caller", "concurrent callers", "concurrent request",
@@ -99,6 +103,35 @@ def _apply_shape_downweight(
         finding["confidence"] = _SHAPE_DOWNWEIGHT
 
 
+def _apply_precedent_downweight(
+    finding: dict[str, object], fingerprints: set[str] | None,
+) -> None:
+    """Drop confidence to ~25 when this finding's fingerprint matches a
+    finding the user previously dismissed in this project.
+
+    Skipped when:
+    * the user has dismissed nothing yet (fingerprints empty / None).
+    * the finding is a compliance entry (precedents only suppress noise,
+      not "code is fine" signals).
+    * the LLM already lowered confidence below 100 (we trust its self-doubt).
+    """
+    if not fingerprints:
+        return
+    if finding.get("t") != "violation":
+        return
+    req = finding.get("req")
+    snippet = finding.get("snippet")
+    fp = _precedent_fingerprint(
+        req if isinstance(req, str) else None,
+        snippet if isinstance(snippet, str) else None,
+    )
+    if fp is None or fp not in fingerprints:
+        return
+    existing = finding.get("confidence")
+    if existing is None or existing == 100:
+        finding["confidence"] = _PRECEDENT_DOWNWEIGHT
+
+
 @dataclass
 class CompiledContext:
     """Grouped compiled-standards data for finding enrichment."""
@@ -108,6 +141,7 @@ class CompiledContext:
     dimension: str | None = None
     work_dir: Path | None = None
     project_shape: ProjectShape | None = None
+    precedent_fingerprints: set[str] = field(default_factory=set)
 
 
 @runtime_checkable
@@ -185,6 +219,7 @@ class FindingsRouter:
         self._seen: DeduplicationStore = seen_store if seen_store is not None else set()
         self._work_dir = ctx.work_dir
         self._project_shape = ctx.project_shape
+        self._precedent_fingerprints = ctx.precedent_fingerprints
         self._read_file = file_reader or _default_read_file
         self._findings_repo = findings_repo
         self.counter = 0
@@ -223,6 +258,7 @@ class FindingsRouter:
         enrich_code(finding, self._work_dir, self._read_file)
         _apply_path_role_downweight(finding)
         _apply_shape_downweight(finding, self._project_shape)
+        _apply_precedent_downweight(finding, self._precedent_fingerprints)
 
         line = json.dumps(finding) + "\n"
         _locked_write(self._fh, line)

--- a/src/quodeq/context/__init__.py
+++ b/src/quodeq/context/__init__.py
@@ -6,6 +6,7 @@ service emits a confidence multiplier on top of the LLM's verdict; nothing
 is suppressed.
 """
 from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
+from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
 from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
 
 __all__ = [
@@ -14,5 +15,7 @@ __all__ = [
     "ProjectShape",
     "Role",
     "detect_shape",
+    "fingerprint",
+    "load_precedent_fingerprints",
     "path_role",
 ]

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -1,0 +1,79 @@
+"""Project-local precedent matching for the context-enricher pipeline.
+
+A precedent is a finding that was previously dismissed for this project.
+On the next evaluation, the scanner will likely surface the same code
+pattern again; without precedent tracking, the user has to dismiss it
+every run. This module computes a stable fingerprint for each dismissed
+finding so the post-LLM pipeline can downweight matches.
+
+Fingerprint = sha256 of ``(req, normalized_snippet)``. Whitespace and
+trailing punctuation are normalized so cosmetic edits to surrounding
+code don't break the match. Code identifiers are *not* normalized:
+renaming a variable produces legitimately different code.
+
+The global cross-project precedent corpus (sentence-transformer
+embeddings) is a follow-up; this module ships exact-match only.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_DISMISSED_FILENAME = "dismissed.json"
+_WS_RE = re.compile(r"\s+")
+
+
+def _normalize_snippet(snippet: str | None) -> str:
+    """Collapse runs of whitespace and trim trailing punctuation/space."""
+    if not snippet:
+        return ""
+    collapsed = _WS_RE.sub(" ", snippet).strip()
+    return collapsed.rstrip(",;.")
+
+
+def fingerprint(req: str | None, snippet: str | None) -> str | None:
+    """Hex sha256 of ``req + '|' + normalized_snippet``, or None when blank.
+
+    Returning None for blank inputs lets callers skip lookup entirely
+    instead of poisoning the precedent set with a useless all-empty key.
+    """
+    norm = _normalize_snippet(snippet)
+    req_part = (req or "").strip()
+    if not req_part and not norm:
+        return None
+    payload = f"{req_part}|{norm}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def load_precedent_fingerprints(project_dir: Path) -> set[str]:
+    """Load fingerprints for every dismissed finding in *project_dir*.
+
+    Reads ``<project_dir>/dismissed.json``. Missing / malformed files
+    return an empty set: precedent matching degrades gracefully and never
+    breaks an evaluation.
+    """
+    if not project_dir or not project_dir.is_dir():
+        return set()
+    path = project_dir / _DISMISSED_FILENAME
+    if not path.exists():
+        return set()
+    try:
+        entries = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _logger.warning("Could not read precedent corpus at %s: %s", path, exc)
+        return set()
+    if not isinstance(entries, list):
+        return set()
+    out: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        fp = fingerprint(entry.get("req"), entry.get("snippet"))
+        if fp is not None:
+            out.add(fp)
+    return out

--- a/tests/analysis/mcp/test_findings_server.py
+++ b/tests/analysis/mcp/test_findings_server.py
@@ -21,6 +21,24 @@ def test_build_router_wires_sqlite_repo_with_run_dir(tmp_path: Path):
     assert router._findings_repo._run_dir == tmp_path / "run-1"
 
 
+def test_build_router_loads_precedent_fingerprints_from_project_dir(tmp_path: Path):
+    import json
+
+    from quodeq.context.precedent import fingerprint
+
+    # Layout: <project_dir>/<run_dir>/evidence/<dim>_evidence.jsonl
+    project_dir = tmp_path
+    findings_path = project_dir / "run-1" / "evidence" / "security_evidence.jsonl"
+    findings_path.parent.mkdir(parents=True)
+    (project_dir / "dismissed.json").write_text(json.dumps([
+        {"req": "S-CON-1", "snippet": "password = 'secret'"},
+    ]))
+
+    router = _build_router(io.StringIO(), findings_path, CompiledContext())
+
+    assert fingerprint("S-CON-1", "password = 'secret'") in router._precedent_fingerprints
+
+
 def test_build_router_emits_findings_to_both_jsonl_and_sqlite(tmp_path: Path):
     findings_path = tmp_path / "run-1" / "evidence" / "timeliness_evidence.jsonl"
     findings_path.parent.mkdir(parents=True)

--- a/tests/context/test_precedent.py
+++ b/tests/context/test_precedent.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
+
+
+def test_fingerprint_is_stable_for_same_inputs():
+    a = fingerprint("S-CON-1", "password = 'secret'")
+    b = fingerprint("S-CON-1", "password = 'secret'")
+    assert a == b
+    assert a is not None
+
+
+def test_fingerprint_normalizes_whitespace():
+    a = fingerprint("S-CON-1", "password = 'secret'")
+    b = fingerprint("S-CON-1", "  password = 'secret'  ")
+    c = fingerprint("S-CON-1", "password\t=\t'secret'")
+    assert a == b == c
+
+
+def test_fingerprint_changes_with_req():
+    a = fingerprint("S-CON-1", "x = 1")
+    b = fingerprint("S-CON-2", "x = 1")
+    assert a != b
+
+
+def test_fingerprint_changes_with_snippet():
+    a = fingerprint("S-CON-1", "x = 1")
+    b = fingerprint("S-CON-1", "y = 1")
+    assert a != b
+
+
+def test_fingerprint_returns_none_for_empty_inputs():
+    assert fingerprint(None, None) is None
+    assert fingerprint("", "") is None
+    assert fingerprint("  ", "  ") is None
+
+
+def test_fingerprint_works_with_only_req():
+    assert fingerprint("S-CON-1", None) is not None
+    assert fingerprint("S-CON-1", "") is not None
+
+
+def test_fingerprint_strips_trailing_punctuation():
+    a = fingerprint("R", "do_it()")
+    b = fingerprint("R", "do_it();")
+    c = fingerprint("R", "do_it().")
+    assert a == b == c
+
+
+def test_load_returns_empty_for_missing_dir(tmp_path: Path):
+    assert load_precedent_fingerprints(tmp_path / "missing") == set()
+
+
+def test_load_returns_empty_for_missing_file(tmp_path: Path):
+    assert load_precedent_fingerprints(tmp_path) == set()
+
+
+def test_load_returns_fingerprints_for_each_entry(tmp_path: Path):
+    entries = [
+        {"req": "S-CON-1", "snippet": "password = 'secret'"},
+        {"req": "M-MOD-2", "snippet": "def foo(): pass"},
+    ]
+    (tmp_path / "dismissed.json").write_text(json.dumps(entries))
+    out = load_precedent_fingerprints(tmp_path)
+    assert len(out) == 2
+    assert fingerprint("S-CON-1", "password = 'secret'") in out
+    assert fingerprint("M-MOD-2", "def foo(): pass") in out
+
+
+def test_load_skips_blank_entries(tmp_path: Path):
+    entries = [
+        {"req": "", "snippet": ""},
+        {"req": "M-MOD-2", "snippet": "def foo(): pass"},
+        "not a dict",
+        {},
+    ]
+    (tmp_path / "dismissed.json").write_text(json.dumps(entries))
+    out = load_precedent_fingerprints(tmp_path)
+    assert out == {fingerprint("M-MOD-2", "def foo(): pass")}
+
+
+def test_load_handles_malformed_json(tmp_path: Path):
+    (tmp_path / "dismissed.json").write_text("{not valid json")
+    assert load_precedent_fingerprints(tmp_path) == set()
+
+
+def test_load_handles_non_list_root(tmp_path: Path):
+    (tmp_path / "dismissed.json").write_text('{"oops": "object instead of list"}')
+    assert load_precedent_fingerprints(tmp_path) == set()

--- a/tests/engine/test_mcp_findings_router.py
+++ b/tests/engine/test_mcp_findings_router.py
@@ -147,6 +147,74 @@ class TestFindingsRouter:
         written = json.loads(findings_file.read_text().strip())
         assert "confidence" not in written
 
+    def test_precedent_match_downweights_to_25(self, tmp_path: Path) -> None:
+        from quodeq.context.precedent import fingerprint
+        findings_file = tmp_path / "findings.jsonl"
+        snippet = "password = 'hunter2'"
+        fp = fingerprint("S-CON-1", snippet)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(precedent_fingerprints={fp}),
+            )
+            router.receive({
+                "p": "Confidentiality", "t": "violation", "d": "security",
+                "req": "S-CON-1", "w": "Hardcoded credential",
+                "snippet": snippet,
+                "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert written["confidence"] == 25
+
+    def test_precedent_miss_keeps_full_confidence(self, tmp_path: Path) -> None:
+        findings_file = tmp_path / "findings.jsonl"
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(precedent_fingerprints={"some-other-fp"}),
+            )
+            router.receive({
+                "p": "P1", "t": "violation", "d": "security",
+                "req": "S-CON-1", "w": "Hardcoded credential",
+                "snippet": "password = 'hunter2'",
+                "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert "confidence" not in written
+
+    def test_precedent_does_not_downweight_compliance(self, tmp_path: Path) -> None:
+        from quodeq.context.precedent import fingerprint
+        findings_file = tmp_path / "findings.jsonl"
+        snippet = "password = 'hunter2'"
+        fp = fingerprint("S-CON-1", snippet)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(precedent_fingerprints={fp}),
+            )
+            router.receive({
+                "p": "P1", "t": "compliance", "d": "security",
+                "req": "S-CON-1", "w": "OK",
+                "snippet": snippet, "file": "src/main.py", "line": 5,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert "confidence" not in written
+
+    def test_precedent_respects_llm_emitted_confidence(self, tmp_path: Path) -> None:
+        from quodeq.context.precedent import fingerprint
+        findings_file = tmp_path / "findings.jsonl"
+        snippet = "password = 'hunter2'"
+        fp = fingerprint("S-CON-1", snippet)
+        with open(findings_file, "w") as fh:
+            router = mcp_findings.FindingsRouter(
+                fh, CompiledContext(precedent_fingerprints={fp}),
+            )
+            router.receive({
+                "p": "P1", "t": "violation", "d": "security",
+                "req": "S-CON-1", "w": "Hardcoded credential",
+                "snippet": snippet, "file": "src/main.py", "line": 5,
+                "confidence": 60,
+            })
+        written = json.loads(findings_file.read_text().strip())
+        assert written["confidence"] == 60
+
     def test_shape_does_not_downweight_for_web_service(self, tmp_path: Path) -> None:
         from quodeq.context.project_shape import Deployment, ProjectShape
         findings_file = tmp_path / "findings.jsonl"


### PR DESCRIPTION
## Summary

Slice 4 (phase 1) of the context-enricher plan. Closes the loop between dismissals and the next evaluation: when the scanner re-emits a finding the user has already dismissed in this project, confidence drops to 25 so it lands in the LowConfidenceGroup instead of pretending to be a fresh issue.

This is the **forcing function** that's been showing up on every recent PR: the bot keeps flagging \"SQL injection\" on \`findings_repository.py\` even though those exact patterns were dismissed during the audit. After this slice ships, dismissals stick across runs.

### What lands

- New \`quodeq.context.precedent\` with:
  - \`fingerprint(req, snippet) -> str | None\` -- sha256 of \`(req, normalized snippet)\`. Whitespace and trailing punctuation are normalized; identifiers are not (renaming a variable should produce a different fingerprint).
  - \`load_precedent_fingerprints(project_dir) -> set[str]\` -- reads the existing \`<project_dir>/dismissed.json\`, no new on-disk format.
- \`CompiledContext\` gets \`precedent_fingerprints: set[str]\`. \`FindingsRouter._apply_precedent_downweight\` drops confidence to 25 on match. Skipped for compliance findings and when the LLM already lowered confidence below 100.
- Wired through both \`mcp/findings_server._build_router\` and \`analysis/_api_runner.run_api_analysis\` (both derive \`project_dir\` from the JSONL output path's three-level parent).

### Out of scope (deferred to slice 4b/4c)

- **Cross-project global corpus** (\`~/.quodeq/global_precedent.db\`). Needs a sentence-transformer dependency or a local-Ollama embedding pipeline; deserves its own PR with the dependency call-out.
- **Bootstrap from the 1,249 audit rationales.** Encoded once into the global corpus, also belongs in 4b.
- **Prompt enrichment** with prior-rationale text (\"previously judged similar findings...\"). Slice 4 today is post-LLM only; if the LLM is already pre-conditioned by the path-role / project-shape blocks, the rationale-block ROI is unclear and worth measuring before adding token cost.

## Test plan

- [x] \`tests/context/test_precedent.py\` -- 13 cases: fingerprint stability, whitespace normalization, req sensitivity, snippet sensitivity, blank-input handling, malformed JSON / non-list root.
- [x] \`tests/engine/test_mcp_findings_router.py\` -- precedent match downweights to 25, miss keeps full confidence, compliance not downweighted, LLM-emitted low confidence preserved.
- [x] \`tests/analysis/mcp/test_findings_server.py\` -- \`_build_router\` reads \`dismissed.json\` from the great-grandparent of the findings file.
- [x] Full Python suite (2546 passed). Mypy clean on \`quodeq.context\`.
- [x] Manual: dismiss a finding in the UI, re-run the same dimension, verify the finding now appears in the LowConfidenceGroup with confidence 25.

## Notes for review

The fingerprint format intentionally excludes \`file\` and \`line\`. Same code at a new line (because someone added imports above) should still match -- which is the existing dismissed.json's failure mode and the main reason this slice exists.