### PR TITLE
fix(dashboard): cancel auto-promotes phantom 'running' rows

### DIFF
--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -183,6 +183,70 @@ def _delete_orphan_non_terminal_rows(db: sqlite3.Connection) -> int:
     return len(orphan_ids)
 
 
+def force_promote_to_cancelled_stale(
+    db: sqlite3.Connection, job_id: str, *, run_dir: Path | None = None,
+) -> bool:
+    """Mark a non-terminal index row as ``cancelled(stale_detected)``.
+
+    Called from the cancel path when SIGTERM has nothing to signal (PID is
+    dead). The row stays in the index — history is preserved. State flips
+    to terminal so the dashboard no longer treats the job as live.
+
+    If *run_dir* is provided and exists, ``status.json`` is also rewritten
+    so the on-disk source of truth matches the index. Findings inside
+    ``run_dir`` are not touched.
+
+    Returns True if the row was promoted, False if it didn't exist or was
+    already terminal.
+    """
+    row = db.execute(
+        "SELECT state, project_uuid, run_id, started_at, phase, "
+        "current_dimension, pid FROM runs WHERE job_id = ?", (job_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    state, project_uuid, run_id, started_at, phase, current_dimension, pid = row
+    if state in _TERMINAL_STATE_VALUES:
+        return False
+
+    # Prefer the FS path: write status.json and let the upsert sync the row.
+    if run_dir is not None and run_dir.is_dir():
+        try:
+            existing = read_status(run_dir) or {}
+            dimensions = existing.get("dimensions") or []
+            write_status(
+                run_dir,
+                state=RunState.CANCELLED,
+                job_id=job_id,
+                started_at=started_at or existing.get("started_at", ""),
+                dimensions=dimensions,
+                phase=phase,
+                current_dimension=current_dimension,
+                pid=pid if isinstance(pid, int) else None,
+                exit_reason="stale_detected",
+            )
+            _upsert_from_status(
+                db, run_dir, project_uuid=project_uuid, run_id=run_id,
+            )
+            return True
+        except (OSError, UnsupportedSchemaError) as exc:
+            _logger.warning(
+                "force-promote: status.json write failed for %s (%s); "
+                "falling back to index-only update", job_id, exc,
+            )
+            # Fall through to DB-only path.
+
+    # No run_dir on disk (full orphan): update the index row directly.
+    from datetime import datetime, timezone
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    db.execute(
+        "UPDATE runs SET state = ?, exit_reason = ?, finalized_at = ?, "
+        "updated_at = ? WHERE job_id = ?",
+        ("cancelled", "stale_detected", now_iso, now_iso, job_id),
+    )
+    return True
+
+
 def _check_stale_and_promote(
     db: sqlite3.Connection, run_dir: Path, *,
     project_uuid: str, run_id: str, stale_seconds: int = 30,

--- a/src/quodeq/services/filesystem.py
+++ b/src/quodeq/services/filesystem.py
@@ -197,6 +197,54 @@ class FilesystemActionProvider(FsEvaluationMixin, FsToolingMixin, ActionProvider
             return None
         return self._run_row_to_snapshot(row)
 
+    def cancel_evaluation(
+        self, job_id: str, reports_dir: str | None = None,
+        *, discard_partial: bool = False,
+    ) -> bool:
+        """Cancel a running job. Falls back to ``stale_detected`` promotion
+        when SIGTERM has nothing to signal (PID dead).
+
+        The base mixin's ``cancel_evaluation`` returns False when the
+        underlying process is gone, which the route turns into 409 — leaving
+        the user stuck on an "Evaluation in Progress" panel that won't
+        progress. After verifying the snapshot was non-terminal, we promote
+        the index row to ``cancelled(stale_detected)`` so the UI flips out
+        of "running" and the user can close the panel. The row stays in the
+        index (history preserved) and findings on disk are not touched.
+        """
+        ok = super().cancel_evaluation(
+            job_id, reports_dir=reports_dir, discard_partial=discard_partial,
+        )
+        if ok:
+            return True
+
+        snapshot = self.get_evaluation_status(job_id, reports_dir=reports_dir)
+        if snapshot is None:
+            # The row is gone — either it never existed, or the orphan sweep
+            # inside ``sync_index`` removed it during ``super()``'s call. The
+            # user's intent ("stop this job") is satisfied: there's nothing
+            # running. Report success so the UI escapes the stuck panel.
+            return True
+        if snapshot.status != "running":
+            # Already terminal — preserve original contract (don't fabricate
+            # a state transition).
+            return False
+
+        from quodeq.services._index_sync import force_promote_to_cancelled_stale
+
+        run_dir: Path | None = None
+        if snapshot.output_project and snapshot.output_run_id and reports_dir:
+            candidate = Path(reports_dir) / snapshot.output_project / snapshot.output_run_id
+            if candidate.is_dir():
+                run_dir = candidate
+
+        db = self._open_index()
+        try:
+            with db:
+                return force_promote_to_cancelled_stale(db, job_id, run_dir=run_dir)
+        finally:
+            db.close()
+
     @staticmethod
     def _tail_run_log(run_dir: Path, max_lines: int = 500) -> list[str]:
         """Return the last *max_lines* lines from run.log. Cheap for normal logs."""

--- a/tests/services/test_cancel_evaluation_orphan.py
+++ b/tests/services/test_cancel_evaluation_orphan.py
@@ -1,0 +1,166 @@
+"""Cancel must escape the user from a phantom 'running' row.
+
+When the index says ``state=running`` but the underlying process is gone
+(SIGTERM has nothing to signal), cancel today returns False and the dashboard
+returns 409. The user is stuck. The fix: at cancel time, verify liveness; if
+the process is dead, promote the row to ``cancelled(stale_detected)`` so the
+UI flips to a terminal state. Findings on disk and the index row are preserved.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from quodeq.services.filesystem import FilesystemActionProvider
+from quodeq.services.run_index import open_index
+from quodeq.shared.run_status import RunState, write_status
+
+
+def _make_run_dir(reports: Path, project: str, run_id: str) -> Path:
+    d = reports / project / run_id
+    (d / "evidence").mkdir(parents=True)
+    (d / "evidence" / "manifest.json").write_text("{}")
+    return d
+
+
+def test_cancel_orphan_no_run_dir_unblocks_user(tmp_path: Path) -> None:
+    """The exact production trap: row says running, process gone, run_dir gone.
+
+    Cancel must return True so the dashboard returns 200 and the UI escapes
+    the stuck "Evaluation in Progress" panel. Whether the row gets swept
+    by ``sync_index``'s orphan sweeper or promoted to cancelled is an
+    implementation detail; the contract is "this job is no longer running."
+    """
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    db_path = tmp_path / "idx.db"
+    db = open_index(db_path)
+    try:
+        ghost_dir = reports / "ghost-project" / "ghost-run"
+        db.execute(
+            "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+            "started_at, updated_at, status_mtime, pid) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ext-ghost", "ghost-project", "ghost-run", str(ghost_dir),
+                "running", "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00", 0, 999999999,
+            ),
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    provider = FilesystemActionProvider(index_db_path=db_path)
+    ok = provider.cancel_evaluation("ext-ghost", reports_dir=str(reports))
+    assert ok is True, "cancel must unblock the user when the process is gone"
+
+    # Post-condition: the job is no longer surfaced as running. The row is
+    # either gone (swept) or cancelled (promoted) — both unblock the UI.
+    snapshot = provider.get_evaluation_status("ext-ghost", reports_dir=str(reports))
+    assert snapshot is None or snapshot.status != "running"
+
+
+def test_cancel_orphan_with_run_dir_preserves_findings(tmp_path: Path) -> None:
+    """When the run_dir exists with partial work, cancel-on-orphan must
+    preserve evidence and update status.json — not delete anything.
+
+    Realistic scenario: process died but heartbeat is still fresh, so the
+    background stale-check (in ``_check_stale_and_promote``) hasn't promoted
+    the row yet. The user clicks Cancel; SIGTERM has nothing to signal; the
+    fallback must promote the row to ``cancelled(stale_detected)``.
+    """
+    reports = tmp_path / "reports"
+    run = _make_run_dir(reports, "p", "stale-run")
+    write_status(
+        run, state=RunState.RUNNING, job_id="ext-stale-run",
+        started_at="2026-04-20T00:00:00+00:00", dimensions=["security"],
+        pid=999999999,
+    )
+    # Fresh heartbeat — keeps the background stale-check from auto-promoting
+    # before our cancel call has a chance to run.
+    (run / ".heartbeat").touch()
+    # .pid mirrors the dead PID written into status.json so cancel_external_run
+    # finds the file and treats the pid-liveness check as authoritative.
+    (run / ".pid").write_text("999999999")
+    # Sentinel that proves we don't wipe findings on the cancel-orphan path.
+    sentinel = run / "evidence" / "security_evidence.jsonl"
+    sentinel.write_text('{"finding":"x"}\n')
+
+    db_path = tmp_path / "idx.db"
+    provider = FilesystemActionProvider(index_db_path=db_path)
+    # Seed the index from disk
+    provider.list_evaluations(limit=0, reports_dir=str(reports))
+
+    ok = provider.cancel_evaluation("ext-stale-run", reports_dir=str(reports))
+    assert ok is True
+
+    snapshot = provider.get_evaluation_status("ext-stale-run", reports_dir=str(reports))
+    assert snapshot is not None
+    assert snapshot.status == "cancelled"
+    assert sentinel.exists(), "evidence must be preserved on cancel-orphan path"
+    assert run.exists(), "run_dir must be preserved (history)"
+
+
+def test_cancel_terminal_state_unchanged(tmp_path: Path) -> None:
+    """Cancel must not touch a row that is already in a terminal state.
+
+    Guards against accidentally rewriting history when the user double-clicks
+    Cancel or there's a race between client and server.
+    """
+    reports = tmp_path / "reports"
+    run = _make_run_dir(reports, "p", "done-run")
+    write_status(
+        run, state=RunState.DONE, job_id="ext-done-run",
+        started_at="2026-04-20T00:00:00+00:00", dimensions=[],
+    )
+    db_path = tmp_path / "idx.db"
+    provider = FilesystemActionProvider(index_db_path=db_path)
+    provider.list_evaluations(limit=0, reports_dir=str(reports))
+
+    ok = provider.cancel_evaluation("ext-done-run", reports_dir=str(reports))
+    assert ok is False, "cancelling a terminal row must be a no-op (returns False)"
+
+    snapshot = provider.get_evaluation_status("ext-done-run", reports_dir=str(reports))
+    assert snapshot is not None
+    assert snapshot.status == "done", "terminal state must not be rewritten"
+
+
+def test_cancel_live_pid_unchanged_behavior(tmp_path: Path) -> None:
+    """Sanity check: when the PID is genuinely alive, cancel still goes
+    through the SIGTERM path (and our promote-on-orphan fallback does NOT
+    fire). Uses os.getpid() — a guaranteed live PID."""
+    reports = tmp_path / "reports"
+    run = _make_run_dir(reports, "p", "live-run")
+    write_status(
+        run, state=RunState.RUNNING, job_id="ext-live-run",
+        started_at="2026-04-20T00:00:00+00:00", dimensions=[],
+        pid=os.getpid(),
+    )
+    # .pid file is what cancel_external_run reads
+    (run / ".pid").write_text(str(os.getpid()))
+
+    db_path = tmp_path / "idx.db"
+    provider = FilesystemActionProvider(index_db_path=db_path)
+    provider.list_evaluations(limit=0, reports_dir=str(reports))
+
+    # We don't want to actually SIGTERM ourselves; intercept the syscall.
+    import quodeq.services._external_jobs as _ext_mod
+    original_kill = os.kill
+    sent_signals: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        if sig == 0:
+            return original_kill(pid, sig)  # liveness probe
+        sent_signals.append((pid, sig))
+
+    _ext_mod.os.kill = fake_kill  # type: ignore[attr-defined]
+    try:
+        ok = provider.cancel_evaluation("ext-live-run", reports_dir=str(reports))
+    finally:
+        _ext_mod.os.kill = original_kill  # type: ignore[attr-defined]
+
+    assert ok is True
+    assert sent_signals, "SIGTERM path must be taken when PID is alive"


### PR DESCRIPTION
## Summary

Follow-up to #381. After that PR landed, the orphan-row sweep clears phantom rows on the next ``sync_index`` call — but a user who clicks **Cancel** on a stuck "Evaluation in Progress" panel in the meantime still hits a 409. The mixin's ``cancel_evaluation`` returns False whenever SIGTERM has no live process to signal, regardless of whether the row is genuinely stuck.

This PR makes Cancel actually cancel in that case: when the underlying ``cancel_job`` returns False, the provider verifies the row is still non-terminal and promotes it to ``cancelled(stale_detected)`` — the same end state as the periodic background stale-check, just triggered on user intent instead of a timer.

## Constraints (from product feedback)

- **Liveness must be verified, not assumed.** SIGTERM still goes to live processes unchanged — fallback only fires after ``cancel_external_run`` confirms the PID is dead via ``os.kill(pid, 0)``.
- **History must be preserved.** Index rows are never deleted by this path. Run dir contents (evidence, partial findings) are never touched. Only the row's ``state`` flips and ``status.json`` is rewritten when the run_dir exists.
- **Terminal rows are immutable.** Cancelling a ``done``/``failed``/``cancelled`` row remains a no-op (returns False).

## What changed

- ``FilesystemActionProvider.cancel_evaluation`` overrides the mixin to add the fallback after a False result from ``super()``.
- New helper ``force_promote_to_cancelled_stale`` in ``services/_index_sync.py``: writes ``status.json`` when the run_dir exists (FS source-of-truth stays consistent with the index) or updates the index row directly when it doesn't (full orphan from a deleted/missing run_dir).
- The override also handles the race where the #381 orphan sweep already removed the row during ``super()``'s ``get_evaluation_status`` call — returning True since the user's intent is satisfied.

## Test plan

- [x] ``uv run pytest tests/`` — 2604 passed
- [x] New ``tests/services/test_cancel_evaluation_orphan.py`` — 4 cases:
  1. Orphan, no run_dir → cancel returns True, row no longer surfaces as running
  2. Orphan, run_dir present, dead PID, fresh heartbeat → cancel returns True, row promoted to ``cancelled(stale_detected)``, evidence preserved, run_dir preserved
  3. Terminal row (``done``) → cancel returns False, state untouched
  4. Live PID → SIGTERM path unchanged
- [x] In-app: open dashboard with a phantom row in ``index.db``, click Cancel — confirm panel transitions to "cancelled (stale)" and Close button appears, instead of getting stuck