### PR TITLE
fix(dashboard): unstuck phantom 'running' evaluations + UI escape hatch

### DIFF
--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -161,6 +161,28 @@ def _sync_legacy_run(
     )
 
 
+def _delete_orphan_non_terminal_rows(db: sqlite3.Connection) -> int:
+    """Remove non-terminal rows whose ``run_dir`` no longer exists on disk.
+
+    Without this sweep, an orphan row (e.g. left by a crashed test, a manually
+    deleted run dir, or a partial cleanup) stays as ``running`` forever:
+    ``_check_stale_and_promote`` reads ``.heartbeat`` from ``run_dir``, and an
+    unreadable heartbeat (no dir) provides no liveness signal, so the row is
+    never promoted. Terminal rows are left alone — users may prune old dirs
+    to save disk and the index is their only record.
+    """
+    placeholders = ", ".join("?" for _ in _TERMINAL_STATE_VALUES)
+    rows = db.execute(
+        f"SELECT job_id, run_dir FROM runs WHERE state NOT IN ({placeholders})",
+        tuple(_TERMINAL_STATE_VALUES),
+    ).fetchall()
+    orphan_ids = [job_id for job_id, run_dir in rows if not Path(run_dir).is_dir()]
+    if not orphan_ids:
+        return 0
+    db.executemany("DELETE FROM runs WHERE job_id = ?", [(j,) for j in orphan_ids])
+    return len(orphan_ids)
+
+
 def _check_stale_and_promote(
     db: sqlite3.Connection, run_dir: Path, *,
     project_uuid: str, run_id: str, stale_seconds: int = 30,

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from quodeq.services._index_sync import (
     _check_stale_and_promote,
+    _delete_orphan_non_terminal_rows,
     _sync_legacy_run,
     _upsert_from_status,
     _status_mtime_ns,
@@ -177,11 +178,13 @@ def _sync_one_run(
 def sync_index(db: sqlite3.Connection, evaluations_root: Path) -> None:
     """Lazy upsert: walk *evaluations_root*, sync any run whose status.json
     changed since last seen OR that lacks an index row entirely. Promote
-    stale non-terminal runs.
+    stale non-terminal runs. Sweep non-terminal rows whose ``run_dir`` is
+    gone — those can't be rescued by the heartbeat-based stale check.
     """
     with db:
         for project_uuid, run_id, run_dir in _walk_run_dirs(evaluations_root):
             _sync_one_run(db, run_dir, project_uuid=project_uuid, run_id=run_id)
+        _delete_orphan_non_terminal_rows(db)
 
 
 def sync_index_for_run(db: sqlite3.Connection, run_dir: Path) -> None:

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -49,6 +49,7 @@ function JobHeader({ job, onDismiss, onCancel }) {
       </div>
       <div className="job-header-right">
         {isRunning && <button type="button" className="job-cancel-inline" onClick={onCancel}>Cancel</button>}
+        {isRunning && <button type="button" className="job-header-dismiss-btn" onClick={() => onDismiss('close')}>Hide</button>}
         {!isRunning && isDone && <button type="button" className="job-header-view-btn" onClick={() => onDismiss('view')}>View Results</button>}
         {!isRunning && <button type="button" className="job-header-dismiss-btn" onClick={() => onDismiss('close')}>{isDone ? 'Dismiss' : 'Close'}</button>}
         <StatusChip status={job.status} exitReason={job.exitReason} />

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import EvaluationStatus from './EvaluationStatus.jsx';
 
@@ -44,6 +44,26 @@ describe('StatusChip', () => {
     expect(chip.textContent).toBe('failed');
     expect(chip.className).not.toContain('job-status-badge--stale');
     expect(chip.getAttribute('title')).toBe('exception: EvaluationError');
+  });
+});
+
+describe('JobHeader escape hatch', () => {
+  it('renders a Hide button alongside Cancel when status is running', () => {
+    render(<EvaluationStatus job={{ ...baseJob, status: 'running' }} onCancel={() => {}} onDismiss={() => {}} />);
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /hide/i })).toBeInTheDocument();
+  });
+
+  it('clicking Hide on a running job calls onDismiss with "close"', () => {
+    const onDismiss = vi.fn();
+    render(<EvaluationStatus job={{ ...baseJob, status: 'running' }} onCancel={() => {}} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole('button', { name: /hide/i }));
+    expect(onDismiss).toHaveBeenCalledWith('close');
+  });
+
+  it('does not render Hide for a done job (Dismiss already covers it)', () => {
+    render(<EvaluationStatus job={{ ...baseJob, status: 'done' }} onCancel={() => {}} onDismiss={() => {}} />);
+    expect(screen.queryByRole('button', { name: /^hide$/i })).toBeNull();
   });
 });
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -182,6 +182,17 @@ export function useEvaluation() {
         queryClient.invalidateQueries({ queryKey: evaluationKeys.evaluation(jobId) });
       }
     },
+    onError: (err) => {
+      // The backend returns 409 when the job is no longer cancellable
+      // (process gone, status already terminal, etc.). Without this handler
+      // the user is trapped: status stays "running", Cancel does nothing
+      // visible. Surface the message and clear locally so the panel closes.
+      const msg = err?.message || "Could not cancel evaluation";
+      setJobError(msg);
+      const id = jobId;
+      if (id) queryClient.removeQueries({ queryKey: evaluationKeys.evaluation(id) });
+      setJobId(null);
+    },
   });
 
   const startEvaluation = useCallback(

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -5,6 +5,10 @@ import { useEvaluation } from "./useEvaluation";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
 import { ApiProvider } from "../../../api/ApiContext.jsx";
 
+vi.mock("../../../utils/confirmDialog.js", () => ({
+  confirmDialog: vi.fn().mockResolvedValue({ ok: true, checked: false }),
+}));
+
 const fakeApi = {
   getEvaluation: vi.fn(),
   startEvaluation: vi.fn(),
@@ -100,6 +104,29 @@ describe("useEvaluation", () => {
         aiModel: "llama3.1",
       }),
     );
+  });
+
+  it("cancelEvaluation surfaces an error and clears the job when the API rejects", async () => {
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j-stuck",
+      status: "running",
+      dimensions: [],
+    });
+    fakeApi.cancelEvaluation.mockRejectedValue(new Error("Could not cancel job"));
+    const { result } = renderHook(() => useEvaluation(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    await waitFor(() => expect(result.current.job?.jobId).toBe("j-stuck"));
+
+    await act(async () => {
+      await result.current.cancelEvaluation();
+    });
+
+    await waitFor(() => {
+      expect(result.current.jobError).toMatch(/cancel/i);
+      expect(result.current.job).toBeNull();
+    });
   });
 
   it("startEvaluation surfaces a useful error when no provider is configured", async () => {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,26 @@ import pytest
 @pytest.fixture(autouse=True)
 def _isolate_quodeq_home(tmp_path_factory: pytest.TempPathFactory,
                          monkeypatch: pytest.MonkeyPatch) -> None:
-    """Point QUODEQ_HOME at an empty per-test tmp dir.
+    """Redirect every Quodeq state path at an empty per-test tmp dir.
 
-    Defensive isolation so tests cannot accidentally read or write the
-    developer's real ``~/.quodeq`` (which holds the existing global
-    ``index.db`` from ``services/run_index.py``, plus per-run state).
+    Tests have repeatedly written to the developer's real ``~/.quodeq``
+    (a stuck ``state=running`` row in ``index.db`` once leaked through and
+    the dashboard auto-resumed it as a phantom job). The previous version
+    of this fixture set ``QUODEQ_HOME``, which **nothing in the codebase
+    reads** — so the defaults in ``shared/_env.py`` continued to fall
+    through to ``Path.home() / ".quodeq"``.
+
+    Set the env vars the production code actually consults:
+      * ``QUODEQ_INDEX_DB_PATH``    — ``services/filesystem._open_index``
+      * ``QUODEQ_EVALUATIONS_DIR``  — ``services/filesystem.list_evaluations`` etc.
+      * ``QUODEQ_DIR``              — ``dashboard/_build_npm._quodeq_dir``
+    ``QUODEQ_HOME`` is kept for any out-of-tree consumer that may rely on it.
     """
     home = tmp_path_factory.mktemp("quodeq-home")
     monkeypatch.setenv("QUODEQ_HOME", str(home))
+    monkeypatch.setenv("QUODEQ_DIR", str(home))
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(home / "index.db"))
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(home / "evaluations"))
 
 
 class DummyProcess:

--- a/tests/services/test_index_sync.py
+++ b/tests/services/test_index_sync.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from quodeq.shared.run_status import RunState, write_status
-from quodeq.services.run_index import open_index
+from quodeq.services.run_index import open_index, sync_index
 from quodeq.services._index_sync import (
     _is_pid_alive,
     _sync_legacy_run,
@@ -215,6 +215,91 @@ def test_stale_promotion_after_sigkill_real_subprocess(tmp_path: Path) -> None:
         if proc.poll() is None:
             proc.kill()
             proc.wait(timeout=5)
+        db.close()
+
+
+def test_sync_index_deletes_orphan_non_terminal_row(tmp_path: Path) -> None:
+    """A non-terminal row whose run_dir is missing on disk must be removed.
+
+    Reproduces the production trap where a row gets stuck as `running` because
+    `_check_stale_and_promote` reads `.heartbeat` from a run_dir that no longer
+    exists, so the heartbeat is unreadable and the row is never promoted.
+    """
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    db = open_index(tmp_path / "idx.db")
+    try:
+        # Row points at a run_dir that does not exist on disk.
+        ghost_dir = reports / "ghost-project" / "ghost-run"
+        db.execute(
+            "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+            "started_at, updated_at, status_mtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ext-ghost", "ghost-project", "ghost-run", str(ghost_dir),
+                "running", "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00", 0,
+            ),
+        )
+        db.commit()
+
+        sync_index(db, reports)
+
+        row = db.execute(
+            "SELECT job_id FROM runs WHERE job_id = ?", ("ext-ghost",),
+        ).fetchone()
+        assert row is None, "orphan non-terminal row should be removed by sync_index"
+    finally:
+        db.close()
+
+
+def test_sync_index_keeps_orphan_terminal_row(tmp_path: Path) -> None:
+    """A terminal-state row whose run_dir is missing should be preserved.
+
+    Users may prune old run dirs to save disk; the index entry is the only
+    record of that run's outcome and must not be silently deleted.
+    """
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    db = open_index(tmp_path / "idx.db")
+    try:
+        ghost_dir = reports / "p" / "old-run"
+        db.execute(
+            "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+            "started_at, updated_at, status_mtime) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ext-old", "p", "old-run", str(ghost_dir),
+                "done", "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00", 0,
+            ),
+        )
+        db.commit()
+
+        sync_index(db, reports)
+
+        row = db.execute(
+            "SELECT state FROM runs WHERE job_id = ?", ("ext-old",),
+        ).fetchone()
+        assert row is not None and row[0] == "done"
+    finally:
+        db.close()
+
+
+def test_sync_index_keeps_rows_whose_run_dir_exists(tmp_path: Path) -> None:
+    """Sanity check: rows backed by a real run_dir survive the orphan sweep."""
+    reports = tmp_path / "reports"
+    run = _make_run_dir(reports, "p", "real-run")
+    write_status(
+        run, state=RunState.RUNNING, job_id="ext-real-run",
+        started_at="2026-04-20T00:00:00+00:00", dimensions=[], pid=os.getpid(),
+    )
+    db = open_index(tmp_path / "idx.db")
+    try:
+        sync_index(db, reports)
+        row = db.execute(
+            "SELECT state FROM runs WHERE job_id = ?", ("ext-real-run",),
+        ).fetchone()
+        assert row is not None and row[0] == "running"
+    finally:
         db.close()
 
 

--- a/tests/services/test_test_isolation.py
+++ b/tests/services/test_test_isolation.py
@@ -1,0 +1,50 @@
+"""Regression: tests must never touch the developer's real ``~/.quodeq``.
+
+A pytest run that constructs ``FilesystemActionProvider()`` with no explicit
+``index_db_path`` previously fell through to ``Path.home() / ".quodeq" /
+"index.db"`` and wrote test rows to the user's production DB — leaving stuck
+"running" jobs that the dashboard then auto-resumed. The autouse fixture in
+``tests/conftest.py`` must redirect ``QUODEQ_INDEX_DB_PATH`` and
+``QUODEQ_EVALUATIONS_DIR`` at a per-test tmp dir so this can't happen.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.services.filesystem import FilesystemActionProvider
+from quodeq.shared._env import get_evaluations_dir, get_index_db_path
+
+
+def test_default_index_db_path_resolves_inside_tmp() -> None:
+    real_home_db = str(Path.home() / ".quodeq" / "index.db")
+    resolved = get_index_db_path()
+    assert resolved != real_home_db, (
+        f"get_index_db_path() returned the production path {resolved}; "
+        "the autouse isolation fixture is not setting QUODEQ_INDEX_DB_PATH"
+    )
+
+
+def test_default_evaluations_dir_resolves_inside_tmp() -> None:
+    real_home_dir = str(Path.home() / ".quodeq" / "evaluations")
+    resolved = get_evaluations_dir()
+    assert resolved != real_home_dir, (
+        f"get_evaluations_dir() returned the production path {resolved}; "
+        "the autouse isolation fixture is not setting QUODEQ_EVALUATIONS_DIR"
+    )
+
+
+def test_default_provider_open_index_writes_to_tmp() -> None:
+    """The exact failure mode that polluted ~/.quodeq/index.db: provider
+    constructed with no kwargs and ``_open_index`` lazily resolves the path."""
+    provider = FilesystemActionProvider()
+    db = provider._open_index()
+    try:
+        # The lazy resolver in _open_index sets _index_db_path to the resolved
+        # value; assert it is not the real home DB.
+        real_home_db = Path.home() / ".quodeq" / "index.db"
+        assert provider._index_db_path != real_home_db, (
+            f"FilesystemActionProvider() opened the production DB at "
+            f"{provider._index_db_path}; isolation fixture is broken"
+        )
+    finally:
+        db.close()

--- a/tests/test_cli_evaluate_flags.py
+++ b/tests/test_cli_evaluate_flags.py
@@ -1,8 +1,7 @@
-from pathlib import Path
-
 import pytest
 
 from quodeq.cli import build_parser
+from quodeq.shared.utils import get_evaluations_dir
 
 _TEST_REPO = "tmp/repo"
 _TEST_LANGUAGE = "python"
@@ -33,7 +32,10 @@ def test_evaluate_mode(parsed_evaluate_args):
 
 
 def test_evaluate_default_output(parsed_evaluate_args):
-    assert parsed_evaluate_args.output == str(Path.home() / ".quodeq" / "evaluations")
+    # The parser resolves the default via ``get_evaluations_dir()``, which
+    # honours ``QUODEQ_EVALUATIONS_DIR``. Compare against the same helper so
+    # the test stays correct under the autouse isolation fixture.
+    assert parsed_evaluate_args.output == get_evaluations_dir()
 
 
 def test_evaluate_no_prescan_default(parsed_evaluate_args):


### PR DESCRIPTION
## Summary

Fixes the trap where the Evaluate tab shows an "Evaluation in Progress" panel for a job that isn't actually running, with no way to close it.

A non-terminal row in `~/.quodeq/index.db` whose `run_dir` no longer exists on disk gets stuck forever: `_check_stale_and_promote` reads `.heartbeat` from a missing directory and finds nothing, so the row is never promoted to cancelled. The Evaluate-tab auto-resume (PR #366) then adopts the phantom row as a live job — Cancel returns 409 (process gone, can't SIGTERM), the existing `cancelMutation` has no `onError`, and the JobHeader hides Close while `status === 'running'`. The user is trapped.

## Layered fix

- **Backend** — `sync_index` sweeps non-terminal rows whose `run_dir` is gone after the FS walk. Terminal rows are preserved (the index is the user's audit trail if a run dir gets pruned to save disk).
- **UI escape hatch** — `EvaluationStatus.JobHeader` renders a "Hide" button alongside Cancel while running. `cancelMutation` now has an `onError` that surfaces the message via the toast and clears local job state, so the panel always closes.
- **Test isolation** — the autouse fixture in `tests/conftest.py` was setting `QUODEQ_HOME`, which nothing in the codebase reads. Defaults in `shared/_env.py` fell through to `Path.home() / ".quodeq"`, so tests using `FilesystemActionProvider()` with no explicit `index_db_path` were writing to the developer's real DB — exactly how this bug surfaced. Set the env vars production code actually consults (`QUODEQ_INDEX_DB_PATH`, `QUODEQ_EVALUATIONS_DIR`, `QUODEQ_DIR`) and add regression tests that fail loudly if isolation slips again.

## Test plan

- [x] `uv run pytest tests/` — 2598 passed
- [x] `npx vitest run src/features/evaluation/{components,hooks}` — 19 passed (all four new tests + existing 15)
- [ ] Open Evaluate tab on a dashboard with a phantom `state=running` row in `~/.quodeq/index.db` whose `run_dir` doesn't exist — confirm the row is swept on first `sync_index` call and the panel doesn't appear
- [ ] Manually trigger Cancel on a running job whose process has died — confirm the toast shows the error and the panel closes instead of hanging