### PR TITLE
feat(scoring): fold instance density into the violation weighted sum

### DIFF
--- a/src/quodeq/core/scoring/_principle.py
+++ b/src/quodeq/core/scoring/_principle.py
@@ -9,9 +9,10 @@ from quodeq.core.scoring.overall import MODE_NUMERICAL
 from quodeq.core.scoring.internals import (
     build_deductions,
     compliance_dampening,
-    compliance_lift,
+    compliance_lift_from_wv,
     confidence_interval_for,
     count_grade_drops,
+    density_weighted_sum,
     drop_grade,
     evidence_has_taxonomy,
     score_to_grade_label,
@@ -20,8 +21,8 @@ from quodeq.core.scoring.internals import (
     tally_compliance_types_by_taxonomy,
     tally_types_by_reason,
     tally_types_by_taxonomy,
-    violation_base,
-    violation_ceiling,
+    violation_base_from_wv,
+    violation_ceiling_from_wv,
 )
 
 _BASE_SCORE = 10
@@ -35,6 +36,12 @@ class _PrincipleContext:
     pct: float
     vt_counts: dict[str, int]
     ct_counts: dict[str, int]
+    # Density-aware weighted sums (severity weight × log2(1 + instances)
+    # per (severity, type) group). Used by violation_base_from_wv and
+    # violation_ceiling_from_wv so a principle with many instances of
+    # one type is punished more than one with a single instance.
+    wv_density: float
+    wc_density: float
     dampening: float
     using_taxonomy: bool
     conf_level: str
@@ -74,11 +81,16 @@ def _score_numerical(ctx: _PrincipleContext) -> PrincipleScore:
             deductions=build_deductions({}, scale_multiplier=ctx.scale_mult),
             final_score=0.0, grade="Insufficient",
         )
-    base = violation_base(ctx.vt_counts)
-    lift = compliance_lift(ctx.ct_counts, ctx.vt_counts)
+    base = violation_base_from_wv(ctx.wv_density)
+    # compliance_lift uses an unweighted compliance count vs the weighted
+    # violation total — keep that legacy semantic to avoid disturbing the
+    # lift balance that's already calibrated. We only feed the
+    # density-aware wv on the violation side.
+    cc = sum(ctx.ct_counts.get(sev, 0) for sev in ctx.ct_counts)
+    lift = compliance_lift_from_wv(cc, ctx.wv_density)
     raw = base + (_BASE_SCORE - base) * lift
     final_pts = round(max(severity_grade_floor(ctx.vt_counts),
-                          min(violation_ceiling(ctx.vt_counts), raw)), 1)
+                          min(violation_ceiling_from_wv(ctx.wv_density), raw)), 1)
     return PrincipleScore(
         **kwargs, base_score=round(base, 1),
         deductions=build_deductions(ctx.vt_counts, scale_multiplier=ctx.scale_mult),
@@ -110,9 +122,11 @@ def _build_context(
     metrics = pdata.get("metrics", {})
     pct = metrics.get("compliance_percentage", 0.0)
     conf_level = metrics.get("confidence_level", "medium")
-    vt_counts, ct_counts, using_taxonomy = compute_tallies(
-        pdata.get("violations", []), pdata.get("compliance", []),
-    )
+    violations = pdata.get("violations", [])
+    compliance = pdata.get("compliance", [])
+    vt_counts, ct_counts, using_taxonomy = compute_tallies(violations, compliance)
+    wv_density = density_weighted_sum(violations, using_taxonomy=using_taxonomy)
+    wc_density = density_weighted_sum(compliance, using_taxonomy=using_taxonomy)
     ci = confidence_interval_for(
         confidence_level=conf_level,
         is_balanced=metrics.get("is_balanced", True),
@@ -121,7 +135,8 @@ def _build_context(
     )
     return _PrincipleContext(
         key=key, pdata=pdata, pct=pct, vt_counts=vt_counts,
-        ct_counts=ct_counts, dampening=compliance_dampening(ct_counts, vt_counts),
+        ct_counts=ct_counts, wv_density=wv_density, wc_density=wc_density,
+        dampening=compliance_dampening(ct_counts, vt_counts),
         using_taxonomy=using_taxonomy, conf_level=conf_level, ci=ci,
         scale_mult=scale_mult,
     )

--- a/src/quodeq/core/scoring/_tallies.py
+++ b/src/quodeq/core/scoring/_tallies.py
@@ -1,6 +1,9 @@
 """Violation and compliance type-counting helpers."""
 from __future__ import annotations
 
+import math
+from collections import defaultdict
+
 from quodeq.core.scoring._constants import _SEVERITY_WEIGHT
 
 
@@ -54,4 +57,33 @@ def _weighted_sum(type_counts: dict[str, int]) -> float:
     return sum(
         count * _SEVERITY_WEIGHT.get(sev, 0.25)
         for sev, count in type_counts.items()
+    )
+
+
+def density_weighted_sum(items: list[dict], *, using_taxonomy: bool) -> float:
+    """Severity-weighted sum that folds in *instance density* per type.
+
+    The legacy ``_weighted_sum`` only counts the number of *distinct* types
+    per severity, so a principle with one violation of type X scores the
+    same as one with a hundred violations of type X. That hides bad
+    densities (a single rule violated everywhere reads as a single point
+    of damage). This variant adds a ``log2(1 + n)`` factor per
+    ``(severity, type)`` group so the cost grows with instance count
+    without being linear: 1 instance → ×1.0, 10 → ×3.46, 100 → ×6.66.
+
+    *using_taxonomy* selects the grouping key, mirroring the existing
+    ``tally_types_by_taxonomy`` / ``tally_types_by_reason`` switch.
+    """
+    grouped: dict[tuple[str, str], int] = defaultdict(int)
+    for item in items:
+        sev = item.get("severity", "minor")
+        key = item.get("vt") if using_taxonomy else item.get("reason")
+        if not key:
+            if using_taxonomy:
+                continue
+            key = "unknown"
+        grouped[(sev, key)] += 1
+    return sum(
+        _SEVERITY_WEIGHT.get(sev, 0.25) * math.log2(1 + n)
+        for (sev, _), n in grouped.items()
     )

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -24,6 +24,7 @@ from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
 from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
     _tally_types,
     _weighted_sum,
+    density_weighted_sum,
     evidence_has_taxonomy,
     tally_compliance_types_by_reason,
     tally_compliance_types_by_taxonomy,
@@ -41,16 +42,35 @@ from quodeq.core.scoring.numerical import (  # noqa: F401 — re-export
 # 4-stage scoring formula
 # ---------------------------------------------------------------------------
 
+def violation_base_from_wv(wv: float) -> float:
+    """Hyperbolic base score from a precomputed weighted-violation total.
+
+    Split out from :func:`violation_base` so principle-level scoring can
+    feed in a density-aware weighted sum (see
+    :func:`density_weighted_sum`) instead of the legacy distinct-type
+    sum. Existing callers that only have ``vt_counts`` keep working
+    through the wrapper below.
+    """
+    if wv == 0:
+        return 10.0
+    return 10.0 / (1.0 + _BASE_K * wv)
+
+
 def violation_base(violation_type_counts: dict[str, int]) -> float:
     """Compute the base score from violations alone (ignoring compliance).
 
     Uses a hyperbolic curve: ``base = 10 / (1 + K * weighted_violations)``
     Returns a value in [0, 10].
     """
-    wv = _weighted_sum(violation_type_counts)
-    if wv == 0:
-        return 10.0
-    return 10.0 / (1.0 + _BASE_K * wv)
+    return violation_base_from_wv(_weighted_sum(violation_type_counts))
+
+
+def compliance_lift_from_wv(wc: float, wv: float) -> float:
+    """Lift factor from precomputed weighted compliance/violation totals."""
+    if wc == 0 or wv == 0:
+        return 0.0
+    raw_lift = wc / (wc + wv)
+    return raw_lift ** _LIFT_COMPRESS
 
 
 def compliance_lift(
@@ -63,10 +83,14 @@ def compliance_lift(
     """
     wv = _weighted_sum(violation_type_counts)
     cc = sum(compliance_type_counts.get(sev, 0) for sev in compliance_type_counts)
-    if cc == 0 or wv == 0:
-        return 0.0
-    raw_lift = cc / (cc + wv)
-    return raw_lift ** _LIFT_COMPRESS
+    return compliance_lift_from_wv(cc, wv)
+
+
+def violation_ceiling_from_wv(wv: float) -> float:
+    """Ceiling score from a precomputed weighted-violation total."""
+    if wv == 0:
+        return 10.0
+    return 10.0 - math.log2(1.0 + wv) * _CEIL_SCALE
 
 
 def violation_ceiling(violation_type_counts: dict[str, int]) -> float:
@@ -74,10 +98,7 @@ def violation_ceiling(violation_type_counts: dict[str, int]) -> float:
 
     ``ceiling = 10 - log2(1 + wv) * CEIL_SCALE``
     """
-    wv = _weighted_sum(violation_type_counts)
-    if wv == 0:
-        return 10.0
-    return 10.0 - math.log2(1.0 + wv) * _CEIL_SCALE
+    return violation_ceiling_from_wv(_weighted_sum(violation_type_counts))
 
 
 def severity_grade_floor(violation_type_counts: dict[str, int]) -> float:

--- a/tests/engine/test_scoring_internals.py
+++ b/tests/engine/test_scoring_internals.py
@@ -8,6 +8,7 @@ import pytest
 from quodeq.core.scoring.internals import (
     compliance_dampening,
     compliance_lift,
+    density_weighted_sum,
     drop_grade,
     score_to_grade_label,
     severity_grade_floor,
@@ -152,6 +153,38 @@ class TestDropGrade:
 
     def test_invalid_grade_returns_insufficient(self):
         assert drop_grade("Unknown", 0) == "Insufficient"
+
+
+class TestDensityWeightedSum:
+    def test_empty(self):
+        assert density_weighted_sum([], using_taxonomy=True) == 0.0
+
+    def test_single_instance_matches_legacy(self):
+        # A single instance per type → log2(2) = 1.0, so the result equals
+        # the legacy weighted sum (severity_weight × type_count).
+        items = [
+            {"severity": "critical", "vt": "A"},
+            {"severity": "critical", "vt": "B"},
+            {"severity": "major", "vt": "C"},
+        ]
+        # 2 critical types × 4.0 + 1 major type × 1.5 = 9.5
+        assert density_weighted_sum(items, using_taxonomy=True) == pytest.approx(9.5)
+
+    def test_high_instance_density_dominates(self):
+        """Many instances of one type weigh more than a single instance — the
+        whole point of the density formula."""
+        sparse = [{"severity": "critical", "vt": "A"}]
+        dense = [{"severity": "critical", "vt": "A"}] * 10
+        assert density_weighted_sum(dense, using_taxonomy=True) > density_weighted_sum(sparse, using_taxonomy=True)
+        # 10 instances → severity_weight × log2(11) ≈ 4.0 × 3.46 ≈ 13.84
+        assert density_weighted_sum(dense, using_taxonomy=True) == pytest.approx(4.0 * math.log2(11))
+
+    def test_skips_taxonomy_items_without_vt(self):
+        items = [
+            {"severity": "critical", "vt": "A"},
+            {"severity": "critical"},  # no vt → skipped in taxonomy mode
+        ]
+        assert density_weighted_sum(items, using_taxonomy=True) == pytest.approx(4.0 * math.log2(2))
 
 
 class TestWeightAsMultiplier:


### PR DESCRIPTION
## Summary
The hyperbolic violation curve in [\`violation_base\` / \`violation_ceiling\`](src/quodeq/core/scoring/internals.py:42) keys off the legacy \`_weighted_sum\`, which counts only **distinct violation types** per severity. So a principle with one violation of type \`X\` scored the same as one with a hundred — high-density bad code (one rule violated everywhere) read as a single point of damage. On a small-but-rough repo (e.g. **18 files / 190 violations**) that produced grade-D scores around **4.7** instead of bottoming out as the realities of the codebase warranted.

## Approach
New helper [\`density_weighted_sum\`](src/quodeq/core/scoring/_tallies.py): same severity weights as before, but each \`(severity, type)\` group contributes

\`\`\`
severity_weight × log2(1 + instance_count)
\`\`\`

| instances per type | factor |
| --- | --- |
| 1 | ×1.0 |
| 4 | ×2.32 |
| 10 | ×3.46 |
| 100 | ×6.66 |

Saturating: a single bad rule can't single-handedly bury a score, but it scales meaningfully beyond the first instance.

## Plumbing
Public API surface preserved:
- Added \`violation_base_from_wv\` / \`violation_ceiling_from_wv\` / \`compliance_lift_from_wv\` that take a precomputed \`wv\` directly.
- Legacy \`violation_base(vt_counts)\` / \`violation_ceiling(vt_counts)\` / \`compliance_lift(...)\` wrappers delegate to those — existing callers and the entire \`test_scoring_internals\` suite stay untouched.
- \`_PrincipleContext\` gains \`wv_density\` / \`wc_density\` fields, computed from the raw violation/compliance lists in \`_build_context\`.
- \`_score_numerical\` feeds \`wv_density\` into base/ceiling.
- **Compliance lift continues to use the unweighted compliance count** (legacy semantic — the lift balance is already calibrated and changing both sides at once would shift scores in unrelated ways).

## Sanity check on a Critical principle (high confidence)
| Case | Old final | New final |
| --- | --- | --- |
| 4 distinct critical types × 1 instance | 3.4 (Poor) | 3.4 (Poor) |
| 1 critical type × 4 instances | 6.76 (Adequate) | **4.7 (Poor)** |
| 3 types × [4, 3, 2] | ~4–5 | **2.6 (Critical)** |
| 1 type × 100 instances | 6.76 (Adequate) | **2.4 (Critical)** |

## Test plan
- [ ] Re-run the user's 18-file repo with heavy violations; reliability should drop from ~4.7 toward Critical territory consistent with the actual density.
- [ ] Re-run a clean / mostly-compliant project; scores stay near the top of the scale (single-instance density factor is 1.0, matching legacy behavior).
- [ ] Spot-check a couple of medium-density real projects to confirm the curve still feels right (no sudden cliff).
- [ ] All 2727 tests pass (4 new in \`TestDensityWeightedSum\`).