### PR TITLE
Revert "fix(scoring): grant violation-cap leniency to very small projects" (#438)

### DIFF
--- a/src/quodeq/core/scoring/_constants.py
+++ b/src/quodeq/core/scoring/_constants.py
@@ -80,36 +80,3 @@ def scale_multiplier(source_file_count: int) -> int:
         if source_file_count >= threshold:
             return multiplier
     return 1
-
-
-# Very small projects (e.g. demo / test repos) hit the violation type-cap
-# thresholds (3 critical / 5 major) too aggressively: a handful of distinct
-# critical types in a 10–30 file repo immediately drops the grade to Poor in
-# graded mode, even though the same density on a "Medium" project would only
-# drop it by one level. Mirror the large-project scaling at the small end.
-_SMALL_PROJECT_FLOOR = 30
-_SMALL_PROJECT_LENIENCY = 2
-
-
-def small_project_multiplier(source_file_count: int) -> int:
-    """Extra cap leniency for very small projects.
-
-    Returns an additional multiplier on top of :func:`scale_multiplier`
-    so the violation type caps and graded-mode drop thresholds scale up
-    for tiny repos (where a few distinct types is noisier signal).
-    """
-    if 0 < source_file_count < _SMALL_PROJECT_FLOOR:
-        return _SMALL_PROJECT_LENIENCY
-    return 1
-
-
-def effective_cap_multiplier(source_file_count: int) -> int:
-    """Combined size-based multiplier used for violation type caps.
-
-    Composes :func:`scale_multiplier` (raises caps for large projects)
-    with :func:`small_project_multiplier` (raises caps for very small
-    projects). The reported tier (``ScaleInfo.tier``) continues to use
-    :func:`scale_multiplier` alone — leniency is invisible to the
-    surface UI and only affects how harshly type counts are scored.
-    """
-    return scale_multiplier(source_file_count) * small_project_multiplier(source_file_count)

--- a/src/quodeq/core/scoring/engine.py
+++ b/src/quodeq/core/scoring/engine.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 from quodeq.core.types import ScaleInfo, ScoringResult
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.scoring.overall import weighted_overall
-from quodeq.core.scoring.internals import (
-    SCALE_TIER_NAMES, effective_cap_multiplier, scale_multiplier, score_to_grade_label,
-)
+from quodeq.core.scoring.internals import SCALE_TIER_NAMES, scale_multiplier, score_to_grade_label
 from quodeq.core.scoring._principle import _score_all_principles, compute_tallies
 
 
@@ -24,16 +22,10 @@ def run_scoring(evidence: dict, mode: str) -> ScoringResult:
     """Compute per-principle scores and return the full result."""
     source_file_count = evidence.get("source_file_count", 0)
     files_read = evidence.get("files_read", 0)
-    # `scale_mult` is the surfaced tier (Small / Medium / …); `cap_mult`
-    # is what the scoring math uses for violation type caps and graded
-    # drop thresholds — equal for typical projects, but raised at the
-    # very-small end so e.g. a 5-file demo isn't held to the same hard
-    # caps as a 100-file mid-size project.
     scale_mult = scale_multiplier(source_file_count)
-    cap_mult = effective_cap_multiplier(source_file_count)
 
     per_principle = _score_all_principles(
-        evidence.get("principles", {}), mode, cap_mult, files_read,
+        evidence.get("principles", {}), mode, scale_mult, files_read,
     )
     return ScoringResult(
         repository=evidence.get("repository", ""),

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -17,9 +17,7 @@ from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
     _SEVERITY_WEIGHT,
     _WEIGHT_DOUBLE,
     _WEIGHT_TRIPLE,
-    effective_cap_multiplier,
     scale_multiplier,
-    small_project_multiplier,
 )
 from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
     _tally_types,


### PR DESCRIPTION
## Summary
Reverts #438. The leniency it added (a 2× cap multiplier for projects below 30 files) softens graded-mode drops and the violation type-cap thresholds, but field testing on a small repo with heavy violations (18 files, 39 critical / 101 major / 50 minor → grade D / score 4.9) made it clear the existing scores already read **too soft**, not too harsh — the small-project bonus was pushing in the wrong direction.

Restores the strict caps (3 critical / 5 major) on small projects so graded mode and the hard-cap math are back to their pre-#438 behavior.

The deeper softness in numerical mode lives elsewhere — the hyperbolic curve in \`violation_base\`/\`violation_ceiling\` is keyed on distinct violation *types* rather than instance density, so a principle with 100 violations of one type scores the same as one with a single instance. That'll be addressed in a separate change.

All 1158 scoring/service tests pass after the revert.