### PR TITLE
fix(ui): tiny evaluate-screen + wizard polish

### DIFF
--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -18,7 +18,7 @@ from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 _BLOCKED_SCAN_PATHS = ("/proc", "/sys", "/dev", "/etc", "/var/run", "/private/etc", "/private/var/run")
-_EMPTY_SCAN: dict[str, object] = {"total_files": 0, "languages": {}, "branches": [], "modules": [], "file_tree": []}
+_EMPTY_SCAN: dict[str, object] = {"total_files": 0, "code_files": 0, "languages": {}, "branches": [], "modules": [], "file_tree": []}
 
 
 def _find_existing_project(reports_root: str, repo: str, scope_path: str | None) -> str | None:

--- a/src/quodeq/core/types/scan.py
+++ b/src/quodeq/core/types/scan.py
@@ -15,3 +15,6 @@ class ScanData:
     modules: list[str] = field(default_factory=list)
     scanned_at: str = ""
     total_files: int = 0
+    # Subset of total_files whose extension is recognised as analysable
+    # source code (matches the language ext-map used by the evaluation).
+    code_files: int = 0

--- a/src/quodeq/services/_fs_scan.py
+++ b/src/quodeq/services/_fs_scan.py
@@ -17,6 +17,16 @@ _logger = logging.getLogger(__name__)
 _SKIP_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv", ".tox", "dist", "build", ".eggs"}
 _GIT_TIMEOUT_S = 10
 
+# Source-code extensions — kept in sync with `data/config/detection.json`
+# (`extensions` map). Used to compute `code_files` so the wizard can show
+# how many of the scanned files will actually be analysed by the eval.
+_CODE_EXTENSIONS = frozenset({
+    "py", "pyx", "ts", "tsx", "js", "jsx", "java", "kt", "kts", "swift", "m",
+    "go", "rs", "rb", "php", "sh", "bash", "cs", "cpp", "c", "h", "scala",
+    "dart", "ex", "exs", "r", "hs", "lhs", "lua", "jl", "zig", "ml", "mli",
+    "cr", "pl", "pm",
+})
+
 
 def scan_project(project_dir: Path, *, output_dir: Path | None = None) -> ScanData:
     """Run a quick scan of a local project directory.
@@ -27,6 +37,7 @@ def scan_project(project_dir: Path, *, output_dir: Path | None = None) -> ScanDa
     project_dir = project_dir.resolve()
     file_tree: list[str] = []
     languages: dict[str, int] = {}
+    code_file_count = 0
 
     for path in _walk_files(project_dir):
         rel = str(path.relative_to(project_dir))
@@ -34,6 +45,8 @@ def scan_project(project_dir: Path, *, output_dir: Path | None = None) -> ScanDa
         ext = path.suffix.lstrip(".")
         if ext:
             languages[ext] = languages.get(ext, 0) + 1
+            if ext in _CODE_EXTENSIONS:
+                code_file_count += 1
 
     branches = _list_branches(project_dir)
     modules = _list_modules(project_dir)
@@ -46,6 +59,7 @@ def scan_project(project_dir: Path, *, output_dir: Path | None = None) -> ScanDa
         modules=modules,
         scanned_at=scanned_at,
         total_files=len(file_tree),
+        code_files=code_file_count,
     )
 
     if output_dir is not None:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -65,7 +65,7 @@ function useEffectiveDark(themeMode) {
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
  * @returns {JSX.Element}
  */
-function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects }) {
+function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings }) {
   const { connected, setConnected } = serverHealth;
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
@@ -75,7 +75,7 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onG
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
         context={{ selectedProject, projectInfo }}
-        actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects }}
+        actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects, onGoToSettings }}
       />
     </>
   );
@@ -278,7 +278,7 @@ const ROUTE_RENDERERS = {
       trend={props.dashboardData.dashboard?.trend || []}
     />
   ),
-  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} onGoToProjects={() => props.navigation.navTab('projects')} />,
+  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />,
   file: (params) => <FileDetailPage file={params.file} />,
   evalprinciple: renderEvalPrincipleDetail,
   'eval-principle-detail': renderEvalPrincipleDetail,

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -7,16 +7,29 @@ import { TermHeader } from '../../../components/terminal/index.js';
 
 const TOAST_DISMISS_TIMEOUT_MS = 5000;
 
-function ActiveProviderBadge({ storage = localStorage }) {
+function ActiveProviderBadge({ storage = localStorage, onClick }) {
   const provider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
   const model = storage.getItem(providerKey(provider, 'model')) || '';
   if (!provider) return null;
-  return (
-    <div className="eval-provider-badge">
+  const content = (
+    <>
       <span className="eval-provider-name">{provider}</span>
       {model && <span className="eval-provider-model">{model}</span>}
-    </div>
+    </>
   );
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className="eval-provider-badge eval-provider-badge--clickable"
+        onClick={onClick}
+        title="Open provider settings"
+      >
+        {content}
+      </button>
+    );
+  }
+  return <div className="eval-provider-badge">{content}</div>;
 }
 
 function readBudgetSeconds(storage = localStorage) {
@@ -30,7 +43,7 @@ function readBudgetSeconds(storage = localStorage) {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function EvaluateHeader({ job }) {
+function EvaluateHeader({ job, onGoToSettings }) {
   // Page title stays steady ("evaluate"); the live "in progress / failed /
   // done" state is carried by the JobHeader card title below to avoid
   // doubling the same status on screen.
@@ -47,7 +60,7 @@ function EvaluateHeader({ job }) {
       </div>
       <div className="evaluate-header__right">
         <CountdownTimer deadlineAt={deadlineAt} budgetSeconds={budgetSeconds} phase={phase} />
-        <ActiveProviderBadge />
+        <ActiveProviderBadge onClick={onGoToSettings} />
       </div>
     </header>
   );
@@ -100,7 +113,7 @@ function NoProjectSelected({ onGoToProjects }) {
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
   const { selectedProject, projectInfo } = context;
-  const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects } = actions;
+  const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects, onGoToSettings } = actions;
   const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
 
@@ -116,7 +129,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
   return (
     <section className="evaluate-screen">
-      <EvaluateHeader job={job} />
+      <EvaluateHeader job={job} onGoToSettings={onGoToSettings} />
 
       <div className="evaluate-content">
         {!job && selectedProject && (

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,17 +1,12 @@
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
 import ScanProgress from './ScanProgress.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
+import HelpHint from '../../../components/HelpHint.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
-import { ACTIVE_PROVIDER_KEY, providerKey } from '../../../constants.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 import JobStatStrip from './JobStatStrip.jsx';
 
 const STATUS = { RUNNING: 'running', DONE: 'done', FAILED: 'failed', LOST: 'lost' };
-
-function deriveProjectName(repo) {
-  if (!repo) return null;
-  return repo.replace(/\.git$/, '').split(/[/\\]/).filter(Boolean).pop() || null;
-}
 
 function termNameForStatus(status) {
   if (status === STATUS.RUNNING) return 'evaluation_in_progress';
@@ -19,15 +14,6 @@ function termNameForStatus(status) {
   if (status === STATUS.FAILED)  return 'evaluation_failed';
   if (status === STATUS.LOST)    return 'evaluation_lost';
   return 'evaluation_cancelled';
-}
-
-function ExternalRunBadge() {
-  return (
-    <div className="term-meta-grid__item">
-      <span className="term-meta-grid__label">Source</span>
-      <span className="term-meta-grid__value">External</span>
-    </div>
-  );
 }
 
 function StatusPill({ status, exitReason }) {
@@ -41,15 +27,13 @@ function StatusPill({ status, exitReason }) {
   );
 }
 
-function JobProviderBadge() {
-  const provider = localStorage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  const model = localStorage.getItem(providerKey(provider, 'model')) || '';
-  if (!provider) return null;
+function ActionsHelp() {
   return (
-    <div className="term-meta-grid__item">
-      <span className="term-meta-grid__label">AI Provider</span>
-      <span className="term-meta-grid__value">{provider}{model ? ` / ${model}` : ''}</span>
-    </div>
+    <HelpHint label="Job actions help">
+      <div><strong>Cancel</strong> — stop the running evaluation.</div>
+      <div><strong>View Results</strong> — open the completed run's full report.</div>
+      <div><strong>Close</strong> — dismiss this panel without affecting the run.</div>
+    </HelpHint>
   );
 }
 
@@ -60,6 +44,7 @@ function JobHeader({ job, onDismiss, onCancel }) {
     <div className="evaluate-panel__top evaluate-panel__top--row">
       <TermHeader name={termNameForStatus(job.status)} />
       <div className="evaluate-panel__top-actions">
+        <ActionsHelp />
         {isRunning && (
           <button type="button" className="term-btn term-btn--ghost" onClick={onCancel}>cancel</button>
         )}
@@ -71,36 +56,18 @@ function JobHeader({ job, onDismiss, onCancel }) {
         {!isRunning && (
           <button type="button" className="term-btn term-btn--secondary" onClick={() => onDismiss('close')}>close</button>
         )}
-        <StatusPill status={job.status} exitReason={job.exitReason} />
+        {!isRunning && <StatusPill status={job.status} exitReason={job.exitReason} />}
       </div>
     </div>
   );
 }
 
-function JobMeta({ job, projectName }) {
-  const isExternal = job.source === 'external';
+function JobIdLine({ jobId }) {
   return (
-    <div className="term-meta-grid">
-      {projectName && (
-        <div className="term-meta-grid__item">
-          <span className="term-meta-grid__label">Project</span>
-          <span className="term-meta-grid__value">{projectName}</span>
-        </div>
-      )}
-      {isExternal ? <ExternalRunBadge /> : <JobProviderBadge />}
-      <div className="term-meta-grid__item">
-        <span className="term-meta-grid__label">Job ID</span>
-        <div className="term-meta-grid__value">
-          <code>{job.jobId}</code>
-          <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(job.jobId)} />
-        </div>
-      </div>
-      {job.repo && (
-        <div className="term-meta-grid__item term-meta-grid__item--full">
-          <span className="term-meta-grid__label">Repository</span>
-          <code className="term-meta-grid__value">{job.repo}</code>
-        </div>
-      )}
+    <div className="evaluate-job-id-line">
+      <span className="evaluate-job-id-line__label">job</span>
+      <code>{jobId}</code>
+      <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(jobId)} />
     </div>
   );
 }
@@ -112,7 +79,7 @@ export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, 
     <div className="panel evaluate-panel--terminal">
       <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
       <JobStatStrip job={job} liveViolations={liveViolations} />
-      <JobMeta job={job} projectName={deriveProjectName(job.repo)} />
+      <JobIdLine jobId={job.jobId} />
       <ScanProgress job={job} hasEvaluations={hasEvaluations} />
       <LiveViolationsFeed liveViolations={liveViolations} />
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -53,15 +53,10 @@ describe('StatusPill', () => {
   });
 });
 
-describe('ExternalRunBadge', () => {
-  it('renders "External" when job.source is "external"', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, source: 'external' }} />);
-    expect(screen.getByText('External')).toBeInTheDocument();
-  });
-
-  it('renders nothing for source="internal"', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, source: 'internal' }} />);
-    expect(screen.queryByText('External')).toBeNull();
-    expect(screen.queryByText('Running outside the dashboard')).toBeNull();
+describe('JobIdLine', () => {
+  it('renders the job ID with a copy button', () => {
+    renderWithClient(<EvaluationStatus job={{ ...baseJob, jobId: 'job-123' }} />);
+    expect(screen.getByText('job-123')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy job id/i })).toBeInTheDocument();
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -14,6 +14,21 @@ function sumLiveViolations(liveViolations) {
   return Object.values(liveViolations).reduce((n, vs) => n + (vs?.length || 0), 0);
 }
 
+// Backend-reported elapsed (`progress.totalElapsedS`) lands on a few ticks
+// inside a poll, leaving the cell blank for the first second or two of a
+// run and silent for runs whose progress payload omits the field. Fall
+// back to the wall-clock delta from `job.startedAt` so the strip always
+// shows something live as soon as the job has started.
+function deriveElapsedS(progressElapsed, startedAt, endedAt, isTerminal) {
+  if (progressElapsed != null && Number.isFinite(progressElapsed)) return progressElapsed;
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  if (Number.isNaN(start)) return null;
+  const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
+  if (Number.isNaN(end)) return null;
+  return Math.max(0, (end - start) / 1000);
+}
+
 export default function JobStatStrip({ job, liveViolations }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
@@ -30,10 +45,10 @@ export default function JobStatStrip({ job, liveViolations }) {
   const cells = useMemo(() => {
     if (!jobId) return [];
     const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
-    const elapsedS = progress?.totalElapsedS;
+    const elapsedS = deriveElapsedS(progress?.totalElapsedS, job?.startedAt, job?.endedAt, isTerminal);
     const liveCount = sumLiveViolations(liveViolations);
     return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount });
-  }, [jobId, job?.status, progress, liveViolations]);
+  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/OnboardingWizard.jsx
@@ -116,53 +116,55 @@ export default function OnboardingWizard({ entry, onClose, onLaunch }) {
 
   return (
     <div className="onboarding-wizard" role="dialog" aria-modal="true" aria-label="onboarding">
-      <button type="button" className="onboarding-wizard__close" aria-label="Close onboarding" onClick={handleClose}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <line x1="18" y1="6" x2="6" y2="18" />
-          <line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
-      </button>
+      <div className="onboarding-wizard__panel-frame">
+        <button type="button" className="onboarding-wizard__close" aria-label="Close onboarding" onClick={handleClose}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
 
-      {wizard.state.step === 'welcome' && (
-        <WelcomeStep onStart={() => wizard.goToStep('repo-scan')} onSkip={handleSkipWelcome} />
-      )}
+        {wizard.state.step === 'welcome' && (
+          <WelcomeStep onStart={() => wizard.goToStep('repo-scan')} onSkip={handleSkipWelcome} />
+        )}
 
-      {wizard.state.step === 'repo-scan' && (
-        <RepoScanStep
-          state={wizard.state}
-          actions={wizard}
-          createProject={registerProject}
-          getProjectInfo={getProjectInfo}
-          onContinue={nextStep}
-          onCancel={handleSavedExit}
-          stepIndex={currentIndex}
-          stepTotal={visible.length}
-        />
-      )}
+        {wizard.state.step === 'repo-scan' && (
+          <RepoScanStep
+            state={wizard.state}
+            actions={wizard}
+            createProject={registerProject}
+            getProjectInfo={getProjectInfo}
+            onContinue={nextStep}
+            onCancel={handleSavedExit}
+            stepIndex={currentIndex}
+            stepTotal={visible.length}
+          />
+        )}
 
-      {wizard.state.step === 'provider' && (
-        <ProviderStep
-          state={wizard.state}
-          actions={wizard}
-          onContinue={nextStep}
-          onBack={prevStep}
-          stepIndex={currentIndex}
-          stepTotal={visible.length}
-        />
-      )}
+        {wizard.state.step === 'provider' && (
+          <ProviderStep
+            state={wizard.state}
+            actions={wizard}
+            onContinue={nextStep}
+            onBack={prevStep}
+            stepIndex={currentIndex}
+            stepTotal={visible.length}
+          />
+        )}
 
-      {wizard.state.step === 'standard-launch' && (
-        <StandardLaunchStep
-          state={wizard.state}
-          actions={wizard}
-          standards={standards}
-          onLaunch={handleLaunch}
-          onCancel={handleSavedExit}
-          onBack={prevStep}
-          stepIndex={currentIndex}
-          stepTotal={visible.length}
-        />
-      )}
+        {wizard.state.step === 'standard-launch' && (
+          <StandardLaunchStep
+            state={wizard.state}
+            actions={wizard}
+            standards={standards}
+            onLaunch={handleLaunch}
+            onCancel={handleSavedExit}
+            onBack={prevStep}
+            stepIndex={currentIndex}
+            stepTotal={visible.length}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -94,6 +94,7 @@ export default function RepoScanStep({ state, actions, createProject, getProject
 
       {sub === 'scanned' && (() => {
         const totalFiles = state.scan?.total_files ?? 0;
+        const codeFiles = state.scan?.code_files ?? 0;
         const langs = state.scan?.languages || {};
         const langCount = Object.keys(langs).length;
         const branchCount = state.scan?.branches?.length ?? 0;
@@ -101,7 +102,8 @@ export default function RepoScanStep({ state, actions, createProject, getProject
         return (
           <div className="onboarding-scan-summary">
             <StatStrip cards>
-              <Stat label="FILES" value={totalFiles} />
+              <Stat label="FILES" value={totalFiles} hint="all files in repo" />
+              <Stat label="CODE" value={codeFiles} hint="files the eval will analyse" />
               <Stat label="LANGUAGES" value={langCount} />
               <Stat label="BRANCHES" value={branchCount} />
             </StatStrip>

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -49,6 +49,21 @@
   font-size: 0.72rem;
 }
 
+/* Clickable variant — used on the Evaluate page header to navigate to settings. */
+button.eval-provider-badge--clickable {
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 120ms, background 120ms;
+}
+button.eval-provider-badge--clickable:hover {
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface-alt));
+}
+button.eval-provider-badge--clickable:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
 .evaluate-content {
   display: grid;
   gap: 24px;
@@ -2830,6 +2845,33 @@
 }
 .term-meta-grid__value code {
   color: var(--color-text);
+  background: transparent;
+  padding: 0;
+  font-family: var(--term-font-mono);
+}
+
+/* ------------------------------------------------------------
+   evaluate-job-id-line — minimal mono row showing just the job
+   ID with a copy button. Replaces the old `term-meta-grid`
+   block that surfaced project / provider / repo redundantly.
+   ------------------------------------------------------------ */
+.evaluate-job-id-line {
+  display: flex;
+  align-items: center;
+  gap: var(--term-space-2);
+  padding: var(--term-space-2) 0;
+  margin-bottom: var(--term-space-3);
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+.evaluate-job-id-line__label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.evaluate-job-id-line code {
+  color: var(--color-text-muted);
+  font-size: 11px;
   background: transparent;
   padding: 0;
   font-family: var(--term-font-mono);

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -11,6 +11,16 @@
   z-index: 1000;
   padding: var(--term-space-4);
 }
+.onboarding-wizard__panel-frame {
+  position: relative;
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+}
+.onboarding-wizard__panel-frame > .onboarding-step {
+  max-width: none;
+}
 .onboarding-wizard__close {
   position: absolute;
   top: var(--term-space-3);
@@ -20,6 +30,7 @@
   cursor: pointer;
   padding: 0;
   color: var(--color-accent);
+  z-index: 2;
 }
 .onboarding-wizard__close:hover {
   color: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));

--- a/tests/services/test_fs_scan.py
+++ b/tests/services/test_fs_scan.py
@@ -27,7 +27,7 @@ def _make_git_repo(path: Path) -> None:
 
 
 def test_scan_project_collects_files(tmp_path: Path) -> None:
-    """Scan should list all files and count them."""
+    """Scan should list all files and count them, splitting out code files."""
     from quodeq.services._fs_scan import scan_project
     project_dir = tmp_path / "repo"
     project_dir.mkdir()
@@ -37,9 +37,25 @@ def test_scan_project_collects_files(tmp_path: Path) -> None:
     result = scan_project(project_dir)
     assert isinstance(result, ScanData)
     assert result.total_files == 3
+    assert result.code_files == 2  # the two .py files; .md is not source code
     assert "app.py" in result.file_tree
     assert result.languages.get("py") == 2
     assert result.languages.get("md") == 1
+
+
+def test_scan_project_code_files_excludes_non_source(tmp_path: Path) -> None:
+    """code_files should count only extensions in the analysable source set."""
+    from quodeq.services._fs_scan import scan_project
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    (project_dir / "app.kt").write_text("fun main() {}")
+    (project_dir / "build.gradle.kts").write_text("// gradle")
+    (project_dir / "config.json").write_text("{}")
+    (project_dir / "doc.md").write_text("# notes")
+    (project_dir / "image.webp").write_bytes(b"")
+    result = scan_project(project_dir)
+    assert result.total_files == 5
+    assert result.code_files == 2  # only .kt and .kts count
 
 
 def test_scan_project_lists_branches(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Stacks on top of [#390](https://github.com/quodeq/quodeq/pull/390) with six small fixes that came up during testing of the evaluate-screen restyle.

**Base is `claude/evaluate-screen-terminal-restyle` so the diff stays focused — once #390 merges, retarget this PR to `develop`.**

### Evaluate screen polish (commit 1)

1. **Hide redundant `running` pill** in the in-job header. Cancel button + `▶ evaluation_in_progress` header + STATUS strip cell already convey it. Pill stays visible for done/failed/cancelled where it's load-bearing for the stale-cancel hint.
2. **ELAPSED never showed a value.** `progress.totalElapsedS` is empty until the backend pumps a tick. Now falls back to wall-clock from `job.startedAt` (and `endedAt` when terminal).
3. **Trim the job-meta block** down to a single small `job: <id>` line with a copy button. Project name, repo path, and AI provider are already shown elsewhere — the 4-cell grid was just noise.
4. **Provider badge in the page header is now clickable** and routes to settings (`onGoToSettings` threaded through App.jsx → EvaluateScreen).
5. **HelpHint left of the action buttons** with a single tooltip explaining cancel / view results / close.

### Wizard polish (commit 2)

6. **Wizard close (`×`) was positioned at the viewport top-right** instead of the panel's top-right because `position: absolute` resolved against the full-screen overlay. Wrapped the active step in an `.onboarding-wizard__panel-frame` (the new positioning context, sized to the step) so the close button now sits in the panel's top-right corner where it belongs.

## Test plan

- [x] `npm test` (node:test): pass
- [x] `npm run test:ui` (vitest, evaluation + onboarding): 14 files / 66 tests pass
- [x] `npm run build`: clean
- [x] Manual: confirm running header has no pill, ELAPSED ticks, job-id line is small, provider badge navigates to settings, HelpHint opens on click
- [x] Manual: open the onboarding wizard from Projects → confirm `×` is now inside the panel's top-right corner