### PR TITLE
ui: polish header tooltip + add principle descriptions

### DIFF
--- a/src/quodeq/data/standards/compiled/flexibility.json
+++ b/src/quodeq/data/standards/compiled/flexibility.json
@@ -8,6 +8,7 @@
   "principles": [
     {
       "name": "Adaptability",
+      "description": "The product runs in different environments without code changes. Configuration is externalised, platform-specific concerns are isolated, and locale and timezone are not hardcoded.",
       "source": "iso25010",
       "requirements": [
         {
@@ -74,6 +75,7 @@
     },
     {
       "name": "Scalability",
+      "description": "The product can grow to serve more work without a rewrite. Stateless request handling, queue-based dispatch, and replaceable storage keep horizontal scale on the table.",
       "source": "iso25010",
       "requirements": [
         {
@@ -140,6 +142,7 @@
     },
     {
       "name": "Installability",
+      "description": "A new operator can get the product running cleanly. Dependencies are pinned, build and run steps are documented, and system requirements are spelled out rather than assumed.",
       "source": "iso25010",
       "requirements": [
         {
@@ -206,6 +209,7 @@
     },
     {
       "name": "Replaceability",
+      "description": "A module or dependency can be swapped for another with similar contracts. Dependency inversion, versioned interfaces, and minimal lock-in keep substitutions cheap.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/data/standards/compiled/maintainability.json
+++ b/src/quodeq/data/standards/compiled/maintainability.json
@@ -9,6 +9,7 @@
   "principles": [
     {
       "name": "Modularity",
+      "description": "Each part of the codebase has a focused responsibility and clean boundaries. Small modules, low coupling, and limited fan-out make a single change easy to reason about.",
       "source": "iso25010",
       "requirements": [
         {
@@ -348,6 +349,7 @@
     },
     {
       "name": "Reusability",
+      "description": "Useful pieces can be lifted into other contexts without dragging unrelated code. Stable interfaces, no hidden global state, and clear inputs and outputs keep components portable.",
       "source": "iso25010",
       "requirements": [
         {
@@ -416,7 +418,7 @@
         {
           "id": "M-REU-4",
           "source": "iso25010",
-          "text": "Configuration MUST be injectable — functions that read environment variables MUST accept an override parameter (e.g., env dict) so callers can provide values without relying on process environment",
+          "text": "Configuration MUST be injectable \u2014 functions that read environment variables MUST accept an override parameter (e.g., env dict) so callers can provide values without relying on process environment",
           "severity": null,
           "scope": null,
           "refs": [
@@ -507,6 +509,7 @@
     },
     {
       "name": "Analyzability",
+      "description": "A reader can understand what the code does and why. Naming, documentation, type annotations, and consistent structure shorten the time between opening a file and trusting it.",
       "source": "iso25010",
       "requirements": [
         {
@@ -888,6 +891,7 @@
     },
     {
       "name": "Modifiability",
+      "description": "Changes can be made safely without unexpected consequences elsewhere. Encapsulation, tests, and avoiding hidden assumptions let edits stay local.",
       "source": "iso25010",
       "requirements": [
         {
@@ -1113,6 +1117,7 @@
     },
     {
       "name": "Testability",
+      "description": "The system is built to be exercised by automated tests. Pure functions, dependency injection, deterministic behaviour, and seams between layers make assertions easy to write and trust.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/data/standards/compiled/performance.json
+++ b/src/quodeq/data/standards/compiled/performance.json
@@ -9,6 +9,7 @@
   "principles": [
     {
       "name": "Time Behaviour",
+      "description": "How fast the system responds and completes its work. The hot path avoids redundant work, batches I/O, and picks appropriate algorithms and data structures for the scale of input.",
       "source": "iso25010",
       "requirements": [
         {
@@ -198,6 +199,7 @@
     },
     {
       "name": "Resource Utilisation",
+      "description": "How carefully the system uses CPU, memory, network, and disk. Resources are bounded, released promptly, and never leaked or held longer than necessary.",
       "source": "iso25010",
       "requirements": [
         {
@@ -396,6 +398,7 @@
     },
     {
       "name": "Capacity",
+      "description": "How much load the system can handle before it degrades. Limits are explicit, work scales horizontally where possible, and back pressure protects the system from being swamped.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/data/standards/compiled/reliability.json
+++ b/src/quodeq/data/standards/compiled/reliability.json
@@ -10,6 +10,7 @@
   "principles": [
     {
       "name": "Maturity",
+      "description": "How rarely the system fails under normal use. Higher maturity comes from tests, type checks, and disciplined error handling on every path so defects do not reach production.",
       "source": "iso25010",
       "requirements": [
         {
@@ -250,6 +251,7 @@
     },
     {
       "name": "Availability",
+      "description": "How often the system is operational and reachable when users need it. Availability suffers when single points of failure, slow startups, or unbounded resources take the system offline.",
       "source": "iso25010",
       "requirements": [
         {
@@ -355,6 +357,7 @@
     },
     {
       "name": "Fault Tolerance",
+      "description": "How well the system keeps working when something goes wrong. Errors are isolated, retries and timeouts are explicit, and a misbehaving dependency does not bring everything down.",
       "source": "iso25010",
       "requirements": [
         {
@@ -808,6 +811,7 @@
     },
     {
       "name": "Recoverability",
+      "description": "How quickly the system returns to a known good state after a failure. Backups, replayable state, idempotent operations, and predictable shutdown make recovery routine rather than heroic.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/data/standards/compiled/security.json
+++ b/src/quodeq/data/standards/compiled/security.json
@@ -10,6 +10,7 @@
   "principles": [
     {
       "name": "Confidentiality",
+      "description": "Sensitive information is only readable by people and processes entitled to see it. Secrets stay out of source, logs, and error messages, and storage uses encryption appropriate for the data.",
       "source": "iso25010",
       "requirements": [
         {
@@ -868,6 +869,7 @@
     },
     {
       "name": "Integrity",
+      "description": "Data and behaviour are not altered in unauthorised or undetected ways. Inputs are validated, output encoding prevents injection, and modifications go through the rules the domain expects.",
       "source": "iso25010",
       "requirements": [
         {
@@ -1780,6 +1782,7 @@
     },
     {
       "name": "Non-repudiation",
+      "description": "Actions can be traced back to whoever performed them. Authenticated audit trails make it hard for a user or service to plausibly deny an operation later.",
       "source": "iso25010",
       "requirements": [
         {
@@ -1930,6 +1933,7 @@
     },
     {
       "name": "Accountability",
+      "description": "Every privileged operation is attributed to an identity and recorded in a way investigators can use. Logs, request IDs, and identity propagation across services make the trail navigable.",
       "source": "iso25010",
       "requirements": [
         {
@@ -2239,6 +2243,7 @@
     },
     {
       "name": "Authenticity",
+      "description": "The system can prove a claim of identity before granting access. Strong credentials, session handling, and verified API tokens stop impostors before any other check matters.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/data/standards/compiled/usability.json
+++ b/src/quodeq/data/standards/compiled/usability.json
@@ -9,6 +9,7 @@
   "principles": [
     {
       "name": "Appropriateness Recognisability",
+      "description": "A new user can tell what the product is for at first glance. Names, error messages, and the visible API match the user's mental model rather than internal jargon.",
       "source": "iso25010",
       "requirements": [
         {
@@ -60,6 +61,7 @@
     },
     {
       "name": "Learnability",
+      "description": "The product can be picked up without external help. Help text, examples, sensible defaults, and consistent patterns let users go from new to productive quickly.",
       "source": "iso25010",
       "requirements": [
         {
@@ -126,6 +128,7 @@
     },
     {
       "name": "Operability",
+      "description": "Day-to-day use stays smooth and predictable. Long operations show progress, destructive actions confirm, exit codes reflect outcomes, and the product behaves the same way each time.",
       "source": "iso25010",
       "requirements": [
         {
@@ -177,6 +180,7 @@
     },
     {
       "name": "User Error Protection",
+      "description": "Users are guarded from making damaging mistakes. Inputs are validated with helpful messages, dangerous defaults are avoided, and required information is enforced before anything is committed.",
       "source": "iso25010",
       "requirements": [
         {
@@ -243,6 +247,7 @@
     },
     {
       "name": "User Interface Aesthetics",
+      "description": "The interface is pleasant to look at and read. Layout, spacing, and typography respect hierarchy and make the important parts easy to find.",
       "source": "iso25010",
       "requirements": [
         {
@@ -294,6 +299,7 @@
     },
     {
       "name": "Accessibility",
+      "description": "People with different abilities and assistive tools can use the product effectively. Keyboard navigation, semantic markup, sufficient contrast, and predictable focus all matter.",
       "source": "iso25010",
       "requirements": [
         {

--- a/src/quodeq/ui/src/components/terminal/TermHeader.jsx
+++ b/src/quodeq/ui/src/components/terminal/TermHeader.jsx
@@ -1,3 +1,5 @@
+import HelpHint from '../HelpHint.jsx';
+
 /**
  * TermHeader — page header with a `▶ name` prompt and optional sub line.
  * Renders in the active theme's accent color. Structural only; no layout
@@ -6,8 +8,8 @@
  * @param {object} props
  * @param {string} props.name   The label after the ▶ glyph.
  * @param {React.ReactNode} [props.sub]  Optional second line (e.g. stats, breadcrumb).
- * @param {string} [props.description]   Optional description shown via a `?`
- *   tooltip after the name. Omit (or pass falsy) to hide the tooltip trigger.
+ * @param {string} [props.description]   Optional description shown via a click-to-open
+ *   `?` popover after the name. Omit (or pass falsy) to hide the trigger.
  */
 export default function TermHeader({ name, sub, description }) {
   const tip = typeof description === 'string' ? description.trim() : '';
@@ -16,17 +18,7 @@ export default function TermHeader({ name, sub, description }) {
       <div className="term-header__prompt">
         <span className="term-header__glyph" aria-hidden="true">▶</span>
         <span className="term-header__name">{name}</span>
-        {tip && (
-          <span className="term-header__help">
-            <button
-              type="button"
-              className="term-header__help-btn"
-              aria-label="Show description"
-              title={tip}
-            >?</button>
-            <span className="term-header__help-tip" role="tooltip">{tip}</span>
-          </span>
-        )}
+        {tip && <HelpHint label={`About ${name}`}>{tip}</HelpHint>}
       </div>
       {sub != null && <div className="term-header__sub">{sub}</div>}
     </header>

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -38,7 +38,7 @@
 }
 .term-header__prompt {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--term-space-2);
 }
 .term-header__glyph {
@@ -56,57 +56,6 @@
   color: var(--color-text-muted);
   font-size: 12px;
   font-variant-numeric: tabular-nums;
-}
-.term-header__help {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-}
-.term-header__help-btn {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  border: 1px solid var(--color-text-muted);
-  background: transparent;
-  color: var(--color-text-muted);
-  font-family: var(--term-font-mono);
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 1;
-  padding: 0;
-  cursor: help;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.term-header__help-btn:hover,
-.term-header__help-btn:focus-visible {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
-  outline: none;
-}
-.term-header__help-tip {
-  display: none;
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  z-index: 20;
-  width: max-content;
-  max-width: 360px;
-  padding: var(--term-space-2) var(--term-space-3);
-  background: var(--color-surface);
-  border: var(--term-border);
-  border-radius: var(--term-radius);
-  color: var(--color-text);
-  font-family: var(--term-font-mono);
-  font-size: 12px;
-  line-height: 1.4;
-  white-space: normal;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-.term-header__help:hover .term-header__help-tip,
-.term-header__help-btn:focus-visible + .term-header__help-tip {
-  display: block;
 }
 
 /* ------------------------------------------------------------


### PR DESCRIPTION
## Summary
Follow-up to #396 in two parts:

**Header tooltip polish**
- Replaces the custom hover popover in `TermHeader` with the existing `HelpHint` component used on the settings page. The `?` now opens on click, dismisses on click-outside or Escape, and styles match the rest of the app.
- Switches `.term-header__prompt` from baseline to center alignment so the round `?` no longer floats above the text baseline.
- Removes the now-unused `.term-header__help*` rules from `terminal.css`.

**Principle descriptions**
- The previous PR added top-level descriptions to each ISO 25010 standard, but the principle detail page (the `availability.detail`, `modularity.detail`, etc. screens) had no descriptions to pull from, so the `?` tooltip never appeared there.
- Adds 1–2 line descriptions to all 27 principles across the six ISO standards: reliability (4), security (5), maintainability (5), performance (3), usability (6), flexibility (4).

## Test plan
- [x] `pytest tests/services/test_standards_*.py tests/api/test_standards_routes.py` (67 passing)
- [x] Open dimension overview → `?` next to the standard name opens on click, closes on click-outside / Escape, lines up with the title (no baseline drift)
- [x] Open a principle (e.g. `availability`) → `?` next to the principle name now appears and shows the new principle description
- [x] Visual check on a wide and narrow viewport that the popover does not overlap stat cards awkwardly