### PR TITLE
feat(ui): onboarding silently resumes existing project on 409 when no evaluations

### DIFF
--- a/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { registerProject, listStandards } from '../../../api/index.js';
+import { registerProject, listStandards, getProjectInfo } from '../../../api/index.js';
 import { useWizardState } from '../hooks/useWizardState.js';
 import { saveDraft, clearDraft } from '../hooks/useWizardDraft.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
@@ -132,6 +132,7 @@ export default function OnboardingWizard({ entry, onClose, onLaunch }) {
           state={wizard.state}
           actions={wizard}
           createProject={registerProject}
+          getProjectInfo={getProjectInfo}
           onContinue={nextStep}
           onCancel={handleSavedExit}
         />

--- a/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.test.jsx
@@ -10,6 +10,7 @@ vi.mock('../hooks/useProviderDetection.js', () => ({
 vi.mock('../../../api/index.js', () => ({
   registerProject: vi.fn().mockResolvedValue({ projectId: 'uuid-9', scanData: { total_files: 7, languages: { py: 7 }, branches: ['main'], modules: [] } }),
   listStandards: vi.fn().mockResolvedValue([{ id: 'std-a', name: 'Security 101', description: 'Common checks' }]),
+  getProjectInfo: vi.fn().mockResolvedValue({ id: 'uuid-9', runsCount: 0 }),
 }));
 
 describe('OnboardingWizard', () => {

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -3,9 +3,27 @@ import { RepoInput } from '../../../evaluation/components/EvaluationForm.jsx';
 import ScanProgress from '../../../evaluation/components/ScanProgress.jsx';
 import FolderBrowser from '../../../evaluation/components/FolderBrowser.jsx';
 
-export default function RepoScanStep({ state, actions, createProject, onContinue, onCancel }) {
+export default function RepoScanStep({ state, actions, createProject, getProjectInfo, onContinue, onCancel }) {
   const sub = state.repoScanSubState;
   const [folderBrowserOpen, setFolderBrowserOpen] = useState(false);
+
+  // 409 + existingProjectId means a project was already registered for this
+  // repo. If it has no evaluations yet, silently resume into it — the user
+  // most likely abandoned an earlier onboarding attempt. If it does have
+  // evaluations, fall through to the normal error UI so the user can decide.
+  async function tryResumeExisting(existingProjectId) {
+    try {
+      const info = await getProjectInfo(existingProjectId);
+      if (info.runsCount > 0) return false;
+      const scanRes = await fetch(`/api/projects/${encodeURIComponent(existingProjectId)}/scan`);
+      if (!scanRes.ok) return false;
+      const scanData = await scanRes.json();
+      actions.succeedScan(existingProjectId, scanData);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 
   async function handleSubmit() {
     if (!state.repo.value) return;
@@ -14,6 +32,10 @@ export default function RepoScanStep({ state, actions, createProject, onContinue
       const { projectId, scanData } = await createProject({ repo: state.repo.value });
       actions.succeedScan(projectId, scanData);
     } catch (err) {
+      if (err.status === 409 && err.existingProjectId) {
+        const resumed = await tryResumeExisting(err.existingProjectId);
+        if (resumed) return;
+      }
       actions.failScan({ message: err.message, status: err.status, existingProjectId: err.existingProjectId });
     }
   }

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.test.jsx
@@ -73,4 +73,57 @@ describe('RepoScanStep', () => {
     await waitFor(() => expect(failScan).toHaveBeenCalled());
     expect(failScan.mock.calls[0][0].message).toBe('boom');
   });
+
+  it('409 with no evaluations on the existing project silently resumes into it', async () => {
+    const succeedScan = vi.fn();
+    const failScan = vi.fn();
+    const createProject = vi.fn().mockRejectedValue(
+      Object.assign(new Error('already added'), { status: 409, existingProjectId: 'uuid-existing' }),
+    );
+    const getProjectInfo = vi.fn().mockResolvedValue({ id: 'uuid-existing', runsCount: 0 });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ total_files: 12, languages: { py: 12 }, branches: ['main'], modules: [] }),
+    });
+    try {
+      render(<RepoScanStep
+        state={{ repoScanSubState: 'idle', repo: { value: '/some/path' } }}
+        actions={{ setRepo: noop, startScan: noop, succeedScan, failScan, resetScan: noop }}
+        createProject={createProject}
+        getProjectInfo={getProjectInfo}
+        onContinue={noop}
+        onCancel={noop}
+      />);
+      fireEvent.click(screen.getByRole('button', { name: /scan repository/i }));
+      await waitFor(() => expect(succeedScan).toHaveBeenCalled());
+      expect(succeedScan).toHaveBeenCalledWith('uuid-existing', expect.objectContaining({ total_files: 12 }));
+      expect(failScan).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('409 with evaluations on the existing project surfaces the error normally', async () => {
+    const succeedScan = vi.fn();
+    const failScan = vi.fn();
+    const createProject = vi.fn().mockRejectedValue(
+      Object.assign(new Error('already added'), { status: 409, existingProjectId: 'uuid-existing' }),
+    );
+    const getProjectInfo = vi.fn().mockResolvedValue({ id: 'uuid-existing', runsCount: 3 });
+    render(<RepoScanStep
+      state={{ repoScanSubState: 'idle', repo: { value: '/some/path' } }}
+      actions={{ setRepo: noop, startScan: noop, succeedScan, failScan, resetScan: noop }}
+      createProject={createProject}
+      getProjectInfo={getProjectInfo}
+      onContinue={noop}
+      onCancel={noop}
+    />);
+    fireEvent.click(screen.getByRole('button', { name: /scan repository/i }));
+    await waitFor(() => expect(failScan).toHaveBeenCalled());
+    expect(failScan.mock.calls[0][0]).toMatchObject({
+      status: 409,
+      existingProjectId: 'uuid-existing',
+    });
+    expect(succeedScan).not.toHaveBeenCalled();
+  });
 });

--- a/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
@@ -15,6 +15,7 @@ vi.mock('../../api/index.js', async () => {
       { id: 'std-a', name: 'Security 101', description: 'Common checks' },
       { id: 'std-b', name: 'Code style', description: 'Formatting' },
     ]),
+    getProjectInfo: vi.fn().mockResolvedValue({ id: 'uuid-9', runsCount: 0 }),
     getProviderConfigs: vi.fn().mockResolvedValue({}),
   };
 });


### PR DESCRIPTION
## Summary

Fixes a UX dead-end in the onboarding wizard: registering the project happens on the **Repo & Scan** step, but if the user abandons before launching an evaluation, that project sticks around as a partially-onboarded record. Re-attempting the same repo path on the next onboarding lands on a 409 error ("Project already exists"), with no obvious way forward.

After this change, when the API returns 409 with an `existingProjectId`:

- The wizard fetches the existing project's info via \`getProjectInfo\`.
- **If \`runsCount === 0\`** (no evaluations yet, i.e. the user abandoned earlier): the wizard fetches the scan data via \`/api/projects/{id}/scan\` and dispatches \`succeedScan(existingProjectId, scanData)\`. The user lands on the "scanned / Continue" screen — to them it looks like the scan just worked.
- **If \`runsCount > 0\`** (the project is already in real use): fall through to the existing error UI. Surfacing a richer "Open this project" CTA can be a follow-up; today's behavior preserves the explicit error.

The plumbing this leans on (the 409 response carrying \`existingProjectId\`, \`getProjectInfo\` returning \`runsCount\`, the \`succeedScan\` reducer action, and the \`/scan\` endpoint) all already existed.

## Test Plan

- [x] \`npx vite build\` clean
- [x] \`npm run test:ui\` — 257/259 (2 pre-existing unrelated failures on \`develop\`)
- [x] Two new RepoScanStep tests cover both 409 branches (0 evals → \`succeedScan\` with the existing project; >0 evals → \`failScan\` surfaces the conflict)
- [x] Integration & wizard-level tests updated to mock \`getProjectInfo\`
- [x] Manual: register a repo, close the wizard before launching, re-open onboarding with the same repo path → it lands on Continue rather than showing an error
- [x] Manual: confirm a project with existing evaluations still surfaces the conflict error