### PR TITLE
ui: help refresh, evaluate polish, score-history click fix

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -279,7 +279,7 @@ const ROUTE_RENDERERS = {
     />
   ),
   evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />,
-  file: (params) => <FileDetailPage file={params.file} />,
+  file: (params) => <FileDetailPage file={params.file} runId={params.runId} dateLabel={params.dateLabel} />,
   evalprinciple: renderEvalPrincipleDetail,
   'eval-principle-detail': renderEvalPrincipleDetail,
   finding: (params, props) => (

--- a/src/quodeq/ui/src/components/scoreChartHelpers.js
+++ b/src/quodeq/ui/src/components/scoreChartHelpers.js
@@ -1,0 +1,57 @@
+import { scoreColorClass } from '../utils/formatters.js';
+
+/**
+ * Shared helpers for the run/score history bar charts (Overview, History,
+ * Explorer dimension panel). Centralises:
+ *  - a memoised getComputedStyle reader for theme tokens
+ *  - the bar fill mapping (score -> grade tier -> CSS variable)
+ *  - reference-line positions and chart margins reused across charts
+ */
+
+const _cssVarCache = new Map();
+
+export function cssVar(name, fallback = '') {
+  if (_cssVarCache.has(name)) return _cssVarCache.get(name);
+  if (typeof document === 'undefined') return fallback;
+  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  const result = val || fallback;
+  _cssVarCache.set(name, result);
+  return result;
+}
+
+/** Clear the cache; called automatically on theme change, exported for tests. */
+export function clearCssVarCache() { _cssVarCache.clear(); }
+
+if (typeof document !== 'undefined') {
+  new MutationObserver(() => _cssVarCache.clear()).observe(
+    document.documentElement,
+    { attributes: true, attributeFilter: ['data-theme'] },
+  );
+}
+
+const GRADE_CSS_VARS = {
+  'grade-top':    '--color-grade-top-text',
+  'grade-high':   '--color-grade-high-text',
+  'grade-mid':    '--color-grade-mid-text',
+  'grade-low':    '--color-grade-low-text',
+  'grade-bottom': '--color-grade-bottom-text',
+  'grade-none':   '--color-text-muted',
+};
+
+/** Bar color follows the active theme's grade spectrum. */
+export function scoreBarColor(score) {
+  const varName = GRADE_CSS_VARS[scoreColorClass(score)] || '--color-accent';
+  return cssVar(varName);
+}
+
+/** Reference-line ticks at 25% / 50% / 75% of the 0-10 score range. */
+export const REF_LINE_LOW = 2.5;
+export const REF_LINE_MID = 5;
+export const REF_LINE_HIGH = 7.5;
+
+/** Margin zeroed so bars span edge-to-edge inside the panel body. */
+export const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
+
+/** Opacity for the selected vs deselected bars across all score charts. */
+export const SELECTED_BAR_OPACITY = 0.85;
+export const DESELECTED_BAR_OPACITY = 0.4;

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -76,15 +76,16 @@ function buildTrendData(trend, selectedRunId) {
 }
 
 
-function RunHistoryTooltip({ active, hoveredIndex, data }) {
-  if (!active || hoveredIndex === null) return null;
-  const entry = data[hoveredIndex];
+function RunHistoryTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0]?.payload;
   if (!entry) return null;
+  const score = Number.isFinite(entry.numericAverage) ? entry.numericAverage.toFixed(1) : '—';
+  const grade = gradeLetter(entry.overallGrade);
   return (
     <div className="run-history-tooltip">
       <span className="rht-date">{entry.dateLabel}</span>
-      <span className="rht-score">{entry.numericAverage.toFixed(1)} / 10</span>
-      <span className="rht-grade">{gradeLetter(entry.overallGrade)}</span>
+      <span className="rht-score">{score} - {grade}</span>
     </div>
   );
 }
@@ -94,7 +95,11 @@ function SelectedDot({ cx, cy, payload, selectedRunId }) {
   return <circle cx={cx} cy={cy} r={4} fill={cssVar('--color-chart-line')} stroke="white" strokeWidth={1.5} />;
 }
 
-function ScoreBars({ data, hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }) {
+function ScoreBars({ data, hoveredIndex, selectedRunId, onBarClick }) {
+  // Bar's onClick covers taps that land on the visible 28-px bar — those
+  // never bubble to the chart container because Recharts stops
+  // propagation internally. Chart-level onClick (set on ComposedChart)
+  // covers taps in the gap or above the bar.
   return (
     <Bar
       dataKey="numericAverage"
@@ -102,9 +107,7 @@ function ScoreBars({ data, hoveredIndex, setHoveredIndex, selectedRunId, onBarCl
       maxBarSize={28}
       isAnimationActive={false}
       cursor={onBarClick ? 'pointer' : 'default'}
-      onMouseEnter={(_, index) => setHoveredIndex(index)}
-      onMouseLeave={() => setHoveredIndex(null)}
-      onClick={(entry) => onBarClick?.(entry.runId)}
+      onClick={(entry) => { if (entry?.runId) onBarClick?.(entry.runId); }}
     >
       {data.map((entry, i) => (
         <Cell
@@ -121,9 +124,31 @@ function ScoreBars({ data, hoveredIndex, setHoveredIndex, selectedRunId, onBarCl
 
 function ScoreHistoryChart({ data, interaction }) {
   const { hoveredIndex, setHoveredIndex, selectedRunId, onBarClick } = interaction;
+  // Hit-detection lives on the chart, not on the Bar: the <Area> gradient
+  // and <Line> stroke layer on top of the bars and swallow click events
+  // before they reach the Bar's onClick. The chart's onMouseMove and
+  // onClick are dispatched on the container itself, so they fire wherever
+  // you tap inside the chart and Recharts already computes the nearest
+  // category as `activeTooltipIndex`.
+  const handleMove = (state) => {
+    setHoveredIndex(state?.activeTooltipIndex ?? null);
+  };
+  const handleClick = (state) => {
+    const idx = state?.activeTooltipIndex;
+    if (idx == null) return;
+    const runId = data[idx]?.runId;
+    if (runId) onBarClick?.(runId);
+  };
   return (
     <ResponsiveContainer width="100%" height="100%" minHeight={CHART_HEIGHT}>
-      <ComposedChart data={data} margin={CHART_MARGIN}>
+      <ComposedChart
+        data={data}
+        margin={CHART_MARGIN}
+        onMouseMove={handleMove}
+        onMouseLeave={() => setHoveredIndex(null)}
+        onClick={onBarClick ? handleClick : undefined}
+        style={onBarClick ? { cursor: 'pointer' } : undefined}
+      >
         <defs>
           <linearGradient id="scoreAreaGrad" x1="0" y1="0" x2="0" y2="1">
             <stop offset="0%" stopColor={cssVar('--color-accent')} stopOpacity={0.08} />
@@ -135,7 +160,7 @@ function ScoreHistoryChart({ data, interaction }) {
             on top. Labels live in the banner (MIN / MAX / AVG). */}
         <XAxis dataKey="dateLabel" hide />
         <YAxis domain={[0, 10]} hide />
-        <Tooltip cursor={false} isAnimationActive={false} offset={20} content={({ active }) => <RunHistoryTooltip active={active} hoveredIndex={hoveredIndex} data={data} />} />
+        <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
         {/* Soft horizontal reference lines at 25% / 50% / 75% of the range —
             kept as subtle grid anchors even though the numeric ticks are
             hidden. */}
@@ -143,7 +168,7 @@ function ScoreHistoryChart({ data, interaction }) {
         <ReferenceLine y={REF_LINE_MID}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
         <ReferenceLine y={REF_LINE_HIGH} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
         <Area dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
-        <ScoreBars data={data} hoveredIndex={hoveredIndex} setHoveredIndex={setHoveredIndex} selectedRunId={selectedRunId} onBarClick={onBarClick} />
+        <ScoreBars data={data} hoveredIndex={hoveredIndex} selectedRunId={selectedRunId} onBarClick={onBarClick} />
         <Line isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
       </ComposedChart>
     </ResponsiveContainer>

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -95,19 +95,17 @@ function SelectedDot({ cx, cy, payload, selectedRunId }) {
   return <circle cx={cx} cy={cy} r={4} fill={cssVar('--color-chart-line')} stroke="white" strokeWidth={1.5} />;
 }
 
-function ScoreBars({ data, hoveredIndex, selectedRunId, onBarClick }) {
-  // Bar's onClick covers taps that land on the visible 28-px bar — those
-  // never bubble to the chart container because Recharts stops
-  // propagation internally. Chart-level onClick (set on ComposedChart)
-  // covers taps in the gap or above the bar.
+function ScoreBars({ data, hoveredIndex, selectedRunId }) {
+  // Click handling lives on the chart container (see ScoreHistoryChart).
+  // The shared `.run-history-panel .recharts-surface *` CSS rule sets
+  // pointer-events:none so the Area gradient cannot swallow clicks before
+  // they reach the chart-level onClick handler.
   return (
     <Bar
       dataKey="numericAverage"
       radius={[0, 0, 0, 0]}
       maxBarSize={28}
       isAnimationActive={false}
-      cursor={onBarClick ? 'pointer' : 'default'}
-      onClick={(entry) => { if (entry?.runId) onBarClick?.(entry.runId); }}
     >
       {data.map((entry, i) => (
         <Cell
@@ -168,7 +166,7 @@ function ScoreHistoryChart({ data, interaction }) {
         <ReferenceLine y={REF_LINE_MID}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
         <ReferenceLine y={REF_LINE_HIGH} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
         <Area dataKey="numericAverage" type="monotone" fill="url(#scoreAreaGrad)" stroke="none" isAnimationActive={false} />
-        <ScoreBars data={data} hoveredIndex={hoveredIndex} selectedRunId={selectedRunId} onBarClick={onBarClick} />
+        <ScoreBars data={data} hoveredIndex={hoveredIndex} selectedRunId={selectedRunId} />
         <Line isAnimationActive={false} dataKey="numericAverage" type="monotone" stroke={cssVar('--color-accent')} strokeOpacity={0.9} strokeWidth={2} dot={<SelectedDot selectedRunId={selectedRunId} />} activeDot={false} />
       </ComposedChart>
     </ResponsiveContainer>

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { gradeLetter, scoreColorClass } from '../../../utils/formatters.js';
+import { gradeLetter } from '../../../utils/formatters.js';
 import { SectionLabel } from '../../../components/terminal/index.js';
 import {
   ComposedChart,
@@ -13,55 +13,19 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+import {
+  cssVar,
+  scoreBarColor,
+  REF_LINE_LOW,
+  REF_LINE_MID,
+  REF_LINE_HIGH,
+  CHART_MARGIN,
+  SELECTED_BAR_OPACITY,
+  DESELECTED_BAR_OPACITY,
+} from '../../../components/scoreChartHelpers.js';
 
 const MAX_CHART_RUNS = 20;
 const CHART_HEIGHT = 160;
-const REF_LINE_LOW = 2.5;
-const REF_LINE_MID = 5;
-const REF_LINE_HIGH = 7.5;
-/* Margin zeroed so bars span edge-to-edge inside the panel body. */
-const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
-
-// Module-level CSS variable cache. Cleared automatically by MutationObserver
-// when the data-theme attribute changes. Use clearCssVarCache() for test resets.
-const _cssVarCache = new Map();
-const cssVar = (name, fallback) => {
-  if (_cssVarCache.has(name)) return _cssVarCache.get(name);
-  if (typeof document === 'undefined') return fallback;
-  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  const result = val || fallback;
-  _cssVarCache.set(name, result);
-  return result;
-};
-
-/** Clear the CSS variable cache. Called automatically by MutationObserver on theme change; exported for test resets. */
-export function clearCssVarCache() { _cssVarCache.clear(); }
-
-// Auto-clear cache when theme changes (data-theme attribute mutation)
-if (typeof document !== 'undefined') {
-  new MutationObserver(() => _cssVarCache.clear()).observe(
-    document.documentElement,
-    { attributes: true, attributeFilter: ['data-theme'] },
-  );
-}
-
-const GRADE_CSS_VARS = {
-  'grade-top':    '--color-grade-top-text',
-  'grade-high':   '--color-grade-high-text',
-  'grade-mid':    '--color-grade-mid-text',
-  'grade-low':    '--color-grade-low-text',
-  'grade-bottom': '--color-grade-bottom-text',
-  'grade-none':   '--color-text-muted',
-};
-
-// Bar color follows the active theme's grade spectrum — flynn renders cyan→red,
-// daruma renders gold→crimson, neo renders matrix-green→red, etc. Each theme's
-// `--color-grade-*-text` tokens map through `scoreColorClass` into the 5-step
-// spectrum defined in tokens.css.
-function scoreBarColor(score) {
-  const varName = GRADE_CSS_VARS[scoreColorClass(score)] || '--color-accent';
-  return cssVar(varName);
-}
 
 
 function buildTrendData(trend, selectedRunId) {
@@ -111,7 +75,7 @@ function ScoreBars({ data, hoveredIndex, selectedRunId }) {
         <Cell
           key={entry.runId ?? i}
           fill={scoreBarColor(entry.numericAverage)}
-          opacity={entry.runId === selectedRunId ? 0.85 : 0.4}
+          opacity={entry.runId === selectedRunId ? SELECTED_BAR_OPACITY : DESELECTED_BAR_OPACITY}
           stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
           strokeWidth={hoveredIndex === i ? 1.5 : 0}
         />

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -1,7 +1,6 @@
 import LiveViolationsFeed from './LiveViolationsFeed.jsx';
 import ScanProgress from './ScanProgress.jsx';
 import CopyButton from '../../../components/CopyButton.jsx';
-import HelpHint from '../../../components/HelpHint.jsx';
 import { copyToClipboard } from '../../../utils/clipboard.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 import JobStatStrip from './JobStatStrip.jsx';
@@ -16,27 +15,6 @@ function termNameForStatus(status) {
   return 'evaluation_cancelled';
 }
 
-function StatusPill({ status, exitReason }) {
-  const isStale = status === 'cancelled' && typeof exitReason === 'string' && exitReason.startsWith('stale_');
-  const text = isStale ? 'cancelled (stale)' : status;
-  const className = `term-status-pill term-status-pill--${status}${isStale ? ' term-status-pill--stale' : ''}`;
-  return (
-    <span className={className} title={exitReason ?? ''}>
-      {text}
-    </span>
-  );
-}
-
-function ActionsHelp() {
-  return (
-    <HelpHint label="Job actions help">
-      <div><strong>Cancel</strong> — stop the running evaluation.</div>
-      <div><strong>View Results</strong> — open the completed run's full report.</div>
-      <div><strong>Close</strong> — dismiss this panel without affecting the run.</div>
-    </HelpHint>
-  );
-}
-
 function JobHeader({ job, onDismiss, onCancel }) {
   const isRunning = job.status === STATUS.RUNNING;
   const isDone = job.status === STATUS.DONE;
@@ -44,7 +22,6 @@ function JobHeader({ job, onDismiss, onCancel }) {
     <div className="evaluate-panel__top evaluate-panel__top--row">
       <TermHeader name={termNameForStatus(job.status)} />
       <div className="evaluate-panel__top-actions">
-        <ActionsHelp />
         {isRunning && (
           <button type="button" className="term-btn term-btn--ghost" onClick={onCancel}>cancel</button>
         )}
@@ -56,7 +33,6 @@ function JobHeader({ job, onDismiss, onCancel }) {
         {!isRunning && (
           <button type="button" className="term-btn term-btn--secondary" onClick={() => onDismiss('close')}>close</button>
         )}
-        {!isRunning && <StatusPill status={job.status} exitReason={job.exitReason} />}
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -20,39 +20,6 @@ const baseJob = {
   dimensions: [],
 };
 
-describe('StatusPill', () => {
-  it('renders plain status text for a done run', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, status: 'done' }} />);
-    const chip = document.querySelector('.term-status-pill');
-    expect(chip.textContent).toBe('done');
-    expect(chip.className).not.toContain('term-status-pill--stale');
-  });
-
-  it('renders "cancelled (stale)" with --stale class when exitReason starts with "stale_"', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, status: 'cancelled', exitReason: 'stale_detected' }} />);
-    const chip = document.querySelector('.term-status-pill');
-    expect(chip.textContent).toBe('cancelled (stale)');
-    expect(chip.className).toContain('term-status-pill--stale');
-    expect(chip.getAttribute('title')).toBe('stale_detected');
-  });
-
-  it('renders plain "cancelled" for user-initiated cancel (signal)', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, status: 'cancelled', exitReason: 'signal_SIGTERM' }} />);
-    const chip = document.querySelector('.term-status-pill');
-    expect(chip.textContent).toBe('cancelled');
-    expect(chip.className).not.toContain('term-status-pill--stale');
-    expect(chip.getAttribute('title')).toBe('signal_SIGTERM');
-  });
-
-  it('renders "failed" with tooltip showing exception reason', () => {
-    renderWithClient(<EvaluationStatus job={{ ...baseJob, status: 'failed', exitReason: 'exception: EvaluationError' }} />);
-    const chip = document.querySelector('.term-status-pill');
-    expect(chip.textContent).toBe('failed');
-    expect(chip.className).not.toContain('term-status-pill--stale');
-    expect(chip.getAttribute('title')).toBe('exception: EvaluationError');
-  });
-});
-
 describe('JobIdLine', () => {
   it('renders the job ID with a copy button', () => {
     renderWithClient(<EvaluationStatus job={{ ...baseJob, jobId: 'job-123' }} />);

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -8,6 +8,14 @@ import CleanScanToggle from './CleanScanToggle.jsx';
 import DimensionSelector from './DimensionSelector.jsx';
 import FolderBrowser from './FolderBrowser.jsx';
 import { TermHeader } from '../../../components/terminal/index.js';
+import HelpHint from '../../../components/HelpHint.jsx';
+
+const EVAL_OPTIONS_HINT = (
+  <>
+    <div><strong>Scope</strong> — restrict the evaluation to a subfolder. Default is the whole project.</div>
+    <div><strong>Clean scan</strong> — when off, only changed files since the last run are re-analyzed (incremental). Turn it on to re-evaluate everything from scratch.</div>
+  </>
+);
 
 const NO_STANDARDS_MESSAGE = 'Select at least one standard before evaluating.';
 
@@ -245,6 +253,7 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
         <CloneSection info={info} cloning={cloning} cloneDest={cloneDest} cloneError={cloneError} setCloneBrowserOpen={setCloneBrowserOpen} />
 
         <div className="re-eval-toggle-row">
+          <HelpHint label="Evaluation options help">{EVAL_OPTIONS_HINT}</HelpHint>
           {scope.isLocal && (
             <BranchScopeSelector
               branches={scope.scanData?.branches}

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -12,8 +12,8 @@ import HelpHint from '../../../components/HelpHint.jsx';
 
 const EVAL_OPTIONS_HINT = (
   <>
-    <div><strong>Scope</strong> — restrict the evaluation to a subfolder. Default is the whole project.</div>
-    <div><strong>Clean scan</strong> — when off, only changed files since the last run are re-analyzed (incremental). Turn it on to re-evaluate everything from scratch.</div>
+    <div><strong>Scope</strong>: restrict the evaluation to a subfolder. Default is the whole project.</div>
+    <div><strong>Clean scan</strong>: when off, only changed files since the last run are re-analyzed (incremental). Turn it on to re-evaluate everything from scratch.</div>
   </>
 );
 

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -1,73 +1,168 @@
+import { useMemo, useState } from 'react';
+import {
+  ComposedChart,
+  Area,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+  ReferenceLine,
+} from 'recharts';
 import { SectionLabel } from '../../../components/terminal/index.js';
-import { extractDimensionHistory } from '../../../components/DimensionSparkline.jsx';
-import { scoreGradeColorVar } from '../../../utils/formatters.js';
+import { gradeLetter } from '../../../utils/formatters.js';
+import {
+  cssVar,
+  scoreBarColor,
+  REF_LINE_LOW,
+  REF_LINE_MID,
+  REF_LINE_HIGH,
+  CHART_MARGIN,
+  SELECTED_BAR_OPACITY,
+  DESELECTED_BAR_OPACITY,
+} from '../../../components/scoreChartHelpers.js';
 
 const MAX = 16;
+const CHART_HEIGHT = 160;
 
-function summarise(scores) {
-  if (scores.length === 0) return null;
-  const min = Math.min(...scores);
-  const max = Math.max(...scores);
-  const avg = scores.reduce((s, x) => s + x, 0) / scores.length;
-  return { min, max, avg };
+/**
+ * Build chart data points for a single dimension's history.
+ * Walks the trend (newest-first) and emits one point per run that
+ * scored this dimension, oldest-first to read left-to-right.
+ */
+function buildDimensionData(trend, dimensionName, limit) {
+  if (!Array.isArray(trend) || !dimensionName) return [];
+  const want = String(dimensionName).toLowerCase();
+  const points = [];
+  for (const entry of trend) {
+    const details = entry?.dimensionDetails;
+    if (!Array.isArray(details)) continue;
+    const match = details.find((d) => (d.dimension || '').toLowerCase() === want);
+    const score = match ? parseFloat(match.score) : NaN;
+    if (!Number.isFinite(score)) continue;
+    points.push({
+      runId: entry.runId,
+      dateLabel: entry.dateLabel,
+      numericAverage: score,
+      overallGrade: match.grade ?? entry.overallGrade,
+    });
+    if (points.length >= limit) break;
+  }
+  return points.reverse();
 }
 
-export default function DimensionScoreHistoryPanel({ trend = [], dimension }) {
-  const scores = extractDimensionHistory(trend, dimension, MAX); // oldest-first
-  const stats = summarise(scores);
+function DimensionTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0]?.payload;
+  if (!entry) return null;
+  const score = Number.isFinite(entry.numericAverage) ? entry.numericAverage.toFixed(1) : '?';
+  const grade = gradeLetter(entry.overallGrade);
+  return (
+    <div className="run-history-tooltip">
+      <span className="rht-date">{entry.dateLabel}</span>
+      <span className="rht-score">{score} - {grade}</span>
+    </div>
+  );
+}
+
+function SelectedDot({ cx, cy, payload, selectedRunId }) {
+  if (payload?.runId !== selectedRunId) return null;
+  return <circle cx={cx} cy={cy} r={4} fill={cssVar('--color-chart-line')} stroke="white" strokeWidth={1.5} />;
+}
+
+function DimensionHistoryChart({ data, selectedRunId, hoveredIndex, setHoveredIndex, onBarClick }) {
+  const handleClick = (state) => {
+    const idx = state?.activeTooltipIndex;
+    if (idx == null) return;
+    const point = data[idx];
+    if (point?.runId) onBarClick?.(point);
+  };
+  return (
+    <ResponsiveContainer width="100%" height="100%" minHeight={CHART_HEIGHT}>
+      <ComposedChart
+        data={data}
+        margin={CHART_MARGIN}
+        onMouseMove={(state) => setHoveredIndex(state?.activeTooltipIndex ?? null)}
+        onMouseLeave={() => setHoveredIndex(null)}
+        onClick={onBarClick ? handleClick : undefined}
+        style={onBarClick ? { cursor: 'pointer' } : undefined}
+      >
+        <defs>
+          <linearGradient id="dimScoreAreaGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={cssVar('--color-accent')} stopOpacity={0.08} />
+            <stop offset="100%" stopColor={cssVar('--color-accent')} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <XAxis dataKey="dateLabel" hide />
+        <YAxis domain={[0, 10]} hide />
+        <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<DimensionTooltip />} />
+        <ReferenceLine y={REF_LINE_LOW}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_MID}  stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <ReferenceLine y={REF_LINE_HIGH} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
+        <Area dataKey="numericAverage" type="monotone" fill="url(#dimScoreAreaGrad)" stroke="none" isAnimationActive={false} />
+        <Bar dataKey="numericAverage" radius={[0, 0, 0, 0]} maxBarSize={28} isAnimationActive={false}>
+          {data.map((entry, i) => (
+            <Cell
+              key={entry.runId ?? i}
+              fill={scoreBarColor(entry.numericAverage)}
+              opacity={entry.runId === selectedRunId ? SELECTED_BAR_OPACITY : DESELECTED_BAR_OPACITY}
+              stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
+              strokeWidth={hoveredIndex === i ? 1.5 : 0}
+            />
+          ))}
+        </Bar>
+        <Line
+          isAnimationActive={false}
+          dataKey="numericAverage"
+          type="monotone"
+          stroke={cssVar('--color-accent')}
+          strokeOpacity={0.9}
+          strokeWidth={2}
+          dot={<SelectedDot selectedRunId={selectedRunId} />}
+          activeDot={false}
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
+
+export default function DimensionScoreHistoryPanel({ trend = [], dimension, selectedRunId = null, onBarClick }) {
+  const [hoveredIndex, setHoveredIndex] = useState(null);
+  const data = useMemo(() => buildDimensionData(trend, dimension, MAX), [trend, dimension]);
+
+  const stats = useMemo(() => {
+    const scores = data.map((d) => d.numericAverage).filter(Number.isFinite);
+    if (scores.length === 0) return null;
+    return {
+      min: Math.min(...scores),
+      max: Math.max(...scores),
+      avg: scores.reduce((s, n) => s + n, 0) / scores.length,
+    };
+  }, [data]);
 
   return (
     <section className="run-history-panel run-history-panel--terminal panel" aria-label={`${dimension} score history`}>
       <div className="run-history-panel__header">
-        <SectionLabel>score_history · {scores.length}d</SectionLabel>
+        <SectionLabel>score_history · {data.length}d</SectionLabel>
         {stats && (
           <span className="run-history-panel__stats">
             MIN {stats.min.toFixed(1)} / MAX {stats.max.toFixed(1)} / AVG {stats.avg.toFixed(1)}
           </span>
         )}
       </div>
-      {scores.length === 0 ? (
+      {data.length === 0 ? (
         <div className="qd-history-empty">no history yet for this dimension</div>
       ) : (
-        <DimensionHistoryChart scores={scores} />
+        <DimensionHistoryChart
+          data={data}
+          selectedRunId={selectedRunId}
+          hoveredIndex={hoveredIndex}
+          setHoveredIndex={setHoveredIndex}
+          onBarClick={onBarClick}
+        />
       )}
     </section>
-  );
-}
-
-// Fixed visible scale matches the inline DimensionSparkline so bar heights
-// read consistently across both surfaces. The top of the chart always
-// represents 10/10 (the "100%" reference).
-const SCALE_MIN = 4;
-const SCALE_MAX = 10;
-
-function DimensionHistoryChart({ scores }) {
-  const W = 480;
-  const H = 180;
-  const PAD_X = 10;
-  const PAD_TOP = 10;
-  const PAD_BOT = 6;
-  const GAP = 12;
-  const barW = (W - PAD_X * 2 - GAP * (scores.length - 1)) / scores.length;
-  const yFor = (v) => {
-    const clipped = Math.max(SCALE_MIN, Math.min(SCALE_MAX, v));
-    const ratio = (clipped - SCALE_MIN) / (SCALE_MAX - SCALE_MIN);
-    return H - PAD_BOT - ratio * (H - PAD_TOP - PAD_BOT);
-  };
-  const xFor = (i) => PAD_X + i * (barW + GAP);
-  return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: '100%', minHeight: H, display: 'block' }}>
-      {[0.25, 0.5, 0.75].map((p) => (
-        <line key={p} x1="0" y1={H * p} x2={W} y2={H * p}
-              stroke="var(--color-border)" strokeDasharray="2 3" strokeWidth="0.5" />
-      ))}
-      {/* 100% reference at the top of the plot area */}
-      <line x1="0" y1={PAD_TOP} x2={W} y2={PAD_TOP}
-            stroke="var(--color-border)" strokeWidth="0.6" />
-      {scores.map((v, i) => {
-        const y = yFor(v);
-        return <rect key={i} x={xFor(i)} y={y} width={barW} height={H - PAD_BOT - y} fill={scoreGradeColorVar(v)} />;
-      })}
-    </svg>
   );
 }

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import { complianceRatio } from '../../../utils/formatters.js';
 import { buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
@@ -66,12 +66,21 @@ export default function ExplorerPage({
   refreshSignal,
   trend = [],
 }) {
-  const d = useExplorerData(project, dimension, runId, refreshSignal);
+  // Local run/date state lets the score-history bar click swap which run
+  // is shown without pushing a new entry onto the nav stack (avoids the
+  // "security / security / security ..." breadcrumb pile-up). The props
+  // are the source of truth when the user navigates here from elsewhere;
+  // local state takes over once the user starts clicking bars.
+  const [activeRunId, setActiveRunId] = useState(runId);
+  const [activeDateLabel, setActiveDateLabel] = useState(dateLabel);
+  useEffect(() => { setActiveRunId(runId); }, [runId]);
+  useEffect(() => { setActiveDateLabel(dateLabel); }, [dateLabel]);
+  const d = useExplorerData(project, dimension, activeRunId, refreshSignal);
   const { standardDescription } = useStandardDescriptions(dimension);
 
   const buildEvalPrincipal = useMemo(
-    () => d.evalData ? buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple, project, runId) : () => ({}),
-    [d.evalData, d.complianceByPrinciple, project, runId]
+    () => d.evalData ? buildEvalPrincipalFn(d.evalData, d.complianceByPrinciple, project, activeRunId, activeDateLabel) : () => ({}),
+    [d.evalData, d.complianceByPrinciple, project, activeRunId, activeDateLabel]
   );
 
   const reportSpec = useMemo(() => {
@@ -82,18 +91,18 @@ export default function ExplorerPage({
       principleGrades: d.principleGrades || [],
       allViolations: d.allViolations,
       overallGrade: d.overallGrade,
-      dateLabel,
-      runId,
+      dateLabel: activeDateLabel,
+      runId: activeRunId,
     });
     return {
-      id: `report:dimension:${dim}:${runId ?? 'current'}`,
+      id: `report:dimension:${dim}:${activeRunId ?? 'current'}`,
       type: 'report',
       title: `${dim} report`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `${dim}-report.md`, body: buildMarkdown() }),
     };
-  }, [d.evalData, d.principleGrades, d.allViolations, d.overallGrade, dateLabel, runId]);
+  }, [d.evalData, d.principleGrades, d.allViolations, d.overallGrade, activeDateLabel, activeRunId]);
   useRegisterWindowSpec('report', reportSpec);
 
   const fixPlanSpec = useMemo(() => {
@@ -101,14 +110,14 @@ export default function ExplorerPage({
     const dim = (d.evalData.dimension || 'unknown').toLowerCase();
     const buildMarkdown = () => buildDimensionPlanFromViolations(d.evalData.dimension, d.allViolations);
     return {
-      id: `fixplan:dimension:${dim}:${runId ?? 'current'}`,
+      id: `fixplan:dimension:${dim}:${activeRunId ?? 'current'}`,
       type: 'fixplan',
       title: `${dim} fix plan`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `${dim}-fix-plan.md`, body: buildMarkdown() }),
     };
-  }, [d.evalData, d.allViolations, runId]);
+  }, [d.evalData, d.allViolations, activeRunId]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
   if (d.loading) return <div className="loading" role="status" aria-live="polite">Loading…</div>;
@@ -122,10 +131,11 @@ export default function ExplorerPage({
 
   const overallScoreNum = parseFloat(d.overallGrade?.score);
   const sev = d.severityCounts;
+  const isRefreshing = d.isFetching && !!d.evalData;
 
   return (
-    <>
-      <TermHeader name={dim} description={standardDescription} sub={dateLabel || runId || null} />
+    <div className={`explorer-page dashboard-fade${isRefreshing ? ' dashboard-refreshing' : ''}`}>
+      <TermHeader name={dim} description={standardDescription} sub={activeDateLabel || activeRunId || null} />
 
       <div className="qd-top-grid">
         <div className="qd-top-left">
@@ -158,7 +168,15 @@ export default function ExplorerPage({
             />
           </StatGrid2x2>
 
-          <DimensionScoreHistoryPanel trend={trend} dimension={d.evalData.dimension} />
+          <DimensionScoreHistoryPanel
+            trend={trend}
+            dimension={d.evalData.dimension}
+            selectedRunId={activeRunId}
+            onBarClick={(point) => {
+              setActiveRunId(point.runId);
+              setActiveDateLabel(point.dateLabel);
+            }}
+          />
         </div>
 
         <div className="qd-top-right">
@@ -194,9 +212,9 @@ export default function ExplorerPage({
         </div>
         <TopOffendingFilesTable
           files={d.topFiles}
-          onFileClick={(f) => onNavigate?.('file', { file: f })}
+          onFileClick={(f) => onNavigate?.('file', { file: f, runId: activeRunId, dateLabel: activeDateLabel })}
         />
       </section>
-    </>
+    </div>
   );
 }

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -75,13 +75,13 @@ function FileSevBadgeRow({ file }) {
   );
 }
 
-function FileHeader({ file, totalViolations, totalCompliance, dimensionsCount }) {
+function FileHeader({ file, totalViolations, totalCompliance, dimensionsCount, dateLabel, runId }) {
   const totalChecks = totalViolations + totalCompliance;
   const ratio = complianceRatio(totalViolations, totalCompliance);
   return (
     <section className="principle-detail-header principle-detail-header--terminal">
       <div className="principle-detail-header__top">
-        <TermHeader name={file.file} />
+        <TermHeader name={file.file} sub={dateLabel || runId || null} />
       </div>
       <StatStrip cards>
         <Stat
@@ -126,7 +126,7 @@ function SeverityGroup({ sev, violations }) {
   );
 }
 
-const FileDetailPage = memo(function FileDetailPage({ file }) {
+const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel }) {
   const totalViolations = file.total || 0;
   const totalCompliance = file.compliance?.length || 0;
   const dimensionsCount = file.dimensionsCount || 0;
@@ -194,6 +194,8 @@ const FileDetailPage = memo(function FileDetailPage({ file }) {
         totalViolations={totalViolations}
         totalCompliance={totalCompliance}
         dimensionsCount={dimensionsCount}
+        dateLabel={dateLabel}
+        runId={runId}
       />
 
       {showFilters && (

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -68,7 +68,7 @@ function SevBadgeRow({ sevCounts }) {
 }
 
 function PrincipleHeader({ data }) {
-  const { principle, description, score, grade, violations, compliance, sevCounts } = data;
+  const { principle, description, score, grade, violations, compliance, sevCounts, dateLabel, runId } = data;
   const scoreDisplay = score ? String(score).replace('/10', '') : '—';
   const ratioDisplay = (compliance.length > 0 && violations.length > 0)
     ? `1:${Math.round(compliance.length / violations.length)}`
@@ -81,7 +81,11 @@ function PrincipleHeader({ data }) {
   return (
     <section className="principle-detail-header principle-detail-header--terminal">
       <div className="principle-detail-header__top">
-        <TermHeader name={(principle || '').toLowerCase()} description={description} />
+        <TermHeader
+          name={(principle || '').toLowerCase()}
+          description={description}
+          sub={dateLabel || runId || null}
+        />
       </div>
       <StatStrip cards>
         <Stat label="SCORE" value={scoreDisplay} hint={scoreHint} />
@@ -181,7 +185,7 @@ function usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss) {
 }
 
 const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, severityFilter, onDismiss }) {
-  const { principleData, principle, score, grade, dimension, runId } = evalPrincipal;
+  const { principleData, principle, score, grade, dimension, runId, dateLabel } = evalPrincipal;
   const { principleDescriptions } = useStandardDescriptions(dimension);
   const principleDescription = principleDescriptions[principle] || '';
 
@@ -229,7 +233,7 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
   return (
     <>
       <PrincipleHeader
-        data={{ principle, description: principleDescription, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts }}
+        data={{ principle, description: principleDescription, score: liveScore ?? score, grade: liveGrade ?? grade, violations: filteredViolations, compliance, sevCounts: liveSevCounts, dateLabel, runId }}
       />
       <PrincipleContext principleData={principleData} />
       {(filteredViolations.length > 0 || compliance.length > 0) && (

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -34,7 +34,7 @@ function computeComplianceByPrinciple(evalData) {
   return map;
 }
 
-export function buildEvalPrincipalFn(evalData, complianceByPrinciple, project, runId) {
+export function buildEvalPrincipalFn(evalData, complianceByPrinciple, project, runId, dateLabel = '') {
   const principlesByName = new Map((evalData.principles || []).map((p) => [p.name, p]));
   const gradesByPrinciple = new Map((evalData.principleGrades || []).map((p) => [p.principle, p]));
   return function buildEvalPrincipal(principleId) {
@@ -43,7 +43,7 @@ export function buildEvalPrincipalFn(evalData, complianceByPrinciple, project, r
     return {
       principle: principleId, score: pg?.score || null, grade: pg?.grade || null,
       dimension: evalData.dimension || '',
-      project: project || '', runId: runId || '',
+      project: project || '', runId: runId || '', dateLabel: dateLabel || '',
       principleData, dimViolations: principleData?.violations || [],
       dimCompliance: complianceByPrinciple.get(principleId) || [],
     };
@@ -106,13 +106,18 @@ export function useExplorerData(project, dimension, runId, refreshSignal) {
   const { getDimensionEval, getRunScores } = useApi();
   const [evalData, setEvalData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    setLoading(true);
+    // First load shows the LoadingScreen; subsequent run-switches keep
+    // the previous run's data on screen and toggle isFetching so the
+    // caller can dim the page during the background refetch (matches
+    // the Overview placeholderData behaviour).
+    setIsFetching(true);
     fetchAndRescore(project, runId, dimension, getDimensionEval, getRunScores)
-      .then((data) => { setEvalData(data); setLoading(false); })
-      .catch((err) => { setError(err.message); setLoading(false); });
+      .then((data) => { setEvalData(data); setLoading(false); setIsFetching(false); })
+      .catch((err) => { setError(err.message); setLoading(false); setIsFetching(false); });
   }, [project, dimension, runId, getDimensionEval, getRunScores]);
 
   const initialRef = useRef(refreshSignal);
@@ -129,5 +134,5 @@ export function useExplorerData(project, dimension, runId, refreshSignal) {
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);
   const stats = useDerivedExplorerStats(evalData, allViolations);
-  return { evalData, loading, error, overallGrade, principleGrades, allViolations, ...stats };
+  return { evalData, loading, isFetching, error, overallGrade, principleGrades, allViolations, ...stats };
 }

--- a/src/quodeq/ui/src/features/help/components/HelpPage.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.jsx
@@ -1,158 +1,64 @@
 import { useState } from 'react';
-import { Dimensions, Violations, CodeMap, Standards, Settings, SubProjects } from './HelpSections.jsx';
+import {
+  Philosophy,
+  GettingStarted,
+  Projects,
+  Providers,
+  Evaluations,
+  Dimensions,
+  Violations,
+  CodeMap,
+  History,
+  Standards,
+  Settings,
+} from './HelpSections.jsx';
 import { TermHeader } from '../../../components/terminal/index.js';
 import BrandCarousel from '../../../components/BrandCarousel.jsx';
 
 const SECTIONS = [
   { id: 'philosophy', label: 'Philosophy' },
   { id: 'getting-started', label: 'Getting Started' },
+  { id: 'projects', label: 'Projects' },
   { id: 'providers', label: 'AI Providers' },
   { id: 'evaluations', label: 'Running Evaluations' },
   { id: 'dimensions', label: 'Quality Dimensions' },
-  { id: 'violations', label: 'Violations' },
+  { id: 'violations', label: 'Violations & Fix Plans' },
   { id: 'map', label: 'Code Map' },
+  { id: 'history', label: 'History & Trends' },
   { id: 'standards', label: 'Custom Standards' },
   { id: 'settings', label: 'Settings' },
-  { id: 'subprojects', label: 'Sub-projects' },
 ];
-
-function SectionNav({ active, onSelect }) {
-  return (
-    <nav className="help-section-nav">
-      {SECTIONS.map(s => (
-        <button key={s.id} className={`help-section-btn${active === s.id ? ' active' : ''}`} onClick={() => onSelect(s.id)} aria-pressed={active === s.id}>{s.label}</button>
-      ))}
-    </nav>
-  );
-}
-
-function Philosophy() {
-  return (
-    <section className="help-section">
-      <h2>The Quodeq Philosophy</h2>
-      <p>Quodeq is a quality compass for your codebase. Not a linter, not a static analyzer. An AI-powered evaluator that reads and understands your code the way a senior engineer would.</p>
-
-      <h3>Why Quodeq exists</h3>
-      <p>Traditional code quality tools count syntax violations. They can tell you a function is too long, but not whether your architecture has a dependency leak. They can flag a missing null check, but not whether your error handling strategy is coherent across the project.</p>
-      <p>Quodeq takes a different approach. It sends an AI agent into your codebase with read-only tools to explore, understand context, and evaluate quality against structured standards. The agent reads actual code, follows imports, understands patterns, and reports what it finds with specific file locations and evidence.</p>
-
-      <h3>How evaluation works</h3>
-      <ol>
-        <li><strong>Detect</strong> identifies the languages, frameworks, and structure of your codebase</li>
-        <li><strong>Analyze</strong> spawns AI agents with read-only tools (Bash, Grep, Read, Glob) to systematically explore the code</li>
-        <li><strong>Collect</strong> streams findings in real-time as structured JSONL via tool calls</li>
-        <li><strong>Score</strong> maps findings to ISO 25010 principles with CWE classifications</li>
-        <li><strong>Report</strong> produces per-dimension reports with grades, violations, and compliance evidence</li>
-        <li><strong>Fix Plan</strong> for each violation, you can copy a structured fix plan with file path, line number, code context, and remediation guidance, ready to paste into your AI agent or IDE</li>
-      </ol>
-
-      <h3>Both sides of the story</h3>
-      <p>Quodeq reports <strong>violations AND compliance</strong>. The scoring uses the ratio between them. A project with many violations but also strong compliance patterns is scored more fairly than one with the same violations and no evidence of good practices. The AI actively looks for files that follow standards correctly, not just files that break them.</p>
-
-      <h3>The Q&#xB2; Scoring Formula</h3>
-      <p>Each principle is scored 0 to 10 using four independent constraints that together avoid the typical pitfalls of naive scoring. A hyperbolic <strong>violation base</strong> means the first violations hurt most, preventing fifty minor issues from tanking a score the same way five critical ones would. A <strong>compliance lift</strong> fills the gap between the base and 10 with evidence of good practices, so compliance always helps and never hurts. A log-based <strong>violation ceiling</strong> prevents compliance from overriding significant violations, so you cannot reach Exemplary with critical issues in play. A <strong>severity grade floor</strong> keeps the grade label honest, so only actual critical violations can produce a "Critical" grade.</p>
-
-      <p>Quodeq ships with ISO 25010 dimensions plus Clean Architecture and DDD standards, and evaluates any codebase in any language: Python, TypeScript, Go, Rust, Java, Swift, or anything else. You can also write your own standards for whatever quality means in your project.</p>
-    </section>
-  );
-}
-
-function GettingStarted() {
-  return (
-    <section className="help-section">
-      <h2>Getting Started</h2>
-      <p>Quodeq evaluates your codebase across six quality dimensions based on ISO 25010. It uses AI to analyze source code, identify violations, and score each dimension.</p>
-      <h3>Quick start</h3>
-      <ol>
-        <li>Go to the <strong>Evaluate</strong> tab</li>
-        <li>Enter a local path, GitHub URL, or SSH path to your repository</li>
-        <li>Click <strong>Start Evaluation</strong></li>
-        <li>Once complete, explore results in the <strong>Overview</strong>, <strong>Violations</strong>, and <strong>Map</strong> tabs</li>
-      </ol>
-      <h3>Requirements</h3>
-      <ul>
-        <li><strong>Python 3.12+</strong> and <strong>Node.js 18+</strong></li>
-        <li>At least one AI provider configured (see AI Providers section)</li>
-      </ul>
-    </section>
-  );
-}
-
-function Providers() {
-  return (
-    <section className="help-section">
-      <h2>AI Providers</h2>
-      <p>Quodeq supports multiple AI providers for analysis. Configure them in the <strong>Settings</strong> tab.</p>
-
-      <h3>Local Providers (Ollama)</h3>
-      <p><strong>Recommended model:</strong> <code>gemma4:26b</code> offers an excellent quality-to-cost ratio for local analysis. Even with context limited to 32k tokens, results are strong.</p>
-      <p>To use Ollama:</p>
-      <ol>
-        <li>Install Ollama from <code>ollama.com</code></li>
-        <li>Pull a model: <code>ollama pull gemma4:26b</code></li>
-        <li>In Settings, select the <strong>Ollama</strong> provider tab</li>
-        <li>Choose your model and configure the number of subagents</li>
-      </ol>
-      <p>Local models are <strong>free and private</strong>. Your code never leaves your machine. The trade-off is slower analysis and potentially lower accuracy compared to cloud models.</p>
-
-      <h3>Cloud Providers</h3>
-      <p>Cloud providers charge per token, so watch your usage. A full evaluation of a medium codebase can consume significant tokens, so monitor your usage in your provider's dashboard. <strong>Claude Sonnet</strong> (Anthropic) is the best balance of speed, quality, and cost; <strong>GPT-5.3-codex</strong> (OpenAI) is a strong alternative for diverse codebases.</p>
-      <p>To configure a cloud provider:</p>
-      <ol>
-        <li>In Settings, select the <strong>CLI Provider</strong> tab</li>
-        <li>Ensure your AI CLI (Claude Code, Codex, etc.) is installed and authenticated</li>
-        <li>Select the model and power level for your evaluation</li>
-      </ol>
-      <p>Power level trades speed for depth: <strong>fast</strong>, <strong>balanced</strong>, and <strong>thorough</strong> map to small, medium, and large model tiers respectively.</p>
-    </section>
-  );
-}
-
-function Evaluations() {
-  return (
-    <section className="help-section">
-      <h2>Running Evaluations</h2>
-      <p>Navigate to the <strong>Evaluate</strong> tab to start an analysis.</p>
-
-      <h3>Input types</h3>
-      <ul>
-        <li><strong>Local path</strong> <code>/path/to/your/project</code></li>
-        <li><strong>GitHub URL</strong> <code>https://github.com/org/repo</code></li>
-        <li><strong>SSH path</strong> <code>git@github.com:org/repo.git</code></li>
-      </ul>
-
-      <h3>Evaluation options</h3>
-      <ul>
-        <li><strong>Dimensions</strong> choose which quality dimensions to evaluate (default: all six)</li>
-        <li><strong>Branch</strong> select a specific branch to analyze</li>
-        <li><strong>Scope</strong> narrow analysis to a subdirectory within the repository</li>
-        <li><strong>Subagents</strong> number of parallel AI agents (more agents means faster analysis but more tokens)</li>
-      </ul>
-
-      <h3>Scan types</h3>
-      <ul>
-        <li><strong>Full scan</strong> evaluates the entire codebase from scratch. Use for first-time analysis or after major refactors.</li>
-        <li><strong>Incremental scan</strong> detects changed files via git diff and only re-evaluates those. Previous findings for unchanged files are carried forward, making it significantly faster and cheaper. Enable the <em>Incremental</em> toggle before starting.</li>
-      </ul>
-
-      <h3>Evaluate an existing project</h3>
-      <p>From the <strong>Evaluate</strong> tab, you can run a new evaluation on an existing project. The results appear as a new run in the history, allowing you to track quality over time.</p>
-    </section>
-  );
-}
 
 const SECTION_COMPONENTS = {
   'philosophy': Philosophy,
   'getting-started': GettingStarted,
+  'projects': Projects,
   'providers': Providers,
   'evaluations': Evaluations,
   'dimensions': Dimensions,
   'violations': Violations,
   'map': CodeMap,
+  'history': History,
   'standards': Standards,
   'settings': Settings,
-  'subprojects': SubProjects,
 };
+
+function SectionNav({ active, onSelect }) {
+  return (
+    <nav className="help-section-nav">
+      {SECTIONS.map(s => (
+        <button
+          key={s.id}
+          className={`help-section-btn${active === s.id ? ' active' : ''}`}
+          onClick={() => onSelect(s.id)}
+          aria-pressed={active === s.id}
+        >
+          {s.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
 
 export default function HelpPage() {
   const [activeSection, setActiveSection] = useState('philosophy');
@@ -163,7 +69,7 @@ export default function HelpPage() {
       <div className="help-header">
         <TermHeader
           name="help"
-          sub="learn how to use quodeq to evaluate and improve your code quality"
+          sub="how quodeq works and how to get the most out of it"
         />
         <BrandCarousel />
       </div>

--- a/src/quodeq/ui/src/features/help/components/HelpSections.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpSections.jsx
@@ -5,41 +5,247 @@ const ICON_EYE_ON = (
   </svg>
 );
 
+function Tip({ title, children }) {
+  return (
+    <aside className="help-tip" role="note">
+      {title && <div className="help-tip__title">{title}</div>}
+      <div className="help-tip__body">{children}</div>
+    </aside>
+  );
+}
+
+function KeyTable({ rows }) {
+  return (
+    <div className="help-keytable" role="table">
+      {rows.map(([k, v]) => (
+        <div className="help-keytable__row" key={k} role="row">
+          <div className="help-keytable__k" role="cell">{k}</div>
+          <div className="help-keytable__v" role="cell">{v}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function Philosophy() {
+  return (
+    <section className="help-section">
+      <h2>The Quodeq Philosophy</h2>
+      <p>Quodeq is a quality compass for your codebase. Not a linter, not a static analyzer. An AI-powered evaluator that reads and understands your code the way a senior engineer would, then reports both what is wrong and what is right.</p>
+
+      <h3>Why Quodeq exists</h3>
+      <p>Traditional code-quality tools count syntax violations. They flag a long function or a missing null check, but they cannot tell you whether your architecture has a dependency leak, whether your error-handling strategy is coherent, or whether your domain model has eroded.</p>
+      <p>Quodeq sends AI agents into your codebase with read-only tools to explore, follow imports, understand patterns, and evaluate quality against structured standards. Every finding cites a file, a line, a code snippet, and a principle.</p>
+
+      <h3>How an evaluation runs</h3>
+      <ol>
+        <li><strong>Detect</strong> identifies languages, frameworks, and structure.</li>
+        <li><strong>Analyze</strong> spawns parallel sub-agents with read-only tools (Bash, Grep, Read, Glob).</li>
+        <li><strong>Collect</strong> streams structured findings (JSONL) live as the agents work.</li>
+        <li><strong>Score</strong> maps findings to principles and computes per-dimension scores.</li>
+        <li><strong>Report</strong> produces grades, trend deltas, and per-finding fix plans.</li>
+      </ol>
+
+      <h3>Both sides of the story</h3>
+      <p>Quodeq reports <strong>violations and compliance</strong>. Scoring uses the ratio between them, so a project with many violations but strong compliance patterns scores more fairly than one with the same violations and no evidence of good practice. Agents actively look for files that follow standards correctly, not just files that break them.</p>
+
+      <h3>The Q&#xB2; scoring formula</h3>
+      <p>Each principle is scored 0 to 10 using four constraints designed to avoid the usual pitfalls of naive scoring.</p>
+      <ul>
+        <li>A hyperbolic <strong>violation base</strong> means the first violations hurt most. Fifty minor issues will not tank a score the way five critical ones do.</li>
+        <li>A <strong>compliance lift</strong> fills the gap between the base and 10 with evidence of good practice, so compliance always helps and never hurts.</li>
+        <li>A log-based <strong>violation ceiling</strong> stops compliance from masking real problems. You cannot reach <em>Exemplary</em> with critical issues in play.</li>
+        <li>A <strong>severity grade floor</strong> keeps the label honest. Only an actual critical violation can produce a <em>Critical</em> grade.</li>
+      </ul>
+
+      <p>Quodeq ships with ISO 25010 dimensions plus Clean Architecture and DDD. It evaluates any codebase in any language: Python, TypeScript, Go, Rust, Java, Swift, anything. You can also write your own standards for whatever quality means in your project.</p>
+    </section>
+  );
+}
+
+export function GettingStarted() {
+  return (
+    <section className="help-section">
+      <h2>Getting Started</h2>
+      <p>The first time you launch Quodeq, the onboarding wizard opens automatically. Four short steps and you have your first evaluation running.</p>
+
+      <h3>The onboarding wizard</h3>
+      <ol>
+        <li><strong>Welcome</strong> a quick orientation.</li>
+        <li><strong>Repo Scan</strong> paste a local path, GitHub URL, or SSH path. Quodeq scans and shows file counts and detected languages.</li>
+        <li><strong>Provider</strong> pick where the AI runs. Skipped automatically if you already have one configured.</li>
+        <li><strong>Standard Launch</strong> choose dimensions, scope, branch, and a time budget, then start the evaluation.</li>
+      </ol>
+      <Tip title="Drafts are saved">
+        The wizard remembers what you typed. If you close it midway, your draft comes back next time. You can also resume an interrupted setup from the <strong>Projects</strong> tab.
+      </Tip>
+
+      <h3>What happens next</h3>
+      <ul>
+        <li>The <strong>Evaluate</strong> tab streams the run live, including findings as they appear.</li>
+        <li>When it finishes, the <strong>Overview</strong> tab opens with grades and top findings.</li>
+        <li><strong>Violations</strong>, <strong>Map</strong>, and <strong>History</strong> let you drill in from different angles.</li>
+      </ul>
+
+      <h3>Requirements</h3>
+      <ul>
+        <li><strong>Python 3.12+</strong> and <strong>Node.js 18+</strong>.</li>
+        <li>At least one AI provider configured. See <em>AI Providers</em>.</li>
+      </ul>
+    </section>
+  );
+}
+
+export function Projects() {
+  return (
+    <section className="help-section">
+      <h2>Projects</h2>
+      <p>The <strong>Projects</strong> tab is your home base. Every codebase you evaluate becomes a project with its own grade, score, and run history.</p>
+
+      <h3>What each row tells you</h3>
+      <ul>
+        <li><strong>Grade and score</strong> from the latest run, on a 0 to 10 scale.</li>
+        <li><strong>File and line counts</strong> of the analyzed scope.</li>
+        <li><strong>Last run timestamp</strong> and the model that produced it.</li>
+        <li><strong>Setup state</strong> — projects with an interrupted onboarding show a <em>Resume setup</em> action.</li>
+      </ul>
+
+      <h3>What you can do</h3>
+      <KeyTable rows={[
+        ['Select project', 'Open it. Goes to Overview if it has runs, otherwise Evaluate.'],
+        ['+ Add project', 'Open the wizard at Repo Scan to add another codebase.'],
+        ['Resume setup', 'Pick up an interrupted wizard with the same draft.'],
+        ['Relocate', 'Update the local path if the repo moved on disk.'],
+        ['Export', 'Download the run findings as JSON.'],
+        ['Delete', 'Remove the project and all its runs. Not reversible.'],
+      ]} />
+
+      <h3>Sub-projects and monorepos</h3>
+      <p>You can evaluate a subdirectory of a repository as its own project by setting <strong>Scope</strong> in the wizard or in <em>Evaluate</em>. Each scoped run becomes a distinct project; Quodeq detects the parent-child relationship and groups them in the list so you can compare quality across packages.</p>
+
+      <Tip title="Wiping the slate">
+        Projects, runs, and findings live under <code>~/.quodeq</code>. Delete that directory and Quodeq starts fresh, including the welcome wizard.
+      </Tip>
+    </section>
+  );
+}
+
+export function Providers() {
+  return (
+    <section className="help-section">
+      <h2>AI Providers</h2>
+      <p>Quodeq runs evaluations through one of three provider types. Pick what matches your privacy and cost constraints. You can switch any time from <strong>Settings</strong>.</p>
+
+      <h3>Cloud (OpenRouter or custom)</h3>
+      <p>Routes through a hosted API using your key. Good when you want the latest frontier models without installing a CLI.</p>
+      <ul>
+        <li><strong>OpenRouter</strong> single key, broad catalog. From cheapest to most capable, try <code>meta-llama/llama-3.1-8b-instruct:free</code>, <code>anthropic/claude-haiku-4-5</code>, <code>anthropic/claude-sonnet-4</code>, or <code>anthropic/claude-opus-4-7</code>.</li>
+        <li><strong>Custom</strong> any OpenAI-compatible endpoint. You provide the base URL and model id.</li>
+      </ul>
+      <p>Use <strong>Test connection</strong> in the provider tab to verify the key and model before launching a real run.</p>
+
+      <h3>CLI (Claude Code, Codex)</h3>
+      <p>Delegates to an AI CLI you already have authenticated on your machine. The CLI handles auth and billing; Quodeq drives it.</p>
+      <ol>
+        <li>Install and sign in to your CLI of choice (Claude Code, Codex, etc.).</li>
+        <li>In <strong>Settings → CLI Provider</strong>, pick the binary and a model id like <code>gpt-5</code> or <code>claude-sonnet-4-6</code>.</li>
+        <li>Optionally pin a different model per power tier (Fast, Balanced, Thorough).</li>
+      </ol>
+
+      <h3>Ollama (local, private)</h3>
+      <p>Runs entirely on your machine. Code never leaves the host. The trade-off is slower analysis and lower ceiling on quality compared to frontier cloud models.</p>
+      <ol>
+        <li>Install Ollama from <code>ollama.com</code>.</li>
+        <li>Pull a capable instruction model, for example <code>ollama pull gemma4:26b</code>.</li>
+        <li>In <strong>Settings → Ollama</strong>, your installed models appear automatically. Pick one and set sub-agent count.</li>
+      </ol>
+      <Tip title="Picking sub-agent count">
+        More sub-agents finish faster but use more tokens (cloud) or more VRAM (local). For local Ollama on a 32 GB machine, start with 2 or 3 and scale up only if you have headroom.
+      </Tip>
+
+      <h3>Power tiers</h3>
+      <p>Each provider exposes three power levels that map to model size:</p>
+      <KeyTable rows={[
+        ['Fast', 'Smallest tier. Good for incremental scans and tight budgets.'],
+        ['Balanced', 'Default. Best quality-per-cost for most evaluations.'],
+        ['Thorough', 'Largest tier. Use for first scans, audits, or sensitive areas.'],
+      ]} />
+    </section>
+  );
+}
+
+export function Evaluations() {
+  return (
+    <section className="help-section">
+      <h2>Running Evaluations</h2>
+      <p>The <strong>Evaluate</strong> tab is where you start, watch, and finish a run. The same screen handles configuration, live progress, and the result hand-off.</p>
+
+      <h3>Inputs</h3>
+      <KeyTable rows={[
+        ['Local path', <><code>/path/to/your/project</code></>],
+        ['GitHub URL', <><code>https://github.com/org/repo</code></>],
+        ['SSH path', <><code>git@github.com:org/repo.git</code></>],
+      ]} />
+
+      <h3>Options</h3>
+      <ul>
+        <li><strong>Dimensions</strong> which quality dimensions to include. Hidden dimensions in <em>Standards</em> are skipped automatically.</li>
+        <li><strong>Branch</strong> which git branch to analyze. Defaults to the repo default.</li>
+        <li><strong>Scope</strong> a subdirectory to focus on, e.g. <code>packages/frontend</code>. Useful for monorepos.</li>
+        <li><strong>Sub-agents</strong> how many parallel agents run. Higher is faster, costs more.</li>
+        <li><strong>Time budget</strong> a soft cap on run length. Quodeq scores whatever has completed when the timer expires.</li>
+      </ul>
+
+      <h3>Full vs incremental scans</h3>
+      <ul>
+        <li><strong>Full scan</strong> evaluates the entire scope from scratch. Use for first runs, after big refactors, or when you change standards.</li>
+        <li><strong>Incremental scan</strong> uses <code>git diff</code> to detect changed files and re-evaluates only those. Findings for unchanged files carry forward. Toggle <em>Incremental</em> on before launching.</li>
+      </ul>
+
+      <h3>What you see while it runs</h3>
+      <p>The Evaluate tab streams a live phase indicator (detect → analyze → collect → score → report), an active provider badge, a countdown against your time budget, and a feed of findings as the agents discover them. Click any finding in the feed to jump straight to its file context, even mid-run.</p>
+
+      <h3>Cancelling a run</h3>
+      <p>Hit <strong>Cancel evaluation</strong> any time. You will be asked whether to <strong>keep partial findings</strong> (everything collected so far is scored as a partial run) or <strong>discard</strong> (the run is dropped). Completed dimensions are always scored on cancel; dimensions in flight stop where they are.</p>
+
+      <h3>When it finishes</h3>
+      <p>The result card offers <strong>View results</strong>, <strong>Evaluate again</strong>, or <strong>Back to project</strong>. Each completed run is added to history with its grade, score, and delta from the previous run.</p>
+
+      <Tip title="Re-evaluating an existing project">
+        From any project you can launch a fresh run on the same scope. Subsequent runs are added to <em>History</em> so you can track quality over time without losing previous results.
+      </Tip>
+    </section>
+  );
+}
+
 export function Dimensions() {
   return (
     <section className="help-section">
-      <h2>Quality Dimensions (ISO 25010)</h2>
-      <p>Quodeq evaluates code across six dimensions derived from the ISO/IEC 25010 software quality standard.</p>
+      <h2>Quality Dimensions</h2>
+      <p>Quodeq evaluates code across six dimensions derived from the ISO/IEC 25010 software-quality standard, plus two architecture dimensions you can opt into.</p>
 
+      <h3>The six ISO dimensions</h3>
       <ul>
         <li><strong>Security</strong> vulnerabilities, authentication, data protection. Examples: SQL injection, hardcoded secrets, missing auth.</li>
         <li><strong>Reliability</strong> error handling, fault tolerance, recovery. Examples: unhandled exceptions, missing retries, resource leaks.</li>
-        <li><strong>Maintainability</strong> code clarity, modularity, testability. Examples: long functions, duplicated code, tight coupling.</li>
-        <li><strong>Performance</strong> efficiency, resource usage, scalability. Examples: N+1 queries, memory leaks, missing caching.</li>
+        <li><strong>Maintainability</strong> clarity, modularity, testability. Examples: long functions, duplicated code, tight coupling.</li>
+        <li><strong>Performance</strong> efficiency, resource use, scalability. Examples: N+1 queries, memory leaks, missing caching.</li>
         <li><strong>Flexibility</strong> extensibility, configurability, portability. Examples: hardcoded values, missing interfaces, vendor lock-in.</li>
         <li><strong>Usability</strong> API design, documentation, developer experience. Examples: confusing APIs, missing docs, inconsistent naming.</li>
       </ul>
 
-      <p>Each dimension is scored 0 to 10 and receives a letter grade (A to F). The overall score is a weighted average across all dimensions.</p>
-
-      <h3>Quodeq Dimensions</h3>
-      <p>In addition to the six ISO dimensions, Quodeq includes two extra dimensions focused on software architecture:</p>
+      <h3>Architecture dimensions (opt-in)</h3>
       <ul>
         <li><strong>Clean Architecture</strong> layer separation, dependency rules, import direction, boundary enforcement.</li>
         <li><strong>DDD Design</strong> domain modeling, bounded contexts, aggregates, value objects, ubiquitous language.</li>
       </ul>
-      <p>These dimensions come <strong>disabled by default</strong>. To enable them, go to the <strong>Standards</strong> tab and click the {ICON_EYE_ON} eye icon on the dimension card. Enabled dimensions will appear in the Evaluation and Overview tabs.</p>
+      <p>These ship <strong>disabled by default</strong>. Open <em>Standards</em> and click the {ICON_EYE_ON} eye on the dimension card to enable them. Once visible, they appear in Evaluate and Overview alongside the ISO six.</p>
 
       <h3>Showing and hiding dimensions</h3>
-      <p>Control which dimensions are included in evaluations and displayed in the Overview using the {ICON_EYE_ON} <strong>visibility toggle</strong> on each standard card in the Standards tab:</p>
-      <ul>
-        <li>{ICON_EYE_ON} <strong>Eye open</strong> the dimension is active and will be included in evaluations and the Overview.</li>
-        <li><strong>Eye closed</strong> the dimension is hidden from evaluations and the Overview.</li>
-      </ul>
-      <p>This lets you customize which quality aspects matter for your project without deleting any standards.</p>
+      <p>The {ICON_EYE_ON} <strong>visibility toggle</strong> on each standard card controls whether a dimension is part of evaluations and the Overview. Hide a dimension to ignore it without deleting any standards. Re-enable it any time, the next run will include it.</p>
 
-      <h3>Creating custom dimensions</h3>
-      <p>You can create your own evaluation standards in the <strong>Standards</strong> tab. Each standard defines principles and requirements that the AI evaluates against. See the <strong>Custom Standards</strong> section for the full schema and instructions, including how to use an AI agent to generate standards for you.</p>
+      <h3>Scoring summary</h3>
+      <p>Each dimension is scored 0 to 10 with a letter grade. The project grade is a weighted average across enabled dimensions. See <em>Philosophy</em> for the full Q² formula.</p>
     </section>
   );
 }
@@ -47,37 +253,46 @@ export function Dimensions() {
 export function Violations() {
   return (
     <section className="help-section">
-      <h2>Violations</h2>
-      <p>The <strong>Violations</strong> tab is where you review, explore, and manage all findings from your evaluations.</p>
+      <h2>Violations &amp; Fix Plans</h2>
+      <p>The <strong>Violations</strong> tab is where you triage findings, drill into evidence, and ship fixes. Active and dismissed findings live in their own sub-tabs.</p>
 
       <h3>Severity levels</h3>
       <ul>
-        <li><strong>Critical</strong> immediate security or reliability risk. Fix immediately.</li>
-        <li><strong>Major</strong> significant quality issue. Fix before release.</li>
-        <li><strong>Minor</strong> code improvement opportunity. Fix when convenient.</li>
-        <li><strong>Info</strong> suggestion or best practice. Consider for future.</li>
+        <li><span className="severity-tag critical">CRITICAL</span> immediate security or reliability risk. Fix now.</li>
+        <li><span className="severity-tag major">MAJOR</span> significant quality issue. Fix before the next release.</li>
+        <li><span className="severity-tag minor">MINOR</span> improvement opportunity. Fix when convenient.</li>
+        <li><span className="severity-tag compliance">COMPLIANCE</span> not a violation: a file that follows the standard correctly. Lifts the score.</li>
       </ul>
 
-      <h3>Navigating findings</h3>
+      <h3>Two views, one dataset</h3>
+      <p>Use the view switcher at the top of the tab:</p>
       <ul>
-        <li><strong>Click a dimension</strong> to see all findings for that quality area.</li>
-        <li><strong>Click a file</strong> to see all violations in that specific file with code context.</li>
-        <li><strong>Click a principle</strong> to see all violations for that evaluation rule.</li>
-        <li><strong>Severity cells</strong> in the grid are clickable and filter by both dimension and severity.</li>
+        <li><strong>Heatgrid</strong> a dimension × severity matrix with counts per cell. Click a cell to filter by both dimension and severity at once.</li>
+        <li><strong>File tree</strong> the same findings grouped by directory, with a breadcrumb you can drill into. Useful for tracking down a single hot spot.</li>
       </ul>
 
-      <h3>Viewing dimensions and code</h3>
-      <p>From any violation, you can drill into its dimension to see the full picture: all principles, their scores, and every finding with the relevant code snippet. This helps you understand the context around a violation and decide whether to fix it, dismiss it, or accept the trade-off.</p>
+      <h3>Drilling in</h3>
+      <KeyTable rows={[
+        ['Click a dimension', 'Open the Explorer with all principles, scores, and findings.'],
+        ['Click a principle', 'Open the principle detail with violations grouped by severity and a compliance list.'],
+        ['Click a file', 'Open the file detail with every finding (active and compliance) for that file.'],
+        ['Click a finding', 'Open the leaf finding card with breadcrumb context.'],
+      ]} />
 
-      <h3>Dismissing findings</h3>
-      <p>If a finding is a false positive or intentionally accepted, you can dismiss it directly from the violation detail view. Dismissed findings:</p>
+      <h3>Fix plans</h3>
+      <p>From any violation, the <strong>Fix plan</strong> button opens a side-pane with a structured remediation packet: file path, line number, code context, the violated principle, and concrete guidance. Copy it and paste into your AI agent or IDE — it is designed to give the receiving model everything it needs to apply the fix without follow-up questions.</p>
+
+      <h3>Dismissing a finding</h3>
+      <p>If a finding is a false positive or an accepted trade-off, dismiss it from the violation detail. You will be asked for a reason. Dismissed findings:</p>
       <ul>
-        <li>Are moved to the <strong>Dismissed</strong> sub-tab in the Violations view.</li>
-        <li>Are <strong>excluded from scoring</strong>. The dimension score updates immediately after dismissal.</li>
-        <li>Are <strong>excluded from future evaluations</strong>. Re-running the evaluation will not report dismissed findings again.</li>
-        <li>Can be <strong>restored at any time</strong> from the Dismissed tab, which brings them back into the active results.</li>
+        <li>move to the <strong>Dismissed</strong> sub-tab,</li>
+        <li>are <strong>excluded from scoring</strong> (the dimension score updates immediately),</li>
+        <li>are <strong>excluded from future evaluations</strong> for the same principle and file,</li>
+        <li>can be <strong>restored</strong> individually or in bulk via <em>Restore all</em>.</li>
       </ul>
-      <p>Use this to filter out noise and focus on the violations that matter to your team. You can also use <strong>Restore All</strong> to bring back all dismissed findings at once.</p>
+      <Tip title="Dismissals are durable">
+        Dismissals persist across runs. They are tied to the finding's principle and file, so renaming or moving the file may bring the finding back — that is intentional.
+      </Tip>
     </section>
   );
 }
@@ -86,21 +301,61 @@ export function CodeMap() {
   return (
     <section className="help-section">
       <h2>Code Map</h2>
-      <p>The <strong>Map</strong> tab provides a visual representation of your codebase structure and quality.</p>
+      <p>The <strong>Map</strong> tab visualizes your codebase as shapes you can scan at a glance. Two metrics, three layouts, six combinations.</p>
 
-      <h3>Treemap view</h3>
-      <p>Files are displayed as rectangles sized by their line count. Color indicates severity density: red areas have more critical violations, green areas are clean.</p>
-      <p>This makes it easy to spot:</p>
+      <h3>Pick a metric</h3>
       <ul>
-        <li><strong>Large red blocks</strong> big files with many issues, high-impact refactoring targets</li>
-        <li><strong>Clusters of red</strong> entire modules that need attention</li>
-        <li><strong>Green areas</strong> well-maintained parts of the codebase</li>
+        <li><strong>Health</strong> color encodes the dimension grade of each file. Greener is healthier.</li>
+        <li><strong>Violations</strong> color encodes raw violation density, weighted by severity.</li>
       </ul>
 
-      <h3>Risk matrix</h3>
-      <p>The risk matrix plots files by complexity (size) vs. issue density, helping you prioritize which files to fix first. Files in the top-right quadrant are both complex and problematic. Tackle those first.</p>
+      <h3>Pick a layout</h3>
+      <KeyTable rows={[
+        ['Circle Pack', 'Nested circles sized by line count. Best for spotting heavy files at a glance.'],
+        ['Galaxy', 'Force-directed cluster view. Two sub-modes: filesystem (by directory) or standards (by violated principle).'],
+        ['Risk Matrix', 'Files plotted by complexity (size) vs. issue density. Top-right quadrant is your priority list.'],
+      ]} />
 
-      <p>Click any file in the map to see its detailed violations and code context.</p>
+      <h3>Reading the views</h3>
+      <ul>
+        <li><strong>Large red blocks</strong> big files with many issues, high-impact refactor targets.</li>
+        <li><strong>Clusters of red</strong> entire modules drifting from the standard.</li>
+        <li><strong>Galaxy by standards</strong> reveals which principles are violated most across the project, regardless of where the files live.</li>
+        <li><strong>Green islands</strong> well-maintained areas — protect them when refactoring nearby.</li>
+      </ul>
+
+      <h3>Drilling in</h3>
+      <p>Click any node to drill down. The Map keeps a local breadcrumb so you can pop back without leaving the tab. Click a leaf node to open the file detail, or jump from a galaxy-by-standards cluster directly to the offending principle.</p>
+    </section>
+  );
+}
+
+export function History() {
+  return (
+    <section className="help-section">
+      <h2>History &amp; Trends</h2>
+      <p>The <strong>History</strong> tab is your project's quality timeline. Every completed run lives there with its grade, score, and delta from the run before.</p>
+
+      <h3>The run list</h3>
+      <ul>
+        <li><strong>Grade and score</strong> for each run.</li>
+        <li><strong>Delta</strong> against the previous run, so you can spot regressions immediately.</li>
+        <li><strong>Run metadata</strong> model, sub-agent count, scope, branch, duration.</li>
+        <li><strong>Tombstones</strong> deleted runs leave a marker so the trend stays continuous.</li>
+      </ul>
+
+      <h3>The trend chart</h3>
+      <p>A small chart above the list plots overall score over time, with per-dimension lines you can toggle. Hover a point to see that run's stats; click to open it.</p>
+
+      <h3>Run detail and the navigator</h3>
+      <p>Clicking a run opens its <strong>Run Detail</strong> page — the same shell as Overview but locked to that single run. From there, the run navigator at the top lets you step <strong>previous / next / latest</strong> without going back to the list. Drill into any dimension and the Explorer keeps the run id, so you stay anchored to that snapshot.</p>
+
+      <h3>Partial and cancelled runs</h3>
+      <p>Cancelled runs that kept their partial findings appear with a <em>partial</em> tag. They count for trend purposes but the Run Detail page makes the partial state obvious so you do not over-interpret it.</p>
+
+      <Tip title="Comparing across time">
+        The Run Detail navigator is the fastest way to A/B compare. Open the dimension you care about in run N, hit <em>previous</em>, and watch the principle scores shift.
+      </Tip>
     </section>
   );
 }
@@ -109,74 +364,58 @@ export function Standards() {
   return (
     <section className="help-section">
       <h2>Custom Standards</h2>
-      <p>The <strong>Standards</strong> tab lets you create, edit, and manage evaluation standards. Define what quality means for your project.</p>
+      <p>The <strong>Standards</strong> tab is where you decide what quality means for your project. Browse, edit, import, and create the rules Quodeq evaluates against.</p>
 
       <h3>Built-in standards</h3>
-      <p>Quodeq ships with standards based on ISO 25010 for each of the six dimensions, plus Clean Architecture and DDD Design. These provide comprehensive coverage out of the box.</p>
+      <p>Quodeq ships with managed standards for the six ISO 25010 dimensions plus Clean Architecture and DDD Design. They are <strong>read-only</strong> (you can view them but not edit) and marked as <em>Managed</em>. To turn one off, hide it with the {ICON_EYE_ON} visibility toggle.</p>
 
       <h3>Creating your own</h3>
       <ol>
-        <li>Click <strong>New Standard</strong> in the Standards tab.</li>
-        <li>Define principles (evaluation categories) and requirements (specific checks).</li>
-        <li>Assign severity levels to each requirement (<code>critical</code>, <code>major</code>, or <code>minor</code>).</li>
-        <li>Save and your standard will be used in the next evaluation.</li>
+        <li>Click <strong>New standard</strong>.</li>
+        <li>Name it and pick the dimension it belongs to.</li>
+        <li>Add <strong>principles</strong> (categories) and inside each, <strong>requirements</strong> (the specific checks).</li>
+        <li>Set a severity per requirement: <code>critical</code>, <code>major</code>, or <code>minor</code>.</li>
+        <li>Save. The next evaluation picks it up automatically.</li>
       </ol>
+      <p>Custom standards are fully editable and can be duplicated, exported, or deleted at any time.</p>
 
-      <h3>Importing from library</h3>
-      <p>You can import pre-built standards from the Quodeq library. Click <strong>Import</strong> and browse available standards.</p>
+      <h3>Importing</h3>
+      <p>Click <strong>Import</strong> to load a JSON file you wrote yourself or got from elsewhere. Quodeq validates the shape and tells you what is wrong if it does not parse.</p>
 
       <h3>Standard schema</h3>
-      <p>Every standard follows this JSON structure:</p>
       <pre className="help-pre">{`{
-  "id": "my-standard",
-  "name": "My Custom Standard",
-  "dimension": "security",
+  "id": "react-best-practices",
+  "name": "React Best Practices",
+  "dimension": "maintainability",
   "version": "1.0",
   "principles": [
     {
-      "name": "Principle Name",
-      "description": "What this principle evaluates",
+      "id": "P-REACT-A11Y",
+      "name": "Accessibility",
+      "description": "Components must be accessible by default.",
       "requirements": [
         {
-          "id": "MY-REQ-1",
-          "text": "The specific requirement to check",
+          "id": "R-A11Y-1",
+          "rule": "Interactive elements expose semantic roles.",
           "severity": "major"
         }
       ]
     }
   ]
 }`}</pre>
-      <p>Key fields:</p>
       <ul>
-        <li><strong>id</strong> unique identifier, used as filename (<code>my-standard.json</code>).</li>
-        <li><strong>dimension</strong> the quality dimension this standard belongs to.</li>
-        <li><strong>principles</strong> categories of evaluation (for example, "Error Handling", "Input Validation").</li>
-        <li><strong>requirements</strong> specific checks within each principle, each with an ID and severity.</li>
+        <li><strong>id</strong> unique slug, used as the filename.</li>
+        <li><strong>dimension</strong> which quality dimension this standard rolls up into.</li>
+        <li><strong>principles</strong> categories of evaluation. Each principle becomes a card on the Explorer page.</li>
+        <li><strong>requirements</strong> specific checks. Each one is what the AI cites when it reports a finding.</li>
       </ul>
 
-      <h3>Using AI to generate standards</h3>
-      <p>You can ask any AI (Claude, ChatGPT, Gemini, etc.) to generate a custom standard for you. Just ask it to produce a <code>.json</code> file following the schema above, then import it into Quodeq.</p>
-      <p>Ask the AI something like:</p>
-      <pre className="help-pre">{`Generate a .quodeq JSON file for evaluating React component
-best practices. Include principles for accessibility,
-performance, state management, and error boundaries.
-
-Use this structure:
-{
-  "id": "react-best-practices",
-  "name": "React Best Practices",
-  "dimension": "react",
-  "principles": [
-    {
-      "id": "P-REACT-A11Y",
-      "name": "Accessibility",
-      "requirements": [
-        { "id": "R-A11Y-1", "rule": "...", "severity": "major" }
-      ]
-    }
-  ]
-}`}</pre>
-      <p>The AI will generate a complete standard JSON file. Save it as a <code>.json</code> file (the <code>.quodeq</code> extension is optional, it's a regular JSON file), then click the <strong>Import</strong> button in the <strong>Standards</strong> tab to load it into Quodeq.</p>
+      <h3>Generating standards with AI</h3>
+      <p>Any chat AI (Claude, ChatGPT, Gemini) can write a standard for you. Paste the schema above, describe what you want evaluated, and ask for a JSON file. Save the result and import it. A starter prompt:</p>
+      <pre className="help-pre">{`Generate a Quodeq standard JSON file for evaluating React
+component best practices. Cover accessibility, performance,
+state management, and error boundaries. Use this schema:
+{ ...paste schema above... }`}</pre>
     </section>
   );
 }
@@ -185,43 +424,27 @@ export function Settings() {
   return (
     <section className="help-section">
       <h2>Settings</h2>
-      <p>Configure your AI provider, models, and dashboard preferences in the <strong>Settings</strong> tab.</p>
+      <p>Provider configuration, model overrides, server status, and appearance live in <strong>Settings</strong>. Most of it is set once and forgotten.</p>
 
-      <h3>Provider configuration</h3>
+      <h3>Provider tabs</h3>
       <ul>
-        <li><strong>CLI Provider</strong> uses an installed AI CLI (Claude Code, Codex). Configure the power level and model.</li>
-        <li><strong>Ollama</strong> uses a locally running Ollama instance. Select a model and configure parallelism.</li>
+        <li><strong>Cloud</strong> hosted APIs (OpenRouter or a custom OpenAI-compatible endpoint). API key, base URL, model id, and a <em>Test connection</em> button.</li>
+        <li><strong>CLI</strong> local AI CLIs you have authenticated (Claude Code, Codex). Pick the binary, then a model id.</li>
+        <li><strong>Ollama</strong> models on your local Ollama server. Quodeq lists whatever you have pulled.</li>
       </ul>
+      <p>Each tab also exposes <strong>sub-agent count</strong> and a <strong>time budget</strong> default. Start an evaluation and you can override these per-run.</p>
 
-      <h3>Model selection</h3>
-      <p>Each power level maps to a model tier. You can override the default model for each level in Settings. Custom model names are stored locally.</p>
+      <h3>Model overrides per tier</h3>
+      <p>Power tiers (Fast / Balanced / Thorough) ship with sensible defaults. You can pin a different model to each tier if you want a small model for incremental scans and a large one for audits. Leave a tier blank to inherit the main model.</p>
 
-      <h3>Server info</h3>
-      <p>The Settings tab shows the current server status including port and version. Use this to verify the dashboard is connected to the correct backend.</p>
+      <h3>Server</h3>
+      <p>Shows the current dashboard server: port, version, and status. Live log streams (server, Ollama, evaluation) are wired into the side-pane log viewer — open it from the bottom-bar log buttons to tail what is happening.</p>
 
-      <h3>Theme</h3>
-      <p>Choose between light and dark mode, and select a theme family for the dashboard appearance.</p>
-    </section>
-  );
-}
+      <h3>Appearance</h3>
+      <p>Light or dark mode plus a theme family selector. Themes change accent colors and surface tones; layout stays the same.</p>
 
-export function SubProjects() {
-  return (
-    <section className="help-section">
-      <h2>Evaluating Sub-projects</h2>
-      <p>Quodeq supports evaluating specific parts of a monorepo or multi-project repository.</p>
-
-      <h3>Using scope</h3>
-      <p>When starting an evaluation, use the <strong>Scope</strong> option to specify a subdirectory:</p>
-      <pre className="help-pre">{`Repository: /path/to/monorepo
-Scope:      packages/frontend`}</pre>
-      <p>This evaluates only the files within that subdirectory, producing a focused report for that sub-project.</p>
-
-      <h3>Multiple evaluations</h3>
-      <p>Run separate evaluations for each sub-project. Each appears as a distinct project in the dashboard with its own history and scores. You can compare quality across sub-projects in the <strong>Projects</strong> tab.</p>
-
-      <h3>Project hierarchy</h3>
-      <p>When you evaluate subdirectories of the same repository, Quodeq automatically detects the parent-child relationship and groups them in the project list.</p>
+      <h3>About</h3>
+      <p>Version info, links to docs and the repo, and the kill-switch environment variables you can set if you need to disable side features. Most users will not need this section.</p>
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/help/components/HelpSections.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpSections.jsx
@@ -107,7 +107,7 @@ export function Projects() {
         <li><strong>Grade and score</strong> from the latest run, on a 0 to 10 scale.</li>
         <li><strong>File and line counts</strong> of the analyzed scope.</li>
         <li><strong>Last run timestamp</strong> and the model that produced it.</li>
-        <li><strong>Setup state</strong> — projects with an interrupted onboarding show a <em>Resume setup</em> action.</li>
+        <li><strong>Setup state</strong>: projects with an interrupted onboarding show a <em>Resume setup</em> action.</li>
       </ul>
 
       <h3>What you can do</h3>
@@ -280,7 +280,7 @@ export function Violations() {
       ]} />
 
       <h3>Fix plans</h3>
-      <p>From any violation, the <strong>Fix plan</strong> button opens a side-pane with a structured remediation packet: file path, line number, code context, the violated principle, and concrete guidance. Copy it and paste into your AI agent or IDE — it is designed to give the receiving model everything it needs to apply the fix without follow-up questions.</p>
+      <p>From any violation, the <strong>Fix plan</strong> button opens a side-pane with a structured remediation packet: file path, line number, code context, the violated principle, and concrete guidance. Copy it and paste into your AI agent or IDE. It is designed to give the receiving model everything it needs to apply the fix without follow-up questions.</p>
 
       <h3>Dismissing a finding</h3>
       <p>If a finding is a false positive or an accepted trade-off, dismiss it from the violation detail. You will be asked for a reason. Dismissed findings:</p>
@@ -291,7 +291,7 @@ export function Violations() {
         <li>can be <strong>restored</strong> individually or in bulk via <em>Restore all</em>.</li>
       </ul>
       <Tip title="Dismissals are durable">
-        Dismissals persist across runs. They are tied to the finding's principle and file, so renaming or moving the file may bring the finding back — that is intentional.
+        Dismissals persist across runs. They are tied to the finding's principle and file, so renaming or moving the file may bring the finding back. That is intentional.
       </Tip>
     </section>
   );
@@ -321,7 +321,7 @@ export function CodeMap() {
         <li><strong>Large red blocks</strong> big files with many issues, high-impact refactor targets.</li>
         <li><strong>Clusters of red</strong> entire modules drifting from the standard.</li>
         <li><strong>Galaxy by standards</strong> reveals which principles are violated most across the project, regardless of where the files live.</li>
-        <li><strong>Green islands</strong> well-maintained areas — protect them when refactoring nearby.</li>
+        <li><strong>Green islands</strong>: well-maintained areas. Protect them when refactoring nearby.</li>
       </ul>
 
       <h3>Drilling in</h3>
@@ -348,7 +348,7 @@ export function History() {
       <p>A small chart above the list plots overall score over time, with per-dimension lines you can toggle. Hover a point to see that run's stats; click to open it.</p>
 
       <h3>Run detail and the navigator</h3>
-      <p>Clicking a run opens its <strong>Run Detail</strong> page — the same shell as Overview but locked to that single run. From there, the run navigator at the top lets you step <strong>previous / next / latest</strong> without going back to the list. Drill into any dimension and the Explorer keeps the run id, so you stay anchored to that snapshot.</p>
+      <p>Clicking a run opens its <strong>Run Detail</strong> page: the same shell as Overview but locked to that single run. From there, the run navigator at the top lets you step <strong>previous / next / latest</strong> without going back to the list. Drill into any dimension and the Explorer keeps the run id, so you stay anchored to that snapshot.</p>
 
       <h3>Partial and cancelled runs</h3>
       <p>Cancelled runs that kept their partial findings appear with a <em>partial</em> tag. They count for trend purposes but the Run Detail page makes the partial state obvious so you do not over-interpret it.</p>
@@ -438,7 +438,7 @@ export function Settings() {
       <p>Power tiers (Fast / Balanced / Thorough) ship with sensible defaults. You can pin a different model to each tier if you want a small model for incremental scans and a large one for audits. Leave a tier blank to inherit the main model.</p>
 
       <h3>Server</h3>
-      <p>Shows the current dashboard server: port, version, and status. Live log streams (server, Ollama, evaluation) are wired into the side-pane log viewer — open it from the bottom-bar log buttons to tail what is happening.</p>
+      <p>Shows the current dashboard server: port, version, and status. Live log streams (server, Ollama, evaluation) are wired into the side-pane log viewer. Open it from the bottom-bar log buttons to tail what is happening.</p>
 
       <h3>Appearance</h3>
       <p>Light or dark mode plus a theme family selector. Themes change accent colors and surface tones; layout stays the same.</p>

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -11,51 +11,24 @@ import {
   Cell,
   ReferenceLine,
 } from 'recharts';
+import {
+  cssVar,
+  scoreBarColor,
+  REF_LINE_LOW,
+  REF_LINE_MID,
+  REF_LINE_HIGH,
+  CHART_MARGIN,
+  SELECTED_BAR_OPACITY,
+  DESELECTED_BAR_OPACITY,
+} from '../../../components/scoreChartHelpers.js';
 
 const MAX_CHART_RUNS = 40;
 const CHART_HEIGHT = 220;
-const REF_LINE_LOW = 2.5;
-const REF_LINE_MID = 5;
-const REF_LINE_HIGH = 7.5;
 const REF_LINE_FLOOR = 0;
 const REF_LINE_CEIL = 10;
-const DESELECTED_BAR_OPACITY = 0.62;
-const CHART_MARGIN = { top: 8, right: 0, bottom: 0, left: 0 };
 const HOVER_STROKE_WIDTH = 1.5;
 const TREND_LINE_STROKE_WIDTH = 2;
 const TREND_LINE_OPACITY = 0.9;
-
-const _cssVarCache = new Map();
-const cssVar = (name, fallback) => {
-  if (_cssVarCache.has(name)) return _cssVarCache.get(name) || fallback;
-  if (typeof document === 'undefined') return fallback;
-  const val = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-  _cssVarCache.set(name, val);
-  return val || fallback;
-};
-if (typeof document !== 'undefined') {
-  new MutationObserver(() => _cssVarCache.clear()).observe(
-    document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] },
-  );
-}
-
-const GRADE_CSS_VARS = {
-  'grade-top':    '--color-grade-top-text',
-  'grade-high':   '--color-grade-high-text',
-  'grade-mid':    '--color-grade-mid-text',
-  'grade-low':    '--color-grade-low-text',
-  'grade-bottom': '--color-grade-bottom-text',
-};
-
-function scoreBarColor(score) {
-  const n = parseFloat(score);
-  if (Number.isNaN(n)) return cssVar('--color-accent');
-  if (n >= 9) return cssVar(GRADE_CSS_VARS['grade-top']);
-  if (n >= 7) return cssVar(GRADE_CSS_VARS['grade-high']);
-  if (n >= 5) return cssVar(GRADE_CSS_VARS['grade-mid']);
-  if (n >= 3) return cssVar(GRADE_CSS_VARS['grade-low']);
-  return cssVar(GRADE_CSS_VARS['grade-bottom']);
-}
 
 function windowAroundSelected(trend, selectedRunId) {
   if (trend.length <= MAX_CHART_RUNS) return trend;
@@ -137,7 +110,7 @@ function ScoreHistoryChart({ data, interaction }) {
             <Cell
               key={entry.runId ?? i}
               fill={scoreBarColor(entry.numericAverage)}
-              opacity={entry.runId === selectedRunId ? 1 : DESELECTED_BAR_OPACITY}
+              opacity={entry.runId === selectedRunId ? SELECTED_BAR_OPACITY : DESELECTED_BAR_OPACITY}
               stroke={hoveredIndex === i ? cssVar('--color-chart-stroke') : 'none'}
               strokeWidth={hoveredIndex === i ? HOVER_STROKE_WIDTH : 0}
             />

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -79,27 +79,49 @@ function buildTrendData(trend, selectedRunId) {
   });
 }
 
-function RunHistoryTooltip({ active, hoveredIndex, data }) {
-  if (!active || hoveredIndex === null) return null;
-  const entry = data[hoveredIndex];
+function RunHistoryTooltip({ active, payload }) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0]?.payload;
   if (!entry) return null;
+  const score = Number.isFinite(entry.numericAverage) ? entry.numericAverage.toFixed(1) : '?';
+  const grade = gradeLetter(entry.overallGrade);
   return (
     <div className="run-history-tooltip">
       <span className="rht-date">{entry.dateLabel}</span>
-      <span className="rht-score">{entry.numericAverage.toFixed(1)} / 10</span>
-      <span className="rht-grade">{gradeLetter(entry.overallGrade)}</span>
+      <span className="rht-score">{score} - {grade}</span>
     </div>
   );
 }
 
 function ScoreHistoryChart({ data, interaction }) {
   const { hoveredIndex, setHoveredIndex, selectedRunId, onBarClick } = interaction;
+  // Click and hover live on the chart container, not on the Bar. The
+  // shared `.run-history-panel .recharts-surface *` rule sets
+  // pointer-events:none so the Area/Line layers cannot swallow clicks
+  // before they reach the visible bar; in turn we read activeTooltipIndex
+  // from Recharts' chart-level events.
+  const handleMove = (state) => {
+    setHoveredIndex(state?.activeTooltipIndex ?? null);
+  };
+  const handleClick = (state) => {
+    const idx = state?.activeTooltipIndex;
+    if (idx == null) return;
+    const runId = data[idx]?.runId;
+    if (runId) onBarClick?.(runId);
+  };
   return (
     <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-      <ComposedChart data={data} margin={CHART_MARGIN}>
+      <ComposedChart
+        data={data}
+        margin={CHART_MARGIN}
+        onMouseMove={handleMove}
+        onMouseLeave={() => setHoveredIndex(null)}
+        onClick={onBarClick ? handleClick : undefined}
+        style={onBarClick ? { cursor: 'pointer' } : undefined}
+      >
         <XAxis dataKey="dateLabel" hide />
         <YAxis domain={[0, 10]} hide />
-        <Tooltip cursor={false} isAnimationActive={false} offset={20} content={({ active }) => <RunHistoryTooltip active={active} hoveredIndex={hoveredIndex} data={data} />} />
+        <Tooltip cursor={false} isAnimationActive={false} offset={20} content={<RunHistoryTooltip />} />
         <ReferenceLine y={REF_LINE_FLOOR} stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.6} />
         <ReferenceLine y={REF_LINE_LOW}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
         <ReferenceLine y={REF_LINE_MID}   stroke={cssVar('--color-chart-axis')} strokeDasharray="4 4" strokeOpacity={0.45} />
@@ -110,10 +132,6 @@ function ScoreHistoryChart({ data, interaction }) {
           radius={[0, 0, 0, 0]}
           maxBarSize={32}
           isAnimationActive={false}
-          cursor={onBarClick ? 'pointer' : 'default'}
-          onMouseEnter={(_, index) => setHoveredIndex(index)}
-          onMouseLeave={() => setHoveredIndex(null)}
-          onClick={(entry) => onBarClick?.(entry.runId)}
         >
           {data.map((entry, i) => (
             <Cell

--- a/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
@@ -1,4 +1,5 @@
 import { TermHeader, StatStrip, Stat } from '../../../../components/terminal/index.js';
+import HelpHint from '../../../../components/HelpHint.jsx';
 
 function formatTimeLimit(seconds) {
   if (!seconds || seconds <= 0) return 'No limit';
@@ -41,9 +42,16 @@ export default function StandardLaunchStep({ state, actions, standards, onLaunch
                 onChange={() => actions.toggleStandard(s.id)}
                 aria-label={s.name}
               />
-              <div>
+              <div className="onboarding-standard-card__body">
                 <strong>{s.name}</strong>
-                <p>{s.description}</p>
+                {s.description && (
+                  <span
+                    className="onboarding-standard-card__hint"
+                    onClick={(e) => e.preventDefault()}
+                  >
+                    <HelpHint label={`${s.name} description`}>{s.description}</HelpHint>
+                  </span>
+                )}
               </div>
             </label>
           </li>

--- a/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/onboarding.integration.test.jsx
@@ -73,7 +73,7 @@ describe('Onboarding integration — happy path', () => {
 
     // Standard & Launch — pitch text is unchanged and uniquely identifies this step
     expect(screen.getByText(/pick one for your first run/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText(/security 101/i));
+    fireEvent.click(screen.getByRole('radio', { name: /security 101/i }));
     fireEvent.click(screen.getByRole('button', { name: /start evaluation/i }));
 
     await waitFor(() => expect(onLaunch).toHaveBeenCalled());

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -147,7 +147,6 @@ export default function ProviderTabs({ providerConfigs }) {
                 onClick={() => selectTab(c.id)}
               >
                 {c.label}
-                {!installed && <span className="settings-pill-badge"> Not installed</span>}
               </button>
             );
           })}

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -104,7 +104,9 @@ export function useAppState() {
   // past runs in a comparison-oriented mental model — flashing the previous
   // run's data via placeholderData is confusing. Overview navigation, by
   // contrast, benefits from the instant swap because consecutive runs are
-  // usually nearly identical.
+  // usually nearly identical. The dashboard-refreshing class dims the
+  // page during the background refetch so the user sees that something
+  // is happening without the jarring full-screen LoadingScreen.
   const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard } = useDashboard({
     selectedProject,
     selectedRun: effectiveRun,

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1541,14 +1541,6 @@ textarea:focus {
   border-color: var(--color-accent);
 }
 
-.settings-pill-badge {
-  margin-left: 6px;
-  font-size: 0.85em;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  opacity: 0.8;
-}
-
 .settings-install-hint {
   padding: 12px 16px;
   margin: 0 var(--space-6, 24px) var(--space-4, 16px);

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2147,6 +2147,17 @@
   user-select: none;
 }
 
+/* Recharts attaches click handlers to bar/line/area elements that call
+ * stopPropagation, so clicks landing on a bar never reach the chart's
+ * onClick handler. Make every inner SVG element transparent to pointer
+ * events; the surface itself still receives the events and bubbles
+ * them up to the ComposedChart wrapper, which converts them into
+ * "active bar" clicks via activeTooltipIndex. Hover/tooltip continue
+ * to work because Recharts uses onMouseMove on the wrapper too. */
+.run-history-panel .recharts-surface * {
+  pointer-events: none;
+}
+
 .run-history-panel {
   display: flex;
   flex-direction: column;
@@ -2210,7 +2221,6 @@
 
 .rht-date  { color: var(--color-text-muted); }
 .rht-score { font-weight: 600; color: var(--color-text); }
-.rht-grade { color: var(--color-text-muted); font-size: 0.75rem; }
 
 /* ── History panels row (Score History + Dimension Scores side-by-side) ── */
 

--- a/src/quodeq/ui/src/styles/help.css
+++ b/src/quodeq/ui/src/styles/help.css
@@ -158,6 +158,94 @@
   white-space: pre;
 }
 
+/* ── Tip callout ─────────────────────────────────────── */
+
+.help-tip {
+  display: flex;
+  gap: var(--space-3);
+  margin: var(--space-4) 0;
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in srgb, var(--color-accent) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
+  border-left: 2px solid var(--color-accent);
+  border-radius: var(--radius-md);
+}
+
+.help-tip__title {
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-accent);
+  margin-bottom: var(--space-1);
+}
+
+.help-tip__body {
+  font-size: clamp(0.85rem, 0.4vw + 0.7rem, 1rem);
+  color: var(--color-text);
+  line-height: 1.65;
+}
+
+.help-tip__body p {
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
+}
+.help-tip__body p:last-child { margin-bottom: 0; }
+
+.help-tip__body code {
+  font-size: 0.85em;
+}
+
+/* ── Key/value table for "what each thing does" ──────── */
+
+.help-keytable {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.4fr) 1fr;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  margin: var(--space-3) 0 var(--space-5);
+  background: var(--color-surface-alt);
+}
+
+.help-keytable__row {
+  display: contents;
+}
+
+.help-keytable__k,
+.help-keytable__v {
+  padding: var(--space-2) var(--space-3);
+  font-size: clamp(0.8rem, 0.4vw + 0.7rem, 0.95rem);
+  line-height: 1.6;
+  border-top: 1px solid var(--color-border);
+}
+
+.help-keytable__row:first-child .help-keytable__k,
+.help-keytable__row:first-child .help-keytable__v {
+  border-top: none;
+}
+
+.help-keytable__k {
+  font-weight: var(--weight-semibold);
+  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-bg) 35%, transparent);
+}
+
+.help-keytable__v {
+  color: var(--color-text-muted);
+}
+
+.help-keytable__v code {
+  font-size: 0.85em;
+}
+
+/* ── Severity tag inline use in help body ────────────── */
+
+.help-section .severity-tag {
+  margin-right: var(--space-1);
+  vertical-align: baseline;
+}
+
 /* ── Responsive ──────────────────────────────────────── */
 
 @media (max-width: 900px) {
@@ -178,5 +266,14 @@
     flex-direction: row;
     flex-wrap: wrap;
     min-width: auto;
+  }
+
+  .help-keytable {
+    grid-template-columns: 1fr;
+  }
+
+  .help-keytable__v {
+    border-top: none;
+    padding-top: 0;
   }
 }

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -273,10 +273,15 @@
   margin-top: 2px;
   flex-shrink: 0;
 }
-.onboarding-standard-card p {
-  margin: 4px 0 0;
-  font-size: 11px;
-  color: var(--color-text-muted);
+.onboarding-standard-card__body {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.onboarding-standard-card__hint {
+  display: inline-flex;
+  align-items: center;
 }
 
 /* ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Misc UI polish bundled together. All scoped to `src/quodeq/ui/`.

- **Help refresh** ([HelpPage.jsx](src/quodeq/ui/src/features/help/components/HelpPage.jsx), [HelpSections.jsx](src/quodeq/ui/src/features/help/components/HelpSections.jsx), [help.css](src/quodeq/ui/src/styles/help.css)): rewrote help to match the app today. Adds Projects, History & Trends, Fix Plans coverage. Replaces stale single-treemap Code Map with the Health/Violations × Pack/Galaxy/Risk Matrix matrix. Updates Providers to cover Cloud (OpenRouter/custom) alongside CLI and Ollama with current model ids. Folds Sub-projects into Running Evaluations under Scope. New Tip callout and key/value workflow table styles.
- **Provider tab badge cleanup** ([ProviderTabs.jsx](src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx)): drop the inline `Not installed` text from disabled provider pills. State already conveyed by the greyed-out style and tooltip.
- **Onboarding standards step** ([StandardLaunchStep.jsx](src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx)): just the standard name on the card with a `?` HelpHint for the description, matching the Settings interrogation pattern.
- **Score-history bar clicks** ([RunHistoryPanel.jsx](src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx), [HistoryChartPanel.jsx](src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx), [dashboard.css](src/quodeq/ui/src/styles/dashboard.css)): clicks on bars register everywhere in the chart column (gaps + bars). Recharts' inner bar/line elements were stopping click propagation; `pointer-events: none` on `.recharts-surface *` lets clicks bubble to chart-level `onClick`, which uses `activeTooltipIndex` for hit detection. Both Overview and History charts updated. Tooltip switched to Recharts' standard `payload` prop (no more top-left ghost) and trimmed to `date / score - grade`.
- **Evaluate screen polish** ([EvaluationStatus.jsx](src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx), [ReEvaluateCard.jsx](src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx)): drop the redundant `cancelled`/`failed` status pill (TermHeader already names the state). Move the actions HelpHint into the Re-evaluate card next to Scope and Clean scan, where it explains what those toggles do.

## Test plan

- [x] Open `/help` and walk through each section. Verify all 11 sections render and content reflects current app behaviour.
- [x] Settings tab: confirm disabled provider pills show only the name, no `Not installed` text.
- [x] Onboarding wizard step 2 (standards): verify card shows just the name with a clickable `?` for description.
- [x] Overview dashboard score history: click anywhere in any column (bar or gap) and confirm the page swaps to that run's data with a smooth dim transition.
- [x] History tab score chart: same — click any bar or gap, run-detail page reflects the click.
- [x] Tooltip on either chart: shows two lines, `date` then `score - grade`. No `/10`, no separate grade line, no top-left ghost on hover-out.
- [ ] Evaluate tab on a finished/cancelled run: status pill is gone; the only `?` is in the Re-evaluate card next to Scope/Clean scan.