### PR TITLE
fix(ui): wait for projects to load before bouncing off project-data tabs

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -385,14 +385,20 @@ export default function App() {
   // Project-data tabs (overview/violations/map/history) only make sense once
   // the selected project has at least one completed evaluation run. Until
   // then, hide them from the sidebar and bounce the user to Evaluate if a
-  // cached activeTab lands them on a now-hidden tab.
+  // cached activeTab lands them on a now-hidden tab. The guards below wait
+  // for /api/projects to resolve and for selectedProjectInfo to populate so
+  // the bouncer doesn't fire against the transient "no projects loaded yet"
+  // state on first paint and strand the user on Evaluate.
   const PROJECT_DATA_TABS = ['overview', 'violations', 'map', 'history'];
   const hasCurrentProjectRuns = (selectedProjectInfo?.runsCount ?? 0) > 0;
   useEffect(() => {
+    if (!state.projectsLoaded) return;
+    if (state.projects.length === 0) return;
+    if (!selectedProjectInfo) return;
     if (!hasCurrentProjectRuns && PROJECT_DATA_TABS.includes(state.activeTab)) {
       state.navTab('evaluate');
     }
-  }, [hasCurrentProjectRuns, state.activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [state.projectsLoaded, state.projects.length, selectedProjectInfo, hasCurrentProjectRuns, state.activeTab]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const sidebarProvider = (typeof localStorage !== 'undefined' && localStorage.getItem(ACTIVE_PROVIDER_KEY)) || null;
   const sidebarModel = sidebarProvider && typeof localStorage !== 'undefined'


### PR DESCRIPTION
## Summary
The bouncer at \`App.jsx\` that routes the user from a project-data tab (overview/violations/map/history) to Evaluate when the current project has no runs was firing on first paint, before \`/api/projects\` had resolved. With \`selectedProjectInfo === null\`, \`runsCount ?? 0\` collapsed to \`0\` and the effect immediately navigated away from the default \`overview\` tab — so every launch landed on Evaluate, even when the selected project had a long run history.

Wait for \`projectsLoaded\`, a non-empty project list (the onboarding wizard handles truly-empty), and a resolved \`selectedProjectInfo\` before deciding "no runs."

## Test plan
- [x] \`npx vitest run\` — 260/262 pass; 2 pre-existing failures in \`CliProviderTab.test.jsx\` / \`OllamaTab.test.jsx\` reproduce on clean \`develop\` (unrelated, flaky settings tests).
- [x] Manual: launch dashboard with a project that has runs → lands on \`overview\`.
- [x] Manual: launch with a project that has no runs → still bounces to \`evaluate\` (intended bouncer behavior preserved).
- [x] Manual: launch with no projects → wizard auto-opens (unchanged).
- [x] Manual: launch while a CLI \`quodeq evaluate\` is in progress → adopts the running job and lands on \`evaluate\` (unchanged from #366).