### PR TITLE
fix(ui): single-click Console toggle + tidy side-pane header buttons

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
@@ -38,9 +38,8 @@ function statusWord(jobStatus, streamStatus, terminalState) {
   return STREAM_STATUS_WORD[streamStatus] || '';
 }
 
-function buildSpec({ jobId, label, jobStatus, logs, status, terminalState }) {
+function buildSpec({ jobId, jobStatus, logs, status, terminalState }) {
   if (!jobId) return null;
-  const baseFilename = (label || jobId).replace(/[^A-Za-z0-9._-]+/g, '-');
   const word = statusWord(jobStatus, status, terminalState);
   const parts = ['log evaluation'];
   if (word) parts.push(word);
@@ -50,8 +49,6 @@ function buildSpec({ jobId, label, jobStatus, logs, status, terminalState }) {
     type: 'eval-log',
     title: parts.join(' · '),
     render: () => <ConsoleLogViewer logs={logs} />,
-    copy: () => logs.join('\n'),
-    download: () => ({ filename: `${baseFilename}.log`, body: logs.join('\n') }),
   };
 }
 
@@ -65,8 +62,8 @@ export function EvalLogProvider({ children }) {
   const { addWindow, removeWindow, replaceWindow, hasWindow } = useSidePane();
 
   const spec = useMemo(
-    () => buildSpec({ jobId: activeJobId, label: activeJobLabel, jobStatus: activeJobStatus, logs, status, terminalState }),
-    [activeJobId, activeJobLabel, activeJobStatus, logs, status, terminalState],
+    () => buildSpec({ jobId: activeJobId, jobStatus: activeJobStatus, logs, status, terminalState }),
+    [activeJobId, activeJobStatus, logs, status, terminalState],
   );
 
   useEffect(() => {
@@ -78,7 +75,7 @@ export function EvalLogProvider({ children }) {
     setActiveJobId(jobId);
     setActiveJobLabel(label);
     setActiveJobStatus(jobStatus);
-    const fresh = buildSpec({ jobId, label, jobStatus, logs: [], status: 'streaming' });
+    const fresh = buildSpec({ jobId, jobStatus, logs: [], status: 'streaming' });
     addWindow(fresh);
     replaceWindow(fresh);
   }, [addWindow, replaceWindow]);

--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
@@ -55,12 +55,14 @@ function buildSpec({ jobId, label, jobStatus, logs, status, terminalState }) {
   };
 }
 
+const WINDOW_ID = 'eval-log';
+
 export function EvalLogProvider({ children }) {
   const [activeJobId, setActiveJobId] = useState(null);
   const [activeJobLabel, setActiveJobLabel] = useState(null);
   const [activeJobStatus, setActiveJobStatus] = useState(null);
   const { logs, status, terminalState } = useJobLogStream(activeJobId);
-  const { addWindow, removeWindow, replaceWindow } = useSidePane();
+  const { addWindow, removeWindow, replaceWindow, hasWindow } = useSidePane();
 
   const spec = useMemo(
     () => buildSpec({ jobId: activeJobId, label: activeJobLabel, jobStatus: activeJobStatus, logs, status, terminalState }),
@@ -89,8 +91,19 @@ export function EvalLogProvider({ children }) {
     setActiveJobId(null);
     setActiveJobLabel(null);
     setActiveJobStatus(null);
-    removeWindow('eval-log');
+    removeWindow(WINDOW_ID);
   }, [removeWindow]);
+
+  // If the user closes the side-pane window via the X (or Escape closes
+  // all panes), sync our active-job state — otherwise `consoleOpen` stays
+  // truthy and the Console button needs two clicks to reopen.
+  useEffect(() => {
+    if (activeJobId && !hasWindow(WINDOW_ID)) {
+      setActiveJobId(null);
+      setActiveJobLabel(null);
+      setActiveJobStatus(null);
+    }
+  }, [activeJobId, hasWindow]);
 
   const value = useMemo(
     () => ({ activeJobId, activeJobLabel, activeJobStatus, status, openLog, closeLog, updateJobStatus }),

--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.test.jsx
@@ -128,6 +128,34 @@ describe('EvalLogProvider', () => {
     expect(screen.getByTestId('body')).toHaveTextContent('hello world');
   });
 
+  it('clears activeJobId when the side-pane window is removed externally', () => {
+    function SyncProbe() {
+      const { activeJobId, openLog } = useEvalLog();
+      const { windows, removeWindow, closeAll } = useSidePane();
+      return (
+        <div>
+          <div data-testid="active">{activeJobId || 'none'}</div>
+          <div data-testid="dock">{windows.map((w) => w.id).join(',') || 'empty'}</div>
+          <button onClick={() => openLog('job-a', 'Run A')}>open</button>
+          <button onClick={() => removeWindow('eval-log')}>remove-via-x</button>
+          <button onClick={closeAll}>close-all</button>
+        </div>
+      );
+    }
+    renderWithProviders(<SyncProbe />);
+    fireEvent.click(screen.getByText('open'));
+    expect(screen.getByTestId('active')).toHaveTextContent('job-a');
+    // Simulate the user closing the pane via its X button.
+    fireEvent.click(screen.getByText('remove-via-x'));
+    expect(screen.getByTestId('dock')).toHaveTextContent('empty');
+    expect(screen.getByTestId('active')).toHaveTextContent('none');
+    // And via the Escape-style close-all path.
+    fireEvent.click(screen.getByText('open'));
+    expect(screen.getByTestId('active')).toHaveTextContent('job-a');
+    fireEvent.click(screen.getByText('close-all'));
+    expect(screen.getByTestId('active')).toHaveTextContent('none');
+  });
+
   it('window title reflects job lifecycle status when provided', () => {
     function StatusProbe() {
       const { openLog, updateJobStatus } = useEvalLog();

--- a/src/quodeq/ui/src/features/settings/ollama-log/OllamaLogProvider.jsx
+++ b/src/quodeq/ui/src/features/settings/ollama-log/OllamaLogProvider.jsx
@@ -19,8 +19,6 @@ function buildSpec(logs, status) {
     type: WINDOW_ID,
     title: `Ollama log${STATUS_LABEL[status] || ''}`,
     render: () => <ConsoleLogViewer logs={logs} />,
-    copy: () => logs.join('\n'),
-    download: () => ({ filename: 'ollama-server.log', body: logs.join('\n') }),
   };
 }
 

--- a/src/quodeq/ui/src/features/settings/server-log/ServerLogProvider.jsx
+++ b/src/quodeq/ui/src/features/settings/server-log/ServerLogProvider.jsx
@@ -12,8 +12,6 @@ function buildSpec(logs) {
     type: WINDOW_ID,
     title: 'Server log',
     render: () => <ConsoleLogViewer logs={logs} />,
-    copy: () => logs.join('\n'),
-    download: () => ({ filename: 'server.log', body: logs.join('\n') }),
   };
 }
 

--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -89,27 +89,41 @@
 }
 .side-pane-window__actions {
   display: flex;
-  gap: 4px;
+  gap: 6px;
 }
+/* Buttons read as buttons at rest — copying a fix-plan into an LLM
+   prompt is a primary flow, so the affordance shouldn't hide until
+   hover. Same chip treatment is reused for download and close so the
+   header reads as a consistent toolstrip. */
 .side-pane-window__icon-btn {
-  background: transparent;
-  border: 1px solid transparent;
-  color: var(--color-text-muted);
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 80ms ease, border-color 80ms ease, color 80ms ease;
 }
 .side-pane-window__icon-btn:hover {
-  background: var(--color-surface-alt);
-  color: var(--color-text);
+  background: color-mix(in srgb, var(--color-accent) 14%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-border));
+  color: var(--color-accent);
+}
+.side-pane-window__icon-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
 }
 .side-pane-window__icon-btn--ok,
 .side-pane-window__icon-btn--ok:hover {
   color: var(--color-accent);
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--color-surface));
+  border-color: color-mix(in srgb, var(--color-accent) 50%, var(--color-border));
 }
 
 /* ── Window body ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Two small UI fixes shipped together because they touch the same area.

### 1. Console button needs two clicks after closing the side-pane externally
`ScanProgress` derived its open state from `EvalLogProvider.activeJobId`, but the side-pane window can be removed by its own ✕ button or by Escape (which calls `setWindows([])`). Neither path invokes `closeLog()`, so `activeJobId` stayed truthy while the window was gone — first click ran `closeLog()` as a visual no-op, second click finally reopened.

Fix mirrors the sync effect already used by `ServerLogProvider` / `OllamaLogProvider`: when `hasWindow('eval-log')` flips to false, clear `activeJobId`. Single click now always works.

### 2. Side-pane header tidy-up
- **Logs no longer show copy / download.** They're streaming output — the panel just needs a clean way to dismiss. Eval log, server log, ollama log: close-only.
- **Markdown / fix-plan panels keep all three.** Copying a fix plan into an LLM prompt is a primary flow.
- **Buttons get a chip treatment** so they read as buttons at rest instead of vanishing until hover: 28×28, 14px glyph, always-on border + bg, accent-tinted hover, focus-visible outline. Same chip applied to copy/download/close so the toolstrip stays visually uniform regardless of which buttons appear.

## Test plan
- [x] `npx vitest run` — 280/280 pass (regression test for sync effect added in commit 1)
- [x] Open Console on an evaluation, close pane via ✕, click Console again → opens on first click
- [x] Same with Escape instead of ✕
- [x] Open a violation fix plan → header shows copy / download / close, all chip-styled
- [x] Open the server log or ollama log → header shows close only