### PR TITLE
fix(api): keep eval-log SSE alive during job's preparing phase

### DIFF
--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -49,6 +49,43 @@ def _resolve_run_log(job_id: str) -> tuple[Path | None, int]:
     return log_path, 0
 
 
+def _is_preparing_job(provider, job_id: str) -> bool:
+    """Return True if *job_id* refers to a job that may still produce output.
+
+    Used by the SSE log-stream route to keep the EventSource alive while a
+    runner is in the "preparing" phase — resolving inputs, cloning a remote
+    repo, creating the run directory — but hasn't yet emitted the
+    ``report_path`` marker that lets the dashboard locate ``run.log``.
+
+    Returns False for unknown ids so a typo or a stale jobId from the
+    client doesn't keep a connection (and a polling Python thread) open
+    forever.
+    """
+    if provider is None:
+        return False
+    # Internal job: must be in the in-memory store with a non-terminal
+    # status. Pre-marker, ``output_project`` is None so ``get_log_run_dir``
+    # returns None — without this check the route would 404 the moment the
+    # frontend opens the stream after Start.
+    jobs = getattr(provider, "_jobs", None)
+    store = getattr(jobs, "_store", None) if jobs is not None else None
+    if store is not None:
+        job = store.get(job_id)
+        if job is not None and getattr(job, "status", None) not in {
+            "done", "failed", "cancelled",
+        }:
+            return True
+    # External job: the CLI creates the run directory before opening the
+    # ``run.log`` writer, so there is a brief window where the directory
+    # exists but the file does not. If the provider can resolve a real
+    # run_dir, treat the run as live.
+    if hasattr(provider, "get_log_run_dir"):
+        run_dir = provider.get_log_run_dir(job_id)
+        if run_dir is not None and run_dir.is_dir():
+            return True
+    return False
+
+
 def _read_tail(log_path: Path, since: int) -> tuple[list[str], int]:
     """Read lines starting at byte offset *since*. Returns (lines, next_offset).
 
@@ -91,22 +128,39 @@ def register_log_stream_routes(app: Flask) -> None:
 
     @app.get("/api/jobs/<job_id>/logs/stream")
     def stream_logs(job_id: str) -> Response | tuple[Response, int]:
+        provider = current_app.config.get("_provider")
         log_path, err = _resolve_run_log(job_id)
-        if log_path is None:
+        # If run.log isn't on disk yet but the job is still preparing
+        # (no report_path marker yet, or the runner just hasn't created
+        # the file), keep the SSE response open and let the generator
+        # wait for the file to appear. Only refuse for jobs we cannot
+        # recognise as live — otherwise the dashboard pane would show
+        # "stream disconnected" until the user reopens the console.
+        if log_path is None and not _is_preparing_job(provider, job_id):
             return jsonify({"error": "log unavailable", "code": "NOT_FOUND"}), err
         last_event_id = request.headers.get("Last-Event-ID", "")
         try:
             initial_offset = int(last_event_id) if last_event_id else 0
         except ValueError:
             initial_offset = 0
-        provider = current_app.config.get("_provider")
         is_done = (
             lambda: bool(
                 provider
                 and getattr(provider, "is_job_complete", lambda _: False)(job_id)
             )
         )
-        run_dir = log_path.parent
+
+        def resolve_log_path() -> Path | None:
+            # Re-resolved each tick. A job that started in the
+            # "preparing" state (no output_project yet) eventually emits
+            # the report_path marker; from then on get_log_run_dir
+            # returns the real run dir and run.log appears.
+            if not hasattr(provider, "get_log_run_dir"):
+                return None
+            run_dir = provider.get_log_run_dir(job_id)
+            if run_dir is None or not run_dir.is_dir():
+                return None
+            return run_dir / "run.log"
 
         def terminal_state() -> str:
             # In-memory job (internal runs) carries the most up-to-date status
@@ -118,7 +172,10 @@ def register_log_stream_routes(app: Flask) -> None:
                     if job is not None and job.status in {"done", "failed", "cancelled"}:
                         return job.status
             # Fall back to the on-disk status.json the runner writes on exit.
-            status_path = run_dir / "status.json"
+            path = resolve_log_path()
+            if path is None:
+                return "completed"
+            status_path = path.parent / "status.json"
             if status_path.exists():
                 try:
                     import json
@@ -132,7 +189,7 @@ def register_log_stream_routes(app: Flask) -> None:
 
         resp = Response(
             _sse_tail_generator(
-                log_path,
+                resolve_log_path,
                 initial_offset,
                 is_done=is_done,
                 line_filter=_is_visible_log_line,

--- a/src/quodeq/api/_sse_log_helpers.py
+++ b/src/quodeq/api/_sse_log_helpers.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+from typing import Callable
 
 _POLL_MS = int(os.environ.get("QUODEQ_LOG_STREAM_POLL_MS", "100"))
 _MAX_WAIT_S = int(os.environ.get("QUODEQ_LOG_STREAM_MAX_WAIT_S", "10"))
+# Cadence for SSE comments emitted while waiting on a not-yet-existing log
+# file. Keeps the EventSource from being torn down by intermediaries even
+# when the runner spends a long time in the "preparing" phase.
+_KEEPALIVE_MS = 2000
 
 # Per-tick byte cap on the SSE tail read. Caps a runaway log file from blowing
 # out RAM in a single read; remaining bytes are served on the next tick.
@@ -35,7 +40,7 @@ def sse_line(data: str, event: str | None = None, event_id: int | None = None) -
 
 
 def sse_tail_generator(
-    log_path: Path,
+    log_path: Path | Callable[[], Path | None],
     initial_offset: int,
     is_done=None,
     line_filter=None,
@@ -43,8 +48,16 @@ def sse_tail_generator(
 ):
     """Yield SSE frames by tailing *log_path*.
 
+    log_path: either a ``Path`` or a zero-arg callable returning ``Path | None``.
+             The callable form lets callers resolve the path lazily — useful
+             when a job is still in the "preparing" phase and the run
+             directory hasn't been created yet. The generator polls until the
+             callable returns an existing file, emitting SSE comments to keep
+             the EventSource alive in the meantime.
     is_done: optional callable returning True when streaming should terminate
-             with an ``event: done`` frame. None means tail forever.
+             with an ``event: done`` frame. None means tail forever (subject
+             to the legacy 10s ``_MAX_WAIT_S`` timeout when the file never
+             materializes).
     line_filter: optional callable(str) -> bool. Lines for which it returns
              False are not emitted (kept in the file but hidden from clients).
     terminal_state: optional callable returning a string describing why the
@@ -53,18 +66,58 @@ def sse_tail_generator(
              as ``data:`` so the client can show the right title without
              relying on a separate dashboard poll.
     """
+    def _resolve() -> Path | None:
+        return log_path() if callable(log_path) else log_path
+
+    def _emit_done() -> str:
+        state = ""
+        if terminal_state is not None:
+            try:
+                state = terminal_state() or ""
+            except Exception:  # noqa: BLE001 — never block the done frame on a bad reader
+                state = ""
+        parts: list[str] = []
+        if offset:
+            parts.append(f"id: {offset}\n")
+        parts.append("event: done\n")
+        parts.append(f"data: {state}\n\n")
+        return "".join(parts)
+
     offset = initial_offset
     waited_ms = 0
+    keepalive_ms = 0
     yield ":keepalive\n\n"
     while True:
-        if not log_path.exists():
-            if waited_ms >= _MAX_WAIT_S * 1000:
-                yield sse_line("log file unavailable", event="error")
-                return
+        path = _resolve()
+        if path is None or not path.exists():
+            # Two regimes when the file is missing:
+            #   - is_done provided (job-log stream): wait as long as the
+            #     job is still active. The runner's "preparing" phase
+            #     (resolving inputs, cloning a remote repo) routinely
+            #     takes longer than the legacy 10s timeout, and a 404
+            #     during that window shows up in the dashboard as a
+            #     dead "stream disconnected" pane until the user
+            #     reopens it.
+            #   - is_done absent (legacy callers, e.g. ollama log
+            #     stream): preserve the original "give up after
+            #     _MAX_WAIT_S" behaviour so a missing file doesn't
+            #     hang the connection forever.
+            if is_done is None:
+                if waited_ms >= _MAX_WAIT_S * 1000:
+                    yield sse_line("log file unavailable", event="error")
+                    return
+                waited_ms += _POLL_MS
+            else:
+                if is_done():
+                    yield _emit_done()
+                    return
+                keepalive_ms += _POLL_MS
+                if keepalive_ms >= _KEEPALIVE_MS:
+                    yield ":keepalive\n\n"
+                    keepalive_ms = 0
             time.sleep(_POLL_MS / 1000)
-            waited_ms += _POLL_MS
             continue
-        with open(log_path, "rb") as fh:
+        with open(path, "rb") as fh:
             fh.seek(offset)
             raw = fh.read(_tail_max_bytes())
         text = raw.decode("utf-8", errors="replace")
@@ -76,17 +129,6 @@ def sse_tail_generator(
                     if line_filter is None or line_filter(line):
                         yield sse_line(line, event_id=offset)
         if is_done is not None and is_done():
-            state = ""
-            if terminal_state is not None:
-                try:
-                    state = terminal_state() or ""
-                except Exception:  # noqa: BLE001 — never block the done frame on a bad reader
-                    state = ""
-            done_parts = []
-            if offset:
-                done_parts.append(f"id: {offset}\n")
-            done_parts.append("event: done\n")
-            done_parts.append(f"data: {state}\n\n")
-            yield "".join(done_parts)
+            yield _emit_done()
             return
         time.sleep(_POLL_MS / 1000)

--- a/tests/api/test_log_stream_routes.py
+++ b/tests/api/test_log_stream_routes.py
@@ -134,13 +134,132 @@ def test_sse_respects_last_event_id(tmp_path, app) -> None:
     assert [e["data"] for e in line_events] == ["beta", "gamma"]
 
 
-def test_sse_404_on_missing_log(tmp_path, app) -> None:
+def test_sse_waits_when_run_log_missing_then_emits_done(tmp_path, app) -> None:
+    """run_dir exists, run.log doesn't — the job is still preparing.
+
+    The stream must not 404 (which would close the EventSource and leave
+    the dashboard's console pane showing "stream disconnected" forever).
+    Instead it stays open and emits ``event: done`` once the job ends.
+    """
     run_dir = tmp_path / "empty"
     run_dir.mkdir()
-    app.config["_provider"].map["job-sse-3"] = run_dir
+    # The fake provider's is_job_complete returns True for ids ending in
+    # "-done", so the generator terminates on the first iteration.
+    app.config["_provider"].map["job-prep-done"] = run_dir
     client = app.test_client()
-    resp = client.get("/api/jobs/job-sse-3/logs/stream")
-    assert resp.status_code == HTTPStatus.NOT_FOUND
+    resp = client.get("/api/jobs/job-prep-done/logs/stream")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.content_type.startswith("text/event-stream")
+    events = _collect_sse(resp)
+    line_events = [e for e in events if "data" in e and e.get("event") != "done"]
+    assert line_events == []
+    assert any(e.get("event") == "done" for e in events)
+
+
+def test_sse_410_for_unknown_job(tmp_path, app) -> None:
+    """A jobId the provider can't resolve and that JobManager doesn't know
+    about must still be rejected — we don't want a typo'd id to pin a
+    polling thread open indefinitely."""
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-unknown/logs/stream")
+    assert resp.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.GONE)
+
+
+def test_sse_waits_for_preparing_internal_job(tmp_path, app) -> None:
+    """Internal jobs registered with JobManager have no run_dir until the
+    runner emits the report_path marker. The SSE stream stays open
+    during that preparing window even though get_log_run_dir returns
+    None, and emits ``event: done`` when the in-memory job flips to a
+    terminal state."""
+    class FakeJob:
+        def __init__(self, status: str) -> None:
+            self.status = status
+
+    class FakeStore:
+        def __init__(self, job: FakeJob) -> None:
+            self._job = job
+
+        def get(self, _job_id: str) -> FakeJob:
+            return self._job
+
+    class JobsHolder:
+        def __init__(self, store: FakeStore) -> None:
+            self._store = store
+
+    job = FakeJob("running")
+    provider = app.config["_provider"]
+    provider._jobs = JobsHolder(FakeStore(job))
+
+    # Flip the job to "done" on the second is_job_complete call so the
+    # generator first sees an active preparing job (path None, not done)
+    # and on the next tick gets the done frame.
+    calls = [0]
+    original_is_done = provider.is_job_complete
+
+    def is_done(job_id: str) -> bool:
+        calls[0] += 1
+        if calls[0] >= 2:
+            job.status = "done"
+            return True
+        return original_is_done(job_id)
+
+    provider.is_job_complete = is_done
+
+    client = app.test_client()
+    resp = client.get("/api/jobs/internal-prep/logs/stream")
+    assert resp.status_code == HTTPStatus.OK
+    events = _collect_sse(resp)
+    assert any(e.get("event") == "done" for e in events)
+
+
+def test_sse_streams_log_after_it_appears(tmp_path, app) -> None:
+    """When run.log materializes mid-stream (the runner finally emitted
+    the report_path marker and JobManager flushed the buffered preparing
+    output), the generator picks it up and emits the lines."""
+    run_dir = tmp_path / "appears"
+    run_dir.mkdir()
+    log_path = run_dir / "run.log"
+
+    # Job is in JobManager's in-memory store so _is_preparing_job
+    # accepts the request even though get_log_run_dir initially says
+    # "no run dir yet" (mirrors the pre-marker reality).
+    class FakeJob:
+        status = "running"
+
+    class FakeStore:
+        def get(self, _job_id):
+            return FakeJob()
+
+    class JobsHolder:
+        _store = FakeStore()
+
+    provider = app.config["_provider"]
+    provider._jobs = JobsHolder()
+
+    # First call (from the route's _resolve_run_log) returns None, so
+    # the route falls through to _is_preparing_job and opens the SSE
+    # response. From the second call onward (generator's lazy resolver)
+    # the run dir is "available" and run.log gets seeded — that's the
+    # exact moment the dashboard's preparing burst arrives in real life.
+    calls = [0]
+
+    def get_log_run_dir(_job_id):
+        calls[0] += 1
+        if calls[0] == 1:
+            return None
+        if calls[0] == 2:
+            log_path.write_text("preparing-line-1\npreparing-line-2\n")
+        return run_dir
+
+    provider.get_log_run_dir = get_log_run_dir
+
+    client = app.test_client()
+    resp = client.get("/api/jobs/job-appears-done/logs/stream")
+    assert resp.status_code == HTTPStatus.OK
+    events = _collect_sse(resp)
+    line_events = [e for e in events if "data" in e and e.get("event") != "done"]
+    assert [e["data"] for e in line_events] == ["preparing-line-1", "preparing-line-2"]
+    assert any(e.get("event") == "done" for e in events)
 
 
 def test_plain_logs_filters_resources_lines(tmp_path, app) -> None:


### PR DESCRIPTION
## Summary

- The dashboard's eval-log SSE route returned 404 whenever `run.log` wasn't on disk yet. EventSource saw the error, fired `onerror`, and the console pane stuck on `── stream disconnected ──` with no reconnect — the user had to wait for the runner to actually start emitting and remount the pane.
- Pre-marker (during input resolution / repo cloning / run-dir creation) the runner hasn't emitted `report_path`, so JobManager has no `output_project` and `provider.get_log_run_dir(jobId)` returns `None`. That trips the 404 in `_resolve_run_log` → the route fails the request before the SSE generator even runs.

This change keeps the SSE response open while the job is still preparing, so the dashboard pane stays connected. When JobManager finally flushes its buffered preparing output to `run.log`, the generator picks it up and the entire preparing log streams into the pane in one go.

### Changes

- `api/_log_stream_routes.py`: new `_is_preparing_job` helper. The `stream_logs` route bypasses the 404 when the job is recognised as still preparing (in JobManager's in-memory store with non-terminal status, or has a real `run_dir` even if `run.log` isn't on disk yet). Unknown jobs still get the 404/410 they used to.
- `api/_log_stream_routes.py`: route now passes a `resolve_log_path` callable to the generator so the run dir is re-resolved each tick — a pre-marker job's `output_project` gets set later, and `get_log_run_dir` starts returning a path from that point.
- `api/_sse_log_helpers.py`: `sse_tail_generator` accepts `Path | Callable[[], Path | None]`. With `is_done` provided it waits as long as the job is alive (with periodic SSE-comment keepalives) instead of giving up after the legacy 10s `_MAX_WAIT_S`. The Ollama log route (no `is_done`) keeps its original timeout behaviour, so nothing changed there.
- Tests: replaced the old 404-on-missing-log assertion (the behaviour it asserted is the bug) and added three new tests:
  - `test_sse_waits_when_run_log_missing_then_emits_done` — run_dir exists, no run.log → stream stays open and emits `done` cleanly.
  - `test_sse_410_for_unknown_job` — a typo'd jobId is still rejected so a stale id can't pin a polling thread.
  - `test_sse_waits_for_preparing_internal_job` — internal pre-marker job (no run_dir yet) keeps the stream open until the in-memory job flips terminal.
  - `test_sse_streams_log_after_it_appears` — run.log materialises mid-stream and the generator emits the lines.

## Test plan

- [x] `uv run pytest tests/api/test_log_stream_routes.py` — 13 passed
- [x] `uv run pytest tests/api/ tests/services/` — 862 passed
- [x] `uv run pytest tests/ --ignore=tests/integration` — 2562 passed
- [x] Manual: start an evaluation in the dashboard with a slow preparing phase (cloud model / remote repo). Confirm the console pane shows no `── stream disconnected ──` during preparing and that the preparing log lines stream in once the runner emits the marker.