### PR TITLE
fix(windows): parse pyproject version in PowerShell, not via python -c

### DIFF
--- a/packaging/windows/build-exe.ps1
+++ b/packaging/windows/build-exe.ps1
@@ -9,8 +9,16 @@ $RepoRoot = (Resolve-Path "$ScriptDir\..\..").Path
 $BuildDir = "$RepoRoot\dist\dashboard-build"
 $DistDir = "$RepoRoot\dist"
 
-# Extract version
-$Version = python -c "import re; print(re.search(r'version = \`"(.+?)\`"', open('$RepoRoot\pyproject.toml').read()).group(1))"
+# Extract version. Parse in PowerShell rather than shelling to Python:
+# embedding $RepoRoot in a Python string literal triggers escape-sequence
+# decoding (e.g. D:\a -> \x07 / bell), so the path reaches open() corrupted.
+$pyprojectText = Get-Content "$RepoRoot\pyproject.toml" -Raw
+if ($pyprojectText -match 'version = "(.+?)"') {
+    $Version = $Matches[1]
+} else {
+    Write-Error "ERROR: could not extract version from pyproject.toml"
+    exit 1
+}
 Write-Host "Building Quodeq v$Version..."
 
 # Clean build dir


### PR DESCRIPTION
## Why
The v1.0.9 Build Desktop Apps workflow failed on the Windows EXE job with:

\`\`\`
OSError: [Errno 22] Invalid argument: 'D:\x07\\quodeq\\quodeq\\pyproject.toml'
\`\`\`

[packaging/windows/build-exe.ps1:13](packaging/windows/build-exe.ps1#L13) embedded \`\$RepoRoot\` directly inside a Python string literal:

\`\`\`powershell
python -c "...open('\$RepoRoot\pyproject.toml')..."
\`\`\`

On GHA Windows runners \`\$RepoRoot\` is \`D:\a\quodeq\quodeq\`. Python interprets \`\a\` in a non-raw literal as \`\x07\` (bell), corrupting the path before \`open()\` sees it. This was added in #404 and would have failed on every future release.

## What
Read the file with \`Get-Content\` and extract the version with PowerShell's native regex. No Python invocation, no cross-language string interpolation.

## Test plan
- [x] Run the [Build Desktop Apps](.github/workflows/build-dmg.yml) workflow on a v1.0.10 release (or trigger manually) and confirm the Windows EXE/zip is produced.
- [x] Other targets (macOS DMGs) unchanged.