### PR TITLE
chore(log): tighten heartbeat line format

### DIFF
--- a/src/quodeq/analysis/subagents/_heartbeat.py
+++ b/src/quodeq/analysis/subagents/_heartbeat.py
@@ -14,9 +14,9 @@ _HEARTBEAT_INTERVAL = 10
 _SECONDS_PER_MINUTE = 60
 _HEARTBEAT_FMT = (
     "[{dimension}] {mins}m{secs:02d}s | "
-    "{active} active agent{plural} | "
+    "{violations} v · {compliance} c | "
     "files {taken}/{total_files} · {remaining} left | "
-    "{violations} violations · {compliance} compliance"
+    "{active} agent{plural}"
 )
 
 

--- a/tests/analysis/test_heartbeat_coverage.py
+++ b/tests/analysis/test_heartbeat_coverage.py
@@ -73,9 +73,9 @@ class TestHeartbeatFormat:
             violations=2, compliance=5,
         )
         assert line.startswith("[security] 1m02s")
-        assert "2 active agents" in line
+        assert "2 v · 5 c" in line
         assert "files 10/30 · 20 left" in line
-        assert "2 violations · 5 compliance" in line
+        assert line.endswith("2 agents")
         assert "findings" not in line
         assert "total" not in line
 
@@ -86,7 +86,7 @@ class TestHeartbeatFormat:
             taken=1, total_files=2, remaining=1,
             violations=0, compliance=0,
         )
-        assert "1 active agent |" in line
+        assert line.endswith("1 agent")
 
 
 class TestHeartbeatLoop:
@@ -122,4 +122,4 @@ class TestHeartbeatLoop:
 
         assert emitted, "heartbeat should emit at least one log line"
         assert "[security]" in emitted[0]
-        assert "1 violations" in emitted[0]
+        assert "1 v · 0 c" in emitted[0]


### PR DESCRIPTION
## Summary
Reorder and abbreviate the per-dimension heartbeat line emitted by the subagent pool so the most useful counters land closest to the dimension marker:

\`\`\`
before: [security] 0m10s | 1 active agent | files 3/18 · 15 left | 0 violations · 0 compliance
after:  [security] 0m10s | 0 v · 0 c       | files 3/18 · 15 left | 1 agent
\`\`\`

Same counters, less visual noise:
- The \`v / c\` pair scans at a glance instead of two long words.
- Agent count drops the redundant "active" qualifier and moves to the tail where it changes least often.

Updated test assertions in \`tests/analysis/test_heartbeat_coverage.py\` to match the new format. All 2723 tests pass.