### PR TITLE
fix(api-pool): stop truncating shared evidence JSONL on empty batch

### DIFF
--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -270,7 +270,9 @@ def _gather_api_source_files(
         ]
         _log.debug("Took %d files from queue for API analysis", len(source_files))
         if not source_files:
-            jsonl_file.write_text("")
+            # Don't touch jsonl_file — it's the SHARED `{dim}_evidence.jsonl`
+            # that every agent in the pool appends to via MCP. Truncating it
+            # here wipes findings from every other agent in the pool.
             stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
             return None
         return source_files

--- a/tests/analysis/test_source_gathering.py
+++ b/tests/analysis/test_source_gathering.py
@@ -1,7 +1,13 @@
 """Tests for source file gathering — _gather_source_files and skip dirs from subprocess.py."""
 from __future__ import annotations
 
-from quodeq.analysis.subprocess import _gather_source_files, _SKIP_DIRS
+from quodeq.analysis._config import AnalysisConfig
+from quodeq.analysis.subagents.file_queue import FileQueue
+from quodeq.analysis.subprocess import (
+    _gather_api_source_files,
+    _gather_source_files,
+    _SKIP_DIRS,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +91,34 @@ class TestGatherSourceFiles:
 # ---------------------------------------------------------------------------
 # _SKIP_DIRS
 # ---------------------------------------------------------------------------
+
+class TestGatherApiSourceFiles:
+    """When no usable files come back from the queue, the shared per-dimension
+    JSONL must NOT be truncated — other agents in the same pool write to it via
+    MCP and would lose every finding accumulated so far.
+    """
+
+    def test_does_not_truncate_shared_jsonl_when_batch_yields_no_files(self, tmp_path):
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+        jsonl_file = evidence_dir / "security_evidence.jsonl"
+        existing = (
+            '{"t":"violation","p":"SEC-001","file":"a.py","line":10}\n'
+            '{"t":"compliance","p":"SEC-002","file":"b.py","line":20}\n'
+        )
+        jsonl_file.write_text(existing)
+
+        queue_path = evidence_dir / "queue.json"
+        FileQueue(queue_path, files=["missing1.py", "missing2.py", "missing3.py"])
+
+        stream_file = evidence_dir / "agent.stream"
+        cfg = AnalysisConfig(queue_path=queue_path, agent_id="agent-1")
+
+        result = _gather_api_source_files(tmp_path, cfg, jsonl_file, stream_file)
+
+        assert result is None
+        assert jsonl_file.read_text() == existing
+
 
 class TestLoadSkipDirs:
     def test_returns_frozenset(self):

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -239,11 +239,16 @@ class TestRunApiAnalysisBridge:
              pytest.raises(Exception, match="No API base URL configured"):
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
 
-    def test_empty_queue_writes_empty_files(self, tmp_path):
+    def test_empty_queue_writes_complete_marker_and_preserves_shared_jsonl(self, tmp_path):
+        """Empty queue: write the per-agent stream 'complete' marker, but
+        leave the SHARED `{dim}_evidence.jsonl` alone — other pool agents
+        append findings to it via MCP and would lose them otherwise.
+        """
         stream = tmp_path / "stream.json"
         jsonl = tmp_path / "evidence.jsonl"
+        # Pre-populate the shared JSONL with findings from other agents
+        jsonl.write_text('{"t":"violation","p":"X","file":"a.py","line":1}\n')
         queue_path = tmp_path / "queue.json"
-        # Create a queue that returns no files
         queue_path.write_text(json.dumps({"version": 1, "pending": [], "taken": [], "max_files_per_agent": 10}))
 
         cfg = AnalysisConfig(
@@ -255,8 +260,8 @@ class TestRunApiAnalysisBridge:
         with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
 
-        assert jsonl.read_text() == ""
         assert "complete" in stream.read_text()
+        assert jsonl.read_text() == '{"t":"violation","p":"X","file":"a.py","line":1}\n'
 
     def test_calls_run_api_analysis(self, tmp_path):
         stream = tmp_path / "stream.json"


### PR DESCRIPTION
## Summary

For API-mode providers (ollama, openrouter, custom), when a subagent took a batch from the file queue and every file was missing or exceeded `_MAX_API_FILE_SIZE` (15 KB default), `_gather_api_source_files` called `jsonl_file.write_text("")` to mark the run done. But all agents in a pool share the same `{dim}_evidence.jsonl` path — that write **wiped findings every other agent in the pool had appended via MCP**.

The symptom was a mid-scan reset of the heartbeat tally:

```
[security] 30m00s | 1 active (28 total) | 84 files taken (1056 left) | 54 findings | 18 violations · 36 compliance
[security] 31m51s | 1 active (30 total) | 90 files taken (1050 left) | 0 findings  | 0 violations  · 0 compliance
```

`files_taken` kept climbing (queue.take ran before the truncate), then findings rebuilt slowly as remaining agents kept appending. Findings never re-discovered are silently lost.

## Fix

Drop the `write_text("")` call in `_gather_api_source_files`. The per-agent stream "complete" marker on the next line is enough to signal an empty-batch exit; the shared JSONL stays untouched.

## Test plan

- [x] New regression test `TestGatherApiSourceFiles::test_does_not_truncate_shared_jsonl_when_batch_yields_no_files` — pre-populates the shared JSONL, sets up a queue with non-existent files, asserts the JSONL is unchanged after the call. Verified failing on the bug, passing after the fix.
- [x] Updated `test_empty_queue_writes_complete_marker_and_preserves_shared_jsonl` (was `test_empty_queue_writes_empty_files`) — the previous test had codified the buggy behavior with `assert jsonl.read_text() == ""`. Rewrote to assert the correct contract.
- [x] `pytest tests/analysis/` — 402/402 pass.

## Notes for release

This is the kind of bug that warrants a v1.0.10 patch right after merge — silent wrong scan results for ollama users.