### PR TITLE
Release v1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.10] - 2026-05-06
+
+### Fixes
+- **Ollama / API providers**: subagents no longer wipe the shared findings file mid-scan when a batch yields no usable source files (e.g., all skipped because they exceed the 15 KB API limit). Findings from other agents in the pool were being silently lost, surfacing as a scan-progress reset to "0 findings".
+- **Windows EXE build**: the release script no longer fails on GitHub Actions runners. PowerShell was interpolating `$RepoRoot` (e.g., `D:\a\quodeq\quodeq`) into a Python string literal where `\a` got decoded as a bell character, breaking path resolution. Version is now parsed with PowerShell's native regex.
+
 ## [1.0.9] - 2026-05-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.0.9</strong></p>
+<p align="center"><strong>v1.0.10</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.0.9" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.0.10" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/packaging/windows/build-exe.ps1
+++ b/packaging/windows/build-exe.ps1
@@ -9,8 +9,16 @@ $RepoRoot = (Resolve-Path "$ScriptDir\..\..").Path
 $BuildDir = "$RepoRoot\dist\dashboard-build"
 $DistDir = "$RepoRoot\dist"
 
-# Extract version
-$Version = python -c "import re; print(re.search(r'version = \`"(.+?)\`"', open('$RepoRoot\pyproject.toml').read()).group(1))"
+# Extract version. Parse in PowerShell rather than shelling to Python:
+# embedding $RepoRoot in a Python string literal triggers escape-sequence
+# decoding (e.g. D:\a -> \x07 / bell), so the path reaches open() corrupted.
+$pyprojectText = Get-Content "$RepoRoot\pyproject.toml" -Raw
+if ($pyprojectText -match 'version = "(.+?)"') {
+    $Version = $Matches[1]
+} else {
+    Write-Error "ERROR: could not extract version from pyproject.toml"
+    exit 1
+}
 Write-Host "Building Quodeq v$Version..."
 
 # Clean build dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.0.9"
+version = "1.0.10"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -270,7 +270,9 @@ def _gather_api_source_files(
         ]
         _log.debug("Took %d files from queue for API analysis", len(source_files))
         if not source_files:
-            jsonl_file.write_text("")
+            # Don't touch jsonl_file — it's the SHARED `{dim}_evidence.jsonl`
+            # that every agent in the pool appends to via MCP. Truncating it
+            # here wipes findings from every other agent in the pool.
             stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
             return None
         return source_files

--- a/tests/analysis/test_source_gathering.py
+++ b/tests/analysis/test_source_gathering.py
@@ -1,7 +1,13 @@
 """Tests for source file gathering — _gather_source_files and skip dirs from subprocess.py."""
 from __future__ import annotations
 
-from quodeq.analysis.subprocess import _gather_source_files, _SKIP_DIRS
+from quodeq.analysis._config import AnalysisConfig
+from quodeq.analysis.subagents.file_queue import FileQueue
+from quodeq.analysis.subprocess import (
+    _gather_api_source_files,
+    _gather_source_files,
+    _SKIP_DIRS,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +91,34 @@ class TestGatherSourceFiles:
 # ---------------------------------------------------------------------------
 # _SKIP_DIRS
 # ---------------------------------------------------------------------------
+
+class TestGatherApiSourceFiles:
+    """When no usable files come back from the queue, the shared per-dimension
+    JSONL must NOT be truncated — other agents in the same pool write to it via
+    MCP and would lose every finding accumulated so far.
+    """
+
+    def test_does_not_truncate_shared_jsonl_when_batch_yields_no_files(self, tmp_path):
+        evidence_dir = tmp_path / "evidence"
+        evidence_dir.mkdir()
+        jsonl_file = evidence_dir / "security_evidence.jsonl"
+        existing = (
+            '{"t":"violation","p":"SEC-001","file":"a.py","line":10}\n'
+            '{"t":"compliance","p":"SEC-002","file":"b.py","line":20}\n'
+        )
+        jsonl_file.write_text(existing)
+
+        queue_path = evidence_dir / "queue.json"
+        FileQueue(queue_path, files=["missing1.py", "missing2.py", "missing3.py"])
+
+        stream_file = evidence_dir / "agent.stream"
+        cfg = AnalysisConfig(queue_path=queue_path, agent_id="agent-1")
+
+        result = _gather_api_source_files(tmp_path, cfg, jsonl_file, stream_file)
+
+        assert result is None
+        assert jsonl_file.read_text() == existing
+
 
 class TestLoadSkipDirs:
     def test_returns_frozenset(self):

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -239,11 +239,16 @@ class TestRunApiAnalysisBridge:
              pytest.raises(Exception, match="No API base URL configured"):
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
 
-    def test_empty_queue_writes_empty_files(self, tmp_path):
+    def test_empty_queue_writes_complete_marker_and_preserves_shared_jsonl(self, tmp_path):
+        """Empty queue: write the per-agent stream 'complete' marker, but
+        leave the SHARED `{dim}_evidence.jsonl` alone — other pool agents
+        append findings to it via MCP and would lose them otherwise.
+        """
         stream = tmp_path / "stream.json"
         jsonl = tmp_path / "evidence.jsonl"
+        # Pre-populate the shared JSONL with findings from other agents
+        jsonl.write_text('{"t":"violation","p":"X","file":"a.py","line":1}\n')
         queue_path = tmp_path / "queue.json"
-        # Create a queue that returns no files
         queue_path.write_text(json.dumps({"version": 1, "pending": [], "taken": [], "max_files_per_agent": 10}))
 
         cfg = AnalysisConfig(
@@ -255,8 +260,8 @@ class TestRunApiAnalysisBridge:
         with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
 
-        assert jsonl.read_text() == ""
         assert "complete" in stream.read_text()
+        assert jsonl.read_text() == '{"t":"violation","p":"X","file":"a.py","line":1}\n'
 
     def test_calls_run_api_analysis(self, tmp_path):
         stream = tmp_path / "stream.json"

--- a/uv.lock
+++ b/uv.lock
@@ -1303,7 +1303,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Cuts v1.0.10. Patch release with two fixes:

- Ollama / API providers: subagents no longer wipe shared findings file on empty batch (silent data loss in mid-scan).
- Windows EXE build: PowerShell version parser no longer mis-decodes `\a` in `D:\a\quodeq\quodeq` paths on GitHub runners.

Full notes in CHANGELOG.md.