### PR TITLE
feat(llamacpp): auto-create ~/.quodeq/logs/ when probing log paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Choose what fits your workflow. Configure in **Settings** from the dashboard.
 llama.cpp is one process per model, fixed at launch. Start `llama-server` yourself, then point Quodeq at it from **Settings → AI Provider → llama.cpp**.
 
 ```bash
-# Redirect to ~/.quodeq/logs so the dashboard's CONSOLE button picks it up
-mkdir -p ~/.quodeq/logs
+# Quodeq creates ~/.quodeq/logs/ on first launch — just redirect there
+# and the CONSOLE button picks it up automatically.
 llama-server -m path/to/target.gguf --port 8080 \
   > ~/.quodeq/logs/llama-server.log 2>&1
 

--- a/src/quodeq/api/_llamacpp_log_routes.py
+++ b/src/quodeq/api/_llamacpp_log_routes.py
@@ -35,14 +35,26 @@ def _default_log_paths() -> list[Path]:
     First match wins. Order:
 
     1. ``~/.quodeq/logs/llama-server.log`` — Quodeq-namespaced, same path
-       on every OS, easy for users to discover and clean up.
+       on every OS, easy for users to discover and clean up. The parent
+       directory is created on probe so users can redirect there
+       without running ``mkdir -p`` themselves.
     2. Platform-standard log directory (macOS Library/Logs, XDG state
        dir on Linux, LocalAppData on Windows). Honors host conventions
        and integrates with system log viewers like macOS Console.app.
     3. ``/tmp/llama-server.log`` as a lowest-friction last resort.
     """
     home = Path.home()
-    candidates: list[Path] = [home / ".quodeq" / "logs" / "llama-server.log"]
+    quodeq_logs = home / ".quodeq" / "logs"
+    # Create the directory eagerly so the suggested redirect command in
+    # the README and the offline-message hint just works, even on a
+    # fresh install before the user has run any evaluations.
+    try:
+        quodeq_logs.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        # Permission denied or read-only home — fall through to other
+        # candidates rather than failing the whole probe.
+        pass
+    candidates: list[Path] = [quodeq_logs / "llama-server.log"]
     if sys.platform == "darwin":
         candidates.append(home / "Library" / "Logs" / "llama-server.log")
     elif sys.platform == "win32":


### PR DESCRIPTION
## Summary
Follow-up to #424. Eliminates the ``mkdir -p ~/.quodeq/logs`` step from the recommended llama.cpp launch command.

The default-path probe now creates ``~/.quodeq/logs/`` itself (errors swallowed for read-only homes), so users can just redirect ``llama-server``'s output to the path the README suggests and the **CONSOLE** button picks it up — no preflight directory creation needed.

## Recipe after merge
```bash
llama-server -m ~/models/foo.gguf --port 8080 \
  > ~/.quodeq/logs/llama-server.log 2>&1
```
No ``mkdir``, no env var.

## Test plan
- [x] Existing tests in ``tests/api/test_llamacpp_log_routes.py`` still pass — the directory creation is benign and the probe behavior is unchanged from the test's perspective.