### PR TITLE
fix(history): show scored dims on running rows instead of "in progress"

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -177,8 +177,17 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
             // Stubs (hasScoredDims === false) have no completed standards yet
             // and would land on an empty dashboard. Block the click and tell
             // the user to wait. Running runs that ARE in trend (i.e. already
-            // have at least one scored dim) remain clickable.
+            // have at least one scored dim) remain clickable, and we surface
+            // the dims that *have* completed instead of a generic
+            // "in progress" placeholder.
             const notReady = entry.hasScoredDims === false;
+            const dimsCell = notReady
+              ? <span className="history-row__muted">no scores yet</span>
+              : (
+                <span className="history-row__muted">
+                  <FittedText text={formatDimSummary(entry)} mode="end" />
+                </span>
+              );
             return (
               <HistoryRow
                 key={entry.runId}
@@ -196,7 +205,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
                   grade: <span className="history-row__muted">—</span>,
                   score: <span className="history-row__muted">—</span>,
                   delta: <span className="history-delta history-delta--muted">—</span>,
-                  dims: <span className="history-row__muted">{notReady ? 'no scores yet' : 'in progress'}</span>,
+                  dims: dimsCell,
                 }}
               />
             );


### PR DESCRIPTION
## Summary
Follow-up to #440. Once a running evaluation has even one scored dimension, the History row already has the full \`dimensionDetails\` (delivered via the trend payload). But the in-progress branch was rendering a generic **"in progress"** placeholder anyway, hiding the partial-progress information the user is actually trying to see.

Reuse the same \`formatDimSummary\` helper that completed rows use, so a running row reads e.g. \`reliability 4.7\` while still flagging the **TIME** column as "running". Stubs (\`hasScoredDims === false\`) keep the **"no scores yet"** message — that's the genuine "nothing to show yet" case.

## Test plan
- [x] Start a fresh evaluation. Before any dim has scored, the row should show \`running\` + \`no scores yet\`.
- [x] After a dim scores, refresh — the row stays \`running\` but the dims column lists the scored dim with its score (e.g. \`reliability 4.7\`).
- [x] Once the run finishes, the row flips to a real timestamp + grade + score; the dims column unchanged behavior.
- [x] Cancelled / failed runs unaffected.