### PR TITLE
fix(ui): scale sidebar count + responsive eval panel

### DIFF
--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -32,7 +32,17 @@ function Logo() {
   );
 }
 
+// Cap the count badge text so the absolutely-positioned chip can't grow
+// past the rail edge. Anything four digits or more reads as "999+", and
+// the title carries the exact number.
+function formatNavCount(count) {
+  if (count == null) return null;
+  if (count >= 1000) return '999+';
+  return String(count);
+}
+
 function NavButton({ id, label, icon, activeTab, onNavTab, count }) {
+  const countLabel = formatNavCount(count);
   return (
     <button
       type="button"
@@ -42,7 +52,11 @@ function NavButton({ id, label, icon, activeTab, onNavTab, count }) {
     >
       {icon}
       <span className="sidebar-nav-label">{label}</span>
-      {count != null && <span className="sidebar-nav-count">{count}</span>}
+      {countLabel != null && (
+        <span className="sidebar-nav-count" title={count >= 1000 ? String(count) : undefined}>
+          {countLabel}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -9,7 +9,24 @@
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--term-space-2);
   margin-bottom: 12px;
+}
+
+@media (max-width: 600px) {
+  /* On narrow viewports stack the title above the right-hand cluster
+     (countdown timer + provider badge) so neither truncates. */
+  .evaluate-header {
+    align-items: flex-start;
+  }
+  .evaluate-header__right {
+    width: 100%;
+    justify-content: flex-start;
+  }
+  .evaluate-panel__top--row {
+    flex-wrap: wrap;
+  }
 }
 
 .evaluate-header h1 {
@@ -3021,11 +3038,12 @@ button.eval-provider-badge--clickable:focus-visible {
   display: flex;
   align-items: center;
   gap: var(--term-space-2);
-  padding: var(--term-space-2) 0;
-  margin-bottom: var(--term-space-3);
+  padding: var(--term-space-1) 0;
+  margin-bottom: var(--term-space-2);
   font-family: var(--term-font-mono);
   font-size: 11px;
   color: var(--color-text-muted);
+  flex-wrap: wrap;
 }
 .evaluate-job-id-line__label {
   text-transform: uppercase;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -63,26 +63,38 @@
    ------------------------------------------------------------ */
 .term-stat-strip {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: var(--term-space-4);
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--term-space-3);
   font-family: var(--term-font-mono);
-  padding: var(--term-space-3) 0;
+  padding: var(--term-space-2) 0;
 }
 /* cards variant: each <Stat> renders as its own bordered card with a subtle
-   surface fill so the top row reads as a band of chrome rather than bare page.
-   Vertical padding is deliberately generous so the large numeric value has
-   breathing room above the hint line. */
+   surface fill so the top row reads as a band of chrome rather than bare page. */
 .term-stat-strip--cards {
   padding: 0;
 }
 .term-stat-strip--cards .term-stat {
   border: var(--term-border);
   border-radius: var(--term-radius);
-  padding: var(--term-space-3) var(--term-space-3) 18px;
+  padding: var(--term-space-2) var(--term-space-3) var(--term-space-3);
   background: var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: var(--term-space-1);
+}
+
+/* Tablet/mobile — drop card padding and shrink the value font so the stat
+   strip stays readable when it wraps to two columns or stacks. */
+@media (max-width: 600px) {
+  .term-stat-strip {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: var(--term-space-2);
+  }
+  .term-stat-strip--cards .term-stat {
+    padding: var(--term-space-2);
+  }
+  .term-stat__value { font-size: 22px; }
+  .term-stat__label { margin-bottom: 0; }
 }
 
 /* `count-abbr` sev badge variant used in the VIOLATIONS stat cell */
@@ -1716,12 +1728,22 @@
   white-space: nowrap;
 }
 .sidebar.sidebar--expanded .sidebar-nav-count {
-  font-size: 10px;
+  font-size: 11px;
+  line-height: 1.4;
   color: var(--color-text-muted);
   background: color-mix(in srgb, var(--color-border) 65%, transparent);
-  padding: 1px 5px;
+  padding: 1px 6px;
   border-radius: var(--term-radius);
   font-variant-numeric: tabular-nums;
+  /* Constant min-width so single-digit counts don't render as a tiny dot,
+     plus a max-width as a final safety net (the JSX caps display at
+     "999+", so this should never actually ellipsize in practice). */
+  min-width: 22px;
+  max-width: 48px;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidebar.sidebar--expanded .sidebar-spacer { flex: 1 1 auto; }


### PR DESCRIPTION
## Summary
Two related UI follow-ups.

### Sidebar count badge
Handles count growth so a 4+ digit number can't push past the 240px rail edge.
- Cap rendered text at \`999+\` in Sidebar; the exact count moves to the badge's \`title\` attribute.
- Bump font 10px → 11px (was hard to read on the 545 case the user pointed out).
- Add \`min-width\` so single-digit chips don't shrink to a tiny dot, plus a \`max-width\` safety net with ellipsis (the JSX cap already prevents overflow in practice).

### Evaluation panel — running state + mobile
Same compaction treatment as #433, extended to the in-progress job panel and to narrow viewports.
- **Stat-strip cards**: tighter card padding, min column width 160 → 140, gap reduced. Below 600px, columns shrink further and the value font drops 28px → 22px so a 4-up strip stays legible when it stacks.
- **Job ID row**: vertical padding/margin halved; \`flex-wrap\` so long ID + copy button don't force the row off-screen on mobile.
- **Evaluate header**: \`flex-wrap\` and a 600px breakpoint so title + provider-badge cluster stack instead of clipping on narrow viewports.
- \`.evaluate-panel__top--row\` also wraps on mobile so cancel/close + the running-state title don't fight for the same row.

## Test plan
- [x] Open a project with a low violations count (e.g. 7) — chip stays readable as a small pill (≥22px).
- [x] Open a project with a 3-digit count (e.g. 545) — chip is wider but unconstrained, no clipping.
- [x] Force-test in DevTools: change the count to 4321 — chip renders as \`999+\`, hover title shows the full number.
- [x] Resize the window below 600px on the Evaluate screen (idle and running) — header stacks, stat strip wraps to 2 columns and stays readable.
- [x] Run an evaluation — running panel reads tighter; stat cards aren't loose.
- [x] Verify in light and dark themes.