### PR TITLE
fix(ui): wizard scroll + close icon + burger + StatStrip/radio theme

### DIFF
--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -52,9 +52,8 @@ function Dot({ ok }) {
 function BurgerIcon() {
   return (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <line x1="3" y1="6" x2="21" y2="6" />
-      <line x1="3" y1="12" x2="21" y2="12" />
-      <line x1="3" y1="18" x2="21" y2="18" />
+      <rect x="3" y="4" width="18" height="16" rx="2" />
+      <line x1="9" y1="4" x2="9" y2="20" />
     </svg>
   );
 }

--- a/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
@@ -117,7 +117,10 @@ export default function OnboardingWizard({ entry, onClose, onLaunch }) {
   return (
     <div className="onboarding-wizard" role="dialog" aria-modal="true" aria-label="onboarding">
       <button type="button" className="onboarding-wizard__close" aria-label="Close onboarding" onClick={handleClose}>
-        <kbd className="onboarding-wizard__close-kbd">esc</kbd>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
       </button>
 
       {wizard.state.step === 'welcome' && (

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -78,6 +78,8 @@
   border-radius: var(--term-radius);
   width: 100%;
   max-width: 640px;
+  max-height: calc(100vh - 2 * var(--term-space-4));
+  overflow-y: auto;
   padding: var(--term-space-4) var(--term-space-4) var(--term-space-3);
   font-family: var(--term-font-mono);
   color: var(--color-text);
@@ -242,6 +244,21 @@
 /* ──────────────────────────────────────────────────────────────
    Standard & Launch step
    ────────────────────────────────────────────────────────────── */
+
+/* The StatStrip default value size (28px) is calibrated for dashboard
+   score numerals. The wizard's summary strip carries prose content
+   (UUIDs, provider names, "5 min") — at 28px the row dominates and
+   breaks alignment. Scope down to terminal body size. */
+.onboarding-step--standard-launch .term-stat__value {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+  word-break: break-all;
+}
+.onboarding-step--standard-launch .term-stat__hint {
+  font-size: 11px;
+}
+
 .onboarding-standard-list {
   list-style: none;
   padding: 0;
@@ -268,6 +285,12 @@
 .onboarding-standard-card--selected {
   border-color: var(--color-accent);
   background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+.onboarding-standard-card input[type="radio"],
+.onboarding-standard-card input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  margin-top: 2px;
+  flex-shrink: 0;
 }
 .onboarding-standard-card p {
   margin: 4px 0 0;


### PR DESCRIPTION
## Summary

Five UI fixes from in-browser testing of the onboarding terminal redesign (#378).

- **Wizard isn't scrollable.** \`.onboarding-step\` had no \`max-height\` or \`overflow-y\`, so the Provider step (with the embedded ProviderTabs + Model selector + Time-limit block) clipped at the bottom of the viewport. Added \`max-height: calc(100vh - 2 * var(--term-space-4))\` + \`overflow-y: auto\` so long content scrolls inside the modal frame.
- **\`[esc]\` close kbd → proper X SVG.** The kbd-styled "esc" caption read as awkward. Replaced with a 24×24 monoline X icon matching the app's existing icon vocabulary (BackIcon, BurgerIcon, etc.).
- **TopBar burger icon refresh.** The plain three-horizontal-lines burger felt generic. Replaced with a panel-style icon (rounded rect + vertical divider) that signals "open the side panel" more clearly.
- **StatStrip values too huge in the Standard step.** \`.term-stat__value\` defaults to 28px (dashboard score numeral size). For the wizard's prose summary (project UUID, provider name, "5 min") that dominates the screen and breaks alignment. Scoped down to 13px / weight 500 + word-break for the long UUIDs.
- **Native radio/checkbox not theme-friendly in the standards picker.** The browser-default blue radio dot looked alien against the terminal aesthetic. Added \`accent-color: var(--color-accent)\` on the inputs so the selected dot renders in the theme accent.

3 files, 29 insertions / 4 deletions.

## Test plan

- [x] \`npx vite build\` clean
- [x] \`npx vitest run src/features/onboarding/\` — 47/47 pass
- [x] Manual: open the wizard at the Provider step on a viewport short enough to overflow — content scrolls
- [x] Manual: close button shows an X icon, click closes the wizard
- [x] Manual: TopBar burger (mobile / narrow viewport) shows the new panel-style icon
- [x] Manual: Standard step summary row reads at body-text size and doesn't wrap the project UUID across multiple lines
- [x] Manual: selecting a standard shows the radio dot in the theme accent color (not browser blue)