### PR TITLE
feat(ui): hide project-data tabs in sidebar until first run completes

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -374,6 +374,18 @@ export default function App() {
     }
   }, [state.projectsLoaded, state.projects.length]);
 
+  // Project-data tabs (overview/violations/map/history) only make sense once
+  // the selected project has at least one completed evaluation run. Until
+  // then, hide them from the sidebar and bounce the user to Evaluate if a
+  // cached activeTab lands them on a now-hidden tab.
+  const PROJECT_DATA_TABS = ['overview', 'violations', 'map', 'history'];
+  const hasCurrentProjectRuns = (selectedProjectInfo?.runsCount ?? 0) > 0;
+  useEffect(() => {
+    if (!hasCurrentProjectRuns && PROJECT_DATA_TABS.includes(state.activeTab)) {
+      state.navTab('evaluate');
+    }
+  }, [hasCurrentProjectRuns, state.activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const sidebarProvider = (typeof localStorage !== 'undefined' && localStorage.getItem(ACTIVE_PROVIDER_KEY)) || null;
   const sidebarModel = sidebarProvider && typeof localStorage !== 'undefined'
     ? localStorage.getItem(providerKey(sidebarProvider, 'model'))
@@ -460,6 +472,7 @@ export default function App() {
               activeTab={activeTab}
               onNavTab={navTab}
               hasEvaluations={state.projects.length > 0}
+              showProjectTabs={hasCurrentProjectRuns}
               projectInfo={{
                 displayName: resolvedDisplayName,
                 meta: state.headerMeta,

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -68,6 +68,10 @@ export default function Sidebar({
   activeTab,
   onNavTab,
   hasEvaluations,
+  /* When false, the project-data tabs (overview, violations, map, history)
+     are hidden from the sidebar — they have nothing useful to show until at
+     least one evaluation has completed for the selected project. */
+  showProjectTabs = true,
   projectInfo = null,
   version = null,
   violationsCount = null,
@@ -141,12 +145,14 @@ export default function Sidebar({
         />
       </nav>
 
-        <nav className="sidebar-nav sidebar-block">
-          <NavButton id="overview"   label="overview"   icon={ICON_OVERVIEW}   activeTab={activeTab} onNavTab={handleNav} />
-          <NavButton id="violations" label="violations" icon={ICON_VIOLATIONS} activeTab={activeTab} onNavTab={handleNav} count={violationsCount} />
-          <NavButton id="map"        label="map"        icon={ICON_MAP}        activeTab={activeTab} onNavTab={handleNav} />
-          <NavButton id="history"    label="history"    icon={ICON_HISTORY}    activeTab={activeTab} onNavTab={handleNav} count={historyCount} />
-        </nav>
+        {showProjectTabs && (
+          <nav className="sidebar-nav sidebar-block">
+            <NavButton id="overview"   label="overview"   icon={ICON_OVERVIEW}   activeTab={activeTab} onNavTab={handleNav} />
+            <NavButton id="violations" label="violations" icon={ICON_VIOLATIONS} activeTab={activeTab} onNavTab={handleNav} count={violationsCount} />
+            <NavButton id="map"        label="map"        icon={ICON_MAP}        activeTab={activeTab} onNavTab={handleNav} />
+            <NavButton id="history"    label="history"    icon={ICON_HISTORY}    activeTab={activeTab} onNavTab={handleNav} count={historyCount} />
+          </nav>
+        )}
 
         <nav className="sidebar-nav sidebar-block">
           <NavButton id="evaluate" label="evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={handleNav} />


### PR DESCRIPTION
## Summary

Before this change, a fresh-onboarded project showed Overview / Violations / Map / History in the sidebar with empty states reading "Add a project" or "No evaluations yet" — confusing for a user who just *did* add a project and is in the middle of their first evaluation.

After this change, those four tabs are hidden from the sidebar until the **selected project** has \`runsCount > 0\`. Sidebar in that state shows: project header, Evaluate, Standards, Settings, Help. The moment the first run lands, the four tabs reappear automatically (\`useEvaluationLifecycle\` already refetches projects on job completion, so \`runsCount\` updates and the sidebar re-renders).

If a cached \`activeTab\` would land the user on a now-hidden tab (e.g. they were on Overview last session and the new project hasn't run yet), \`App\` redirects to Evaluate so the page matches what's actually in the sidebar.

The per-page empty states (\`No projects yet\`, \`No project selected\`, \`No evaluations yet\`) stay in place as defensive fallbacks. They cost near nothing and protect against direct URL nav, brief loading windows, and any stale state we haven't anticipated.

## Test Plan

- [x] \`npx vite build\` clean
- [x] \`npm run test:ui\` — 257/259 (2 pre-existing failures on \`develop\` unrelated)
- [x] \`npm test\` — 134/134
- [x] Manual: fresh project mid-evaluation → sidebar shows project + Evaluate + Standards/Settings/Help; the four data tabs are gone
- [x] Manual: first evaluation completes → all four tabs appear without a refresh
- [x] Manual: switch to a different project that has no runs → tabs hide; switch back to one with runs → tabs reappear
- [x] Manual: reload while last session's activeTab is Overview but selected project has 0 runs → app lands on Evaluate