### PR TITLE
fix(ui): restore eval-log external-close sync, fix batched-stream tests

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.jsx
@@ -45,6 +45,8 @@ function statusWord(jobStatus, streamStatus, terminalState) {
   return STREAM_STATUS_WORD[streamStatus] || '';
 }
 
+const WINDOW_ID = 'eval-log';
+
 function buildSpec({ jobId, jobStatus, status, terminalState }) {
   if (!jobId) return null;
   const word = statusWord(jobStatus, status, terminalState);
@@ -52,7 +54,7 @@ function buildSpec({ jobId, jobStatus, status, terminalState }) {
   if (word) parts.push(word);
   parts.push(jobId);
   return {
-    id: 'eval-log',
+    id: WINDOW_ID,
     type: 'eval-log',
     title: parts.join(' · '),
     render: () => <EvalLogPaneBody />,
@@ -64,7 +66,7 @@ export function EvalLogProvider({ children }) {
   const [activeJobLabel, setActiveJobLabel] = useState(null);
   const [activeJobStatus, setActiveJobStatus] = useState(null);
   const { logs, status, terminalState } = useJobLogStream(activeJobId);
-  const { addWindow, removeWindow, replaceWindow } = useSidePane();
+  const { addWindow, removeWindow, replaceWindow, hasWindow } = useSidePane();
 
   const spec = useMemo(
     () => buildSpec({ jobId: activeJobId, jobStatus: activeJobStatus, status, terminalState }),
@@ -93,8 +95,19 @@ export function EvalLogProvider({ children }) {
     setActiveJobId(null);
     setActiveJobLabel(null);
     setActiveJobStatus(null);
-    removeWindow('eval-log');
+    removeWindow(WINDOW_ID);
   }, [removeWindow]);
+
+  // If the user closes the side-pane window via the X (or Escape closes all
+  // panes), sync our active-job state — otherwise consoleOpen stays truthy
+  // and the Console button needs two clicks to reopen.
+  useEffect(() => {
+    if (activeJobId && !hasWindow(WINDOW_ID)) {
+      setActiveJobId(null);
+      setActiveJobLabel(null);
+      setActiveJobStatus(null);
+    }
+  }, [activeJobId, hasWindow]);
 
   const value = useMemo(
     () => ({ activeJobId, activeJobLabel, activeJobStatus, status, openLog, closeLog, updateJobStatus }),

--- a/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/EvalLogProvider.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { SidePaneProvider } from '../../side-pane/index.js';
@@ -103,29 +103,36 @@ describe('EvalLogProvider', () => {
   });
 
   it('updates the side-pane window body as new log lines arrive', () => {
-    function ProbeWithRender() {
-      const { openLog } = useEvalLog();
-      const { windows } = useSidePane();
-      const body = windows[0]?.render?.() ?? null;
-      return (
-        <div>
-          <button onClick={() => openLog('job-x', 'Run X')}>open</button>
-          <div data-testid="body">{body}</div>
-        </div>
+    vi.useFakeTimers();
+    try {
+      function ProbeWithRender() {
+        const { openLog } = useEvalLog();
+        const { windows } = useSidePane();
+        const body = windows[0]?.render?.() ?? null;
+        return (
+          <div>
+            <button onClick={() => openLog('job-x', 'Run X')}>open</button>
+            <div data-testid="body">{body}</div>
+          </div>
+        );
+      }
+      render(
+        <SidePaneProvider>
+          <EvalLogProvider>
+            <ProbeWithRender />
+          </EvalLogProvider>
+        </SidePaneProvider>
       );
+      fireEvent.click(screen.getByText('open'));
+      expect(screen.getByTestId('body')).toHaveTextContent('Waiting for output');
+      const es = MockEventSource.instances[0];
+      act(() => { es.emit('message', { data: 'hello world' }); });
+      // useJobLogStream batches via rAF + 50ms timer; drain it.
+      act(() => { vi.runAllTimers(); });
+      expect(screen.getByTestId('body')).toHaveTextContent('hello world');
+    } finally {
+      vi.useRealTimers();
     }
-    render(
-      <SidePaneProvider>
-        <EvalLogProvider>
-          <ProbeWithRender />
-        </EvalLogProvider>
-      </SidePaneProvider>
-    );
-    fireEvent.click(screen.getByText('open'));
-    expect(screen.getByTestId('body')).toHaveTextContent('Waiting for output');
-    const es = MockEventSource.instances[0];
-    act(() => { es.emit('message', { data: 'hello world' }); });
-    expect(screen.getByTestId('body')).toHaveTextContent('hello world');
   });
 
   it('clears activeJobId when the side-pane window is removed externally', () => {

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.test.jsx
@@ -3,6 +3,14 @@ import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { useJobLogStream } from './useJobLogStream.js';
 
+// The hook coalesces SSE bursts via requestAnimationFrame + a 50ms timer
+// fallback. Tests need to drain that queue between an emit and an assertion.
+function flushBatched() {
+  act(() => {
+    vi.runAllTimers();
+  });
+}
+
 // --- Mock EventSource ---
 class MockEventSource {
   static instances = [];
@@ -43,12 +51,14 @@ function Probe({ jobId }) {
 describe('useJobLogStream', () => {
   let originalEventSource;
   beforeEach(() => {
+    vi.useFakeTimers();
     originalEventSource = globalThis.EventSource;
     globalThis.EventSource = MockEventSource;
     MockEventSource.instances = [];
   });
   afterEach(() => {
     globalThis.EventSource = originalEventSource;
+    vi.useRealTimers();
   });
 
   it('opens EventSource at the right URL for given jobId', () => {
@@ -63,6 +73,7 @@ describe('useJobLogStream', () => {
     const es = MockEventSource.instances[0];
     act(() => { es.emit('message', { data: 'first line' }); });
     act(() => { es.emit('message', { data: 'second line' }); });
+    flushBatched();
     expect(screen.getByTestId('logs')).toHaveTextContent('first line|second line');
   });
 
@@ -80,6 +91,7 @@ describe('useJobLogStream', () => {
     act(() => {
       for (let i = 0; i < 5050; i++) es.emit('message', { data: `line-${i}` });
     });
+    flushBatched();
     const text = screen.getByTestId('logs').textContent;
     const lines = text.split('|');
     expect(lines.length).toBe(5000);


### PR DESCRIPTION
Two issues caught by vitest while running release pre-flight on develop.

## EvalLogProvider regression

[#808e0beb](https://github.com/quodeq/quodeq/commit/808e0beb) (decouple side-pane spec from the log array) accidentally dropped the \`useEffect\` from [#22c9a77e](https://github.com/quodeq/quodeq/commit/22c9a77e) that clears \`activeJobId\` when the side-pane window goes away externally (X button or Escape). Without it, \`consoleOpen\` stays truthy after the pane closes and the Console button on \`ScanProgress\` needs two clicks to reopen.

Restores the \`hasWindow\`-based sync effect.

## Stale rAF-batching tests

\`useJobLogStream\` now coalesces SSE bursts via \`requestAnimationFrame\` plus a 50ms timer fallback. Two tests in \`useJobLogStream.test.jsx\` and one in \`EvalLogProvider.test.jsx\` were emitting messages and asserting synchronously, so the buffered state never showed up.

Switched the affected specs to \`vi.useFakeTimers()\` and drain pending callbacks via \`vi.runAllTimers()\` before asserting. Production behavior unchanged.

## Verification

- \`uv run pytest -q\` — 2723 passed
- \`npx vitest run\` — 319 passed (was 4 failed | 315 passed)