### PR TITLE
feat: permanent finding deletion with principle+file suppression

### DIFF
--- a/src/quodeq/analysis/subagents/_verification.py
+++ b/src/quodeq/analysis/subagents/_verification.py
@@ -17,6 +17,7 @@ from quodeq.analysis.subagents.verify import (
     _group_by_file,
     _write_verify_manifest,
 )
+from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.shared.logging import log_info, log_success
 
@@ -39,13 +40,19 @@ def _load_and_filter_previous(
     if config.options.incremental_file_filter is not None:
         filter_set = config.options.incremental_file_filter
         prev_findings = [f for f in prev_findings if f.get("file") in filter_set]
-    # Filter out dismissed findings
+    # Filter out dismissed and permanently-deleted findings
     project_dir = evidence_dir.parent
     dkeys = dismissed_keys(project_dir)
+    delkeys = deleted_keys(project_dir)
     if dkeys:
         prev_findings = [
             f for f in prev_findings
             if (f.get("p", ""), f.get("file", ""), f.get("line", 0)) not in dkeys
+        ]
+    if delkeys:
+        prev_findings = [
+            f for f in prev_findings
+            if (dim_id, f.get("p", ""), f.get("file", "")) not in delkeys
         ]
     return prev_findings
 

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from flask import Flask, Response, abort, jsonify, request
 
+from quodeq.services.deleted import delete_all_dismissed, delete_finding
 from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
@@ -76,3 +77,24 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project is required"}), 400
         count = restore_all_findings(_project_dir(_eval_dir(), project))
         return jsonify({"ok": True, "restored": count}), 200
+
+    @app.post("/api/findings/delete")
+    def delete() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        dimension = body.get("dimension", "")
+        principle = body.get("principle", "")
+        file = body.get("file", "")
+        if not project or not dimension or not principle or not file:
+            return jsonify({"error": "project, dimension, principle, and file are required"}), 400
+        swept = delete_finding(_project_dir(_eval_dir(), project), body)
+        return jsonify({"ok": True, "swept": swept}), 200
+
+    @app.post("/api/findings/delete-all")
+    def delete_all() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        if not project:
+            return jsonify({"error": "project is required"}), 400
+        count = delete_all_dismissed(_project_dir(_eval_dir(), project))
+        return jsonify({"ok": True, "deleted": count}), 200

--- a/src/quodeq/api/routes_rescore.py
+++ b/src/quodeq/api/routes_rescore.py
@@ -8,6 +8,7 @@ from flask import Flask, Response, jsonify, request
 
 from quodeq.api.helpers import error_response
 from quodeq.services.ports import list_runs, read_run_data
+from quodeq.services.deleted import deleted_keys as load_deleted_keys
 from quodeq.services.dismissed import dismissed_keys as load_dismissed_keys
 from quodeq.services.rescore import rescore_dimensions
 from quodeq.shared.utils import get_evaluations_dir
@@ -53,6 +54,7 @@ def register_rescore_routes(app: Flask) -> None:
 
         project_dir = Path(eval_dir) / project
         dismissed = load_dismissed_keys(project_dir)
+        deleted = load_deleted_keys(project_dir)
 
-        result = rescore_dimensions(dimensions, dismissed)
+        result = rescore_dimensions(dimensions, dismissed, deleted)
         return jsonify(result)

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -29,6 +29,7 @@ def _parse_jsonl_findings(
     lines: Iterable[str], dimension: str, req_refs_lookup: dict[str, list[dict]] | None = None,
     req_to_principle: dict[str, str] | None = None,
     dismissed_keys: "set[tuple] | None" = None,
+    deleted_keys: "set[tuple] | None" = None,
 ) -> tuple[list[Finding], list[Finding]]:
     """Parse raw JSONL lines into deduplicated violation and compliance lists."""
     violations: list[Finding] = []
@@ -52,6 +53,11 @@ def _parse_jsonl_findings(
             if dismissed_key in dismissed_keys:
                 continue
         obj["p"] = req_to_principle.get(principle, principle) if req_to_principle else principle
+        # Skip permanently-deleted findings -- match by (dimension, principle, file).
+        if deleted_keys and obj.get("t") == _TYPE_VIOLATION:
+            deleted_key = (dimension, obj["p"], obj.get("file", ""))
+            if deleted_key in deleted_keys:
+                continue
         dedup_key = (principle, obj.get("t"), obj.get("file"), obj.get("line"))
         if dedup_key in seen:
             continue
@@ -98,6 +104,7 @@ def parse_violations_from_jsonl(
     jsonl_path: Path, stream_path: Path | None, ctx: ViolationContext,
     compiled_dir: Path | None = None,
     dismissed_keys: "set[tuple] | None" = None,
+    deleted_keys: "set[tuple] | None" = None,
 ) -> ViolationResponse | None:
     """Parse live JSONL findings written by the MCP server."""
     req_refs_lookup = build_req_refs_lookup(compiled_dir, ctx.dimension) if compiled_dir else None
@@ -105,7 +112,8 @@ def parse_violations_from_jsonl(
     try:
         with open_text(jsonl_path) as _f:
             violations, compliance = _parse_jsonl_findings(
-                _f, ctx.dimension, req_refs_lookup, req_to_principle, dismissed_keys=dismissed_keys,
+                _f, ctx.dimension, req_refs_lookup, req_to_principle,
+                dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
             )
     except OSError as exc:
         _logger.warning("Failed to read findings file: %s", exc)

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -12,6 +12,7 @@ from quodeq.core.types import DimensionResult
 from quodeq.shared.utils import _env_int
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services.dim_resolution import is_eligible_for_default_view, is_successful_run
+from quodeq.services.deleted import filter_deleted_from_dimensions
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.services._fs_projects import find_children as _find_children
 
@@ -114,7 +115,9 @@ def _build_accumulated_for_runs(
     latest_by_dim, prev_occurrence, prev_run_latest = _read_all_run_data(
         reports_root, project, run_infos, runs, get_run_data,
     )
-    all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), reports_root / project)
+    project_dir = reports_root / project
+    all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), project_dir)
+    all_dims = filter_deleted_from_dimensions(all_dims, project_dir)
     dims_with_trend = _compute_accumulated_trends(all_dims, prev_occurrence)
     severity = _aggregate_severity_counts(all_dims)
     avg, prev_avg = _compute_accumulated_scores(all_dims, prev_run_latest)

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -1,0 +1,212 @@
+"""Persistent storage for permanently-deleted findings — per-project JSON file.
+
+Unlike the dismissed list (which only excludes findings from scoring), the
+deleted list permanently suppresses any finding whose
+``(dimension, principle, file)`` matches an entry. Future scans will not
+surface those findings again. Deletion is one-way: there is no restore.
+
+The on-disk file ``deleted.json`` lives next to ``dismissed.json`` and is
+guarded by the same kind of POSIX file lock used by ``dismissed.py``.
+"""
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from quodeq.core.types.finding import Finding
+from quodeq.data._file_lock import lock_file, unlock_file
+from quodeq.services.dismissed import load_dismissed, recount_totals
+
+
+@runtime_checkable
+class DeletedStoreProtocol(Protocol):
+    """Abstraction for permanent-suppression storage."""
+
+    def load(self, project_dir: Path) -> list[dict]: ...
+    def delete(self, project_dir: Path, finding: dict) -> None: ...
+    def delete_all_dismissed(self, project_dir: Path) -> int: ...
+
+
+_FILENAME = "deleted.json"
+
+
+def _deleted_path(project_dir: Path) -> Path:
+    return project_dir / _FILENAME
+
+
+@contextmanager
+def _locked(project_dir: Path):
+    lock_path = project_dir / "deleted.json.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o600)
+    try:
+        lock_file(fd)
+        yield
+    finally:
+        unlock_file(fd)
+        os.close(fd)
+
+
+def _key(entry: dict) -> tuple:
+    return (
+        entry.get("dimension", "") or "",
+        entry.get("principle", "") or "",
+        entry.get("file", "") or "",
+    )
+
+
+def load_deleted(project_dir: Path) -> list[dict]:
+    """Load deleted suppressions for a project. Returns empty list if none."""
+    path = _deleted_path(project_dir)
+    if not path.exists():
+        return []
+    try:
+        items = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(items, list):
+        return []
+    return items
+
+
+def deleted_keys(project_dir: Path) -> set[tuple]:
+    """Return ``{(dimension, principle, file)}`` tuples for the project."""
+    return {_key(e) for e in load_deleted(project_dir)}
+
+
+def _entry_from_finding(finding: dict) -> dict:
+    return {
+        "dimension": finding.get("dimension", ""),
+        "principle": finding.get("principle", ""),
+        "file": finding.get("file", ""),
+        "deleted_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _write_deleted(project_dir: Path, entries: list[dict]) -> None:
+    path = _deleted_path(project_dir)
+    if entries:
+        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+    elif path.exists():
+        path.unlink()
+
+
+def delete_finding(project_dir: Path, finding: dict) -> int:
+    """Permanently suppress a finding by (dimension, principle, file).
+
+    Also removes any entries from ``dismissed.json`` that share the same
+    suppression key, so the dismissed list stays clean. Returns the number
+    of dismissed entries swept (0 if none).
+    """
+    new_key = _key(finding)
+    if not new_key[1] or not new_key[2]:
+        return 0
+    swept = 0
+    with _locked(project_dir):
+        existing = load_deleted(project_dir)
+        if new_key not in {_key(e) for e in existing}:
+            existing.append(_entry_from_finding(finding))
+            _write_deleted(project_dir, existing)
+        swept = _sweep_dismissed_matching(project_dir, new_key)
+    return swept
+
+
+def delete_all_dismissed(project_dir: Path) -> int:
+    """Convert every currently-dismissed entry into a permanent suppression.
+
+    Adds a deleted entry for each unique ``(dimension, principle, file)``
+    pair found in ``dismissed.json``, then clears the dismissed list.
+    Returns the count of dismissed entries removed.
+    """
+    with _locked(project_dir):
+        dismissed_entries = load_dismissed(project_dir)
+        if not dismissed_entries:
+            return 0
+        existing = load_deleted(project_dir)
+        existing_keys = {_key(e) for e in existing}
+        for entry in dismissed_entries:
+            k = _key(entry)
+            if not k[1] or not k[2] or k in existing_keys:
+                continue
+            existing.append(_entry_from_finding(entry))
+            existing_keys.add(k)
+        _write_deleted(project_dir, existing)
+        # Clear dismissed.json now that everything is permanently suppressed.
+        dismissed_path = project_dir / "dismissed.json"
+        count = len(dismissed_entries)
+        if dismissed_path.exists():
+            dismissed_path.unlink()
+        return count
+
+
+def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
+    """Remove every dismissed entry whose ``(dimension, principle, file)`` matches *key*."""
+    dismissed_path = project_dir / "dismissed.json"
+    if not dismissed_path.exists():
+        return 0
+    try:
+        entries = json.loads(dismissed_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return 0
+    if not isinstance(entries, list):
+        return 0
+    kept = [e for e in entries if _key(e) != key]
+    swept = len(entries) - len(kept)
+    if swept == 0:
+        return 0
+    if kept:
+        dismissed_path.write_text(json.dumps(kept, indent=2), encoding="utf-8")
+    else:
+        dismissed_path.unlink()
+    return swept
+
+
+def is_finding_deleted(
+    deleted: set[tuple],
+    *,
+    dimension: str,
+    principle: str,
+    file: str,
+) -> bool:
+    """Return True if ``(dimension, principle, file)`` is in *deleted*."""
+    if not deleted:
+        return False
+    return (dimension or "", principle or "", file or "") in deleted
+
+
+def filter_deleted_from_dimensions(
+    dimensions: list, project_dir: Path,
+) -> list:
+    """Return a new list of DimensionResult with permanently-deleted findings removed.
+
+    Mirrors ``filter_dismissed_from_dimensions``: recalculates totals for any
+    dimension whose violations were filtered, leaves other fields unchanged.
+    """
+    keys = deleted_keys(project_dir)
+    if not keys:
+        return dimensions
+    result = []
+    for dim in dimensions:
+        dim_id = (getattr(dim, "dimension", "") or "")
+        filtered = [
+            v for v in dim.violations
+            if (dim_id, _principle_of(v), v.file or "") not in keys
+        ]
+        if len(filtered) == len(dim.violations):
+            result.append(dim)
+        else:
+            result.append(replace(
+                dim,
+                violations=filtered,
+                totals=recount_totals(filtered, old_totals=dim.totals),
+            ))
+    return result
+
+
+def _principle_of(f: Finding) -> str:
+    return getattr(f, "principle", "") or ""

--- a/src/quodeq/services/rescore.py
+++ b/src/quodeq/services/rescore.py
@@ -92,11 +92,18 @@ def _score_all_principles(
     return principle_scores, principle_grades
 
 
-def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> DimensionResult:
-    """Rescore a single dimension after filtering dismissed findings."""
+def _rescore_dimension(
+    dim: DimensionResult,
+    dismissed: set[tuple],
+    deleted: set[tuple] | None = None,
+) -> DimensionResult:
+    """Rescore a single dimension after filtering dismissed and deleted findings."""
+    deleted = deleted or set()
+    dim_id = dim.dimension or ""
     filtered_violations = [
         v for v in dim.violations
         if (v.req or "", v.file or "", v.line or 0) not in dismissed
+        and (dim_id, v.principle or "", v.file or "") not in deleted
     ]
     if len(filtered_violations) == len(dim.violations):
         return dim
@@ -127,12 +134,13 @@ def _rescore_dimension(dim: DimensionResult, dismissed: set[tuple]) -> Dimension
 def rescore_dimensions(
     dimensions: list[DimensionResult],
     dismissed_keys: set[tuple],
+    deleted_keys: set[tuple] | None = None,
 ) -> dict[str, Any]:
-    """Rescore all dimensions after filtering dismissed findings.
+    """Rescore all dimensions after filtering dismissed and deleted findings.
 
     Returns a dict with 'dimensions' (list of camelCase dicts) and 'summary' (camelCase dict).
     """
-    rescored = [_rescore_dimension(dim, dismissed_keys) for dim in dimensions]
+    rescored = [_rescore_dimension(dim, dismissed_keys, deleted_keys) for dim in dimensions]
     summary = summarize_dimensions(rescored)
     return {
         "dimensions": [to_camel_dict(d) for d in rescored],

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -22,6 +22,7 @@ from quodeq.services.dashboard import (
     _make_run_dimension_fetcher,
 )
 from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.ports import RunInfo, list_runs
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
@@ -50,19 +51,22 @@ def _make_rescoring_fetcher(
     automatically gets rescored data.
     """
     base_fetcher = _make_run_dimension_fetcher(reports_root, project)
-    dismissed = dismissed_keys(reports_root / project)
-    if not dismissed:
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    deleted = deleted_keys(project_dir)
+    if not dismissed and not deleted:
         return base_fetcher
 
     def rescoring_fetcher(run_id: str) -> list[DimensionResult]:
         dims = base_fetcher(run_id)
-        return [_rescore_dimension(d, dismissed) for d in dims]
+        return [_rescore_dimension(d, dismissed, deleted) for d in dims]
 
     return rescoring_fetcher
 
 
 def _rescore_runs_by_dimension(
-    dims: list[dict], reports_root: Path, project: str, dismissed: set[tuple],
+    dims: list[dict], reports_root: Path, project: str,
+    dismissed: set[tuple], deleted: set[tuple] | None = None,
 ) -> dict[str, dict]:
     """Rescore each unique run and return a map of dim_key -> rescored dict."""
     dim_to_run: dict[str, str] = {}
@@ -78,7 +82,7 @@ def _rescore_runs_by_dimension(
     for dim_key, run_id in dim_to_run.items():
         if run_id not in seen_runs:
             run_dims = fetcher(run_id)
-            result = rescore_dimensions(run_dims, dismissed)
+            result = rescore_dimensions(run_dims, dismissed, deleted)
             seen_runs[run_id] = {
                 (rd.get("dimension") or "").lower(): rd
                 for rd in result.get("dimensions", [])
@@ -120,15 +124,17 @@ def _rescore_accumulated_response(
     Filters dismissed violations from each dimension, recalculates scores,
     and recomputes the summary.
     """
-    dismissed = dismissed_keys(reports_root / project)
-    if not dismissed or not accumulated:
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    deleted = deleted_keys(project_dir)
+    if (not dismissed and not deleted) or not accumulated:
         return accumulated
 
     dims = accumulated.get("dimensions", [])
     if not dims:
         return accumulated
 
-    rescored_by_dim = _rescore_runs_by_dimension(dims, reports_root, project, dismissed)
+    rescored_by_dim = _rescore_runs_by_dimension(dims, reports_root, project, dismissed, deleted)
     new_dims = _merge_rescored_dims(dims, rescored_by_dim)
 
     new_summary = recompute_summary(new_dims, accumulated.get("summary", {}))

--- a/src/quodeq/services/scoring/_rescore.py
+++ b/src/quodeq/services/scoring/_rescore.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from quodeq.core.types import DimensionResult
+from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.rescore import rescore_dimensions as _raw_rescore
 from quodeq.services.scoring._run_scores import get_run_dimensions, parse_score
@@ -44,10 +45,11 @@ def rescore_run(
     dimensions = get_run_dimensions(reports_root, project, run_id)
     project_dir = reports_root / project
     dismissed = dismissed_keys(project_dir)
-    if not dismissed:
+    deleted = deleted_keys(project_dir)
+    if not dismissed and not deleted:
         return _dims_to_scored(dimensions, run_id)
 
-    result = _raw_rescore(dimensions, dismissed)
+    result = _raw_rescore(dimensions, dismissed, deleted)
     return [
         _dim_result_to_scored(d, from_run_id=run_id)
         for d in result.get("dimensions", [])
@@ -64,14 +66,15 @@ def rescore_run_raw(
     dimensions = get_run_dimensions(reports_root, project, run_id)
     project_dir = reports_root / project
     dismissed = dismissed_keys(project_dir)
-    if not dismissed:
+    deleted = deleted_keys(project_dir)
+    if not dismissed and not deleted:
         from quodeq.data.fs.report_parser.grades import summarize_dimensions
         from quodeq.core.types import to_camel_dict
         return {
             "dimensions": [to_camel_dict(d) for d in dimensions],
             "summary": to_camel_dict(summarize_dimensions(dimensions)),
         }
-    return _raw_rescore(dimensions, dismissed)
+    return _raw_rescore(dimensions, dismissed, deleted)
 
 
 def _dims_to_scored(

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -10,6 +10,7 @@ from quodeq.data.fs.report_parser import parse_eval_from_json, parse_eval_markdo
 from quodeq.core.types import ViolationFileEntry, ViolationResponse, ViolationSummary
 from quodeq.shared.utils import _env_int, read_text
 from quodeq.services.violation_context import ViolationContext  # noqa: F401 — re-export
+from quodeq.services.deleted import deleted_keys as _deleted_keys
 from quodeq.services.dismissed import dismissed_keys as _dismissed_keys
 from quodeq.services.violations_parsing import (
     parse_violations_from_evidence,
@@ -57,37 +58,50 @@ def _dismissed_key_for_violation(v: dict) -> tuple:
     return (req, raw_file, 0)
 
 
+def _deleted_key_for_violation(v: dict, dimension: str) -> tuple:
+    """Build a (dimension, principle, file) suppression key from a violation dict."""
+    raw_file = v.get("file", "")
+    if v.get("line") is None and ":" in raw_file:
+        raw_file = raw_file.rsplit(":", 1)[0]
+    return (dimension or "", v.get("principle", "") or "", raw_file)
+
+
 def _filter_dismissed_from_result(
     result: "ViolationResponse | dict[str, Any] | None",
     dkeys: "set[tuple]",
+    delkeys: "set[tuple] | None" = None,
+    dimension: str = "",
 ) -> "ViolationResponse | dict[str, Any] | None":
-    """Remove dismissed violations from any result format."""
-    if not result or not dkeys:
+    """Remove dismissed and permanently-deleted violations from any result format."""
+    if not result or (not dkeys and not delkeys):
         return result
     if isinstance(result, dict):
         if "violations" in result:
             result["violations"] = [
                 v for v in result["violations"]
                 if _dismissed_key_for_violation(v) not in dkeys
+                and (not delkeys or _deleted_key_for_violation(v, dimension) not in delkeys)
             ]
         for p in result.get("principles", []):
             if "violations" in p:
                 p["violations"] = [
                     v for v in p["violations"]
                     if _dismissed_key_for_violation(v) not in dkeys
+                    and (not delkeys or _deleted_key_for_violation(v, dimension) not in delkeys)
                 ]
     return result
 
 
 def _try_evidence_formats(
     base: Path, dimension: str, ctx: ViolationContext,
-    _exists, _stat, compiled_dir, dkeys: set[tuple],
+    _exists, _stat, compiled_dir, dkeys: set[tuple], delkeys: set[tuple],
 ) -> ViolationResponse | dict[str, Any] | None:
     """Try evidence file formats (JSON, JSONL, stream) as fallbacks."""
     evidence_path = base / "evidence" / f"{dimension}_evidence.json"
     if _exists(evidence_path):
         return _filter_dismissed_from_result(
             parse_violations_from_evidence(evidence_path, ctx), dkeys,
+            delkeys, dimension,
         )
 
     jsonl_path = base / "evidence" / f"{dimension}_evidence.jsonl"
@@ -95,7 +109,7 @@ def _try_evidence_formats(
     if _exists(jsonl_path) and _stat(jsonl_path).st_size > 0:
         return parse_violations_from_jsonl(
             jsonl_path, stream_path, ctx, compiled_dir=compiled_dir,
-            dismissed_keys=dkeys,
+            dismissed_keys=dkeys, deleted_keys=delkeys,
         )
 
     if _exists(stream_path):
@@ -118,11 +132,13 @@ def resolve_dimension_eval(
     _stat = opts.stat_fn
     compiled_dir = opts.compiled_dir
     dkeys = _dismissed_keys(base.parent)
+    delkeys = _deleted_keys(base.parent)
 
     eval_path = base / "evaluation" / f"{dimension}.json"
     if _exists(eval_path):
         return _filter_dismissed_from_result(
-            parse_eval_from_json(eval_path, project, run_id, dimension), dkeys,
+            parse_eval_from_json(eval_path, project, run_id, dimension),
+            dkeys, delkeys, dimension,
         )
 
     markdown_path = base / "evaluation" / f"{dimension}_eval.md"
@@ -132,11 +148,12 @@ def resolve_dimension_eval(
         except OSError:
             return None
         return _filter_dismissed_from_result(
-            parse_eval_markdown(content, project, run_id, dimension), dkeys,
+            parse_eval_markdown(content, project, run_id, dimension),
+            dkeys, delkeys, dimension,
         )
 
     ctx = ViolationContext(project=project, run_id=run_id, dimension=dimension)
-    return _try_evidence_formats(base, dimension, ctx, _exists, _stat, compiled_dir, dkeys)
+    return _try_evidence_formats(base, dimension, ctx, _exists, _stat, compiled_dir, dkeys, delkeys)
 
 
 def aggregate_violations(dashboard: dict[str, Any]) -> ViolationSummary:

--- a/src/quodeq/ui/src/api/findings.js
+++ b/src/quodeq/ui/src/api/findings.js
@@ -70,3 +70,30 @@ export async function getRescore(projectId, run = 'latest') {
   if (run && run !== 'latest') params.set('run', run);
   return request(`/rescore?${params}`);
 }
+
+/**
+ * Permanently delete a finding (suppress by dimension+principle+file forever).
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - { dimension, principle, file }
+ * @returns {Promise<{ok: boolean, swept: number}>} Server response
+ */
+export async function deleteFinding(projectId, finding) {
+  return request('/findings/delete', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId, ...finding }),
+  });
+}
+
+/**
+ * Permanently delete all currently-dismissed findings for a project.
+ * Each unique (dimension, principle, file) becomes a permanent suppression
+ * and the dismissed list is cleared.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<{ok: boolean, deleted: number}>} Server response
+ */
+export async function deleteAllFindings(projectId) {
+  return request('/findings/delete-all', {
+    method: 'POST',
+    body: JSON.stringify({ project: projectId }),
+  });
+}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -14,7 +14,7 @@ import { createJob } from '../models/job.js';
 import { createProject } from '../models/project.js';
 import { request, BASE } from './request.js';
 
-export { listDismissedFindings, dismissFinding, restoreFinding, restoreAllFindings, getRescore } from './findings.js';
+export { listDismissedFindings, dismissFinding, restoreFinding, restoreAllFindings, getRescore, deleteFinding, deleteAllFindings } from './findings.js';
 export { listStandards, getStandard, createStandard, updateStandard, deleteStandard, duplicateStandard, listLibrary, listCwes, importFromLibrary, importStandard, exportStandard } from './standards.js';
 
 // ── Health ──────────────────────────────────────────────────────────────

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { listDismissedFindings, restoreFinding, restoreAllFindings } from '../../../api/index.js';
+import {
+  listDismissedFindings,
+  restoreFinding,
+  restoreAllFindings,
+  deleteFinding,
+  deleteAllFindings,
+} from '../../../api/index.js';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 export function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
@@ -34,8 +40,18 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
 
   const handleDelete = useCallback(async (d) => {
     try {
-      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
-      setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
+      await deleteFinding(selectedProject, {
+        dimension: d.dimension,
+        principle: d.principle,
+        file: d.file,
+      });
+      // Sweep every dismissed entry that shares the same (dimension, principle, file),
+      // matching the backend sweep so the local list stays in sync without a refetch.
+      setDismissed((prev) => prev.filter((item) => !(
+        item.dimension === d.dimension
+        && item.principle === d.principle
+        && item.file === d.file
+      )));
       onRefresh?.();
     } catch (err) {
       console.error('Failed to delete finding:', err);
@@ -54,7 +70,7 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
     });
     if (!ok) return;
     try {
-      await restoreAllFindings(selectedProject);
+      await deleteAllFindings(selectedProject);
       setDismissed([]);
       onRefresh?.();
     } catch (err) {

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -7,6 +7,8 @@ vi.mock('../../../api/index.js', () => ({
   listDismissedFindings: vi.fn(),
   restoreFinding: vi.fn(),
   restoreAllFindings: vi.fn(),
+  deleteFinding: vi.fn(),
+  deleteAllFindings: vi.fn(),
 }));
 
 vi.mock('../../../utils/confirmDialog.js', () => ({
@@ -17,12 +19,20 @@ import {
   listDismissedFindings,
   restoreFinding,
   restoreAllFindings,
+  deleteFinding,
+  deleteAllFindings,
 } from '../../../api/index.js';
 
 import { confirmDialog } from '../../../utils/confirmDialog.js';
 
-const sampleA = { req: 'A1', file: 'a.py', line: 10, severity: 'minor' };
-const sampleB = { req: 'B1', file: 'b.py', line: 20, severity: 'major' };
+const sampleA = {
+  req: 'A1', file: 'a.py', line: 10, severity: 'minor',
+  dimension: 'security', principle: 'Path Validation',
+};
+const sampleB = {
+  req: 'B1', file: 'b.py', line: 20, severity: 'major',
+  dimension: 'reliability', principle: 'Fault Tolerance',
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -77,9 +87,9 @@ describe('useDismissedFindings — restore handlers', () => {
 });
 
 describe('useDismissedFindings — handleDelete', () => {
-  it('removes the matching entry on success and calls onRefresh (mirrors restore on disk, distinct error message)', async () => {
+  it('permanently deletes by (dimension, principle, file) and removes the entry locally', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
-    restoreFinding.mockResolvedValueOnce({ ok: true });
+    deleteFinding.mockResolvedValueOnce({ ok: true, swept: 1 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
     const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
@@ -87,15 +97,32 @@ describe('useDismissedFindings — handleDelete', () => {
 
     await act(async () => { await result.current.handleDelete(sampleA); });
 
-    expect(restoreFinding).toHaveBeenCalledWith('proj', { req: 'A1', file: 'a.py', line: 10 });
+    expect(deleteFinding).toHaveBeenCalledWith('proj', {
+      dimension: 'security',
+      principle: 'Path Validation',
+      file: 'a.py',
+    });
+    expect(restoreFinding).not.toHaveBeenCalled();
     expect(result.current.dismissed).toEqual([sampleB]);
     expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(setRestoreError).not.toHaveBeenCalled();
   });
 
+  it('sweeps every dismissed entry sharing the same (dimension, principle, file)', async () => {
+    const dupA = { ...sampleA, line: 99 };
+    listDismissedFindings.mockResolvedValueOnce([sampleA, dupA, sampleB]);
+    deleteFinding.mockResolvedValueOnce({ ok: true, swept: 2 });
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), vi.fn()));
+    await waitFor(() => expect(result.current.dismissed).toHaveLength(3));
+
+    await act(async () => { await result.current.handleDelete(sampleA); });
+
+    expect(result.current.dismissed).toEqual([sampleB]);
+  });
+
   it('reports a delete-specific error and leaves state unchanged on failure', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA]);
-    restoreFinding.mockRejectedValueOnce(new Error('boom'));
+    deleteFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
     const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
@@ -110,10 +137,10 @@ describe('useDismissedFindings — handleDelete', () => {
 });
 
 describe('useDismissedFindings — handleDeleteAll', () => {
-  it('opens the confirmation dialog and clears state when the user confirms', async () => {
+  it('opens the confirmation dialog and permanently deletes all on confirm', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA, sampleB]);
     confirmDialog.mockResolvedValueOnce(true);
-    restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
+    deleteAllFindings.mockResolvedValueOnce({ ok: true, deleted: 2 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
     const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
@@ -127,7 +154,8 @@ describe('useDismissedFindings — handleDeleteAll', () => {
       confirmLabel: 'Delete',
       message: expect.stringContaining('permanently delete those 2 findings'),
     }));
-    expect(restoreAllFindings).toHaveBeenCalledWith('proj');
+    expect(deleteAllFindings).toHaveBeenCalledWith('proj');
+    expect(restoreAllFindings).not.toHaveBeenCalled();
     expect(result.current.dismissed).toEqual([]);
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
@@ -143,15 +171,15 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     await act(async () => { await result.current.handleDeleteAll(); });
 
     expect(confirmDialog).toHaveBeenCalledTimes(1);
-    expect(restoreAllFindings).not.toHaveBeenCalled();
+    expect(deleteAllFindings).not.toHaveBeenCalled();
     expect(result.current.dismissed).toEqual([sampleA, sampleB]);
     expect(onRefresh).not.toHaveBeenCalled();
   });
 
-  it('reports a delete-specific error if restoreAllFindings fails after confirmation', async () => {
+  it('reports a delete-specific error if deleteAllFindings fails after confirmation', async () => {
     listDismissedFindings.mockResolvedValueOnce([sampleA]);
     confirmDialog.mockResolvedValueOnce(true);
-    restoreAllFindings.mockRejectedValueOnce(new Error('boom'));
+    deleteAllFindings.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
     const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));

--- a/tests/services/test_deleted.py
+++ b/tests/services/test_deleted.py
@@ -1,0 +1,126 @@
+"""Tests for the deleted (permanent suppression) findings storage service."""
+import json
+
+from quodeq.services.deleted import (
+    delete_all_dismissed,
+    delete_finding,
+    deleted_keys,
+    is_finding_deleted,
+    load_deleted,
+)
+from quodeq.services.dismissed import dismiss_finding, load_dismissed
+
+
+def _finding(*, req="M-MOD-1", file="foo.py", line=10, dimension="maintainability", principle="Modularity"):
+    return {
+        "req": req, "file": file, "line": line,
+        "dimension": dimension, "principle": principle, "severity": "minor",
+    }
+
+
+class TestDeletedStorage:
+    def test_load_empty_when_no_file(self, tmp_path):
+        assert load_deleted(tmp_path / "nonexistent") == []
+
+    def test_delete_creates_file_with_suppression_key(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        delete_finding(project_dir, _finding())
+        entries = load_deleted(project_dir)
+        assert len(entries) == 1
+        assert entries[0]["dimension"] == "maintainability"
+        assert entries[0]["principle"] == "Modularity"
+        assert entries[0]["file"] == "foo.py"
+        assert "deleted_at" in entries[0]
+
+    def test_delete_deduplicates_same_key(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        delete_finding(project_dir, _finding(line=10))
+        delete_finding(project_dir, _finding(line=99))  # different line, same (dim, principle, file)
+        assert len(load_deleted(project_dir)) == 1
+
+    def test_delete_requires_principle_and_file(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        delete_finding(project_dir, {"dimension": "x", "principle": "", "file": "f.py"})
+        delete_finding(project_dir, {"dimension": "x", "principle": "P", "file": ""})
+        assert load_deleted(project_dir) == []
+
+    def test_deleted_keys_returns_tuple_set(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        delete_finding(project_dir, _finding())
+        assert deleted_keys(project_dir) == {("maintainability", "Modularity", "foo.py")}
+
+    def test_delete_sweeps_matching_dismissed_entries(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        # Two dismissed entries share (dim, principle, file); a third does not.
+        dismiss_finding(project_dir, _finding(line=10))
+        dismiss_finding(project_dir, _finding(line=42))
+        dismiss_finding(project_dir, _finding(file="other.py", line=1))
+        swept = delete_finding(project_dir, _finding(line=10))
+        assert swept == 2
+        remaining = load_dismissed(project_dir)
+        assert len(remaining) == 1
+        assert remaining[0]["file"] == "other.py"
+
+    def test_delete_returns_zero_swept_when_no_dismissed(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        assert delete_finding(project_dir, _finding()) == 0
+
+
+class TestDeleteAllDismissed:
+    def test_returns_zero_when_no_dismissed(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        assert delete_all_dismissed(project_dir) == 0
+
+    def test_converts_dismissed_to_deleted_and_clears(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        dismiss_finding(project_dir, _finding(req="A", file="a.py", line=1))
+        dismiss_finding(project_dir, _finding(req="B", file="b.py", line=2, principle="Cohesion"))
+        count = delete_all_dismissed(project_dir)
+        assert count == 2
+        assert load_dismissed(project_dir) == []
+        keys = deleted_keys(project_dir)
+        assert keys == {
+            ("maintainability", "Modularity", "a.py"),
+            ("maintainability", "Cohesion", "b.py"),
+        }
+
+    def test_collapses_duplicate_keys_in_dismissed_list(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        # Same (dim, principle, file) at two different lines.
+        dismiss_finding(project_dir, _finding(req="A", line=1))
+        dismiss_finding(project_dir, _finding(req="B", line=2))
+        delete_all_dismissed(project_dir)
+        assert len(load_deleted(project_dir)) == 1
+
+
+class TestIsFindingDeleted:
+    def test_empty_set_returns_false(self):
+        assert is_finding_deleted(set(), dimension="x", principle="y", file="z") is False
+
+    def test_match(self):
+        s = {("security", "Path", "f.py")}
+        assert is_finding_deleted(s, dimension="security", principle="Path", file="f.py") is True
+
+    def test_no_match_on_different_file(self):
+        s = {("security", "Path", "f.py")}
+        assert is_finding_deleted(s, dimension="security", principle="Path", file="g.py") is False
+
+
+class TestPersistedJson:
+    def test_file_is_valid_json_list(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        delete_finding(project_dir, _finding())
+        path = project_dir / "deleted.json"
+        data = json.loads(path.read_text())
+        assert isinstance(data, list)
+        assert data[0]["principle"] == "Modularity"


### PR DESCRIPTION
## Summary

- Makes the "Delete" button on dismissed findings actually delete forever instead of silently aliasing Restore.
- Adds a per-project `deleted.json` suppression list keyed by `(dimension, principle, file)`. Any future scan or rescore filters those keys out before scoring, so deleted findings don't come back.
- Delete-All converts every currently-dismissed entry into a permanent suppression and clears the dismissed list. Delete is one-way (no restore UI).

## Why

`handleDelete` previously called `restoreFinding`, which meant clicking Delete and clicking Restore did the same thing on disk. The Delete affordance was a lie. This was flagged as a "logic error" in a static-analysis pass; the right fix is real delete semantics, not a one-line swap.

## What changed

**Backend**
- New `services/deleted.py` — file-locked storage (mirrors `dismissed.py`), with `delete_finding`, `delete_all_dismissed`, `deleted_keys`, `filter_deleted_from_dimensions`, `is_finding_deleted`. `delete_finding` also sweeps any matching dismissed entries so the dismissed list stays clean.
- New routes: `POST /api/findings/delete` and `POST /api/findings/delete-all`.
- Deleted-key filter wired through every existing dismissed-filter site:
  - `_violations_jsonl.py` (leaf parser, applies after principle normalization)
  - `services/violations.py` (`resolve_dimension_eval` + `_filter_dismissed_from_result`)
  - `services/rescore.py` (`rescore_dimensions` / `_rescore_dimension`)
  - `services/accumulated.py`, `services/scoring/__init__.py`, `services/scoring/_rescore.py`
  - `analysis/subagents/_verification.py` (pre-scan filter on previous findings)
  - `api/routes_rescore.py`

**UI**
- New `deleteFinding` / `deleteAllFindings` clients in `ui/src/api/findings.js`, re-exported from `ui/src/api/index.js`.
- `useDismissedFindings.js` `handleDelete` now calls `deleteFinding({ dimension, principle, file })` and locally sweeps every entry sharing the same `(dimension, principle, file)` to mirror the backend sweep without an extra refetch. `handleDeleteAll` calls `deleteAllFindings` (existing confirm dialog kept).

**Tests**
- New `tests/services/test_deleted.py` covers storage, dedup, dismissed-sweep, delete-all conversion, and the predicate helper.
- `useDismissedFindings.test.jsx` updated for the new API surface, including a new test for the multi-entry sweep.

## Design notes

- Suppression key is `(dimension, principle, file)` — broad enough to catch repeated false positives in the same file (e.g. UI components flagged for "unvalidated path" across many lines), narrow enough to avoid silencing a principle globally.
- Deleted entries store an ISO `deleted_at` timestamp for auditability.
- Delete-All collapses duplicate `(dim, principle, file)` tuples in the dismissed list before persisting.
- No undelete UI by design — destructive intent is opt-in via the existing confirm dialog on Delete-All.

## Test plan

- [x] `pytest` — full suite (2621 passed)
- [x] `pytest tests/services/test_deleted.py` — new module (16 passed)
- [x] `vitest useDismissedFindings` — 9 passed (handleRestore, handleRestoreAll, handleDelete x3 incl. sweep, handleDeleteAll x3)
- [x] Pre-existing failures in `CliProviderTab.test.jsx` and `OllamaTab.test.jsx` confirmed unrelated (already failing on develop)
- [x] Manual: dismiss a finding, click Delete, confirm it disappears from the dismissed list and a fresh scan does not resurface it
- [x] Manual: dismiss several findings sharing a `(dim, principle, file)`, click Delete on one, confirm all matching siblings are swept locally
- [x] Manual: Delete-All on a non-empty dismissed list, confirm the suppression takes effect on the next rescore