### PR TITLE
ui: sidebar reorder, project card polish, dark grade contrast

### DIFF
--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -146,6 +146,9 @@ export default function Sidebar({
 
         <nav className="sidebar-nav sidebar-block">
           <NavButton id="evaluate" label="evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={handleNav} />
+        </nav>
+
+        <nav className="sidebar-nav sidebar-block">
           <NavButton
             id="projects"
             label={repoName || 'project'}

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -135,16 +135,6 @@ export default function Sidebar({
           {version && <span className="sidebar-version">v{version}</span>}
         </div>
 
-      <nav className="sidebar-nav sidebar-block">
-        <NavButton
-          id="projects"
-          label={repoName || 'project'}
-          icon={ICON_FOLDER}
-          activeTab={activeTab}
-          onNavTab={handleNav}
-        />
-      </nav>
-
         {showProjectTabs && (
           <nav className="sidebar-nav sidebar-block">
             <NavButton id="overview"   label="overview"   icon={ICON_OVERVIEW}   activeTab={activeTab} onNavTab={handleNav} />
@@ -156,6 +146,13 @@ export default function Sidebar({
 
         <nav className="sidebar-nav sidebar-block">
           <NavButton id="evaluate" label="evaluate" icon={ICON_EVALUATE} activeTab={activeTab} onNavTab={handleNav} />
+          <NavButton
+            id="projects"
+            label={repoName || 'project'}
+            icon={ICON_FOLDER}
+            activeTab={activeTab}
+            onNavTab={handleNav}
+          />
         </nav>
 
         <div className="sidebar-spacer" />

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -271,12 +271,12 @@ function EmptyProjectsCTA({ onAddProject, isEvaluating }) {
       </p>
       <button
         type="button"
-        className={`projects-empty__cta-btn${isEvaluating ? ' is-disabled' : ''}`}
+        className={`term-btn term-btn--primary term-btn--filled projects-empty__cta-btn${isEvaluating ? ' is-disabled' : ''}`}
         onClick={onAddProject}
         aria-disabled={isEvaluating || undefined}
         title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
       >
-        + Add project
+        <span aria-hidden="true">▸</span> add project
       </button>
     </div>
   );
@@ -298,13 +298,13 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
         {projects.length > 0 && onAddProject && (
           <button
             type="button"
-            className={`projects-page__add-btn${isEvaluating ? ' is-disabled' : ''}`}
+            className={`term-btn term-btn--primary term-btn--filled projects-page__add-btn${isEvaluating ? ' is-disabled' : ''}`}
             onClick={onAddProject}
             aria-label="Add project"
             aria-disabled={isEvaluating || undefined}
             title={isEvaluating ? EVAL_BLOCKED_TITLE : undefined}
           >
-            + Add project
+            <span aria-hidden="true">▸</span> add project
           </button>
         )}
       </div>

--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -185,7 +185,7 @@ function CardFooter({ name, confirming, setConfirming, onDelete, onExport }) {
   );
 }
 
-function ProjectPathContent({ id, p, relocateActions }) {
+function ProjectPathContent({ id, p, relocateActions, subprojectCount = 0 }) {
   const { relocating, relocatePath, setRelocatePath, submitRelocate, setRelocating, startRelocate } = relocateActions;
   const path = formatPath(p.path);
   const pathMissing = p.location === 'local' && p.pathExists === false;
@@ -210,6 +210,11 @@ function ProjectPathContent({ id, p, relocateActions }) {
       )}
       {pathMissing && (
         <button type="button" className="project-path-action project-path-action--warn" onClick={(e) => { e.stopPropagation(); startRelocate(id, p.path); }}>Relocate</button>
+      )}
+      {subprojectCount > 0 && (
+        <span className="project-subprojects-tag">
+          subprojects <span className="project-subprojects-tag-count">{subprojectCount}</span>
+        </span>
       )}
     </div>
   );
@@ -241,8 +246,7 @@ function ProjectCardGroup({ p, children: childProjects, selectedProject, onSelec
   return (
     <div key={id} className={`project-card-group${childSelected && !isSelected ? ' project-card--child-selected' : ''}`}>
       <ProjectCard project={p} isSelected={isSelected} cardProps={{ onSelect, onResumeSetup, footer: <CardFooter name={id} confirming={confirming} setConfirming={setConfirming} onDelete={onDelete} onExport={onExport} /> }}>
-        <ProjectPathContent id={id} p={p} relocateActions={relocateActions} />
-        {hasChildren && (() => { const childCount = childProjects[id].length; return <span className="parent-summary">{childCount} sub-project{childCount !== 1 ? 's' : ''}</span>; })()}
+        <ProjectPathContent id={id} p={p} relocateActions={relocateActions} subprojectCount={hasChildren ? childProjects[id].length : 0} />
       </ProjectCard>
       {hasChildren && <ProjectChildren childList={childProjects[id]} selectedProject={selectedProject} onSelect={onSelect} confirmActions={confirmActions} onResumeSetup={onResumeSetup} />}
     </div>

--- a/src/quodeq/ui/src/features/onboarding/components/steps/ProviderStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/ProviderStep.jsx
@@ -109,8 +109,8 @@ export default function ProviderStep({ state, actions, onContinue, onBack, stepI
       </div>
 
       <div className="onboarding-step__actions">
-        <button type="button" className="term-btn--primary" disabled={continueDisabled} onClick={handleContinue}>continue</button>
-        <button type="button" className="term-btn--secondary" onClick={onBack}>back</button>
+        <button type="button" className="term-btn term-btn--primary term-btn--filled" disabled={continueDisabled} onClick={handleContinue}>continue</button>
+        <button type="button" className="term-btn term-btn--secondary" onClick={onBack}>back</button>
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -123,10 +123,10 @@ export default function RepoScanStep({ state, actions, createProject, getProject
 
       <div className="onboarding-step__actions">
         {sub === 'idle' && (
-          <button type="button" className="term-btn--primary" onClick={handleSubmit} disabled={!state.repo.value}>scan repository</button>
+          <button type="button" className="term-btn term-btn--primary term-btn--filled" onClick={handleSubmit} disabled={!state.repo.value}>scan repository</button>
         )}
         {sub === 'scanned' && (
-          <button type="button" className="term-btn--primary" onClick={onContinue}>continue</button>
+          <button type="button" className="term-btn term-btn--primary term-btn--filled" onClick={onContinue}>continue</button>
         )}
       </div>
 

--- a/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/StandardLaunchStep.jsx
@@ -61,13 +61,13 @@ export default function StandardLaunchStep({ state, actions, standards, onLaunch
       <div className="onboarding-step__actions">
         <button
           type="button"
-          className="term-btn--primary"
+          className="term-btn term-btn--primary term-btn--filled"
           disabled={selectedIds.length === 0}
           onClick={() => onLaunch(selectedIds)}
         >
           start evaluation
         </button>
-        <button type="button" className="term-btn--secondary" onClick={onBack}>back</button>
+        <button type="button" className="term-btn term-btn--secondary" onClick={onBack}>back</button>
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/features/onboarding/components/steps/WelcomeStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/WelcomeStep.jsx
@@ -25,8 +25,8 @@ export default function WelcomeStep({ onStart, onSkip }) {
         ))}
       </ul>
       <div className="onboarding-welcome__actions">
-        <button type="button" className="term-btn--primary" onClick={onStart}>get started</button>
-        <button type="button" className="term-btn--secondary" onClick={onSkip}>maybe later</button>
+        <button type="button" className="term-btn term-btn--primary term-btn--filled" onClick={onStart}>get started</button>
+        <button type="button" className="term-btn term-btn--secondary" onClick={onSkip}>maybe later</button>
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2335,20 +2335,34 @@
   padding: 0;
   overflow: hidden;
   cursor: default;
-  transition: border-color 140ms ease, box-shadow 140ms ease;
+  position: relative;
+  transition: border-color 140ms ease;
 }
 
+/* Selected state: a 3 px accent rail on the left edge instead of a
+   full-perimeter glow. Lighter, terminal-flavoured, and doesn't shift
+   layout. */
 .project-card--selected {
-  border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-accent) 20%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+}
+
+.project-card--selected::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--color-accent);
+  border-radius: var(--radius-md, 6px) 0 0 var(--radius-md, 6px);
 }
 
 .project-card--child-selected {
-  border-color: color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+  border-color: color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
 }
 
 .project-card-main {
-  padding: var(--space-5);
+  padding: var(--space-4) var(--space-5);
   cursor: pointer;
   transition: background 120ms ease;
 }
@@ -2396,8 +2410,16 @@
 .project-card-bottom {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+}
+
+/* The path row is rendered as a child of `.project-card-bottom` (via
+   `cardChildren` in the JSX). Letting it claim the next line keeps it
+   visually anchored to the language stats above instead of floating
+   far-right with a wide gap on roomy screens. */
+.project-card-bottom > .project-path-row {
+  flex-basis: 100%;
 }
 
 .project-lang-row {
@@ -2452,7 +2474,6 @@
 }
 
 .project-card-path {
-  margin-top: var(--space-2);
   font-size: var(--text-xs);
   font-family: var(--font-data);
   color: var(--color-text-muted);
@@ -2460,6 +2481,8 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 /* ── Grade chip ── */
@@ -2561,6 +2584,7 @@
   gap: var(--space-2);
   padding: var(--space-1) 0 var(--space-1);
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .project-path-row .detail-copy-btn {
@@ -2702,7 +2726,9 @@
   background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
 }
 
-/* ── Project card footer / delete ── */
+/* ── Project card footer / delete ──
+   Hover-revealed on desktop, always-visible on touch (no hover), and
+   pinned visible while a delete-confirm prompt is showing. */
 
 .project-card-footer {
   display: flex;
@@ -2710,6 +2736,23 @@
   align-items: center;
   padding: var(--space-2) var(--space-4);
   border-top: 1px solid var(--color-border);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease;
+}
+
+.project-card:hover .project-card-footer,
+.project-card:focus-within .project-card-footer,
+.project-card:has(.project-delete-btn--confirm) .project-card-footer {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (hover: none) {
+  .project-card-footer {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 .project-card-actions {

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2617,34 +2617,40 @@
   padding: var(--space-6);
 }
 
-/* ── Projects page header (with "+ Add project" button) ── */
+/* ── Projects page header (with "+ Add project" button) ──
+   Visual styling for the button itself comes from `.term-btn--filled`
+   (composed in JSX). The rules below only handle layout: keep the
+   header in two columns when there's room, drop the CTA below the
+   title at narrow widths, and stretch it to full width on mobile. */
 
 .projects-page__header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--space-4);
+  flex-wrap: wrap;
+  gap: var(--space-3);
   margin-bottom: var(--space-4);
 }
 
 .projects-page__add-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: var(--space-2) var(--space-4);
-  background: var(--color-accent);
-  color: var(--color-bg);
-  border: none;
-  border-radius: var(--radius-md, 6px);
-  font-size: var(--text-sm);
-  font-weight: 500;
-  cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.1s;
+  margin-left: auto;
 }
 
-.projects-page__add-btn:hover {
-  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
+/* Disabled (evaluation in progress) — `aria-disabled` keeps the click
+   firing so a snackbar can explain the block, so we can't rely on
+   the native :disabled selector. */
+.term-btn--filled[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .projects-page__add-btn {
+    margin-left: 0;
+    width: 100%;
+    justify-content: center;
+  }
 }
 
 /* ── Empty-projects centered CTA ── */
@@ -2672,21 +2678,9 @@
   color: var(--color-text-muted);
 }
 
+/* Small layout-only adjustments on top of the term-btn--filled visual. */
 .projects-empty__cta-btn {
   margin-top: var(--space-3);
-  padding: var(--space-3) var(--space-6);
-  background: var(--color-accent);
-  color: var(--color-bg);
-  border: none;
-  border-radius: var(--radius-md, 6px);
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.1s;
-}
-
-.projects-empty__cta-btn:hover {
-  background: color-mix(in srgb, var(--color-accent) 80%, var(--color-text));
 }
 
 /* ── Global empty-state CTA (used on overview/violations/map when no projects) ── */

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2576,6 +2576,29 @@
   color: var(--color-text-muted);
 }
 
+.project-subprojects-tag {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.65rem;
+  font-weight: var(--weight-medium);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.project-subprojects-tag-count {
+  color: var(--color-text);
+  font-weight: var(--weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
 /* ── Path row (warning / copy / relocate) ── */
 
 .project-path-row {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -46,7 +46,7 @@
 
 .eval-provider-model {
   font-family: monospace;
-  font-size: 0.72rem;
+  font-size: 0.62rem;
 }
 
 /* Clickable variant — used on the Evaluate page header to navigate to settings. */

--- a/src/quodeq/ui/src/styles/onboarding.css
+++ b/src/quodeq/ui/src/styles/onboarding.css
@@ -80,6 +80,17 @@
   margin-top: var(--term-space-3);
   flex-wrap: wrap;
 }
+/* Wizard CTA rows: on narrow viewports the buttons grow to fill the
+   row so longer labels (e.g. "scan repository", "start evaluation")
+   stay legible and the primary action is comfortably tappable. */
+@media (max-width: 600px) {
+  .onboarding-step__actions > .term-btn--primary,
+  .onboarding-step__actions > .term-btn--secondary,
+  .onboarding-step__actions > .term-btn--ghost {
+    flex: 1 1 140px;
+    min-width: 0;
+  }
+}
 
 /* ──────────────────────────────────────────────────────────────
    Welcome step
@@ -130,8 +141,16 @@
 }
 .onboarding-welcome__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--term-space-2);
   margin-top: var(--term-space-2);
+}
+@media (max-width: 600px) {
+  .onboarding-welcome__actions > .term-btn--primary,
+  .onboarding-welcome__actions > .term-btn--secondary {
+    flex: 1 1 140px;
+    min-width: 0;
+  }
 }
 
 /* ──────────────────────────────────────────────────────────────

--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -485,12 +485,12 @@ html[data-theme="dark"]:root, [data-theme="dark"] {
   --color-grade-top-bg:      color-mix(in srgb, var(--primitive-flynn-accent) 12%, transparent);
   --color-grade-high-text:   #8aafcc;
   --color-grade-high-bg:     color-mix(in srgb, #8aafcc 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-300);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-300) 12%, transparent);
+  --color-grade-mid-text:    #ff8a8a;
+  --color-grade-mid-bg:      color-mix(in srgb, #ff8a8a 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-400);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-400) 13%, transparent);
-  --color-grade-bottom-text: var(--primitive-crimson-200);
-  --color-grade-bottom-bg:   color-mix(in srgb, var(--primitive-crimson-200) 4%, transparent);
+  --color-grade-bottom-text: #e6182a;
+  --color-grade-bottom-bg:   color-mix(in srgb, #e6182a 12%, transparent);
 
   --color-warning:      var(--primitive-amber-400);
   --color-warning-text: var(--primitive-amber-400);


### PR DESCRIPTION
## Summary
- Onboarding wizard CTAs and add-project use the filled-accent term-btn variant for stronger affordance.
- Project cards get left-rail / hover-footer / path-reflow polish in dashboard.css.
- Sidebar reordered: overview/violations/map/history first, then evaluate, then a separated project block; the existing \`.sidebar-block + .sidebar-block\` rule draws a divider between evaluate and project.
- Projects page now renders sub-project count as a small right-aligned \"subprojects N\" tag inside the project path row instead of a separate parent-summary line.
- Evaluate header provider badge: model identifier shrinks 0.72rem → 0.62rem so the cli-style code reads as secondary next to the provider name.
- Daruma-dark grade colors: Adequate/Poor/Critical were three near-identical reds. Widened the spread to a brightness ramp — Adequate \`#ff8a8a\`, Poor \`#f55050\` (unchanged), Critical \`#e6182a\` — same warm family, readable in dense bubble layouts.

## Test plan
- [x] Sidebar: verify divider line shows between \`evaluate\` and \`project\` (only when sidebar expanded).
- [x] Projects page with a multi-package repo: \`subprojects N\` tag is right-aligned inside the path row.
- [x] Evaluate page header: provider badge model code is visibly smaller than provider name.
- [x] Map page on daruma-dark: Adequate / Poor / Critical bubbles are distinguishable; Critical reads as the most intense red.
- [x] Onboarding wizard primary buttons render with filled accent on each step.
- [x] No regressions in light theme grade colors (only dark theme grade tokens changed).