### PR TITLE
fix(ui): reset scroll on screen change

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -407,6 +407,15 @@ export default function App() {
     : null;
   const { activePage, navStack, navPop, navGoTo, navTab, activeTab } = state;
 
+  // Reset scroll on project switch — useNavStack handles the same for
+  // tab/page changes, but selectedProject lives outside the nav stack.
+  // Without this, switching from a project scrolled deep into Projects
+  // lands the user partway down the next project's Overview.
+  useEffect(() => {
+    const main = document.querySelector('.app-shell__main-column > .dashboard');
+    if (main) main.scrollTop = 0;
+  }, [state.selectedProject]);
+
   const currentDayLabel = useMemo(
     () => formatDayLabel(state.dashboard?.trend, state.currentOverviewRun, state.dailyRuns, state.overviewRunIndex),
     [state.dashboard?.trend, state.currentOverviewRun, state.dailyRuns, state.overviewRunIndex]

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -86,7 +86,12 @@ export function useNavStack({ historyAdapter } = {}) {
   const activePage = navStack[navStack.length - 1];
 
   useEffect(() => {
-    window.scrollTo({ top: 0 });
+    // The window itself doesn't scroll — the dashboard <main> does.
+    // Reset its scrollTop so navigating to a new screen always lands
+    // at the top instead of inheriting the previous screen's offset.
+    const main = document.querySelector('.app-shell__main-column > .dashboard');
+    if (main) main.scrollTop = 0;
+    else window.scrollTo({ top: 0 });
   }, [activePage]);
 
   return { navStack, activePage, navPush, navPop, navGoTo, navReset, navTab };


### PR DESCRIPTION
## Summary
- Navigating between screens (sidebar tab, nav-stack push/pop, project switch) carried over the previous screen's scroll offset. Selecting a project from a long list scrolled near the bottom would land you already partway down its Overview instead of at the top.
- The existing reset in \`useNavStack\` called \`window.scrollTo({ top: 0 })\` — a no-op here, since the actual scroll container is \`.app-shell__main-column > .dashboard\`. Switched to scrolling that element directly (with a window fallback to keep behavior safe outside the app shell).
- \`selectedProject\` lives outside the nav stack, so a sibling effect in \`App.jsx\` resets the same container on project change. Together they cover all three navigation paths.

## Test plan
- [x] Scroll deep into the Projects list, click a different project — Overview opens at the top.
- [x] Scroll deep on Overview, switch to Violations / Map / History via the sidebar — new screen opens at the top.
- [x] Push into a detail screen (e.g., a finding), scroll, then back-pop — coming back to a parent screen still resets to top (matches current activePage-change semantics).
- [x] Browser back/forward through nav stack still works.
- [x] Verified in preview: \`main.scrollTop\` jumps from 800 / 262 → 0 across each navigation.