### PR TITLE
Fix eval-log follow reliability and lighten side-pane button chrome

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
@@ -135,6 +135,7 @@ function FollowToggle({ active, onToggle }) {
 
 export default function ConsoleLogViewer({ logs }) {
   const scrollRef = useRef(null);
+  const contentRef = useRef(null);
   const [follow, setFollow] = useState(true);
   const followRef = useRef(true);
   const lastLogCount = useRef(0);
@@ -189,7 +190,27 @@ export default function ConsoleLogViewer({ logs }) {
       setFollow((prev) => (prev === atBottom ? prev : atBottom));
     };
     el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
+    // Resize alone never fires `scroll`, so adding a side-pane window or
+    // dragging a divider would shrink clientHeight and silently leave the
+    // user above the bottom — even with follow=true — until the next log
+    // line. Watch BOTH the scroller (clientHeight changes) and its inner
+    // content (scrollHeight changes from late `content-visibility` re-measures
+    // and from new lines settling in) and re-snap on size changes.
+    const snap = () => {
+      if (!followRef.current) return;
+      if (hasActiveSelectionInside(el)) return;
+      programmaticScroll.current = true;
+      el.scrollTop = el.scrollHeight;
+      lastScrollHeight.current = el.scrollHeight;
+      requestAnimationFrame(() => { programmaticScroll.current = false; });
+    };
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(snap) : null;
+    ro?.observe(el);
+    if (contentRef.current) ro?.observe(contentRef.current);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      ro?.disconnect();
+    };
   }, []);
 
   const handleToggle = useCallback(() => {
@@ -203,11 +224,13 @@ export default function ConsoleLogViewer({ logs }) {
   return (
     <div className="console-shell">
       <div className="console-scroll" ref={scrollRef}>
-        {cleanedLogs.length === 0 ? (
-          <div className="console-log-empty">Waiting for output…</div>
-        ) : (
-          cleanedLogs.map((line, i) => <LogLine key={i} text={line} />)
-        )}
+        <div className="console-content" ref={contentRef}>
+          {cleanedLogs.length === 0 ? (
+            <div className="console-log-empty">Waiting for output…</div>
+          ) : (
+            cleanedLogs.map((line, i) => <LogLine key={i} text={line} />)
+          )}
+        </div>
       </div>
       <FollowToggle active={follow} onToggle={handleToggle} />
     </div>

--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogContext.js
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogContext.js
@@ -2,8 +2,17 @@ import { createContext, useContext } from 'react';
 
 export const EvalLogContext = createContext(null);
 
+// Split out the high-frequency `logs` value so consumers of the stable
+// (status / openLog / closeLog) context don't re-render on every appended
+// line. Only the in-pane log view subscribes here.
+export const EvalLogLogsContext = createContext({ logs: [] });
+
 export function useEvalLog() {
   const ctx = useContext(EvalLogContext);
   if (!ctx) throw new Error('useEvalLog must be used inside <EvalLogProvider>');
   return ctx;
+}
+
+export function useEvalLogLogs() {
+  return useContext(EvalLogLogsContext);
 }

--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
 import ConsoleLogViewer from '../components/ConsoleLogViewer.jsx';
-import { EvalLogContext } from './EvalLogContext.js';
+import { EvalLogContext, EvalLogLogsContext, useEvalLogLogs } from './EvalLogContext.js';
 import { useJobLogStream } from './useJobLogStream.js';
+
+// Read logs from the dedicated logs context so the side-pane's spec stays
+// stable across log appends — only this leaf re-renders on each batch.
+function EvalLogPaneBody() {
+  const { logs } = useEvalLogLogs();
+  return <ConsoleLogViewer logs={logs} />;
+}
 
 const STREAM_STATUS_WORD = {
   idle: '',
@@ -38,7 +45,7 @@ function statusWord(jobStatus, streamStatus, terminalState) {
   return STREAM_STATUS_WORD[streamStatus] || '';
 }
 
-function buildSpec({ jobId, jobStatus, logs, status, terminalState }) {
+function buildSpec({ jobId, jobStatus, status, terminalState }) {
   if (!jobId) return null;
   const word = statusWord(jobStatus, status, terminalState);
   const parts = ['log evaluation'];
@@ -48,22 +55,20 @@ function buildSpec({ jobId, jobStatus, logs, status, terminalState }) {
     id: 'eval-log',
     type: 'eval-log',
     title: parts.join(' · '),
-    render: () => <ConsoleLogViewer logs={logs} />,
+    render: () => <EvalLogPaneBody />,
   };
 }
-
-const WINDOW_ID = 'eval-log';
 
 export function EvalLogProvider({ children }) {
   const [activeJobId, setActiveJobId] = useState(null);
   const [activeJobLabel, setActiveJobLabel] = useState(null);
   const [activeJobStatus, setActiveJobStatus] = useState(null);
   const { logs, status, terminalState } = useJobLogStream(activeJobId);
-  const { addWindow, removeWindow, replaceWindow, hasWindow } = useSidePane();
+  const { addWindow, removeWindow, replaceWindow } = useSidePane();
 
   const spec = useMemo(
-    () => buildSpec({ jobId: activeJobId, jobStatus: activeJobStatus, logs, status, terminalState }),
-    [activeJobId, activeJobStatus, logs, status, terminalState],
+    () => buildSpec({ jobId: activeJobId, jobStatus: activeJobStatus, status, terminalState }),
+    [activeJobId, activeJobStatus, status, terminalState],
   );
 
   useEffect(() => {
@@ -75,7 +80,7 @@ export function EvalLogProvider({ children }) {
     setActiveJobId(jobId);
     setActiveJobLabel(label);
     setActiveJobStatus(jobStatus);
-    const fresh = buildSpec({ jobId, jobStatus, logs: [], status: 'streaming' });
+    const fresh = buildSpec({ jobId, jobStatus, status: 'streaming' });
     addWindow(fresh);
     replaceWindow(fresh);
   }, [addWindow, replaceWindow]);
@@ -88,24 +93,21 @@ export function EvalLogProvider({ children }) {
     setActiveJobId(null);
     setActiveJobLabel(null);
     setActiveJobStatus(null);
-    removeWindow(WINDOW_ID);
+    removeWindow('eval-log');
   }, [removeWindow]);
-
-  // If the user closes the side-pane window via the X (or Escape closes
-  // all panes), sync our active-job state — otherwise `consoleOpen` stays
-  // truthy and the Console button needs two clicks to reopen.
-  useEffect(() => {
-    if (activeJobId && !hasWindow(WINDOW_ID)) {
-      setActiveJobId(null);
-      setActiveJobLabel(null);
-      setActiveJobStatus(null);
-    }
-  }, [activeJobId, hasWindow]);
 
   const value = useMemo(
     () => ({ activeJobId, activeJobLabel, activeJobStatus, status, openLog, closeLog, updateJobStatus }),
     [activeJobId, activeJobLabel, activeJobStatus, status, openLog, closeLog, updateJobStatus],
   );
 
-  return <EvalLogContext.Provider value={value}>{children}</EvalLogContext.Provider>;
+  const logsValue = useMemo(() => ({ logs }), [logs]);
+
+  return (
+    <EvalLogContext.Provider value={value}>
+      <EvalLogLogsContext.Provider value={logsValue}>
+        {children}
+      </EvalLogLogsContext.Provider>
+    </EvalLogContext.Provider>
+  );
 }

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const MAX_LINES = 5000;
 const READYSTATE_CLOSED = 2;
@@ -16,10 +16,25 @@ export function useJobLogStream(jobId) {
   const [logs, setLogs] = useState([]);
   const [status, setStatus] = useState('idle');
   const [terminalState, setTerminalState] = useState(null);
+  // Coalesce bursts of SSE messages into one render per frame. Each `onmessage`
+  // is its own task, so without batching a chatty stream commits N times in
+  // 16ms — which means N reconciliations of the entire log list.
+  const pendingRef = useRef([]);
+  const rafRef = useRef(null);
+  const timerRef = useRef(null);
 
   useEffect(() => {
     setLogs([]);
     setTerminalState(null);
+    pendingRef.current = [];
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
     if (!jobId) {
       setStatus('idle');
       return undefined;
@@ -28,14 +43,39 @@ export function useJobLogStream(jobId) {
     const url = `/api/jobs/${encodeURIComponent(jobId)}/logs/stream`;
     const es = new EventSource(url);
 
-    function append(line) {
+    const flush = () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      const batch = pendingRef.current;
+      if (batch.length === 0) return;
+      pendingRef.current = [];
       setLogs((prev) => {
-        if (prev.length >= MAX_LINES) {
-          return [...prev.slice(prev.length - MAX_LINES + 1), line];
+        const merged = prev.length === 0 ? batch.slice() : prev.concat(batch);
+        if (merged.length > MAX_LINES) {
+          return merged.slice(merged.length - MAX_LINES);
         }
-        return [...prev, line];
+        return merged;
       });
-    }
+    };
+    const append = (line) => {
+      pendingRef.current.push(line);
+      // Schedule both a rAF (for smooth in-frame batching while visible) and
+      // a timer fallback. Browsers throttle rAF to 0 when the tab is hidden,
+      // so without the timer the queue would never drain in background tabs.
+      // Whichever fires first runs flush; the other becomes a no-op.
+      if (rafRef.current == null) {
+        rafRef.current = requestAnimationFrame(flush);
+      }
+      if (timerRef.current == null) {
+        timerRef.current = setTimeout(flush, 50);
+      }
+    };
 
     es.onmessage = (e) => append(e.data);
     es.addEventListener('done', (e) => {
@@ -54,6 +94,15 @@ export function useJobLogStream(jobId) {
 
     return () => {
       es.close();
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      pendingRef.current = [];
     };
   }, [jobId]);
 

--- a/src/quodeq/ui/src/features/side-pane/SidePane.css
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.css
@@ -89,21 +89,24 @@
 }
 .side-pane-window__actions {
   display: flex;
-  gap: 6px;
+  gap: 4px;
 }
 /* Buttons read as buttons at rest — copying a fix-plan into an LLM
    prompt is a primary flow, so the affordance shouldn't hide until
    hover. Same chip treatment is reused for download and close so the
-   header reads as a consistent toolstrip. */
+   header reads as a consistent toolstrip. The chip is dimmed at rest
+   (faint surface fill + outline, slightly muted glyph) so it doesn't
+   compete with the title; hover restores full contrast and tints to
+   the accent. */
 .side-pane-window__icon-btn {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  color: var(--color-text);
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
+  background: color-mix(in srgb, var(--color-surface) 35%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 28%, transparent);
+  color: color-mix(in srgb, var(--color-text) 80%, transparent);
+  width: 24px;
+  height: 24px;
+  border-radius: 5px;
   cursor: pointer;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
   display: inline-flex;
   align-items: center;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -214,9 +214,31 @@ button.eval-provider-badge--clickable:focus-visible {
   flex: 1 1 auto;
   min-height: 0;
   max-height: none;
+  /* Tighter horizontal padding than the default 16px — combined with the
+     thin scrollbar below it gives long log lines visibly more room before
+     wrapping in narrow docks. */
+  padding: 12px 10px;
   /* Reserve space below the last line so the floating follow button doesn't
      sit on top of in-progress output. */
   padding-bottom: 48px;
+  scrollbar-width: thin;
+}
+
+.side-pane-window__body > .console-shell .console-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+.side-pane-window__body > .console-shell .console-scroll:hover::-webkit-scrollbar {
+  width: 12px;
+}
+.side-pane-window__body > .console-shell .console-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+.side-pane-window__body > .console-shell .console-scroll::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-console-text) 22%, transparent);
+  border-radius: 4px;
+}
+.side-pane-window__body > .console-shell .console-scroll::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--color-console-text) 38%, transparent);
 }
 
 /* During a side-pane drag (outer or inner divider), skip layout/paint of


### PR DESCRIPTION
## Summary

- Follow button now reliably tracks the bottom across pane resize, divider drag, OS window resize, and `content-visibility: auto` re-measure jitter.
- Coalesce SSE log bursts into one render per frame (rAF + setTimeout fallback so background tabs still flush).
- Decouple the side-pane spec from the log array so per-line appends no longer re-render the side-pane subtree.
- Tighten console padding (16 to 10 px) and add a thin scrollbar so log lines fit better in narrow docks.
- Dim the side-pane icon buttons at rest (smaller chip + faint fill, border, and glyph) so the report and fix-plan headers feel quieter; hover still gives the full accent chip.

Eval-log pane keeps the close-only header from dd3cbc86; copy and download remain on the report and fix-plan panes.

## Test plan

- [x] Open a running evaluation, expand the eval-log side pane, click follow, scroll up and back down: button toggles correctly.
- [x] With follow on, drag the side-pane divider or add a second pane: scroll position snaps to the bottom rather than stranding above it.
- [x] Hide the tab during a chatty run, return after a few seconds: queued lines flush within ~50 ms instead of staying frozen.
- [x] Open a Report or Fix Plan pane: copy, download, and close buttons are present, dim at rest, and tint to accent on hover.