### PR TITLE
fix(history): mark running runs as "running" once they enter the trend

### DIFF
--- a/src/quodeq/services/_dashboard_trend.py
+++ b/src/quodeq/services/_dashboard_trend.py
@@ -61,6 +61,11 @@ def build_accumulated_trend(
                 "runId": item.run_id,
                 "dateISO": item.date_iso,
                 "dateLabel": item.date_label,
+                # Surface the run's lifecycle state so the History row can
+                # render "running" instead of a misleading completion time
+                # while the evaluation is still in progress (some dims have
+                # scored, others haven't).
+                "status": item.status,
                 "dimensionsCount": len(run_dim_names),
                 "dimensions": run_dim_names,
                 "dimensionDetails": dim_details,


### PR DESCRIPTION
## Summary
The History row already has a branch that renders **"running"** instead of a completion time, gated on \`entry.status === 'in_progress'\`. But the trend payload built by [\`services/_dashboard_trend.py\`](src/quodeq/services/_dashboard_trend.py:59) never included the \`status\` field — so as soon as a running evaluation scored its first dimension and got promoted into the trend, the UI saw \`entry.status\` as \`undefined\` and treated the row as complete, surfacing the moment-of-first-score timestamp as if it were the run's finish time.

That's exactly the screenshot you saw: a row with a real time and a partial \`reliability 4.7\` even though the eval was still in progress.

**Fix:** add \`"status": item.status\` to each trend entry. The existing UI logic in \`HistoryPage\` and \`HistoryRunRow\` already does the right thing once the field is present — the time cell turns into the spinning "running" indicator and grade / score / Δ render as "—" until the run actually completes.

The same field already flows through \`availableRuns\` (see [\`scoring/__init__.py:188\`](src/quodeq/services/scoring/__init__.py:188) and [\`dashboard.py:174\`](src/quodeq/services/dashboard.py:174)) — this just makes the trend payload consistent.

## Test plan
- [x] Start a fresh evaluation. Once the first dimension scores, open the History tab — the row should show "running" (not the timestamp).
- [x] Wait for the eval to finish — row flips to a real timestamp + grade + score.
- [x] Already-completed past runs render normally.
- [x] All 699 service tests pass.