### PR TITLE
feat(ui): onboarding standards picker respects visible-standards setting

### DIFF
--- a/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { registerProject, listStandards } from '../../../api/index.js';
 import { useWizardState } from '../hooks/useWizardState.js';
 import { saveDraft, clearDraft } from '../hooks/useWizardDraft.js';
+import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import StepProgress from './StepProgress.jsx';
 import WelcomeStep from './steps/WelcomeStep.jsx';
 import RepoScanStep from './steps/RepoScanStep.jsx';
@@ -26,8 +27,14 @@ export default function OnboardingWizard({ entry, onClose, onLaunch }) {
   const [standards, setStandards] = useState([]);
 
   // Fetch standards once when the step that needs them is reachable.
+  // Filter to the user's visible-standards setting so the picker matches
+  // what's enabled in the Standards tab. Lowercase both sides because the
+  // default list and the storage payload use lowercase ids.
   useEffect(() => {
-    listStandards().then(setStandards).catch(() => setStandards([]));
+    const visibleSet = new Set(readVisibleStandardIds().map((id) => (id || '').toLowerCase()));
+    listStandards()
+      .then((all) => setStandards(all.filter((s) => visibleSet.has((s.id || '').toLowerCase()))))
+      .catch(() => setStandards([]));
   }, []);
 
   // Persist a draft on every step transition or relevant state change.

--- a/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
@@ -41,6 +41,9 @@ describe('Onboarding integration — happy path', () => {
     // when the user reaches it (otherwise the wizard can't advance).
     localStorage.setItem('cc-active-provider', 'codex');
     localStorage.setItem('cc-codex-model', 'gpt-5.2-codex');
+    // The wizard filters standards by the user's visible-standards setting
+    // (matches the Standards tab). Seed both mock ids so the picker shows them.
+    localStorage.setItem('quodeq-visible-standards', JSON.stringify(['std-a', 'std-b']));
   });
 
   it('walks Welcome → Repo & Scan → Provider → Standard & Launch and emits onLaunch', async () => {


### PR DESCRIPTION
## Summary

The wizard's **Pick a standard** step now filters the fetched standards through \`readVisibleStandardIds()\`, so it only offers the standards the user has enabled in the Standards tab. Today the step shows everything the API returns (e.g. Clean Architecture, Domain-Driven Design) even when the user has hidden them from the rest of the app — that mismatch is what this fixes.

The filter happens once at fetch time in [OnboardingWizard.jsx](src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx). Both sides of the comparison are lowercased to be defensive against any casing drift between \`DEFAULT_VISIBLE_STANDARDS\` and the API's \`id\` field.

## Test Plan

- [x] \`npx vite build\` clean
- [x] \`npm run test:ui\` — 255/257 (2 pre-existing failures on \`develop\` unrelated)
- [x] All 48 onboarding tests pass; the integration test was updated to seed \`quodeq-visible-standards\` with the mock standard ids
- [x] Manual: with default visible standards (6 ISO ones), the wizard's standard picker shows 6 options (no Clean Architecture / DDD)
- [x] Manual: hide one standard in the Standards tab → reopen the wizard → that standard is gone from the picker