### PR TITLE
ui: explorer header polish + standards descriptions + sidebar reorder

### DIFF
--- a/src/quodeq/data/standards/compiled/clean-architecture.json
+++ b/src/quodeq/data/standards/compiled/clean-architecture.json
@@ -1,7 +1,7 @@
 {
   "id": "clean-architecture",
   "name": "Clean Architecture",
-  "description": "Evaluates adherence to Robert C. Martin's Clean Architecture principles",
+  "description": "Adherence to Clean Architecture as described by Robert C. Martin. Source code dependencies point inward toward the domain, frameworks and infrastructure stay at the edges, and use cases remain decoupled from delivery and persistence concerns.",
   "managed": true,
   "type": "quodeq",
   "source": "Robert C. Martin",

--- a/src/quodeq/data/standards/compiled/domain-driven-design.json
+++ b/src/quodeq/data/standards/compiled/domain-driven-design.json
@@ -1,7 +1,7 @@
 {
   "id": "domain-driven-design",
   "name": "Domain-Driven Design",
-  "description": "Evaluates adherence to Eric Evans' Domain-Driven Design tactical and strategic patterns",
+  "description": "Adherence to Domain-Driven Design tactical and strategic patterns from Eric Evans and Vaughn Vernon. Bounded contexts, aggregates, repositories, and a ubiquitous language let the code reflect the real domain rather than incidental implementation details.",
   "managed": true,
   "type": "quodeq",
   "source": "Eric Evans / Vaughn Vernon",

--- a/src/quodeq/data/standards/compiled/flexibility.json
+++ b/src/quodeq/data/standards/compiled/flexibility.json
@@ -1,6 +1,7 @@
 {
   "id": "flexibility",
   "name": "Flexibility",
+  "description": "How well the product adapts to new environments, scale, and integrations without rework. Adaptability, scalability, installability, and replaceability keep deployment and runtime contexts open as requirements evolve.",
   "sources": [
     "iso25010"
   ],

--- a/src/quodeq/data/standards/compiled/maintainability.json
+++ b/src/quodeq/data/standards/compiled/maintainability.json
@@ -1,6 +1,7 @@
 {
   "id": "maintainability",
   "name": "Maintainability",
+  "description": "How effectively the codebase can be modified by people who did not write it. Modularity, reusability, analysability, modifiability, and testability keep changes safe, fast, and predictable as the system grows.",
   "sources": [
     "iso25010",
     "cisq"

--- a/src/quodeq/data/standards/compiled/performance.json
+++ b/src/quodeq/data/standards/compiled/performance.json
@@ -1,6 +1,7 @@
 {
   "id": "performance",
   "name": "Performance Efficiency",
+  "description": "How efficiently the system uses time, memory, and capacity for the work it does. Time behaviour, resource utilisation, and capacity headroom keep response times steady under expected and peak load.",
   "sources": [
     "iso25010",
     "cisq"

--- a/src/quodeq/data/standards/compiled/reliability.json
+++ b/src/quodeq/data/standards/compiled/reliability.json
@@ -1,6 +1,7 @@
 {
   "id": "reliability",
   "name": "Reliability",
+  "description": "How dependably the system performs its required functions over time. Maturity, fault tolerance, and recoverability keep failures rare, contained, and easy to bounce back from when they happen.",
   "sources": [
     "iso25010",
     "cisq",

--- a/src/quodeq/data/standards/compiled/security.json
+++ b/src/quodeq/data/standards/compiled/security.json
@@ -1,6 +1,7 @@
 {
   "id": "security",
   "name": "Security",
+  "description": "How well the system protects information and behaviour so users and processes can only do what they are entitled to. Covers confidentiality, integrity, authentication, accountability, and resistance to misuse across the application surface.",
   "sources": [
     "iso25010",
     "cisq",

--- a/src/quodeq/data/standards/compiled/usability.json
+++ b/src/quodeq/data/standards/compiled/usability.json
@@ -1,6 +1,7 @@
 {
   "id": "usability",
   "name": "Usability",
+  "description": "How easy the product is to learn, operate, and recover from mistakes with. Appropriateness recognisability, learnability, operability, user error protection, and accessibility shape the everyday experience for real users.",
   "sources": [
     "iso25010",
     "wcag22"

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -55,9 +55,10 @@ def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDet
 
 def build_builtin_detail(data: dict, standard_id: str, weight: float) -> StandardDetail:
     source = data.get("source", "") or ", ".join(data.get("sources", []))
+    description = data.get("description") or f"{data.get('name', standard_id)} standard"
     return StandardDetail(
         id=standard_id, name=data.get("name", standard_id),
-        description=f"{data.get('name', standard_id)} standard",
+        description=description,
         weight=weight, source=source,
         type=data.get("type", _TYPE_BUILTIN), managed=True,
         origin=None, origin_hash=None, principles=data.get("principles", []),
@@ -77,12 +78,20 @@ def build_custom_meta(data: dict, p_count: int, r_count: int) -> StandardMeta:
     )
 
 
-def build_builtin_meta(dim: dict, p_count: int, r_count: int) -> StandardMeta:
-    """Build a StandardMeta for a built-in dimension."""
+def build_builtin_meta(
+    dim: dict, p_count: int, r_count: int, description: str = "",
+) -> StandardMeta:
+    """Build a StandardMeta for a built-in dimension.
+
+    *description* is the description loaded from the compiled standard file,
+    when available. Falls back to a generic "{source} standard" label so
+    older compiled files without the field keep their historical meta text.
+    """
     did = _require_id(dim, "built-in dimension")
+    final_description = description or f'{dim.get("source", "Built-in")} standard'
     return StandardMeta(
         id=did, name=dim.get("iso_25010") or dim.get("name", did),
-        description=f'{dim.get("source", "Built-in")} standard',
+        description=final_description,
         weight=dim.get("weight", 1.0), source=dim.get("source", ""),
         type=dim.get("type", _TYPE_BUILTIN), managed=True,
         origin=None, origin_hash=None,

--- a/src/quodeq/services/_standards_queries.py
+++ b/src/quodeq/services/_standards_queries.py
@@ -24,19 +24,25 @@ def list_builtin(dimensions_file: Path, compiled_dir: Path,
     except (OSError, ValueError) as exc:
         logger.warning("Cannot read dimensions file: %s", exc)
         return []
-    return [build_builtin_meta(dim, *_count_compiled(dim["id"], compiled_dir, read_json))
-            for dim in data.get("applies", [])]
+    out: list[StandardMeta] = []
+    for dim in data.get("applies", []):
+        p_count, r_count, description = _read_compiled_meta(dim["id"], compiled_dir, read_json)
+        out.append(build_builtin_meta(dim, p_count, r_count, description))
+    return out
 
 
-def _count_compiled(dimension_id: str, compiled_dir: Path,
-                    read_json: Callable) -> tuple[int, int]:
+def _read_compiled_meta(dimension_id: str, compiled_dir: Path,
+                        read_json: Callable) -> tuple[int, int, str]:
+    """Return (principle_count, requirement_count, description) for *dimension_id*."""
     path = compiled_dir / f"{dimension_id}.json"
     if not path.is_file():
-        return 0, 0
+        return 0, 0, ""
     try:
-        return count_principles_and_requirements(read_json(path))
+        compiled = read_json(path)
     except (OSError, ValueError):
-        return 0, 0
+        return 0, 0, ""
+    p_count, r_count = count_principles_and_requirements(compiled)
+    return p_count, r_count, compiled.get("description", "")
 
 
 def list_custom(evaluators_dir: Path, read_json: Callable) -> list[StandardMeta]:

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -182,8 +182,8 @@ export default function Sidebar({
             )}
           </div>
           <div className="sidebar-nav sidebar-block sidebar-block--flush">
-            <NavButton id="standards" label="standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
             <NavButton id="settings" label="settings" icon={ICON_SETTINGS} activeTab={activeTab} onNavTab={handleNav} />
+            <NavButton id="standards" label="standards" icon={ICON_STANDARDS} activeTab={activeTab} onNavTab={handleNav} count={standardsCount} />
             <NavButton id="help" label="help" icon={ICON_HELP} activeTab={activeTab} onNavTab={handleNav} />
           </div>
         </div>

--- a/src/quodeq/ui/src/components/terminal/TermHeader.jsx
+++ b/src/quodeq/ui/src/components/terminal/TermHeader.jsx
@@ -6,13 +6,27 @@
  * @param {object} props
  * @param {string} props.name   The label after the ▶ glyph.
  * @param {React.ReactNode} [props.sub]  Optional second line (e.g. stats, breadcrumb).
+ * @param {string} [props.description]   Optional description shown via a `?`
+ *   tooltip after the name. Omit (or pass falsy) to hide the tooltip trigger.
  */
-export default function TermHeader({ name, sub }) {
+export default function TermHeader({ name, sub, description }) {
+  const tip = typeof description === 'string' ? description.trim() : '';
   return (
     <header className="term-header">
       <div className="term-header__prompt">
         <span className="term-header__glyph" aria-hidden="true">▶</span>
         <span className="term-header__name">{name}</span>
+        {tip && (
+          <span className="term-header__help">
+            <button
+              type="button"
+              className="term-header__help-btn"
+              aria-label="Show description"
+              title={tip}
+            >?</button>
+            <span className="term-header__help-tip" role="tooltip">{tip}</span>
+          </span>
+        )}
       </div>
       {sub != null && <div className="term-header__sub">{sub}</div>}
     </header>

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -5,6 +5,7 @@ import { buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.j
 import { buildDimensionReport } from '../../../utils/reportBuilder.js';
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useExplorerData, buildEvalPrincipalFn } from './explorerDataHooks.js';
+import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 import {
   TermHeader,
   Stat,
@@ -66,6 +67,7 @@ export default function ExplorerPage({
   trend = [],
 }) {
   const d = useExplorerData(project, dimension, runId, refreshSignal);
+  const { standardDescription } = useStandardDescriptions(dimension);
 
   const buildEvalPrincipal = useMemo(
     () => d.evalData ? buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple, project, runId) : () => ({}),
@@ -123,7 +125,7 @@ export default function ExplorerPage({
 
   return (
     <>
-      <TermHeader name={`${dim}.overview`} sub={dateLabel || runId || null} />
+      <TermHeader name={dim} description={standardDescription} sub={dateLabel || runId || null} />
 
       <div className="qd-top-grid">
         <div className="qd-top-left">

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -81,7 +81,7 @@ function FileHeader({ file, totalViolations, totalCompliance, dimensionsCount })
   return (
     <section className="principle-detail-header principle-detail-header--terminal">
       <div className="principle-detail-header__top">
-        <TermHeader name={`${file.file}.detail`} />
+        <TermHeader name={file.file} />
       </div>
       <StatStrip cards>
         <Stat

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -7,6 +7,7 @@ import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
+import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 
 // Off-screen rows skip layout/paint via CSS `content-visibility: auto` on
 // `.vdetail-row` (see styles/explorer.css), so no JS virtualizer or
@@ -67,7 +68,7 @@ function SevBadgeRow({ sevCounts }) {
 }
 
 function PrincipleHeader({ data }) {
-  const { principle, score, grade, violations, compliance, sevCounts } = data;
+  const { principle, description, score, grade, violations, compliance, sevCounts } = data;
   const scoreDisplay = score ? String(score).replace('/10', '') : '—';
   const ratioDisplay = (compliance.length > 0 && violations.length > 0)
     ? `1:${Math.round(compliance.length / violations.length)}`
@@ -80,7 +81,7 @@ function PrincipleHeader({ data }) {
   return (
     <section className="principle-detail-header principle-detail-header--terminal">
       <div className="principle-detail-header__top">
-        <TermHeader name={`${principle}.detail`} />
+        <TermHeader name={(principle || '').toLowerCase()} description={description} />
       </div>
       <StatStrip cards>
         <Stat label="SCORE" value={scoreDisplay} hint={scoreHint} />
@@ -181,6 +182,8 @@ function usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss) {
 
 const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, severityFilter, onDismiss }) {
   const { principleData, principle, score, grade, dimension, runId } = evalPrincipal;
+  const { principleDescriptions } = useStandardDescriptions(dimension);
+  const principleDescription = principleDescriptions[principle] || '';
 
   const {
     violations, compliance, violationsBySeverity,
@@ -226,7 +229,7 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
   return (
     <>
       <PrincipleHeader
-        data={{ principle, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts }}
+        data={{ principle, description: principleDescription, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts }}
       />
       <PrincipleContext principleData={principleData} />
       {(filteredViolations.length > 0 || compliance.length > 0) && (

--- a/src/quodeq/ui/src/features/explorer/hooks/useStandardDescriptions.js
+++ b/src/quodeq/ui/src/features/explorer/hooks/useStandardDescriptions.js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useApi } from '../../../api/ApiContext.jsx';
+
+/**
+ * Fetch a standard's description plus a map of principle name -> description.
+ * Dimensions in eval data correspond 1:1 with standard ids (reliability,
+ * security, etc.), so the dimension is passed through to `getStandard`.
+ *
+ * Returns `{ standardDescription, principleDescriptions }`. Both fields are
+ * empty until the fetch resolves; callers should treat undefined as "no
+ * description" so the help icon stays hidden.
+ */
+export function useStandardDescriptions(dimension) {
+  const { getStandard } = useApi();
+  const [state, setState] = useState({ standardDescription: '', principleDescriptions: {} });
+
+  useEffect(() => {
+    if (!dimension) return;
+    let cancelled = false;
+    getStandard(dimension)
+      .then((std) => {
+        if (cancelled || !std) return;
+        const principleDescriptions = {};
+        for (const p of std.principles || []) {
+          if (p?.name && p?.description) principleDescriptions[p.name] = p.description;
+        }
+        setState({
+          standardDescription: std.description || '',
+          principleDescriptions,
+        });
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [dimension, getStandard]);
+
+  return state;
+}

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 function TreeNodeRow({ node, actions, titles, expand }) {
   const { label, isSelected } = node;
@@ -50,10 +50,16 @@ function TreeNodeRow({ node, actions, titles, expand }) {
 function TreeNode({ node, actions, titles, children }) {
   const { depth = 0, alwaysExpanded = false, defaultExpanded = true, isSelected } = node;
   const [expanded, setExpanded] = useState(alwaysExpanded || defaultExpanded);
+  const prevSelected = useRef(isSelected);
 
   useEffect(() => {
-    if (isSelected && !expanded) setExpanded(true);
-  }, [isSelected, expanded]);
+    // Auto-expand only when selection arrives from outside the tree (e.g. a
+    // principle was just added programmatically). Re-firing on every render
+    // while the row stays selected would block the user from collapsing the
+    // currently-selected node by clicking it.
+    if (isSelected && !prevSelected.current) setExpanded(true);
+    prevSelected.current = isSelected;
+  }, [isSelected]);
   const hasChildren = Array.isArray(children) ? children.length > 0 : !!children;
   const showExpand = hasChildren && !alwaysExpanded;
 

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -57,6 +57,57 @@
   font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
+.term-header__help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.term-header__help-btn {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid var(--color-text-muted);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-family: var(--term-font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0;
+  cursor: help;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.term-header__help-btn:hover,
+.term-header__help-btn:focus-visible {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  outline: none;
+}
+.term-header__help-tip {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  width: max-content;
+  max-width: 360px;
+  padding: var(--term-space-2) var(--term-space-3);
+  background: var(--color-surface);
+  border: var(--term-border);
+  border-radius: var(--term-radius);
+  color: var(--color-text);
+  font-family: var(--term-font-mono);
+  font-size: 12px;
+  line-height: 1.4;
+  white-space: normal;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+.term-header__help:hover .term-header__help-tip,
+.term-header__help-btn:focus-visible + .term-header__help-tip {
+  display: block;
+}
 
 /* ------------------------------------------------------------
    StatStrip: horizontal label/value cells


### PR DESCRIPTION
## Summary
- **Explorer headers**: drop `.overview` / `.detail` suffixes, lowercase the principle name, add a `?` tooltip button next to the title that surfaces the standard or principle description when one exists. Description is loaded once from the existing standards API.
- **Standards descriptions**: surface the `description` field from each compiled standard JSON through `build_builtin_detail` and `build_builtin_meta`, then write 2–3 line descriptions for the six ISO 25010 standards (`reliability`, `security`, `maintainability`, `performance`, `usability`, `flexibility`) and the two quodeq-managed standards (`clean-architecture`, `domain-driven-design`).
- **Sidebar**: bottom rail now reads `settings → standards → help`; `evaluate` keeps its own block above the spacer.
- **Standard tree fix**: a selected principle could not be collapsed because the auto-expand effect re-fired on every render while it stayed selected. The effect is now gated on the `false → true` selection transition, so clicking the selected row collapses it correctly.

## Test plan
- [x] `pytest tests/services/test_standards_*.py tests/api/test_standards_routes.py` (67 passing)
- [x] Open explorer for a dimension → header reads `reliability` (lowercase, no `.overview`) with a `?` tooltip showing the new description on hover
- [x] Drill into a principle → header reads `availability` (lowercase, no `.detail`) with `?` tooltip showing the principle description
- [x] Drill into a file → header reads the bare filename (no `.detail`)
- [x] Edit a standard → expand a principle, then click it again to collapse; it should stay collapsed (no flicker)
- [x] Sidebar bottom rail order is settings, standards, help