### PR TITLE
fix(services): external runs surface deadline_at so the countdown timer ticks

### DIFF
--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -198,6 +198,9 @@ def _check_stale_and_promote(
             current_dimension=status.get("current_dimension"),
             pid=pid if isinstance(pid, int) else None,
             exit_reason="stale_detected",
+            # Preserve deadline_at across the stale → cancelled rewrite so
+            # downstream readers (filesystem snapshot builder) still see it.
+            deadline_at=status.get("deadline_at"),
         )
         with db:
             _upsert_from_status(db, run_dir, project_uuid=project_uuid, run_id=run_id)

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -225,9 +225,33 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
         dims = data.get("dimensions")
         return dims if isinstance(dims, list) else None
 
+    @staticmethod
+    def _read_deadline_from_status(run_dir: Path) -> str | None:
+        """Read the `deadline_at` ISO string from status.json, or None if unavailable.
+
+        External (CLI) runs are not tracked by ``JobManager`` and so don't go
+        through the marker-parsing path that sets ``Job.deadline_at``. Reading
+        directly from status.json — which the run lifecycle writes via
+        ``write_status(deadline_at=...)`` — keeps the dashboard's countdown
+        timer ticking for external runs too.
+        """
+        import json as _json  # noqa: PLC0415
+        status_path = run_dir / "status.json"
+        if not status_path.is_file():
+            return None
+        try:
+            data = _json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        val = data.get("deadline_at")
+        return val if isinstance(val, str) else None
+
     def _run_row_to_snapshot(self, row: "_run_index.RunRow") -> JobSnapshot:
         logs: list[str] = []
         dimensions: list[str] | None = None
+        deadline_at: str | None = None
         if row.run_dir:
             run_dir_path = Path(row.run_dir)
             try:
@@ -238,6 +262,10 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
                 dimensions = self._read_dimensions_from_status(run_dir_path)
             except (OSError, ValueError):
                 dimensions = None
+            try:
+                deadline_at = self._read_deadline_from_status(run_dir_path)
+            except (OSError, ValueError):
+                deadline_at = None
         return JobSnapshot(
             job_id=row.job_id,
             status=row.state,
@@ -249,6 +277,7 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             output_project=row.project_uuid,
             output_run_id=row.run_id,
             phase=row.phase,
+            deadline_at=deadline_at,
             current_dimension=row.current_dimension,
             dimensions=dimensions,
             error=row.exit_reason,

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -187,3 +188,91 @@ def test_start_evaluation_writes_repository_info_for_online_repo(tmp_path: Path)
     assert payload["location"] == "online"
     assert payload["path"] == repo_url
     assert "uuid" in payload
+
+
+def test_get_evaluation_status_external_surfaces_deadline_at(tmp_path: Path) -> None:
+    """External (CLI / ext-prefixed) runs must surface deadline_at on the snapshot.
+
+    The dashboard's countdown timer reads ``job.deadlineAt`` to render a
+    live ticker. Internal runs get this populated via the ``analyzing_start``
+    marker parsed by JobManager. External runs bypass JobManager, so the
+    snapshot builder must read deadline_at from the run's status.json.
+    """
+    reports = tmp_path / "reports"
+    project_uuid = "11111111-2222-3333-4444-555555555555"
+    run_id = "20260101120000"
+    run_dir = reports / project_uuid / run_id
+    run_dir.mkdir(parents=True)
+
+    # A real run is signalled by the evidence/manifest.json file. Without it
+    # the index sync skips the directory.
+    (run_dir / "evidence").mkdir()
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+
+    deadline_iso = "2026-01-01T12:05:00+00:00"
+    _write_json(
+        run_dir / "status.json",
+        {
+            "schema_version": 1,
+            "job_id": f"ext-{run_id}",
+            "state": "running",
+            "started_at": "2026-01-01T12:00:00+00:00",
+            "updated_at": "2026-01-01T12:00:30+00:00",
+            "finalized_at": None,
+            "phase": "analyzing",
+            "current_dimension": "reliability",
+            "dimensions": ["reliability"],
+            # Use the test process's own PID so the stale-promotion check
+            # (heartbeat fresh + PID alive) treats this as a live run and
+            # does NOT rewrite status.json without the deadline.
+            "pid": os.getpid(),
+            "exit_reason": None,
+            "deadline_at": deadline_iso,
+        },
+    )
+    # Fresh heartbeat — the stale check requires < 30s since last heartbeat.
+    (run_dir / ".heartbeat").write_text("")
+
+    provider = FilesystemActionProvider()
+    snapshot = provider.get_evaluation_status(f"ext-{run_id}", reports_dir=reports)
+
+    assert snapshot is not None
+    assert snapshot.job_id == f"ext-{run_id}"
+    assert snapshot.deadline_at == deadline_iso
+    assert snapshot.source == "external"
+
+
+def test_get_evaluation_status_external_handles_missing_deadline(tmp_path: Path) -> None:
+    """Snapshot builder must tolerate runs that have no deadline (unlimited budget)."""
+    reports = tmp_path / "reports"
+    project_uuid = "11111111-2222-3333-4444-555555555555"
+    run_id = "20260101120000"
+    run_dir = reports / project_uuid / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "evidence").mkdir()
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+
+    _write_json(
+        run_dir / "status.json",
+        {
+            "schema_version": 1,
+            "job_id": f"ext-{run_id}",
+            "state": "running",
+            "started_at": "2026-01-01T12:00:00+00:00",
+            "updated_at": "2026-01-01T12:00:30+00:00",
+            "finalized_at": None,
+            "phase": "analyzing",
+            "current_dimension": None,
+            "dimensions": ["reliability"],
+            "pid": os.getpid(),
+            "exit_reason": None,
+            # no deadline_at field — unlimited budget
+        },
+    )
+    (run_dir / ".heartbeat").write_text("")
+
+    provider = FilesystemActionProvider()
+    snapshot = provider.get_evaluation_status(f"ext-{run_id}", reports_dir=reports)
+
+    assert snapshot is not None
+    assert snapshot.deadline_at is None


### PR DESCRIPTION
## Summary

The dashboard countdown timer was stuck at the budget value (e.g. \`5:00\`) for any evaluation with an \`ext-\` job ID — the timer never ticked because \`job.deadlineAt\` was always null on those snapshots.

**Root cause:** External (CLI-launched / \`ext-{run_id}\`) runs bypass \`JobManager\` and so never hit the \`_apply_marker\` parser that sets \`Job.deadline_at\` from the \`analyzing_start\` stdout marker. The CLI's \`run_lifecycle\` does write \`deadline_at\` to \`status.json\` (via \`lifecycle.set_deadline(...)\`) — but the snapshot builder for ext- runs never read it back.

**Fix:**

- \`FilesystemActionProvider._run_row_to_snapshot\` now reads \`deadline_at\` from \`status.json\` (parallel to the existing dimensions-from-status helper) and passes it through to \`JobSnapshot.deadline_at\`. The existing \`to_camel_dict\` API serializer then surfaces it as \`deadlineAt\` to the frontend.
- \`_check_stale_and_promote\` previously rewrote \`status.json\` on stale-detection without passing \`deadline_at\` — fixed to preserve it across the \`running → cancelled\` transition.

Two new tests cover the read path:

- A live ext- run with \`deadline_at\` populates \`snapshot.deadline_at\`.
- An ext- run with no deadline (unlimited budget) yields \`snapshot.deadline_at is None\` without raising.

## Why does \`ext-\` exist at all?

Worth answering since it's a recurring source of bugs like this.

The CLI (\`quodeq scan ...\`) is designed to run standalone without the dashboard server. It writes output directly to disk. The dashboard discovers those runs after-the-fact by reading a SQLite index of runs on disk, and assigns \`ext-{run_id}\` IDs to anything not tracked by the in-memory JobManager. That separation is real:

- Internal: dashboard-launched, marker-based stdout protocol, JobManager-tracked.
- External: CLI-launched, persisted on disk, served by reading filesystem state.

Eliminating \`ext-\` would mean making the CLI a client of the dashboard server — a bigger refactor that breaks the standalone-CLI use case. The smaller win (and what this PR delivers) is to make sure the *data* surfaces consistently across both paths. Field-level parity, not architectural parity.

## Test plan

- [x] \`uv run pytest tests/services/\` — 637/637 passing
- [x] New tests cover the deadline read path (with and without deadline)
- [x] Manual: start an evaluation with a 5-minute time limit, observe the timer ticking down (was frozen at 5:00)
- [x] Manual: cancel a long-running eval; the cancelled snapshot retains its \`deadline_at\` (no longer dropped on stale-promotion)

## Files

- \`src/quodeq/services/filesystem.py\` — read \`deadline_at\` from status.json in the snapshot builder
- \`src/quodeq/services/_index_sync.py\` — preserve \`deadline_at\` across stale → cancelled rewrite
- \`tests/services/test_action_provider_fs_evaluations.py\` — two new tests