### PR TITLE
feat(llm_bridge): add llama.cpp as a first-class local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,26 @@ Choose what fits your workflow. Configure in **Settings** from the dashboard.
 | Provider | Type | Getting started |
 |---|---|---|
 | [Ollama](https://ollama.com/download) | Local | Free, private, code never leaves your machine |
+| [llama.cpp](https://github.com/ggml-org/llama.cpp) | Local | Run any GGUF directly. Supports speculative decoding (MTP) via a draft model |
 | [Claude Code](https://code.claude.com/docs/en/quickstart) | Cloud | Best balance of speed, quality, and cost |
 | [Codex CLI](https://developers.openai.com/codex/quickstart) | Cloud | OpenAI models |
 | [Gemini CLI](https://geminicli.com/docs/get-started/installation/) | Cloud | Google models |
 
 > For local analysis we recommend [Gemma 4](https://deepmind.google/models/gemma/gemma-4/) ([`gemma4:26b`](https://ollama.com/library/gemma4:26b)). Reducing the context window to 32k still gives good results and allows running multiple subagents in parallel.
+
+### Using llama.cpp
+
+llama.cpp is one process per model, fixed at launch. Start `llama-server` yourself, then point Quodeq at it from **Settings → AI Provider → llama.cpp**.
+
+```bash
+# Single model
+llama-server -m path/to/target.gguf --port 8080
+
+# Speculative decoding (MTP), pair a target with a smaller drafter
+llama-server -m path/to/target.gguf -md path/to/drafter.gguf --port 8080
+```
+
+Quodeq probes `http://localhost:8080`. To use a different port or host, set `LLAMACPP_BASE_URL`. To switch models, stop `llama-server` and relaunch with a different `-m`.
 
 ---
 

--- a/src/quodeq/api/_llamacpp_log_routes.py
+++ b/src/quodeq/api/_llamacpp_log_routes.py
@@ -1,0 +1,80 @@
+"""llama.cpp log-stream route — opt-in SSE tail of a user-pointed file.
+
+Quodeq does not start ``llama-server``; the user does. So unlike the
+Ollama log (which lives in a known location), the only way to surface
+llama-server output in the dashboard is to have the user point us at a
+log file via the ``LLAMACPP_LOG_FILE`` env var. If unset or missing,
+the route returns 404 and the UI hides the console button.
+
+Typical usage:
+
+    llama-server -m model.gguf --port 8080 > /tmp/llama-server.log 2>&1
+    LLAMACPP_LOG_FILE=/tmp/llama-server.log quodeq
+"""
+from __future__ import annotations
+
+import os
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.api._sse_log_helpers import sse_tail_generator
+
+
+def _llamacpp_log_path() -> Path | None:
+    """Return the user-configured llama.cpp log path, or None."""
+    override = os.environ.get("LLAMACPP_LOG_FILE")
+    if not override:
+        return None
+    return Path(override)
+
+
+def register_llamacpp_log_routes(app: Flask) -> None:
+    """Register the /api/llamacpp/logs/{available,stream} endpoints.
+
+    Auth: inherits protection from the global before_request hook.
+    """
+
+    @app.get("/api/llamacpp/logs/available")
+    def llamacpp_logs_available() -> Response:
+        """Tell the UI whether log streaming is configured.
+
+        The console toggle in the llama.cpp settings tab is only shown
+        when this returns ``{"available": true}``, since opening an SSE
+        connection that immediately 404s would just produce a confusing
+        red error pill.
+        """
+        log_path = _llamacpp_log_path()
+        return jsonify({"available": bool(log_path and log_path.exists())})
+
+    @app.get("/api/llamacpp/logs/stream")
+    def stream_llamacpp_logs() -> Response | tuple[Response, int]:
+        log_path = _llamacpp_log_path()
+        if log_path is None or not log_path.exists():
+            return (
+                jsonify({
+                    "error": "llamacpp log unavailable",
+                    "code": "NOT_FOUND",
+                    "help": (
+                        "Set the LLAMACPP_LOG_FILE env var to a file llama-server is "
+                        "writing to (for example: "
+                        "`llama-server -m model.gguf --port 8080 > /tmp/llama-server.log 2>&1`, "
+                        "then `LLAMACPP_LOG_FILE=/tmp/llama-server.log quodeq`)."
+                    ),
+                }),
+                HTTPStatus.NOT_FOUND,
+            )
+        last_event_id = request.headers.get("Last-Event-ID", "")
+        try:
+            initial_offset = int(last_event_id) if last_event_id else 0
+        except ValueError:
+            initial_offset = 0
+
+        resp = Response(
+            sse_tail_generator(log_path, initial_offset),
+            mimetype="text/event-stream",
+        )
+        resp.headers["Cache-Control"] = "no-cache"
+        resp.headers["X-Accel-Buffering"] = "no"
+        return resp

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -10,6 +10,9 @@ from quodeq.llm_bridge import (
     list_ollama_models,
     estimate_max_agents,
     run_concurrency_test,
+    get_llamacpp_status,
+    list_llamacpp_models,
+    run_llamacpp_concurrency_test,
     get_known_models,
     get_provider_configs,
     check_cloud_connection,
@@ -45,6 +48,25 @@ def register_llm_bridge_routes(app: Flask) -> None:
         model_size = data.get("model_size", 0)
         gpu_memory = data.get("gpu_memory", 0)
         return jsonify(estimate_max_agents(model_size=model_size, gpu_memory=gpu_memory))
+
+    @app.get("/api/llamacpp/status")
+    def llamacpp_status() -> Response:
+        return jsonify(get_llamacpp_status())
+
+    @app.get("/api/llamacpp/models")
+    def llamacpp_models() -> Response:
+        return jsonify({"models": list_llamacpp_models()})
+
+    @app.post("/api/llamacpp/test-concurrency")
+    def llamacpp_test_concurrency() -> Response:
+        data = request.get_json() or {}
+        model = data.get("model", "")
+        if not isinstance(model, str):
+            return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
+        if "\\" in model or ".." in model or "\0" in model:
+            return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+        result = run_llamacpp_concurrency_test(model)
+        return jsonify(result)
 
     @app.post("/api/provider/test")
     def provider_test() -> Response:

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -10,6 +10,7 @@ from quodeq.api._log_routes import register_log_routes
 from quodeq.api._log_stream_routes import register_log_stream_routes
 from quodeq.api._run_events_routes import register_run_events_routes
 from quodeq.api._ollama_log_routes import register_ollama_log_routes
+from quodeq.api._llamacpp_log_routes import register_llamacpp_log_routes
 from quodeq.api._rate_limit import RateLimitStore
 from quodeq.api.routes import (
     register_project_list_routes,
@@ -47,6 +48,7 @@ def register_all_routes(
     register_log_stream_routes(app)
     register_run_events_routes(app)
     register_ollama_log_routes(app)
+    register_llamacpp_log_routes(app)
     register_discovery_routes(app, provider)
     register_standards_routes(app)
     register_findings_routes(app)

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -18,6 +18,7 @@ PROVIDERS = {
     "codex": ("CODEX_API_KEY", "codex"),
     "gemini": ("GEMINI_API_KEY", "gemini"),
     "ollama": ("", "ollama"),
+    "llamacpp": ("", "llamacpp"),
     "openrouter": ("OPENROUTER_API_KEY", "openrouter"),
     "custom": ("AI_API_KEY", "custom"),
 }

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -5,6 +5,12 @@
     "model": "gemma4:26b",
     "api_base": "http://localhost:11434/v1"
   },
+  "llamacpp": {
+    "type": "api",
+    "order": 5,
+    "model": "",
+    "api_base": "http://localhost:8080/v1"
+  },
   "claude": {
     "type": "cli",
     "order": 1,

--- a/src/quodeq/llm_bridge/__init__.py
+++ b/src/quodeq/llm_bridge/__init__.py
@@ -14,6 +14,11 @@ from quodeq.llm_bridge._ollama import (
     estimate_max_agents,
     run_concurrency_test,
 )
+from quodeq.llm_bridge._llamacpp import (
+    get_llamacpp_status,
+    list_llamacpp_models,
+    run_concurrency_test as run_llamacpp_concurrency_test,
+)
 from quodeq.llm_bridge._cloud import check_cloud_connection
 from quodeq.llm_bridge._models import get_known_models
 
@@ -25,6 +30,9 @@ __all__ = [
     "list_ollama_models",
     "estimate_max_agents",
     "run_concurrency_test",
+    "get_llamacpp_status",
+    "list_llamacpp_models",
+    "run_llamacpp_concurrency_test",
     "check_cloud_connection",
     "get_known_models",
 ]

--- a/src/quodeq/llm_bridge/_llamacpp.py
+++ b/src/quodeq/llm_bridge/_llamacpp.py
@@ -1,0 +1,134 @@
+"""llama.cpp-specific integration: server status, model list, VRAM estimation.
+
+Mirrors the Ollama bridge but targets a running ``llama-server`` process
+(from the llama.cpp project). llama-server is one-process-per-model:
+the loaded model is fixed at launch time via ``-m``, and a separate
+draft model can be supplied via ``--model-draft`` for speculative
+decoding (MTP). There is no model registry to browse or pull from.
+
+Endpoints used:
+  - GET /health           — llama.cpp native health check
+  - GET /v1/models        — OpenAI-compatible list (single entry, the loaded model)
+
+Concurrency estimation reuses ``estimate_max_agents`` from the Ollama
+module, since the math (VRAM per context vs total GPU memory) is the
+same. We do not have an ``/api/ps``-equivalent endpoint, so model size
+falls back to whatever ``/v1/models`` reports plus host memory probing.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+import urllib.error
+
+from quodeq.llm_bridge._ollama import (
+    _detect_memory,
+    estimate_max_agents,
+)
+
+_log = logging.getLogger(__name__)
+
+# llama-server defaults to port 8080. Users can override via env.
+_LLAMACPP_BASE = os.environ.get("LLAMACPP_BASE_URL", "http://localhost:8080")
+_TIMEOUT_S = 3
+
+
+def _normalize_base(base_url: str) -> str:
+    """Strip a trailing /v1 (or /v1/) so /health and /v1/models both work.
+
+    Quodeq stores ``api_base`` as the OpenAI-compatible ``/v1`` URL for use
+    by the analysis runner. The native llama.cpp ``/health`` endpoint sits
+    one level up, so we accept either form here.
+    """
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/v1"):
+        stripped = stripped[: -len("/v1")]
+    return stripped
+
+
+def get_llamacpp_status(base_url: str = _LLAMACPP_BASE) -> dict:
+    """Check if a llama-server process is running and reachable."""
+    root = _normalize_base(base_url)
+    try:
+        req = urllib.request.Request(f"{root}/health")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read() or b"{}")
+            return {
+                "running": True,
+                "status": data.get("status", "ok"),
+                "address": root.replace("http://", ""),
+            }
+    except (urllib.error.URLError, ConnectionRefusedError, OSError, ValueError) as exc:
+        _log.warning("llama.cpp status check failed: %s", exc)
+        return {"running": False, "error": "Connection failed"}
+
+
+def list_llamacpp_models(base_url: str = _LLAMACPP_BASE) -> list[dict]:
+    """List the model loaded by llama-server.
+
+    Always returns 0 or 1 entries: llama-server is one-model-per-process.
+    The model name is whatever llama-server reports for the GGUF passed
+    via ``-m``, which is typically the file basename.
+    """
+    root = _normalize_base(base_url)
+    try:
+        req = urllib.request.Request(f"{root}/v1/models")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read())
+            entries = data.get("data", []) or []
+            return [
+                {
+                    "name": m.get("id", ""),
+                    "size": 0,
+                    "quantization": "",
+                    "family": "",
+                }
+                for m in entries
+                if m.get("id")
+            ]
+    except (urllib.error.URLError, ConnectionRefusedError, OSError, ValueError) as exc:
+        _log.warning("Could not list llama.cpp models: %s", exc)
+        return []
+
+
+def run_concurrency_test(
+    model: str,
+    base_url: str = _LLAMACPP_BASE,
+) -> dict:
+    """Estimate max parallel agents for the loaded llama.cpp model.
+
+    llama-server does not expose per-model VRAM, so we probe host memory
+    and assume the loaded model occupies it. The estimate is conservative,
+    capped by ``estimate_max_agents``.
+    """
+    gpu_memory = _detect_memory()
+    models = list_llamacpp_models(base_url)
+    if not models:
+        return {
+            "recommended": 1,
+            "vram_per_context": 0,
+            "gpu_memory": gpu_memory,
+            "reason": "llama-server is not running or no model loaded",
+        }
+
+    # No size data from /v1/models, so use a fraction of host memory as a
+    # rough per-context budget. This mirrors Ollama's behavior when VRAM
+    # info is missing: we still return at least 1.
+    vram_per_context = models[0].get("size", 0) or max(int(gpu_memory * 0.5), 1)
+
+    if gpu_memory <= 0:
+        return {
+            "recommended": 1,
+            "vram_per_context": vram_per_context,
+            "gpu_memory": gpu_memory,
+            "reason": "Could not detect host memory",
+        }
+
+    result = estimate_max_agents(model_size=vram_per_context, gpu_memory=gpu_memory)
+    return {
+        "recommended": result["estimate"],
+        "vram_per_context": vram_per_context,
+        "gpu_memory": gpu_memory,
+    }

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -207,12 +207,15 @@ class FsToolingMixin:
 
         # API providers: always available (no CLI binary needed)
         provider_configs = get_provider_configs()
+        # Display labels for provider IDs whose default capitalize() form
+        # reads awkwardly (e.g. "Llamacpp" instead of "llama.cpp").
+        api_label_overrides = {"llamacpp": "llama.cpp"}
         for provider_id, cfg in provider_configs.items():
             if cfg.get("type") == "api" and provider_id != "custom":
                 if not any(c["id"] == provider_id for c in clients):
                     clients.append({
                         "id": provider_id,
-                        "label": provider_id.capitalize(),
+                        "label": api_label_overrides.get(provider_id, provider_id.capitalize()),
                         "type": "api",
                         "installed": True,
                     })

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -135,6 +135,19 @@ def _check_api_provider(provider: str, *, env: dict[str, str] | None = None) -> 
                 "  ollama serve\n\n"
                 "Or install Ollama from https://ollama.com/download"
             ) from exc
+    elif provider == "llamacpp":
+        try:
+            _base = _env.get("LLAMACPP_BASE_URL", "http://localhost:8080")
+            urllib.request.urlopen(f"{_base}/health", timeout=_API_CHECK_TIMEOUT_S)
+        except (urllib.error.URLError, OSError) as exc:
+            raise RuntimeError(
+                "llama.cpp is configured as your AI provider but llama-server is not running.\n\n"
+                "Start it with a GGUF model, for example:\n"
+                "  llama-server -m path/to/model.gguf --port 8080\n\n"
+                "For speculative decoding (MTP), pair it with a draft model:\n"
+                "  llama-server -m path/to/target.gguf -md path/to/drafter.gguf --port 8080\n\n"
+                "Install llama.cpp from https://github.com/ggml-org/llama.cpp"
+            ) from exc
 
 
 def _collect_tool_issue(cmd: list[str], tool_name: str, min_major: int) -> str | None:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -31,6 +31,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { EvalLogProvider } from './features/evaluation/eval-log/EvalLogProvider.jsx';
 import { ServerLogProvider } from './features/settings/server-log/ServerLogProvider.jsx';
 import { OllamaLogProvider } from './features/settings/ollama-log/OllamaLogProvider.jsx';
+import { LlamaCppLogProvider } from './features/settings/llamacpp-log/LlamaCppLogProvider.jsx';
 
 // Tabs that are reachable with zero projects. `projects` is in here so a
 // fresh-install user can land on Projects and add their first one without
@@ -506,7 +507,8 @@ export default function App() {
       <EvalLogProvider>
         <ServerLogProvider>
           <OllamaLogProvider>
-            <AppShell
+            <LlamaCppLogProvider>
+              <AppShell
           sidebar={
             <Sidebar
               activeTab={activeTab}
@@ -598,6 +600,7 @@ export default function App() {
             </Suspense>
           }
             />
+            </LlamaCppLogProvider>
           </OllamaLogProvider>
         </ServerLogProvider>
       </EvalLogProvider>

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -235,6 +235,25 @@ export function testOllamaConcurrency(model) {
   });
 }
 
+/** @returns {Promise<Object>} llama.cpp connection status */
+export function getLlamacppStatus() {
+  return request('/llamacpp/status');
+}
+
+/** @returns {Promise<Object[]>} Loaded llama.cpp model (0 or 1 entries) */
+export async function getLlamacppModels() {
+  const data = await request('/llamacpp/models');
+  return data?.models ?? [];
+}
+
+/** @returns {Promise<Object>} Concurrency test results for the loaded model */
+export function testLlamacppConcurrency(model) {
+  return request('/llamacpp/test-concurrency', {
+    method: 'POST',
+    body: JSON.stringify({ model: model || '' }),
+  });
+}
+
 /** @returns {Promise<Object>} Connection test result for the provider */
 export function testProviderConnection({ provider, apiBase, model, apiKey }) {
   return request('/provider/test', {

--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -30,6 +30,7 @@ export const systemKeys = {
   all: () => ["system"],
   health: () => ["system", "health"],
   ollama: () => ["system", "ollama"],
+  llamacpp: () => ["system", "llamacpp"],
 };
 
 export const standardsKeys = {
@@ -44,4 +45,5 @@ export const settingsKeys = {
   aiClients: () => ["settings", "aiClients"],
   knownModels: (providerId) => ["settings", "knownModels", providerId],
   ollamaModels: () => ["settings", "ollamaModels"],
+  llamacppModels: () => ["settings", "llamacppModels"],
 };

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -38,7 +38,7 @@ function readBudgetSeconds(storage = localStorage) {
   // Read new key first; fall back to legacy 'pool-budget' for back-compat.
   const raw = storage.getItem(providerKey(provider, 'time-limit'))
     ?? storage.getItem(providerKey(provider, 'pool-budget'));
-  if (raw === null || raw === undefined) return provider === 'ollama' ? 0 : DEFAULT_TIME_LIMIT_S;
+  if (raw === null || raw === undefined) return (provider === 'ollama' || provider === 'llamacpp') ? 0 : DEFAULT_TIME_LIMIT_S;
   const parsed = parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -41,6 +41,7 @@ const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
 const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
+const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp"]);
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)
@@ -54,11 +55,11 @@ function preparePayload(payload, storage = localStorage) {
   const get = (key) => storage.getItem(providerKey(activeProvider, key));
   const model = get("model");
   if (!model) throw new Error("No model selected. Go to Settings and select one.");
-  const isOllama = activeProvider === "ollama";
-  const subagents = parseInt(get("subagents") || (isOllama ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS), 10);
+  const isLocalApi = LOCAL_API_PROVIDERS.has(activeProvider);
+  const subagents = parseInt(get("subagents") || (isLocalApi ? DEFAULT_OLLAMA_SUBAGENTS : DEFAULT_CLI_SUBAGENTS), 10);
   // Read new key first; fall back to legacy 'pool-budget' for back-compat.
   const timeLimit = parseInt(
-    get("time-limit") || get("pool-budget") || (isOllama ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET),
+    get("time-limit") || get("pool-budget") || (isLocalApi ? DEFAULT_OLLAMA_BUDGET : DEFAULT_CLI_BUDGET),
     10,
   );
   const result = {

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { MIN_SUBAGENTS, MAX_SUBAGENTS } from '../../../constants.js';
+import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
+import HelpHint from '../../../components/HelpHint.jsx';
+import { useLlamacppServerStatus } from '../hooks/useLlamacppServerStatus.js';
+import { TimeLimitSetting, AdvancedAnalysisSettings, SUBAGENTS_HINT_OLLAMA } from './ProviderSettings.jsx';
+import { settingsKeys } from '../../../api/queryKeys.js';
+
+const LLAMACPP_MODEL_HINT = (
+  <>
+    <p>llama-server runs one model at a time, fixed at launch by the <code>-m</code> flag. Whatever you started it with is what shows up here.</p>
+    <p>To switch models, stop llama-server and relaunch it with a different GGUF file. For speculative decoding (MTP), pair the target model with a smaller drafter via <code>--model-draft</code>.</p>
+  </>
+);
+
+function LoadedModel({ models }) {
+  if (!models.length) {
+    return <span className="settings-model-hint">No model loaded yet. Start llama-server with a GGUF file.</span>;
+  }
+  return (
+    <div className="settings-model-field">
+      <input className="settings-model-input" value={models[0].name} readOnly aria-label="Loaded model" />
+    </div>
+  );
+}
+
+export default function LlamaCppTab({ state, update }) {
+  const { getLlamacppModels, testLlamacppConcurrency } = useApi();
+  const llamacppStatus = useLlamacppServerStatus();
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
+  const [testError, setTestError] = useState(null);
+
+  const queryClient = useQueryClient();
+  const { data: models = [], error: modelsQueryError } = useQuery({
+    queryKey: settingsKeys.llamacppModels(),
+    queryFn: () => getLlamacppModels(),
+  });
+  const modelsError = modelsQueryError
+    ? 'We couldn’t reach llama-server. Make sure it is running on port 8080.'
+    : null;
+
+  // When llama-server transitions offline -> online, refresh the models query
+  // so the loaded model populates as soon as the status pill flips to green.
+  const prevStatusRef = useRef(llamacppStatus?.status ?? 'offline');
+  useEffect(() => {
+    const status = llamacppStatus?.status ?? 'offline';
+    if (prevStatusRef.current !== 'online' && status === 'online') {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.llamacppModels() });
+    }
+    prevStatusRef.current = status;
+  }, [llamacppStatus?.status, queryClient]);
+
+  // The model name comes from llama-server itself. Mirror it into provider
+  // state so the analysis runner has a model to send.
+  useEffect(() => {
+    if (models.length && models[0].name && state.model !== models[0].name) {
+      update('model', models[0].name);
+    }
+  }, [models, state.model, update]);
+
+  const runTest = async () => {
+    setTesting(true);
+    try {
+      const result = await testLlamacppConcurrency(state.model || (models[0]?.name ?? ''));
+      setTestResult(result);
+      if (result.recommended) update('subagents', String(result.recommended));
+    } catch (err) {
+      console.warn('llama.cpp concurrency test failed', err);
+      setTestResult(null);
+      setTestError('The concurrency test didn’t finish. Make sure llama-server is running.');
+    }
+    setTesting(false);
+  };
+
+  return (
+    <>
+      <ServerStatusPill
+        status={llamacppStatus?.status ?? 'offline'}
+        address={llamacppStatus?.address}
+        offlineMessage={
+          <span>
+            llama-server isn&apos;t running. Start it with <code>llama-server -m model.gguf --port 8080</code>.
+          </span>
+        }
+      />
+      {modelsError && <div className="settings-row"><span className="settings-error">{modelsError}</span></div>}
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label-row">
+            <span className="settings-label">Loaded model</span>
+            <HelpHint label="Loaded model help">{LLAMACPP_MODEL_HINT}</HelpHint>
+          </span>
+          <span className="settings-description">The GGUF currently loaded by llama-server.</span>
+        </div>
+        <LoadedModel models={models} />
+      </div>
+      <TimeLimitSetting state={state} update={update} providerType="local-api" />
+      <details className="settings-advanced">
+        <summary className="settings-advanced-toggle">Advanced</summary>
+        <div className="settings-advanced-content">
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label-row">
+                <span className="settings-label">Max parallel agents</span>
+                <HelpHint label="Max parallel agents help">{SUBAGENTS_HINT_OLLAMA}</HelpHint>
+              </span>
+              <span className="settings-description">Estimated from your VRAM. Run a quick test for a more accurate number.</span>
+            </div>
+            <div className="settings-budget-control">
+              <input type="number" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
+              <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !models.length}>
+                {testing ? 'Testing...' : 'Auto-detect'}
+              </button>
+            </div>
+            {testResult && <span className="settings-description">Recommended: {testResult.recommended} agents</span>}
+            {testError && <span className="settings-error">{testError}</span>}
+          </div>
+          <AdvancedAnalysisSettings state={state} update={update} />
+        </div>
+      </details>
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
@@ -6,6 +6,7 @@ import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
 import { useLlamacppServerStatus } from '../hooks/useLlamacppServerStatus.js';
 import { TimeLimitSetting, AdvancedAnalysisSettings, SUBAGENTS_HINT_OLLAMA } from './ProviderSettings.jsx';
+import { useLlamaCppLog } from '../llamacpp-log/LlamaCppLogContext.js';
 import { settingsKeys } from '../../../api/queryKeys.js';
 
 const LLAMACPP_MODEL_HINT = (
@@ -29,6 +30,7 @@ function LoadedModel({ models }) {
 export default function LlamaCppTab({ state, update }) {
   const { getLlamacppModels, testLlamacppConcurrency } = useApi();
   const llamacppStatus = useLlamacppServerStatus();
+  const llamacppLog = useLlamaCppLog();
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [testError, setTestError] = useState(null);
@@ -85,6 +87,12 @@ export default function LlamaCppTab({ state, update }) {
             llama-server isn&apos;t running. Start it with <code>llama-server -m model.gguf --port 8080</code>.
           </span>
         }
+        onToggleConsole={
+          llamacppLog.available
+            ? () => (llamacppLog.open ? llamacppLog.closeLog() : llamacppLog.openLog())
+            : undefined
+        }
+        consoleOpen={llamacppLog.open}
       />
       {modelsError && <div className="settings-row"><span className="settings-error">{modelsError}</span></div>}
       <div className="settings-row">

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.test.jsx
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
 import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { LlamaCppLogContext } from '../llamacpp-log/LlamaCppLogContext.js';
 import LlamaCppTab from './LlamaCppTab.jsx';
 
 const fakeApi = {
@@ -11,12 +12,16 @@ const fakeApi = {
   getLlamacppStatus: vi.fn().mockResolvedValue({ running: false }),
 };
 
+const stubLog = { open: false, available: false, openLog: vi.fn(), closeLog: vi.fn() };
+
 function makeWrapper() {
   const QueryWrapper = withQueryClient();
   return function Wrapper({ children }) {
     return (
       <QueryWrapper>
-        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        <ApiProvider value={fakeApi}>
+          <LlamaCppLogContext.Provider value={stubLog}>{children}</LlamaCppLogContext.Provider>
+        </ApiProvider>
       </QueryWrapper>
     );
   };

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.test.jsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import LlamaCppTab from './LlamaCppTab.jsx';
+
+const fakeApi = {
+  getLlamacppModels: vi.fn(),
+  testLlamacppConcurrency: vi.fn(),
+  getLlamacppStatus: vi.fn().mockResolvedValue({ running: false }),
+};
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('LlamaCppTab', () => {
+  beforeEach(() => {
+    fakeApi.getLlamacppModels.mockReset();
+    fakeApi.testLlamacppConcurrency.mockReset();
+  });
+
+  it('shows the loaded model returned by getLlamacppModels', async () => {
+    fakeApi.getLlamacppModels.mockResolvedValue([{ name: 'qwen3.gguf' }]);
+    const Wrapper = makeWrapper();
+    const update = vi.fn();
+    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
+    const { container } = render(
+      <Wrapper>
+        <LlamaCppTab state={state} update={update} />
+      </Wrapper>,
+    );
+    await waitFor(() => {
+      const input = container.querySelector('input[aria-label="Loaded model"]');
+      expect(input).toBeTruthy();
+      expect(input.value).toBe('qwen3.gguf');
+    });
+    // The tab mirrors the loaded model into provider state.
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith('model', 'qwen3.gguf');
+    });
+  });
+
+  it('shows the models error when getLlamacppModels rejects', async () => {
+    fakeApi.getLlamacppModels.mockRejectedValue(new Error('no llama-server'));
+    const Wrapper = makeWrapper();
+    const state = { model: '', subagents: '4', 'time-limit-min': '60' };
+    const { findByText } = render(
+      <Wrapper>
+        <LlamaCppTab state={state} update={vi.fn()} />
+      </Wrapper>,
+    );
+    expect(await findByText(/couldn(?:'|’)t reach llama-server/i)).toBeTruthy();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -4,6 +4,7 @@ import { ACTIVE_PROVIDER_KEY, DEFAULT_MAX_SUBAGENTS, DEFAULT_TIME_LIMIT_S } from
 import useProviderSettings from '../hooks/useProviderSettings.js';
 import { classifyProvider } from './providerUtils.js';
 import OllamaTab from './OllamaTab.jsx';
+import LlamaCppTab from './LlamaCppTab.jsx';
 import CliProviderTab from './CliProviderTab.jsx';
 import CloudProviderTab from './CloudProviderTab.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
@@ -37,6 +38,7 @@ const INSTALL_INSTRUCTIONS = {
 
 const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit': String(DEFAULT_TIME_LIMIT_S) };
 const OLLAMA_DEFAULTS = { 'time-limit': '0' };
+const LLAMACPP_DEFAULTS = { 'time-limit': '0' };
 const CLOUD_DEFAULTS_BY_ID = {
   openrouter: { 'time-limit': String(DEFAULT_TIME_LIMIT_S), 'model': 'baidu/cobuddy:free' },
 };
@@ -55,14 +57,18 @@ const LEGACY_SETTING_MIGRATIONS = {
 
 function TabContent({ provider, providerConfig }) {
   const classification = classifyProvider(provider.id, provider.type, providerConfig);
+  const localApiDefaults = provider.id === 'llamacpp' ? LLAMACPP_DEFAULTS : OLLAMA_DEFAULTS;
   const defaults = classification === 'cli'
     ? CLI_DEFAULTS
     : classification === 'local-api'
-      ? OLLAMA_DEFAULTS
+      ? localApiDefaults
       : CLOUD_DEFAULTS_BY_ID[provider.id];
   const { state, update } = useProviderSettings(provider.id, defaults);
 
   if (classification === 'local-api') {
+    if (provider.id === 'llamacpp') {
+      return <LlamaCppTab state={state} update={update} />;
+    }
     return <OllamaTab state={state} update={update} />;
   }
   if (classification === 'cli') {

--- a/src/quodeq/ui/src/features/settings/hooks/useLlamacppServerStatus.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useLlamacppServerStatus.js
@@ -1,0 +1,34 @@
+/**
+ * useLlamacppServerStatus - TanStack Query poll for llama-server status.
+ *
+ * Polls every 5s and reports { status: 'online' | 'offline', address }.
+ * A fetch rejection is treated as offline.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { systemKeys } from '../../../api/queryKeys.js';
+
+const POLL_MS = 5000;
+
+export function useLlamacppServerStatus() {
+  const { getLlamacppStatus } = useApi();
+
+  const { data } = useQuery({
+    queryKey: systemKeys.llamacpp(),
+    queryFn: async () => {
+      try {
+        const result = await getLlamacppStatus();
+        if (result?.running) {
+          return { status: 'online', address: result.address ?? null };
+        }
+        return { status: 'offline', address: null };
+      } catch {
+        return { status: 'offline', address: null };
+      }
+    },
+    refetchInterval: POLL_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  return data ?? null;
+}

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogContext.js
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogContext.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+export const LlamaCppLogContext = createContext(null);
+
+export function useLlamaCppLog() {
+  const ctx = useContext(LlamaCppLogContext);
+  if (!ctx) throw new Error('useLlamaCppLog must be used inside <LlamaCppLogProvider>');
+  return ctx;
+}

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
+import ConsoleLogViewer from '../../evaluation/components/ConsoleLogViewer.jsx';
+import { LlamaCppLogContext } from './LlamaCppLogContext.js';
+import { useLlamaCppLogStream } from './useLlamaCppLogStream.js';
+
+const WINDOW_ID = 'llamacpp-log';
+
+const STATUS_LABEL = {
+  idle: '',
+  streaming: ' · running',
+  done: ' · stopped',
+  error: ' · unavailable',
+};
+
+function buildSpec(logs, status) {
+  return {
+    id: WINDOW_ID,
+    type: WINDOW_ID,
+    title: `llama.cpp log${STATUS_LABEL[status] || ''}`,
+    render: () => <ConsoleLogViewer logs={logs} />,
+  };
+}
+
+export function LlamaCppLogProvider({ children }) {
+  const [open, setOpen] = useState(false);
+  const [available, setAvailable] = useState(false);
+  const { logs, status } = useLlamaCppLogStream(open);
+  const { addWindow, removeWindow, replaceWindow, hasWindow } = useSidePane();
+
+  // The console toggle is hidden unless the server reports a configured
+  // LLAMACPP_LOG_FILE. Probe once on mount; the result is stable for the
+  // session since the env var is set at server-launch time.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/llamacpp/logs/available')
+      .then((r) => (r.ok ? r.json() : { available: false }))
+      .then((data) => {
+        if (!cancelled) setAvailable(Boolean(data?.available));
+      })
+      .catch(() => {
+        if (!cancelled) setAvailable(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const spec = useMemo(() => (open ? buildSpec(logs, status) : null), [open, logs, status]);
+
+  useEffect(() => {
+    if (spec) replaceWindow(spec);
+  }, [spec, replaceWindow]);
+
+  const openLog = useCallback(() => {
+    setOpen(true);
+    const fresh = buildSpec([], 'streaming');
+    addWindow(fresh);
+    replaceWindow(fresh);
+  }, [addWindow, replaceWindow]);
+
+  const closeLog = useCallback(() => {
+    setOpen(false);
+    removeWindow(WINDOW_ID);
+  }, [removeWindow]);
+
+  // Sync open state if user closes the window via the X.
+  useEffect(() => {
+    if (open && !hasWindow(WINDOW_ID)) setOpen(false);
+  }, [open, hasWindow]);
+
+  const value = useMemo(
+    () => ({ open, available, openLog, closeLog }),
+    [open, available, openLog, closeLog],
+  );
+
+  return <LlamaCppLogContext.Provider value={value}>{children}</LlamaCppLogContext.Provider>;
+}

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/useLlamaCppLogStream.js
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/useLlamaCppLogStream.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+const URL = '/api/llamacpp/logs/stream';
+const MAX_LINES = 5000;
+
+export function useLlamaCppLogStream(active) {
+  const [logs, setLogs] = useState([]);
+  const [status, setStatus] = useState('idle');
+
+  useEffect(() => {
+    if (!active) {
+      setLogs([]);
+      setStatus('idle');
+      return undefined;
+    }
+    setLogs([]);
+    setStatus('streaming');
+    const es = new EventSource(URL);
+
+    es.onmessage = (e) => {
+      setLogs((prev) => {
+        const next = prev.length >= MAX_LINES ? prev.slice(prev.length - MAX_LINES + 1) : prev;
+        return [...next, e.data];
+      });
+    };
+    es.addEventListener('done', () => {
+      setStatus('done');
+      es.close();
+    });
+    es.onerror = () => {
+      const READYSTATE_CLOSED = 2;
+      if (es.readyState === READYSTATE_CLOSED) setStatus('error');
+    };
+
+    return () => { es.close(); };
+  }, [active]);
+
+  return { logs, status };
+}

--- a/tests/api/test_llamacpp_log_routes.py
+++ b/tests/api/test_llamacpp_log_routes.py
@@ -1,0 +1,44 @@
+"""Tests for the opt-in llama.cpp log SSE route."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def client():
+    from quodeq.api.app import create_app
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+class TestAvailability:
+    def test_unconfigured_returns_unavailable(self, client, monkeypatch):
+        monkeypatch.delenv("LLAMACPP_LOG_FILE", raising=False)
+        resp = client.get("/api/llamacpp/logs/available")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"available": False}
+
+    def test_configured_but_missing_file(self, client, monkeypatch, tmp_path):
+        monkeypatch.setenv("LLAMACPP_LOG_FILE", str(tmp_path / "nope.log"))
+        resp = client.get("/api/llamacpp/logs/available")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"available": False}
+
+    def test_configured_and_present(self, client, monkeypatch, tmp_path):
+        log_file = tmp_path / "llama.log"
+        log_file.write_text("hello\n")
+        monkeypatch.setenv("LLAMACPP_LOG_FILE", str(log_file))
+        resp = client.get("/api/llamacpp/logs/available")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"available": True}
+
+
+class TestStream:
+    def test_unconfigured_returns_404(self, client, monkeypatch):
+        monkeypatch.delenv("LLAMACPP_LOG_FILE", raising=False)
+        resp = client.get("/api/llamacpp/logs/stream")
+        assert resp.status_code == 404
+        body = resp.get_json()
+        assert body["code"] == "NOT_FOUND"
+        assert "LLAMACPP_LOG_FILE" in body["help"]

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -39,6 +39,41 @@ class TestOllamaModels:
         assert len(data["models"]) == 1
 
 
+class TestLlamacppRoutes:
+    def test_status(self, client):
+        with patch("quodeq.api.llm_bridge_routes.get_llamacpp_status") as mock:
+            mock.return_value = {"running": True, "status": "ok", "address": "localhost:8080"}
+            resp = client.get("/api/llamacpp/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["running"] is True
+
+    def test_models(self, client):
+        with patch("quodeq.api.llm_bridge_routes.list_llamacpp_models") as mock:
+            mock.return_value = [{"name": "qwen3.gguf", "size": 0, "quantization": "", "family": ""}]
+            resp = client.get("/api/llamacpp/models")
+        assert resp.status_code == 200
+        assert len(resp.get_json()["models"]) == 1
+
+    def test_concurrency(self, client):
+        with patch("quodeq.api.llm_bridge_routes.run_llamacpp_concurrency_test") as mock:
+            mock.return_value = {"recommended": 3, "vram_per_context": 0, "gpu_memory": 128e9}
+            resp = client.post(
+                "/api/llamacpp/test-concurrency",
+                json={"model": "qwen3.gguf"},
+                headers={"Origin": "http://localhost"},
+            )
+        assert resp.status_code == 200
+        assert resp.get_json()["recommended"] == 3
+
+    def test_concurrency_rejects_path_traversal(self, client):
+        resp = client.post(
+            "/api/llamacpp/test-concurrency",
+            json={"model": "../etc/passwd"},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+
 class TestProviderTest:
     def test_success(self, client):
         with patch("quodeq.api.llm_bridge_routes.check_cloud_connection") as mock:

--- a/tests/llm_bridge/test_llamacpp.py
+++ b/tests/llm_bridge/test_llamacpp.py
@@ -1,0 +1,122 @@
+"""Tests for llama.cpp integration in llm_bridge."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+from quodeq.llm_bridge._llamacpp import (
+    _normalize_base,
+    get_llamacpp_status,
+    list_llamacpp_models,
+    run_concurrency_test,
+)
+
+
+class TestNormalizeBase:
+    def test_strips_v1_suffix(self):
+        assert _normalize_base("http://localhost:8080/v1") == "http://localhost:8080"
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_base("http://localhost:8080/") == "http://localhost:8080"
+
+    def test_leaves_root_alone(self):
+        assert _normalize_base("http://localhost:8080") == "http://localhost:8080"
+
+
+class TestGetLlamacppStatus:
+    def test_running(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"status":"ok"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", return_value=mock_resp):
+            result = get_llamacpp_status("http://localhost:8080")
+
+        assert result["running"] is True
+        assert result["status"] == "ok"
+        assert "8080" in result["address"]
+
+    def test_running_with_v1_suffix(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            get_llamacpp_status("http://localhost:8080/v1")
+
+        # /health must be called on the root, not under /v1
+        called_url = mock_open.call_args[0][0].full_url
+        assert called_url.endswith("/health")
+        assert "/v1/health" not in called_url
+
+    def test_not_running(self):
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            result = get_llamacpp_status()
+
+        assert result["running"] is False
+        assert "error" in result
+
+
+class TestListLlamacppModels:
+    def test_returns_loaded_model(self):
+        mock_data = {
+            "object": "list",
+            "data": [
+                {"id": "qwen3-coder-30b.gguf", "object": "model"},
+            ],
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", return_value=mock_resp):
+            models = list_llamacpp_models()
+
+        assert len(models) == 1
+        assert models[0]["name"] == "qwen3-coder-30b.gguf"
+
+    def test_skips_entries_without_id(self):
+        mock_data = {"data": [{"object": "model"}, {"id": "real.gguf"}]}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", return_value=mock_resp):
+            models = list_llamacpp_models()
+
+        assert len(models) == 1
+        assert models[0]["name"] == "real.gguf"
+
+    def test_server_offline(self):
+        with patch("quodeq.llm_bridge._llamacpp.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            assert list_llamacpp_models() == []
+
+
+class TestConcurrency:
+    def test_no_model_loaded(self):
+        with patch("quodeq.llm_bridge._llamacpp.list_llamacpp_models", return_value=[]), \
+             patch("quodeq.llm_bridge._llamacpp._detect_memory", return_value=48e9):
+            result = run_concurrency_test("any")
+        assert result["recommended"] == 1
+        assert "reason" in result
+
+    def test_estimates_with_loaded_model(self):
+        with patch(
+            "quodeq.llm_bridge._llamacpp.list_llamacpp_models",
+            return_value=[{"name": "model.gguf", "size": 0}],
+        ), patch("quodeq.llm_bridge._llamacpp._detect_memory", return_value=128e9):
+            result = run_concurrency_test("model.gguf")
+        assert result["recommended"] >= 1
+        assert result["gpu_memory"] == 128e9
+
+    def test_no_host_memory_detected(self):
+        with patch(
+            "quodeq.llm_bridge._llamacpp.list_llamacpp_models",
+            return_value=[{"name": "model.gguf", "size": 0}],
+        ), patch("quodeq.llm_bridge._llamacpp._detect_memory", return_value=0):
+            result = run_concurrency_test("model.gguf")
+        assert result["recommended"] == 1

--- a/tests/services/test_tooling_api_clients.py
+++ b/tests/services/test_tooling_api_clients.py
@@ -36,6 +36,18 @@ class TestGetAiClientsIncludesApiProviders:
         ollama = [c for c in result["clients"] if c["id"] == "ollama"][0]
         assert ollama["type"] == "api"
 
+    def test_llamacpp_label_is_dotted(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "llamacpp": {"type": "api", "model": "", "api_base": "http://localhost:8080/v1"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        llamacpp = next((c for c in result["clients"] if c["id"] == "llamacpp"), None)
+        assert llamacpp is not None
+        assert llamacpp["label"] == "llama.cpp"
+
     def test_cli_providers_marked_uninstalled_when_missing(self):
         mixin = FsToolingMixin()
         with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -68,8 +68,13 @@ class TestCheckApiProvider:
             with pytest.raises(RuntimeError, match="server is not running"):
                 _check_api_provider("ollama")
 
+    def test_llamacpp_not_running_raises(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("Connection refused")):
+            with pytest.raises(RuntimeError, match="llama-server is not running"):
+                _check_api_provider("llamacpp")
+
     def test_non_ollama_api_passes(self):
-        # Non-ollama API providers have no connectivity check
+        # Cloud API providers have no connectivity check
         _check_api_provider("openrouter")
 
 


### PR DESCRIPTION
## Summary
- Adds `llamacpp` as a selectable local provider alongside Ollama. Quodeq talks to a user-launched `llama-server` over its OpenAI-compatible API on `localhost:8080`.
- Unlocks the wider llama.cpp ecosystem on local hardware: any GGUF can be run directly, and speculative decoding (MTP) works by pairing the target with a smaller drafter via `--model-draft`.
- Mirrors the Ollama bridge shape (`status`, `list_models`, concurrency estimate) but accommodates the conceptual gap: llama-server is one process per model with no registry.

## What changed
- **Bridge**: `src/quodeq/llm_bridge/_llamacpp.py` — `/health` for status, `/v1/models` for the loaded model, VRAM math reused from `_ollama.py`.
- **Registration**: `ai_providers.json` (port 8080, OpenAI-compatible) and `config/ai_provider.py::PROVIDERS`. The local-api classifier already keys off `localhost`.
- **API routes**: `/api/llamacpp/{status,models,test-concurrency}`.
- **Prereqs**: when `llamacpp` is selected and the daemon is down, the user gets launch instructions including the MTP drafter form.
- **UI**: new `LlamaCppTab` (read-only loaded model since the GGUF is fixed at launch), a status hook polling `/api/llamacpp/status`, and a small dispatch tweak in `ProviderTabs.jsx`. Display label is `llama.cpp` rather than the default `Llamacpp`. The `provider === 'ollama'` defaults in the eval flow are generalized to cover any local-api provider.
- **Docs**: README `AI Providers` table now lists llama.cpp, with a section showing target-only and target+drafter launch commands.

## Out of scope
- Spawning or managing the `llama-server` process from Quodeq.
- A model browse/pull UI for llama.cpp (no registry exists).
- Bundling llama.cpp binaries.

## Test plan
- [x] Python: `tests/llm_bridge/test_llamacpp.py`, `tests/api/test_llm_bridge_routes.py::TestLlamacppRoutes`, `tests/shared/test_prereqs.py::TestCheckApiProvider::test_llamacpp_not_running_raises`, `tests/services/test_tooling_api_clients.py::test_llamacpp_label_is_dotted`. Full suite green (2718 passed).
- [x] UI: `LlamaCppTab.test.jsx` covers loaded-model rendering and the offline-error path; `npx vitest run src/features/settings/` green. UI builds cleanly via `npm run build`.
- [x] End-to-end: launch `llama-server -m foo.gguf --port 8080`, pick llama.cpp in Settings, run an analysis. (Reviewer to verify on a machine with llama.cpp installed.)