### PR TITLE
feat(cache): add analyze_unit runner with TDD invariant suite (Phase B2)

### DIFF
--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -19,6 +19,13 @@ from quodeq.analysis.cache.entry import CacheEntry
 from quodeq.analysis.cache.flags import is_cache_v2_enabled, is_result_cache_disabled
 from quodeq.analysis.cache.key import CacheKey, compute_key
 from quodeq.analysis.cache.local import LocalFileBackend, default_cache_root
+from quodeq.analysis.cache.runner import (
+    Dispatcher,
+    DispatchResult,
+    UnitResult,
+    WorkUnit,
+    analyze_unit,
+)
 from quodeq.analysis.cache.tiered import TieredCache
 
 __all__ = [
@@ -26,8 +33,13 @@ __all__ = [
     "CacheEntry",
     "CacheKey",
     "CacheStats",
+    "DispatchResult",
+    "Dispatcher",
     "LocalFileBackend",
     "TieredCache",
+    "UnitResult",
+    "WorkUnit",
+    "analyze_unit",
     "compute_key",
     "default_cache_root",
     "is_cache_v2_enabled",

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -1,0 +1,125 @@
+"""Cache-aware work unit runner — the primitive of the V2 incremental flow.
+
+The contract is intentionally minimal:
+
+    result = analyze_unit(unit, cache, dispatcher)
+
+The runner computes the cache key from ``unit``, consults ``cache``, and
+on miss invokes ``dispatcher(unit)`` to produce findings. A successful
+dispatch is wrapped in a ``CacheEntry`` (key supplied by the runner, not
+the dispatcher) and persisted before returning.
+
+Crash safety: a dispatcher exception propagates and *no* entry is
+written. The next invocation with the same inputs misses again and
+re-dispatches. There is no half-state to recover from.
+
+This module replaces the implicit fingerprint+JSONL+queue state model.
+It is dimension-agnostic and pipeline-agnostic; the existing dispatch
+machinery (subagent pool, API runner, ...) plugs in via the
+``Dispatcher`` Protocol.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from quodeq.analysis.cache.backend import CacheBackend
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.key import CacheKey, compute_key
+
+
+@dataclass(frozen=True)
+class WorkUnit:
+    """One (file, dimension) analysis request and the inputs that key it.
+
+    Hashes are passed in pre-computed so the runner doesn't need to know
+    how to read files or hash standards directories. The orchestrator
+    builds these once per run and feeds them to the runner per file.
+    """
+
+    file_path: str
+    file_content_hash: str
+    dimension: str
+    standards_hash: str
+    prompts_hash: str
+    evaluator_hash: str
+    model_id: str
+    language: str
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    """What a dispatcher returns on success.
+
+    The runner wraps this into a ``CacheEntry`` — the dispatcher does not
+    know its own cache key and never needs to.
+    """
+
+    findings: list[dict]
+    files_read: int
+
+
+class Dispatcher(Protocol):
+    """Plugs the existing analysis machinery into the cache runner."""
+
+    def __call__(self, unit: WorkUnit) -> DispatchResult: ...
+
+
+@dataclass(frozen=True)
+class UnitResult:
+    """What ``analyze_unit`` returns to the caller."""
+
+    entry: CacheEntry
+    cache_hit: bool
+
+
+def _key_for(unit: WorkUnit, schema_version: int) -> str:
+    return compute_key(CacheKey(
+        schema_version=schema_version,
+        file_content_hash=unit.file_content_hash,
+        file_path=unit.file_path,
+        dimension=unit.dimension,
+        standards_hash=unit.standards_hash,
+        prompts_hash=unit.prompts_hash,
+        evaluator_hash=unit.evaluator_hash,
+        model_id=unit.model_id,
+        language=unit.language,
+        temperature=unit.temperature,
+        max_tokens=unit.max_tokens,
+    ))
+
+
+def analyze_unit(
+    unit: WorkUnit,
+    *,
+    cache: CacheBackend,
+    dispatcher: Dispatcher,
+    schema_version: int = 1,
+) -> UnitResult:
+    """Cache-or-dispatch one work unit.
+
+    A miss invokes the dispatcher and writes the result before returning.
+    A dispatcher exception propagates without writing — next call retries.
+    """
+    key = _key_for(unit, schema_version)
+
+    if hit := cache.get(key):
+        return UnitResult(entry=hit, cache_hit=True)
+
+    # Crash boundary: any exception below propagates and no entry is
+    # written. The cache is only mutated on the success path.
+    dispatch_result = dispatcher(unit)
+
+    entry = CacheEntry(
+        key=key,
+        schema_version=schema_version,
+        findings=list(dispatch_result.findings),
+        files_read=dispatch_result.files_read,
+        file_path=unit.file_path,
+        dimension=unit.dimension,
+        model_id=unit.model_id,
+    )
+    cache.put(key, entry)
+    return UnitResult(entry=entry, cache_hit=False)

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -1,0 +1,213 @@
+"""analyze_unit — cache-aware work unit runner.
+
+These tests pin down the structural invariants of the cache layer
+without involving real LLM calls. The dispatcher is stubbed so each
+property is observable and deterministic:
+
+  - hits never call the dispatcher; misses always do
+  - dispatcher exceptions never write entries (crash = retry)
+  - any input change in the cache key invalidates
+  - schema_version is the global blast-radius lever
+  - dispatcher does not need to know its own cache key
+  - the runner is the single source of truth for the entry's key
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.local import LocalFileBackend
+from quodeq.analysis.cache.runner import (
+    DispatchResult,
+    WorkUnit,
+    analyze_unit,
+)
+
+
+def _unit(**overrides) -> WorkUnit:
+    defaults = dict(
+        file_path="src/auth.py",
+        file_content_hash="aa" * 32,
+        dimension="security",
+        standards_hash="bb" * 32,
+        prompts_hash="cc" * 32,
+        evaluator_hash="dd" * 32,
+        model_id="claude-opus-4-7",
+        language="python",
+        temperature=None,
+        max_tokens=None,
+    )
+    defaults.update(overrides)
+    return WorkUnit(**defaults)
+
+
+class _RecordingDispatcher:
+    """Stub dispatcher that records calls and returns canned results."""
+
+    def __init__(self, findings: list[dict] | None = None, files_read: int = 1) -> None:
+        self._findings = findings if findings is not None else [{"file": "a.py", "line": 1, "t": "violation"}]
+        self._files_read = files_read
+        self.calls: list[WorkUnit] = []
+
+    def __call__(self, unit: WorkUnit) -> DispatchResult:
+        self.calls.append(unit)
+        return DispatchResult(findings=list(self._findings), files_read=self._files_read)
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+# ---------- core hit/miss ----------
+
+class TestHitMiss:
+    def test_first_call_misses_and_dispatches(self, cache: LocalFileBackend):
+        dispatcher = _RecordingDispatcher()
+        result = analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+        assert result.cache_hit is False
+        assert len(dispatcher.calls) == 1
+        assert result.entry.findings == [{"file": "a.py", "line": 1, "t": "violation"}]
+
+    def test_second_call_hits_without_dispatching(self, cache: LocalFileBackend):
+        dispatcher = _RecordingDispatcher()
+        unit = _unit()
+        analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        result = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        assert result.cache_hit is True
+        assert len(dispatcher.calls) == 1  # still just the first one
+
+    def test_hit_returns_findings_identical_to_miss(self, cache: LocalFileBackend):
+        dispatcher = _RecordingDispatcher(findings=[{"file": "x.py", "line": 5, "msg": "test"}])
+        unit = _unit()
+        first = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        second = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        assert first.entry.findings == second.entry.findings
+        assert first.entry.files_read == second.entry.files_read
+        assert first.entry.key == second.entry.key
+
+
+# ---------- crash safety ----------
+
+class TestDispatcherFailure:
+    def test_dispatcher_exception_writes_no_entry(self, cache: LocalFileBackend):
+        def boom(unit: WorkUnit) -> DispatchResult:
+            raise RuntimeError("model timeout")
+
+        with pytest.raises(RuntimeError, match="model timeout"):
+            analyze_unit(_unit(), cache=cache, dispatcher=boom)
+
+        # Next call must still miss — no half-state was written.
+        dispatcher = _RecordingDispatcher()
+        result = analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+        assert result.cache_hit is False
+        assert len(dispatcher.calls) == 1
+
+    def test_dispatcher_exception_does_not_corrupt_other_entries(self, cache: LocalFileBackend):
+        unit_ok = _unit(file_path="ok.py")
+        unit_bad = _unit(file_path="bad.py")
+
+        # Successfully cache one unit.
+        analyze_unit(unit_ok, cache=cache, dispatcher=_RecordingDispatcher())
+
+        # Fail another. The first must still hit.
+        def boom(_: WorkUnit) -> DispatchResult:
+            raise RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            analyze_unit(unit_bad, cache=cache, dispatcher=boom)
+
+        result = analyze_unit(unit_ok, cache=cache, dispatcher=_RecordingDispatcher())
+        assert result.cache_hit is True
+
+
+# ---------- key sensitivity (every CacheKey field invalidates) ----------
+
+class TestInvalidation:
+    @pytest.mark.parametrize("override", [
+        {"file_content_hash": "00" * 32},
+        {"file_path": "src/other.py"},
+        {"dimension": "documentation"},
+        {"standards_hash": "11" * 32},
+        {"prompts_hash": "22" * 32},
+        {"evaluator_hash": "33" * 32},
+        {"model_id": "claude-sonnet-4-6"},
+        {"language": "typescript"},
+        {"temperature": 0.7},
+        {"max_tokens": 4096},
+    ])
+    def test_each_input_change_misses(self, cache: LocalFileBackend, override: dict):
+        dispatcher = _RecordingDispatcher()
+        analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+        result = analyze_unit(_unit(**override), cache=cache, dispatcher=dispatcher)
+        assert result.cache_hit is False
+        assert len(dispatcher.calls) == 2
+
+    def test_schema_version_bump_invalidates_everything(self, cache: LocalFileBackend):
+        dispatcher = _RecordingDispatcher()
+        unit = _unit()
+        analyze_unit(unit, cache=cache, dispatcher=dispatcher, schema_version=1)
+        result = analyze_unit(unit, cache=cache, dispatcher=dispatcher, schema_version=2)
+        assert result.cache_hit is False
+        assert len(dispatcher.calls) == 2
+
+
+# ---------- runner owns the key ----------
+
+class TestRunnerOwnsKey:
+    def test_dispatcher_does_not_supply_key(self, cache: LocalFileBackend):
+        # The dispatcher signature returns DispatchResult (findings + metadata).
+        # The runner is the only thing that computes and stamps the key.
+        dispatcher = _RecordingDispatcher()
+        result = analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+        assert len(result.entry.key) == 64  # SHA-256 hex
+        # And the persisted entry carries the same key.
+        loaded = cache.get(result.entry.key)
+        assert loaded is not None
+        assert loaded.key == result.entry.key
+
+    def test_entry_metadata_propagates_from_unit(self, cache: LocalFileBackend):
+        unit = _unit(file_path="src/special.py", dimension="performance", model_id="claude-haiku-4")
+        result = analyze_unit(unit, cache=cache, dispatcher=_RecordingDispatcher())
+        assert result.entry.file_path == "src/special.py"
+        assert result.entry.dimension == "performance"
+        assert result.entry.model_id == "claude-haiku-4"
+
+
+# ---------- concurrency (atomic writes from the backend) ----------
+
+class TestConcurrency:
+    def test_two_runners_for_same_key_both_succeed(self, cache: LocalFileBackend):
+        # Simulates two processes racing for the same cache key. Backend
+        # writes are atomic via os.replace, so both succeed and the final
+        # entry is well-formed (last writer wins; content is equivalent
+        # because inputs match).
+        unit = _unit()
+        d1 = _RecordingDispatcher(findings=[{"x": 1}])
+        d2 = _RecordingDispatcher(findings=[{"x": 1}])  # same inputs → same findings
+        r1 = analyze_unit(unit, cache=cache, dispatcher=d1)
+        r2 = analyze_unit(unit, cache=cache, dispatcher=d2)
+        # First was a miss (dispatched); second hit cache from first.
+        assert r1.cache_hit is False
+        assert r2.cache_hit is True
+        loaded = cache.get(r1.entry.key)
+        assert loaded is not None
+        assert loaded.findings == [{"x": 1}]
+
+
+# ---------- empty results are still cached ----------
+
+class TestEmptyResults:
+    def test_empty_findings_cache_normally(self, cache: LocalFileBackend):
+        # A successful analysis that finds nothing must still cache so the
+        # next run doesn't re-pay the dispatch cost.
+        dispatcher = _RecordingDispatcher(findings=[], files_read=1)
+        unit = _unit()
+        first = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        second = analyze_unit(unit, cache=cache, dispatcher=dispatcher)
+        assert first.cache_hit is False
+        assert second.cache_hit is True
+        assert second.entry.findings == []
+        assert len(dispatcher.calls) == 1


### PR DESCRIPTION
## Summary

Builds on the cache foundation from #428. \`analyze_unit\` is the V2 incremental primitive: compute the cache key from inputs, consult the cache, on miss dispatch and write the entry. Crash-safe by construction — a dispatcher exception propagates and *no* entry is written, so half-state is impossible.

This module is **dimension-agnostic and pipeline-agnostic**. The existing dispatch machinery (subagent pool, API runner) will plug in as a \`Dispatcher\` Protocol implementation in Phase B4. **Nothing in the live pipeline calls it yet** — this PR ships the primitive plus invariant tests.

## TDD: tests first

Per discussion, tests pin down the contract before the implementation exists. Written failing → implementation → green.

\`\`\`
tests/analysis/cache/test_runner.py:23: in <module>
    from quodeq.analysis.cache.runner import (
E   ModuleNotFoundError: No module named 'quodeq.analysis.cache.runner'
\`\`\`

Then implemented \`runner.py\` until all 20 tests pass.

## Invariants tested

| Class | Property |
|---|---|
| \`TestHitMiss\` | first call dispatches (miss); second call hits without dispatching; hit findings == miss findings (byte-equal) |
| \`TestDispatcherFailure\` | dispatcher exception writes no entry; other entries unaffected by a sibling unit's failure |
| \`TestInvalidation\` (parametrized) | every \`CacheKey\` field independently invalidates: \`file_content_hash\`, \`file_path\`, \`dimension\`, \`standards_hash\`, \`prompts_hash\`, \`evaluator_hash\`, \`model_id\`, \`language\`, \`temperature\`, \`max_tokens\` |
| \`TestInvalidation\` | \`schema_version\` bump invalidates everything (global blast radius) |
| \`TestRunnerOwnsKey\` | dispatcher returns \`DispatchResult(findings, files_read)\` only — the runner stamps the cache key. Persisted entry carries the runner's key |
| \`TestRunnerOwnsKey\` | entry metadata (\`file_path\`, \`dimension\`, \`model_id\`) propagates from the \`WorkUnit\` |
| \`TestConcurrency\` | two runners for the same key both succeed (relies on the local backend's atomic \`os.replace\`) |
| \`TestEmptyResults\` | empty findings cache normally — a successful no-op is a hit |

## Public API

\`\`\`python
from quodeq.analysis.cache import (
    WorkUnit, DispatchResult, Dispatcher, UnitResult, analyze_unit,
)

result = analyze_unit(
    unit,                    # WorkUnit with all key inputs
    cache=local_or_tiered,   # any CacheBackend
    dispatcher=fn,           # Callable[[WorkUnit], DispatchResult]
    schema_version=1,
)
# result.entry.findings, result.cache_hit
\`\`\`

## Test plan

- [x] 20 new tests pass
- [x] Full unit suite: 2789 passed (was 2769; +20)
- [x] Zero behavior change for users — nothing imports the new runner yet
- [x] Reviewer sanity-check: is the \`DispatchResult\` shape right? Does any pipeline path produce findings the dispatcher couldn't return as a flat list?

## What's next (Phase B3)

A separate PR will build the parity harness against \`tests/fixtures/discipline_corpus/\` (69 projects). Approach: capture V1 output for a curated subset with a thin record-and-replay layer for model calls, then assert V2 produces identical findings/scores. That's the hard validation gate before any cutover.