### PR TITLE
ui(dashboard): native chrome on Windows, unified Mac dots elsewhere

### DIFF
--- a/src/quodeq/dashboard/_webview_html.py
+++ b/src/quodeq/dashboard/_webview_html.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 import json
 import sys
 
+# Windows uses native chrome (frameless=False in _webview_window), so no
+# in-page controls are injected. macOS and Linux use frameless windows with
+# Mac-style traffic-light dots on the left — keeping them on the left avoids
+# colliding with topbar actions that live on the right (e.g. Re-evaluate
+# toggles).
 _CONTROLS_MAC = """\
 <style>
   /* Traffic-light dots sit INSIDE the topbar's empty left-padding area
@@ -45,38 +50,7 @@ _CONTROLS_MAC = """\
   <button class="qd-dot qd-dot--maximize" title="Fullscreen" onclick="pywebview.api.maximize()"></button>
 </div>"""
 
-_CONTROLS_WIN = """\
-<style>
-  .qd-winbtns {
-    position: fixed;
-    top: 0;
-    right: 0;
-    display: flex;
-    z-index: 99999;
-  }
-  .qd-winbtn {
-    width: 46px; height: 32px;
-    border: none;
-    background: transparent;
-    color: var(--color-text-muted, #888);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 13px;
-    transition: background 0.1s;
-  }
-  .qd-winbtn:hover { background: var(--color-surface-alt, rgba(255,255,255,0.1)); }
-  .qd-winbtn--close:hover { background: #e81123; color: #fff; }
-  body { padding-top: 32px !important; }
-</style>
-<div class="qd-winbtns">
-  <button class="qd-winbtn" title="Minimize" onclick="pywebview.api.minimize()">&#x2013;</button>
-  <button class="qd-winbtn" title="Maximize" onclick="pywebview.api.maximize()">&#x2610;</button>
-  <button class="qd-winbtn qd-winbtn--close" title="Close" onclick="pywebview.api.close()">&#x2715;</button>
-</div>"""
-
-_CONTROLS_HTML = _CONTROLS_WIN if sys.platform == "win32" else _CONTROLS_MAC
+_CONTROLS_HTML = "" if sys.platform == "win32" else _CONTROLS_MAC
 
 _CONTROLS_JS = """\
 (function() {

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -508,6 +508,35 @@ def _install_about_panel_override() -> None:
         print(f"[quodeq-about] NSTimer schedule failed: {exc}", file=_diag, flush=True)
 
 
+def _enable_windows_dark_titlebar(window_title: str) -> None:
+    """Tell DWM to render the native Windows titlebar in dark mode.
+
+    Without this, frameless=False shows a light titlebar that clashes with
+    the dark UI. Uses DWMWA_USE_IMMERSIVE_DARK_MODE — attribute id 20 on
+    Windows 10 build 19041+ and Windows 11, falling back to id 19 on older
+    builds. Failures are non-fatal: a light titlebar is ugly but functional.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        from ctypes import wintypes
+        hwnd = ctypes.windll.user32.FindWindowW(None, window_title)
+        if not hwnd:
+            return
+        value = ctypes.c_int(1)
+        size = ctypes.sizeof(value)
+        for attr in (20, 19):
+            res = ctypes.windll.dwmapi.DwmSetWindowAttribute(
+                wintypes.HWND(hwnd), wintypes.DWORD(attr),
+                ctypes.byref(value), wintypes.DWORD(size),
+            )
+            if res == 0:
+                return
+    except (AttributeError, OSError):
+        pass
+
+
 def _set_app_icon() -> None:
     """Set the application icon (dock on macOS, taskbar on Windows)."""
     if sys.platform == "darwin":
@@ -538,11 +567,17 @@ def main() -> None:
     instance = InstanceController(sock_path)
     api = _WindowApi()
 
+    # Windows uses native chrome so users get the conventional top-right
+    # min/max/close, Snap layouts and Alt+Space. macOS and Linux stay
+    # frameless and rely on the Mac-style traffic-light dots injected by
+    # _webview_html.INJECT_JS.
+    #
     # easy_drag intercepts pointer events on any non-interactive element to
     # move the window — that breaks our resize splitter (a <div>, not a
     # <button>). Disable it and let the topbar opt-in via -webkit-app-region.
+    _frameless = sys.platform != "win32"
     window = webview.create_window("quodeq", url, width=_WINDOW_WIDTH, height=_WINDOW_HEIGHT,
-                                    frameless=True, easy_drag=False,
+                                    frameless=_frameless, easy_drag=False,
                                     background_color=_WINDOW_BG_COLOR, hidden=True,
                                     js_api=api)
     api.bind(window, api_pid=api_pid, instance=instance, base_url=url)
@@ -560,6 +595,8 @@ def main() -> None:
         # targets the pre-pywebview NSApp and gets overridden.
         if sys.platform == "darwin":
             _set_macos_app_identity()
+        elif sys.platform == "win32":
+            _enable_windows_dark_titlebar("quodeq")
 
     def _on_closing() -> bool:
         """Intercept native close (Cmd+Q, red button, window manager).


### PR DESCRIPTION
## Summary
- **Windows** switches to native chrome (`frameless=False`). Users get the conventional top-right min/max/close, Snap layouts, Alt+Space, taskbar peek and accessibility tooling for free. The titlebar is rendered in dark mode via `DwmSetWindowAttribute(DWMWA_USE_IMMERSIVE_DARK_MODE)` — attribute 20 on Win 10 19041+ / Win 11, 19 as fallback. Failures are non-fatal.
- **macOS and Linux** keep `frameless=True` with the same Mac-style traffic-light dots on the left. Linux previously fell through to the Mac branch silently; now the unification is explicit.
- **Removes** the right-side `_CONTROLS_WIN` HTML strip that collided with the top-right Re-evaluate toggles introduced in #401.

## Why
The injected Windows controls sat at `top:0; right:0` and overlapped any topbar action that lives on the right. Putting Mac-style dots on the left for Windows would solve the collision but place the close button somewhere Windows users don't expect. Letting the OS draw chrome avoids both problems and gives Windows users a more idiomatic experience.

## Test plan
- [x] macOS: dashboard window opens frameless, traffic-light dots on the left, Cmd+Q + close-button still trigger the running-scan dialog.
- [x] Linux (GTK + WebKit2GTK): same as macOS — frameless, Mac-style dots on the left, Re-evaluate toggles visible top-right with no overlap.
- [x] Windows: dashboard window opens with a native dark titlebar, top-right min/max/close work, no white flash on first paint, drag from titlebar moves the window, Snap layouts work on the maximize hover, in-flight scan dialog still fires when closing via the native X.
- [x] No regressions in `pytest` (`2642 passed` locally).