### PR TITLE
fix(ui): give sidebar count badge breathing room from rail edge

### DIFF
--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1666,7 +1666,7 @@
   /* Cap label width so long names truncate without colliding with the
      count badge's anchored position; box width stays constant across
      rail states so the text doesn't visibly shrink as it fades. */
-  max-width: 140px;
+  max-width: 124px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1678,8 +1678,9 @@
      this badge occupies in the 240px expanded rail. A `right` anchor
      would slide leftward with the button-right edge during the
      collapse animation — the same horizontal motion the user
-     disliked. */
-  left: 184px;
+     disliked. The offset gives a 3-digit badge clear breathing room
+     to the rail edge (button content ends at ~224, rail at 240). */
+  left: 168px;
   top: 50%;
   transform: translateY(-50%);
 }


### PR DESCRIPTION
## Summary
Follow-up to #434. The badge was anchored at \`left: 184px\` inside the 240px rail, which left a 3-digit count like \`545\` only ~8px from the rail edge — visually it looked like it was about to fall off, exactly the concern raised in the screenshot.

- Shift the anchor to \`left: 168px\` so 3-digit counts have real breathing room.
- Reduce the label's \`max-width\` 140 → 124 so a long label can't overlap the badge at the new anchor.

Verified geometry in preview (240px rail, 207px button content):
- \`7\` → 22px chip, 34px clear to rail edge.
- \`545\` → 32px chip, 24px clear (was ~8).
- \`999+\` → 38px chip, 18px clear.

## Test plan
- [x] Open a project with a 3-digit violations count — chip sits well inside the rail, not against the edge.
- [x] Verify the longer labels (\`violations\`, \`evaluate\`, \`standards\`) don't overlap the chip.
- [x] Single-digit counts (e.g. \`7\` on history) still look balanced.
- [x] Light + dark themes.