### PR TITLE
chore: sync develop with main after v1.0.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.10] - 2026-05-06
+
+### Fixes
+- **Ollama / API providers**: subagents no longer wipe the shared findings file mid-scan when a batch yields no usable source files (e.g., all skipped because they exceed the 15 KB API limit). Findings from other agents in the pool were being silently lost, surfacing as a scan-progress reset to "0 findings".
+- **Windows EXE build**: the release script no longer fails on GitHub Actions runners. PowerShell was interpolating `$RepoRoot` (e.g., `D:\a\quodeq\quodeq`) into a Python string literal where `\a` got decoded as a bell character, breaking path resolution. Version is now parsed with PowerShell's native regex.
+
 ## [1.0.9] - 2026-05-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.0.9</strong></p>
+<p align="center"><strong>v1.0.10</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.0.9" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.0.10" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.0.9"
+version = "1.0.10"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1303,7 +1303,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.0.9"
+version = "1.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Brings the version bump and CHANGELOG entry from main back into develop.