### PR TITLE
feat(ui): block add-project + double-evaluation while a job is running

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -296,7 +296,7 @@ const ROUTE_RENDERERS = {
     />
   ),
   settings: (params, props) => <SettingsCase settings={props.settings} />,
-  projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject, onAddProject: props.navigation.onAddProject, onResumeSetup: props.navigation.onResumeSetup }} />,
+  projects: (params, props) => <ProjectsPage projects={props.navigation.projects} selectedProject={props.navigation.selectedProject} isEvaluating={props.navigation.isEvaluating} actions={{ onSelect: (id) => { props.navigation.handleProjectChange(id); props.navigation.navTab('overview'); }, onDelete: props.navigation.handleDeleteProject, onExport: props.navigation.handleExportProject, onRelocate: props.navigation.handleRelocateProject, onAddProject: props.navigation.onAddProject, onResumeSetup: props.navigation.onResumeSetup }} />,
   standards: () => <StandardsPage />,
   help: () => <HelpPage />,
 };
@@ -315,6 +315,7 @@ function MainContent({ activePage, props }) {
         <EmptyStateWithTour
           onAdd={() => props.navigation.onAddProject()}
           onTour={() => props.navigation.onTakeTour()}
+          isEvaluating={props.navigation.isEvaluating}
         />
       );
     }
@@ -359,6 +360,11 @@ export default function App() {
   // auto-open job is done for this page load.
   const autoOpenedRef = useRef(false);
 
+  // While an evaluation is running we block any path that would open the
+  // onboarding wizard or start a second evaluation — only one job may be in
+  // flight at a time.
+  const isEvaluating = state.evalLifecycle?.job?.status === 'running';
+
   // Auto-open wizard on first paint when there are no projects and the user
   // has not explicitly skipped. The skip flag only suppresses auto-open — it
   // never blocks "Add a project" or "Take the tour" buttons.
@@ -366,13 +372,14 @@ export default function App() {
     if (autoOpenedRef.current) return;
     if (!state.projectsLoaded) return;
     if (state.projects.length > 0) { autoOpenedRef.current = true; return; }
+    if (isEvaluating) return;
     let skipped = false;
     try { skipped = localStorage.getItem('quodeq_onboarding_skipped') === 'true'; } catch { /* ignore */ }
     autoOpenedRef.current = true;
     if (!skipped) {
       setWizardEntry({ startStep: 'welcome', isFirstProject: true });
     }
-  }, [state.projectsLoaded, state.projects.length]);
+  }, [state.projectsLoaded, state.projects.length, isEvaluating]);
 
   const sidebarProvider = (typeof localStorage !== 'undefined' && localStorage.getItem(ACTIVE_PROVIDER_KEY)) || null;
   const sidebarModel = sidebarProvider && typeof localStorage !== 'undefined'
@@ -422,13 +429,26 @@ export default function App() {
       historySelectedRun: state.historySelectedRun, setHistorySelectedRun: state.setHistorySelectedRun,
       currentOverviewRun: state.currentOverviewRun, handleRunPrev: state.handleRunPrev, handleRunNext: state.handleRunNext, handleRunLatest: state.handleRunLatest,
       prefetchHandlers: state.prefetchHandlers,
-      onAddProject: () => setWizardEntry({ startStep: 'repo-scan', isFirstProject: state.projects.length === 0 }),
-      onTakeTour: () => setWizardEntry({ startStep: 'welcome', isFirstProject: true }),
-      onResumeSetup: (projectId) => setWizardEntry({
-        startStep: 'provider',
-        isFirstProject: false,
-        presetProjectId: projectId,
-      }),
+      onAddProject: () => {
+        if (isEvaluating) {
+          console.warn('[onboarding] add-project ignored — evaluation in progress');
+          return;
+        }
+        setWizardEntry({ startStep: 'repo-scan', isFirstProject: state.projects.length === 0 });
+      },
+      onTakeTour: () => {
+        if (isEvaluating) return;
+        setWizardEntry({ startStep: 'welcome', isFirstProject: true });
+      },
+      onResumeSetup: (projectId) => {
+        if (isEvaluating) return;
+        setWizardEntry({
+          startStep: 'provider',
+          isFirstProject: false,
+          presetProjectId: projectId,
+        });
+      },
+      isEvaluating,
     },
     evaluation: state.evalLifecycle,
     serverHealth: { connected: state.serverConnected, setConnected: state.setServerConnected },

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -257,7 +257,9 @@ function useRelocateDialog(onRelocate) {
   return { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate };
 }
 
-function EmptyProjectsCTA({ onAddProject }) {
+const EVAL_BLOCKED_TITLE = 'Cannot add a project while an evaluation is running';
+
+function EmptyProjectsCTA({ onAddProject, isEvaluating }) {
   return (
     <div className="projects-empty projects-empty--cta">
       <h3 className="projects-empty__title">Add your first project</h3>
@@ -268,6 +270,8 @@ function EmptyProjectsCTA({ onAddProject }) {
         type="button"
         className="projects-empty__cta-btn"
         onClick={onAddProject}
+        disabled={isEvaluating}
+        title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
       >
         + Add project
       </button>
@@ -275,7 +279,7 @@ function EmptyProjectsCTA({ onAddProject }) {
   );
 }
 
-export default function ProjectsPage({ projects = [], selectedProject, actions }) {
+export default function ProjectsPage({ projects = [], selectedProject, isEvaluating = false, actions }) {
   const { onSelect, onDelete, onExport, onRelocate, onAddProject, onResumeSetup } = actions;
   const { children, roots } = useMemo(() => computeProjectTree(projects), [projects]);
   const [confirming, setConfirming] = useState(null);
@@ -294,13 +298,15 @@ export default function ProjectsPage({ projects = [], selectedProject, actions }
             className="projects-page__add-btn"
             onClick={onAddProject}
             aria-label="Add project"
+            disabled={isEvaluating}
+            title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
           >
             + Add project
           </button>
         )}
       </div>
       {projects.length === 0 ? (
-        <EmptyProjectsCTA onAddProject={onAddProject} />
+        <EmptyProjectsCTA onAddProject={onAddProject} isEvaluating={isEvaluating} />
       ) : (
         <div className="projects-cards">
           {roots.map((p) => (

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
@@ -4,7 +4,8 @@ function clearSkip() {
   try { localStorage.removeItem(SKIPPED_STEPS_KEY); } catch { /* ignore */ }
 }
 
-export default function EmptyStateWithTour({ onAdd, onTour }) {
+export default function EmptyStateWithTour({ onAdd, onTour, isEvaluating = false }) {
+  const blockedTitle = isEvaluating ? 'Cannot add a project while an evaluation is running' : undefined;
   return (
     <section className="empty-state empty-state--with-tour">
       <h2>No projects yet.</h2>
@@ -14,6 +15,8 @@ export default function EmptyStateWithTour({ onAdd, onTour }) {
           type="button"
           className="btn-primary"
           onClick={() => { clearSkip(); onAdd(); }}
+          disabled={isEvaluating}
+          title={blockedTitle}
         >
           Add a project
         </button>
@@ -21,6 +24,8 @@ export default function EmptyStateWithTour({ onAdd, onTour }) {
           type="button"
           className="btn-secondary"
           onClick={() => { clearSkip(); onTour(); }}
+          disabled={isEvaluating}
+          title={blockedTitle}
         >
           Take the tour
         </button>

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -46,6 +46,14 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
   }, [job]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleStartEvaluation(payload) {
+    // Hard guard: only one evaluation may run at a time. A second start
+    // request (e.g. user clicked through the onboarding wizard while a
+    // re-evaluation was already in flight on a different project) would
+    // otherwise overwrite the live job state and confuse the lifecycle.
+    if (job && job.status === 'running') {
+      console.warn('[evaluation] start request ignored — a job is already running');
+      return;
+    }
     const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
     const get = (key) => storage.getItem(providerKey(activeProvider, key));
     // Ollama uses a single analysis model; CLI providers use tier-based selection.


### PR DESCRIPTION
## Summary

Two related concerns the user surfaced together:
- "We should have a way to prevent to add projects if you are running an evaluation"
- "You can evaluate twice…"

Both reduce to: **at most one evaluation in flight at a time**, and **no opening the onboarding wizard while one is running** (since the wizard's Start evaluation button would otherwise kick off a second job).

Three layered guards:

1. **\`useEvaluationLifecycle.handleStartEvaluation\`** early-returns with a \`console.warn\` when \`job.status === 'running'\`. A second start request — from the wizard, from a Re-evaluate card, from anywhere — is now a no-op rather than overwriting the live job state. Belt-and-suspenders behind the UI.
2. **\`App.onAddProject\` / \`onTakeTour\` / \`onResumeSetup\` and the first-paint auto-open \`useEffect\`** all check \`isEvaluating\` and short-circuit. The wizard cannot be opened from any normal UI path while a job is running.
3. **Visible disabled state** with a 'Cannot add a project while an evaluation is running' tooltip on the \`Add project\` button in \`ProjectsPage\` and on both buttons in \`EmptyStateWithTour\`. The user sees a clear reason instead of a silent no-op.

## Test Plan

- [x] \`npx vite build\` clean
- [x] \`npm run test:ui\` — 257/259 (2 pre-existing unrelated failures on \`develop\`)
- [x] \`npm test\` — 134/134
- [x] Manual: while an evaluation is running, the \`Add project\` button on the Projects tab is disabled with a tooltip
- [x] Manual: same for the \`Add a project\` / \`Take the tour\` buttons in the empty-state when there are no projects
- [x] Manual: clicking \`Start evaluation\` in the wizard while another job is running is a no-op (console warning, no second job created)
- [x] Manual: once the running job finishes, the buttons re-enable automatically