### PR TITLE
fix(parser): emit run date_iso with explicit UTC marker

### DIFF
--- a/src/quodeq/data/fs/report_parser/_date_utils.py
+++ b/src/quodeq/data/fs/report_parser/_date_utils.py
@@ -14,15 +14,21 @@ def normalize_date(raw: str) -> tuple[str, str] | None:
     """Parse a date/datetime string and return (sortable_iso, human_label).
 
     Accepts ISO datetime (2026-03-01T14:30:25), ISO date (2026-03-01),
-    or compact date (20260301).  The first element is the full string
-    (including time when available) so that same-day runs sort correctly.
+    or compact date (20260301). Datetime values are normalized to UTC
+    and emitted with an explicit ``Z`` suffix so JavaScript clients
+    render them in the user's local timezone — without the suffix the
+    ECMAScript spec interprets the offset-less string as *local* time,
+    which surfaces UTC as if it were the user's wall clock.
     """
     for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d", "%Y%m%d"):
         try:
             parsed = datetime.strptime(raw, fmt)
-            if parsed.tzinfo is not None:
-                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-            sortable = parsed.isoformat(timespec='seconds') if "T" in fmt else parsed.date().isoformat()
+            if "T" in fmt:
+                if parsed.tzinfo is not None:
+                    parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+                sortable = parsed.isoformat(timespec='seconds') + 'Z'
+            else:
+                sortable = parsed.date().isoformat()
             label = parsed.strftime(f"{parsed.day} %b %Y")
             return sortable, label
         except ValueError:


### PR DESCRIPTION
## Summary
The history view was showing the wrong wall-clock time (e.g. \`04:33 PM\` instead of the user's actual \`06:33 PM\` local time in a UTC+2 zone).

**Root cause:** The pipeline writes run dates as UTC ISO strings with a \`+00:00\` offset, but [\`normalize_date\`](src/quodeq/data/fs/report_parser/_date_utils.py:13) was stripping \`tzinfo\` before storing, producing offset-less strings like \`2026-05-08T16:33:25\`. The web client parses those with \`new Date(...)\`, which **per the ECMAScript spec** interprets offset-less ISO datetimes as *local* time — so the raw UTC value was being surfaced as if it were the user's wall clock.

**Fix:** Append \`Z\` to datetime values in \`normalize_date\`. JavaScript then parses them as UTC and \`toLocaleTimeString\` correctly converts to the browser's timezone. Date-only formats (\`YYYY-MM-DD\`, \`YYYYMMDD\`) are unaffected. Sorting is purely lexical and stays consistent — both old (no \`Z\`) and new (with \`Z\`) sortable strings keep the same ordering relative to each other.

Verified in Node (Europe/Amsterdam, UTC+2):
- Old format \`2026-05-08T16:33:25\` → displays \`04:33 PM\` (the bug)
- New format \`2026-05-08T16:33:25Z\` → displays \`06:33 PM\` (correct)

All 1085 existing service / data / api tests pass.

## Test plan
- [x] Open the History tab on a project — run timestamps reflect the user's local timezone, not UTC.
- [x] Same for the date+time strings in the dashboard / overview / chart tooltips that share \`dateISO\`.
- [x] Existing runs with already-stored \`date_iso\` values continue to render (the parser is the only producer; old reports are re-parsed on each load via \`parse_run_date\`).
- [x] Verify in a non-UTC timezone (e.g. \`TZ=America/Los_Angeles\`).