### PR TITLE
feat(ui): show project name in overview header

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -90,7 +90,7 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
     <section className="acc-eval-panel acc-eval-panel--terminal">
       <div className="acc-eval-panel__top">
         <TermHeader
-          name="overview"
+          name={projectInfo?.displayName || projectInfo?.name || projectName || 'overview'}
           sub={buildLanguageSub(projectInfo) || (lastDate ? `last_evaluated · ${lastDate}` : null)}
         />
         <LastFetchedLine lastFetchedAt={projectInfo?.lastFetchedAt} />


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `overview` title in the AccumulatedOverviewPanel hero section with the project's display name (falls back to `projectInfo.name`, then the project id, then the literal `overview`).
- The page header above already shows the project name; the section header is what the user reads when scanning the cards, so it should match.

## Test plan
- [x] UI build clean.
- [x] Visually confirm the overview hero now shows the project name and the language sub-line still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)