### PR TITLE
feat(cache): dimension-level cache helpers (Phase B4)

### DIFF
--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -15,6 +15,12 @@ The module is loaded eagerly but the cache itself is only consulted when
 from __future__ import annotations
 
 from quodeq.analysis.cache.backend import CacheBackend, CacheStats
+from quodeq.analysis.cache.dimension_helpers import (
+    ClassifyResult,
+    build_cache_key_for_file,
+    classify_files_via_cache,
+    persist_dispatch_results,
+)
 from quodeq.analysis.cache.entry import CacheEntry
 from quodeq.analysis.cache.flags import is_cache_v2_enabled, is_result_cache_disabled
 from quodeq.analysis.cache.key import CacheKey, compute_key
@@ -33,6 +39,7 @@ __all__ = [
     "CacheEntry",
     "CacheKey",
     "CacheStats",
+    "ClassifyResult",
     "DispatchResult",
     "Dispatcher",
     "LocalFileBackend",
@@ -40,8 +47,11 @@ __all__ = [
     "UnitResult",
     "WorkUnit",
     "analyze_unit",
+    "build_cache_key_for_file",
+    "classify_files_via_cache",
     "compute_key",
     "default_cache_root",
     "is_cache_v2_enabled",
     "is_result_cache_disabled",
+    "persist_dispatch_results",
 ]

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -1,0 +1,183 @@
+"""Dimension-level cache helpers — bridge between RunConfig + filesystem
+and the cache layer.
+
+These are pure functions used by the V2 dimension processor (Phase B5):
+
+  - ``build_cache_key_for_file``: derive a deterministic cache key from
+    the current ``RunConfig`` and a target file. The key composition
+    matches ``CacheKey``: file content, dimension, standards, prompts,
+    model, language. Sampling params are not yet plumbed through
+    ``AnalysisOptions``; once they are, add them to the key.
+
+  - ``classify_files_via_cache``: split a file list into cache hits
+    (with findings) and misses (need dispatch). The miss-key mapping is
+    returned so the caller can write entries after dispatch without
+    recomputing keys.
+
+  - ``persist_dispatch_results``: after a dispatch run writes its JSONL,
+    group its findings by file and write per-file cache entries for the
+    files that were actually dispatched. Empty-finding files get an
+    empty entry — a clean analysis is still a hit, not a miss.
+
+These helpers do not call into the live pipeline. The Phase B5 wrapper
+will compose them with ``process_dimension_with_subagents`` behind the
+``QUODEQ_CACHE_V2`` flag.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from quodeq.analysis._types import RunConfig
+from quodeq.analysis.cache.backend import CacheBackend
+from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.key import CacheKey, compute_key
+from quodeq.analysis.fingerprint import _hash_file, _hash_prompts_map, _hash_standards
+
+_logger = logging.getLogger(__name__)
+
+# Bumped on any breaking change to key composition or entry format.
+_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ClassifyResult:
+    """Result of splitting a file list against the cache."""
+
+    cached_findings: list[dict] = field(default_factory=list)
+    misses: list[str] = field(default_factory=list)
+    # Per-file cache key for the missed files, so the caller can write
+    # entries after dispatch without recomputing the key.
+    miss_keys: dict[str, str] = field(default_factory=dict)
+
+
+def _hash_prompts_combined() -> str:
+    """Hash all rules-bearing prompts into a single SHA-256.
+
+    The fingerprint module stores a per-file map for selective
+    invalidation; here we collapse it to one string so the cache key
+    stays simple. Any prompt change still invalidates correctly.
+    """
+    pmap = _hash_prompts_map() or {}
+    if not pmap:
+        return ""
+    h = hashlib.sha256()
+    for name in sorted(pmap):
+        h.update(name.encode())
+        h.update(pmap[name].encode())
+    return h.hexdigest()
+
+
+def _model_id_from(config: RunConfig) -> str:
+    """Pick the most specific model identifier available."""
+    opts = config.options
+    return opts.subagent_model or opts.ai_model or "unknown"
+
+
+def build_cache_key_for_file(config: RunConfig, file_path: str, dimension: str) -> str:
+    """Compute the cache key for a (file, dimension) pair under ``config``.
+
+    Returns a 64-char hex SHA-256. Same inputs always produce the same key.
+    """
+    content_hash = _hash_file(config.src / file_path) or ""
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension)
+        if config.standards_dir else ""
+    ) or ""
+    key = CacheKey(
+        schema_version=_SCHEMA_VERSION,
+        file_content_hash=content_hash,
+        file_path=file_path,
+        dimension=dimension,
+        standards_hash=standards_hash,
+        prompts_hash=_hash_prompts_combined(),
+        evaluator_hash="",  # not yet versioned; revisit when evaluators are.
+        model_id=_model_id_from(config),
+        language=config.language or "",
+    )
+    return compute_key(key)
+
+
+def classify_files_via_cache(
+    config: RunConfig, dimension: str, files: list[str],
+    cache: CacheBackend,
+) -> ClassifyResult:
+    """Split ``files`` into cache hits (findings) and misses (need dispatch)."""
+    cached_findings: list[dict] = []
+    misses: list[str] = []
+    miss_keys: dict[str, str] = {}
+    for f in files:
+        key = build_cache_key_for_file(config, f, dimension)
+        hit = cache.get(key)
+        if hit is None:
+            misses.append(f)
+            miss_keys[f] = key
+        else:
+            cached_findings.extend(hit.findings)
+    return ClassifyResult(
+        cached_findings=cached_findings,
+        misses=misses,
+        miss_keys=miss_keys,
+    )
+
+
+def _group_findings_by_file(jsonl_path: Path) -> dict[str, list[dict]]:
+    """Read a JSONL of findings and group lines by their ``file`` field."""
+    grouped: dict[str, list[dict]] = {}
+    if not jsonl_path.is_file():
+        return grouped
+    try:
+        text = jsonl_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _logger.warning("failed to read JSONL %s: %s", jsonl_path, exc)
+        return grouped
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        f = entry.get("file")
+        if isinstance(f, str) and f:
+            grouped.setdefault(f, []).append(entry)
+    return grouped
+
+
+def persist_dispatch_results(
+    config: RunConfig, dimension: str, *, miss_files: list[str],
+    jsonl_path: Path, miss_keys: dict[str, str], cache: CacheBackend,
+) -> None:
+    """Write per-file cache entries from a dispatch run's JSONL output.
+
+    A successful dispatch that produced no findings for a given file
+    still writes an empty entry — the next run hits instead of
+    re-dispatching. If the JSONL doesn't exist (dispatch crashed before
+    writing), no entries are written: we don't fabricate "no findings"
+    when there's no evidence the analysis ran.
+    """
+    if not jsonl_path.is_file():
+        # Dispatch failed before writing; let the next run retry.
+        return
+    grouped = _group_findings_by_file(jsonl_path)
+    model_id = _model_id_from(config)
+    for f in miss_files:
+        key = miss_keys.get(f)
+        if key is None:
+            # Caller error: missed file with no key. Skip rather than fabricate.
+            _logger.debug("persist_dispatch_results: no key for %s; skipping", f)
+            continue
+        entry = CacheEntry(
+            key=key,
+            schema_version=_SCHEMA_VERSION,
+            findings=grouped.get(f, []),
+            files_read=1,
+            file_path=f,
+            dimension=dimension,
+            model_id=model_id,
+        )
+        cache.put(key, entry)

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -1,0 +1,334 @@
+"""Dimension-level cache helpers — pure functions that bridge between
+RunConfig + filesystem and the cache layer.
+
+This is the building block for Phase B5's wiring. Three helpers:
+
+  - build_cache_key_for_file: derive the cache key from RunConfig + file
+  - classify_files_via_cache: split files into hits and misses
+  - persist_dispatch_results: after dispatch, write per-file entries
+
+Tests use the real cache backend with synthetic RunConfigs. No live
+dispatch needed.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.cache import LocalFileBackend, CacheEntry
+from quodeq.analysis.cache.dimension_helpers import (
+    ClassifyResult,
+    build_cache_key_for_file,
+    classify_files_via_cache,
+    persist_dispatch_results,
+)
+
+
+def _write_files(root: Path, contents: dict[str, str]) -> list[str]:
+    root.mkdir(parents=True, exist_ok=True)
+    for name, text in contents.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+    return sorted(contents.keys())
+
+
+def _make_config(
+    src: Path, *, work_dir: Path | None = None,
+    standards_dir: Path | None = None, model: str = "test-model",
+    language: str = "python",
+) -> RunConfig:
+    opts = AnalysisOptions(subagent_model=model)
+    return RunConfig(
+        src=src, language=language, standards_dir=standards_dir,
+        work_dir=work_dir or src, options=opts,
+    )
+
+
+def _write_compiled_standards(standards_dir: Path, dim: str, payload: str) -> None:
+    compiled = standards_dir / "compiled"
+    compiled.mkdir(parents=True, exist_ok=True)
+    (compiled / f"{dim}.json").write_text(payload)
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+# ============================================================
+# build_cache_key_for_file
+# ============================================================
+
+class TestKeyComposition:
+    def test_returns_64_hex_string(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src")
+        key = build_cache_key_for_file(config, "a.py", "security")
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+    def test_file_content_change_invalidates(self, tmp_path: Path):
+        src = tmp_path / "src"
+        _write_files(src, {"a.py": "version1"})
+        config = _make_config(src)
+        k1 = build_cache_key_for_file(config, "a.py", "security")
+
+        (src / "a.py").write_text("version2")
+        k2 = build_cache_key_for_file(config, "a.py", "security")
+        assert k1 != k2
+
+    def test_dimension_change_invalidates(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src")
+        assert (
+            build_cache_key_for_file(config, "a.py", "security")
+            != build_cache_key_for_file(config, "a.py", "documentation")
+        )
+
+    def test_model_change_invalidates(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        c1 = _make_config(tmp_path / "src", model="claude-opus-4-7")
+        c2 = _make_config(tmp_path / "src", model="claude-sonnet-4-6")
+        assert (
+            build_cache_key_for_file(c1, "a.py", "security")
+            != build_cache_key_for_file(c2, "a.py", "security")
+        )
+
+    def test_language_change_invalidates(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        c1 = _make_config(tmp_path / "src", language="python")
+        c2 = _make_config(tmp_path / "src", language="typescript")
+        assert (
+            build_cache_key_for_file(c1, "a.py", "security")
+            != build_cache_key_for_file(c2, "a.py", "security")
+        )
+
+    def test_standards_change_invalidates(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        std_dir = tmp_path / "standards"
+        _write_compiled_standards(std_dir, "security", '{"v": 1}')
+        c1 = _make_config(tmp_path / "src", standards_dir=std_dir)
+        k1 = build_cache_key_for_file(c1, "a.py", "security")
+
+        _write_compiled_standards(std_dir, "security", '{"v": 2}')
+        k2 = build_cache_key_for_file(c1, "a.py", "security")
+        assert k1 != k2
+
+    def test_path_change_invalidates(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x", "sub/a.py": "x"})
+        config = _make_config(tmp_path / "src")
+        # Same content, different paths → distinct keys.
+        assert (
+            build_cache_key_for_file(config, "a.py", "security")
+            != build_cache_key_for_file(config, "sub/a.py", "security")
+        )
+
+    def test_stable_across_calls(self, tmp_path: Path):
+        _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src")
+        assert (
+            build_cache_key_for_file(config, "a.py", "security")
+            == build_cache_key_for_file(config, "a.py", "security")
+        )
+
+
+# ============================================================
+# classify_files_via_cache
+# ============================================================
+
+class TestClassify:
+    def test_empty_cache_all_misses(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y"})
+        config = _make_config(tmp_path / "src")
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.cached_findings == []
+        assert sorted(result.misses) == files
+        assert set(result.miss_keys.keys()) == set(files)
+
+    def test_full_cache_all_hits(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y"})
+        config = _make_config(tmp_path / "src")
+        # Pre-populate cache for both files.
+        canned: dict[str, list[dict]] = {
+            "a.py": [{"file": "a.py", "line": 1, "t": "violation"}],
+            "b.py": [{"file": "b.py", "line": 2, "t": "compliance"}],
+        }
+        for f in files:
+            key = build_cache_key_for_file(config, f, "security")
+            cache.put(key, CacheEntry(
+                key=key, schema_version=1, findings=canned[f],
+                files_read=1, file_path=f, dimension="security",
+                model_id="test-model",
+            ))
+
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.misses == []
+        assert {f["file"] for f in result.cached_findings} == set(files)
+
+    def test_partial_cache_split(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y", "c.py": "z"})
+        config = _make_config(tmp_path / "src")
+        # Only b.py is cached.
+        key_b = build_cache_key_for_file(config, "b.py", "security")
+        cache.put(key_b, CacheEntry(
+            key=key_b, schema_version=1,
+            findings=[{"file": "b.py", "line": 1, "t": "violation"}],
+            files_read=1, file_path="b.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert sorted(result.misses) == ["a.py", "c.py"]
+        assert [f["file"] for f in result.cached_findings] == ["b.py"]
+
+    def test_modified_file_invalidates_hit(self, tmp_path: Path, cache: LocalFileBackend):
+        src = tmp_path / "src"
+        files = _write_files(src, {"a.py": "v1"})
+        config = _make_config(src)
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1, findings=[{"file": "a.py"}],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        # Modify file → key changes → miss.
+        (src / "a.py").write_text("v2")
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.misses == ["a.py"]
+        assert result.cached_findings == []
+
+
+# ============================================================
+# persist_dispatch_results
+# ============================================================
+
+class TestPersist:
+    def test_writes_per_file_entry_from_jsonl(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work")
+        miss_keys = {f: build_cache_key_for_file(config, f, "security") for f in files}
+
+        # Simulate a dispatch run: JSONL has findings for both files.
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.write_text(
+            json.dumps({"file": "a.py", "line": 1, "t": "violation", "w": "a-issue"}) + "\n"
+            + json.dumps({"file": "b.py", "line": 2, "t": "compliance", "w": "b-ok"}) + "\n"
+            + json.dumps({"file": "a.py", "line": 5, "t": "violation", "w": "a-issue-2"}) + "\n"
+        )
+
+        persist_dispatch_results(
+            config, "security", miss_files=files,
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+
+        a_entry = cache.get(miss_keys["a.py"])
+        b_entry = cache.get(miss_keys["b.py"])
+        assert a_entry is not None
+        assert b_entry is not None
+        assert len(a_entry.findings) == 2
+        assert len(b_entry.findings) == 1
+        assert a_entry.findings[0]["w"] == "a-issue"
+
+    def test_empty_findings_still_written(self, tmp_path: Path, cache: LocalFileBackend):
+        # A successful analysis that found nothing must cache an empty
+        # entry so the next run hits instead of re-dispatching.
+        files = _write_files(tmp_path / "src", {"clean.py": "x"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work")
+        miss_keys = {f: build_cache_key_for_file(config, f, "security") for f in files}
+
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        # No findings for clean.py — JSONL is empty.
+        jsonl.write_text("")
+
+        persist_dispatch_results(
+            config, "security", miss_files=files,
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+
+        entry = cache.get(miss_keys["clean.py"])
+        assert entry is not None
+        assert entry.findings == []
+
+    def test_only_writes_for_miss_files(self, tmp_path: Path, cache: LocalFileBackend):
+        # JSONL might contain findings for files that weren't in misses
+        # (e.g. carry-forward findings). We only cache entries for the
+        # missed files we actually dispatched.
+        files = _write_files(tmp_path / "src", {"a.py": "x", "carried.py": "y"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work")
+        miss_keys = {"a.py": build_cache_key_for_file(config, "a.py", "security")}
+
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.write_text(
+            json.dumps({"file": "a.py", "line": 1}) + "\n"
+            + json.dumps({"file": "carried.py", "line": 2}) + "\n"
+        )
+
+        persist_dispatch_results(
+            config, "security", miss_files=["a.py"],
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+
+        # Only a.py's key is in the cache; carried.py was never dispatched here.
+        assert cache.get(miss_keys["a.py"]) is not None
+        # No entry for carried.py — its key isn't even in miss_keys.
+
+    def test_handles_missing_jsonl(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work")
+        miss_keys = {"a.py": build_cache_key_for_file(config, "a.py", "security")}
+
+        # JSONL doesn't exist (e.g. dispatch failed before writing).
+        persist_dispatch_results(
+            config, "security", miss_files=["a.py"],
+            jsonl_path=tmp_path / "work" / "missing.jsonl",
+            miss_keys=miss_keys, cache=cache,
+        )
+
+        # No entry written — we don't fabricate "no findings" when we
+        # have no evidence the analysis actually ran.
+        assert cache.get(miss_keys["a.py"]) is None
+
+
+# ============================================================
+# end-to-end roundtrip
+# ============================================================
+
+class TestRoundTrip:
+    def test_classify_dispatch_persist_then_classify_all_hits(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work")
+
+        # First call: empty cache → all misses.
+        first = classify_files_via_cache(config, "security", files, cache)
+        assert sorted(first.misses) == files
+
+        # Simulate dispatch: write JSONL with findings for the misses.
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.write_text(
+            json.dumps({"file": "a.py", "line": 1, "t": "violation"}) + "\n"
+            + json.dumps({"file": "b.py", "line": 2, "t": "compliance"}) + "\n"
+        )
+
+        # Persist results.
+        persist_dispatch_results(
+            config, "security", miss_files=first.misses,
+            jsonl_path=jsonl, miss_keys=first.miss_keys, cache=cache,
+        )
+
+        # Second call: cache should be fully populated → all hits.
+        second = classify_files_via_cache(config, "security", files, cache)
+        assert second.misses == []
+        assert {f["file"] for f in second.cached_findings} == set(files)


### PR DESCRIPTION
## Summary

Pure-function building blocks for the V2 dimension processor that lands in **B5**. These bridge between \`RunConfig\` + filesystem and the cache layer without touching the live pipeline.

Following the established pattern (B1, B2, B3): **build tested primitives first, wire them in a focused follow-up**. The B5 wiring diff will be small precisely because the primitives are already tested here.

## Why split this from the wiring

The full integration interacts with V1's carry-forward, fingerprint, queue salvage, and verify-step logic — too many moving pieces to land cleanly in one PR. Splitting keeps each diff focused, reviewable, and rollback-safe.

## Three helpers

\`\`\`python
from quodeq.analysis.cache import (
    build_cache_key_for_file,
    classify_files_via_cache,
    persist_dispatch_results,
    ClassifyResult,
)
\`\`\`

| Helper | Purpose |
|---|---|
| \`build_cache_key_for_file(config, file, dim)\` | Derive a deterministic SHA-256 from file content, standards (\`compiled/<dim>.json\`), rules-bearing prompts, model, language, path, and dimension. Reuses the existing fingerprint hashing helpers (\`_hash_file\`, \`_hash_standards\`, \`_hash_prompts_map\`) so V1 and V2 observe the same source of truth. |
| \`classify_files_via_cache(config, dim, files, cache)\` | Split a file list into cache hits (with findings) and misses (with per-file keys for later writeback). The \`miss_keys\` map lets the caller persist entries after dispatch without recomputing. |
| \`persist_dispatch_results(config, dim, miss_files, jsonl_path, miss_keys, cache)\` | Group findings from a dispatch run's JSONL by file and write per-file cache entries. Empty-finding files get an empty entry — a clean analysis is a hit, not a miss. Missing JSONL writes nothing — we don't fabricate "no findings" without evidence the analysis ran. |

## TDD

Tests written first → \`ModuleNotFoundError\` on first run → implementation until green.

\`\`\`
tests/analysis/cache/test_dimension_helpers.py:24: in <module>
    from quodeq.analysis.cache.dimension_helpers import (
E   ModuleNotFoundError: No module named 'quodeq.analysis.cache.dimension_helpers'
\`\`\`

## Tests (17 new)

| Class | Coverage |
|---|---|
| \`TestKeyComposition\` | Hex shape; sensitivity to file content / dimension / model / language / standards / path; stability across calls |
| \`TestClassify\` | Empty cache → all misses; full cache → all hits with findings; partial cache → correct split; modified file → invalidation |
| \`TestPersist\` | Per-file entries from JSONL; empty findings still written; only miss files cached (carried-forward findings in JSONL ignored); missing JSONL → no writes |
| \`TestRoundTrip\` | classify → mock dispatch + JSONL → persist → re-classify all hits |

## Test plan

- [x] 17 new tests pass
- [x] Full unit suite: 2812 passed (was 2795; +17)
- [x] Zero behaviour change — nothing imports \`dimension_helpers\` yet
- [x] Reviewer note: \`evaluator_hash\` defaults to \`""\` because evaluators aren't currently version-stamped. Add to the key when they are.

## What's next (Phase B5)

The wiring PR. Adds one branch to \`_process_single_dimension\`:

\`\`\`python
if is_cache_v2_enabled():
    return process_dimension_with_cache(config, dim_id, idx, ctx, callbacks)
\`\`\`

\`process_dimension_with_cache\` composes the three helpers above with the existing dispatcher, plus \`cache_hit\` / \`cache_miss\` telemetry. Default off (\`QUODEQ_CACHE_V2\` opt-in). Soaks before the flag flips on.