### PR TITLE
fix(ui): violations icon clipped by count badge in collapsed sidebar

### DIFF
--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1635,6 +1635,14 @@
 .sidebar.sidebar--expanded:not(:hover):not(.sidebar--pinned) .sidebar-nav-item.active {
   color: var(--color-accent);
 }
+/* Hide labels and count badges entirely when collapsed — leaving them at
+   opacity 0 still consumed flex width, which pushed the icon off centre and
+   let the count badge overlap glyphs that have content near the right edge
+   (e.g. the violations alert triangle). */
+.sidebar.sidebar--expanded:not(:hover):not(.sidebar--pinned) .sidebar-nav-label,
+.sidebar.sidebar--expanded:not(:hover):not(.sidebar--pinned) .sidebar-nav-count {
+  display: none !important;
+}
 .sidebar.sidebar--expanded:not(:hover):not(.sidebar--pinned) .sidebar-nav-item::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
Follow-up to [#387](https://github.com/quodeq/quodeq/pull/387). In the collapsed sidebar rail the nav label and count badge were left at \`opacity: 0\` rather than hidden, so they still consumed flex width — under \`justify-content: center\` that pushed the icon off centre and let the count badge overlap glyphs with content near the right edge. Most visible on the violations row, where the \`39\` badge clipped the alert-triangle icon.

Set \`display: none\` on \`.sidebar-nav-label\` and \`.sidebar-nav-count\` while collapsed so only the icon participates in layout. The expanded/hover/pinned states are unaffected.

## Test plan
- [x] Collapse the sidebar and confirm the violations alert-triangle icon is fully visible and centred inside its circular highlight.
- [x] Hover the rail to expand: label and count badge re-appear normally.
- [x] Pin the sidebar: same expanded behaviour, no layout jump.