### PR TITLE
feat(cache): foundation for content-addressed result cache (Phase B1)

### DIFF
--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -1,0 +1,35 @@
+"""Content-addressed cache for analysis results.
+
+A successful (file, dimension) analysis is keyed by the SHA-256 of its
+inputs (file content, standards, prompts, model, ...) and stored as one
+atomic JSON entry. The next run computes the same key and either serves
+the recorded result or dispatches the work and writes the new entry.
+
+This replaces the implicit-state model of fingerprint+JSONL+queue with
+an explicit cache lookup. Half-computed work never gets a key, so there
+is no partial state to recover from.
+
+The module is loaded eagerly but the cache itself is only consulted when
+``QUODEQ_CACHE_V2`` is set; see ``flags`` for the wiring guard.
+"""
+from __future__ import annotations
+
+from quodeq.analysis.cache.backend import CacheBackend, CacheStats
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.flags import is_cache_v2_enabled, is_result_cache_disabled
+from quodeq.analysis.cache.key import CacheKey, compute_key
+from quodeq.analysis.cache.local import LocalFileBackend, default_cache_root
+from quodeq.analysis.cache.tiered import TieredCache
+
+__all__ = [
+    "CacheBackend",
+    "CacheEntry",
+    "CacheKey",
+    "CacheStats",
+    "LocalFileBackend",
+    "TieredCache",
+    "compute_key",
+    "default_cache_root",
+    "is_cache_v2_enabled",
+    "is_result_cache_disabled",
+]

--- a/src/quodeq/analysis/cache/backend.py
+++ b/src/quodeq/analysis/cache/backend.py
@@ -1,0 +1,30 @@
+"""Cache backend protocol.
+
+Implementations:
+- ``LocalFileBackend`` — atomic file writes under ``~/.quodeq/cache/results``.
+- ``RemoteHTTPBackend`` (future) — opt-in shared cache via signed URLs.
+
+The protocol is deliberately minimal: get/put/has/delete plus stats.
+Anything richer (bulk ops, prefix queries) can be added when a concrete
+need shows up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from quodeq.analysis.cache.entry import CacheEntry
+
+
+@dataclass
+class CacheStats:
+    entries: int
+    bytes: int
+
+
+class CacheBackend(Protocol):
+    def get(self, key: str) -> CacheEntry | None: ...
+    def put(self, key: str, entry: CacheEntry) -> None: ...
+    def has(self, key: str) -> bool: ...
+    def delete(self, key: str) -> None: ...
+    def stats(self) -> CacheStats: ...

--- a/src/quodeq/analysis/cache/entry.py
+++ b/src/quodeq/analysis/cache/entry.py
@@ -1,0 +1,42 @@
+"""Cache entry — the persisted record for one cache key.
+
+Stored as a single JSON file written atomically by the backend.
+``findings`` mirrors the existing JSONL line schema, so a JSONL file is
+just a stream of finding dicts and migration is mechanical.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+
+# Bumped whenever the entry format itself changes shape. Independent of
+# CacheKey.schema_version, which gates input-side invalidation.
+ENTRY_FORMAT_VERSION = 1
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+@dataclass
+class CacheEntry:
+    """One cached analysis result, keyed by ``key``."""
+
+    key: str
+    schema_version: int
+    findings: list[dict]
+    files_read: int
+    file_path: str
+    dimension: str
+    model_id: str
+    created_at: str = field(default_factory=_utc_now)
+    cache_format_version: int = ENTRY_FORMAT_VERSION
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, text: str) -> CacheEntry:
+        data = json.loads(text)
+        return cls(**data)

--- a/src/quodeq/analysis/cache/flags.py
+++ b/src/quodeq/analysis/cache/flags.py
@@ -1,0 +1,25 @@
+"""Feature flags and kill switches for the result cache."""
+from __future__ import annotations
+
+import os
+
+_V2_ENV = "QUODEQ_CACHE_V2"
+_DISABLE_ENV = "QUODEQ_DISABLE_RESULT_CACHE"
+
+
+def _truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_cache_v2_enabled() -> bool:
+    """True when callers should consult the result cache.
+
+    Phase B opt-in. When the migration completes the flag flips default-on
+    and is eventually deleted alongside the legacy incremental path.
+    """
+    return _truthy(_V2_ENV)
+
+
+def is_result_cache_disabled() -> bool:
+    """Kill switch — bypass the cache entirely (mirrors online_cache pattern)."""
+    return _truthy(_DISABLE_ENV)

--- a/src/quodeq/analysis/cache/key.py
+++ b/src/quodeq/analysis/cache/key.py
@@ -1,0 +1,44 @@
+"""Cache key — content-addressed identity for a (file, dimension) work unit.
+
+The key is the SHA-256 of a canonical JSON serialization of every input
+that affects the analysis output. Two runs with identical inputs compute
+the same key and share the cached result; any diverging input produces
+a different key and forces a fresh dispatch.
+
+What is intentionally NOT in the key:
+- timestamps, run_id, machine, user, git_commit, branch — those are
+  metadata about the run, not inputs to the analysis itself.
+
+What might be added later:
+- evaluator code hash, when evaluators start shaping output deterministically.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    """Inputs that uniquely determine the analysis output for one work unit."""
+
+    schema_version: int
+    file_content_hash: str
+    file_path: str
+    dimension: str
+    standards_hash: str
+    prompts_hash: str
+    evaluator_hash: str
+    model_id: str
+    language: str
+    # Sampling params: optional today, but baked into the key so any future
+    # variation invalidates correctly without a schema bump.
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+def compute_key(key: CacheKey) -> str:
+    """Return the hex SHA-256 of the canonical serialization of ``key``."""
+    canonical = json.dumps(asdict(key), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/quodeq/analysis/cache/local.py
+++ b/src/quodeq/analysis/cache/local.py
@@ -1,0 +1,122 @@
+"""Local filesystem cache backend.
+
+Layout (git-style two-char sharding to keep each directory bounded):
+
+    <root>/<sha[:2]>/<sha[2:]>/entry.json
+
+Writes go via temp file + ``os.rename``, which is atomic on POSIX and on
+NTFS for same-volume renames. A reader either sees the previous contents
+or the new contents, never a partial. A crash mid-write leaves an
+orphaned ``.tmp.*`` file that's skipped by readers and cleaned up on the
+next visit to the same directory.
+
+Cache root resolution mirrors ``context/online_cache.py``:
+``QUODEQ_CACHE_ROOT`` overrides ``~/.quodeq/cache`` so tests can sandbox.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from quodeq.analysis.cache.backend import CacheStats
+from quodeq.analysis.cache.entry import CacheEntry
+
+_logger = logging.getLogger(__name__)
+
+_ROOT_ENV = "QUODEQ_CACHE_ROOT"
+_RESULTS_SUBDIR = "results"
+_ENTRY_FILENAME = "entry.json"
+_TMP_PREFIX = ".tmp."
+
+
+def default_cache_root() -> Path:
+    """Resolve the result cache root, honouring ``QUODEQ_CACHE_ROOT``.
+
+    Returns ``<base>/results`` so this cache is a sibling of the online
+    repo cache under the same shared parent directory.
+    """
+    raw = os.environ.get(_ROOT_ENV, "").strip()
+    base = Path(raw) if raw else Path.home() / ".quodeq" / "cache"
+    return base / _RESULTS_SUBDIR
+
+
+class LocalFileBackend:
+    """Sharded filesystem cache with atomic writes."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = root if root is not None else default_cache_root()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _dir_for(self, key: str) -> Path:
+        if len(key) < 3:
+            raise ValueError(f"cache key too short: {key!r}")
+        return self._root / key[:2] / key[2:]
+
+    def _entry_path(self, key: str) -> Path:
+        return self._dir_for(key) / _ENTRY_FILENAME
+
+    def get(self, key: str) -> CacheEntry | None:
+        path = self._entry_path(key)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            _logger.warning("cache read failed for %s: %s", key, exc)
+            return None
+        try:
+            return CacheEntry.from_json(text)
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            # Corrupt entry — treat as miss and remove so the next put can heal.
+            _logger.warning("cache entry corrupt at %s, removing: %s", path, exc)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return None
+
+    def put(self, key: str, entry: CacheEntry) -> None:
+        target_dir = self._dir_for(key)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / _ENTRY_FILENAME
+        tmp = target_dir / f"{_TMP_PREFIX}{os.getpid()}.{id(entry):x}"
+        try:
+            tmp.write_text(entry.to_json(), encoding="utf-8")
+            os.replace(tmp, target)
+        except OSError as exc:
+            _logger.warning("cache write failed for %s: %s", key, exc)
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def has(self, key: str) -> bool:
+        return self._entry_path(key).is_file()
+
+    def delete(self, key: str) -> None:
+        target_dir = self._dir_for(key)
+        if not target_dir.exists():
+            return
+        try:
+            shutil.rmtree(target_dir)
+        except OSError as exc:
+            _logger.warning("cache delete failed for %s: %s", key, exc)
+
+    def stats(self) -> CacheStats:
+        if not self._root.exists():
+            return CacheStats(entries=0, bytes=0)
+        entries = 0
+        total_bytes = 0
+        for entry_path in self._root.rglob(_ENTRY_FILENAME):
+            try:
+                total_bytes += entry_path.stat().st_size
+                entries += 1
+            except OSError:
+                continue
+        return CacheStats(entries=entries, bytes=total_bytes)

--- a/src/quodeq/analysis/cache/tiered.py
+++ b/src/quodeq/analysis/cache/tiered.py
@@ -1,0 +1,74 @@
+"""Tiered cache — local-first with optional remote fallback.
+
+The remote tier is intentionally unimplemented in this PR. The shape is
+fixed now so that adding an HTTP/S3-backed ``CacheBackend`` later is a
+small, isolated change rather than a refactor.
+"""
+from __future__ import annotations
+
+import logging
+
+from quodeq.analysis.cache.backend import CacheBackend, CacheStats
+from quodeq.analysis.cache.entry import CacheEntry
+
+_logger = logging.getLogger(__name__)
+
+
+class TieredCache:
+    """Composes a local backend with an optional remote backend.
+
+    Read path: local hit returns immediately; on miss, remote is tried and
+    a remote hit warms the local tier before returning. Write path:
+    always writes local; remote write is best-effort and never raises.
+    """
+
+    def __init__(self, local: CacheBackend, remote: CacheBackend | None = None) -> None:
+        self._local = local
+        self._remote = remote
+
+    def get(self, key: str) -> CacheEntry | None:
+        if hit := self._local.get(key):
+            return hit
+        if self._remote is None:
+            return None
+        try:
+            hit = self._remote.get(key)
+        except Exception as exc:  # noqa: BLE001 — remote failures must never propagate
+            _logger.warning("remote cache get failed for %s: %s", key, exc)
+            return None
+        if hit is None:
+            return None
+        self._local.put(key, hit)
+        return hit
+
+    def put(self, key: str, entry: CacheEntry) -> None:
+        self._local.put(key, entry)
+        if self._remote is None:
+            return
+        try:
+            self._remote.put(key, entry)
+        except Exception as exc:  # noqa: BLE001 — remote failures must never propagate
+            _logger.warning("remote cache put failed for %s: %s", key, exc)
+
+    def has(self, key: str) -> bool:
+        if self._local.has(key):
+            return True
+        if self._remote is None:
+            return False
+        try:
+            return self._remote.has(key)
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("remote cache has failed for %s: %s", key, exc)
+            return False
+
+    def delete(self, key: str) -> None:
+        self._local.delete(key)
+        if self._remote is None:
+            return
+        try:
+            self._remote.delete(key)
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("remote cache delete failed for %s: %s", key, exc)
+
+    def stats(self) -> CacheStats:
+        return self._local.stats()

--- a/tests/analysis/cache/test_entry.py
+++ b/tests/analysis/cache/test_entry.py
@@ -1,0 +1,44 @@
+"""Cache entry — JSON round-trip and shape."""
+from __future__ import annotations
+
+from quodeq.analysis.cache.entry import CacheEntry, ENTRY_FORMAT_VERSION
+
+
+def _make(**overrides) -> CacheEntry:
+    defaults = dict(
+        key="abc123",
+        schema_version=1,
+        findings=[{"file": "a.py", "line": 1, "t": "violation"}],
+        files_read=1,
+        file_path="a.py",
+        dimension="security",
+        model_id="claude-opus-4-7",
+    )
+    defaults.update(overrides)
+    return CacheEntry(**defaults)
+
+
+def test_round_trip_preserves_fields():
+    original = _make()
+    restored = CacheEntry.from_json(original.to_json())
+    assert restored.key == original.key
+    assert restored.findings == original.findings
+    assert restored.files_read == original.files_read
+    assert restored.dimension == original.dimension
+    assert restored.model_id == original.model_id
+
+
+def test_default_format_version_baked_in():
+    entry = _make()
+    assert entry.cache_format_version == ENTRY_FORMAT_VERSION
+
+
+def test_created_at_is_iso_utc():
+    entry = _make()
+    assert "T" in entry.created_at
+    assert entry.created_at.endswith("+00:00")
+
+
+def test_empty_findings_round_trip():
+    entry = _make(findings=[])
+    assert CacheEntry.from_json(entry.to_json()).findings == []

--- a/tests/analysis/cache/test_flags.py
+++ b/tests/analysis/cache/test_flags.py
@@ -1,0 +1,27 @@
+"""Feature flags — env var parsing."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.analysis.cache.flags import is_cache_v2_enabled, is_result_cache_disabled
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("1", True), ("true", True), ("TRUE", True), ("yes", True), ("on", True),
+    ("0", False), ("false", False), ("", False), ("no", False), ("  ", False),
+])
+def test_v2_flag(monkeypatch, value, expected):
+    monkeypatch.setenv("QUODEQ_CACHE_V2", value)
+    assert is_cache_v2_enabled() is expected
+
+
+def test_v2_flag_unset(monkeypatch):
+    monkeypatch.delenv("QUODEQ_CACHE_V2", raising=False)
+    assert is_cache_v2_enabled() is False
+
+
+def test_kill_switch(monkeypatch):
+    monkeypatch.setenv("QUODEQ_DISABLE_RESULT_CACHE", "1")
+    assert is_result_cache_disabled() is True
+    monkeypatch.delenv("QUODEQ_DISABLE_RESULT_CACHE", raising=False)
+    assert is_result_cache_disabled() is False

--- a/tests/analysis/cache/test_key.py
+++ b/tests/analysis/cache/test_key.py
@@ -1,0 +1,82 @@
+"""Cache key — stability and sensitivity properties."""
+from __future__ import annotations
+
+from quodeq.analysis.cache.key import CacheKey, compute_key
+
+
+def _base_key(**overrides) -> CacheKey:
+    defaults = dict(
+        schema_version=1,
+        file_content_hash="aa" * 32,
+        file_path="src/auth.py",
+        dimension="security",
+        standards_hash="bb" * 32,
+        prompts_hash="cc" * 32,
+        evaluator_hash="dd" * 32,
+        model_id="claude-opus-4-7",
+        language="python",
+        temperature=None,
+        max_tokens=None,
+    )
+    defaults.update(overrides)
+    return CacheKey(**defaults)
+
+
+class TestStability:
+    def test_same_inputs_same_key(self):
+        assert compute_key(_base_key()) == compute_key(_base_key())
+
+    def test_field_declaration_order_does_not_affect_key(self):
+        # CacheKey is frozen and the canonicalization sorts keys, so a key
+        # built piecewise in any order produces the same hash.
+        k1 = _base_key(model_id="claude-sonnet-4-6")
+        k2 = CacheKey(
+            schema_version=1, file_content_hash="aa" * 32, file_path="src/auth.py",
+            dimension="security", standards_hash="bb" * 32, prompts_hash="cc" * 32,
+            evaluator_hash="dd" * 32, language="python", model_id="claude-sonnet-4-6",
+        )
+        assert compute_key(k1) == compute_key(k2)
+
+
+class TestSensitivity:
+    def test_file_content_change_invalidates(self):
+        a = compute_key(_base_key(file_content_hash="00" * 32))
+        b = compute_key(_base_key(file_content_hash="ff" * 32))
+        assert a != b
+
+    def test_dimension_change_invalidates(self):
+        a = compute_key(_base_key(dimension="security"))
+        b = compute_key(_base_key(dimension="documentation"))
+        assert a != b
+
+    def test_standards_change_invalidates(self):
+        assert compute_key(_base_key(standards_hash="11" * 32)) != compute_key(_base_key(standards_hash="22" * 32))
+
+    def test_prompts_change_invalidates(self):
+        assert compute_key(_base_key(prompts_hash="11" * 32)) != compute_key(_base_key(prompts_hash="22" * 32))
+
+    def test_evaluator_change_invalidates(self):
+        assert compute_key(_base_key(evaluator_hash="11" * 32)) != compute_key(_base_key(evaluator_hash="22" * 32))
+
+    def test_model_change_invalidates(self):
+        assert compute_key(_base_key(model_id="claude-opus-4-7")) != compute_key(_base_key(model_id="claude-sonnet-4-6"))
+
+    def test_schema_version_change_invalidates(self):
+        assert compute_key(_base_key(schema_version=1)) != compute_key(_base_key(schema_version=2))
+
+    def test_temperature_change_invalidates(self):
+        assert compute_key(_base_key(temperature=None)) != compute_key(_base_key(temperature=0.7))
+
+    def test_max_tokens_change_invalidates(self):
+        assert compute_key(_base_key(max_tokens=None)) != compute_key(_base_key(max_tokens=4096))
+
+    def test_path_change_invalidates(self):
+        # Path-sensitive rules (e.g. src/ vs tests/) must produce distinct keys.
+        assert compute_key(_base_key(file_path="src/a.py")) != compute_key(_base_key(file_path="tests/a.py"))
+
+
+class TestKeyShape:
+    def test_returns_64_char_hex(self):
+        h = compute_key(_base_key())
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)

--- a/tests/analysis/cache/test_local_backend.py
+++ b/tests/analysis/cache/test_local_backend.py
@@ -1,0 +1,135 @@
+"""Local filesystem backend — atomic writes, sharding, corruption handling."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.local import LocalFileBackend, default_cache_root
+
+
+def _make_entry(key: str = "k" * 64) -> CacheEntry:
+    return CacheEntry(
+        key=key, schema_version=1, findings=[{"file": "a.py", "line": 1}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="claude-opus-4-7",
+    )
+
+
+@pytest.fixture
+def backend(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+class TestRoundTrip:
+    def test_put_then_get(self, backend: LocalFileBackend):
+        entry = _make_entry()
+        backend.put(entry.key, entry)
+        loaded = backend.get(entry.key)
+        assert loaded is not None
+        assert loaded.key == entry.key
+        assert loaded.findings == entry.findings
+
+    def test_miss_returns_none(self, backend: LocalFileBackend):
+        assert backend.get("0" * 64) is None
+
+    def test_has_reflects_state(self, backend: LocalFileBackend):
+        entry = _make_entry()
+        assert backend.has(entry.key) is False
+        backend.put(entry.key, entry)
+        assert backend.has(entry.key) is True
+        backend.delete(entry.key)
+        assert backend.has(entry.key) is False
+
+
+class TestSharding:
+    def test_uses_two_char_prefix(self, backend: LocalFileBackend, tmp_path: Path):
+        key = "abcdef" + "0" * 58
+        backend.put(key, _make_entry(key))
+        expected = tmp_path / "cache" / "ab" / ("cdef" + "0" * 58) / "entry.json"
+        assert expected.is_file()
+
+    def test_short_key_rejected(self, backend: LocalFileBackend):
+        with pytest.raises(ValueError):
+            backend.has("ab")
+
+
+class TestAtomicity:
+    def test_put_overwrites_atomically(self, backend: LocalFileBackend):
+        # Two successive puts: reader always sees a complete entry, never partial.
+        entry_v1 = _make_entry()
+        backend.put(entry_v1.key, entry_v1)
+        entry_v2 = CacheEntry(
+            key=entry_v1.key, schema_version=1, findings=[{"new": True}],
+            files_read=2, file_path="a.py", dimension="security",
+            model_id="claude-opus-4-7",
+        )
+        backend.put(entry_v2.key, entry_v2)
+        loaded = backend.get(entry_v1.key)
+        assert loaded is not None
+        assert loaded.findings == [{"new": True}]
+        assert loaded.files_read == 2
+
+    def test_orphan_tmp_file_does_not_block_reader(self, backend: LocalFileBackend, tmp_path: Path):
+        entry = _make_entry()
+        backend.put(entry.key, entry)
+        # Simulate a crashed concurrent writer: an orphan .tmp.* file in the
+        # same directory must not affect readers of the committed entry.
+        target_dir = tmp_path / "cache" / entry.key[:2] / entry.key[2:]
+        (target_dir / ".tmp.99999.deadbeef").write_text("partial garbage")
+        loaded = backend.get(entry.key)
+        assert loaded is not None
+        assert loaded.findings == entry.findings
+
+
+class TestCorruption:
+    def test_corrupt_entry_treated_as_miss_and_removed(self, backend: LocalFileBackend, tmp_path: Path):
+        key = "ff" * 32
+        target_dir = tmp_path / "cache" / key[:2] / key[2:]
+        target_dir.mkdir(parents=True)
+        (target_dir / "entry.json").write_text("{not valid json")
+        # Get returns None and deletes the corrupt file so the next put can heal.
+        assert backend.get(key) is None
+        assert not (target_dir / "entry.json").exists()
+
+    def test_missing_root_returns_none(self, tmp_path: Path):
+        backend = LocalFileBackend(root=tmp_path / "does-not-exist")
+        assert backend.get("a" * 64) is None
+        assert backend.has("a" * 64) is False
+
+
+class TestStats:
+    def test_empty_root_zero_stats(self, backend: LocalFileBackend):
+        s = backend.stats()
+        assert s.entries == 0
+        assert s.bytes == 0
+
+    def test_counts_entries_and_bytes(self, backend: LocalFileBackend):
+        keys = [f"{i:064x}" for i in range(3)]
+        for k in keys:
+            backend.put(k, _make_entry(k))
+        s = backend.stats()
+        assert s.entries == 3
+        assert s.bytes > 0
+
+
+class TestCacheRoot:
+    def test_default_under_quodeq_cache(self, monkeypatch):
+        monkeypatch.delenv("QUODEQ_CACHE_ROOT", raising=False)
+        root = default_cache_root()
+        assert root.name == "results"
+        assert root.parent.name == "cache"
+        assert root.parent.parent.name == ".quodeq"
+
+    def test_root_env_override(self, monkeypatch, tmp_path: Path):
+        override = tmp_path / "sandboxed"
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(override))
+        root = default_cache_root()
+        assert root == override / "results"
+
+    def test_root_ignored_when_blank(self, monkeypatch):
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", "   ")
+        root = default_cache_root()
+        assert ".quodeq" in root.parts

--- a/tests/analysis/cache/test_tiered.py
+++ b/tests/analysis/cache/test_tiered.py
@@ -1,0 +1,114 @@
+"""TieredCache — local-first with optional remote fallback."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache.backend import CacheStats
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.local import LocalFileBackend
+from quodeq.analysis.cache.tiered import TieredCache
+
+
+class _SpyBackend:
+    """In-memory backend with optional failure injection."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.store: dict[str, CacheEntry] = {}
+        self.fail = fail
+        self.calls: list[tuple[str, str]] = []
+
+    def _check(self, op: str, key: str) -> None:
+        self.calls.append((op, key))
+        if self.fail:
+            raise RuntimeError(f"injected {op} failure")
+
+    def get(self, key: str) -> CacheEntry | None:
+        self._check("get", key)
+        return self.store.get(key)
+
+    def put(self, key: str, entry: CacheEntry) -> None:
+        self._check("put", key)
+        self.store[key] = entry
+
+    def has(self, key: str) -> bool:
+        self._check("has", key)
+        return key in self.store
+
+    def delete(self, key: str) -> None:
+        self._check("delete", key)
+        self.store.pop(key, None)
+
+    def stats(self) -> CacheStats:
+        return CacheStats(entries=len(self.store), bytes=0)
+
+
+def _entry(key: str) -> CacheEntry:
+    return CacheEntry(
+        key=key, schema_version=1, findings=[{"file": "a.py"}],
+        files_read=1, file_path="a.py", dimension="security",
+        model_id="claude-opus-4-7",
+    )
+
+
+@pytest.fixture
+def local(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+class TestLocalOnly:
+    def test_local_hit(self, local: LocalFileBackend):
+        cache = TieredCache(local=local)
+        e = _entry("a" * 64)
+        cache.put(e.key, e)
+        assert cache.get(e.key) is not None
+
+    def test_local_miss_no_remote(self, local: LocalFileBackend):
+        cache = TieredCache(local=local)
+        assert cache.get("0" * 64) is None
+
+
+class TestRemoteFallback:
+    def test_remote_hit_warms_local(self, local: LocalFileBackend):
+        remote = _SpyBackend()
+        e = _entry("b" * 64)
+        remote.store[e.key] = e
+        cache = TieredCache(local=local, remote=remote)
+        # First read: local miss, remote hit, local now warmed.
+        loaded = cache.get(e.key)
+        assert loaded is not None
+        assert local.has(e.key)
+        # Second read: local hit, remote untouched.
+        remote.calls.clear()
+        cache.get(e.key)
+        assert remote.calls == []
+
+    def test_put_writes_both_tiers(self, local: LocalFileBackend):
+        remote = _SpyBackend()
+        cache = TieredCache(local=local, remote=remote)
+        e = _entry("c" * 64)
+        cache.put(e.key, e)
+        assert local.has(e.key)
+        assert e.key in remote.store
+
+
+class TestRemoteFailureIsolation:
+    def test_remote_get_failure_does_not_propagate(self, local: LocalFileBackend):
+        remote = _SpyBackend(fail=True)
+        cache = TieredCache(local=local, remote=remote)
+        # Local miss + remote raise → returns None, no exception.
+        assert cache.get("0" * 64) is None
+
+    def test_remote_put_failure_does_not_propagate(self, local: LocalFileBackend):
+        remote = _SpyBackend(fail=True)
+        cache = TieredCache(local=local, remote=remote)
+        e = _entry("d" * 64)
+        cache.put(e.key, e)  # must not raise
+        # Local write still succeeded.
+        assert local.has(e.key)
+
+    def test_remote_has_failure_returns_false(self, local: LocalFileBackend):
+        remote = _SpyBackend(fail=True)
+        cache = TieredCache(local=local, remote=remote)
+        assert cache.has("0" * 64) is False


### PR DESCRIPTION
## Summary

First PR of the incremental rearchitecture. Lands the **foundation** of a content-addressed result cache that will replace the implicit \`fingerprint + JSONL + queue\` state model. **No dimension is wired through it yet** — that comes in Phase B2 behind \`QUODEQ_CACHE_V2\`.

The structural property: each \`(file, dimension)\` work unit's inputs hash to a key; the result is stored as one atomic JSON entry. Half-computed work never gets a key, so there is no partial state to recover from. The class of bug fixed in #427 cannot exist in this model — it is structurally absent.

## What's in this PR

\`src/quodeq/analysis/cache/\`:

| File | Purpose |
|---|---|
| \`key.py\` | \`CacheKey\` + \`compute_key()\`. SHA-256 over canonical JSON. |
| \`entry.py\` | \`CacheEntry\` with JSON round-trip. \`findings\` mirrors JSONL line schema. |
| \`backend.py\` | Minimal \`CacheBackend\` Protocol (get/put/has/delete/stats). |
| \`local.py\` | \`LocalFileBackend\` — git-style two-char sharding under \`~/.quodeq/cache/results/\`, atomic writes via temp-file + \`os.replace\`. |
| \`tiered.py\` | Local-first with optional remote fallback; remote failures never propagate. Remote backend deliberately not implemented. |
| \`flags.py\` | \`QUODEQ_CACHE_V2\` (opt-in) + \`QUODEQ_DISABLE_RESULT_CACHE\` (kill switch). |

## Key design choices

- **What's in the key**: file content, file path, dimension, standards, prompts, evaluator, model, language, schema version, optional sampling params (\`temperature\`, \`max_tokens\`).
- **What's deliberately not**: timestamps, run id, machine, user, branch, git commit. They are run metadata, not analysis inputs.
- **Cache root**: \`~/.quodeq/cache/results/\`, sibling to \`~/.quodeq/cache/online/\`. Honours existing \`QUODEQ_CACHE_ROOT\` env override (matches \`context/online_cache.py\` convention).
- **Atomic writes**: \`tmp\` file + \`os.replace\`. Reader sees old or new, never partial. Crash mid-write leaves an orphan \`.tmp.*\` invisible to readers.
- **Corruption healing**: a corrupt entry on read returns None and is removed so the next put can heal.

## Tests

50 new tests, all passing. Full suite: 2769 passed (was 2719).

| Area | Coverage |
|---|---|
| Key | stability under reorder; sensitivity to each input; hex shape |
| Entry | round-trip; default format version; ISO UTC timestamps |
| Local backend | round-trip; sharding; short-key rejection; atomic overwrite; orphan-tmp isolation; corruption recovery; missing-root handling; stats; env-var resolution |
| Tiered | local hit; remote-hit warms local; both-tier writes; remote failure isolation (get/put/has) |
| Flags | env-var truthy parsing; kill switch |

## What's next (Phase B2)

A separate PR will:
1. Wire the \`documentation\` dimension through the cache behind \`QUODEQ_CACHE_V2\`.
2. Add cache_hit / cache_miss telemetry to the existing logger and SSE stream.
3. Soak for one release cycle.

After soak, dimensions migrate one at a time in their own PRs, each deleting the corresponding piece of the legacy \`_incr_*\` path. Final cleanup PR removes the flag and any remaining incremental scaffolding.

## Test plan

- [x] \`tests/analysis/cache/\` (50 tests) pass
- [x] Full unit suite (2769 tests) pass
- [x] No existing module imports the new cache yet — zero behavior change for default users
- [ ] Reviewer sanity-check on the key composition (anything missing? \`temperature\`/\`max_tokens\` are speculative)