### PR TITLE
feat(context): persistent shallow-clone cache for online repositories (slice 5)

### DIFF
--- a/src/quodeq/context/__init__.py
+++ b/src/quodeq/context/__init__.py
@@ -5,6 +5,15 @@ precedent corpus) that wrap quodeq's existing dimension scanners. Each
 service emits a confidence multiplier on top of the LLM's verdict; nothing
 is suppressed.
 """
+from quodeq.context.online_cache import (
+    cache_disabled,
+    cache_dir_for_url,
+    cache_root,
+    ensure_clone,
+    is_inside_cache,
+    repo_path_for_url,
+    wipe_cache,
+)
 from quodeq.context.path_role import NON_PROD_ROLES, Role, path_role
 from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
 from quodeq.context.project_shape import Deployment, ProjectShape, detect_shape
@@ -14,8 +23,15 @@ __all__ = [
     "NON_PROD_ROLES",
     "ProjectShape",
     "Role",
+    "cache_disabled",
+    "cache_dir_for_url",
+    "cache_root",
     "detect_shape",
+    "ensure_clone",
     "fingerprint",
+    "is_inside_cache",
     "load_precedent_fingerprints",
     "path_role",
+    "repo_path_for_url",
+    "wipe_cache",
 ]

--- a/src/quodeq/context/online_cache.py
+++ b/src/quodeq/context/online_cache.py
@@ -1,0 +1,151 @@
+"""Persistent shallow-clone cache for online repositories.
+
+Today every evaluation of an online repo re-clones into ``mkdtemp()`` and
+deletes the temp dir on exit, paying the full clone cost every run. This
+module replaces that with a deterministic cache under
+``~/.quodeq/cache/online/<url_hash>/repo``: the first evaluation clones
+shallow, every subsequent evaluation fetches and fast-forwards instead.
+
+The cache is purely derivative. Wipe it and the next evaluation will
+re-populate it; no user data lives here. The location is fixed
+(``~/.quodeq/cache/online/``) and survives subprocess boundaries, so
+both the GUI and the CLI converge on the same path.
+
+A kill switch (``QUODEQ_DISABLE_ONLINE_CACHE=1``) bypasses the cache and
+restores the old mkdtemp-based flow, in case a user hits a corrupt cache
+entry or wants reproducible-from-scratch evaluations.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_CACHE_ENV = "QUODEQ_CACHE_ROOT"  # override the cache root for tests / sandboxing
+_DISABLE_ENV = "QUODEQ_DISABLE_ONLINE_CACHE"
+_DEFAULT_CLONE_TIMEOUT_S = 300
+
+
+def cache_root() -> Path:
+    """Return the cache root, creating it if needed.
+
+    Defaults to ``~/.quodeq/cache``; override with ``QUODEQ_CACHE_ROOT``
+    so tests can point at a sandbox without touching the user's real cache.
+    """
+    raw = os.environ.get(_CACHE_ENV, "").strip()
+    base = Path(raw) if raw else Path.home() / ".quodeq" / "cache"
+    online = base / "online"
+    online.mkdir(parents=True, exist_ok=True)
+    return online
+
+
+def cache_disabled() -> bool:
+    """True when the user has flipped the kill switch."""
+    return os.environ.get(_DISABLE_ENV, "").strip() in {"1", "true", "yes"}
+
+
+def _url_hash(url: str) -> str:
+    return hashlib.sha256(url.strip().encode("utf-8")).hexdigest()[:16]
+
+
+def cache_dir_for_url(url: str) -> Path:
+    """Return the per-URL cache directory (``<root>/<url_hash>/``).
+
+    The repo itself is cloned into the ``repo`` subdirectory; metadata
+    (last-fetched timestamp, marker files) lives next to it. Truncating
+    the hash to 16 hex chars keeps paths readable while still avoiding
+    collisions on any plausible number of cached repos.
+    """
+    return cache_root() / _url_hash(url)
+
+
+def repo_path_for_url(url: str) -> Path:
+    """Return the working-copy path inside the cache for *url*."""
+    return cache_dir_for_url(url) / "repo"
+
+
+def is_inside_cache(path: str | Path) -> bool:
+    """True when *path* lives under the cache root.
+
+    Used by the eval-cleanup hook so an old ``rmtree(parent)`` doesn't
+    nuke the cache when the working dir happens to live inside it.
+    """
+    try:
+        resolved = Path(path).resolve()
+        return resolved.is_relative_to(cache_root().resolve())
+    except (OSError, RuntimeError):
+        return False
+
+
+def _git(args: list[str], *, cwd: Path | None = None,
+         timeout: int = _DEFAULT_CLONE_TIMEOUT_S) -> bool:
+    env = {**os.environ, "GIT_LFS_SKIP_SMUDGE": "1"}
+    try:
+        subprocess.run(
+            ["git", *args], check=True, env=env, timeout=timeout,
+            cwd=str(cwd) if cwd is not None else None,
+        )
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        _logger.warning("git %s failed: %s", " ".join(args), exc)
+        return False
+
+
+def _refresh_existing(repo: Path) -> bool:
+    """Fast-forward an existing cached clone to ``origin/HEAD``.
+
+    Uses a shallow fetch + hard reset so cosmetic diffs from prior runs
+    can't poison the next evaluation. If the fetch fails (network outage,
+    upstream gone), the cached working copy is left as-is and the eval
+    runs against stale code. That's strictly better than failing outright,
+    and the user can always wipe the cache to retry from scratch.
+    """
+    if not _git(["fetch", "--depth", "1", "origin", "HEAD"], cwd=repo):
+        return False
+    return _git(["reset", "--hard", "FETCH_HEAD"], cwd=repo)
+
+
+def ensure_clone(url: str) -> Path | None:
+    """Return a cached working copy of *url*, cloning or refreshing as needed.
+
+    First call shallow-clones into ``<cache>/<url_hash>/repo``. Subsequent
+    calls fetch + reset that same directory. Returns ``None`` if the
+    initial clone fails so the caller can fall back to the old mkdtemp
+    path; established cache entries are returned even if refresh fails.
+    """
+    repo = repo_path_for_url(url)
+    repo.parent.mkdir(parents=True, exist_ok=True)
+
+    if (repo / ".git").exists():
+        # Refresh failures don't invalidate the cache: stale code is
+        # better than a hard failure when the network is flaky.
+        _refresh_existing(repo)
+        return repo
+
+    # First-time clone — shallow, single-branch, default ref.
+    if not _git(["clone", "--depth", "1", "--", url, str(repo)]):
+        # Clean up a half-clone so the next ensure_clone retries cleanly.
+        shutil.rmtree(repo, ignore_errors=True)
+        return None
+    return repo
+
+
+def wipe_cache() -> int:
+    """Remove every cached clone. Returns the number of entries wiped.
+
+    The cache root itself is preserved (just emptied) so the next call
+    to ``cache_root()`` doesn't have to recreate it.
+    """
+    root = cache_root()
+    count = 0
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        shutil.rmtree(entry, ignore_errors=True)
+        count += 1
+    return count

--- a/src/quodeq/data/fs/repo_clone.py
+++ b/src/quodeq/data/fs/repo_clone.py
@@ -1,4 +1,11 @@
-"""Repository cloning and cleanup — manages temporary clone directories."""
+"""Repository cloning and cleanup — manages clone directories.
+
+Online repos are cached under ``~/.quodeq/cache/online/<url_hash>/repo``
+via :mod:`quodeq.context.online_cache`, so subsequent evaluations against
+the same URL reuse the working copy (fetch + reset) instead of re-cloning
+into a fresh temp dir. Set ``QUODEQ_DISABLE_ONLINE_CACHE=1`` to fall back
+to the legacy mkdtemp flow (one fresh clone per evaluation).
+"""
 
 from __future__ import annotations
 
@@ -9,6 +16,11 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from quodeq.context.online_cache import (
+    cache_disabled,
+    ensure_clone,
+    is_inside_cache,
+)
 from quodeq.data.fs.repo_validation import (
     _PRIVATE_HOST_RE,
     _REPO_URL_RE,
@@ -28,22 +40,25 @@ def _get_clone_timeout(env: dict[str, str] | None = None) -> int:
         return _DEFAULT_CLONE_TIMEOUT_S
 
 
-def prepare_repository(repo_input: str) -> str:
-    """Clone a remote repository to a temporary directory and return its path.
-
-    Raises ValueError if the URL does not match the expected git repository format.
-    """
+def _validate_remote_url(repo_input: str) -> None:
+    """Reject malformed / private / DNS-rebinding URLs."""
     if not _REPO_URL_RE.match(repo_input):
         raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
     if _PRIVATE_HOST_RE.match(repo_input):
         raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
-    # Post-resolution check: guard against DNS rebinding where a public hostname
-    # resolves to a private IP at clone time.
     if repo_input.startswith("http"):
         import urllib.parse
         hostname = urllib.parse.urlparse(repo_input).hostname or ""
         if hostname and _resolves_to_private(hostname):
             raise ValueError("Repository URL resolves to a private/internal address")
+
+
+def _legacy_tempdir_clone(repo_input: str) -> str:
+    """Fall-back path: fresh ``mkdtemp`` + ``git clone`` every call.
+
+    Used when the online cache is disabled or when the cache helper
+    couldn't produce a working copy (e.g. the cache directory is read-only).
+    """
     repo_name = repo_input.split("/")[-1].replace(".git", "")
     tmp_dir = tempfile.mkdtemp()
     dest = Path(tmp_dir) / repo_name
@@ -60,12 +75,37 @@ def prepare_repository(repo_input: str) -> str:
     return str(dest.resolve())
 
 
+def prepare_repository(repo_input: str) -> str:
+    """Return a local working copy of *repo_input*, cloning if necessary.
+
+    Routes through :func:`quodeq.context.online_cache.ensure_clone` so the
+    second-and-onward evaluations of the same URL reuse a shallow cached
+    clone (fetched + reset to ``origin/HEAD``). The legacy mkdtemp clone
+    path is kept as a fallback and behind ``QUODEQ_DISABLE_ONLINE_CACHE``.
+
+    Raises ValueError if the URL does not match the expected git
+    repository format.
+    """
+    _validate_remote_url(repo_input)
+    if cache_disabled():
+        return _legacy_tempdir_clone(repo_input)
+    cached = ensure_clone(repo_input)
+    if cached is not None:
+        return str(cached.resolve())
+    # Cache-miss + clone failure: try the old path so a corrupt cache
+    # entry doesn't take an entire evaluation offline.
+    return _legacy_tempdir_clone(repo_input)
+
+
 def cleanup_cloned_repo(repo_path: str) -> None:
     """Remove the temporary clone directory for *repo_path*.
 
-    Call this after the evaluation completes to free disk space promptly
-    instead of accumulating temp directories until process exit.
+    No-op when *repo_path* lives inside the persistent online cache:
+    that dir survives between evaluations on purpose. Only the legacy
+    mkdtemp clones get torn down here.
     """
+    if is_inside_cache(repo_path):
+        return
     parent = str(Path(repo_path).resolve().parent)
     try:
         shutil.rmtree(parent, ignore_errors=True)

--- a/tests/context/test_online_cache.py
+++ b/tests/context/test_online_cache.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.context import online_cache
+
+
+@pytest.fixture(autouse=True)
+def isolate_cache(tmp_path, monkeypatch):
+    """Point QUODEQ_CACHE_ROOT at a tmpdir for every test in this module."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    monkeypatch.delenv("QUODEQ_DISABLE_ONLINE_CACHE", raising=False)
+    yield
+
+
+def test_cache_root_creates_online_subdir(tmp_path):
+    root = online_cache.cache_root()
+    assert root.exists()
+    assert root.name == "online"
+    assert root.parent == tmp_path / "cache"
+
+
+def test_cache_dir_for_url_is_deterministic():
+    a = online_cache.cache_dir_for_url("https://github.com/quodeq/quodeq")
+    b = online_cache.cache_dir_for_url("https://github.com/quodeq/quodeq")
+    assert a == b
+
+
+def test_cache_dir_for_url_separates_distinct_urls():
+    a = online_cache.cache_dir_for_url("https://github.com/owner/a")
+    b = online_cache.cache_dir_for_url("https://github.com/owner/b")
+    assert a != b
+
+
+def test_cache_dir_normalizes_whitespace_around_url():
+    a = online_cache.cache_dir_for_url("https://github.com/x/y")
+    b = online_cache.cache_dir_for_url("  https://github.com/x/y  ")
+    assert a == b
+
+
+def test_repo_path_for_url_is_under_cache_dir():
+    repo = online_cache.repo_path_for_url("https://github.com/x/y")
+    assert repo.name == "repo"
+    assert repo.parent == online_cache.cache_dir_for_url("https://github.com/x/y")
+
+
+def test_is_inside_cache_recognizes_cache_paths():
+    cached = online_cache.repo_path_for_url("https://github.com/x/y")
+    cached.mkdir(parents=True)
+    assert online_cache.is_inside_cache(cached) is True
+
+
+def test_is_inside_cache_rejects_external_paths(tmp_path):
+    external = tmp_path / "elsewhere"
+    external.mkdir()
+    assert online_cache.is_inside_cache(external) is False
+
+
+def test_cache_disabled_reads_env(monkeypatch):
+    monkeypatch.setenv("QUODEQ_DISABLE_ONLINE_CACHE", "1")
+    assert online_cache.cache_disabled() is True
+    monkeypatch.setenv("QUODEQ_DISABLE_ONLINE_CACHE", "")
+    assert online_cache.cache_disabled() is False
+
+
+def test_ensure_clone_first_time_calls_git_clone():
+    url = "https://github.com/x/y"
+
+    def fake_git(args, *, cwd=None, timeout=300):
+        if args and args[0] == "clone":
+            # Simulate a successful clone by creating the .git marker.
+            dest = Path(args[-1])
+            (dest / ".git").mkdir(parents=True)
+            return True
+        return True
+
+    with patch.object(online_cache, "_git", side_effect=fake_git) as mock_git:
+        repo = online_cache.ensure_clone(url)
+    assert repo is not None
+    assert (repo / ".git").exists()
+    # First call: clone. No fetch / reset on a fresh clone.
+    clone_calls = [c for c in mock_git.call_args_list if c.args[0][0] == "clone"]
+    assert len(clone_calls) == 1
+
+
+def test_ensure_clone_existing_calls_fetch_and_reset(tmp_path):
+    url = "https://github.com/x/y"
+    repo = online_cache.repo_path_for_url(url)
+    (repo / ".git").mkdir(parents=True)
+
+    with patch.object(online_cache, "_git", return_value=True) as mock_git:
+        result = online_cache.ensure_clone(url)
+    assert result == repo
+    arg_lists = [c.args[0] for c in mock_git.call_args_list]
+    assert ["fetch", "--depth", "1", "origin", "HEAD"] in arg_lists
+    assert ["reset", "--hard", "FETCH_HEAD"] in arg_lists
+    # No clone — already present.
+    assert not any(args[0] == "clone" for args in arg_lists)
+
+
+def test_ensure_clone_returns_none_when_initial_clone_fails():
+    url = "https://github.com/missing/repo"
+    with patch.object(online_cache, "_git", return_value=False):
+        assert online_cache.ensure_clone(url) is None
+    # Ensure no half-clone left behind.
+    assert not online_cache.repo_path_for_url(url).exists()
+
+
+def test_ensure_clone_returns_existing_path_even_if_refresh_fails(tmp_path):
+    """A flaky network shouldn't take out evals against an already-cached repo."""
+    url = "https://github.com/x/y"
+    repo = online_cache.repo_path_for_url(url)
+    (repo / ".git").mkdir(parents=True)
+    with patch.object(online_cache, "_git", return_value=False):
+        assert online_cache.ensure_clone(url) == repo
+
+
+def test_wipe_cache_removes_all_entries():
+    online_cache.repo_path_for_url("https://x/a").mkdir(parents=True)
+    online_cache.repo_path_for_url("https://x/b").mkdir(parents=True)
+    assert len(list(online_cache.cache_root().iterdir())) == 2
+    wiped = online_cache.wipe_cache()
+    assert wiped == 2
+    assert list(online_cache.cache_root().iterdir()) == []
+    # Cache root itself still exists.
+    assert online_cache.cache_root().exists()

--- a/tests/data/test_evaluate_repo_handler.py
+++ b/tests/data/test_evaluate_repo_handler.py
@@ -15,11 +15,31 @@ def test_is_repo_url():
     assert not is_repo_url("/local/path/to/repo")
 
 
-def test_prepare_repository_url_creates_tmp(monkeypatch, tmp_path: Path):
-    called = {}
+def test_prepare_repository_url_uses_cache(monkeypatch, tmp_path: Path):
+    """A URL routes through the persistent online cache."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    monkeypatch.delenv("QUODEQ_DISABLE_ONLINE_CACHE", raising=False)
 
     def fake_run(cmd, check, **kwargs):
-        called["cmd"] = cmd
+        dest = Path(cmd[-1])
+        (dest / ".git").mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    url = "https://example.com/my-repo.git"
+    dest = prepare_repository(url)
+
+    # Cache layout: <cache>/<url_hash>/repo
+    assert Path(dest).name == "repo"
+    assert Path(dest).exists()
+    assert Path(dest).is_relative_to(tmp_path / "cache")
+
+
+def test_prepare_repository_legacy_tempdir_when_cache_disabled(monkeypatch):
+    """`QUODEQ_DISABLE_ONLINE_CACHE=1` keeps the old mkdtemp behavior."""
+    monkeypatch.setenv("QUODEQ_DISABLE_ONLINE_CACHE", "1")
+
+    def fake_run(cmd, check, **kwargs):
         dest = Path(cmd[-1])
         dest.mkdir(parents=True, exist_ok=True)
 
@@ -27,12 +47,35 @@ def test_prepare_repository_url_creates_tmp(monkeypatch, tmp_path: Path):
 
     url = "https://example.com/my-repo.git"
     dest = prepare_repository(url)
-
     assert Path(dest).name == "my-repo"
+
+
+def test_prepare_repository_falls_back_when_cache_clone_fails(monkeypatch, tmp_path):
+    """Cache miss + clone fail -> retry via legacy path so a broken cache
+    doesn't take down evals."""
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    monkeypatch.delenv("QUODEQ_DISABLE_ONLINE_CACHE", raising=False)
+
+    call_count = {"n": 0}
+
+    def fake_run(cmd, check, **kwargs):
+        call_count["n"] += 1
+        # First (cache) clone fails, second (legacy) clone succeeds.
+        if call_count["n"] == 1:
+            raise subprocess.CalledProcessError(128, cmd)
+        dest = Path(cmd[-1])
+        dest.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    dest = prepare_repository("https://example.com/repo.git")
     assert Path(dest).exists()
+    assert call_count["n"] == 2
 
 
-def test_prepare_repository_clone_failure(monkeypatch):
+def test_prepare_repository_clone_failure_raises_when_cache_disabled(monkeypatch):
+    monkeypatch.setenv("QUODEQ_DISABLE_ONLINE_CACHE", "1")
+
     def fake_run(cmd, check, **kwargs):
         raise subprocess.CalledProcessError(128, cmd)
 
@@ -40,3 +83,28 @@ def test_prepare_repository_clone_failure(monkeypatch):
 
     with pytest.raises(subprocess.CalledProcessError):
         prepare_repository("https://example.com/bad-repo.git")
+
+
+def test_cleanup_preserves_cached_clones(monkeypatch, tmp_path):
+    """The persistent cache must survive eval-end cleanup."""
+    from quodeq.shared.repo_handler import cleanup_cloned_repo
+    from quodeq.context.online_cache import repo_path_for_url
+
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "cache"))
+    cached = repo_path_for_url("https://example.com/x.git")
+    cached.mkdir(parents=True)
+
+    cleanup_cloned_repo(str(cached))
+
+    assert cached.exists(), "cleanup_cloned_repo wiped the persistent cache"
+
+
+def test_cleanup_still_removes_legacy_tempdir(monkeypatch, tmp_path):
+    from quodeq.shared.repo_handler import cleanup_cloned_repo
+
+    legacy = tmp_path / "scratch" / "my-repo"
+    legacy.mkdir(parents=True)
+
+    cleanup_cloned_repo(str(legacy))
+
+    assert not legacy.parent.exists()


### PR DESCRIPTION
## Summary

Slice 5 of the context-enricher plan. Today every evaluation of an online URL re-clones the repo into a fresh \`mkdtemp\` and deletes it on exit -- you pay the full clone cost on every re-evaluation. After this slice, online repos live in a deterministic cache under \`~/.quodeq/cache/online/<url_hash>/repo\` and subsequent evals just \`fetch --depth 1 + reset --hard FETCH_HEAD\`.

This also lets dismissals (from slice 4) actually pay off for online projects: same project_uuid, same precedent corpus, same fingerprints.

### What lands

- New \`quodeq.context.online_cache\` module:
  - \`cache_root()\` -- creates \`~/.quodeq/cache/online/\`, override via \`QUODEQ_CACHE_ROOT\` for tests.
  - \`cache_dir_for_url(url)\` / \`repo_path_for_url(url)\` -- deterministic paths keyed by sha256(url).
  - \`ensure_clone(url)\` -- shallow clone on first call, fetch + reset on subsequent calls.
  - \`wipe_cache()\` -- nuke every cached repo (used by a future settings button).
  - \`is_inside_cache(path)\` -- the cleanup hook checks this before \`rmtree\`.
- \`prepare_repository\` routes URLs through \`ensure_clone\`. Legacy \`mkdtemp\` flow stays as a fallback for the kill-switch (\`QUODEQ_DISABLE_ONLINE_CACHE=1\`) and as a recovery path when the cache itself fails (corrupt entry, read-only disk).
- \`cleanup_cloned_repo\` no-ops on cache paths so eval-end teardown can't nuke a cache that should outlive the evaluation.

### Out of scope (follow-ups)

- UI \"Clear project caches\" button on the Settings page.
- Lazy-add flow: \"Add project\" with a URL records the URL only; clone happens on first evaluation. Unblocks the plan's \"online projects converge on one code path\" goal but requires the URL-only project-add path which is a separate UI surgery.
- Branch-aware cache keys (today's key is hash(url), so switching branches in the same repo reuses one working copy).

## Test plan

- [x] \`tests/context/test_online_cache.py\` -- 13 cases: deterministic paths, URL normalization, isolation, kill switch, ensure_clone first-vs-existing, refresh-failure tolerance, wipe_cache.
- [x] \`tests/data/test_evaluate_repo_handler.py\` -- prepare_repository routes URLs into the cache, kill switch keeps mkdtemp behavior, cache-clone-fail falls back to legacy, cleanup preserves cache + still removes legacy tempdirs.
- [x] Full Python suite green (2561 passed). Mypy clean on \`quodeq.context\`.
- [x] Manual: add an online project, run two evals, verify the second scan starts faster (no \"Cloning...\" delay) and that \`~/.quodeq/cache/online/\` contains the working copy.

## Risk

Disk-usage growth: each cached online project is tens of MB. Settings button to clear is a follow-up; meanwhile the kill switch + manual \`rm -rf ~/.quodeq/cache/online/\` are the user-accessible escape hatches.