### PR TITLE
fix(ui): snackbar feedback for blocked actions; remove Hide; rename Re-evaluate

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -26,7 +26,7 @@ import ProjectHeader from './components/ProjectHeader.jsx';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { readVisibleStandardIds } from './utils/visibleStandards.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
-import { SidePane, SidePaneProvider } from './features/side-pane/index.js';
+import { SidePane, useSidePane } from './features/side-pane/index.js';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { EvalLogProvider } from './features/evaluation/eval-log/EvalLogProvider.jsx';
 import { ServerLogProvider } from './features/settings/server-log/ServerLogProvider.jsx';
@@ -359,6 +359,8 @@ export default function App() {
   // auto-open job is done for this page load.
   const autoOpenedRef = useRef(false);
 
+  const { showToast } = useSidePane();
+
   // While an evaluation is running we block any path that would open the
   // onboarding wizard or start a second evaluation — only one job may be in
   // flight at a time.
@@ -442,17 +444,23 @@ export default function App() {
       prefetchHandlers: state.prefetchHandlers,
       onAddProject: () => {
         if (isEvaluating) {
-          console.warn('[onboarding] add-project ignored — evaluation in progress');
+          showToast('An evaluation is in progress. Cancel it before adding a project.');
           return;
         }
         setWizardEntry({ startStep: 'repo-scan', isFirstProject: state.projects.length === 0 });
       },
       onTakeTour: () => {
-        if (isEvaluating) return;
+        if (isEvaluating) {
+          showToast('An evaluation is in progress. Cancel it before starting the tour.');
+          return;
+        }
         setWizardEntry({ startStep: 'welcome', isFirstProject: true });
       },
       onResumeSetup: (projectId) => {
-        if (isEvaluating) return;
+        if (isEvaluating) {
+          showToast('An evaluation is in progress. Cancel it before resuming setup.');
+          return;
+        }
         setWizardEntry({
           startStep: 'provider',
           isFirstProject: false,
@@ -481,7 +489,6 @@ export default function App() {
 
   return (
     <>
-    <SidePaneProvider>
       <EvalLogProvider>
         <ServerLogProvider>
           <OllamaLogProvider>
@@ -580,7 +587,6 @@ export default function App() {
           </OllamaLogProvider>
         </ServerLogProvider>
       </EvalLogProvider>
-    </SidePaneProvider>
     {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
     </>
   );

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -260,6 +260,9 @@ function useRelocateDialog(onRelocate) {
 const EVAL_BLOCKED_TITLE = 'Cannot add a project while an evaluation is running';
 
 function EmptyProjectsCTA({ onAddProject, isEvaluating }) {
+  // The button stays clickable while evaluating so the handler can fire a
+  // snackbar explaining the block. ``aria-disabled`` + the visual muted class
+  // preserve the disabled affordance without swallowing the click.
   return (
     <div className="projects-empty projects-empty--cta">
       <h3 className="projects-empty__title">Add your first project</h3>
@@ -268,9 +271,9 @@ function EmptyProjectsCTA({ onAddProject, isEvaluating }) {
       </p>
       <button
         type="button"
-        className="projects-empty__cta-btn"
+        className={`projects-empty__cta-btn${isEvaluating ? ' is-disabled' : ''}`}
         onClick={onAddProject}
-        disabled={isEvaluating}
+        aria-disabled={isEvaluating || undefined}
         title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
       >
         + Add project
@@ -295,10 +298,10 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
         {projects.length > 0 && onAddProject && (
           <button
             type="button"
-            className="projects-page__add-btn"
+            className={`projects-page__add-btn${isEvaluating ? ' is-disabled' : ''}`}
             onClick={onAddProject}
             aria-label="Add project"
-            disabled={isEvaluating}
+            aria-disabled={isEvaluating || undefined}
             title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
           >
             + Add project

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationForm.jsx
@@ -4,6 +4,9 @@ import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import DimensionSelector from './DimensionSelector.jsx';
 import BranchScopeSelector from './BranchScopeSelector.jsx';
 import { useScanData } from '../hooks/useScanData.js';
+import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
+
+const NO_STANDARDS_MESSAGE = 'Select at least one standard before evaluating.';
 
 
 const FOLDER_MARGIN_BOTTOM = 8;
@@ -61,7 +64,7 @@ function buildAndSubmit(onStart, formState) {
   setScopePath(null);
 }
 
-function useEvaluationForm(onStart) {
+function useEvaluationForm(onStart, onValidationFail) {
   const [repo, setRepo] = useState('');
   const { allDimensions, dimLoadError } = usePluginDimensions();
   const [selectedDims, setSelectedDims] = useState(new Set());
@@ -80,6 +83,10 @@ function useEvaluationForm(onStart) {
   const clearAll = () => setSelectedDims(new Set());
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (allDimensions.length > 0 && selectedDims.size === 0) {
+      onValidationFail?.(NO_STANDARDS_MESSAGE);
+      return;
+    }
     buildAndSubmit(onStart, { repo, selectedDims, branch, scopePath, setRepo, setSelectedDims, setBranch, setScopePath });
   };
   const handleFolderSelect = (path) => { setRepo(path); setFolderBrowserOpen(false); };
@@ -95,16 +102,20 @@ function useEvaluationForm(onStart) {
 }
 
 export default function EvaluationForm({ onStart, disabled, selectedProject }) {
+  const { showToast } = useSidePane();
   const {
     repo, setRepo, allDimensions, selectedDims, folderBrowserOpen, setFolderBrowserOpen,
     toggleDim, selectAll, clearAll, handleSubmit, handleFolderSelect, handleRepoClear, dimLoadError,
     branch, setBranch, scopePath, setScopePath,
-  } = useEvaluationForm(onStart);
+  } = useEvaluationForm(onStart, showToast);
 
   const isLocalRepo = !!repo && !repo.startsWith('http') && !repo.startsWith('git@') && !repo.includes('github.com');
   const { scanData } = useScanData(null, isLocalRepo ? repo : null);
 
-  const canSubmit = !disabled && !!repo && (allDimensions.length === 0 || selectedDims.size > 0);
+  // Submit stays clickable when no standards are selected so the snackbar
+  // can fire on click. ``disabled`` (the prop) covers the running state and
+  // the missing-repo case keeps the button greyed.
+  const canSubmit = !disabled && !!repo;
 
   return (
     <>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -49,9 +49,8 @@ function JobHeader({ job, onDismiss, onCancel }) {
       </div>
       <div className="job-header-right">
         {isRunning && <button type="button" className="job-cancel-inline" onClick={onCancel}>Cancel</button>}
-        {isRunning && <button type="button" className="job-header-dismiss-btn" onClick={() => onDismiss('close')}>Hide</button>}
         {!isRunning && isDone && <button type="button" className="job-header-view-btn" onClick={() => onDismiss('view')}>View Results</button>}
-        {!isRunning && <button type="button" className="job-header-dismiss-btn" onClick={() => onDismiss('close')}>{isDone ? 'Dismiss' : 'Close'}</button>}
+        {!isRunning && <button type="button" className="job-header-dismiss-btn" onClick={() => onDismiss('close')}>Close</button>}
         <StatusChip status={job.status} exitReason={job.exitReason} />
       </div>
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import EvaluationStatus from './EvaluationStatus.jsx';
 
@@ -44,26 +44,6 @@ describe('StatusChip', () => {
     expect(chip.textContent).toBe('failed');
     expect(chip.className).not.toContain('job-status-badge--stale');
     expect(chip.getAttribute('title')).toBe('exception: EvaluationError');
-  });
-});
-
-describe('JobHeader escape hatch', () => {
-  it('renders a Hide button alongside Cancel when status is running', () => {
-    render(<EvaluationStatus job={{ ...baseJob, status: 'running' }} onCancel={() => {}} onDismiss={() => {}} />);
-    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /hide/i })).toBeInTheDocument();
-  });
-
-  it('clicking Hide on a running job calls onDismiss with "close"', () => {
-    const onDismiss = vi.fn();
-    render(<EvaluationStatus job={{ ...baseJob, status: 'running' }} onCancel={() => {}} onDismiss={onDismiss} />);
-    fireEvent.click(screen.getByRole('button', { name: /hide/i }));
-    expect(onDismiss).toHaveBeenCalledWith('close');
-  });
-
-  it('does not render Hide for a done job (Dismiss already covers it)', () => {
-    render(<EvaluationStatus job={{ ...baseJob, status: 'done' }} onCancel={() => {}} onDismiss={() => {}} />);
-    expect(screen.queryByRole('button', { name: /^hide$/i })).toBeNull();
   });
 });
 

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -219,7 +219,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
   return (
     <div className="panel evaluate-panel">
       <div className="panel-header">
-        <h3>Re-evaluate <span className="re-eval-project-name">{info.name || project}</span></h3>
+        <h3>Evaluate <span className="re-eval-project-name">{info.name || project}</span></h3>
       </div>
 
       <div className="evaluate-form-large">

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -135,8 +135,8 @@ function Evaluations() {
         <li><strong>Incremental scan</strong> detects changed files via git diff and only re-evaluates those. Previous findings for unchanged files are carried forward, making it significantly faster and cheaper. Enable the <em>Incremental</em> toggle before starting.</li>
       </ul>
 
-      <h3>Re-evaluate</h3>
-      <p>From the <strong>Evaluate</strong> tab, you can re-run an evaluation on an existing project. The new results appear as a new run in the history, allowing you to track quality over time.</p>
+      <h3>Evaluate an existing project</h3>
+      <p>From the <strong>Evaluate</strong> tab, you can run a new evaluation on an existing project. The results appear as a new run in the history, allowing you to track quality over time.</p>
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
@@ -15,18 +15,18 @@ export default function EmptyStateWithTour({ onAdd, onTour, isEvaluating = false
       <div className="empty-state__actions">
         <button
           type="button"
-          className="term-btn--primary"
+          className={`term-btn--primary${isEvaluating ? ' is-disabled' : ''}`}
           onClick={() => { clearSkip(); onAdd(); }}
-          disabled={isEvaluating}
+          aria-disabled={isEvaluating || undefined}
           title={blockedTitle}
         >
           add a project
         </button>
         <button
           type="button"
-          className="term-btn--secondary"
+          className={`term-btn--secondary${isEvaluating ? ' is-disabled' : ''}`}
           onClick={() => { clearSkip(); onTour(); }}
-          disabled={isEvaluating}
+          aria-disabled={isEvaluating || undefined}
           title={blockedTitle}
         >
           take the tour

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
@@ -77,6 +77,15 @@ export function SidePaneProvider({ children }) {
 
   const clearNotice = useCallback(() => setNotice(null), []);
 
+  // Generic snackbar trigger for callers outside the side-pane (e.g. the
+  // evaluation form's "select at least one standard" hint, or App.jsx's
+  // "an evaluation is in progress" block on Add Project). Reuses the same
+  // visual + auto-dismiss as the side-pane's own at-cap notice.
+  const showToast = useCallback((message) => {
+    if (!message) return;
+    setNotice({ message, key: Date.now() });
+  }, []);
+
   const addWindow = useCallback((spec) => {
     if (!spec || !spec.id) return;
     if (windows.some((w) => w.id === spec.id)) return;
@@ -175,8 +184,9 @@ export function SidePaneProvider({ children }) {
       addWindow, removeWindow, replaceWindow, toggleWindow, hasWindow, closeAll,
       setPaneWidth, MAX_WINDOWS,
       registerSpec, unregisterSpec, getRegisteredSpec,
+      showToast,
     }),
-    [windows, isOpen, paneWidth, addWindow, removeWindow, replaceWindow, toggleWindow, hasWindow, closeAll, setPaneWidth, registerSpec, unregisterSpec, getRegisteredSpec],
+    [windows, isOpen, paneWidth, addWindow, removeWindow, replaceWindow, toggleWindow, hasWindow, closeAll, setPaneWidth, registerSpec, unregisterSpec, getRegisteredSpec, showToast],
   );
 
   return (

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.test.jsx
@@ -184,4 +184,32 @@ describe('SidePaneProvider', () => {
     fireEvent.click(screen.getByText('r'));
     expect(screen.getByTestId('count')).toHaveTextContent('0');
   });
+
+  describe('showToast', () => {
+    function ToastProbe() {
+      const { showToast } = useSidePane();
+      return (
+        <button onClick={() => showToast('blocked: try again later')}>fire</button>
+      );
+    }
+
+    it('renders a toast with the given message when fired', () => {
+      render(<SidePaneProvider><ToastProbe /></SidePaneProvider>);
+      expect(screen.queryByText('blocked: try again later')).toBeNull();
+      fireEvent.click(screen.getByText('fire'));
+      expect(screen.getByText('blocked: try again later')).toBeInTheDocument();
+    });
+
+    it('is exposed as part of the context value (no-op when called with empty)', () => {
+      function NoMessageProbe() {
+        const { showToast } = useSidePane();
+        return <button onClick={() => showToast('')}>fire-empty</button>;
+      }
+      render(<SidePaneProvider><NoMessageProbe /></SidePaneProvider>);
+      // No throw, no toast rendered
+      fireEvent.click(screen.getByText('fire-empty'));
+      // The toast role is "status" — assert none exists.
+      expect(screen.queryByRole('status')).toBeNull();
+    });
+  });
 });

--- a/src/quodeq/ui/src/main.jsx
+++ b/src/quodeq/ui/src/main.jsx
@@ -6,6 +6,7 @@ import { resolveDataTheme } from './utils/themeResolver.js';
 import { ApiProvider } from './api/ApiContext.jsx';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './api/queryClient.js';
+import { SidePaneProvider } from './features/side-pane/index.js';
 
 const LS_THEME = 'cc-theme';
 const LS_THEME_MODE = 'cc-theme-mode';
@@ -85,7 +86,11 @@ if (!rootEl) throw new Error('Root element #root not found in DOM');
 createRoot(rootEl).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ApiProvider><App /></ApiProvider>
+      <ApiProvider>
+        <SidePaneProvider>
+          <App />
+        </SidePaneProvider>
+      </ApiProvider>
     </QueryClientProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary

Three UX follow-ups from review of the evaluation-trap fixes (#381, #382).

### 1. Remove the Hide button from JobHeader
Cancel auto-promotion (#382) already gives a clean exit from a stuck panel; the extra "Hide" affordance was redundant. Removed it and its three component tests.

### 2. Snackbar feedback for blocked actions
Today, three actions silently no-op when an evaluation is running:
- Add Project (in `ProjectsPage` header + empty state, and `EmptyStateWithTour`)
- Take Tour
- Resume Setup

The buttons were `disabled`, so clicks never reached the handler — no chance to explain why. And in `EvaluationForm`, submitting with no standards selected was silently disabled too.

Fix: replace HTML `disabled` with `aria-disabled` + a visual `is-disabled` class. The click reaches the handler, which fires a snackbar describing the block and returns early.

`SidePaneProvider` now exposes a generic `showToast(message)` on the context — reusing the existing `side-pane-toast` styling + 4s auto-dismiss. To make it reachable from `App` and form components, `SidePaneProvider` was hoisted from inside `App` into `main.jsx`. The log providers (Eval/Server/Ollama) stay nested below — no behavior change for them.

### 3. "Dismiss" → "Close" on JobHeader
"Dismiss" read as if it might delete the run — but the action only clears the local React Query cache (`clearJob`). On-disk findings and the index row are untouched. Renaming to "Close" makes the affordance honest. Filed because user explicitly flagged: *"loose sensible data is dangerous."*

### 4. "Re-evaluate" → "Evaluate"
Project re-eval card heading and the help page section. User preferred this wording.

## Test plan

- [x] `npx vitest run` for touched areas — 142 tests pass (Evaluation, Dashboard, Onboarding, SidePane). The two pre-existing failures in `CliProviderTab.test.jsx` / `OllamaTab.test.jsx` are unrelated and present on clean develop.
- [x] New `SidePaneProvider` tests verify `showToast` is exposed and renders the message in a `role="status"` toast.
- [x] Dev server boots clean — no console errors after the `SidePaneProvider` hoist.
- [x] **In-app smoke test** (requires backend): start an evaluation, click Add Project — confirm snackbar fires; on Evaluate tab with no standards selected, click Scan — confirm snackbar fires.