### PR TITLE
fix(jobs): watchdog respects user deadline_at instead of hardcoded 2h

### DIFF
--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -8,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import threading
+import time
 import uuid
 from typing import Any, Callable, Iterable
 
@@ -49,6 +50,14 @@ _PROCESS_WAIT_TIMEOUT_S = 30
 _EXIT_CODE_SPAWN_FAILURE = -1
 _EXIT_CODE_TIMEOUT = -9
 _DEFAULT_LIST_LIMIT = 100
+
+# Watchdog polls process state every N seconds and re-checks deadline_at,
+# which only lands in job state after the analyzing_start marker — so a
+# blocking wait(timeout=full_budget) at spawn time can't see it.
+_WATCHDOG_POLL_INTERVAL_S = 1.0
+# Grace window past deadline_at before SIGKILL — gives the analysis side's
+# graceful-cancel path time to score completed dimensions.
+_WATCHDOG_DEADLINE_GRACE_S = 60
 
 # Canonical job status strings.
 STATUS_RUNNING = "running"
@@ -368,18 +377,51 @@ class JobManager:
                 self._store.delete(jid)
 
     @property
-    def _job_timeout_s(self) -> int:
-        """Job timeout in seconds — reads from env at call time for lazy configuration."""
-        return int(os.environ.get("QUODEQ_JOB_TIMEOUT_S", "7200"))
+    def _job_timeout_cap_s(self) -> float:
+        """Hard sanity cap on job duration (seconds). 0 = no cap (default).
+
+        Was hard-coded to 7200 (2h), which silently SIGKILLed long Ollama
+        runs even when the user had configured a much longer ``--time-limit``.
+        Now opt-in: set ``QUODEQ_JOB_TIMEOUT_S`` to a positive number to
+        re-enable a wall-clock cap. Otherwise the watchdog only enforces
+        the user-set ``deadline_at`` (with a grace window).
+        """
+        return float(os.environ.get("QUODEQ_JOB_TIMEOUT_S", "0"))
+
+    def _watchdog_should_kill(self, job_id: str, started_at: float) -> bool:
+        """Return True when the watchdog should SIGKILL the job process now."""
+        now = time.time()
+        cap = self._job_timeout_cap_s
+        if cap > 0 and (now - started_at) > cap:
+            return True
+        job = self._store.get(job_id)
+        deadline_at = getattr(job, "deadline_at", None) if job else None
+        if not deadline_at:
+            return False
+        try:
+            deadline = datetime.fromisoformat(deadline_at).timestamp()
+        except (TypeError, ValueError):
+            return False
+        return now > deadline + _WATCHDOG_DEADLINE_GRACE_S
 
     def _monitor_process(self, job_id: str, process: subprocess.Popen) -> None:
-        try:
-            exit_code = process.wait(timeout=self._job_timeout_s)
-        except subprocess.TimeoutExpired:
-            _logger.warning("Job %s exceeded %ds timeout — killing", job_id, self._job_timeout_s)
-            process.kill()
-            process.wait(timeout=_PROCESS_WAIT_TIMEOUT_S)
-            exit_code = _EXIT_CODE_TIMEOUT
+        started_at = time.time()
+        exit_code: int = 0
+        while True:
+            try:
+                exit_code = process.wait(timeout=_WATCHDOG_POLL_INTERVAL_S)
+                break
+            except subprocess.TimeoutExpired:
+                if self._watchdog_should_kill(job_id, started_at):
+                    elapsed = int(time.time() - started_at)
+                    _logger.warning("Job %s watchdog killing after %ds", job_id, elapsed)
+                    process.kill()
+                    try:
+                        process.wait(timeout=_PROCESS_WAIT_TIMEOUT_S)
+                    except subprocess.TimeoutExpired:
+                        pass
+                    exit_code = _EXIT_CODE_TIMEOUT
+                    break
         with self._lock:
             self._processes.pop(job_id, None)
             job = self._store.get(job_id)

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -371,31 +371,125 @@ class TestMonitorProcess:
         mgr._monitor_process("j1", proc)  # should not raise
         assert job.status == STATUS_DONE
 
-    def test_timeout_kills_process(self):
+    def test_env_cap_kills_process(self, monkeypatch):
+        """When QUODEQ_JOB_TIMEOUT_S is set, the watchdog kills past that cap
+        even if no deadline_at was set on the job.
+        """
+        from quodeq.services import jobs as jobs_mod
+        monkeypatch.setenv("QUODEQ_JOB_TIMEOUT_S", "0.05")
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+
         store = InMemoryJobStore()
         mgr = JobManager(job_store=store)
-        mgr._JOB_TIMEOUT_S = 0.01  # very short timeout
-
         job = Job("j1", STATUS_RUNNING, ["cmd"], "now", None, None)
         store.put(job)
 
-        class SlowProcess:
-            pid = 123
-            stdout = io.StringIO("")
-
-            def wait(self, timeout=None):
-                if timeout is not None and timeout < 1:
-                    raise subprocess.TimeoutExpired(cmd="cmd", timeout=timeout)
-                return -9
-
-            def kill(self):
-                pass
-
-        proc = SlowProcess()
+        proc = _NeverExitsProcess()
         mgr._processes["j1"] = proc
         mgr._monitor_process("j1", proc)
+
+        assert proc.killed is True
         assert job.exit_code == _EXIT_CODE_TIMEOUT
         assert job.status == STATUS_FAILED
+
+    def test_no_cap_no_deadline_does_not_kill(self, monkeypatch):
+        """With no QUODEQ_JOB_TIMEOUT_S and no deadline_at, the watchdog must
+        never preemptively kill — the user did not opt into a time cap.
+        """
+        from quodeq.services import jobs as jobs_mod
+        monkeypatch.delenv("QUODEQ_JOB_TIMEOUT_S", raising=False)
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        job = Job("j1", STATUS_RUNNING, ["cmd"], "now", None, None)
+        store.put(job)
+
+        # Process exits cleanly after a few poll cycles.
+        proc = _ExitsAfter(returncode=0, exits_after_n_polls=3)
+        mgr._processes["j1"] = proc
+        mgr._monitor_process("j1", proc)
+
+        assert proc.killed is False
+        assert job.exit_code == 0
+        assert job.status == STATUS_DONE
+
+    def test_deadline_in_future_does_not_kill(self, monkeypatch):
+        """Job with deadline_at in the future is not killed by the watchdog."""
+        from datetime import datetime, timedelta, timezone
+        from quodeq.services import jobs as jobs_mod
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        job = Job("j1", STATUS_RUNNING, ["cmd"], "now", None, None, deadline_at=future)
+        store.put(job)
+
+        proc = _ExitsAfter(returncode=0, exits_after_n_polls=3)
+        mgr._processes["j1"] = proc
+        mgr._monitor_process("j1", proc)
+
+        assert proc.killed is False
+        assert job.status == STATUS_DONE
+
+    def test_deadline_past_plus_grace_kills(self, monkeypatch):
+        """Job whose deadline_at has passed (plus the grace window) is killed."""
+        from datetime import datetime, timedelta, timezone
+        from quodeq.services import jobs as jobs_mod
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_POLL_INTERVAL_S", 0.01)
+        monkeypatch.setattr(jobs_mod, "_WATCHDOG_DEADLINE_GRACE_S", 0.02)
+
+        store = InMemoryJobStore()
+        mgr = JobManager(job_store=store)
+        past = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+        job = Job("j1", STATUS_RUNNING, ["cmd"], "now", None, None, deadline_at=past)
+        store.put(job)
+
+        proc = _NeverExitsProcess()
+        mgr._processes["j1"] = proc
+        mgr._monitor_process("j1", proc)
+
+        assert proc.killed is True
+        assert job.exit_code == _EXIT_CODE_TIMEOUT
+        assert job.status == STATUS_FAILED
+
+
+class _NeverExitsProcess:
+    """Subprocess stub: every wait(timeout=...) raises TimeoutExpired until killed."""
+    pid = 123
+
+    def __init__(self):
+        self.stdout = io.StringIO("")
+        self.killed = False
+
+    def wait(self, timeout=None):
+        if self.killed:
+            return -9
+        raise subprocess.TimeoutExpired(cmd="cmd", timeout=timeout)
+
+    def kill(self):
+        self.killed = True
+
+
+class _ExitsAfter:
+    """Subprocess stub that raises TimeoutExpired N times, then returns cleanly."""
+    pid = 124
+
+    def __init__(self, returncode: int, exits_after_n_polls: int):
+        self.stdout = io.StringIO("")
+        self._returncode = returncode
+        self._remaining = exits_after_n_polls
+        self.killed = False
+
+    def wait(self, timeout=None):
+        if self._remaining <= 0:
+            return self._returncode
+        self._remaining -= 1
+        raise subprocess.TimeoutExpired(cmd="cmd", timeout=timeout)
+
+    def kill(self):
+        self.killed = True
 
 
 def test_list_jobs_warns_on_deprecated_reports_root_kwarg(tmp_path):


### PR DESCRIPTION
## Summary

The job-monitor watchdog in `services/jobs.py` was hardcoded to SIGKILL the analysis process at exactly 2h (`QUODEQ_JOB_TIMEOUT_S=7200`), regardless of whatever `--time-limit` the user had set. This silently capped every long-running scan, most painfully for **Ollama users** where one repository × six dimensions on a 26B model routinely needs 4-6 hours.

The 2h default was not a deliberate UX choice. Git blame: it was added in [PR #98](https://github.com/quodeq/quodeq/pull/98) ("resolve 24 reliability violations") to silence the codebase's own quality scanner, which flagged the absence of a `wait(timeout=...)` as a reliability issue. Then made env-configurable via `QUODEQ_JOB_TIMEOUT_S` in [PR #234](https://github.com/quodeq/quodeq/pull/234), but the default stuck.

It also could not respect `job.deadline_at` even if it tried, because `wait(timeout=N)` blocks at spawn time, while `deadline_at` only lands later via the `analyzing_start` marker (jobs.py:244).

## Symptom

User runs ollama scan, sees:
- Status: \`failed\` with \"Analysis failed\" message
- Elapsed: exactly **120:00**
- 4 of 6 dimensions ✓ (graceful-cancel scored what was done), 1 partial, 1 never started

Looks like a real failure. Is actually a hard time-cap.

## Fix

\`_monitor_process\` is now a poll loop:

\`\`\`python
while True:
    try:
        exit_code = process.wait(timeout=_WATCHDOG_POLL_INTERVAL_S)  # 1s
        break
    except subprocess.TimeoutExpired:
        if self._watchdog_should_kill(job_id, started_at):
            process.kill()
            ...
\`\`\`

\`_watchdog_should_kill\` checks two conditions, in order:
1. **Env cap** (\`QUODEQ_JOB_TIMEOUT_S\`, default \`0\` = no cap) — opt-in wall-clock cap for users who want one. Was \`7200\`; now \`0\`.
2. **User deadline** — if \`job.deadline_at\` has passed plus a 60s grace window, kill. The grace gives the analysis-side graceful-cancel path time to score completed dimensions.

If neither applies, the watchdog never preemptively kills. The user did not opt into a time cap.

## Test plan

- [x] New tests for the four behaviors:
  - \`test_env_cap_kills_process\` — env-cap exceeded
  - \`test_no_cap_no_deadline_does_not_kill\` — no cap + no deadline = no kill
  - \`test_deadline_in_future_does_not_kill\` — future deadline = no preemptive kill
  - \`test_deadline_past_plus_grace_kills\` — past deadline + grace = kill
- [x] Replaced \`test_timeout_kills_process\` (it was setting \`mgr._JOB_TIMEOUT_S = 0.01\` — a stale attribute the property never read, so the test passed for the wrong reason: \`SlowProcess.wait\` returned \`-9\` which happened to equal \`_EXIT_CODE_TIMEOUT\`).
- [x] \`pytest tests/services tests/analysis -q\` — 1071/1071 pass.

## Migration / back-compat

- Users who previously relied on the 2h cap can restore it: \`export QUODEQ_JOB_TIMEOUT_S=7200\`.
- No state-format changes. No config-file changes.