### PR TITLE
fix(ui): show project name on the running evaluation panel

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -141,7 +141,15 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
           <NoProjectSelected onGoToProjects={onGoToProjects} />
         )}
 
-        <EvaluationStatus job={job} liveViolations={liveViolations} onDismiss={onDismiss} onCancel={onCancel} hasEvaluations={!!selectedProject} />
+        <EvaluationStatus
+          job={job}
+          project={selectedProject}
+          projectInfo={projectInfo}
+          liveViolations={liveViolations}
+          onDismiss={onDismiss}
+          onCancel={onCancel}
+          hasEvaluations={!!selectedProject}
+        />
       </div>
 
       {jobError && toastVisible && (

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -15,12 +15,12 @@ function termNameForStatus(status) {
   return 'evaluation_cancelled';
 }
 
-function JobHeader({ job, onDismiss, onCancel }) {
+function JobHeader({ job, projectLabel, onDismiss, onCancel }) {
   const isRunning = job.status === STATUS.RUNNING;
   const isDone = job.status === STATUS.DONE;
   return (
     <div className="evaluate-panel__top evaluate-panel__top--row">
-      <TermHeader name={termNameForStatus(job.status)} />
+      <TermHeader name={termNameForStatus(job.status)} sub={projectLabel || undefined} />
       <div className="evaluate-panel__top-actions">
         {isRunning && (
           <button type="button" className="term-btn term-btn--ghost" onClick={onCancel}>cancel</button>
@@ -48,12 +48,13 @@ function JobIdLine({ jobId }) {
   );
 }
 
-export default function EvaluationStatus({ job, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
+export default function EvaluationStatus({ job, project, projectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
   if (!job) return null;
+  const projectLabel = projectInfo?.displayName || projectInfo?.name || project || null;
 
   return (
     <div className="panel evaluate-panel--terminal">
-      <JobHeader job={job} onDismiss={onDismiss} onCancel={onCancel} />
+      <JobHeader job={job} projectLabel={projectLabel} onDismiss={onDismiss} onCancel={onCancel} />
       <JobStatStrip job={job} liveViolations={liveViolations} />
       <JobIdLine jobId={job.jobId} />
       <ScanProgress job={job} hasEvaluations={hasEvaluations} />


### PR DESCRIPTION
## Summary
The running-evaluation card title read \`evaluation_in_progress\` with no indication of *which* project was being evaluated. Easy to confuse with an unrelated session — especially when navigating between projects while a job is alive in another one.

Surface the project's display name as the \`sub\` line under \`evaluation_in_progress\` / \`evaluation_complete\` / etc. Same \`TermHeader\` pattern already used by the idle "evaluate" panel and the \`ReEvaluateCard\`. Falls back to the raw project id when no display name is available.

## Test plan
- [x] Start an evaluation. The panel shows \`▸ evaluation_in_progress\` with the project name immediately below.
- [x] Wait for completion. Title flips to \`evaluation_complete\` but the project name remains.
- [x] Cancelled / failed runs show the same sub-line.