### PR TITLE
feat(violations): add Delete and Delete all to dismissed sub-tab

### DIFF
--- a/src/quodeq/ui/src/features/violations/components/DismissedSubTab.jsx
+++ b/src/quodeq/ui/src/features/violations/components/DismissedSubTab.jsx
@@ -4,7 +4,7 @@ function dismissedLabel(d) {
   return d.principle || d.dimension || (d.req ?? '?');
 }
 
-function DismissedCard({ d, onRestore }) {
+function DismissedCard({ d, onRestore, onDelete }) {
   return (
     <div className="dismissed-card">
       <div className="dismissed-card-top">
@@ -13,6 +13,7 @@ function DismissedCard({ d, onRestore }) {
         <span className="dismissed-label">[{dismissedLabel(d)}]</span>
         <span className="dismissed-file">{d.file}:{d.line}</span>
         <button type="button" className="restore-btn" onClick={() => onRestore(d)}>Restore</button>
+        <button type="button" className="delete-btn" onClick={() => onDelete(d)}>Delete</button>
       </div>
       {(d.reason || d.title) && (
         <div className="dismissed-detail">
@@ -47,7 +48,7 @@ function DismissedCard({ d, onRestore }) {
   );
 }
 
-export default function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) {
+export default function DismissedSubTab({ dismissed, onRestore, onRestoreAll, onDelete, onDeleteAll }) {
   if (dismissed.length === 0) {
     return <p className="empty-state">No dismissed findings.</p>;
   }
@@ -57,14 +58,24 @@ export default function DismissedSubTab({ dismissed, onRestore, onRestoreAll }) 
         <h3 className="section-title">Dismissed Findings</h3>
         <span className="section-count">{dismissed.length} findings · not included in scoring</span>
         {dismissed.length > 1 && (
-          <button type="button" className="restore-btn" style={{ marginLeft: 'auto' }} onClick={onRestoreAll}>
-            Restore all
-          </button>
+          <>
+            <button type="button" className="restore-btn" style={{ marginLeft: 'auto' }} onClick={onRestoreAll}>
+              Restore all
+            </button>
+            <button type="button" className="delete-btn" onClick={onDeleteAll}>
+              Delete all
+            </button>
+          </>
         )}
       </div>
       <div className="dismissed-list-inner">
         {dismissed.map((d) => (
-          <DismissedCard key={`${d.req}-${d.file}-${d.line}`} d={d} onRestore={onRestore} />
+          <DismissedCard
+            key={`${d.req}-${d.file}-${d.line}`}
+            d={d}
+            onRestore={onRestore}
+            onDelete={onDelete}
+          />
         ))}
       </div>
     </>

--- a/src/quodeq/ui/src/features/violations/components/DismissedSubTab.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/DismissedSubTab.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DismissedSubTab from './DismissedSubTab.jsx';
+
+const sampleA = { req: 'A1', file: 'a.py', line: 10, severity: 'minor', principle: 'P1' };
+const sampleB = { req: 'B1', file: 'b.py', line: 20, severity: 'major', principle: 'P2' };
+
+function setup(items, overrides = {}) {
+  const handlers = {
+    onRestore: vi.fn(),
+    onRestoreAll: vi.fn(),
+    onDelete: vi.fn(),
+    onDeleteAll: vi.fn(),
+    ...overrides,
+  };
+  render(<DismissedSubTab dismissed={items} {...handlers} />);
+  return handlers;
+}
+
+describe('DismissedSubTab', () => {
+  it('renders Restore and Delete buttons on each card', () => {
+    setup([sampleA, sampleB]);
+    expect(screen.getAllByRole('button', { name: 'Restore' })).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(2);
+  });
+
+  it('renders Restore all and Delete all in the header when there are 2+ findings', () => {
+    setup([sampleA, sampleB]);
+    expect(screen.getByRole('button', { name: 'Restore all' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete all' })).toBeInTheDocument();
+  });
+
+  it('does not render Restore all / Delete all when there is exactly one finding', () => {
+    setup([sampleA]);
+    expect(screen.queryByRole('button', { name: 'Restore all' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Delete all' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('clicking Delete on a card invokes onDelete with the finding', () => {
+    const handlers = setup([sampleA, sampleB]);
+    const deleteButtons = screen.getAllByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButtons[0]);
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+    expect(handlers.onDelete).toHaveBeenCalledWith(sampleA);
+  });
+
+  it('clicking Delete all invokes onDeleteAll once', () => {
+    const handlers = setup([sampleA, sampleB]);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete all' }));
+    expect(handlers.onDeleteAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the empty state when there are no findings', () => {
+    render(
+      <DismissedSubTab
+        dismissed={[]}
+        onRestore={vi.fn()}
+        onRestoreAll={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No dismissed findings/i)).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -106,7 +106,7 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
   };
 
   const [restoreError, setRestoreError] = useState(null);
-  const { dismissed, handleRestore, handleRestoreAll } = useDismissedFindings(selectedProject, onRefresh, setRestoreError);
+  const { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll } = useDismissedFindings(selectedProject, onRefresh, setRestoreError);
 
   const visibleDimensions = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
@@ -127,7 +127,8 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
 
   return {
     activeSubTab, setActiveSubTab, dismissed,
-    handleRestore, handleRestoreAll, restoreError, visibleDimensions,
+    handleRestore, handleRestoreAll, handleDelete, handleDeleteAll,
+    restoreError, visibleDimensions,
     summary, topFilesCount, uniquePrinciples,
     fileCurrentPath, setFileCurrentPath,
   };
@@ -146,7 +147,11 @@ function SevInline({ severity }) {
 }
 
 function ViolationsSubTabContent(props) {
-  const { activeSubTab, visibleDimensions, dismissed, callbacks, fileCurrentPath, setFileCurrentPath, handleRestore, handleRestoreAll } = props;
+  const {
+    activeSubTab, visibleDimensions, dismissed, callbacks,
+    fileCurrentPath, setFileCurrentPath,
+    handleRestore, handleRestoreAll, handleDelete, handleDeleteAll,
+  } = props;
   if (activeSubTab === 'file') {
     return <FileSubTab dimensions={visibleDimensions} onFileClick={callbacks.onFileClick} currentPath={fileCurrentPath} setCurrentPath={setFileCurrentPath} />;
   }
@@ -155,7 +160,15 @@ function ViolationsSubTabContent(props) {
   }
   if (activeSubTab === 'dismissed') {
     return dismissed.length > 0
-      ? <DismissedSubTab dismissed={dismissed} onRestore={handleRestore} onRestoreAll={handleRestoreAll} />
+      ? (
+        <DismissedSubTab
+          dismissed={dismissed}
+          onRestore={handleRestore}
+          onRestoreAll={handleRestoreAll}
+          onDelete={handleDelete}
+          onDeleteAll={handleDeleteAll}
+        />
+      )
       : <p className="empty-state">No dismissed violations.</p>;
   }
   return null;
@@ -186,7 +199,8 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
 
   const {
     activeSubTab, setActiveSubTab, dismissed,
-    handleRestore, handleRestoreAll, restoreError, visibleDimensions,
+    handleRestore, handleRestoreAll, handleDelete, handleDeleteAll,
+    restoreError, visibleDimensions,
     summary, topFilesCount, uniquePrinciples,
     fileCurrentPath, setFileCurrentPath,
   } = useViolationsData({
@@ -226,6 +240,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
         activeSubTab={activeSubTab} visibleDimensions={visibleDimensions} dismissed={dismissed}
         callbacks={callbacks} fileCurrentPath={fileCurrentPath} setFileCurrentPath={setFileCurrentPath}
         handleRestore={handleRestore} handleRestoreAll={handleRestoreAll}
+        handleDelete={handleDelete} handleDeleteAll={handleDeleteAll}
       />
     </div>
   );

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
 import { readVisibleStandardIds, computeSummaryFromDimensions } from '../../../utils/visibleStandards.js';
 import { readCachedState, writeCachedState, resetCachedScope } from '../../../utils/pageStateCache.js';
 import { buildFileTree, treeNodeToFileObj, HeatGridView } from '../../map/viz/index.js';
 import DimensionHeatGridView from './DimensionHeatGridView.jsx';
 import DismissedSubTab from './DismissedSubTab.jsx';
 import { TermHeader, SevBadge, FlagPill } from '../../../components/terminal/index.js';
+import { useDismissedFindings } from './useDismissedFindings.js';
 
 const MAX_TREE_DEPTH = 64;
 
@@ -91,39 +91,6 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
       <HeatGridView node={currentNode} onDrillDown={setCurrentPath} onFileClick={handleFileClick} onCellClick={handleCellClick} variant="flat" />
     </>
   );
-}
-
-function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
-  const [dismissed, setDismissed] = useState([]);
-
-  useEffect(() => {
-    if (!selectedProject) return;
-    listDismissedFindings(selectedProject).then(setDismissed).catch(() => setDismissed([]));
-  }, [selectedProject]);
-
-  const handleRestore = useCallback(async (d) => {
-    try {
-      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
-      setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
-      onRefresh?.();
-    } catch (err) {
-      console.error('Failed to restore finding:', err);
-      setRestoreError?.('Failed to restore finding. Please try again.');
-    }
-  }, [selectedProject, onRefresh, setRestoreError]);
-
-  const handleRestoreAll = useCallback(async () => {
-    try {
-      await restoreAllFindings(selectedProject);
-      setDismissed([]);
-      onRefresh?.();
-    } catch (err) {
-      console.error('Failed to restore all findings:', err);
-      setRestoreError?.('Failed to restore all findings. Please try again.');
-    }
-  }, [selectedProject, onRefresh, setRestoreError]);
-
-  return { dismissed, handleRestore, handleRestoreAll };
 }
 
 function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, initialSubTab, initialFilePath }) {

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
+import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 export function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
   const [dismissed, setDismissed] = useState([]);
@@ -42,5 +43,25 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
     }
   }, [selectedProject, onRefresh, setRestoreError]);
 
-  return { dismissed, handleRestore, handleRestoreAll, handleDelete };
+  const handleDeleteAll = useCallback(async () => {
+    const count = dismissed.length;
+    const ok = await confirmDialog({
+      title: 'Delete dismissed findings?',
+      message: `Are you sure you want to permanently delete those ${count} findings? This cannot be undone.`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      variant: 'danger',
+    });
+    if (!ok) return;
+    try {
+      await restoreAllFindings(selectedProject);
+      setDismissed([]);
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to delete all findings:', err);
+      setRestoreError?.('Failed to delete all findings. Please try again.');
+    }
+  }, [selectedProject, onRefresh, setRestoreError, dismissed.length]);
+
+  return { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll };
 }

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
+
+export function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
+  const [dismissed, setDismissed] = useState([]);
+
+  useEffect(() => {
+    if (!selectedProject) return;
+    listDismissedFindings(selectedProject).then(setDismissed).catch(() => setDismissed([]));
+  }, [selectedProject]);
+
+  const handleRestore = useCallback(async (d) => {
+    try {
+      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
+      setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to restore finding:', err);
+      setRestoreError?.('Failed to restore finding. Please try again.');
+    }
+  }, [selectedProject, onRefresh, setRestoreError]);
+
+  const handleRestoreAll = useCallback(async () => {
+    try {
+      await restoreAllFindings(selectedProject);
+      setDismissed([]);
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to restore all findings:', err);
+      setRestoreError?.('Failed to restore all findings. Please try again.');
+    }
+  }, [selectedProject, onRefresh, setRestoreError]);
+
+  return { dismissed, handleRestore, handleRestoreAll };
+}

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -31,5 +31,16 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
     }
   }, [selectedProject, onRefresh, setRestoreError]);
 
-  return { dismissed, handleRestore, handleRestoreAll };
+  const handleDelete = useCallback(async (d) => {
+    try {
+      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
+      setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
+      onRefresh?.();
+    } catch (err) {
+      console.error('Failed to delete finding:', err);
+      setRestoreError?.('Failed to delete finding. Please try again.');
+    }
+  }, [selectedProject, onRefresh, setRestoreError]);
+
+  return { dismissed, handleRestore, handleRestoreAll, handleDelete };
 }

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, act, waitFor } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { useDismissedFindings } from './useDismissedFindings.js';
 
@@ -19,12 +18,6 @@ import {
 const sampleA = { req: 'A1', file: 'a.py', line: 10, severity: 'minor' };
 const sampleB = { req: 'B1', file: 'b.py', line: 20, severity: 'major' };
 
-function HookHarness({ project, onRefresh, setRestoreError, onState }) {
-  const state = useDismissedFindings(project, onRefresh, setRestoreError);
-  React.useEffect(() => { onState(state); }, [state, onState]);
-  return null;
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -35,21 +28,13 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreFinding.mockResolvedValueOnce({ ok: true });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    let latest;
-    render(
-      <HookHarness
-        project="proj"
-        onRefresh={onRefresh}
-        setRestoreError={setRestoreError}
-        onState={(s) => { latest = s; }}
-      />,
-    );
-    await waitFor(() => expect(latest.dismissed).toHaveLength(2));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
-    await act(async () => { await latest.handleRestore(sampleA); });
+    await act(async () => { await result.current.handleRestore(sampleA); });
 
     expect(restoreFinding).toHaveBeenCalledWith('proj', { req: 'A1', file: 'a.py', line: 10 });
-    expect(latest.dismissed).toEqual([sampleB]);
+    expect(result.current.dismissed).toEqual([sampleB]);
     expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(setRestoreError).not.toHaveBeenCalled();
   });
@@ -59,21 +44,13 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    let latest;
-    render(
-      <HookHarness
-        project="proj"
-        onRefresh={onRefresh}
-        setRestoreError={setRestoreError}
-        onState={(s) => { latest = s; }}
-      />,
-    );
-    await waitFor(() => expect(latest.dismissed).toHaveLength(1));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
-    await act(async () => { await latest.handleRestore(sampleA); });
+    await act(async () => { await result.current.handleRestore(sampleA); });
 
     expect(setRestoreError).toHaveBeenCalledWith('Failed to restore finding. Please try again.');
-    expect(latest.dismissed).toEqual([sampleA]);
+    expect(result.current.dismissed).toEqual([sampleA]);
     expect(onRefresh).not.toHaveBeenCalled();
   });
 
@@ -82,21 +59,13 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    let latest;
-    render(
-      <HookHarness
-        project="proj"
-        onRefresh={onRefresh}
-        setRestoreError={setRestoreError}
-        onState={(s) => { latest = s; }}
-      />,
-    );
-    await waitFor(() => expect(latest.dismissed).toHaveLength(2));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
-    await act(async () => { await latest.handleRestoreAll(); });
+    await act(async () => { await result.current.handleRestoreAll(); });
 
     expect(restoreAllFindings).toHaveBeenCalledWith('proj');
-    expect(latest.dismissed).toEqual([]);
+    expect(result.current.dismissed).toEqual([]);
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -9,11 +9,17 @@ vi.mock('../../../api/index.js', () => ({
   restoreAllFindings: vi.fn(),
 }));
 
+vi.mock('../../../utils/confirmDialog.js', () => ({
+  confirmDialog: vi.fn(),
+}));
+
 import {
   listDismissedFindings,
   restoreFinding,
   restoreAllFindings,
 } from '../../../api/index.js';
+
+import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 const sampleA = { req: 'A1', file: 'a.py', line: 10, severity: 'minor' };
 const sampleB = { req: 'B1', file: 'b.py', line: 20, severity: 'major' };
@@ -98,6 +104,62 @@ describe('useDismissedFindings — handleDelete', () => {
     await act(async () => { await result.current.handleDelete(sampleA); });
 
     expect(setRestoreError).toHaveBeenCalledWith('Failed to delete finding. Please try again.');
+    expect(result.current.dismissed).toEqual([sampleA]);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDismissedFindings — handleDeleteAll', () => {
+  it('opens the confirmation dialog and clears state when the user confirms', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(true);
+    restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(confirmDialog).toHaveBeenCalledWith(expect.objectContaining({
+      variant: 'danger',
+      title: 'Delete dismissed findings?',
+      confirmLabel: 'Delete',
+      message: expect.stringContaining('permanently delete those 2 findings'),
+    }));
+    expect(restoreAllFindings).toHaveBeenCalledWith('proj');
+    expect(result.current.dismissed).toEqual([]);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the user cancels the confirmation dialog', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    confirmDialog.mockResolvedValueOnce(false);
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(confirmDialog).toHaveBeenCalledTimes(1);
+    expect(restoreAllFindings).not.toHaveBeenCalled();
+    expect(result.current.dismissed).toEqual([sampleA, sampleB]);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('reports a delete-specific error if restoreAllFindings fails after confirmation', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    confirmDialog.mockResolvedValueOnce(true);
+    restoreAllFindings.mockRejectedValueOnce(new Error('boom'));
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(setRestoreError).toHaveBeenCalledWith('Failed to delete all findings. Please try again.');
     expect(result.current.dismissed).toEqual([sampleA]);
     expect(onRefresh).not.toHaveBeenCalled();
   });

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -69,3 +69,36 @@ describe('useDismissedFindings — restore handlers', () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('useDismissedFindings — handleDelete', () => {
+  it('removes the matching entry on success and calls onRefresh (mirrors restore on disk, distinct error message)', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    restoreFinding.mockResolvedValueOnce({ ok: true });
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
+
+    await act(async () => { await result.current.handleDelete(sampleA); });
+
+    expect(restoreFinding).toHaveBeenCalledWith('proj', { req: 'A1', file: 'a.py', line: 10 });
+    expect(result.current.dismissed).toEqual([sampleB]);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(setRestoreError).not.toHaveBeenCalled();
+  });
+
+  it('reports a delete-specific error and leaves state unchanged on failure', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    restoreFinding.mockRejectedValueOnce(new Error('boom'));
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
+
+    await act(async () => { await result.current.handleDelete(sampleA); });
+
+    expect(setRestoreError).toHaveBeenCalledWith('Failed to delete finding. Please try again.');
+    expect(result.current.dismissed).toEqual([sampleA]);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { useDismissedFindings } from './useDismissedFindings.js';
+
+vi.mock('../../../api/index.js', () => ({
+  listDismissedFindings: vi.fn(),
+  restoreFinding: vi.fn(),
+  restoreAllFindings: vi.fn(),
+}));
+
+import {
+  listDismissedFindings,
+  restoreFinding,
+  restoreAllFindings,
+} from '../../../api/index.js';
+
+const sampleA = { req: 'A1', file: 'a.py', line: 10, severity: 'minor' };
+const sampleB = { req: 'B1', file: 'b.py', line: 20, severity: 'major' };
+
+function HookHarness({ project, onRefresh, setRestoreError, onState }) {
+  const state = useDismissedFindings(project, onRefresh, setRestoreError);
+  React.useEffect(() => { onState(state); }, [state, onState]);
+  return null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDismissedFindings — restore handlers', () => {
+  it('handleRestore removes the matching entry on success and calls onRefresh', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    restoreFinding.mockResolvedValueOnce({ ok: true });
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    let latest;
+    render(
+      <HookHarness
+        project="proj"
+        onRefresh={onRefresh}
+        setRestoreError={setRestoreError}
+        onState={(s) => { latest = s; }}
+      />,
+    );
+    await waitFor(() => expect(latest.dismissed).toHaveLength(2));
+
+    await act(async () => { await latest.handleRestore(sampleA); });
+
+    expect(restoreFinding).toHaveBeenCalledWith('proj', { req: 'A1', file: 'a.py', line: 10 });
+    expect(latest.dismissed).toEqual([sampleB]);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(setRestoreError).not.toHaveBeenCalled();
+  });
+
+  it('handleRestore reports an error and leaves state unchanged on failure', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA]);
+    restoreFinding.mockRejectedValueOnce(new Error('boom'));
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    let latest;
+    render(
+      <HookHarness
+        project="proj"
+        onRefresh={onRefresh}
+        setRestoreError={setRestoreError}
+        onState={(s) => { latest = s; }}
+      />,
+    );
+    await waitFor(() => expect(latest.dismissed).toHaveLength(1));
+
+    await act(async () => { await latest.handleRestore(sampleA); });
+
+    expect(setRestoreError).toHaveBeenCalledWith('Failed to restore finding. Please try again.');
+    expect(latest.dismissed).toEqual([sampleA]);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('handleRestoreAll clears state on success and calls onRefresh', async () => {
+    listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
+    restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
+    const onRefresh = vi.fn();
+    const setRestoreError = vi.fn();
+    let latest;
+    render(
+      <HookHarness
+        project="proj"
+        onRefresh={onRefresh}
+        setRestoreError={setRestoreError}
+        onState={(s) => { latest = s; }}
+      />,
+    );
+    await waitFor(() => expect(latest.dismissed).toHaveLength(2));
+
+    await act(async () => { await latest.handleRestoreAll(); });
+
+    expect(restoreAllFindings).toHaveBeenCalledWith('proj');
+    expect(latest.dismissed).toEqual([]);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2728,6 +2728,26 @@
   border-color: var(--color-accent);
   background: rgba(88, 166, 255, 0.08);
 }
+.dismissed-card-top .delete-btn {
+  margin-left: 6px;
+}
+.delete-btn {
+  font-size: 0.7rem;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-danger, #da3633);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 150ms ease;
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+.delete-btn:hover {
+  border-color: var(--color-danger, #da3633);
+  background: rgba(218, 54, 51, 0.08);
+}
 
 /* ─── ScanProgress ─── */
 .scan-progress {


### PR DESCRIPTION
## Summary
- Add per-card **Delete** button and header **Delete all** button to the Violations → Dismissed sub-tab.
- **Delete all** opens a danger-variant `confirmDialog` modal: *"Are you sure you want to permanently delete those N findings? This cannot be undone."*
- Mechanically, both new actions reuse the existing `restoreFinding` / `restoreAllFindings` endpoints — they make the same on-disk mutation as Restore (entry leaves `dismissed.json`, which transitively clears the precedent corpus on the next scan). The buttons differ only in user intent and labeling.
- `useDismissedFindings` extracted from `ViolationsPage.jsx` to its own file so the four mutation handlers can be unit-tested.

## Why
Use case: a wrong / bad LLM run produces junk findings that get dismissed. With PR #363, dismissed entries actively downweight similar findings on the next scan via the precedent corpus — so junk dismissals poison the learning signal. "Restore" implies the violation is real; "Delete" lets the user say "this entry is junk, scrub it from the list (and from the precedent corpus on next scan)."

## Files changed
- `src/quodeq/ui/src/styles/evaluation.css` — `.delete-btn` variant
- `src/quodeq/ui/src/features/violations/components/useDismissedFindings.js` — new hook file with `handleDelete` + `handleDeleteAll`
- `src/quodeq/ui/src/features/violations/components/DismissedSubTab.jsx` — render the two new buttons
- `src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx` — wire handlers
- `src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx` — 8 hook tests
- `src/quodeq/ui/src/features/violations/components/DismissedSubTab.test.jsx` — 6 component tests

## Test plan
- [x] `npm run test:ui` — 194/194 passing (including 14 new tests).
- [x] Manual: at the dismissed sub-tab, Restore / Delete / Restore all / Delete all behave as expected (single click for per-card; modal confirmation for Delete all; cancel is a no-op).
- [x] Manual: error banner appears with delete-specific copy when the API is unreachable.