### PR TITLE
test(ui): refresh stale CliProviderTab/OllamaTab vitest mocks

### DIFF
--- a/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/CliProviderTab.test.jsx
@@ -1,13 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
 import CliProviderTab from './CliProviderTab.jsx';
 
-const fakeApi = {
-  getKnownModels: vi.fn(),
-};
+const fakeApi = {};
 
 function makeWrapper() {
   const QueryWrapper = withQueryClient();
@@ -21,29 +19,16 @@ function makeWrapper() {
 }
 
 describe('CliProviderTab', () => {
-  beforeEach(() => {
-    fakeApi.getKnownModels.mockReset();
-  });
-
-  it('fetches known models for the active provider on mount', async () => {
-    fakeApi.getKnownModels.mockResolvedValue({
-      'cli-foo': [{ id: 'm1', label: 'M1', tier: 'fast' }],
-    });
+  it('renders a free-text model input pre-populated from state', () => {
     const Wrapper = makeWrapper();
-    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
-    const update = vi.fn();
+    const state = { model: 'sonnet', subagents: '4', 'time-limit-min': '60' };
     const { container } = render(
       <Wrapper>
-        <CliProviderTab providerId="cli-foo" state={state} update={update} />
+        <CliProviderTab providerId="claude" state={state} update={() => {}} />
       </Wrapper>,
     );
-    await waitFor(() => {
-      expect(fakeApi.getKnownModels).toHaveBeenCalled();
-    });
-    // datalist is populated with M1 (option value="m1")
-    await waitFor(() => {
-      const datalists = container.querySelectorAll('datalist option');
-      expect([...datalists].some((opt) => opt.value === 'm1')).toBe(true);
-    });
+    const input = container.querySelector('input.settings-model-input[type="text"]');
+    expect(input).toBeTruthy();
+    expect(input.value).toBe('sonnet');
   });
 });

--- a/src/quodeq/ui/src/features/settings/components/OllamaTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OllamaTab.test.jsx
@@ -62,6 +62,6 @@ describe('OllamaTab', () => {
         <OllamaTab state={state} update={vi.fn()} />
       </Wrapper>,
     );
-    expect(await findByText(/Failed to load Ollama models/i)).toBeTruthy();
+    expect(await findByText(/couldn(?:'|’)t load your Ollama models/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- `CliProviderTab.test.jsx` was asserting that `getKnownModels` is fetched on mount; the component switched to a free-text model input and no longer calls it. Test rewritten to match current behavior (renders a text input pre-populated from state).
- `OllamaTab.test.jsx` was matching the old error string `Failed to load Ollama models`; current copy is `We couldn't load your Ollama models...`. Regex updated to match either smart or straight apostrophe.
- These slipped because [.github/workflows/test.yml](.github/workflows/test.yml) only runs pytest, never vitest. Worth a follow-up to wire vitest into CI.

## Test plan
- [x] `npx vitest run` from `src/quodeq/ui/` — 54 files, 279 tests passing
- [x] No source changes; only test files touched

Pre-flight for v1.0.9 release.