### PR TITLE
feat(ui): style import-project button as subtle pill

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/ProjectsPage.jsx
@@ -294,12 +294,12 @@ function EmptyProjectsCTA({ onAddProject, onImportProject, isEvaluating }) {
         {onImportProject && (
           <button
             type="button"
-            className={`term-btn projects-empty__cta-btn${isEvaluating ? ' is-disabled' : ''}`}
+            className={`projects-page__import-btn projects-empty__cta-btn${isEvaluating ? ' is-disabled' : ''}`}
             onClick={onImportProject}
             aria-disabled={isEvaluating || undefined}
             title={isEvaluating ? EVAL_BLOCKED_TITLE : 'Import a previously-exported project'}
           >
-            <span aria-hidden="true">▸</span> import project
+            import project
           </button>
         )}
       </div>
@@ -325,13 +325,13 @@ export default function ProjectsPage({ projects = [], selectedProject, isEvaluat
             {onImportProject && (
               <button
                 type="button"
-                className={`term-btn projects-page__add-btn${isEvaluating ? ' is-disabled' : ''}`}
+                className={`projects-page__import-btn${isEvaluating ? ' is-disabled' : ''}`}
                 onClick={onImportProject}
                 aria-label="Import project"
                 aria-disabled={isEvaluating || undefined}
                 title={isEvaluating ? EVAL_BLOCKED_TITLE : 'Import a previously-exported project'}
               >
-                <span aria-hidden="true">▸</span> import project
+                import project
               </button>
             )}
             {onAddProject && (

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2683,6 +2683,43 @@
   flex-shrink: 0;
 }
 
+/* Pill-style import button — visually aligned with the topbar provider/model
+   pill (muted text, subtle border, transparent bg) so it reads as a
+   secondary action next to the red filled "add project" CTA. */
+.projects-page__import-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  min-height: 28px;
+  box-sizing: border-box;
+  border: 1px solid var(--color-border);
+  border-radius: var(--term-radius);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--color-text-muted);
+  background: transparent;
+  cursor: pointer;
+  transition: border-color 0.14s ease, background 0.14s ease, color 0.14s ease;
+  flex-shrink: 0;
+}
+.projects-page__import-btn:hover:not(.is-disabled) {
+  border-color: var(--color-text-muted);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+.projects-page__import-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+.projects-page__import-btn.is-disabled,
+.projects-page__import-btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .projects-page__header-actions {
   display: flex;
   align-items: center;
@@ -2704,7 +2741,8 @@
     margin-left: 0;
     width: 100%;
   }
-  .projects-page__add-btn {
+  .projects-page__add-btn,
+  .projects-page__import-btn {
     flex: 1 1 auto;
     justify-content: center;
   }


### PR DESCRIPTION
## Summary
- Aligns the import-project button with the topbar provider/model pill aesthetic (12px muted text, subtle border, transparent bg, 28px height) so it reads as a clear secondary action next to the filled red "add project" CTA.
- Drops the leading \`▸\` chevron on the import button — the model pill doesn't use one, and removing it lets the button settle into the same visual register as the rest of the chrome.
- Applies in both surfaces: the projects page header (when projects exist) and the empty-state CTA row.

## Test plan
- [x] Open the Projects page with at least one project — verify the header import button looks like a subtle pill next to the red "Add project" button.
- [x] Open the Projects page with no projects — verify the empty-state import button matches.
- [x] Hover the import button — border darkens and bg shifts to surface-alt; text goes from muted to text color.
- [x] Tab to the import button — focus ring shows.
- [x] Trigger an evaluation, then visit Projects — both import buttons render as disabled (50% opacity, not-allowed cursor).
- [x] Verify in both light and dark themes.
- [x] Narrow viewport (<600px) — header import + add buttons stretch to full width together.