### PR TITLE
fix(ui): empty-state Case A leads to Projects tab

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -95,9 +95,9 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     return (
       <EmptyState
         title="No projects yet"
-        description="Run your first evaluation to start analyzing code quality."
-        actionLabel="Start evaluating"
-        onAction={() => onNavigate?.('evaluate')}
+        description="Add a project to start analyzing code quality."
+        actionLabel="Add a project"
+        onAction={() => onNavigate?.('projects')}
       />
     );
   }

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -379,9 +379,9 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
       <HistoryEmptyShell sub="no projects yet">
         <EmptyState
           title="No projects yet"
-          description="Run your first evaluation to start analyzing code quality."
-          actionLabel="Start evaluating"
-          onAction={() => onNavigate?.('evaluate')}
+          description="Add a project to start analyzing code quality."
+          actionLabel="Add a project"
+          onAction={() => onNavigate?.('projects')}
         />
       </HistoryEmptyShell>
     );

--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -184,9 +184,9 @@ export default function MapPage(props) {
       <MapEmpty sub="no projects yet">
         <EmptyState
           title="No projects yet"
-          description="Run your first evaluation to start analyzing code quality."
-          actionLabel="Start evaluating"
-          onAction={() => onNavigate?.('evaluate')}
+          description="Add a project to start analyzing code quality."
+          actionLabel="Add a project"
+          onAction={() => onNavigate?.('projects')}
         />
       </MapEmpty>
     );

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -221,9 +221,9 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
         <TermHeader name="violations" sub="no projects yet" />
         <EmptyState
           title="No projects yet"
-          description="Run your first evaluation to start analyzing code quality."
-          actionLabel="Start evaluating"
-          onAction={() => onNavigate?.('evaluate')}
+          description="Add a project to start analyzing code quality."
+          actionLabel="Add a project"
+          onAction={() => onNavigate?.('projects')}
         />
       </div>
     );


### PR DESCRIPTION
## Summary

When a user has no projects, the Case A empty state on Overview / Map / Violations / History was sending them to the Evaluate tab. Evaluation requires a project, so the destination didn't make sense — the right next step is to add a project, which lives on the Projects tab (where the onboarding flow runs).

- **CTA target:** `'evaluate'` → `'projects'`
- **CTA label:** "Start evaluating" → "Add a project"
- **Description:** "Run your first evaluation to start analyzing code quality." → "Add a project to start analyzing code quality."

Applied identically to all four self-handled tabs (Overview, Map, Violations, History). Cases B and C are unchanged.

## Test Plan

- [x] `npx vite build` — clean
- [x] Manual: start with no projects on every tab → click **Add a project** → lands on the Projects tab and triggers the onboarding flow