### PR TITLE
fix(windows): retry file lock under contention

### DIFF
--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -80,11 +80,14 @@ def locked(lock_path: Path):
     where one process unlinks it while another is about to lock it.
     """
     fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, _LOCK_FILE_MODE)
+    locked_ok = False
     try:
         lock_file(fd)
+        locked_ok = True
         yield
     finally:
-        unlock_file(fd)
+        if locked_ok:
+            unlock_file(fd)
         os.close(fd)
 
 

--- a/src/quodeq/data/_file_lock.py
+++ b/src/quodeq/data/_file_lock.py
@@ -9,6 +9,13 @@ used by the subagent pool via ``analysis.subagents._file_lock``.
 from __future__ import annotations
 
 import sys
+import time
+
+# Windows blocking lock budget. msvcrt.LK_LOCK only retries 10x at 1s,
+# which is too short under the subagent pool's heavy contention. We use
+# the non-blocking variant in our own retry loop instead.
+_WIN_LOCK_TIMEOUT_S = 60.0
+_WIN_LOCK_RETRY_INTERVAL_S = 0.05
 
 
 def _make_lock_ops() -> tuple:
@@ -16,7 +23,15 @@ def _make_lock_ops() -> tuple:
     if sys.platform == "win32":
         import msvcrt
         def _lock(fd: int) -> None:
-            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            deadline = time.monotonic() + _WIN_LOCK_TIMEOUT_S
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                    return
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise
+                    time.sleep(_WIN_LOCK_RETRY_INTERVAL_S)
         def _unlock(fd: int) -> None:
             msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
     else:


### PR DESCRIPTION
## Summary

Windows CI hit a flake on PR #415 in `tests/engine/test_file_queue.py::TestConcurrency::test_no_file_assigned_twice_many_threads` (10 threads × 200 files):

```
src/quodeq/data/_file_lock.py:19: in _lock
    msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
E   OSError: [Errno 36] Resource deadlock avoided
```

Two real bugs surfaced.

### 1. `LK_LOCK` budget is 10 seconds

Per Python docs, `msvcrt.LK_LOCK` retries once per second for **10 attempts** then raises. Under the subagent pool's contention (10 threads × 200 lock acquisitions on one lock file) a thread can lose the race for >10s and fail. The flake is real on the lab Windows runner, just not reliably reproducible.

Fix: use `LK_NBLCK` (non-blocking) in our own retry loop with a 60s budget and 50ms sleep. POSIX path unchanged.

### 2. `locked()` unlocks even when lock failed

`_queue_state.locked()` had:

```python
try:
    lock_file(fd)
    yield
finally:
    unlock_file(fd)   # runs even if lock_file raised
    os.close(fd)
```

When `lock_file` raised, the `finally` then called `unlock_file` on an unlocked fd, which raised `PermissionError` on Windows and masked the original `OSError`. Track `locked_ok` and only unlock on success.

## Test plan

- [x] `pytest tests/engine tests/analysis -q` — 821/821 pass on macOS (POSIX path unchanged).
- [ ] CI Windows job (this PR) — should pass the contention test reliably with the 60s budget.

## Note

Independent of #415; that PR's Windows failure was this flake, not its own changes.