### PR TITLE
fix(incremental): heal fingerprint state to prevent silent skip-all

### DIFF
--- a/src/quodeq/analysis/_incr_change_detection.py
+++ b/src/quodeq/analysis/_incr_change_detection.py
@@ -103,11 +103,20 @@ def detect_changed_files(
     new_files = file_set - prev_files
     changed |= new_files
 
+    # A previous fingerprint with file_hashes but no analyzed_files is either
+    # legacy (pre-tracking) or a corrupt/incomplete write from a crashed run.
+    # Either way it can't be trusted to mean "everything was analyzed", so
+    # force a full re-analysis to heal the state on the next run.
+    prev_analyzed = set(prev_fingerprint.get("analyzed_files", []))
+    if prev_files and not prev_analyzed:
+        return ChangeDetectionResult(
+            full_reanalysis=True,
+            reason="previous fingerprint has no analyzed_files (incomplete or pre-tracking)",
+        )
+
     # Files that were fingerprinted but never analyzed (e.g. pool timed out)
     # must be treated as changed so they get picked up on the next run.
-    prev_analyzed = set(prev_fingerprint.get("analyzed_files", []))
-    if prev_analyzed:
-        not_analyzed = (file_set & prev_files) - prev_analyzed - changed
-        changed |= not_analyzed
+    not_analyzed = (file_set & prev_files) - prev_analyzed - changed
+    changed |= not_analyzed
 
     return ChangeDetectionResult(changed=changed)

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -135,7 +135,14 @@ def _execute_pool_and_collect(
     )
     pool, results = _launch_pool(config, dc.dim_id, params)
 
-    fp = build_fingerprint(config.src, dc.files, dc.dim_id, config.standards_dir)
+    # Record what the queue actually dispatched. Without this, the saved
+    # fingerprint has analyzed_files=[], which combined with up-to-date
+    # file_hashes makes the next run's change detection skip everything.
+    queue_taken = set(FileQueue(pool_params.queue_path).all_taken_files())
+    fp = build_fingerprint(
+        config.src, dc.files, dc.dim_id, config.standards_dir,
+        analyzed_files=queue_taken or None,
+    )
     save_fingerprint(fp, dc.evidence_dir)
 
     if pool_params.mini_verify_findings:

--- a/tests/engine/test_incremental.py
+++ b/tests/engine/test_incremental.py
@@ -16,6 +16,7 @@ class TestDetectChangedFiles:
             "git_commit": "abc123",
             "file_hashes": {f: hashlib.sha256(c.encode()).hexdigest() for f, c in files_content.items()},
             "standards_checksum": "std_hash_123",
+            "analyzed_files": sorted(files_content.keys()),
             "timestamp": "2026-01-01",
         }
 
@@ -210,6 +211,7 @@ class TestClassifyFiles:
                 "unchanged.py": hashlib.sha256(b"same").hexdigest(),
             },
             "standards_checksum": None,
+            "analyzed_files": ["changed.py", "dependent.py", "unchanged.py"],
         }
         result = classify_files(inputs=ClassificationInput(
             src=tmp_path, files=["changed.py", "dependent.py", "unchanged.py"],
@@ -264,6 +266,7 @@ class TestIncrementalRunnerIntegration:
             "dimension": "security", "git_commit": None,
             "file_hashes": {"a.py": hashlib.sha256(b"same").hexdigest()},
             "standards_checksum": None,
+            "analyzed_files": ["a.py"],
         }
         result = classify_files(inputs=ClassificationInput(
             src=tmp_path, files=["a.py"], prev_fingerprint=prev_fp,

--- a/tests/engine/test_incremental_integration.py
+++ b/tests/engine/test_incremental_integration.py
@@ -18,7 +18,7 @@ class TestIncrementalEndToEnd:
         (tmp_path / "routes.py").write_text("from auth import login")
 
         files = ["auth.py", "utils.py", "routes.py"]
-        fp1 = build_fingerprint(tmp_path, files, "security", standards_dir=None)
+        fp1 = build_fingerprint(tmp_path, files, "security", standards_dir=None, analyzed_files=set(files))
         evidence_dir_1 = tmp_path / "run1"
         evidence_dir_1.mkdir()
         save_fingerprint(fp1, evidence_dir_1)
@@ -63,7 +63,7 @@ class TestIncrementalEndToEnd:
         (tmp_path / "b.py").write_text("also_same")
 
         files = ["a.py", "b.py"]
-        fp = build_fingerprint(tmp_path, files, "reliability", standards_dir=None)
+        fp = build_fingerprint(tmp_path, files, "reliability", standards_dir=None, analyzed_files=set(files))
 
         prev_jsonl = tmp_path / "prev.jsonl"
         prev_jsonl.write_text(


### PR DESCRIPTION
## Summary

Two-part fix for an incremental-evaluation bug where a successful run could leave a fingerprint that caused the **next** run to silently consider every file already parsed and return cached/empty findings.

### Root cause chain

1. `subagents/runner.py:138` wrote the post-pool fingerprint via `build_fingerprint(...)` **without** `analyzed_files`, persisting `analyzed_files: []` alongside up-to-date `file_hashes`.
2. `_incr_change_detection.py` guarded the "fingerprinted but never analyzed" safety net behind `if prev_analyzed:`, so an empty list disabled the only check that would have caught the corrupt state.
3. Result: next run's change detection saw no changes, the phase 1 fast-path returned `parse_evidence_from_jsonl(...)` (which returns `None` on empty/missing JSONL), and analysis was effectively skipped.

### Changes

- **`subagents/runner.py`** — pass `analyzed_files=queue_taken` to `build_fingerprint` so the persisted fingerprint reflects what the queue actually dispatched.
- **`_incr_change_detection.py`** — invert the guard: a previous fingerprint with non-empty `file_hashes` but empty `analyzed_files` is treated as incomplete/legacy and triggers `full_reanalysis=True`. Heals existing bad state on the next run.
- **Tests** — fixture fingerprints updated to populate `analyzed_files` (the new contract for "successful prior run"). Inline call sites in `test_incremental_integration.py` pass `analyzed_files=set(files)`.

### Scope

Hotfix only — deliberately not entangled with the broader cache-layer rewrite. That ships separately behind `QUODEQ_CACHE_V2`.

## Test plan

- [x] `tests/engine/test_incremental*` (70 tests) pass
- [x] `tests/engine` + `tests/analysis` (821 tests) pass
- [x] Full unit suite minus `tests/integration` (2719 tests) pass
- [x] Soak: run an evaluation, cancel mid-run, run again — verify second run picks up rather than skipping
- [x] Soak: run an evaluation to completion, run again with no changes — verify carry-forward still works (no spurious full re-analyses)