### PR TITLE
fix(openrouter): make Test button work + settings input polish

### DIFF
--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -1,6 +1,8 @@
 """API routes for LLM bridge — provider status, models, testing."""
 from __future__ import annotations
 
+import os
+
 from flask import Flask, Response, jsonify, request
 
 from quodeq.llm_bridge import (
@@ -47,18 +49,52 @@ def register_llm_bridge_routes(app: Flask) -> None:
     @app.post("/api/provider/test")
     def provider_test() -> Response:
         data = request.get_json() or {}
-        api_base = data.get("api_base", "")
+        configs = get_provider_configs()
+        provider_id = data.get("provider", "")
+        provider_cfg = configs.get(provider_id, {}) if provider_id else {}
+
+        api_base = data.get("api_base") or provider_cfg.get("api_base", "")
+        api_key = data.get("api_key", "")
+        api_key_env = provider_cfg.get("api_key_env", "")
+        if not api_key:
+            # Resolve env var via provider id when given, else by api_base
+            # match so old clients (without `provider`) still work.
+            if not api_key_env and api_base:
+                for cfg in configs.values():
+                    if cfg.get("api_base") == api_base and cfg.get("api_key_env"):
+                        api_key_env = cfg["api_key_env"]
+                        break
+            if api_key_env:
+                api_key = os.environ.get(api_key_env, "")
+
         if api_base:
             try:
                 validate_url_safe(api_base, allow_private=True)
             except ValueError as exc:
                 return jsonify({"error": str(exc), "code": "INVALID_URL"}), 400
+        if not api_key and api_key_env:
+            return jsonify({
+                "success": False,
+                "error": f"{api_key_env} is not set in the dashboard's environment. "
+                         f"Export it in your shell (e.g. ~/.zshrc) and relaunch the dashboard from that terminal.",
+            })
         result = check_cloud_connection(
             api_base=api_base,
             model=data.get("model", ""),
-            api_key=data.get("api_key", ""),
+            api_key=api_key,
         )
         return jsonify(result)
+
+    @app.get("/api/provider/env-check")
+    def provider_env_check() -> Response:
+        """Report which provider api-key env vars are visible to this process."""
+        configs = get_provider_configs()
+        seen: dict[str, bool] = {}
+        for pid, cfg in configs.items():
+            env_name = cfg.get("api_key_env", "")
+            if env_name:
+                seen[pid] = bool(os.environ.get(env_name, "").strip())
+        return jsonify(seen)
 
     @app.get("/api/known-models")
     def known_models() -> Response:

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -56,8 +56,10 @@
   "openrouter": {
     "type": "api",
     "order": 4,
-    "model": "anthropic/claude-sonnet-4",
-    "api_key_env": "OPENROUTER_API_KEY"
+    "model": "baidu/cobuddy:free",
+    "api_base": "https://openrouter.ai/api/v1",
+    "api_key_env": "OPENROUTER_API_KEY",
+    "browse_url": "https://openrouter.ai/models"
   },
   "custom": {
     "type": "api",

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -248,10 +248,10 @@ export function testOllamaConcurrency(model) {
 }
 
 /** @returns {Promise<Object>} Connection test result for the provider */
-export function testProviderConnection({ apiBase, model, apiKey }) {
+export function testProviderConnection({ provider, apiBase, model, apiKey }) {
   return request('/provider/test', {
     method: 'POST',
-    body: JSON.stringify({ api_base: apiBase, model, api_key: apiKey }),
+    body: JSON.stringify({ provider, api_base: apiBase, model, api_key: apiKey }),
   });
 }
 

--- a/src/quodeq/ui/src/components/terminal/TermInput.jsx
+++ b/src/quodeq/ui/src/components/terminal/TermInput.jsx
@@ -42,6 +42,8 @@ export default function TermInput({
         }}
         spellCheck={false}
         autoComplete="off"
+        autoCapitalize="off"
+        autoCorrect="off"
       />
     </div>
   );

--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.jsx
@@ -56,6 +56,10 @@ function ModelTextInput({ label, value, placeholder, onChange, required }) {
         placeholder={placeholder || 'Type model id'}
         onChange={(e) => onChange(e.target.value)}
         aria-label={label ? `${label} model` : 'Model'}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
       />
     </div>
   );

--- a/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx
@@ -35,6 +35,7 @@ export default function CloudProviderTab({ providerId, providerConfig, state, up
     setTesting(true);
     try {
       const result = await testProviderConnection({
+        provider: providerId,
         apiBase: providerConfig?.api_base || '',
         model: state.model,
         apiKey: '',
@@ -65,6 +66,10 @@ export default function CloudProviderTab({ providerId, providerConfig, state, up
             placeholder="Type model id"
             onChange={(e) => update('model', e.target.value)}
             aria-label="Model identifier"
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
           />
           <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !state.model}>
             {testing ? 'Testing...' : 'Test'}

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
@@ -91,6 +91,10 @@ function ModelOverrideInput({ label, value, setter, level, placeholder }) {
         value={value}
         placeholder={placeholder}
         onChange={(e) => handleModelChange(level, e.target.value, setter)}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+        spellCheck={false}
       />
     </div>
   );
@@ -116,6 +120,10 @@ function ModelSettings({ aiCmd, models }) {
           placeholder="default"
           onChange={(e) => handleModelChange(null, e.target.value, onAiModelChange, AI_MODEL_STORAGE_KEY)}
           aria-label="Model override"
+          autoCapitalize="off"
+          autoCorrect="off"
+          autoComplete="off"
+          spellCheck={false}
         />
       </div>
       <div className="settings-row">

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -37,6 +37,9 @@ const INSTALL_INSTRUCTIONS = {
 
 const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit': String(DEFAULT_TIME_LIMIT_S) };
 const OLLAMA_DEFAULTS = { 'time-limit': '0' };
+const CLOUD_DEFAULTS_BY_ID = {
+  openrouter: { 'time-limit': String(DEFAULT_TIME_LIMIT_S), 'model': 'baidu/cobuddy:free' },
+};
 const DEFAULT_PROVIDER_ORDER = 50;
 
 const MIGRATION_DONE_KEY = 'cc-provider-tabs-migrated';
@@ -56,7 +59,7 @@ function TabContent({ provider, providerConfig }) {
     ? CLI_DEFAULTS
     : classification === 'local-api'
       ? OLLAMA_DEFAULTS
-      : undefined;
+      : CLOUD_DEFAULTS_BY_ID[provider.id];
   const { state, update } = useProviderSettings(provider.id, defaults);
 
   if (classification === 'local-api') {

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1479,6 +1479,19 @@ textarea:focus {
   line-height: 1.5;
 }
 
+.settings-description a,
+.settings-row a,
+.settings-install-hint a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.settings-description a:hover,
+.settings-row a:hover,
+.settings-install-hint a:hover {
+  text-decoration: underline;
+}
+
 /* ── Settings: terminal-aligned pill buttons ── */
 
 .settings-pill {


### PR DESCRIPTION
## Summary

OpenRouter was unusable from the dashboard: hitting **Test** in Settings → Openrouter returned `401 — No cookie auth credentials found` because the request reached OpenRouter without an `Authorization` header. The Test button was hard-coded to send `api_key: ''` and the bundled provider config had no `api_base`, so even users with `OPENROUTER_API_KEY` exported in their shell couldn't verify the connection.

- **Backend** ([`llm_bridge_routes.py`](src/quodeq/api/llm_bridge_routes.py)): `/api/provider/test` now falls back to `os.environ[provider.api_key_env]` when the body's `api_key` is empty. The provider is resolved from the new `provider` field, or by matching `api_base` so older clients keep working. When the env var is unset we return a clear error instead of letting the upstream 401 leak through.
- **Diagnostics** ([`llm_bridge_routes.py`](src/quodeq/api/llm_bridge_routes.py)): new `GET /api/provider/env-check` reports which provider api-key env vars the dashboard process can see (booleans only, no values).
- **Config** ([`ai_providers.json`](src/quodeq/data/config/ai_providers.json)): add `api_base: https://openrouter.ai/api/v1`, `browse_url`, and switch the default model to `baidu/cobuddy:free`.
- **Client** ([`api/index.js`](src/quodeq/ui/src/api/index.js), [`CloudProviderTab.jsx`](src/quodeq/ui/src/features/settings/components/CloudProviderTab.jsx)): `testProviderConnection` and the Test button now send `provider: providerId`.
- **Settings polish**: disable `autoCapitalize` / `autoCorrect` / `autoComplete` / `spellCheck` on model-id inputs (they behave like terminal fields, not prose), link styling in settings rows, and a default `time-limit` for the openrouter cloud tab.

## Test plan

- [x] `export OPENROUTER_API_KEY=...` in shell, launch `quodeq dashboard`, open Settings → Openrouter, click Test → expect `Connected (Xms)`.
- [x] Same flow without exporting the key → expect a clear error mentioning `OPENROUTER_API_KEY` (no upstream 401 leak).
- [x] `curl http://127.0.0.1:7863/api/provider/env-check` → `{"openrouter": true/false, "custom": ...}`.
- [x] Hit `/api/provider/test` with the old body shape (no `provider`, only `api_base`) and confirm the env-var fallback still kicks in via api_base match.
- [x] Run an actual evaluation against OpenRouter end-to-end.