### PR TITLE
fix(ui): bolder weight on filled term-btn for legibility

### DIFF
--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2197,6 +2197,9 @@
   background: var(--color-accent);
   color: var(--color-on-accent);
   border-color: var(--color-accent);
+  /* Heavier weight for legibility on solid accent fills — the default
+     400 monospace reads thin against high-saturation backgrounds. */
+  font-weight: 600;
 }
 .term-btn--filled:hover:not(:disabled) {
   background: var(--color-accent-hover, color-mix(in srgb, var(--color-accent) 90%, black));


### PR DESCRIPTION
## Summary
- Follow-up to #426. The red "add project" CTA (and any other \`term-btn term-btn--filled\` button) renders white-on-accent at 400-weight monospace, which reads thin against high-saturation fills — especially noticeable in light theme on the crimson background.
- Bumps \`.term-btn--filled\` to \`font-weight: 600\` so the label sits clearly on the fill without changing the terminal aesthetic.

## Test plan
- [x] Projects empty-state CTA — "▸ add project" reads bold and crisp on the red fill (light theme) and the cyan fill (dark theme).
- [x] Projects header — same button at the top-right is also bolder.
- [x] Spot-check other filled term-btn usages (onboarding wizard, evaluate screen) for regressions.
- [x] Verify both light and dark themes.