### PR TITLE
fix(scoring): scale confidence threshold to project size

### DIFF
--- a/src/quodeq/core/evidence/merge.py
+++ b/src/quodeq/core/evidence/merge.py
@@ -22,6 +22,12 @@ def merge_evidence(
             else:
                 merged_principles[pid] = pe
 
+    # merge_findings recomputes metrics with default thresholds; redo
+    # the pass with the merged source_file_count so small-project
+    # confidence scaling survives the merge.
+    for pe in merged_principles.values():
+        pe.compute_metrics(source_file_count=source_file_count)
+
     coverage_pct = compute_coverage_pct(total_files_read, source_file_count)
 
     # Inherit module from the first evidence object if not explicitly provided

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -1,11 +1,20 @@
 """Evidence model — dataclasses for judgments, principles, and evaluation output."""
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 
 DEFAULT_WEIGHT = "Medium (x2)"
 _HIGH_CONFIDENCE_THRESHOLD = 10  # minimum total instances for "high" confidence
 _MEDIUM_CONFIDENCE_THRESHOLD = 5  # minimum total instances for "medium" confidence
+# A 5-file project can never produce 5 instances of every principle; the
+# fixed threshold above hides genuine findings as "Insufficient" on small
+# projects. Scale the threshold down by source-file count, capped at the
+# defaults so larger projects keep their existing bar.
+_HIGH_INSTANCES_PER_FILE = 0.2  # 1 instance per 5 files for high confidence
+_MEDIUM_INSTANCES_PER_FILE = 0.1  # 1 instance per 10 files for medium confidence
+_MIN_HIGH_INSTANCES = 2  # absolute floor — never trust "high" on a single sample
+_MIN_MEDIUM_INSTANCES = 1  # absolute floor — at least one finding to be "medium"
 _LOW_CONF_MAJORITY_DIVISOR = 2  # denominator for "low confidence majority" threshold
 PERCENT_SCALE = 100
 
@@ -87,10 +96,31 @@ class PrincipleEvidence:
         self.compliance.extend(other.compliance)
         self.compute_metrics()
 
-    def compute_metrics(self, scale_multiplier: int = 1) -> None:
-        """Calculate compliance percentage and confidence level from violation/compliance counts."""
-        high_threshold = _HIGH_CONFIDENCE_THRESHOLD * scale_multiplier
-        medium_threshold = _MEDIUM_CONFIDENCE_THRESHOLD * scale_multiplier
+    def compute_metrics(self, scale_multiplier: int = 1, source_file_count: int = 0) -> None:
+        """Calculate compliance percentage and confidence level from violation/compliance counts.
+
+        Thresholds scale with project size:
+        - large projects (via ``scale_multiplier``) need more instances
+          to reach high/medium confidence;
+        - small projects (via ``source_file_count``) need fewer, since
+          a 5-file repo can't physically produce 5 findings per
+          principle. Without this, small projects always read as
+          "Insufficient" even when critical violations are present.
+        """
+        base_high = _HIGH_CONFIDENCE_THRESHOLD * scale_multiplier
+        base_medium = _MEDIUM_CONFIDENCE_THRESHOLD * scale_multiplier
+        if source_file_count > 0:
+            high_threshold = max(
+                _MIN_HIGH_INSTANCES,
+                min(base_high, math.ceil(source_file_count * _HIGH_INSTANCES_PER_FILE)),
+            )
+            medium_threshold = max(
+                _MIN_MEDIUM_INSTANCES,
+                min(base_medium, math.ceil(source_file_count * _MEDIUM_INSTANCES_PER_FILE)),
+            )
+        else:
+            high_threshold = base_high
+            medium_threshold = base_medium
 
         n_violations = len(self.violations)
         n_compliance = len(self.compliance)

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -30,7 +30,7 @@ class EvidenceContext:
 
 
 def _build_principles(
-    grouped: _GroupedJudgments, dimension_name: str,
+    grouped: _GroupedJudgments, dimension_name: str, source_file_count: int = 0,
 ) -> dict[str, PrincipleEvidence]:
     """Build scored PrincipleEvidence entries from grouped judgments."""
     all_keys = set(grouped.violations.keys()) | set(grouped.compliance.keys())
@@ -42,7 +42,7 @@ def _build_principles(
             violations=[judgment_to_dict(j) for j in grouped.violations.get(sc, [])],
             compliance=[judgment_to_dict(j) for j in grouped.compliance.get(sc, [])],
         )
-        pe.compute_metrics()
+        pe.compute_metrics(source_file_count=source_file_count)
         principles[sc] = pe
     return principles
 
@@ -82,7 +82,8 @@ def parse_jsonl_to_evidence_by_dimension(
         return {}
     return {
         dim: _build_evidence(context, _build_principles(
-            _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir), dim))
+            _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir),
+            dim, context.source_file_count))
         for dim, dj in by_dim.items()
     }
 
@@ -99,4 +100,4 @@ def parse_jsonl_to_evidence(
     judgments = read_judgments(jsonl_file, compiled_dir)
     dim = judgments[0].dimension if judgments else ""
     grouped = _group_judgments(judgments, dimension=dim, evaluators_dir=evaluators_dir)
-    return _build_evidence(context, _build_principles(grouped, dim))
+    return _build_evidence(context, _build_principles(grouped, dim, context.source_file_count))


### PR DESCRIPTION
## Summary
On small projects (e.g. \`vulnerabilities-test-ollama-gamma4-26b\`, ~5 files), reliability principles like \`fault tolerance\` and \`recoverability\` were rendered as **"Insufficient"** even when they had critical violations. The "Insufficient" label was hiding real findings.

**Root cause:** the confidence thresholds in [\`PrincipleEvidence.compute_metrics\`](src/quodeq/core/evidence/model.py) are fixed at **5 instances for medium** and **10 for high**. Those numbers are calibrated for ~50+ file projects. A 5-file repo physically cannot produce 5 findings per principle, so every principle gets stamped \`"low"\` confidence → \`Insufficient\`, regardless of severity.

**Fix:** scale the thresholds with \`source_file_count\` using the same ratio the defaults imply (~1 instance per 10 files for medium, per 5 for high), capped at the existing constants for larger projects and floored at 1/2 instances so single-finding cases still register.

| files | new \`medium\` threshold | new \`high\` threshold | old (fixed) |
| --- | --- | --- | --- |
| 5 | 1 | 2 | 5 / 10 |
| 30 | 3 | 6 | 5 / 10 |
| 100+ | 5 (unchanged) | 10 (unchanged) | 5 / 10 |

Threading:
- \`model.py\`: \`compute_metrics\` now accepts \`source_file_count\` and applies the per-file ratio with floor/ceiling guards.
- \`parser.py\`: thread \`context.source_file_count\` through \`_build_principles\` into the initial \`compute_metrics\` call.
- \`merge.py\`: re-run \`compute_metrics\` after the merge with the merged \`source_file_count\`, since \`merge_findings\` recomputes with defaults.

**Backward-compatible:** when \`source_file_count\` is \`0\` (no context), behavior is unchanged. All 2723 existing tests pass.

## Test plan
- [ ] Re-run an evaluation on \`vulnerabilities-test-ollama-gamma4-26b\` (or any small repo). Reliability principles with violations now show their score and findings instead of "Insufficient evidence".
- [ ] Re-run on a large project (≥100 files). Confidence behavior is unchanged at 5/10.
- [ ] A single critical violation in a 5-file project is now visible as a Critical/Poor grade, not hidden under "Insufficient".
- [ ] Verify by manual sanity check (already in commit body): 5 files + 1 instance → medium; 30 files + 3 instances → medium; 100 files + 5 instances → medium (unchanged).