### PR TITLE
fix(scoring): grant violation-cap leniency to very small projects

### DIFF
--- a/src/quodeq/core/scoring/_constants.py
+++ b/src/quodeq/core/scoring/_constants.py
@@ -80,3 +80,36 @@ def scale_multiplier(source_file_count: int) -> int:
         if source_file_count >= threshold:
             return multiplier
     return 1
+
+
+# Very small projects (e.g. demo / test repos) hit the violation type-cap
+# thresholds (3 critical / 5 major) too aggressively: a handful of distinct
+# critical types in a 10–30 file repo immediately drops the grade to Poor in
+# graded mode, even though the same density on a "Medium" project would only
+# drop it by one level. Mirror the large-project scaling at the small end.
+_SMALL_PROJECT_FLOOR = 30
+_SMALL_PROJECT_LENIENCY = 2
+
+
+def small_project_multiplier(source_file_count: int) -> int:
+    """Extra cap leniency for very small projects.
+
+    Returns an additional multiplier on top of :func:`scale_multiplier`
+    so the violation type caps and graded-mode drop thresholds scale up
+    for tiny repos (where a few distinct types is noisier signal).
+    """
+    if 0 < source_file_count < _SMALL_PROJECT_FLOOR:
+        return _SMALL_PROJECT_LENIENCY
+    return 1
+
+
+def effective_cap_multiplier(source_file_count: int) -> int:
+    """Combined size-based multiplier used for violation type caps.
+
+    Composes :func:`scale_multiplier` (raises caps for large projects)
+    with :func:`small_project_multiplier` (raises caps for very small
+    projects). The reported tier (``ScaleInfo.tier``) continues to use
+    :func:`scale_multiplier` alone — leniency is invisible to the
+    surface UI and only affects how harshly type counts are scored.
+    """
+    return scale_multiplier(source_file_count) * small_project_multiplier(source_file_count)

--- a/src/quodeq/core/scoring/engine.py
+++ b/src/quodeq/core/scoring/engine.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from quodeq.core.types import ScaleInfo, ScoringResult
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.scoring.overall import weighted_overall
-from quodeq.core.scoring.internals import SCALE_TIER_NAMES, scale_multiplier, score_to_grade_label
+from quodeq.core.scoring.internals import (
+    SCALE_TIER_NAMES, effective_cap_multiplier, scale_multiplier, score_to_grade_label,
+)
 from quodeq.core.scoring._principle import _score_all_principles, compute_tallies
 
 
@@ -22,10 +24,16 @@ def run_scoring(evidence: dict, mode: str) -> ScoringResult:
     """Compute per-principle scores and return the full result."""
     source_file_count = evidence.get("source_file_count", 0)
     files_read = evidence.get("files_read", 0)
+    # `scale_mult` is the surfaced tier (Small / Medium / …); `cap_mult`
+    # is what the scoring math uses for violation type caps and graded
+    # drop thresholds — equal for typical projects, but raised at the
+    # very-small end so e.g. a 5-file demo isn't held to the same hard
+    # caps as a 100-file mid-size project.
     scale_mult = scale_multiplier(source_file_count)
+    cap_mult = effective_cap_multiplier(source_file_count)
 
     per_principle = _score_all_principles(
-        evidence.get("principles", {}), mode, scale_mult, files_read,
+        evidence.get("principles", {}), mode, cap_mult, files_read,
     )
     return ScoringResult(
         repository=evidence.get("repository", ""),

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -17,7 +17,9 @@ from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
     _SEVERITY_WEIGHT,
     _WEIGHT_DOUBLE,
     _WEIGHT_TRIPLE,
+    effective_cap_multiplier,
     scale_multiplier,
+    small_project_multiplier,
 )
 from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
     _tally_types,


### PR DESCRIPTION
## Summary
Symmetric to the existing large-project scaling. The current \`scale_multiplier\` raises the violation type-cap thresholds for projects in the Medium tier and up, so they aren't held to the same absolute counts as a tiny repo. Below the small-project floor, the multiplier stays at 1 — which means a 5–30 file project hits the **3-critical / 5-major** hard caps almost immediately, dropping the graded-mode grade from Exemplary to Proficient (or lower) on the first few distinct critical types.

A demo / test repo with a handful of distinct critical violations therefore reads as harshly as a 100-file project with the same absolute counts, even though the *density* signal is much noisier on a tiny codebase.

## What changes
- **\`_constants.py\`** — new \`small_project_multiplier(source_file_count)\` (returns 2 for projects below 30 files, 1 otherwise) and \`effective_cap_multiplier\` that composes it with \`scale_multiplier\`.
- **\`internals.py\`** — re-export both new symbols.
- **\`engine.py\`** — pass \`effective_cap_multiplier\` into \`_score_all_principles\` while continuing to surface \`scale_multiplier\` as \`ScaleInfo.tier\`. The leniency is invisible in the displayed "Small / Medium / …" tier and only affects how harshly type counts are scored.

## Effect
| Project | Critical types | Old grade (graded) | New grade (graded) |
| --- | --- | --- | --- |
| 18 files | 4 | Proficient (1 drop) | Exemplary (0 drops) |
| 18 files | 8 | Adequate (2 drops) | Proficient (1 drop) |
| 100 files | 4 | Proficient | Proficient (unchanged) |
| 5000 files | 4 | (unchanged) | (unchanged) |

**Numerical mode is unaffected** — \`violation_base\` and \`violation_ceiling\` follow a hyperbolic curve in the *weighted violation count*, which isn't scale-aware. Softening that curve for small projects is a separate decision worth its own change.

All 2723 existing tests pass.

## Test plan
- [x] Re-run on a small repo (< 30 files) with several distinct critical violation types — graded principle grades shouldn't bottom out the way they did before.
- [x] Re-run on a 100+ file project — grades unchanged.
- [x] Verify \`ScaleInfo.tier\` still reads "Small" (not "Medium") for a 10-file project — the leniency multiplier is invisible to the UI tier label.