### PR TITLE
fix(overview): fall back to complete runs when in-progress yields zero dims

### DIFF
--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -11,7 +11,7 @@ from quodeq.services.ports import RunInfo, list_runs
 from quodeq.core.types import DimensionResult
 from quodeq.shared.utils import _env_int
 from quodeq.services._cache import make_lru_dimension_fetcher
-from quodeq.services.dim_resolution import is_eligible_for_default_view
+from quodeq.services.dim_resolution import is_eligible_for_default_view, is_successful_run
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.services._fs_projects import find_children as _find_children
 
@@ -83,15 +83,36 @@ def _compute_result(
     ``dim_resolution.is_eligible_for_default_view`` rule, used by both this
     call site and ``dashboard._resolve_selected_run`` so the headline and
     cards always read from the same set of runs.
+
+    Defensive fallback: if the eligible set yields zero scored dimensions
+    *and* it included a non-complete run, retry across complete runs only.
+    This kicks in when a fresh in-progress run is the newest entry but
+    hasn't produced any scored eval files yet (the overview would
+    otherwise go blank mid-evaluation, even though the previous complete
+    run's data is still on disk).
     """
-    complete_run_infos = [r for r in all_run_infos if is_eligible_for_default_view(r.status)]
-    if not complete_run_infos:
-        complete_run_infos = all_run_infos
-    runs = [r.run_id for r in complete_run_infos]
+    eligible_run_infos = [r for r in all_run_infos if is_eligible_for_default_view(r.status)]
+    if not eligible_run_infos:
+        eligible_run_infos = all_run_infos
+    result = _build_accumulated_for_runs(reports_root, project, eligible_run_infos, cache_config)
+
+    if not result.all_dimensions:
+        complete_only = [r for r in all_run_infos if is_successful_run(r.status)]
+        if complete_only and len(complete_only) < len(eligible_run_infos):
+            result = _build_accumulated_for_runs(reports_root, project, complete_only, cache_config)
+    return result
+
+
+def _build_accumulated_for_runs(
+    reports_root: Path, project: str, run_infos: list[RunInfo],
+    cache_config: AccumulatedCacheConfig | None,
+) -> _AccumulatedResult:
+    """Read run data and assemble the accumulated result for *run_infos*."""
+    runs = [r.run_id for r in run_infos]
     _cache, _lock, _max = _resolve_cache(cache_config)
     get_run_data = make_lru_dimension_fetcher(reports_root, project, _cache, _lock, _max)
     latest_by_dim, prev_occurrence, prev_run_latest = _read_all_run_data(
-        reports_root, project, complete_run_infos, runs, get_run_data,
+        reports_root, project, run_infos, runs, get_run_data,
     )
     all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), reports_root / project)
     dims_with_trend = _compute_accumulated_trends(all_dims, prev_occurrence)

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -235,3 +235,43 @@ class TestComputeAccumulated:
         result = compute_accumulated(str(reports_root), "proj", None)
         assert result is not None
         assert result["dimensions"][0]["overallScore"] == "6.0"
+
+    def test_falls_back_to_complete_when_in_progress_run_yields_no_dims(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        # A fresh in-progress run on top of a previous complete run should
+        # not blank the overview cards if the in-progress run's eval state
+        # makes the eligible-set computation return zero dims (the user-
+        # observed "Evaluating..." regression). The fallback retries with
+        # complete runs only and surfaces the previous run's data.
+        import os
+        reports_root = _setup_project(tmp_path, "proj", [
+            ("run2", [_dim("performance", "9.5", "A")]),
+            ("run1", [_dim("performance", "8.3", "B")]),
+        ])
+        # `list_runs` derives in_progress from a live `.pid` file; the test
+        # process's own pid is guaranteed alive for the call.
+        (reports_root / "proj" / "run2" / ".pid").write_text(str(os.getpid()))
+
+        from quodeq.services import accumulated as acc_mod
+        real_build = acc_mod._build_accumulated_for_runs
+        calls: list[list[str]] = []
+
+        def fake_build(rroot, project, run_infos, cache_config):
+            statuses = [r.status for r in run_infos]
+            calls.append(statuses)
+            if "in_progress" in statuses:
+                return acc_mod._AccumulatedResult([], [], {
+                    "totalViolations": 0, "totalCompliance": 0,
+                    "critical": 0, "major": 0, "minor": 0,
+                }, None, None)
+            return real_build(rroot, project, run_infos, cache_config)
+
+        monkeypatch.setattr(acc_mod, "_build_accumulated_for_runs", fake_build)
+        result = compute_accumulated(str(reports_root), "proj", None)
+        assert result is not None
+        assert len(calls) == 2  # initial + fallback
+        assert "in_progress" in calls[0]
+        assert "in_progress" not in calls[1]
+        scores = {d["dimension"]: d["overallScore"] for d in result["dimensions"]}
+        assert scores == {"performance": "8.3"}


### PR DESCRIPTION
## Summary
- The cross-run overview can momentarily render blank cards (VIOLATIONS 0, COMPLIANCE 0, QUALITY_DIMENSIONS · 0) the moment a fresh evaluation kicks off, even though the History view of the previous completed run still shows the right numbers.
- Root cause: `is_eligible_for_default_view` includes `RUN_STATE_IN_PROGRESS`, so `_compute_result` builds the accumulated payload from the freshly-running run; if that run hasn't yet produced any scored eval files, `latest_by_dim` ends up empty and the cards collapse.
- Adds a defensive retry: when the eligible run set returns zero scored dimensions and it included a non-complete run, recompute across complete runs only so the overview keeps showing the previous run's data until the new one finishes scoring.
- Per-dim incremental updates are preserved — once an in-progress run writes a scored eval file, the first pass returns non-empty and the new dim surfaces immediately, exactly as before.

## Changes
- `src/quodeq/services/accumulated.py` — split `_compute_result` into a thin top-level orchestrator and a reusable `_build_accumulated_for_runs` helper, then add the empty-result fallback.
- `tests/services/test_accumulated.py` — regression test that exercises the fallback path and asserts the previous complete run's dims surface when the in-progress run yields nothing.

## Test plan
- [x] `uv run pytest tests/services/test_accumulated.py` (19 passed)
- [x] `uv run pytest tests/services/` (633 passed)
- [x] `uv run pytest tests/api/` (227 passed)