### PR TITLE
feat: total time limit with live countdown

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 
 from quodeq.config.paths import default_paths
@@ -51,6 +52,33 @@ _logger = logging.getLogger(__name__)
 _ENV_MAX_TURNS = "QUODEQ_MAX_TURNS"
 _ENV_MAX_DURATION = "QUODEQ_MAX_DURATION"
 _ENV_POOL_BUDGET = "QUODEQ_POOL_BUDGET"
+_ENV_TIME_LIMIT = "QUODEQ_TIME_LIMIT"
+
+
+def _resolve_time_limit(args: argparse.Namespace, env: dict[str, str] | None = None) -> int | None:
+    """Resolve the run-level time limit from CLI args or env.
+
+    Precedence: explicit CLI flag > QUODEQ_TIME_LIMIT > legacy QUODEQ_POOL_BUDGET.
+    Emits a one-line deprecation warning when the legacy CLI flag or env var is
+    the source of the value.
+    """
+    src_env = env or os.environ
+    if getattr(args, "pool_budget", None) is not None:
+        # argparse stores both --time-limit and --pool-budget on the same dest;
+        # detect deprecated form by scanning the original argv.
+        if any(a == "--pool-budget" or a.startswith("--pool-budget=") for a in sys.argv[1:]):
+            sys.stderr.write(
+                "warning: --pool-budget is deprecated, use --time-limit instead\n"
+            )
+        return args.pool_budget
+    if src_env.get(_ENV_TIME_LIMIT) is not None:
+        return _env_int(_ENV_TIME_LIMIT, None, env=env)
+    if src_env.get(_ENV_POOL_BUDGET) is not None:
+        sys.stderr.write(
+            f"warning: {_ENV_POOL_BUDGET} is deprecated, use {_ENV_TIME_LIMIT} instead\n"
+        )
+        return _env_int(_ENV_POOL_BUDGET, None, env=env)
+    return None
 
 
 def _env_int(var: str, default: int | None, env: dict[str, str] | None = None) -> int | None:
@@ -205,7 +233,7 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
             subagent_model=subagent_model_val,
             verify_findings=not _no_verify(args, env=env),
             consolidated=consolidated,
-            pool_budget=args.pool_budget if args.pool_budget is not None else _env_int(_ENV_POOL_BUDGET, None, env=env),
+            pool_budget=_resolve_time_limit(args, env=env),
             incremental=args.incremental,
             incremental_file_filter=incremental_file_filter,
             dry_run=getattr(args, "dry_run", False),

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -264,6 +264,15 @@ def _run_pipeline_with_cleanup(
                     # (the UI gates dim-polling on phase in
                     # {analyzing, scoring}).
                     lifecycle.set_phase("analyzing")
+                    # Record the run-level deadline so the dashboard countdown
+                    # has it (visible immediately in status.json and SSE).
+                    budget_s = getattr(args, "pool_budget", None)
+                    if budget_s is not None and budget_s > 0:
+                        from datetime import datetime, timedelta, timezone
+                        deadline_iso = (
+                            datetime.now(timezone.utc) + timedelta(seconds=budget_s)
+                        ).isoformat()
+                        lifecycle.set_deadline(deadline_iso)
                     result = _execute_pipeline(args, config, evidence_dir, evaluation_dir)
                     # run_full writes per-dimension reports as each dimension
                     # completes, so by the time it returns scoring is already

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -294,7 +294,9 @@ def _run_pipeline_with_cleanup(
                     lifecycle.set_phase("analyzing")
                     # Record the run-level deadline so the dashboard countdown
                     # has it (visible immediately in status.json and SSE).
-                    budget_s = getattr(args, "pool_budget", None)
+                    # Resolve from CLI args OR env vars — dashboard runs pass
+                    # QUODEQ_TIME_LIMIT via env, not the CLI flag.
+                    budget_s = _resolve_time_limit(args)
                     if budget_s is not None and budget_s > 0:
                         from datetime import datetime, timedelta, timezone
                         deadline_iso = (

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -233,7 +233,7 @@ def _build_run_config(args: argparse.Namespace, *, inputs: ResolvedInputs, evide
             subagent_model=subagent_model_val,
             verify_findings=not _no_verify(args, env=env),
             consolidated=consolidated,
-            pool_budget=_resolve_time_limit(args, env=env),
+            time_limit=_resolve_time_limit(args, env=env),
             incremental=args.incremental,
             incremental_file_filter=incremental_file_filter,
             dry_run=getattr(args, "dry_run", False),

--- a/src/quodeq/analysis/_backfill.py
+++ b/src/quodeq/analysis/_backfill.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.incremental import identify_backfill_files
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 # NOTE: logging in inner layer — tracked for middleware extraction
 from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
@@ -101,12 +101,12 @@ def run_backfill_phase(
     if not backfill_candidates:
         return backfill_taken
 
-    pool_budget = config.options.pool_budget
-    unlimited = pool_budget is not None and pool_budget <= 0
+    time_limit = config.options.time_limit
+    unlimited = time_limit is not None and time_limit <= 0
 
     if not unlimited:
         elapsed = time.monotonic() - backfill.phase_start
-        total_budget = pool_budget or _DEFAULT_POOL_BUDGET
+        total_budget = time_limit or _DEFAULT_TIME_LIMIT
         remaining_budget = max(0, total_budget - int(elapsed))
 
         if remaining_budget < _min_backfill_budget_s():
@@ -123,7 +123,7 @@ def run_backfill_phase(
     original_options = config.options
     config.options = copy(original_options)
     config.options.incremental_file_filter = set(backfill_candidates)
-    config.options.pool_budget = remaining_budget
+    config.options.time_limit = remaining_budget
     config.options.verify_findings = False
     # Deferred import: circular dependency _dimension_ops → _incremental_evidence → _backfill
     from quodeq.analysis._dimension_ops import _process_single_dimension

--- a/src/quodeq/analysis/_config.py
+++ b/src/quodeq/analysis/_config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 
 HeartbeatCallback = Callable[[int, dict], None]
 
@@ -29,7 +29,7 @@ class AnalysisConfig:
     ai_model: str | None = None
     max_turns: int | None = _DEFAULT_MAX_TURNS
     max_duration: int | None = _DEFAULT_MAX_DURATION
-    pool_budget: int = _DEFAULT_POOL_BUDGET
+    time_limit: int = _DEFAULT_TIME_LIMIT
     deadline_at: float | None = None
     """Absolute monotonic-clock deadline for the whole run. None = unlimited."""
     compiled_dir: Path | None = None

--- a/src/quodeq/analysis/_config.py
+++ b/src/quodeq/analysis/_config.py
@@ -30,6 +30,8 @@ class AnalysisConfig:
     max_turns: int | None = _DEFAULT_MAX_TURNS
     max_duration: int | None = _DEFAULT_MAX_DURATION
     pool_budget: int = _DEFAULT_POOL_BUDGET
+    deadline_at: float | None = None
+    """Absolute monotonic-clock deadline for the whole run. None = unlimited."""
     compiled_dir: Path | None = None
     dimension: str | None = None
     queue_path: Path | None = None

--- a/src/quodeq/analysis/_dimension_steps.py
+++ b/src/quodeq/analysis/_dimension_steps.py
@@ -64,8 +64,8 @@ def _run_dimension_analysis(
         ac_kwargs["max_turns"] = config.options.max_turns
     if config.options.max_duration is not None:
         ac_kwargs["max_duration"] = config.options.max_duration
-    if config.options.pool_budget is not None:
-        ac_kwargs["pool_budget"] = config.options.pool_budget
+    if config.options.time_limit is not None:
+        ac_kwargs["time_limit"] = config.options.time_limit
     if config.options.deadline_at is not None:
         ac_kwargs["deadline_at"] = config.options.deadline_at
     run_analysis(

--- a/src/quodeq/analysis/_dimension_steps.py
+++ b/src/quodeq/analysis/_dimension_steps.py
@@ -66,6 +66,8 @@ def _run_dimension_analysis(
         ac_kwargs["max_duration"] = config.options.max_duration
     if config.options.pool_budget is not None:
         ac_kwargs["pool_budget"] = config.options.pool_budget
+    if config.options.deadline_at is not None:
+        ac_kwargs["deadline_at"] = config.options.deadline_at
     run_analysis(
         work_dir=config.src,
         prompt=prompt,

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from copy import copy
 from dataclasses import replace
 from collections.abc import Callable
@@ -80,6 +81,10 @@ def run_incremental_loop(
     log_info(f"[loop] incremental: {len(dimensions)} dim(s) to process: {', '.join(dimensions)}")
     for idx, dimension in enumerate(dimensions, 1):
         log_info(f"[loop] entering iteration {idx}/{ctx.total} for {dimension}")
+        deadline = getattr(config.options, "deadline_at", None)
+        if deadline is not None and time.monotonic() >= deadline:
+            log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
+            break
         emit_marker("analyzing", dimension=dimension)
         log_info(f"\u2192 [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
         ev: Evidence | None = None
@@ -179,6 +184,10 @@ def run_per_dimension_loop(
     log_info(f"[loop] per-dimension: {len(dimensions)} dim(s) to process: {', '.join(dimensions)}")
     for idx, dimension in enumerate(dimensions, 1):
         log_info(f"[loop] entering iteration {idx}/{ctx.total} for {dimension}")
+        deadline = getattr(config.options, "deadline_at", None)
+        if deadline is not None and time.monotonic() >= deadline:
+            log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
+            break
         ev: Evidence | None = None
         try:
             ev = process_fn(config, dimension, idx, ctx)

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -93,7 +93,7 @@ def _run_dimensions(
     # Set the run-level deadline once, just before the dim loop starts.
     # Skipped for dry runs (already returned above), unlimited budget, or
     # when an outer caller (tests) has pre-set deadline_at.
-    budget_s = config.options.pool_budget
+    budget_s = config.options.time_limit
     if config.options.deadline_at is None and budget_s is not None and budget_s > 0:
         config.options.deadline_at = time.monotonic() + budget_s
         deadline_iso = (

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -1,8 +1,9 @@
 """Pipeline coordination — dimension orchestration, merging, and public API."""
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from quodeq.analysis._dim_estimates import compute_dim_estimates, write_dim_estimates
 from quodeq.analysis._incremental_context import load_analysis_context as _load_ctx
@@ -88,6 +89,17 @@ def _run_dimensions(
 
     dimensions, ctx = load_analysis_context(config)
     _persist_dim_estimates(config, dimensions)
+
+    # Set the run-level deadline once, just before the dim loop starts.
+    # Skipped for dry runs (already returned above), unlimited budget, or
+    # when an outer caller (tests) has pre-set deadline_at.
+    budget_s = config.options.pool_budget
+    if config.options.deadline_at is None and budget_s is not None and budget_s > 0:
+        config.options.deadline_at = time.monotonic() + budget_s
+        deadline_iso = (
+            datetime.now(timezone.utc) + timedelta(seconds=budget_s)
+        ).isoformat()
+        emit_marker("analyzing_start", deadline_at=deadline_iso, budget_s=budget_s)
 
     # Diff mode always per-dimension — consolidated/incremental loops are
     # incompatible with evidence-only runs (no prior fingerprint, no

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -30,6 +30,7 @@ class AnalysisOptions:
     verify_findings: bool = True
     consolidated: bool = True
     pool_budget: int | None = None
+    deadline_at: float | None = None
     incremental: bool = False
     incremental_file_filter: set[str] | None = None
     dry_run: bool = False

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -29,7 +29,7 @@ class AnalysisOptions:
     ai_model: str | None = None
     verify_findings: bool = True
     consolidated: bool = True
-    pool_budget: int | None = None
+    time_limit: int | None = None
     deadline_at: float | None = None
     incremental: bool = False
     incremental_file_filter: set[str] | None = None

--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.subprocess import AnalysisConfig
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence_by_dimension
 from quodeq.analysis.subagents.file_queue import FileQueue
@@ -43,7 +43,7 @@ def _build_consolidated_config(
 ) -> AnalysisConfig:
     """Build AnalysisConfig for consolidated mode."""
     subagent_model = config.options.subagent_model or _default_subagent_model() or config.options.ai_model
-    pool_budget_val = config.options.pool_budget
+    time_limit_val = config.options.time_limit
     return AnalysisConfig(
         analysis_budget=config.options.analysis_budget,
         compiled_dir=compiled_dir,
@@ -52,7 +52,7 @@ def _build_consolidated_config(
         ai_model=subagent_model,
         dimension=",".join(dimensions),
         max_files_per_agent=files_per_agent,
-        pool_budget=pool_budget_val if pool_budget_val is not None else _DEFAULT_POOL_BUDGET,
+        time_limit=time_limit_val if time_limit_val is not None else _DEFAULT_TIME_LIMIT,
         deadline_at=config.options.deadline_at,
     )
 

--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -53,6 +53,7 @@ def _build_consolidated_config(
         dimension=",".join(dimensions),
         max_files_per_agent=files_per_agent,
         pool_budget=pool_budget_val if pool_budget_val is not None else _DEFAULT_POOL_BUDGET,
+        deadline_at=config.options.deadline_at,
     )
 
 

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -9,7 +9,7 @@ from typing import Any
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.subprocess import AnalysisConfig, count_files_from_stream
 from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 from quodeq.shared.logging import log_info
 from quodeq.shared.utils import get_ai_cmd
 
@@ -17,28 +17,28 @@ _MAX_FILES_PER_AGENT = 30
 _MAX_FILES_PER_AGENT_CAP = 50
 _NON_SCOUT_PROVIDERS = tuple(os.environ.get("QUODEQ_NON_SCOUT_PROVIDERS", "codex,gemini").split(","))
 
-# Auto-scale the pool budget so large queues don't get killed mid-run.
+# Auto-scale the time limit so large queues don't get killed mid-run.
 # A fixed 600s cap chokes any dim with a queue larger than ~80 files
 # (observed throughput ≈ 7-12 s/file with 8 agents); the surviving
 # pending files keep haunting the next run via the not_analyzed sweep
-# and the dim never converges. The user's explicit pool_budget is a
+# and the dim never converges. The user's explicit time_limit is a
 # FLOOR — we only ever extend it upward, never shrink it.
 _SECONDS_PER_FILE_AUTOSCALE = 12
 # Hard upper bound so a runaway queue can't lock up the run for days.
 _MAX_AUTO_POOL_BUDGET = 7200  # 2 hours
-# Pool budget = 0 means "unlimited"; respect that and never scale it.
+# time_limit = 0 means "unlimited"; respect that and never scale it.
 _UNLIMITED_BUDGET = 0
 
 
-def _resolve_pool_budget(user_budget: int | None, queue_size: int) -> int:
-    """Compute the effective pool budget for a queue of *queue_size* files.
+def _resolve_time_limit(user_budget: int | None, queue_size: int) -> int:
+    """Compute the effective time limit for a queue of *queue_size* files.
 
-    The user's `pool_budget` (or `_DEFAULT_POOL_BUDGET` if unset) is treated
+    The user's `time_limit` (or `_DEFAULT_TIME_LIMIT` if unset) is treated
     as a floor. For large queues we extend it to give each file a fair
     slice of wallclock time, capped at `_MAX_AUTO_POOL_BUDGET`. A user-set
-    budget of 0 means "unlimited" and is preserved verbatim.
+    limit of 0 means "unlimited" and is preserved verbatim.
     """
-    base = user_budget if user_budget is not None else _DEFAULT_POOL_BUDGET
+    base = user_budget if user_budget is not None else _DEFAULT_TIME_LIMIT
     if base == _UNLIMITED_BUDGET:
         return _UNLIMITED_BUDGET
     if queue_size <= 0:
@@ -79,11 +79,11 @@ def _launch_pool(
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
     subagent_model = config.options.subagent_model or _default_subagent_model() or config.options.ai_model
     queue_size = len(params.all_files) if params.all_files is not None else 0
-    pool_budget = _resolve_pool_budget(config.options.pool_budget, queue_size)
-    base_user_budget = config.options.pool_budget if config.options.pool_budget is not None else _DEFAULT_POOL_BUDGET
-    if pool_budget != base_user_budget and pool_budget != _UNLIMITED_BUDGET:
+    time_limit = _resolve_time_limit(config.options.time_limit, queue_size)
+    base_user_budget = config.options.time_limit if config.options.time_limit is not None else _DEFAULT_TIME_LIMIT
+    if time_limit != base_user_budget and time_limit != _UNLIMITED_BUDGET:
         log_info(
-            f"  [{dim_id}] Pool budget auto-scaled: {base_user_budget}s → {pool_budget}s"
+            f"  [{dim_id}] Time limit auto-scaled: {base_user_budget}s → {time_limit}s"
             f" for {queue_size} files"
         )
     base_ac = AnalysisConfig(
@@ -93,7 +93,7 @@ def _launch_pool(
         max_duration=config.options.max_duration,
         ai_model=subagent_model,
         max_files_per_agent=params.max_files_per_agent,
-        pool_budget=pool_budget,
+        time_limit=time_limit,
         deadline_at=config.options.deadline_at,
     )
     n_agents = config.options.max_subagents

--- a/src/quodeq/analysis/subagents/_pool_launcher.py
+++ b/src/quodeq/analysis/subagents/_pool_launcher.py
@@ -94,6 +94,7 @@ def _launch_pool(
         ai_model=subagent_model,
         max_files_per_agent=params.max_files_per_agent,
         pool_budget=pool_budget,
+        deadline_at=config.options.deadline_at,
     )
     n_agents = config.options.max_subagents
 

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -42,6 +42,7 @@ class LoopContext:
     dimension_key: str
     submit_fn: Callable[[], None]
     max_files_per_agent: int | None = None
+    deadline_at: float | None = None
 
 
 def scout_loop(ctx: LoopContext) -> None:
@@ -54,7 +55,10 @@ def scout_loop(ctx: LoopContext) -> None:
     ctx.submit_fn()
     while ctx.futures:
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
-        scale_ctx = ScaleUpContext(ctx.queue, ctx.queue_path, ctx.submit_fn)
+        scale_ctx = ScaleUpContext(
+            ctx.queue, ctx.queue_path, ctx.submit_fn,
+            deadline_at=ctx.deadline_at,
+        )
         state.scout_done = maybe_scale_up(
             done, state, ctx.n_agents, ctx.max_files_per_agent,
             scale_ctx,
@@ -64,7 +68,10 @@ def scout_loop(ctx: LoopContext) -> None:
             continue
         if state.scout_done:
             for _ in done:
-                if should_respawn(ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration):
+                if should_respawn(
+                    ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration,
+                    deadline_at=ctx.deadline_at,
+                ):
                     ctx.submit_fn()
 
 
@@ -82,5 +89,8 @@ def immediate_loop(ctx: LoopContext) -> None:
             time.sleep(_FUTURE_POLL_INTERVAL_S)
             continue
         for _ in done:
-            if should_respawn(ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration):
+            if should_respawn(
+                ctx.queue, ctx.queue_path, ctx.pool_start, ctx.max_duration,
+                deadline_at=ctx.deadline_at,
+            ):
                 ctx.submit_fn()

--- a/src/quodeq/analysis/subagents/_pool_loops.py
+++ b/src/quodeq/analysis/subagents/_pool_loops.py
@@ -21,7 +21,6 @@ from quodeq.analysis.subagents._pool_scaling import (
     should_respawn,
 )
 from quodeq.analysis.subagents.file_queue import WorkQueue
-from quodeq.shared.logging import log_warning as _log_warn
 
 _SCOUT_BUDGET_FRACTION = 0.5
 
@@ -75,17 +74,9 @@ def immediate_loop(ctx: LoopContext) -> None:
     for _ in range(ctx.n_agents):
         ctx.submit_fn()
     while ctx.futures:
-        # Check pool budget — cancel all running agents if exceeded
-        if ctx.max_duration > 0:
-            elapsed = time.monotonic() - ctx.pool_start
-            if elapsed >= ctx.max_duration:
-                _log_warn(
-                    f"  Pool budget ({ctx.max_duration:.0f}s) exceeded "
-                    f"-- cancelling {len(ctx.futures)} remaining agents"
-                )
-                for future in list(ctx.futures):
-                    future.cancel()
-                break
+        # No deadline-kill here: Future.cancel() is a no-op for running
+        # threads. Enforcement is the spawn-gate in should_respawn() plus
+        # the per-agent max_duration clamp set in build_agent_config().
         done = collect_done(ctx.futures, ctx.finished, ctx.results, ev_paths)
         if not done:
             time.sleep(_FUTURE_POLL_INTERVAL_S)

--- a/src/quodeq/analysis/subagents/_pool_models.py
+++ b/src/quodeq/analysis/subagents/_pool_models.py
@@ -8,7 +8,7 @@ _AGENT_ID_PREFIX = "agent"
 _FUTURE_POLL_INTERVAL_S = 0.5
 _HEARTBEAT_JOIN_TIMEOUT_S = 2
 _SCOUT_TIMEOUT_S = 180             # 3 min before forcing scale-up
-_DEFAULT_MAX_DURATION_S = 1800     # 30 min default pool budget
+_DEFAULT_MAX_DURATION_S = 600      # 10 min per-agent ceiling; clamped lower by remaining run budget when set
 _DEFAULT_FILES_PER_AGENT = 30
 
 

--- a/src/quodeq/analysis/subagents/_pool_scaling.py
+++ b/src/quodeq/analysis/subagents/_pool_scaling.py
@@ -26,6 +26,7 @@ class ScaleUpContext:
     queue: WorkQueue | None
     queue_path: Path
     submit_fn: Callable[[], None]
+    deadline_at: float | None = None
 
 
 @dataclass
@@ -65,9 +66,27 @@ def get_queue(queue: WorkQueue | None, queue_path: Path) -> WorkQueue:
 def should_respawn(
     queue: WorkQueue | None, queue_path: Path,
     pool_start: float, max_duration: float,
+    *, deadline_at: float | None = None,
 ) -> int:
-    """Return remaining file count if a new agent should be spawned, else 0."""
+    """Return remaining file count if a new agent should be spawned, else 0.
+
+    Spawning is gated by two ceilings:
+    - the pool-local *max_duration* (elapsed since *pool_start*), and
+    - the run-level *deadline_at* (a monotonic wall-clock from the run config).
+
+    Without the deadline gate, agents whose per-agent budget was clamped to
+    "remaining run budget" (1s past the deadline) would die and immediately
+    be respawned, producing an infinite stream of 1-second agents that never
+    do useful work.
+    """
     remaining = get_queue(queue, queue_path).remaining()
+    if deadline_at is not None and time.monotonic() >= deadline_at:
+        if remaining > 0:
+            log_warning(
+                f"  Run deadline reached -- {remaining} files left, "
+                f"not spawning new agents"
+            )
+        return 0
     if max_duration <= 0:
         return remaining  # 0 = unlimited
     elapsed = time.monotonic() - pool_start
@@ -132,7 +151,10 @@ def maybe_scale_up(
     scout_timed_out = elapsed >= state.scout_timeout and n_agents > 1
     if not (scout_completed or scout_timed_out):
         return False
-    remaining = should_respawn(ctx.queue, ctx.queue_path, state.pool_start, state.max_duration)
+    remaining = should_respawn(
+        ctx.queue, ctx.queue_path, state.pool_start, state.max_duration,
+        deadline_at=ctx.deadline_at,
+    )
     for _ in range(compute_scale_up(remaining, n_agents, max_files_per_agent)):
         ctx.submit_fn()
     return True

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -33,9 +33,17 @@ def build_agent_config(
     jsonl_file = wctx.evidence_dir / f"{wctx.dimension_key}_evidence.jsonl"
     stream_file = wctx.evidence_dir / f"{wctx.dimension_key}_{agent_id}.stream"
     bc = base_config
-    # Cap per-agent duration to pool budget so agents can't outlive the pool
     agent_dur = bc.max_duration or _DEFAULT_MAX_DURATION_S
-    if bc.pool_budget and bc.pool_budget > 0:
+    # Clamp to remaining budget so the last in-flight agent dies on or
+    # before the run-level deadline. Without this, a respawn near the
+    # deadline gets a fresh full-length cap and extends the run.
+    if bc.deadline_at is not None:
+        import time as _time
+        remaining = max(1, int(bc.deadline_at - _time.monotonic()))
+        agent_dur = min(agent_dur, remaining)
+    elif bc.pool_budget and bc.pool_budget > 0:
+        # Legacy clamp: kept for runs without a deadline. A later task will
+        # retire pool_budget entirely.
         agent_dur = min(agent_dur, bc.pool_budget)
     ac = AnalysisConfig(
         jsonl_file=jsonl_file, analysis_budget=bc.analysis_budget,

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -41,10 +41,10 @@ def build_agent_config(
     if bc.deadline_at is not None:
         remaining = max(1, int(bc.deadline_at - time.monotonic()))
         agent_dur = min(agent_dur, remaining)
-    elif bc.pool_budget and bc.pool_budget > 0:
+    elif bc.time_limit and bc.time_limit > 0:
         # Legacy clamp: kept for runs without a deadline. A later task will
-        # retire pool_budget entirely.
-        agent_dur = min(agent_dur, bc.pool_budget)
+        # retire this branch entirely.
+        agent_dur = min(agent_dur, bc.time_limit)
     ac = AnalysisConfig(
         jsonl_file=jsonl_file, analysis_budget=bc.analysis_budget,
         heartbeat_interval=bc.heartbeat_interval, heartbeat_callback=bc.heartbeat_callback,

--- a/src/quodeq/analysis/subagents/_pool_worker.py
+++ b/src/quodeq/analysis/subagents/_pool_worker.py
@@ -1,6 +1,7 @@
 """Worker logic: building agent configs and running single subagents."""
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -38,8 +39,7 @@ def build_agent_config(
     # before the run-level deadline. Without this, a respawn near the
     # deadline gets a fresh full-length cap and extends the run.
     if bc.deadline_at is not None:
-        import time as _time
-        remaining = max(1, int(bc.deadline_at - _time.monotonic()))
+        remaining = max(1, int(bc.deadline_at - time.monotonic()))
         agent_dur = min(agent_dur, remaining)
     elif bc.pool_budget and bc.pool_budget > 0:
         # Legacy clamp: kept for runs without a deadline. A later task will

--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -89,7 +89,7 @@ def _dispatch_mini_verify(
 
     mini_config = copy(config)
     mini_options = copy(config.options)
-    mini_options.pool_budget = timeout
+    mini_options.time_limit = timeout
     mini_options.max_subagents = min(_MINI_VERIFY_MAX_AGENTS, config.options.max_subagents)
     mini_config.options = mini_options
 

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -109,6 +109,7 @@ def run_verification_pool(
         ai_model=model,
         dimension=dim_id,
         pool_budget=config.options.pool_budget,
+        deadline_at=config.options.deadline_at,
     )
     pool = SubagentPool(
         paths=PoolPaths(work_dir=config.src, evidence_dir=evidence_dir, queue_path=queue_path),

--- a/src/quodeq/analysis/subagents/_verify_pool.py
+++ b/src/quodeq/analysis/subagents/_verify_pool.py
@@ -108,7 +108,7 @@ def run_verification_pool(
         max_duration=_VERIFY_MAX_DURATION,
         ai_model=model,
         dimension=dim_id,
-        pool_budget=config.options.pool_budget,
+        time_limit=config.options.time_limit,
         deadline_at=config.options.deadline_at,
     )
     pool = SubagentPool(

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -115,6 +115,7 @@ class SubagentPool:
                     evidence_dir=self._evidence_dir, dimension_key=self._dimension_key,
                     submit_fn=lambda: self._submit_agent(pool),
                     max_files_per_agent=self._base_config.max_files_per_agent,
+                    deadline_at=self._base_config.deadline_at,
                 )
                 if self._scout_first:
                     scout_loop(ctx)

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -20,7 +20,7 @@ from quodeq.analysis.subagents._pool_worker import WorkerContext, build_agent_co
 from quodeq.analysis.subagents.file_queue import WorkQueue
 from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl, merge_jsonl
 from quodeq.analysis.subprocess import AnalysisConfig
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 from quodeq.shared.logging import log_info
 
 # Re-export public API so existing imports keep working.
@@ -94,7 +94,7 @@ class SubagentPool:
 
     def run(self) -> list[SubagentResult]:
         """Launch agents in parallel, returning a SubagentResult per agent."""
-        max_dur = self._base_config.pool_budget if self._base_config.pool_budget is not None else _DEFAULT_POOL_BUDGET
+        max_dur = self._base_config.time_limit if self._base_config.time_limit is not None else _DEFAULT_TIME_LIMIT
         if self._scout_first:
             log_info(f"[{self._phase}] Launching scout agent for {self._dimension_key} (max {self._n} agents)")
         else:

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -10,7 +10,7 @@ from flask import Response, jsonify, request
 
 from quodeq.api.helpers import error_response
 from quodeq.services.tooling_mixin import get_allowed_client_ids as _get_allowed_ai_cmds
-from quodeq.services.base import _DEFAULT_MAX_SUBAGENTS, _DEFAULT_POOL_BUDGET
+from quodeq.services.base import _DEFAULT_MAX_SUBAGENTS, _DEFAULT_TIME_LIMIT
 
 _CREDENTIALS_RE = re.compile(r"(https?://)([^@]+)@")
 _logger = logging.getLogger(__name__)
@@ -18,8 +18,8 @@ _logger = logging.getLogger(__name__)
 # Bounds for user-supplied evaluation parameters
 _MIN_SUBAGENTS = 1
 _MAX_SUBAGENTS = 10
-_MIN_POOL_BUDGET = 60
-_MAX_POOL_BUDGET = 3600
+_MIN_TIME_LIMIT = 60
+_MAX_TIME_LIMIT = 3600
 _MAX_CONTEXT_SIZE = 2_000_000
 
 
@@ -59,8 +59,11 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
     from quodeq.services.base import EvaluationOptions  # deferred: avoid circular import at module level
     max_subagents_raw = _coerce_int(payload.get("maxSubagents"), _DEFAULT_MAX_SUBAGENTS)
     max_subagents = max(_MIN_SUBAGENTS, min(_MAX_SUBAGENTS, max_subagents_raw))
-    pool_budget_raw = _coerce_int(payload.get("poolBudget"), _DEFAULT_POOL_BUDGET)
-    pool_budget = 0 if pool_budget_raw == 0 else max(_MIN_POOL_BUDGET, min(_MAX_POOL_BUDGET, pool_budget_raw))
+    # Read new key first; fall back to legacy `poolBudget` for back-compat.
+    time_limit_raw = _coerce_int(
+        payload.get("timeLimit", payload.get("poolBudget")), _DEFAULT_TIME_LIMIT,
+    )
+    time_limit = 0 if time_limit_raw == 0 else max(_MIN_TIME_LIMIT, min(_MAX_TIME_LIMIT, time_limit_raw))
     ai_model = payload.get("aiModel") or None
     subagent_model = payload.get("subagentModel") or ai_model  # default to orchestrator
     return EvaluationOptions(
@@ -72,7 +75,7 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
         subagent_model=subagent_model,
         verify_findings=bool(payload.get("verifyFindings", True)),
         max_subagents=max_subagents,
-        pool_budget=pool_budget,
+        time_limit=time_limit,
         incremental=bool(payload.get("incremental", False)),
         per_dimension=bool(payload.get("perDimension", False)),
         context_size=max(0, min(_MAX_CONTEXT_SIZE, _coerce_int(payload.get("contextSize"), 0))),

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -117,16 +117,20 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         if run_dir is None:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        # Pool budget for the running dim's bar — only available for jobs the
+        # Time limit for the running dim's bar — only available for jobs the
         # JobManager started; external runs surface no budget metadata.
-        pool_budget_s: int | None = None
+        time_limit_s: int | None = None
         snapshot = provider.get_evaluation_status(job_id, reports_dir=_reports_dir())
         if snapshot is not None:
             options = getattr(snapshot, "options", None) or {}
-            raw = options.get("poolBudget") if isinstance(options, dict) else None
+            # Read new key first; fall back to legacy `poolBudget` for back-compat.
+            raw = (
+                options.get("timeLimit", options.get("poolBudget"))
+                if isinstance(options, dict) else None
+            )
             if isinstance(raw, int) and raw > 0:
-                pool_budget_s = raw
-        progress = build_scan_progress(job_id, run_dir, pool_budget_s=pool_budget_s)
+                time_limit_s = raw
+        progress = build_scan_progress(job_id, run_dir, time_limit_s=time_limit_s)
         if progress is None:
             body, status = error_response("Run not ready", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/ci/review.py
+++ b/src/quodeq/ci/review.py
@@ -135,8 +135,8 @@ def handle_review(args) -> int:
     dims = getattr(args, "dimensions", None)
     if dims:
         eval_parser_argv.extend(["--dimensions", expand_dimension_aliases(dims)])
-    pool_budget = getattr(args, "pool_budget", None) or 300
-    eval_parser_argv.extend(["--pool-budget", str(pool_budget)])
+    time_limit = getattr(args, "pool_budget", None) or 300
+    eval_parser_argv.extend(["--time-limit", str(time_limit)])
 
     parser = build_parser()
     eval_args = parser.parse_args(eval_parser_argv)

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -57,8 +57,10 @@ def _add_evaluate_args(parser: argparse.ArgumentParser) -> None:
         help="Skip post-analysis verification pass",
     )
     parser.add_argument(
-        "--pool-budget", type=int, default=None,
-        help="Total time budget for agent pool in seconds (default: 600)",
+        "--time-limit", "--pool-budget",
+        dest="pool_budget", type=int, default=None,
+        help="Total evaluation time limit in seconds (0 = unlimited; default: 600). "
+             "--pool-budget is a deprecated alias.",
     )
     parser.add_argument(
         "--no-consolidated", action="store_true",
@@ -152,10 +154,10 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     review_parser.add_argument(
-        "--pool-budget",
-        type=int,
-        dest="pool_budget",
-        help="Total time budget in seconds for the evaluation (default: 300)",
+        "--time-limit", "--pool-budget",
+        dest="pool_budget", type=int,
+        help="Total time budget in seconds for the evaluation (default: 300). "
+             "--pool-budget is a deprecated alias.",
     )
     review_parser.add_argument(
         "--output",

--- a/src/quodeq/core/types/job.py
+++ b/src/quodeq/core/types/job.py
@@ -15,6 +15,7 @@ class JobSnapshot:
     output_project: str | None = None
     output_run_id: str | None = None
     phase: str | None = None
+    deadline_at: str | None = None
     current_dimension: str | None = None
     dimensions: list[str] | None = None
     error: str | None = None

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -40,6 +40,7 @@ class Job:
     output_project: str | None = None
     output_run_id: str | None = None
     phase: str | None = None
+    deadline_at: str | None = None
     current_dimension: str | None = None
     dimensions: list[str] | None = None
 
@@ -79,6 +80,7 @@ class Job:
             output_project=self.output_project,
             output_run_id=self.output_run_id,
             phase=self.phase,
+            deadline_at=self.deadline_at,
             current_dimension=self.current_dimension,
             dimensions=self.dimensions,
         )
@@ -168,6 +170,7 @@ def _job_to_json(job: Job) -> dict:
         "output_project": job.output_project,
         "output_run_id": job.output_run_id,
         "phase": job.phase,
+        "deadline_at": job.deadline_at,
         "current_dimension": job.current_dimension,
         "dimensions": job.dimensions,
     }
@@ -187,6 +190,7 @@ def _job_from_json(data: dict) -> Job:
         output_project=data.get("output_project"),
         output_run_id=data.get("output_run_id"),
         phase=data.get("phase"),
+        deadline_at=data.get("deadline_at"),
         current_dimension=data.get("current_dimension"),
         dimensions=data.get("dimensions"),
     )

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -9,6 +9,7 @@ from quodeq.core.types import JobSnapshot, ViolationSummary
 from quodeq.shared.constants import (  # noqa: F401 — re-export for backward compat
     _DEFAULT_MAX_SUBAGENTS,
     _DEFAULT_POOL_BUDGET,
+    _DEFAULT_TIME_LIMIT,
 )
 
 
@@ -23,7 +24,7 @@ class EvaluationOptions:
     subagent_model: str | None = None
     verify_findings: bool = True
     max_subagents: int = _DEFAULT_MAX_SUBAGENTS
-    pool_budget: int = _DEFAULT_POOL_BUDGET
+    time_limit: int = _DEFAULT_TIME_LIMIT
     incremental: bool = False
     per_dimension: bool = False
     branch: str | None = None

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from quodeq.core.types import JobSnapshot
-from quodeq.services.base import EvaluationOptions, _DEFAULT_MAX_SUBAGENTS, _DEFAULT_POOL_BUDGET
+from quodeq.services.base import EvaluationOptions, _DEFAULT_MAX_SUBAGENTS, _DEFAULT_TIME_LIMIT
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.shared.repo_handler import is_valid_repo_url
 from quodeq.core.evidence.parser import parse_jsonl_to_evidence, EvidenceContext
@@ -170,8 +170,8 @@ class FsEvaluationMixin:
             built_env["SUBAGENT_MODEL"] = subagent_model
         if not options.verify_findings:
             built_env["QUODEQ_NO_VERIFY"] = "1"
-        if options.pool_budget != _DEFAULT_POOL_BUDGET:
-            built_env["QUODEQ_POOL_BUDGET"] = str(options.pool_budget)
+        if options.time_limit != _DEFAULT_TIME_LIMIT:
+            built_env["QUODEQ_TIME_LIMIT"] = str(options.time_limit)
         if options.per_dimension:
             built_env["QUODEQ_NO_CONSOLIDATE"] = "1"
         if options.context_size > 0:

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -240,6 +240,8 @@ class JobManager:
         elif phase in ("analyzing", "scoring"):
             job.current_dimension = marker.get("dimension")
             job.phase = phase
+        elif phase == "analyzing_start":
+            job.deadline_at = marker.get("deadline_at")
         elif phase == "report_path":
             project = marker.get("project")
             run_id = marker.get("runId")

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -180,7 +180,7 @@ def build_scan_progress(
     job_id: str,
     run_dir: Path,
     *,
-    pool_budget_s: int | None = None,
+    time_limit_s: int | None = None,
 ) -> _ScanProgress | None:
     """Compute progress for a run.
 
@@ -255,7 +255,7 @@ def build_scan_progress(
 
         tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
-        budget = pool_budget_s if (d_state == "running" and pool_budget_s and pool_budget_s > 0) else None
+        budget = time_limit_s if (d_state == "running" and time_limit_s and time_limit_s > 0) else None
         active = _active_agents(evidence_dir, dim_id) if d_state == "running" else 0
 
         dim_results.append(_DimProgress(

--- a/src/quodeq/shared/constants.py
+++ b/src/quodeq/shared/constants.py
@@ -2,7 +2,9 @@
 
 # Pool / subagent defaults
 _DEFAULT_MAX_SUBAGENTS = 5
-_DEFAULT_POOL_BUDGET = 600  # 10 minutes total pool budget (seconds)
+_DEFAULT_TIME_LIMIT = 600  # 10 minutes total time limit (seconds)
+# Deprecated alias kept for any external import path; prefer _DEFAULT_TIME_LIMIT.
+_DEFAULT_POOL_BUDGET = _DEFAULT_TIME_LIMIT
 
 # Structured marker key used for job-tracking JSON markers
 CC_MARKER_KEY = "_cc"

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -65,6 +65,7 @@ class RunLifecycleContext:
         self._current_state = RunState.PENDING
         self._phase: str | None = None
         self._current_dimension: str | None = None
+        self._deadline_at: str | None = None
         self._heartbeat = HeartbeatThread(run_dir, interval=heartbeat_interval)
         self._resources = ResourceSampler()
         self._previous_handlers: dict[int, Any] = {}
@@ -132,6 +133,11 @@ class RunLifecycleContext:
         self._current_dimension = current_dimension
         self._write(self._current_state)
 
+    def set_deadline(self, deadline_at: str | None) -> None:
+        """Record the run-level deadline. Visible immediately in status.json."""
+        self._deadline_at = deadline_at
+        self._write(self._current_state)
+
     # ---- Internals ---------------------------------------------------------
 
     def _transition(self, new_state: RunState, *, exit_reason: str | None = None) -> None:
@@ -149,6 +155,7 @@ class RunLifecycleContext:
             phase=self._phase,
             current_dimension=self._current_dimension,
             exit_reason=exit_reason,
+            deadline_at=self._deadline_at,
         )
 
     def _install_signal_handlers(self) -> None:
@@ -172,6 +179,7 @@ class RunLifecycleContext:
                 phase=self._phase,
                 current_dimension=self._current_dimension,
                 exit_reason=f"signal_{name}",
+                deadline_at=self._deadline_at,
             )
             self._current_state = RunState.CANCELLED
             raise SystemExit(128 + signum)
@@ -211,6 +219,7 @@ class RunLifecycleContext:
             phase=self._phase,
             current_dimension=self._current_dimension,
             exit_reason="atexit_unfinalized",
+            deadline_at=self._deadline_at,
         )
 
     def _deregister_atexit(self) -> None:

--- a/src/quodeq/shared/run_status.py
+++ b/src/quodeq/shared/run_status.py
@@ -21,7 +21,7 @@ from typing import Any
 
 _logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 STATUS_FILENAME = "status.json"
 
 
@@ -81,6 +81,7 @@ def write_status(
     pid: int | None = None,
     exit_reason: str | None = None,
     finalized_at: str | None = None,
+    deadline_at: str | None = None,
 ) -> None:
     """Atomically write status.json with *state* and metadata.
 
@@ -104,6 +105,7 @@ def write_status(
         "dimensions": dimensions,
         "pid": pid,
         "exit_reason": exit_reason,
+        "deadline_at": deadline_at,
     }
     body = json.dumps(payload, indent=2)
     tmp_path = run_dir / (STATUS_FILENAME + ".tmp")

--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -3,12 +3,12 @@ export const ISO_25010_URL = 'https://www.iso.org/';
 // Settings defaults & localStorage keys (shared by SettingsPage + useEvaluation).
 // These client-side defaults can be overridden by server config (ai_providers.json).
 export const DEFAULT_MAX_SUBAGENTS = 5;
-export const DEFAULT_POOL_BUDGET = 600;
+export const DEFAULT_TIME_LIMIT_S = 600;
 export const MIN_SUBAGENTS = 1;
 export const MAX_SUBAGENTS = 10;
 export const DEFAULT_SUBAGENTS = 5;
 export const SUBAGENTS_STORAGE_KEY = 'cc-max-subagents';
-export const POOL_BUDGET_STORAGE_KEY = 'cc-pool-budget';
+export const TIME_LIMIT_STORAGE_KEY = 'cc-time-limit';
 
 export const AI_CMD_STORAGE_KEY = 'cc-ai-cmd';
 export const PER_DIMENSION_STORAGE_KEY = 'cc-per-dimension';

--- a/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
@@ -204,7 +204,7 @@ export default function ConsoleLogViewer({ logs }) {
     <div className="console-shell">
       <div className="console-scroll" ref={scrollRef}>
         {cleanedLogs.length === 0 ? (
-          <div className="console-log-empty">Waiting for output\u2026</div>
+          <div className="console-log-empty">Waiting for output…</div>
         ) : (
           cleanedLogs.map((line, i) => <LogLine key={i} text={line} />)
         )}

--- a/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+
+const ALERT_THRESHOLD_S = 30;
+const TICK_MS = 500;
+const TERMINAL_PHASES = new Set(['done', 'failed', 'cancelled', 'lost']);
+
+function format(seconds) {
+  const safe = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+export default function CountdownTimer({ deadlineAt, budgetSeconds, phase }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!deadlineAt) return undefined;
+    const id = setInterval(() => setNow(Date.now()), TICK_MS);
+    return () => clearInterval(id);
+  }, [deadlineAt]);
+
+  if (TERMINAL_PHASES.has(phase)) return null;
+  const unlimited = !budgetSeconds || budgetSeconds <= 0;
+  if (unlimited && !deadlineAt) return null;
+
+  if (!deadlineAt) {
+    return (
+      <span className="eval-countdown eval-countdown--idle" data-testid="eval-countdown">
+        {format(budgetSeconds)}
+      </span>
+    );
+  }
+
+  const remainingS = Math.max(0, (new Date(deadlineAt).getTime() - now) / 1000);
+  const alert = remainingS <= ALERT_THRESHOLD_S;
+  return (
+    <span
+      className={`eval-countdown${alert ? ' eval-countdown--alert' : ''}`}
+      data-testid="eval-countdown"
+    >
+      {format(remainingS)}
+    </span>
+  );
+}

--- a/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/CountdownTimer.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import CountdownTimer from './CountdownTimer.jsx';
+
+describe('CountdownTimer', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('renders nothing when deadline is null and budget is 0 (unlimited)', () => {
+    const { container } = render(<CountdownTimer deadlineAt={null} budgetSeconds={0} phase="analyzing" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows greyed static budget during preparing', () => {
+    render(<CountdownTimer deadlineAt={null} budgetSeconds={600} phase="preparing" />);
+    const el = screen.getByTestId('eval-countdown');
+    expect(el).toHaveTextContent('10:00');
+    expect(el).toHaveClass('eval-countdown--idle');
+  });
+
+  it('counts down from deadline_at', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = new Date(now + 90_000).toISOString();
+    render(<CountdownTimer deadlineAt={deadline} budgetSeconds={600} phase="analyzing" />);
+    expect(screen.getByTestId('eval-countdown')).toHaveTextContent('1:30');
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByTestId('eval-countdown')).toHaveTextContent('0:30');
+  });
+
+  it('switches to alert color in last 30s', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = new Date(now + 25_000).toISOString();
+    render(<CountdownTimer deadlineAt={deadline} budgetSeconds={600} phase="analyzing" />);
+    expect(screen.getByTestId('eval-countdown')).toHaveClass('eval-countdown--alert');
+  });
+
+  it('freezes at 0:00 instead of going negative', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = new Date(now - 10_000).toISOString();
+    render(<CountdownTimer deadlineAt={deadline} budgetSeconds={600} phase="analyzing" />);
+    expect(screen.getByTestId('eval-countdown')).toHaveTextContent('0:00');
+  });
+
+  it('hides on terminal phase', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const deadline = new Date(now + 60_000).toISOString();
+    const { container } = render(<CountdownTimer deadlineAt={deadline} budgetSeconds={600} phase="done" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import EvaluationStatus from './EvaluationStatus.jsx';
 import ReEvaluateCard from './ReEvaluateCard.jsx';
 import CountdownTimer from './CountdownTimer.jsx';
-import { ACTIVE_PROVIDER_KEY, DEFAULT_POOL_BUDGET, providerKey } from '../../../constants.js';
+import { ACTIVE_PROVIDER_KEY, DEFAULT_TIME_LIMIT_S, providerKey } from '../../../constants.js';
 import { TermHeader, SectionLabel } from '../../../components/terminal/index.js';
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
@@ -53,8 +53,10 @@ function ActiveProviderBadge({ storage = localStorage }) {
 function readBudgetSeconds(storage = localStorage) {
   const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
   if (!provider) return 0;
-  const raw = storage.getItem(providerKey(provider, 'pool-budget'));
-  if (raw === null) return provider === 'ollama' ? 0 : DEFAULT_POOL_BUDGET;
+  // Read new key first; fall back to legacy 'pool-budget' for back-compat.
+  const raw = storage.getItem(providerKey(provider, 'time-limit'))
+    ?? storage.getItem(providerKey(provider, 'pool-budget'));
+  if (raw === null || raw === undefined) return provider === 'ollama' ? 0 : DEFAULT_TIME_LIMIT_S;
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import EvaluationStatus from './EvaluationStatus.jsx';
 import ReEvaluateCard from './ReEvaluateCard.jsx';
-import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
+import CountdownTimer from './CountdownTimer.jsx';
+import { ACTIVE_PROVIDER_KEY, DEFAULT_POOL_BUDGET, providerKey } from '../../../constants.js';
 import { TermHeader, SectionLabel } from '../../../components/terminal/index.js';
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
@@ -49,10 +50,22 @@ function ActiveProviderBadge({ storage = localStorage }) {
   );
 }
 
-function EvaluateHeader() {
+function readBudgetSeconds(storage = localStorage) {
+  const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
+  if (!provider) return 0;
+  const raw = storage.getItem(providerKey(provider, 'pool-budget'));
+  if (raw === null) return provider === 'ollama' ? 0 : DEFAULT_POOL_BUDGET;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function EvaluateHeader({ job }) {
   // Page title stays steady ("evaluate"); the live "in progress / failed /
   // done" state is carried by the JobHeader card title below to avoid
   // doubling the same status on screen.
+  const deadlineAt = job?.deadlineAt ?? null;
+  const phase = job?.phase ?? job?.status ?? null;
+  const budgetSeconds = readBudgetSeconds();
   return (
     <header className="evaluate-header evaluate-header--terminal">
       <div className="evaluate-header__left">
@@ -61,7 +74,10 @@ function EvaluateHeader() {
           sub="run a comprehensive code quality evaluation on any repository"
         />
       </div>
-      <ActiveProviderBadge />
+      <div className="evaluate-header__right">
+        <CountdownTimer deadlineAt={deadlineAt} budgetSeconds={budgetSeconds} phase={phase} />
+        <ActiveProviderBadge />
+      </div>
     </header>
   );
 }
@@ -127,7 +143,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
   return (
     <section className="evaluate-screen">
-      <EvaluateHeader />
+      <EvaluateHeader job={job} />
 
       <div className="evaluate-content">
         {!job && selectedProject && (

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -31,7 +31,7 @@ import {
   ACTIVE_PROVIDER_KEY,
   providerKey,
   DEFAULT_MAX_SUBAGENTS,
-  DEFAULT_POOL_BUDGET,
+  DEFAULT_TIME_LIMIT_S,
 } from "../../../constants.js";
 
 const SSE_ENABLED = import.meta.env?.VITE_USE_SSE_EVENTS === "true";
@@ -40,7 +40,7 @@ const DIM_POLL_MS = 2000;
 const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
-const DEFAULT_CLI_BUDGET = String(DEFAULT_POOL_BUDGET);
+const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)
@@ -56,13 +56,17 @@ function preparePayload(payload, storage = localStorage) {
   if (!model) throw new Error("No model selected. Go to Settings and select one.");
   const isOllama = activeProvider === "ollama";
   const subagents = parseInt(get("subagents") || (isOllama ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS), 10);
-  const poolBudget = parseInt(get("pool-budget") || (isOllama ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET), 10);
+  // Read new key first; fall back to legacy 'pool-budget' for back-compat.
+  const timeLimit = parseInt(
+    get("time-limit") || get("pool-budget") || (isOllama ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET),
+    10,
+  );
   const result = {
     ...payload,
     aiCmd: activeProvider,
     aiModel: model,
     maxSubagents: subagents,
-    poolBudget,
+    timeLimit,
   };
   if (get("per-dimension") === "true") result.perDimension = true;
   if (get("verify") === "false") result.verifyFindings = false;

--- a/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
@@ -10,8 +10,8 @@ export function TimeLimitSetting({ state, update }) {
   return (
     <div className="settings-row">
       <div className="settings-row-label">
-        <span className="settings-label">Analysis time limit</span>
-        <span className="settings-description">Max time per dimension. Unlimited runs until all files processed.</span>
+        <span className="settings-label">Total time limit</span>
+        <span className="settings-description">Stops the evaluation after this duration. Completed dimensions are scored. Any dimension still running is partial. Remaining dimensions are skipped.</span>
       </div>
       <div className="settings-budget-control">
         <div className="settings-pill-group">

--- a/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderSettings.jsx
@@ -1,11 +1,11 @@
-import { DEFAULT_POOL_BUDGET } from '../../../constants.js';
+import { DEFAULT_TIME_LIMIT_S } from '../../../constants.js';
 
 const SECONDS_PER_MINUTE = 60;
 const DEFAULT_TIME_LIMIT_MINUTES = '10';
 
 export function TimeLimitSetting({ state, update }) {
-  const poolBudget = parseInt(state['pool-budget'] || '0', 10);
-  const unlimited = poolBudget === 0;
+  const timeLimit = parseInt(state['time-limit'] || '0', 10);
+  const unlimited = timeLimit === 0;
 
   return (
     <div className="settings-row">
@@ -15,18 +15,18 @@ export function TimeLimitSetting({ state, update }) {
       </div>
       <div className="settings-budget-control">
         <div className="settings-pill-group">
-          <button type="button" className={`settings-pill${unlimited ? ' settings-pill--active' : ''}`} onClick={() => update('pool-budget', '0')} aria-pressed={unlimited}>Unlimited</button>
-          <button type="button" className={`settings-pill${!unlimited ? ' settings-pill--active' : ''}`} onClick={() => update('pool-budget', String(DEFAULT_POOL_BUDGET))} aria-pressed={!unlimited}>Limited</button>
+          <button type="button" className={`settings-pill${unlimited ? ' settings-pill--active' : ''}`} onClick={() => update('time-limit', '0')} aria-pressed={unlimited}>Unlimited</button>
+          <button type="button" className={`settings-pill${!unlimited ? ' settings-pill--active' : ''}`} onClick={() => update('time-limit', String(DEFAULT_TIME_LIMIT_S))} aria-pressed={!unlimited}>Limited</button>
         </div>
         <input
           type="number"
           className="settings-model-input"
           min={1}
           max={SECONDS_PER_MINUTE}
-          value={unlimited ? '' : Math.round(poolBudget / SECONDS_PER_MINUTE)}
+          value={unlimited ? '' : Math.round(timeLimit / SECONDS_PER_MINUTE)}
           placeholder={unlimited ? '\u221E' : 'min'}
           disabled={unlimited}
-          onChange={(e) => update('pool-budget', String(parseInt(e.target.value || DEFAULT_TIME_LIMIT_MINUTES, 10) * SECONDS_PER_MINUTE))}
+          onChange={(e) => update('time-limit', String(parseInt(e.target.value || DEFAULT_TIME_LIMIT_MINUTES, 10) * SECONDS_PER_MINUTE))}
         />
       </div>
     </div>

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
-import { ACTIVE_PROVIDER_KEY, DEFAULT_MAX_SUBAGENTS, DEFAULT_POOL_BUDGET } from '../../../constants.js';
+import { ACTIVE_PROVIDER_KEY, DEFAULT_MAX_SUBAGENTS, DEFAULT_TIME_LIMIT_S } from '../../../constants.js';
 import useProviderSettings from '../hooks/useProviderSettings.js';
 import { classifyProvider } from './providerUtils.js';
 import OllamaTab from './OllamaTab.jsx';
@@ -8,14 +8,16 @@ import CliProviderTab from './CliProviderTab.jsx';
 import CloudProviderTab from './CloudProviderTab.jsx';
 import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
 
-const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'pool-budget': String(DEFAULT_POOL_BUDGET) };
+const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit': String(DEFAULT_TIME_LIMIT_S) };
 const DEFAULT_PROVIDER_ORDER = 50;
 
 const MIGRATION_DONE_KEY = 'cc-provider-tabs-migrated';
 const LEGACY_AI_CMD_KEY = 'cc-ai-cmd';
 const LEGACY_SETTING_MIGRATIONS = {
   'cc-max-subagents': 'subagents',
-  'cc-pool-budget': 'pool-budget',
+  // Legacy global key — migrate to provider-scoped 'time-limit' suffix.
+  'cc-pool-budget': 'time-limit',
+  'cc-time-limit': 'time-limit',
   'cc-per-dimension': 'per-dimension',
   'cc-ai-model': 'model',
 };

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { providerKey } from '../../../constants.js';
 
-const SETTINGS = ['model', 'model-analysis', 'model-fast', 'model-balanced', 'model-thorough', 'subagents', 'pool-budget', 'per-dimension', 'verify'];
+const SETTINGS = ['model', 'model-analysis', 'model-fast', 'model-balanced', 'model-thorough', 'subagents', 'time-limit', 'per-dimension', 'verify'];
 const DEFAULTS = {
   'model': '',
   'model-analysis': '',
@@ -9,16 +9,31 @@ const DEFAULTS = {
   'model-balanced': '',
   'model-thorough': '',
   'subagents': '1',
-  'pool-budget': '0',
+  'time-limit': '0',
   'per-dimension': 'true',
   'verify': 'true',
 };
+
+// Legacy storage key fallback, only consulted when the new key has no value.
+const LEGACY_KEY_MAP = { 'time-limit': 'pool-budget' };
 
 function loadProviderState(providerId, overrides, storage = localStorage) {
   const merged = { ...DEFAULTS, ...overrides };
   const state = {};
   for (const key of SETTINGS) {
-    state[key] = storage.getItem(providerKey(providerId, key)) ?? merged[key];
+    let value = storage.getItem(providerKey(providerId, key));
+    if (value === null && LEGACY_KEY_MAP[key]) {
+      // Back-compat: read old key, migrate to new key, drop the old one.
+      const legacy = storage.getItem(providerKey(providerId, LEGACY_KEY_MAP[key]));
+      if (legacy !== null) {
+        value = legacy;
+        try {
+          storage.setItem(providerKey(providerId, key), legacy);
+          storage.removeItem(providerKey(providerId, LEGACY_KEY_MAP[key]));
+        } catch { /* storage write may fail in tests with restricted mocks */ }
+      }
+    }
+    state[key] = value ?? merged[key];
   }
   return state;
 }

--- a/src/quodeq/ui/src/models/job.js
+++ b/src/quodeq/ui/src/models/job.js
@@ -13,6 +13,7 @@
  * @property {string[]}      logs
  * @property {string|null}   startedAt
  * @property {string|null}   endedAt
+ * @property {string|null}   deadlineAt     - ISO-8601 wall-clock deadline for the run; null when unlimited or not yet set
  * @property {number|null}   exitCode
  * @property {string|null}   error
  * @property {'internal'|'external'} source  - 'internal' = launched from dashboard; 'external' = CLI/CI
@@ -38,6 +39,7 @@ export function createJob(raw) {
     logs:             raw.logs ?? [],
     startedAt:        raw.startedAt ?? null,
     endedAt:          raw.endedAt ?? null,
+    deadlineAt:       raw.deadlineAt ?? null,
     exitCode:         raw.exitCode ?? null,
     error:            raw.error ?? null,
     source:           raw.source ?? 'internal',

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2967,3 +2967,18 @@
 .scan-progress__budget--overrun { color: var(--color-sev-critical-text, #f85149); }
 .scan-progress__partial  { color: var(--color-warn, #d29922); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
 .scan-progress__dim-reason { color: var(--color-warn, #d29922); font-style: italic; }
+
+.eval-countdown {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.95rem;
+  color: var(--color-accent);
+  margin-right: 0.75rem;
+  letter-spacing: 0.04em;
+}
+.eval-countdown--idle {
+  color: var(--color-text-muted);
+}
+.eval-countdown--alert {
+  color: var(--color-danger);
+}

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -582,6 +582,11 @@
   min-width: 0;
   flex: 1;
 }
+.evaluate-header--terminal .evaluate-header__right {
+  display: flex;
+  align-items: center;
+  gap: var(--term-space-2);
+}
 .evaluate-header--terminal .term-header {
   margin: 0;
 }

--- a/tests/analysis/test_consolidated_coverage.py
+++ b/tests/analysis/test_consolidated_coverage.py
@@ -26,7 +26,7 @@ class _MockOptions:
     analysis_budget: str | None = None
     max_turns: int | None = None
     max_duration: int | None = None
-    pool_budget: int | None = None
+    time_limit: int | None = None
     max_subagents: int = 3
     deadline_at: float | None = None
 
@@ -80,18 +80,18 @@ class TestBuildConsolidatedConfig:
             ac = _build_consolidated_config(config, ["security"], 5)
         assert ac.ai_model == "opus-3"
 
-    def test_pool_budget_default(self):
-        config = _MockRunConfig(options=_MockOptions(pool_budget=None))
+    def test_time_limit_default(self):
+        config = _MockRunConfig(options=_MockOptions(time_limit=None))
         with patch("quodeq.analysis.subagents._consolidated._default_subagent_model", return_value=None):
             ac = _build_consolidated_config(config, ["security"], 5)
-        # Should use _DEFAULT_POOL_BUDGET
-        assert ac.pool_budget > 0
+        # Should use _DEFAULT_TIME_LIMIT
+        assert ac.time_limit > 0
 
-    def test_pool_budget_custom(self):
-        config = _MockRunConfig(options=_MockOptions(pool_budget=1200))
+    def test_time_limit_custom(self):
+        config = _MockRunConfig(options=_MockOptions(time_limit=1200))
         with patch("quodeq.analysis.subagents._consolidated._default_subagent_model", return_value=None):
             ac = _build_consolidated_config(config, ["security"], 5)
-        assert ac.pool_budget == 1200
+        assert ac.time_limit == 1200
 
     def test_includes_compiled_dir(self, tmp_path):
         config = _MockRunConfig()

--- a/tests/analysis/test_consolidated_coverage.py
+++ b/tests/analysis/test_consolidated_coverage.py
@@ -28,6 +28,7 @@ class _MockOptions:
     max_duration: int | None = None
     pool_budget: int | None = None
     max_subagents: int = 3
+    deadline_at: float | None = None
 
 
 @dataclass

--- a/tests/analysis/test_loops_deadline.py
+++ b/tests/analysis/test_loops_deadline.py
@@ -1,0 +1,74 @@
+"""Tests for run-level deadline enforcement in the dim loops."""
+import time
+from unittest.mock import MagicMock
+
+from quodeq.analysis._loops import run_per_dimension_loop
+
+
+def _mk_config(deadline_at):
+    config = MagicMock()
+    config.options.deadline_at = deadline_at
+    config.options.incremental_file_filter = None
+    # skip_scoring=True bypasses check_zero_findings, which would otherwise
+    # walk the MagicMock Evidence and raise EvaluationError.
+    config.options.skip_scoring = True
+    config.source_file_count = 10
+    return config
+
+
+def test_loop_skips_all_dims_when_deadline_already_past():
+    config = _mk_config(time.monotonic() - 1)
+    ctx = MagicMock(total=3)
+    process_fn = MagicMock(return_value=MagicMock())
+
+    result = run_per_dimension_loop(
+        config, ["a", "b", "c"], ctx,
+        process_fn=process_fn,
+    )
+
+    assert process_fn.call_count == 0
+    assert result == {}
+
+
+def test_loop_runs_first_dim_then_skips_remaining(monkeypatch):
+    deadline = time.monotonic() + 0.1
+    fake_now = [time.monotonic()]
+
+    monkeypatch.setattr(
+        "quodeq.analysis._loops.time.monotonic",
+        lambda: fake_now[0],
+    )
+
+    config = _mk_config(deadline)
+    ctx = MagicMock(total=3)
+
+    ev = MagicMock()
+    def fake_process(_cfg, _dim, _idx, _ctx):
+        # First dim runs, consumes the budget, then deadline passes
+        fake_now[0] = deadline + 0.01
+        return ev
+    process_fn = MagicMock(side_effect=fake_process)
+
+    result = run_per_dimension_loop(
+        config, ["a", "b", "c"], ctx,
+        process_fn=process_fn,
+    )
+
+    assert process_fn.call_count == 1
+    assert "a" in result
+    assert "b" not in result
+    assert "c" not in result
+
+
+def test_loop_runs_all_dims_when_no_deadline():
+    config = _mk_config(None)
+    ctx = MagicMock(total=2)
+    process_fn = MagicMock(return_value=MagicMock())
+
+    result = run_per_dimension_loop(
+        config, ["a", "b"], ctx,
+        process_fn=process_fn,
+    )
+
+    assert process_fn.call_count == 2
+    assert "a" in result and "b" in result

--- a/tests/analysis/test_loops_safety.py
+++ b/tests/analysis/test_loops_safety.py
@@ -47,6 +47,9 @@ def _config() -> MagicMock:
     cfg.source_file_count = 100
     cfg.options.incremental_file_filter = None
     cfg.options.skip_scoring = True
+    # Default: no run-level deadline (would otherwise be a MagicMock and
+    # break the numeric comparison in the loop's deadline guard).
+    cfg.options.deadline_at = None
     return cfg
 
 

--- a/tests/analysis/test_mini_verify.py
+++ b/tests/analysis/test_mini_verify.py
@@ -3,7 +3,7 @@ from unittest.mock import patch, MagicMock
 from quodeq.analysis.subagents._verification import _dispatch_mini_verify
 
 _TEST_MAX_SUBAGENTS = 10
-_TEST_POOL_BUDGET = 300
+_TEST_TIME_LIMIT = 300
 
 
 @patch("quodeq.analysis.subagents._verification._run_verification_pool")
@@ -14,7 +14,7 @@ def test_mini_verify_caps_agents(mock_pool, tmp_path):
     config.standards_dir = None
     config.options.max_subagents = _TEST_MAX_SUBAGENTS
     config.options.ai_model = None
-    config.options.pool_budget = _TEST_POOL_BUDGET
+    config.options.time_limit = _TEST_TIME_LIMIT
 
     findings = [
         {"file": f"f{i}.py", "p": "S", "t": "violation", "line": 1, "reason": "r"}

--- a/tests/analysis/test_pool_respawn_deadline.py
+++ b/tests/analysis/test_pool_respawn_deadline.py
@@ -1,0 +1,60 @@
+"""Tests for the run-deadline gate in should_respawn.
+
+Without the gate, a pool whose per-agent budget has been clamped to
+``max(1, deadline_at - now)`` would die in ~1s, get respawned, die again,
+and so on — pumping out 1-second agents indefinitely until the pool's
+local *max_duration* finally fired. The gate makes ``should_respawn``
+return 0 once the run-level deadline has passed, mirroring the existing
+behaviour for the pool-local time limit.
+"""
+import time
+from pathlib import Path
+
+from quodeq.analysis.subagents._pool_scaling import should_respawn
+from quodeq.analysis.subagents.file_queue import FileQueue
+
+
+def _queue(tmp_path: Path, files: int = 5) -> FileQueue:
+    return FileQueue(tmp_path / "queue.json", files=[f"f{i}.py" for i in range(files)])
+
+
+def test_respawn_blocked_when_run_deadline_passed(tmp_path):
+    queue = _queue(tmp_path, files=5)
+    # Pool itself still has budget left, but the run deadline is in the past.
+    assert should_respawn(
+        queue, queue._path,
+        pool_start=time.monotonic(),
+        max_duration=600,
+        deadline_at=time.monotonic() - 1,
+    ) == 0
+
+
+def test_respawn_allowed_before_run_deadline(tmp_path):
+    queue = _queue(tmp_path, files=5)
+    assert should_respawn(
+        queue, queue._path,
+        pool_start=time.monotonic(),
+        max_duration=600,
+        deadline_at=time.monotonic() + 60,
+    ) == 5
+
+
+def test_respawn_pool_limit_still_enforced_without_deadline(tmp_path):
+    queue = _queue(tmp_path, files=5)
+    # No run deadline — pool-local budget alone must still gate respawn.
+    assert should_respawn(
+        queue, queue._path,
+        pool_start=time.monotonic() - 700,
+        max_duration=600,
+        deadline_at=None,
+    ) == 0
+
+
+def test_respawn_unlimited_when_no_constraints(tmp_path):
+    queue = _queue(tmp_path, files=5)
+    assert should_respawn(
+        queue, queue._path,
+        pool_start=time.monotonic(),
+        max_duration=0,        # 0 = unlimited pool budget
+        deadline_at=None,
+    ) == 5

--- a/tests/analysis/test_pool_worker_clamp.py
+++ b/tests/analysis/test_pool_worker_clamp.py
@@ -1,0 +1,45 @@
+"""Tests for per-agent max_duration clamping to remaining run budget."""
+import time
+from pathlib import Path
+
+from quodeq.analysis._config import AnalysisConfig
+from quodeq.analysis.subagents._pool_worker import build_agent_config, WorkerContext
+
+
+def _wctx(tmp_path: Path) -> WorkerContext:
+    return WorkerContext(
+        dimension="reliability",
+        dimension_key="reliability",
+        evidence_dir=tmp_path,
+        queue_path=tmp_path / "queue.json",
+    )
+
+
+def test_agent_max_duration_clamped_to_remaining_budget(tmp_path):
+    now = time.monotonic()
+    base = AnalysisConfig(
+        jsonl_file=tmp_path / "x.jsonl",
+        ai_cmd="claude",
+        ai_model="claude-opus-4-7",
+        max_duration=600,         # 10 min per-agent baseline
+        pool_budget=600,          # 10 min total budget (legacy field, still used)
+        deadline_at=now + 90,     # only 90s left until deadline
+    )
+    ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))
+    # Agent must die at the deadline, not 10 minutes from now.
+    assert ac.max_duration is not None
+    assert ac.max_duration <= 90
+    assert ac.max_duration >= 80   # allow small slack for monotonic-clock jitter
+
+
+def test_agent_max_duration_unclamped_when_no_deadline(tmp_path):
+    base = AnalysisConfig(
+        jsonl_file=tmp_path / "x.jsonl",
+        ai_cmd="claude",
+        ai_model="claude-opus-4-7",
+        max_duration=600,
+        pool_budget=0,            # unlimited
+        deadline_at=None,
+    )
+    ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))
+    assert ac.max_duration == 600

--- a/tests/analysis/test_pool_worker_clamp.py
+++ b/tests/analysis/test_pool_worker_clamp.py
@@ -43,3 +43,15 @@ def test_agent_max_duration_unclamped_when_no_deadline(tmp_path):
     )
     ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))
     assert ac.max_duration == 600
+
+
+def test_agent_max_duration_floored_when_deadline_passed(tmp_path):
+    base = AnalysisConfig(
+        jsonl_file=tmp_path / "x.jsonl",
+        ai_cmd="claude",
+        ai_model="claude-opus-4-7",
+        max_duration=600,
+        deadline_at=time.monotonic() - 30,  # 30s in the past
+    )
+    ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))
+    assert ac.max_duration == 1

--- a/tests/analysis/test_pool_worker_clamp.py
+++ b/tests/analysis/test_pool_worker_clamp.py
@@ -22,7 +22,7 @@ def test_agent_max_duration_clamped_to_remaining_budget(tmp_path):
         ai_cmd="claude",
         ai_model="claude-opus-4-7",
         max_duration=600,         # 10 min per-agent baseline
-        pool_budget=600,          # 10 min total budget (legacy field, still used)
+        time_limit=600,           # 10 min total time limit (legacy clamp branch)
         deadline_at=now + 90,     # only 90s left until deadline
     )
     ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))
@@ -38,7 +38,7 @@ def test_agent_max_duration_unclamped_when_no_deadline(tmp_path):
         ai_cmd="claude",
         ai_model="claude-opus-4-7",
         max_duration=600,
-        pool_budget=0,            # unlimited
+        time_limit=0,             # unlimited
         deadline_at=None,
     )
     ac, _, _ = build_agent_config(0, base, _wctx(tmp_path))

--- a/tests/analysis/test_time_limit_autoscale.py
+++ b/tests/analysis/test_time_limit_autoscale.py
@@ -1,10 +1,10 @@
-"""Tests for the pool-budget auto-scaling helper.
+"""Tests for the time-limit auto-scaling helper.
 
-The fixed 600s default pool budget chokes on dim queues with hundreds of
+The fixed 600s default time limit chokes on dim queues with hundreds of
 files (observed throughput ≈ 7-12 s/file with 8 agents). When that
 happens, surviving pending files keep haunting the next run via the
 not_analyzed sweep and the dim never converges. The auto-scaler treats
-the user's ``pool_budget`` as a floor and extends it to give each file a
+the user's ``time_limit`` as a floor and extends it to give each file a
 fair slice of wallclock time, capped at a hard upper bound.
 """
 from __future__ import annotations
@@ -13,44 +13,44 @@ from quodeq.analysis.subagents._pool_launcher import (
     _MAX_AUTO_POOL_BUDGET,
     _SECONDS_PER_FILE_AUTOSCALE,
     _UNLIMITED_BUDGET,
-    _resolve_pool_budget,
+    _resolve_time_limit,
 )
-from quodeq.shared.constants import _DEFAULT_POOL_BUDGET
+from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 
 
-class TestResolvePoolBudget:
+class TestResolveTimeLimit:
     def test_small_queue_uses_user_budget_as_floor(self) -> None:
         # 30 files × 12 s/file = 360s, which is below the default 600s
         # floor → return the floor unchanged.
-        assert _resolve_pool_budget(None, 30) == _DEFAULT_POOL_BUDGET
+        assert _resolve_time_limit(None, 30) == _DEFAULT_TIME_LIMIT
 
     def test_large_queue_extends_budget(self) -> None:
         # 800 files × 12 s/file = 9600s, capped at 7200s (2h).
-        assert _resolve_pool_budget(None, 800) == _MAX_AUTO_POOL_BUDGET
+        assert _resolve_time_limit(None, 800) == _MAX_AUTO_POOL_BUDGET
 
     def test_medium_queue_scales_proportionally(self) -> None:
         # 200 files × 12 s/file = 2400s, above the 600s floor and below
         # the 7200s ceiling → return the proportional value.
-        assert _resolve_pool_budget(None, 200) == 200 * _SECONDS_PER_FILE_AUTOSCALE
+        assert _resolve_time_limit(None, 200) == 200 * _SECONDS_PER_FILE_AUTOSCALE
 
     def test_explicit_user_budget_is_floor_not_cap(self) -> None:
         # User wants at least 1800s; queue would only need 600s → keep 1800.
-        assert _resolve_pool_budget(1800, 30) == 1800
+        assert _resolve_time_limit(1800, 30) == 1800
         # User wants 1800s but queue needs 3600s → extend to 3600.
-        assert _resolve_pool_budget(1800, 300) == 300 * _SECONDS_PER_FILE_AUTOSCALE
+        assert _resolve_time_limit(1800, 300) == 300 * _SECONDS_PER_FILE_AUTOSCALE
 
     def test_unlimited_budget_is_preserved(self) -> None:
-        # pool_budget=0 means "no cap"; auto-scaling must not turn that
+        # time_limit=0 means "no cap"; auto-scaling must not turn that
         # into a finite number, otherwise we'd silently cap users who
         # asked for unlimited.
-        assert _resolve_pool_budget(_UNLIMITED_BUDGET, 30) == _UNLIMITED_BUDGET
-        assert _resolve_pool_budget(_UNLIMITED_BUDGET, 10000) == _UNLIMITED_BUDGET
+        assert _resolve_time_limit(_UNLIMITED_BUDGET, 30) == _UNLIMITED_BUDGET
+        assert _resolve_time_limit(_UNLIMITED_BUDGET, 10000) == _UNLIMITED_BUDGET
 
     def test_zero_or_negative_queue_returns_base(self) -> None:
         # Defensive: an empty file list shouldn't produce a 0-second budget.
-        assert _resolve_pool_budget(None, 0) == _DEFAULT_POOL_BUDGET
-        assert _resolve_pool_budget(900, 0) == 900
+        assert _resolve_time_limit(None, 0) == _DEFAULT_TIME_LIMIT
+        assert _resolve_time_limit(900, 0) == 900
 
     def test_runaway_queue_capped_at_max(self) -> None:
-        assert _resolve_pool_budget(None, 100_000) == _MAX_AUTO_POOL_BUDGET
-        assert _resolve_pool_budget(900, 100_000) == _MAX_AUTO_POOL_BUDGET
+        assert _resolve_time_limit(None, 100_000) == _MAX_AUTO_POOL_BUDGET
+        assert _resolve_time_limit(900, 100_000) == _MAX_AUTO_POOL_BUDGET

--- a/tests/analysis/test_verification_coverage.py
+++ b/tests/analysis/test_verification_coverage.py
@@ -113,13 +113,13 @@ class TestDispatchMiniVerify:
         mock_pool.return_value = [{"ok": True}]
         evidence_dir = tmp_path / "evidence"
         evidence_dir.mkdir()
-        opts = AnalysisOptions(max_subagents=10, pool_budget=9999)
+        opts = AnalysisOptions(max_subagents=10, time_limit=9999)
         config = RunConfig(src=tmp_path, language="python", options=opts)
         result = _dispatch_mini_verify(config, "security", evidence_dir, [{"file": "a.py"}])
         assert result == [{"ok": True}]
         actual_config = mock_pool.call_args[0][0]
         assert actual_config.options.max_subagents <= _MINI_VERIFY_MAX_AGENTS
-        assert actual_config.options.pool_budget <= _MINI_VERIFY_MAX_TIMEOUT
+        assert actual_config.options.time_limit <= _MINI_VERIFY_MAX_TIMEOUT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_run_event_stream_deadline.py
+++ b/tests/api/test_run_event_stream_deadline.py
@@ -1,0 +1,12 @@
+"""Smoke test that deadline_at is included in the SSE status payload."""
+from quodeq.api._run_event_stream import serialize_status_event
+
+
+def test_status_event_includes_deadline_at() -> None:
+    payload = serialize_status_event({
+        "state": "running",
+        "phase": "analyzing",
+        "deadline_at": "2026-05-02T11:00:00+00:00",
+    })
+    assert "deadline_at" in payload
+    assert "2026-05-02T11:00:00+00:00" in payload

--- a/tests/engine/test_incremental_fingerprint.py
+++ b/tests/engine/test_incremental_fingerprint.py
@@ -97,7 +97,7 @@ class TestBackfillSkipsVerification:
     def test_verify_findings_disabled_during_backfill(self, mock_process, tmp_path):
         """Backfill disables verify_findings before calling _process_single_dimension."""
         config = MagicMock()
-        config.options.pool_budget = 600
+        config.options.time_limit = 600
         config.options.verify_findings = True
         config.options.incremental_file_filter = None
 
@@ -131,7 +131,7 @@ class TestBackfillSkipsVerification:
     def test_verify_findings_restored_on_error(self, mock_process, tmp_path):
         """verify_findings is restored even if _process_single_dimension raises."""
         config = MagicMock()
-        config.options.pool_budget = 600
+        config.options.time_limit = 600
         config.options.verify_findings = True
         config.options.incremental_file_filter = None
 

--- a/tests/engine/test_prioritization_integration.py
+++ b/tests/engine/test_prioritization_integration.py
@@ -36,20 +36,20 @@ class TestPrioritizationInFileQueue:
         assert taken[0] == "src/auth.py"
 
 
-class TestPoolBudgetFlow:
-    def test_pool_budget_from_analysis_options(self, tmp_path):
-        """Verify pool_budget on AnalysisConfig is used by SubagentPool."""
+class TestTimeLimitFlow:
+    def test_time_limit_from_analysis_options(self, tmp_path):
+        """Verify time_limit on AnalysisConfig is used by SubagentPool."""
         queue_path = tmp_path / "queue.json"
         FileQueue(queue_path, ["f.py"])
 
-        ac = AnalysisConfig(pool_budget=120, max_duration=1800, max_files_per_agent=50)
+        ac = AnalysisConfig(time_limit=120, max_duration=1800, max_files_per_agent=50)
         pool = SubagentPool(
             paths=PoolPaths(work_dir=tmp_path, evidence_dir=tmp_path, queue_path=queue_path),
             options=PoolOptions(n_agents=1, prompt="test", dimension="security"),
             config=ac,
         )
 
-        # Pool budget should be 120 (custom), not 600 (default)
-        assert pool._base_config.pool_budget == 120
-        # Per-agent duration should still be 1800, not affected by pool_budget
+        # Time limit should be 120 (custom), not 600 (default)
+        assert pool._base_config.time_limit == 120
+        # Per-agent duration should still be 1800, not affected by time_limit
         assert pool._base_config.max_duration == 1800

--- a/tests/engine/test_subagent_pool_advanced.py
+++ b/tests/engine/test_subagent_pool_advanced.py
@@ -136,17 +136,17 @@ class TestScoutThenScale:
         assert len(agent_ids) >= 3
 
 
-class TestPoolBudget:
-    def test_pool_uses_pool_budget_not_max_duration(self, tmp_path):
-        """Pool time limit should use pool_budget, not max_duration."""
+class TestTimeLimit:
+    def test_pool_uses_time_limit_not_max_duration(self, tmp_path):
+        """Pool time limit should use time_limit, not max_duration."""
         queue_path = tmp_path / "queue.json"
         FileQueue(queue_path, [f"f{i}.py" for i in range(5)])
 
-        ac = AnalysisConfig(pool_budget=60, max_duration=1800, max_files_per_agent=30)
+        ac = AnalysisConfig(time_limit=60, max_duration=1800, max_files_per_agent=30)
         pool = SubagentPool(
             paths=PoolPaths(work_dir=tmp_path, evidence_dir=tmp_path, queue_path=queue_path),
             options=PoolOptions(n_agents=1, prompt="test", dimension=_TEST_DIMENSION),
             config=ac,
         )
-        assert pool._base_config.pool_budget == 60
+        assert pool._base_config.time_limit == 60
         assert pool._base_config.max_duration == 1800

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
 from quodeq.core.types import JobSnapshot
-from quodeq.services.base import EvaluationOptions, _DEFAULT_MAX_SUBAGENTS, _DEFAULT_POOL_BUDGET
+from quodeq.services.base import EvaluationOptions, _DEFAULT_MAX_SUBAGENTS, _DEFAULT_TIME_LIMIT
 from quodeq.services.evaluation_mixin import (
     FsEvaluationMixin,
     SubprocessDispatcher,
@@ -126,17 +126,17 @@ class TestBuildEvalEnv:
         env = m._build_eval_env("/repo", opts, env={})
         assert "QUODEQ_NO_VERIFY" not in env
 
-    def test_custom_pool_budget(self):
+    def test_custom_time_limit(self):
         m = self._mixin()
-        opts = EvaluationOptions(pool_budget=1200)
+        opts = EvaluationOptions(time_limit=1200)
         env = m._build_eval_env("/repo", opts, env={})
-        assert env["QUODEQ_POOL_BUDGET"] == "1200"
+        assert env["QUODEQ_TIME_LIMIT"] == "1200"
 
-    def test_default_pool_budget_not_set(self):
+    def test_default_time_limit_not_set(self):
         m = self._mixin()
-        opts = EvaluationOptions(pool_budget=_DEFAULT_POOL_BUDGET)
+        opts = EvaluationOptions(time_limit=_DEFAULT_TIME_LIMIT)
         env = m._build_eval_env("/repo", opts, env={})
-        assert "QUODEQ_POOL_BUDGET" not in env
+        assert "QUODEQ_TIME_LIMIT" not in env
 
     def test_per_dimension(self):
         m = self._mixin()

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -205,7 +205,7 @@ class TestSerialization:
         expected_keys = {
             "job_id", "status", "command", "started_at", "ended_at",
             "exit_code", "logs", "output_project", "output_run_id",
-            "phase", "current_dimension", "dimensions",
+            "phase", "deadline_at", "current_dimension", "dimensions",
         }
         assert set(data.keys()) == expected_keys
 

--- a/tests/services/test_jobs_deadline_marker.py
+++ b/tests/services/test_jobs_deadline_marker.py
@@ -1,0 +1,43 @@
+"""Tests for analyzing_start marker propagating deadline_at to the Job."""
+import json
+from datetime import datetime, timezone, timedelta
+
+from quodeq.services.jobs import JobManager
+from quodeq.services._job_model import Job
+
+
+def _job():
+    return Job(
+        job_id="j1",
+        status="running",
+        command=["quodeq"],
+        started_at=datetime.now(timezone.utc).isoformat(),
+        ended_at=None,
+        exit_code=None,
+    )
+
+
+def test_analyzing_start_marker_records_deadline_on_job():
+    job = _job()
+    deadline_iso = (datetime.now(timezone.utc) + timedelta(seconds=600)).isoformat()
+    line = json.dumps({"_cc": "analyzing_start", "deadline_at": deadline_iso, "budget_s": 600})
+
+    JobManager._apply_marker(job, line)
+
+    assert job.deadline_at == deadline_iso
+
+
+def test_analyzing_start_marker_with_no_deadline_keeps_none():
+    job = _job()
+    line = json.dumps({"_cc": "analyzing_start", "deadline_at": None, "budget_s": 0})
+
+    JobManager._apply_marker(job, line)
+
+    assert job.deadline_at is None
+
+
+def test_to_dict_includes_deadline_at():
+    job = _job()
+    job.deadline_at = "2026-05-02T10:00:00+00:00"
+    snapshot = job.to_dict()
+    assert snapshot.deadline_at == "2026-05-02T10:00:00+00:00"

--- a/tests/shared/test_run_lifecycle_deadline.py
+++ b/tests/shared/test_run_lifecycle_deadline.py
@@ -1,0 +1,29 @@
+"""Tests for set_deadline propagating into status.json via the lifecycle."""
+from pathlib import Path
+
+from quodeq.shared.run_lifecycle import RunLifecycleContext
+from quodeq.shared.run_status import read_status
+
+
+def test_set_deadline_writes_to_status_json(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path,
+        job_id="j1",
+        dimensions=["a"],
+    ) as lifecycle:
+        lifecycle.set_deadline("2026-05-02T11:00:00+00:00")
+        data = read_status(tmp_path)
+        assert data is not None
+        assert data["deadline_at"] == "2026-05-02T11:00:00+00:00"
+
+
+def test_no_deadline_set_writes_none(tmp_path: Path) -> None:
+    with RunLifecycleContext(
+        run_dir=tmp_path,
+        job_id="j1",
+        dimensions=["a"],
+    ) as lifecycle:
+        lifecycle.set_phase("analyzing")
+        data = read_status(tmp_path)
+        assert data is not None
+        assert data.get("deadline_at") is None

--- a/tests/shared/test_run_status.py
+++ b/tests/shared/test_run_status.py
@@ -23,7 +23,7 @@ def test_write_and_read_round_trip(tmp_path: Path) -> None:
     assert status["state"] == "pending"
     assert status["job_id"] == "ext-r"
     assert status["dimensions"] == ["security"]
-    assert status["schema_version"] == 1
+    assert status["schema_version"] == 2
 
 
 def test_atomic_write_uses_tmp_then_rename(tmp_path: Path, monkeypatch) -> None:

--- a/tests/shared/test_run_status_deadline.py
+++ b/tests/shared/test_run_status_deadline.py
@@ -1,0 +1,28 @@
+"""Tests for deadline_at in status.json writes."""
+from pathlib import Path
+
+from quodeq.shared.run_status import RunState, read_status, write_status
+
+
+def _common(run_dir: Path):
+    return dict(
+        run_dir=run_dir,
+        state=RunState.RUNNING,
+        job_id="j1",
+        started_at="2026-05-02T10:00:00+00:00",
+        dimensions=["a", "b"],
+    )
+
+
+def test_write_status_records_deadline(tmp_path: Path) -> None:
+    write_status(**_common(tmp_path), deadline_at="2026-05-02T10:10:00+00:00")
+    data = read_status(tmp_path)
+    assert data is not None
+    assert data["deadline_at"] == "2026-05-02T10:10:00+00:00"
+
+
+def test_write_status_deadline_default_none(tmp_path: Path) -> None:
+    write_status(**_common(tmp_path))
+    data = read_status(tmp_path)
+    assert data is not None
+    assert data.get("deadline_at") is None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -179,7 +179,7 @@ class TestBuildRunConfig:
         assert config.options.dimensions == ["security", "reliability"]
         assert config.options.max_turns == 10
         assert config.options.max_duration == 300
-        assert config.options.pool_budget == 120
+        assert config.options.time_limit == 120
         assert config.options.incremental is True
         assert config.options.verify_findings is False
         assert config.standards_dir is None
@@ -236,7 +236,8 @@ class TestBuildRunConfig:
         config = _build_run_config(args, inputs=inputs, evidence_dir=tmp_path, env=env)
         assert config.options.max_turns == 50
         assert config.options.max_duration == 900
-        assert config.options.pool_budget == 300
+        # Legacy QUODEQ_POOL_BUDGET still routes into time_limit via the env-var fallback.
+        assert config.options.time_limit == 300
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace per-dimension time budget with a single **total** wall-clock cap on the evaluation, fix the underlying enforcement leak that let runs overshoot their configured budget, and add a live countdown timer in the evaluate header.

## What changed

### Bug fix (load-bearing)
The pool's per-agent `max_duration` now clamps to the run's remaining budget. Previously each respawned agent got a fresh full-length cap, so an agent spawned at T=8min into a 10-min budget ran until T=18min. Confirmed for both cloud and Ollama. With the clamp, the last in-flight agent dies on or before the deadline.

### Semantics
- `time-limit` is now a **total** budget for the whole evaluation, not per-dimension.
- Defaults preserved per provider: 10 min for cloud/CLI, unlimited for Ollama.
- Enforcement is a spawn-gate plus the per-agent remaining-budget clamp; in-flight agents finish naturally when the deadline hits, completed dims are scored, the running dim is partial-success, remaining dims are skipped.

### CLI / API
- New flag: \`--time-limit\` (with \`--pool-budget\` kept as deprecated alias + warning).
- New env var: \`QUODEQ_TIME_LIMIT\` (with \`QUODEQ_POOL_BUDGET\` kept as deprecated alias + warning).
- Status payload and SSE stream gain a \`deadline_at\` ISO timestamp set when analysis transitions out of preparing.
- API JSON accepts both \`timeLimit\` (new) and \`poolBudget\` (legacy) on inbound.

### UI
- Settings label renamed to "Total time limit" with new copy describing the total-budget semantics.
- New \`CountdownTimer\` component in the evaluate header: greyed \`M:SS\` during preparing, normal teal countdown during analysis, red in the last 30s, frozen at \`0:00\` after deadline. Hidden entirely when budget is unlimited.
- \`cc-pool-budget\` localStorage key migrates to \`cc-time-limit\` (read-both fallback for existing users).

### Internal rename
\`pool_budget\` → \`time_limit\` across Python and JS, with backwards-compat reads at process boundaries (env, JSON, localStorage).

## Follow-up fixes (after manual run)

Three issues surfaced during a real evaluation against a 1k+ file repo. Fixed in the last three commits:

- **Countdown stayed static at the budget value.** \`createJob()\` in \`src/quodeq/ui/src/models/job.js\` only copied fields in its explicit allowlist, so \`deadlineAt\` was stripped before reaching the cache. \`CountdownTimer\` fell into the \`!deadlineAt\` branch and never started its \`setInterval\`. Added \`deadlineAt\` to the allowlist.
- **Empty-state console placeholder rendered \`Waiting for output…\` literally.** The escape was sitting in JSX text, which isn't a JS string literal. Replaced with the U+2026 character.
- **Pool kept respawning agents past the run deadline.** The per-agent \`max_duration\` clamp correctly cut new agents to \`max(1, deadline - now)\`, but \`should_respawn()\` only knew about the pool-local time limit. Result: an endless stream of 1-second agents (\`5 active (50 total)\` and growing) until the pool's local budget finally fired. Threaded \`deadline_at\` through \`LoopContext\` / \`ScaleUpContext\` and gated respawn on it (plus the scout-mode scale-up). New regression test in \`tests/analysis/test_pool_respawn_deadline.py\`.

## Spec & plan

- Design: \`docs/superpowers/specs/2026-05-02-total-time-limit-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-02-total-time-limit.md\`

## Test plan

- [x] Backend: \`uv run pytest tests/ -q\` → 2580 passed (+ 4 new respawn-deadline tests)
- [x] UI: \`cd src/quodeq/ui && npm run test:ui\` → 200 passed
- [x] CLI smoke: \`quodeq evaluate --time-limit 600 --help\` shows the new flag with deprecation note on the alias
- [x] Env-var smoke: \`QUODEQ_POOL_BUDGET=42 quodeq evaluate ...\` emits the deprecation warning to stderr and resolves to 42
- [x] Manual run: 2-min budget against a 1k+ file repo. Countdown ticks down in the header, header phase stays sensible during wrap-up, pool stops respawning at deadline, run ends within ~one heartbeat after \`0:00\`.