### PR TITLE
fix(overview): exclude in-progress runs; live history polling

### DIFF
--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -11,7 +11,7 @@ from quodeq.services.ports import RunInfo, list_runs
 from quodeq.core.types import DimensionResult
 from quodeq.shared.utils import _env_int
 from quodeq.services._cache import make_lru_dimension_fetcher
-from quodeq.services.dim_resolution import is_eligible_for_default_view, is_successful_run
+from quodeq.services.dim_resolution import is_eligible_for_default_view
 from quodeq.services.deleted import filter_deleted_from_dimensions
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 from quodeq.services._fs_projects import find_children as _find_children
@@ -70,38 +70,32 @@ def _compute_result(
 ) -> _AccumulatedResult:
     """Load run data and compute trends, severity, and scores.
 
-    Cancelled/failed runs are excluded from the per-dim "latest" pick so the
-    overview cards don't quietly mix partial-run scores (e.g. inflated 9.x
-    from a dim the model only finished a fraction of) with stable scores
-    from older complete runs. ``in_progress`` runs ARE included so dims
-    that have already produced a scored evaluation file (eval/<dim>.json)
-    surface in the cards as soon as they finish — users shouldn't have to
-    wait for the umbrella run to finalise before seeing those results.
-    If every run on file is partial (fresh project, all attempts crashed),
-    fall back to all runs so the dashboard isn't blank.
+    Only ``complete`` runs feed the overview by default. ``in_progress``
+    runs are excluded so partial mid-flight dims don't leak into the
+    cards: during a running evaluation the overview shows the previous
+    complete run's data unchanged, and when the run terminates with
+    status ``complete`` its dims become the new latest pick. ``failed``
+    runs are excluded outright (no trustworthy data).
+
+    If no complete run exists but cancelled runs do (fresh project where
+    every attempt was stopped early), fall back to those — better to
+    show what real data we have than to render a blank dashboard. The
+    fallback explicitly excludes ``in_progress`` so a brand-new project
+    whose first run is still alive starts blank, matching the rule that
+    in-progress dims never count toward the overview.
 
     The eligibility predicate is the shared
-    ``dim_resolution.is_eligible_for_default_view`` rule, used by both this
-    call site and ``dashboard._resolve_selected_run`` so the headline and
-    cards always read from the same set of runs.
-
-    Defensive fallback: if the eligible set yields zero scored dimensions
-    *and* it included a non-complete run, retry across complete runs only.
-    This kicks in when a fresh in-progress run is the newest entry but
-    hasn't produced any scored eval files yet (the overview would
-    otherwise go blank mid-evaluation, even though the previous complete
-    run's data is still on disk).
+    ``dim_resolution.is_eligible_for_default_view`` rule, used by both
+    this call site and ``dashboard._resolve_selected_run`` so the
+    headline and cards always read from the same set of runs.
     """
     eligible_run_infos = [r for r in all_run_infos if is_eligible_for_default_view(r.status)]
     if not eligible_run_infos:
-        eligible_run_infos = all_run_infos
-    result = _build_accumulated_for_runs(reports_root, project, eligible_run_infos, cache_config)
-
-    if not result.all_dimensions:
-        complete_only = [r for r in all_run_infos if is_successful_run(r.status)]
-        if complete_only and len(complete_only) < len(eligible_run_infos):
-            result = _build_accumulated_for_runs(reports_root, project, complete_only, cache_config)
-    return result
+        # Fall back to terminal-but-not-complete runs (cancelled), still
+        # excluding in_progress. ``_read_all_run_data``'s per-eval-file
+        # trustworthiness check filters out stub evals from these.
+        eligible_run_infos = [r for r in all_run_infos if r.status != "in_progress"]
+    return _build_accumulated_for_runs(reports_root, project, eligible_run_infos, cache_config)
 
 
 def _build_accumulated_for_runs(

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -195,17 +195,20 @@ def _build_dashboard_result(
 def _resolve_selected_run(runs: list[RunInfo], run: str) -> tuple[RunInfo, int]:
     """Return the selected RunInfo and its index in *runs*, raising FileNotFoundError if absent.
 
-    For ``run == _LATEST_RUN``, prefer the most recent run that's eligible
-    to drive the default view (``complete`` or ``in_progress``). The
-    eligibility predicate is the shared
-    ``dim_resolution.is_eligible_for_default_view`` rule, used by both this
-    call site and ``accumulated._compute_result``. Keeping them on the
-    same predicate is what prevents the "headline says one thing, cards
-    say another" inconsistency users hit when the two filters drift.
+    For ``run == _LATEST_RUN``, prefer the most recent ``complete`` run.
+    in_progress and cancelled runs are skipped: the overview waits for a
+    run to terminate cleanly before promoting it to the default
+    landing-page view. The eligibility predicate is the shared
+    ``dim_resolution.is_eligible_for_default_view`` rule, used by both
+    this call site and ``accumulated._compute_result``. Keeping them on
+    the same predicate is what prevents the "headline says one thing,
+    cards say another" inconsistency users hit when the two filters
+    drift.
 
-    If every run is cancelled (fresh project / repeated crashes), fall
-    back to ``runs[0]`` rather than refusing to render. Users can still
-    navigate to a specific partial run via the score-history chart.
+    If no run is complete (fresh project, only run still in progress,
+    every attempt cancelled), fall back to ``runs[0]`` rather than
+    refusing to render. Users can still navigate to a specific partial
+    run via the score-history chart or history table.
 
     Note: run IDs are opaque UUIDs (no sensitive data), safe to include in
     error messages.

--- a/src/quodeq/services/scoring_view/README.md
+++ b/src/quodeq/services/scoring_view/README.md
@@ -115,7 +115,10 @@ See `__init__.py` for the canonical export list. Highlights:
 
 - `is_successful_run(state, exit_reason)` — the success predicate.
 - `is_trustable_run(state)` — for incremental salvage.
-- `is_eligible_for_default_view(state)` — narrower: cards/headline.
+- `is_eligible_for_default_view(state)` — narrowest: cards/headline.
+  Only `complete` qualifies; `in_progress` and `cancelled` are excluded
+  so the overview waits for the umbrella run to terminate cleanly
+  before counting any of its dims.
 - `is_visible_in_history(reports_root, project, run_info)` — for the
   history table filter.
 - `resolve_latest_per_dim(reports_root, project, *, as_of=None)` —

--- a/src/quodeq/services/scoring_view/_resolution.py
+++ b/src/quodeq/services/scoring_view/_resolution.py
@@ -89,8 +89,8 @@ def resolve_latest_per_dim(
     Walks runs newest-first; for each ``(run, dim)`` pair, accepts the
     first one where:
 
-      - the run is **eligible for default view** (``complete`` or
-        ``in_progress``) — stricter than ``is_trustable_run`` because
+      - the run is **eligible for default view** (``complete`` only) —
+        stricter than ``is_trustable_run`` because in-progress and
         cancelled-run evals aren't promoted to the cards by default.
       - ``evaluation/<dim>.json`` exists with ``filesRead > 0``.
       - the run's date is on or before ``as_of`` (when provided).

--- a/src/quodeq/services/scoring_view/_states.py
+++ b/src/quodeq/services/scoring_view/_states.py
@@ -85,10 +85,7 @@ def is_successful_run(status: str, exit_reason: str | None = None) -> bool:
 
     Anything else (manual signal cancel, stale-detect, exception, error,
     or in-progress runs) is **not** successful for the purposes of this
-    predicate. In-progress runs in particular have a distinct
-    ``is_eligible_for_default_view`` predicate — they're allowed in the
-    overview *while running* but don't count as a "completed run" until
-    they reach one of the success states above.
+    predicate.
     """
     if status == RUN_STATE_COMPLETE:
         return True
@@ -120,14 +117,24 @@ def is_trustable_run(status: str) -> bool:
 def is_eligible_for_default_view(status: str) -> bool:
     """A run whose data can drive the overview cards / headline by default.
 
-    Narrower than ``is_trustable_run``: ``cancelled`` is excluded
-    because a run that was signal-cancelled mid-flight may have
-    sparse-coverage stub evals (model only got through 5% of files
-    before stop) — silently mixing those into the cards distorts the
-    score the user reads.
+    The strictest of the three predicates: only ``complete`` qualifies.
 
-    A user can still explicitly navigate to a cancelled run via the
-    chart or history table — this predicate only governs the *default*
+      - ``in_progress`` is excluded because the umbrella run hasn't
+        terminated. Already-scored dims are real, but counting them in
+        the overview while the run is alive means the cards twitch each
+        time a dim finishes; users instead want a stable view of the
+        *last finished* run until the new one terminates. Mid-flight
+        dims are still inspectable on the run-detail page (clicking the
+        running row in history).
+      - ``cancelled`` is excluded because a signal-cancelled run can
+        have sparse-coverage stub evals (model only got through 5% of
+        files before stop) — silently mixing those into the cards
+        distorts the score.
+      - ``failed`` is excluded — the run errored before producing
+        trustworthy data.
+
+    A user can still explicitly navigate to a non-complete run via the
+    chart or history table; this predicate only governs the *default*
     landing-page selection, where surprises are unwelcome.
 
     Used by:
@@ -139,7 +146,7 @@ def is_eligible_for_default_view(status: str) -> bool:
     Both call sites consult this single predicate so they cannot drift
     apart (a class of bug we hit repeatedly before centralisation).
     """
-    return status in (RUN_STATE_COMPLETE, RUN_STATE_IN_PROGRESS)
+    return status == RUN_STATE_COMPLETE
 
 
 # ---------------------------------------------------------------------------

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -6,6 +6,28 @@ import IncompleteSetupCard from './IncompleteSetupCard.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import EmptyState from '../../../components/EmptyState.jsx';
 
+function NoCompletedEvalPanel({ availableRuns = [], onNavigate }) {
+  const hasRunning = availableRuns.some((r) => r?.status === 'in_progress');
+  if (hasRunning) {
+    return (
+      <EmptyState
+        title="Evaluation in progress"
+        description="Results will appear here once the evaluation finishes. You can watch dimensions complete one by one in the History tab."
+        actionLabel="Open history"
+        onAction={() => onNavigate?.('history')}
+      />
+    );
+  }
+  return (
+    <EmptyState
+      title="No completed evaluation yet"
+      description="Previous attempts didn't finish cleanly. Start a new evaluation to populate the overview."
+      actionLabel="Start evaluation"
+      onAction={() => onNavigate?.('evaluate')}
+    />
+  );
+}
+
 function DashboardContent({ runMode, data, focus, callbacks }) {
   const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
@@ -23,6 +45,15 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
   }
   if (!accumulated) {
     return <LoadingScreen />;
+  }
+  if (accumulatedDimensions.length === 0) {
+    // Project has runs (otherwise the upstream `!dashboard` empty
+    // state would have fired) but none have terminated cleanly yet —
+    // first evaluation in progress, or every prior attempt was
+    // cancelled/failed. Render a clear waiting-for-results state in
+    // place of the empty stat strip and dim cards (the page header
+    // above still shows project name, language mix, file count).
+    return <NoCompletedEvalPanel availableRuns={availableRuns} onNavigate={onNavigate} />;
   }
   if (focusedDimension) {
     return (

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, lazy, Suspense } from 'react';
 import { gradeLabel, scoreColorClass } from '../../../utils/formatters.js';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
+import { useRunningRunsRefresh } from '../../../hooks/useRunningRunsRefresh.js';
 const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
@@ -324,6 +325,10 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   const { selectedRunId } = selection;
   const { onRunClick, onDimensionClick, onNavigate, onRunChange, onRunDeleted } = callbacks;
   const { deleteEvaluation } = useApi();
+  // Background refresh while a run is alive so the running row flips
+  // to "complete" without the user manually reloading. Scoped to this
+  // page only — other tabs don't poll.
+  useRunningRunsRefresh({ selectedProject, availableRuns });
   const visibleSet = useMemo(() => new Set(readVisibleStandardIds()), []);
   const trend = useMemo(() => filterTrendByVisibleStandards(rawTrend || [], visibleSet), [rawTrend, visibleSet]);
 

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -50,4 +50,5 @@ describe("useProjectScores", () => {
       expect(result.current.availableRuns).toEqual([{ runId: "r1" }]);
     });
   });
+
 });

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
@@ -1,0 +1,31 @@
+/**
+ * Background refresh while at least one run is in_progress.
+ *
+ * Mounted from the History page only — we deliberately don't put this
+ * on the global score query. Other tabs (Overview, Standards, etc.)
+ * shouldn't poll while the user is reading them; the History list is
+ * the one place where the user is actively watching for the running
+ * row to flip to "complete".
+ *
+ * When the next refresh sees all runs terminal, the interval clears
+ * itself: no runaway polling.
+ */
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { projectKeys } from '../api/queryKeys.js';
+import { pollIntervalForRuns } from '../utils/runPolling.js';
+
+export function useRunningRunsRefresh({ selectedProject, availableRuns }) {
+  const queryClient = useQueryClient();
+  const interval = pollIntervalForRuns(availableRuns);
+
+  useEffect(() => {
+    if (!selectedProject || !interval) return undefined;
+    const id = setInterval(() => {
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.project(selectedProject),
+      });
+    }, interval);
+    return () => clearInterval(id);
+  }, [queryClient, selectedProject, interval]);
+}

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useRunningRunsRefresh } from './useRunningRunsRefresh.js';
+import { IN_PROGRESS_POLL_MS } from '../utils/runPolling.js';
+import { projectKeys } from '../api/queryKeys.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+  function Wrapper({ children }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return { Wrapper, invalidateSpy };
+}
+
+describe('useRunningRunsRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not invalidate when every run is terminal', () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: 'p1',
+          availableRuns: [{ runId: 'r1', status: 'complete' }],
+        }),
+      { wrapper: Wrapper },
+    );
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 3);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates on each tick while a run is in_progress', () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: 'p1',
+          availableRuns: [
+            { runId: 'r1', status: 'in_progress' },
+            { runId: 'r0', status: 'complete' },
+          ],
+        }),
+      { wrapper: Wrapper },
+    );
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 2 + 50);
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectKeys.project('p1'),
+    });
+  });
+
+  it('stops invalidating once all runs become terminal', () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { rerender } = renderHook(
+      ({ runs }) =>
+        useRunningRunsRefresh({ selectedProject: 'p1', availableRuns: runs }),
+      {
+        wrapper: Wrapper,
+        initialProps: {
+          runs: [{ runId: 'r1', status: 'in_progress' }],
+        },
+      },
+    );
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS + 50);
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    invalidateSpy.mockClear();
+    rerender({ runs: [{ runId: 'r1', status: 'complete' }] });
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 5);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing without a selected project', () => {
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: '',
+          availableRuns: [{ runId: 'r1', status: 'in_progress' }],
+        }),
+      { wrapper: Wrapper },
+    );
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 3);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/utils/runPolling.js
+++ b/src/quodeq/ui/src/utils/runPolling.js
@@ -1,0 +1,29 @@
+/**
+ * Polling cadence + predicate for "is any run still alive?".
+ *
+ * Used by the History page to refresh the run list while at least one
+ * run is in progress, so the row's running indicator and the
+ * overview pick up the freshly-completed dims without the user
+ * manually refreshing. Polling is intentionally scoped to the History
+ * page (not the global score query) so the rest of the app doesn't
+ * fire periodic requests while the user is reading other tabs.
+ *
+ * 15 seconds: a finishing run takes minutes, so 15s is plenty tight
+ * to update the row visibly soon after the umbrella run terminates,
+ * while keeping background load near-zero (4 requests/min while a
+ * run is alive, none otherwise).
+ */
+export const IN_PROGRESS_POLL_MS = 15000;
+
+/**
+ * Return the poll interval for `useQuery.refetchInterval`, or `false`
+ * to disable polling entirely.
+ *
+ * @param {Array<{ status?: string }> | null | undefined} availableRuns
+ * @returns {number | false}
+ */
+export function pollIntervalForRuns(availableRuns) {
+  if (!availableRuns || availableRuns.length === 0) return false;
+  const anyRunning = availableRuns.some((r) => r && r.status === 'in_progress');
+  return anyRunning ? IN_PROGRESS_POLL_MS : false;
+}

--- a/src/quodeq/ui/src/utils/runPolling.test.js
+++ b/src/quodeq/ui/src/utils/runPolling.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { pollIntervalForRuns, IN_PROGRESS_POLL_MS } from './runPolling.js';
+
+test('returns false when there are no runs', () => {
+  assert.equal(pollIntervalForRuns([]), false);
+  assert.equal(pollIntervalForRuns(null), false);
+  assert.equal(pollIntervalForRuns(undefined), false);
+});
+
+test('returns false when every run is terminal', () => {
+  const runs = [
+    { runId: 'r1', status: 'complete' },
+    { runId: 'r2', status: 'cancelled' },
+    { runId: 'r3', status: 'failed' },
+  ];
+  assert.equal(pollIntervalForRuns(runs), false);
+});
+
+test('returns the poll interval when at least one run is in_progress', () => {
+  const runs = [
+    { runId: 'r1', status: 'in_progress' },
+    { runId: 'r2', status: 'complete' },
+  ];
+  assert.equal(pollIntervalForRuns(runs), IN_PROGRESS_POLL_MS);
+});
+
+test('IN_PROGRESS_POLL_MS is in the 10-30 second range', () => {
+  // Background-poll cadence: tight enough to flip the row within
+  // seconds of the umbrella run terminating, loose enough that a
+  // local server with one running scan barely notices. Polling is
+  // History-page-only, not global. If this constant moves outside
+  // the band, revisit the UX/perf tradeoff.
+  assert.ok(IN_PROGRESS_POLL_MS >= 10000 && IN_PROGRESS_POLL_MS <= 30000);
+});
+
+test('treats missing status as not in_progress (defensive)', () => {
+  const runs = [
+    { runId: 'r1' },
+    { runId: 'r2', status: undefined },
+  ];
+  assert.equal(pollIntervalForRuns(runs), false);
+});

--- a/tests/services/scoring_view/test_states.py
+++ b/tests/services/scoring_view/test_states.py
@@ -4,9 +4,12 @@ Pinning the contracts described in scoring_view/README.md so that:
 
   - ``is_successful_run`` matches only the user-intended success cases.
   - ``is_trustable_run`` includes cancelled (so incremental can salvage
-    partial work) but excludes failed.
-  - ``is_eligible_for_default_view`` excludes cancelled (so partial-stop
-    data doesn't silently distort the cards) but includes in_progress.
+    partial work) and in_progress (so already-scored dims are real for
+    next-run salvage) but excludes failed.
+  - ``is_eligible_for_default_view`` is the strictest rule: only
+    ``complete`` runs drive the overview cards. in_progress and
+    cancelled are both excluded — overview waits for the umbrella run
+    to terminate before counting any of its dims.
 
 A mismatch between any two of these predicates is what the package
 exists to prevent — these tests fail fast if the rules drift.
@@ -96,11 +99,13 @@ class TestIsEligibleForDefaultView:
     def test_complete_is_eligible(self):
         assert is_eligible_for_default_view("complete") is True
 
-    def test_in_progress_is_eligible(self):
-        # Today's run hasn't finished yet but the dims it has scored
-        # are real — show them on the overview without making the user
-        # wait for finalization.
-        assert is_eligible_for_default_view("in_progress") is True
+    def test_in_progress_is_NOT_eligible(self):
+        # An in-progress run's already-scored dims are real but the
+        # umbrella run hasn't terminated, so they don't count toward
+        # the overview yet. Users see those dims on the run-detail
+        # page (clicking the running row in history); the overview
+        # cards only update when the run reaches a terminal state.
+        assert is_eligible_for_default_view("in_progress") is False
 
     def test_cancelled_is_NOT_eligible(self):
         # A signal-cancelled run can have stub or sparse-coverage

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -201,26 +201,29 @@ class TestComputeAccumulated:
         assert scores == {"security": "7.0", "maintainability": "8.0"}
         assert result["summary"]["numericAverage"] == 7.5  # avg(7.0, 8.0)
 
-    def test_includes_in_progress_run_for_dims_already_scored(self, tmp_path: Path):
-        # A dim that produced an eval file inside an in-progress run is
-        # trustworthy — its score should surface in the cards immediately,
-        # not wait for the umbrella run to finalise. (Without this, users
-        # see today's freshly-completed dim as "Older run · Apr 25" because
-        # the still-running umbrella excluded today's partial state.)
+    def test_excludes_in_progress_run_from_overview(self, tmp_path: Path):
+        # A dim scored inside an in-progress run must NOT leak into the
+        # overview cards — the umbrella run hasn't terminated. The cards
+        # wait until the run reaches a terminal state and fall through
+        # to the previous complete run for every dim in the meantime.
+        # The user can still inspect the running run's already-scored
+        # dims by clicking through the (running) row in history.
+        #
+        # ``list_runs`` derives in_progress from a live ``.pid`` file
+        # (status.json with state="running" doesn't trigger in_progress
+        # — only a live PID does). The test process's own pid is
+        # guaranteed alive for the duration of the call.
+        import os
         reports_root = _setup_project(tmp_path, "proj", [
             ("run2", [_dim("usability", "9.5", "A")]),
             ("run1", [_dim("usability", "7.0", "B"), _dim("flexibility", "6.0", "C")]),
         ])
-        # Mark run2 as still in progress.
-        (reports_root / "proj" / "run2" / "status.json").write_text(
-            json.dumps({"state": "running"}),
-        )
+        (reports_root / "proj" / "run2" / ".pid").write_text(str(os.getpid()))
         result = compute_accumulated(str(reports_root), "proj", None)
         assert result is not None
         scores = {d["dimension"]: d["overallScore"] for d in result["dimensions"]}
-        # usability picked up from in-progress run2 (the freshest score for
-        # that dim); flexibility falls through to run1.
-        assert scores == {"usability": "9.5", "flexibility": "6.0"}
+        # Both dims fall through to run1; run2's mid-flight 9.5 is hidden.
+        assert scores == {"usability": "7.0", "flexibility": "6.0"}
 
     def test_falls_back_when_all_runs_cancelled(self, tmp_path: Path):
         # If every run is cancelled (fresh project, all attempts crashed), we
@@ -236,42 +239,19 @@ class TestComputeAccumulated:
         assert result is not None
         assert result["dimensions"][0]["overallScore"] == "6.0"
 
-    def test_falls_back_to_complete_when_in_progress_run_yields_no_dims(
-        self, tmp_path: Path, monkeypatch,
-    ):
-        # A fresh in-progress run on top of a previous complete run should
-        # not blank the overview cards if the in-progress run's eval state
-        # makes the eligible-set computation return zero dims (the user-
-        # observed "Evaluating..." regression). The fallback retries with
-        # complete runs only and surfaces the previous run's data.
+    def test_first_run_in_progress_yields_empty_overview(self, tmp_path: Path):
+        # Fresh project, only run is in_progress: overview is empty because
+        # no run has terminated yet. The user sees a blank dashboard until
+        # the run finishes — by design. (Previously the overview leaked
+        # mid-flight scores; now it waits for terminal status.)
         import os
         reports_root = _setup_project(tmp_path, "proj", [
-            ("run2", [_dim("performance", "9.5", "A")]),
-            ("run1", [_dim("performance", "8.3", "B")]),
+            ("run1", [_dim("performance", "9.5", "A")]),
         ])
-        # `list_runs` derives in_progress from a live `.pid` file; the test
-        # process's own pid is guaranteed alive for the call.
-        (reports_root / "proj" / "run2" / ".pid").write_text(str(os.getpid()))
+        (reports_root / "proj" / "run1" / ".pid").write_text(str(os.getpid()))
 
-        from quodeq.services import accumulated as acc_mod
-        real_build = acc_mod._build_accumulated_for_runs
-        calls: list[list[str]] = []
-
-        def fake_build(rroot, project, run_infos, cache_config):
-            statuses = [r.status for r in run_infos]
-            calls.append(statuses)
-            if "in_progress" in statuses:
-                return acc_mod._AccumulatedResult([], [], {
-                    "totalViolations": 0, "totalCompliance": 0,
-                    "critical": 0, "major": 0, "minor": 0,
-                }, None, None)
-            return real_build(rroot, project, run_infos, cache_config)
-
-        monkeypatch.setattr(acc_mod, "_build_accumulated_for_runs", fake_build)
         result = compute_accumulated(str(reports_root), "proj", None)
+        # Project exists so result is non-None, but no eligible dims.
         assert result is not None
-        assert len(calls) == 2  # initial + fallback
-        assert "in_progress" in calls[0]
-        assert "in_progress" not in calls[1]
-        scores = {d["dimension"]: d["overallScore"] for d in result["dimensions"]}
-        assert scores == {"performance": "8.3"}
+        assert result["dimensions"] == []
+        assert result["summary"]["dimensionCount"] == 0

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -134,10 +134,10 @@ class TestResolveLatestPerDim:
         assert result["security"].run_id == "run1"
         assert result["security"].files_read == 500
 
-    def test_includes_in_progress_run_for_finished_dims(self, tmp_path: Path):
-        # If a dim has finished scoring inside a running scan, its data
-        # is trustworthy and should surface — users shouldn't have to
-        # wait for the umbrella run to finalise to see results.
+    def test_excludes_in_progress_run_from_default_view(self, tmp_path: Path):
+        # A still-running run's already-scored dims must NOT promote to
+        # the overview — the umbrella run hasn't terminated, so the
+        # overview waits and falls through to the previous complete run.
         # ``in_progress`` is detected upstream via a live PID lookup, which
         # we'd need to fake on disk; mocking ``list_runs`` at its new
         # location in scoring_view._resolution keeps the test focused on
@@ -151,8 +151,10 @@ class TestResolveLatestPerDim:
         ]
         with patch("quodeq.services.scoring_view._resolution.list_runs", return_value=runs_for_mock):
             result = resolve_latest_per_dim(tmp_path, "proj")
-        assert result["security"].run_id == "run2"
-        assert result["security"].run_state == "in_progress"
+        # run2 (in_progress) skipped; run1 (complete) wins.
+        assert result["security"].run_id == "run1"
+        assert result["security"].run_state == "complete"
+        assert result["security"].overall_score == "7.0/10"
 
     def test_excludes_cancelled_run_from_default_view(self, tmp_path: Path):
         # Cancelled runs are NOT promoted to overview cards by default —
@@ -260,13 +262,15 @@ class TestSharedTrustPredicates:
     def test_is_trustable_run_excludes_failed(self):
         assert is_trustable_run("failed") is False
 
-    def test_is_eligible_for_default_view_includes_complete_in_progress(self):
-        # The narrower rule — used by overview cards / headline. Cancelled
-        # is OUT because partial-coverage stub evals can distort the cards.
+    def test_is_eligible_for_default_view_includes_only_complete(self):
+        # The strictest rule — used by overview cards / headline. Only
+        # terminal-and-trustworthy runs count: ``complete``. in_progress
+        # is excluded so partial mid-run dims don't leak into the cards;
+        # cancelled is excluded because of partial-coverage stub evals.
         assert is_eligible_for_default_view("complete") is True
-        assert is_eligible_for_default_view("in_progress") is True
 
-    def test_is_eligible_for_default_view_excludes_cancelled_and_failed(self):
+    def test_is_eligible_for_default_view_excludes_in_progress_cancelled_failed(self):
+        assert is_eligible_for_default_view("in_progress") is False
         assert is_eligible_for_default_view("cancelled") is False
         assert is_eligible_for_default_view("failed") is False
 


### PR DESCRIPTION
## Summary
- Overview cards no longer mix mid-flight scores from a running run with the previous complete run. `is_eligible_for_default_view` now matches `complete` only; in-progress dims show on the run-detail page (clicking the running row in History) but never on the overview.
- History page polls project queries every 15s while any run is `in_progress` so the running row flips to its finished form on its own and the overview picks up newly-completed dims without a manual refresh. Scoped to History only — other tabs don't fire periodic requests.
- Empty-state panel for "no completed evaluation yet" replaces the empty stat strip and dim cards. The project header (name, language mix, file count) stays visible so the user always has context.

## Test plan
- [x] `tests/services/scoring_view/test_states.py`, `test_dim_resolution.py`, `test_accumulated.py` flipped to pin the new contract; full backend suite (699 services tests) passes.
- [x] `useRunningRunsRefresh.test.jsx` — 4 vitest cases with fake timers (no fire on terminal, fires per tick while running, stops on transition, no-op without project).
- [x] `runPolling.test.js` — 5 unit tests for the helper (poll interval predicate + range guard).
- [x] UI build clean.
- [x] Live walkthrough on a project with an in-progress first run: confirm overview shows "Evaluation in progress" panel; History row stays running with dot; ~15s after termination the row flips to finished and overview picks up the new dims without manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)