### PR TITLE
feat(ui): onboarding polish + sidebar cleanup

### DIFF
--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_SETTINGS, ICON_STANDARDS, ICON_HELP } from '../constants/navigation.jsx';
-import { ACTIVE_PROVIDER_KEY, providerKey, SETTINGS_DOT_DISMISSED_KEY, EVALUATE_DOT_DISMISSED_KEY } from '../constants.js';
 
 // Folder glyph for the REPOSITORY row — visually distinct from the list-style
 // ICON_PROJECTS so the repo context reads as a folder even on the collapsed rail.
@@ -9,38 +8,6 @@ const ICON_FOLDER = (
     <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
   </svg>
 );
-
-const SETUP_POLL_INTERVAL_MS = 2000;
-
-function useSetupStatus(hasEvaluations, storage = localStorage) {
-  const [status, setStatus] = useState({ needsSettings: false, readyToEvaluate: false });
-
-  useEffect(() => {
-    function check() {
-      if (hasEvaluations) {
-        setStatus({ needsSettings: false, readyToEvaluate: false });
-        return;
-      }
-      const settingsDismissed = storage.getItem(SETTINGS_DOT_DISMISSED_KEY);
-      const evaluateDismissed = storage.getItem(EVALUATE_DOT_DISMISSED_KEY);
-      const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-      const model = provider ? storage.getItem(providerKey(provider, 'model')) || '' : '';
-      const configured = !!(provider && model);
-
-      const showSettings = !settingsDismissed;
-      setStatus({
-        needsSettings: showSettings,
-        readyToEvaluate: !showSettings && configured && !evaluateDismissed,
-      });
-    }
-    check();
-    window.addEventListener('storage', check);
-    const interval = setInterval(check, SETUP_POLL_INTERVAL_MS);
-    return () => { window.removeEventListener('storage', check); clearInterval(interval); };
-  }, [hasEvaluations]);
-
-  return status;
-}
 
 function Logo() {
   return (
@@ -65,7 +32,7 @@ function Logo() {
   );
 }
 
-function NavButton({ id, label, icon, activeTab, onNavTab, count, showDot }) {
+function NavButton({ id, label, icon, activeTab, onNavTab, count }) {
   return (
     <button
       type="button"
@@ -76,7 +43,6 @@ function NavButton({ id, label, icon, activeTab, onNavTab, count, showDot }) {
       {icon}
       <span className="sidebar-nav-label">{label}</span>
       {count != null && <span className="sidebar-nav-count">{count}</span>}
-      {showDot && <span className="sidebar-nav-dot" />}
     </button>
   );
 }
@@ -118,7 +84,6 @@ export default function Sidebar({
      stays tidy, and the drawer surfaces them here instead. */
   mobileExtras = null,
 }) {
-  const { needsSettings, readyToEvaluate } = useSetupStatus(hasEvaluations);
   const [internalPinned, setInternalPinned] = useState(false);
   const isPinned = controlledPinned != null ? controlledPinned : internalPinned;
   const setPinned = (next) => {
@@ -184,23 +149,7 @@ export default function Sidebar({
         </nav>
 
         <nav className="sidebar-nav sidebar-block">
-          <NavButton
-            id="evaluate"
-            label="evaluate"
-            icon={ICON_EVALUATE}
-            activeTab={activeTab}
-            onNavTab={(id) => { try { localStorage.setItem(EVALUATE_DOT_DISMISSED_KEY, '1'); } catch {} handleNav(id); }}
-            showDot={readyToEvaluate}
-          />
-          <NavButton id="standards" label="standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
-          <NavButton
-            id="settings"
-            label="settings"
-            icon={ICON_SETTINGS}
-            activeTab={activeTab}
-            onNavTab={(id) => { try { localStorage.setItem(SETTINGS_DOT_DISMISSED_KEY, '1'); } catch {} handleNav(id); }}
-            showDot={needsSettings}
-          />
+          <NavButton id="evaluate" label="evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={handleNav} />
         </nav>
 
         <div className="sidebar-spacer" />
@@ -227,6 +176,8 @@ export default function Sidebar({
             )}
           </div>
           <div className="sidebar-nav sidebar-block sidebar-block--flush">
+            <NavButton id="standards" label="standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
+            <NavButton id="settings" label="settings" icon={ICON_SETTINGS} activeTab={activeTab} onNavTab={handleNav} />
             <NavButton id="help" label="help" icon={ICON_HELP} activeTab={activeTab} onNavTab={handleNav} />
           </div>
         </div>

--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -19,11 +19,6 @@ export function providerKey(providerId, setting) {
   return `cc-${providerId}-${setting}`;
 }
 
-// Onboarding dot & toast keys
-export const SETTINGS_DOT_DISMISSED_KEY = 'quodeq-settings-dot-dismissed';
-export const EVALUATE_DOT_DISMISSED_KEY = 'quodeq-evaluate-dot-dismissed';
-export const CONSOLE_DOT_DISMISSED_KEY = 'quodeq-console-dot-dismissed';
-
 export const VISIBLE_STANDARDS_STORAGE_KEY = 'quodeq-visible-standards';
 export const DEFAULT_VISIBLE_STANDARDS = [
   'security', 'reliability', 'maintainability', 'performance', 'usability', 'flexibility',

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -7,37 +7,6 @@ import { TermHeader, SectionLabel } from '../../../components/terminal/index.js'
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
 
-function EvaluateHelpSection() {
-  return (
-    <div className="panel evaluate-help-panel">
-      <SectionLabel>how_it_works</SectionLabel>
-      <div className="help-steps">
-        <div className="help-step">
-          <div className="step-number">1</div>
-          <div className="step-content">
-            <h4>Provide Repository</h4>
-            <p>Enter a GitHub URL, SSH path, or local filesystem path to the repository you want to evaluate.</p>
-          </div>
-        </div>
-        <div className="help-step">
-          <div className="step-number">2</div>
-          <div className="step-content">
-            <h4>Select Dimensions</h4>
-            <p>Choose which quality dimensions to analyze. Each dimension covers different aspects of code quality.</p>
-          </div>
-        </div>
-        <div className="help-step">
-          <div className="step-number">3</div>
-          <div className="step-content">
-            <h4>Review Results</h4>
-            <p>Once complete, view detailed findings, grades, and actionable recommendations in the Overview.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function ActiveProviderBadge({ storage = localStorage }) {
   const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
   const model = storage.getItem(providerKey(provider, 'model')) || '';
@@ -157,8 +126,6 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
         )}
 
         <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} hasEvaluations={!!selectedProject} />
-
-        {!job && <EvaluateHelpSection />}
       </div>
 
       {jobError && toastVisible && (

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { getEvaluationProgress } from '../../../api/index.js';
 import { evaluationKeys } from '../../../api/queryKeys.js';
 import { useEvalLog } from '../eval-log/EvalLogContext.js';
-import { CONSOLE_DOT_DISMISSED_KEY } from '../../../constants.js';
 import { pct, computeOverallProgress } from './scanProgressTotals.js';
 import ConsoleButton from '../../../components/ConsoleButton.jsx';
 
@@ -135,10 +134,6 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   const isLost = status === 'lost';
 
   const [detailOpen, setDetailOpen] = useState(false);
-  const [showDot, setShowDot] = useState(() => {
-    if (hasEvaluations) return false;
-    try { return !localStorage.getItem(CONSOLE_DOT_DISMISSED_KEY); } catch { return true; }
-  });
   const evalLog = useEvalLog();
   const consoleOpen = evalLog.activeJobId === jobId;
   const isTerminal = TERMINAL_STATES.has(status);
@@ -179,10 +174,6 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       evalLog.closeLog();
     } else {
       evalLog.openLog(jobId, progress?.runId || null, status);
-    }
-    if (showDot) {
-      setShowDot(false);
-      try { localStorage.setItem(CONSOLE_DOT_DISMISSED_KEY, '1'); } catch { /* ignore */ }
     }
   }
 
@@ -229,7 +220,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
             </span>
             <span className={`scan-progress__caret${detailOpen ? ' scan-progress__caret--open' : ''}`} aria-hidden="true">▸</span>
           </button>
-          <ConsoleButton open={consoleOpen} showDot={showDot} onToggle={toggleConsole} />
+          <ConsoleButton open={consoleOpen} onToggle={toggleConsole} />
         </div>
       </div>
       {detailOpen && dims.length > 0 && (

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -100,10 +100,7 @@ export default function RepoScanStep({ state, actions, createProject, onContinue
           <button type="button" className="btn-primary" onClick={handleSubmit} disabled={!state.repo.value}>Scan repository</button>
         )}
         {sub === 'scanned' && (
-          <>
-            <button type="button" className="btn-primary" onClick={onContinue}>Continue</button>
-            <button type="button" className="btn-secondary" onClick={onCancel}>Save and finish setup later</button>
-          </>
+          <button type="button" className="btn-primary" onClick={onContinue}>Continue</button>
         )}
       </div>
 

--- a/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
@@ -58,7 +58,6 @@ export default function StandardLaunchStep({ state, actions, standards, onLaunch
           Start evaluation
         </button>
         <button type="button" className="btn-secondary" onClick={onBack}>Back</button>
-        <button type="button" className="btn-secondary" onClick={onCancel}>Save and finish setup later</button>
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/settings/components/AboutSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/AboutSection.jsx
@@ -20,6 +20,10 @@ export default function AboutSection({ appVersion, settingsPhrase }) {
           <a className="settings-about-link" href="https://github.com/quodeq/quodeq" target="_blank" rel="noopener noreferrer">github.com/quodeq/quodeq</a>
         </div>
         <div className="settings-about-row">
+          <span className="settings-about-key">Blog</span>
+          <a className="settings-about-link" href="https://quodeq.ai/blog/" target="_blank" rel="noopener noreferrer">Latest from the team</a>
+        </div>
+        <div className="settings-about-row">
           <span className="settings-about-key">Changelog</span>
           <a className="settings-about-link" href="https://quodeq.github.io/quodeq/CHANGELOG.html" target="_blank" rel="noopener noreferrer">What&apos;s new</a>
         </div>

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -75,11 +75,6 @@
   background: var(--color-surface, #1e293b);
   border: 1px solid var(--color-border, #334155);
   border-radius: 10px;
-  transition: border-color 180ms ease, transform 180ms ease;
-}
-.onboarding-welcome__preview li:hover {
-  border-color: color-mix(in srgb, var(--color-accent, #10b981) 50%, var(--color-border, #334155));
-  transform: translateX(2px);
 }
 .onboarding-welcome__icon {
   display: inline-flex;
@@ -304,9 +299,15 @@
   list-style: none;
   padding: 0;
   margin: 16px 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+}
+.onboarding-standard-list li {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+}
+.onboarding-standard-list .onboarding-standard-card {
+  flex: 1;
 }
 .onboarding-standard-card {
   display: flex;
@@ -318,7 +319,10 @@
   transition: border-color 150ms ease;
 }
 .onboarding-standard-card:hover { border-color: var(--color-accent, #10b981); }
-.onboarding-standard-card--selected { border-color: var(--color-accent, #10b981); }
+.onboarding-standard-card--selected {
+  border-color: var(--color-accent, #10b981);
+  background: color-mix(in srgb, var(--color-accent, #10b981) 8%, transparent);
+}
 .onboarding-standard-card p { margin: 4px 0 0; font-size: 0.85rem; color: var(--color-text-muted, #94a3b8); }
 
 .onboarding-wizard {


### PR DESCRIPTION
## Summary

Seven small UI cleanup items bundled in one PR.

1. **Evaluate tab** — Remove the deprecated `HOW_IT_WORKS` 3-step explainer block.
2. **Onboarding standards picker** — Switch the standards list to a responsive grid (`auto-fit, minmax(260px, 1fr)`); single column on narrow screens. Selected cards now have a tinted accent background so picks stand out.
3. **Welcome step preview rows** — Removed the hover transition (`border-color` + `translateX`) so the three info rows ("Connect a repository / Pick an AI provider / Pick a standard") read as static info, not interactive.
4. **Indicator dots removed** — Sidebar dots on Evaluate and Settings, and the Console button dot in the Evaluating panel. Onboarding handles discovery now. Dropped the `useSetupStatus` hook, the `*_DOT_DISMISSED_KEY` constants, and related localStorage wrappers. Console button keeps its `showDot` prop for `ServerStatusPill`.
5. **Wizard "Save and finish setup later"** — Removed from `RepoScanStep` and `StandardLaunchStep`. The `×` close button (top right) already saves drafts on close via `handleSavedExit`.
6. **Sidebar bottom block reorder** — Moved `standards` and `settings` into the bottom block alongside `help`. Order is now `standards / settings / help`. The middle block has just `evaluate`.
7. **Settings About panel** — Added a **Blog** link (https://quodeq.ai/blog/) above the Changelog row. Opens in a new tab.

## Test Plan

- [x] `npx vite build` clean
- [x] `npm test` (node tests) — 134/134 pass
- [x] `npm run test:ui` (vitest) — 255/257 pass; 2 pre-existing failures on `develop` (`CliProviderTab.test.jsx`, `OllamaTab.test.jsx`) unrelated to this PR
- [x] Manual: Evaluate tab no longer shows the 3-step block
- [x] Manual: Sidebar bottom = standards / settings / help; no dots
- [x] Manual: Console button on Evaluating panel has no dot
- [x] Manual: Welcome step rows don't shift/highlight on hover
- [x] Manual: Standards picker is a grid on wide screens, single column on mobile; selected cards have tinted bg
- [x] Manual: Wizard steps no longer offer "Save and finish setup later"; closing via `×` saves the draft
- [x] Manual: Settings → About shows Blog link before Changelog; click opens https://quodeq.ai/blog/ in a new tab