### PR TITLE
feat(ui): empty states for Overview, Map, Violations, History tabs

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -35,6 +35,7 @@ import { OllamaLogProvider } from './features/settings/ollama-log/OllamaLogProvi
 // fresh-install user can land on Projects and add their first one without
 // hitting the "no analyzed projects yet" wall.
 const NO_PROJECT_TABS = ['projects', 'evaluate', 'standards', 'settings', 'help'];
+const SELF_HANDLED_EMPTY = new Set(['overview', 'map', 'violations', 'history']);
 
 /**
  * Returns whether the app is currently rendering dark, taking the saved
@@ -179,7 +180,16 @@ function ViolationsRoute({ params, props }) {
 
   return (
     <ViolationsPage
-      data={{ accumulated: acc, accumulatedDimensions: dims, selectedProject: props.navigation.selectedProject }}
+      data={{
+        accumulated: acc,
+        accumulatedDimensions: dims,
+        selectedProject: props.navigation.selectedProject,
+        projects: props.navigation.projects,
+        projectsLoaded: props.navigation.projectsLoaded,
+        projectName: props.dashboardData.selectedDisplayName,
+        loading: props.dashboardData.loading,
+        isFetching: props.dashboardData.isFetching,
+      }}
       callbacks={{
         onDimensionClick: (dim) => nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject, sourceTab: 'violations' }),
         onFileClick: (fileObj) => nav('file', { file: fileObj, sourceTab: 'violations' }),
@@ -192,6 +202,7 @@ function ViolationsRoute({ params, props }) {
         },
         onPrincipleClick: (principleObj) => navigateToPrinciple(principleObj),
         onRefresh: props.refreshDashboard,
+        onNavigate: nav,
       }}
       isDirectNav={props.navigation.navStackLength === 1}
       tabKey={params._tabKey || 0}
@@ -205,7 +216,21 @@ const ROUTE_RENDERERS = {
   map: (params, props) => {
     const acc = props.dashboardData.latestAccumulated || props.dashboardData.accumulated;
     const isDirectNav = props.navigation.navStackLength === 1;
-    return <MapPage data={{ accumulated: acc, dashboard: props.dashboardData.dashboard, projectName: props.dashboardData.selectedDisplayName }} callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard }} isDirectNav={isDirectNav} tabKey={params._tabKey || 0} />;
+    return <MapPage
+      data={{
+        accumulated: acc,
+        dashboard: props.dashboardData.dashboard,
+        projectName: props.dashboardData.selectedDisplayName,
+        projects: props.navigation.projects,
+        projectsLoaded: props.navigation.projectsLoaded,
+        selectedProject: props.navigation.selectedProject,
+        loading: props.dashboardData.loading,
+        isFetching: props.dashboardData.isFetching,
+      }}
+      callbacks={{ onNavigate: props.navigation.handleNavigate, onRefresh: props.refreshDashboard }}
+      isDirectNav={isDirectNav}
+      tabKey={params._tabKey || 0}
+    />;
   },
   run: (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
   history: (params, props) => {
@@ -231,6 +256,11 @@ const ROUTE_RENDERERS = {
           onRunChange: props.navigation.setHistorySelectedRun,
           onRunDeleted: () => props.refreshDashboard?.(),
         }}
+        projects={props.navigation.projects}
+        projectsLoaded={props.navigation.projectsLoaded}
+        selectedProject={props.navigation.selectedProject}
+        loading={props.dashboardData.loading}
+        isFetching={props.dashboardData.isFetching}
         projectInfo={props.navigation.projects?.find((p) => (p.id || p.name) === props.navigation.selectedProject) || null}
       />
     );
@@ -275,7 +305,7 @@ const ROUTE_RENDERERS = {
  */
 function MainContent({ activePage, props }) {
   const { page, ...params } = activePage;
-  if (!NO_PROJECT_TABS.includes(page)) {
+  if (!NO_PROJECT_TABS.includes(page) && !SELF_HANDLED_EMPTY.has(page)) {
     const projects = props.navigation?.projects;
     if (!projects || projects.length === 0) {
       if (!props.navigation?.projectsLoaded) return <LoadingScreen />;
@@ -361,12 +391,14 @@ export default function App() {
   const contentProps = {
     dashboardData: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
+      projectsLoaded: state.projectsLoaded,
       dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
       availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
       selectedDisplayName: state.selectedDisplayName,
     },
     navigation: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,
+      projectsLoaded: state.projectsLoaded,
       handleNavigate: state.handleNavigate, handleRunSelect: state.handleRunSelect,
       handleProjectChange: state.handleProjectChange, navTab, navStackLength: navStack.length,
       handleDeleteProject: state.handleDeleteProject, handleExportProject: state.handleExportProject, handleRelocateProject: state.handleRelocateProject,

--- a/src/quodeq/ui/src/components/EmptyState.jsx
+++ b/src/quodeq/ui/src/components/EmptyState.jsx
@@ -1,0 +1,14 @@
+export default function EmptyState({ title, description, actionLabel, onAction, icon }) {
+  return (
+    <section className="empty-state">
+      {icon && <div className="empty-state__icon" aria-hidden="true">{icon}</div>}
+      <h2>{title}</h2>
+      {description && <p>{description}</p>}
+      {actionLabel && onAction && (
+        <button type="button" className="empty-state-btn" onClick={onAction}>
+          {actionLabel}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/components/EmptyState.test.jsx
+++ b/src/quodeq/ui/src/components/EmptyState.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import EmptyState from './EmptyState.jsx';
+
+describe('EmptyState', () => {
+  it('renders the title as h2', () => {
+    render(<EmptyState title="No projects yet" />);
+    expect(screen.getByRole('heading', { level: 2, name: 'No projects yet' })).toBeInTheDocument();
+  });
+
+  it('renders the description when provided', () => {
+    render(<EmptyState title="t" description="Run an evaluation to begin." />);
+    expect(screen.getByText('Run an evaluation to begin.')).toBeInTheDocument();
+  });
+
+  it('omits the description when not provided', () => {
+    const { container } = render(<EmptyState title="t" />);
+    expect(container.querySelector('.empty-state p')).toBeNull();
+  });
+
+  it('renders the CTA button when both actionLabel and onAction are provided', () => {
+    render(<EmptyState title="t" actionLabel="Start" onAction={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
+  });
+
+  it('does not render the CTA button when actionLabel is missing', () => {
+    render(<EmptyState title="t" onAction={() => {}} />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('does not render the CTA button when onAction is missing', () => {
+    render(<EmptyState title="t" actionLabel="Start" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('calls onAction when the CTA is clicked', () => {
+    const onAction = vi.fn();
+    render(<EmptyState title="t" actionLabel="Start" onAction={onAction} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an icon when provided', () => {
+    const { container } = render(
+      <EmptyState title="t" icon={<svg data-testid="icon" />} />
+    );
+    expect(container.querySelector('.empty-state__icon')).not.toBeNull();
+  });
+
+  it('does not render the icon container when icon is omitted', () => {
+    const { container } = render(<EmptyState title="t" />);
+    expect(container.querySelector('.empty-state__icon')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -3,6 +3,7 @@ import DimensionCard from './DimensionCard.jsx';
 import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import EmptyState from '../../../components/EmptyState.jsx';
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
   const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo } = data;
@@ -88,9 +89,38 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const focusedDimensionData = useMemo(() => focusedDimension ? (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null : null, [focusedDimension, dashboard]);
   const handlers = useDashboardHandlers(onNavigate, dashboard);
 
-  if (!projects || projects.length === 0) {
-    if (loading) return <LoadingScreen />;
-    return <section className="empty-state"><h2>No analyzed projects yet</h2><p>Run an evaluation to get started.</p></section>;
+  const { projectsLoaded } = data;
+  if (!projectsLoaded) return <LoadingScreen />;
+  if (projects.length === 0) {
+    return (
+      <EmptyState
+        title="No projects yet"
+        description="Run your first evaluation to start analyzing code quality."
+        actionLabel="Start evaluating"
+        onAction={() => onNavigate?.('evaluate')}
+      />
+    );
+  }
+  if (!selectedProject) {
+    return (
+      <EmptyState
+        title="No project selected"
+        description="Pick a project to view its overview."
+        actionLabel="Choose project"
+        onAction={() => onNavigate?.('projects')}
+      />
+    );
+  }
+  if (!loading && !dashboard) {
+    const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
+    return (
+      <EmptyState
+        title="No evaluations yet"
+        description={`Run an evaluation for ${projectName} to populate this page.`}
+        actionLabel="Start evaluation"
+        onAction={() => onNavigate?.('evaluate')}
+      />
+    );
   }
 
   const isLoading = loading && !dashboard;

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -111,7 +111,7 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       />
     );
   }
-  if (!loading && !dashboard) {
+  if (!loading && !isFetching && !dashboard) {
     const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
     return (
       <EmptyState

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -9,6 +9,8 @@ import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js';
 import { TermHeader } from '../../../components/terminal/index.js';
+import EmptyState from '../../../components/EmptyState.jsx';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import FittedText from '../../../components/FittedText.jsx';
 
 const TOAST_DISMISS_MS = 2600;
@@ -75,13 +77,11 @@ function DeltaText({ delta }) {
   return <span className={cls}>{sign}{trimTrailingZero(abs)}</span>;
 }
 
-function HistoryEmpty() {
+function HistoryEmptyShell({ sub, children }) {
   return (
     <div className="history-page history-page--terminal">
-      <TermHeader name="history" sub="no evaluations yet" />
-      <div className="empty-state">
-        <p>No evaluations yet. Run one from the Evaluate tab.</p>
-      </div>
+      <TermHeader name="history" sub={sub} />
+      {children}
     </div>
   );
 }
@@ -320,7 +320,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
   );
 }
 
-export default function HistoryPage({ trend: rawTrend, selection, availableRuns, dimensions, callbacks, projectInfo }) {
+export default function HistoryPage({ trend: rawTrend, selection, availableRuns, dimensions, callbacks, projectInfo, projects = [], projectsLoaded, selectedProject, loading, isFetching }) {
   const { selectedRunId } = selection;
   const { onRunClick, onDimensionClick, onNavigate, onRunChange, onRunDeleted } = callbacks;
   const { deleteEvaluation } = useApi();
@@ -373,7 +373,45 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
     return sorted.map(([lang, count]) => `${count} ${lang.toLowerCase()}`).join('  ');
   }, [projectInfo]);
 
-  if (!trend || trend.length === 0) return <HistoryEmpty />;
+  if (!projectsLoaded) return <LoadingScreen />;
+  if (projects.length === 0) {
+    return (
+      <HistoryEmptyShell sub="no projects yet">
+        <EmptyState
+          title="No projects yet"
+          description="Run your first evaluation to start analyzing code quality."
+          actionLabel="Start evaluating"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </HistoryEmptyShell>
+    );
+  }
+  if (!selectedProject) {
+    return (
+      <HistoryEmptyShell sub="no project selected">
+        <EmptyState
+          title="No project selected"
+          description="Pick a project to view its history."
+          actionLabel="Choose project"
+          onAction={() => onNavigate?.('projects')}
+        />
+      </HistoryEmptyShell>
+    );
+  }
+  if (!trend || trend.length === 0) {
+    if (loading || isFetching) return <LoadingScreen />;
+    const projectName = projectInfo?.displayName || projectInfo?.name || selectedProject;
+    return (
+      <HistoryEmptyShell sub="no evaluations yet">
+        <EmptyState
+          title="No evaluations yet"
+          description={`Run an evaluation for ${projectName} to populate this page.`}
+          actionLabel="Start evaluation"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </HistoryEmptyShell>
+    );
+  }
 
   return (
     <HistoryContent

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -6,6 +6,8 @@ import {
 import { complianceRatio } from '../../../utils/formatters.js';
 import useMapPageState from './useMapPageState.js';
 import { TermHeader } from '../../../components/terminal/index.js';
+import EmptyState from '../../../components/EmptyState.jsx';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 
 function getAppThemeInfo() {
   const attr = document.documentElement.getAttribute('data-theme') || '';
@@ -157,15 +159,61 @@ function MapVizContainer({ vizState, treeState, dimensions, callbacks, display }
   );
 }
 
+function MapEmpty({ sub, children }) {
+  return (
+    <div className="map-page map-page--terminal">
+      <TermHeader name="map" sub={sub} />
+      {children}
+    </div>
+  );
+}
+
 export default function MapPage(props) {
+  const { data = {}, callbacks = {} } = props;
+  const { projects = [], projectsLoaded, selectedProject, projectName, loading, isFetching } = data;
+  const { onNavigate } = callbacks;
+
+  // Call the hook unconditionally to keep hook order stable across renders.
+  // The hook tolerates missing data — `state.allDimensions` is `[]` when there
+  // is no project or no run data, which is exactly what we use for case C.
   const state = useMapPageState(props);
 
-  if (state.allDimensions.length === 0) {
+  if (!projectsLoaded) return <LoadingScreen />;
+  if (projects.length === 0) {
     return (
-      <div className="map-page map-page--terminal">
-        <TermHeader name="map" sub="no evaluation data · run an evaluation to populate" />
-        <div className="empty-state"><p>No evaluation data yet. Run an evaluation from the Evaluate tab.</p></div>
-      </div>
+      <MapEmpty sub="no projects yet">
+        <EmptyState
+          title="No projects yet"
+          description="Run your first evaluation to start analyzing code quality."
+          actionLabel="Start evaluating"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </MapEmpty>
+    );
+  }
+  if (!selectedProject) {
+    return (
+      <MapEmpty sub="no project selected">
+        <EmptyState
+          title="No project selected"
+          description="Pick a project to view its map."
+          actionLabel="Choose project"
+          onAction={() => onNavigate?.('projects')}
+        />
+      </MapEmpty>
+    );
+  }
+  if (state.allDimensions.length === 0) {
+    if (loading || isFetching) return <LoadingScreen />;
+    return (
+      <MapEmpty sub="no evaluations yet">
+        <EmptyState
+          title="No evaluations yet"
+          description={`Run an evaluation for ${projectName || selectedProject} to populate this page.`}
+          actionLabel="Start evaluation"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </MapEmpty>
     );
   }
 

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -6,6 +6,8 @@ import DimensionHeatGridView from './DimensionHeatGridView.jsx';
 import DismissedSubTab from './DismissedSubTab.jsx';
 import { TermHeader, SevBadge, FlagPill } from '../../../components/terminal/index.js';
 import { useDismissedFindings } from './useDismissedFindings.js';
+import EmptyState from '../../../components/EmptyState.jsx';
+import LoadingScreen from '../../../components/LoadingScreen.jsx';
 
 const MAX_TREE_DEPTH = 64;
 
@@ -176,6 +178,8 @@ function ViolationsSubTabContent(props) {
 
 export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
   const { accumulatedDimensions, selectedProject } = data;
+  const { projects = [], projectsLoaded, projectName, loading, isFetching } = data;
+  const { onNavigate } = callbacks;
   const { onRefresh } = callbacks;
 
   // Fresh tab click (tabKey changed) drops the cached navigation state so
@@ -210,6 +214,49 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     initialSubTab: cached.activeSubTab,
     initialFilePath: cached.fileCurrentPath,
   });
+
+  if (!projectsLoaded) return <LoadingScreen />;
+  if (projects.length === 0) {
+    return (
+      <div className="violations-page violations-page--terminal">
+        <TermHeader name="violations" sub="no projects yet" />
+        <EmptyState
+          title="No projects yet"
+          description="Run your first evaluation to start analyzing code quality."
+          actionLabel="Start evaluating"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </div>
+    );
+  }
+  if (!selectedProject) {
+    return (
+      <div className="violations-page violations-page--terminal">
+        <TermHeader name="violations" sub="no project selected" />
+        <EmptyState
+          title="No project selected"
+          description="Pick a project to view its violations."
+          actionLabel="Choose project"
+          onAction={() => onNavigate?.('projects')}
+        />
+      </div>
+    );
+  }
+  const hasAnyDimensionData = (accumulatedDimensions || []).length > 0;
+  if (!hasAnyDimensionData) {
+    if (loading || isFetching) return <LoadingScreen />;
+    return (
+      <div className="violations-page violations-page--terminal">
+        <TermHeader name="violations" sub="no evaluations yet" />
+        <EmptyState
+          title="No evaluations yet"
+          description={`Run an evaluation for ${projectName || selectedProject} to populate this page.`}
+          actionLabel="Start evaluation"
+          onAction={() => onNavigate?.('evaluate')}
+        />
+      </div>
+    );
+  }
 
   const total = summary.totalViolations || 0;
   const subParts = [

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -177,10 +177,9 @@ function ViolationsSubTabContent(props) {
 }
 
 export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
-  const { accumulatedDimensions, selectedProject } = data;
+  const { accumulatedDimensions = [], selectedProject } = data;
   const { projects = [], projectsLoaded, projectName, loading, isFetching } = data;
-  const { onNavigate } = callbacks;
-  const { onRefresh } = callbacks;
+  const { onNavigate, onRefresh } = callbacks;
 
   // Fresh tab click (tabKey changed) drops the cached navigation state so
   // the user lands at the default sub-tab / root path. Round-tripping

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -608,6 +608,13 @@ textarea:focus {
   text-align: center;
 }
 
+.empty-state__icon {
+  margin-bottom: var(--space-3);
+  color: var(--color-text-muted);
+  display: flex;
+  justify-content: center;
+}
+
 .empty-state-btn {
   margin-top: var(--space-4);
   padding: var(--space-2) var(--space-5);


### PR DESCRIPTION
## Summary

- Adds per-page empty states (with primary CTAs) to the four primary tabs: Overview, Map, Violations, History. Each tab handles three "no data" scenarios — no projects, no project selected, no runs — with a clear next-action button (Start evaluating / Choose project / Start evaluation).
- Introduces a shared `EmptyState` component (title + description + optional CTA + optional icon) used by all four pages. Map / Violations / History keep `TermHeader` framing on empty branches so the user always sees which tab they're on; Overview renders bare to match its existing aesthetic.
- Fixes a pre-existing bug: `projectsLoaded` was read by the global guard at `App.jsx:277` but never plumbed into `props.navigation`, so the existing fallback empty state was dead code (always returned `LoadingScreen`). Now plumbed correctly through both `navigation` and `dashboardData`.

Each empty state is gated behind a "loaded but empty" check so it never flashes during initialization. Case C ("no runs") additionally gates on `loading || isFetching` to avoid flicker on project switch.

## Test Plan

- [x] `npm run test:ui` — 186/186 pass (including 9 new tests for `EmptyState`)
- [x] `npm test` — 134/134 pass
- [x] `npx vite build` — clean
- [x] Manual: with no projects, every tab shows "No projects yet" with **Start evaluating** CTA
- [x] Manual: with a project that has no runs, every tab shows "No evaluations yet" with **Start evaluation** CTA and the project name
- [x] Manual: with a project that has runs, every tab renders normally (no regression)
- [x] Manual: refresh the app — every tab shows `LoadingScreen` until projects resolve (no empty-state flash)