### PR TITLE
refactor(heartbeat): trim progress line to dimension/agents/files/scores

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -16,7 +16,7 @@ _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
     "{active} active agent{plural} | "
     "files {taken}/{total_files} · {remaining} left | "
-    "{violations} violations | {compliance} compliance"
+    "{violations} violations · {compliance} compliance"
 )
 
 

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -15,7 +15,7 @@ _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
     "{active} active agent{plural} | "
-    "files {taken}/{total_files} | "
+    "files {taken}/{total_files} · {remaining} left | "
     "{violations} violations | {compliance} compliance"
 )
 
@@ -64,6 +64,7 @@ def heartbeat_loop(
                 plural="" if active == 1 else "s",
                 taken=taken,
                 total_files=taken + remaining,
+                remaining=remaining,
                 violations=tally.violations,
                 compliance=tally.compliance,
             ))

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -13,17 +13,11 @@ from quodeq.shared.logging import log_info, log_warning
 _HEARTBEAT_INTERVAL = 10
 _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
-    "  [{dimension}] {mins}m{secs:02d}s | "
-    "{active} active ({total_agents} total) | "
-    "{taken} files taken ({remaining} left) | "
-    "{findings} findings{dup_seg} | "
+    "[{dimension}] {mins}m{secs:02d}s | "
+    "{active} active agent{plural} | "
+    "files {taken}/{total_files} | "
     "{violations} violations · {compliance} compliance"
 )
-
-
-def _format_dup_segment(duplicates: int) -> str:
-    """Render the ``(N dup)`` suffix only when there's actual overlap to surface."""
-    return f" ({duplicates} dup)" if duplicates > 0 else ""
 
 
 @dataclass
@@ -51,10 +45,8 @@ def heartbeat_loop(
     """Emit periodic progress lines for the subagent pool.
 
     Each tick re-reads the dimension JSONL and deduplicates by
-    ``(p, file, line, t)`` in memory, so the unique counts always match
-    :mod:`quodeq.services.scan_progress` (which the UI consumes). The
-    ``duplicates`` segment surfaces overlap between parallel agents in real
-    time.
+    ``(p, file, line, t)`` in memory, so the violation/compliance counts
+    always match :mod:`quodeq.services.scan_progress` (which the UI consumes).
     """
     start = time.monotonic()
     while not stop.wait(_HEARTBEAT_INTERVAL):
@@ -63,18 +55,15 @@ def heartbeat_loop(
             mins, secs = divmod(elapsed, _SECONDS_PER_MINUTE)
             tally = _read_tally(ctx.jsonl_path, ctx.lock)
             remaining, taken = FileQueue(ctx.queue_path).stats()
-            total_agents = len(finished)
             active = sum(1 for v in finished.values() if not v)
             log_info(_HEARTBEAT_FMT.format(
                 dimension=ctx.dimension_key,
                 mins=mins,
                 secs=secs,
                 active=active,
-                total_agents=total_agents,
+                plural="" if active == 1 else "s",
                 taken=taken,
-                remaining=remaining,
-                findings=tally.total,
-                dup_seg=_format_dup_segment(tally.duplicates),
+                total_files=taken + remaining,
                 violations=tally.violations,
                 compliance=tally.compliance,
             ))

--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -16,7 +16,7 @@ _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
     "{active} active agent{plural} | "
     "files {taken}/{total_files} | "
-    "{violations} violations · {compliance} compliance"
+    "{violations} violations | {compliance} compliance"
 )
 
 

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -75,7 +75,7 @@ class TestHeartbeatFormat:
         assert line.startswith("[security] 1m02s")
         assert "2 active agents" in line
         assert "files 10/30" in line
-        assert "2 violations · 5 compliance" in line
+        assert "2 violations | 5 compliance" in line
         assert "findings" not in line
         assert "total" not in line
 

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from quodeq.analysis.subagents._heartbeat import (
     HeartbeatContext,
-    _format_dup_segment,
     _read_tally,
     _HEARTBEAT_FMT,
     heartbeat_loop,
@@ -66,30 +65,28 @@ class TestHeartbeatContext:
 
 
 class TestHeartbeatFormat:
-    def test_format_includes_duplicates_segment_when_present(self) -> None:
-        """The duplicates segment must appear when overlap exists."""
+    def test_format_renders_expected_segments(self) -> None:
         line = _HEARTBEAT_FMT.format(
             dimension="security", mins=1, secs=2,
-            active=2, total_agents=5,
-            taken=10, remaining=20,
-            findings=7, dup_seg=_format_dup_segment(3),
+            active=2, plural="s",
+            taken=10, total_files=30,
             violations=2, compliance=5,
         )
-        assert "7 findings (3 dup)" in line
-        assert "2 violations" in line
-        assert "5 compliance" in line
+        assert line.startswith("[security] 1m02s")
+        assert "2 active agents" in line
+        assert "files 10/30" in line
+        assert "2 violations · 5 compliance" in line
+        assert "findings" not in line
+        assert "total" not in line
 
-    def test_format_omits_duplicates_segment_when_zero(self) -> None:
-        """No `(0 dup)` clutter when there's no overlap."""
+    def test_format_uses_singular_for_one_active_agent(self) -> None:
         line = _HEARTBEAT_FMT.format(
-            dimension="security", mins=1, secs=2,
-            active=2, total_agents=5,
-            taken=10, remaining=20,
-            findings=7, dup_seg=_format_dup_segment(0),
-            violations=2, compliance=5,
+            dimension="security", mins=0, secs=5,
+            active=1, plural="",
+            taken=1, total_files=2,
+            violations=0, compliance=0,
         )
-        assert "7 findings |" in line
-        assert "dup" not in line
+        assert "1 active agent |" in line
 
 
 class TestHeartbeatLoop:

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -75,7 +75,7 @@ class TestHeartbeatFormat:
         assert line.startswith("[security] 1m02s")
         assert "2 active agents" in line
         assert "files 10/30 · 20 left" in line
-        assert "2 violations | 5 compliance" in line
+        assert "2 violations · 5 compliance" in line
         assert "findings" not in line
         assert "total" not in line
 

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -69,12 +69,12 @@ class TestHeartbeatFormat:
         line = _HEARTBEAT_FMT.format(
             dimension="security", mins=1, secs=2,
             active=2, plural="s",
-            taken=10, total_files=30,
+            taken=10, total_files=30, remaining=20,
             violations=2, compliance=5,
         )
         assert line.startswith("[security] 1m02s")
         assert "2 active agents" in line
-        assert "files 10/30" in line
+        assert "files 10/30 · 20 left" in line
         assert "2 violations | 5 compliance" in line
         assert "findings" not in line
         assert "total" not in line
@@ -83,7 +83,7 @@ class TestHeartbeatFormat:
         line = _HEARTBEAT_FMT.format(
             dimension="security", mins=0, secs=5,
             active=1, plural="",
-            taken=1, total_files=2,
+            taken=1, total_files=2, remaining=1,
             violations=0, compliance=0,
         )
         assert "1 active agent |" in line


### PR DESCRIPTION
## Summary
- Trim heartbeat output to the segments that matter: `[dimension]`, elapsed, active agents, files progress, violations/compliance.
- Drop the leading two spaces (which clipped the `[dimension]` prefix behind `[INFO]` in the side-pane viewer), the total-agents count, findings count, and duplicates suffix.
- Replace `N files taken (M left)` with `files N/total` for a more compact progress read.

Before:
```
  [maintainability] 35m11s | 1 active (99 total) | 297 files taken (338 left) | 462 findings | 167 violations · 295 compliance
```

After:
```
[maintainability] 35m11s | 1 active agent | files 297/635 | 167 violations · 295 compliance
```

## Test plan
- [x] `pytest tests/analysis/test_heartbeat_coverage.py`
- [x] Spot-check live heartbeat output during an analysis run