### PR TITLE
fix(ui): auto-resume CLI-started external runs on Evaluate tab mount

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -15,11 +15,13 @@
  *   - startMutation: api.startEvaluation -> seeds status cache on success.
  *   - cancelMutation: api.cancelEvaluation -> invalidates the run subtree.
  *
- * Out of scope (vs. legacy hook):
- *   - Auto-resume of CLI-started external runs via listEvaluations on mount.
- *     Restore in a follow-up if required by user reports.
+ * Mount-time auto-resume:
+ *   - On mount, calls api.listEvaluations({ states: ["running"] }) and adopts
+ *     the most recent running job. Lets a `quodeq evaluate` started in the
+ *     terminal surface in the dashboard so users can close and reopen the UI
+ *     without losing visibility into an in-progress scan.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { confirmDialog } from "../../../utils/confirmDialog.js";
@@ -76,6 +78,31 @@ export function useEvaluation() {
   // SSE side-effect — writes status/dimensions/findings into cache.
   // No-op when VITE_USE_SSE_EVENTS is off; refetchInterval below covers.
   useRunEventStream(jobId);
+
+  // Adopt any in-progress CLI-started external run on mount so it surfaces
+  // on the Evaluate tab. setJobId guard prevents a late-resolving resume
+  // from clobbering a job the user started in the meantime.
+  useEffect(() => {
+    let cancelled = false;
+    api.listEvaluations({ states: ["running"], limit: 1 })
+      .then((jobs) => {
+        if (cancelled) return;
+        const running = jobs?.[0];
+        if (!running) return;
+        setJobId((current) => {
+          if (current) return current;
+          queryClient.setQueryData(evaluationKeys.status(running.jobId), running);
+          return running.jobId;
+        });
+      })
+      .catch((err) => {
+        console.warn("Failed to fetch running evaluations:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only resume
+  }, []);
 
   // --- Status (the "job" object) ---------------------------------------
   const statusQuery = useQuery({

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -110,4 +110,53 @@ describe("useEvaluation", () => {
     ).rejects.toThrow(/provider/i);
     await waitFor(() => expect(result.current.jobError).toMatch(/provider/i));
   });
+
+  it("adopts a running CLI-started external run on mount", async () => {
+    const running = {
+      jobId: "ext-abc",
+      status: "running",
+      source: "external",
+      dimensions: ["security"],
+    };
+    fakeApi.listEvaluations.mockResolvedValue([running]);
+    fakeApi.getEvaluation.mockResolvedValue(running);
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.job?.jobId).toBe("ext-abc");
+    });
+    expect(fakeApi.listEvaluations).toHaveBeenCalledWith(
+      expect.objectContaining({ states: ["running"] }),
+    );
+  });
+
+  it("does not overwrite a user-started job when the resume resolves later", async () => {
+    let resolveList;
+    fakeApi.listEvaluations.mockReturnValue(
+      new Promise((r) => {
+        resolveList = r;
+      }),
+    );
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j-fresh",
+      status: "pending",
+      dimensions: [],
+    });
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    expect(result.current.job?.jobId).toBe("j-fresh");
+    await act(async () => {
+      resolveList([{ jobId: "ext-old", status: "running", source: "external" }]);
+    });
+    expect(result.current.job?.jobId).toBe("j-fresh");
+  });
+
+  it("ignores listEvaluations failure on mount", async () => {
+    fakeApi.listEvaluations.mockRejectedValue(new Error("network"));
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(fakeApi.listEvaluations).toHaveBeenCalled());
+    expect(result.current.job).toBeNull();
+    expect(result.current.jobError).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- The TanStack Query rewrite of `useEvaluation` ([#335](https://github.com/quodeq/quodeq/pull/335)) dropped the legacy on-mount `listEvaluations()` call, so a `quodeq evaluate` started in a terminal no longer surfaced in the dashboard's Evaluate tab. The whole point of the External badge flow ([#257](https://github.com/quodeq/quodeq/pull/257)) is that you can close and reopen the dashboard while a scan keeps running.
- Restore the behaviour with a mount-only `useEffect` that calls `api.listEvaluations({ states: ["running"], limit: 1 })`, seeds the status cache, and adopts the job id. Guarded so a user-initiated start during the in-flight resume is not clobbered.
- Drops the "Out of scope: auto-resume" line from the hook's docstring.

## Test plan
- [x] `npx vitest run src/features/evaluation/hooks/useEvaluation.test.jsx` — 9/9 pass (3 new: adopts running ext- run on mount, does not overwrite a user-started job, ignores listEvaluations failure)
- [x] Full UI suite — 194/194 pass
- [x] Dev preview reload — `GET /api/evaluations?limit=1&state=running` fires on Evaluate-tab mount; clean React tree (no error boundary, no hook-order issues post-reload)
- [x] Manual end-to-end: with the backend up, run `quodeq evaluate <repo>` in a terminal, then open the dashboard and confirm the Evaluate tab shows the External badge with live progress