### PR TITLE
feat(cache): wire content-addressed cache into dimension processing (Phase B5)

### DIFF
--- a/src/quodeq/analysis/_dimension_ops.py
+++ b/src/quodeq/analysis/_dimension_ops.py
@@ -8,6 +8,7 @@ from quodeq.analysis._dimension_steps import (
     _parse_dimension_evidence,
     _run_dimension_analysis,
 )
+from quodeq.analysis.cache.flags import is_cache_v2_enabled
 from quodeq.analysis.subagents.runner import DimensionCallbacks, process_dimension_with_subagents
 from quodeq.core.evidence.model import Evidence
 from quodeq.engine._runner_markers import emit_marker
@@ -39,14 +40,17 @@ def _process_single_dimension(
         emit_marker("analyzing", dimension=dimension)
         log_info(f"→ [{idx}/{ctx.total}] Analyzing {dimension}")
 
-    ev = process_dimension_with_subagents(
-        config, dimension, idx, ctx,
-        callbacks=DimensionCallbacks(
-            build_prompt=_build_dimension_prompt,
-            run_analysis=_run_dimension_analysis,
-            parse_evidence=_parse_dimension_evidence,
-        ),
+    callbacks = DimensionCallbacks(
+        build_prompt=_build_dimension_prompt,
+        run_analysis=_run_dimension_analysis,
+        parse_evidence=_parse_dimension_evidence,
     )
+    if is_cache_v2_enabled():
+        # Deferred import: avoids loading the cache stack on default runs.
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+        ev = process_dimension_with_cache(config, dimension, idx, ctx, callbacks)
+    else:
+        ev = process_dimension_with_subagents(config, dimension, idx, ctx, callbacks)
 
     if ev is None:
         log_warning(f"[{idx}/{ctx.total}] {dimension} — no valid evidence, skipping")

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -1,0 +1,132 @@
+"""V2 cache-aware dimension processor — composes B4 helpers with the
+existing dispatcher boundary.
+
+The flow:
+
+  1. List source files (respecting any incremental_file_filter set by
+     the caller)
+  2. Classify each file via the cache: hits return findings directly,
+     misses go to the dispatcher
+  3. All-hits short-circuit: write cached findings to JSONL and parse
+     to Evidence without calling the dispatcher
+  4. Otherwise: dispatch misses via process_dimension_with_subagents
+     with incremental_file_filter restricted to the miss set
+  5. Persist new findings to cache (per-file) from the dispatch JSONL
+  6. If there were also hits, append cached findings to the JSONL and
+     re-parse for the final Evidence
+
+This sits *above* the existing dispatcher — V1's machinery (carry-
+forward, fingerprint, queue salvage) still runs for the dispatched
+files. That's intentional: the cache supersedes V1's incrementality
+decisions but keeps the proven dispatch path intact.
+
+Known limitation: when migrating from a long-lived V1 install to V2,
+V1's carry-forward might surface findings for files V2 has cached,
+producing duplicates in the dispatch JSONL. The fix is to suppress
+V1's carry-forward when V2 is active; B6 cleanup will handle that
+once the V1 path is being deleted.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from quodeq.analysis._incremental_evidence import parse_evidence_from_jsonl
+from quodeq.analysis._types import RunConfig, _AnalysisContext
+from quodeq.analysis.cache.backend import CacheBackend
+from quodeq.analysis.cache.dimension_helpers import (
+    classify_files_via_cache,
+    persist_dispatch_results,
+)
+from quodeq.analysis.cache.local import LocalFileBackend
+from quodeq.analysis.subagents._source_files import _list_source_files
+from quodeq.analysis.subagents.runner import (
+    DimensionCallbacks,
+    process_dimension_with_subagents,
+)
+from quodeq.core.evidence.model import Evidence
+
+_logger = logging.getLogger(__name__)
+
+
+def _evidence_dir(config: RunConfig) -> Path:
+    return config.work_dir or config.src
+
+
+def _jsonl_path(config: RunConfig, dim_id: str) -> Path:
+    return _evidence_dir(config) / f"{dim_id}_evidence.jsonl"
+
+
+def _write_findings(jsonl: Path, findings: list[dict], *, append: bool) -> None:
+    jsonl.parent.mkdir(parents=True, exist_ok=True)
+    mode = "a" if append else "w"
+    with jsonl.open(mode) as out:
+        for finding in findings:
+            out.write(json.dumps(finding) + "\n")
+
+
+def process_dimension_with_cache(
+    config: RunConfig, dim_id: str, idx: int, ctx: _AnalysisContext,
+    callbacks: DimensionCallbacks,
+    *, cache: CacheBackend | None = None,
+) -> Evidence | None:
+    """V2 entry point — content-addressed cache replaces V1 change detection.
+
+    Falls through to ``process_dimension_with_subagents`` when there's
+    no source-file list to classify (matches V1's no-files fallback).
+    """
+    if cache is None:
+        cache = LocalFileBackend()
+
+    files, _ext = _list_source_files(config, dim_id)
+    if not files:
+        # Nothing to classify — defer to existing path so the no-files
+        # warning + single-agent fallback runs unchanged.
+        return process_dimension_with_subagents(config, dim_id, idx, ctx, callbacks)
+
+    classify = classify_files_via_cache(config, dim_id, files, cache)
+    n_hits = len(files) - len(classify.misses)
+    _logger.info(
+        "[%s] cache: %d hits / %d misses (%d total)",
+        dim_id, n_hits, len(classify.misses), len(files),
+    )
+
+    jsonl = _jsonl_path(config, dim_id)
+
+    # All-hits short-circuit: no dispatch needed.
+    if not classify.misses:
+        _write_findings(jsonl, classify.cached_findings, append=False)
+        return parse_evidence_from_jsonl(
+            config, dim_id, ctx, jsonl, files_read=len(files),
+        )
+
+    # Dispatch misses via the existing path, with file filter restricted
+    # to the miss set so the pool only processes uncached files.
+    miss_options = replace(config.options, incremental_file_filter=set(classify.misses))
+    miss_config = replace(config, options=miss_options)
+    miss_evidence = process_dimension_with_subagents(
+        miss_config, dim_id, idx, ctx, callbacks,
+    )
+
+    if miss_evidence is None:
+        # Dispatch failed — propagate without writing cache entries.
+        return None
+
+    # Persist per-file cache entries from the dispatch JSONL.
+    persist_dispatch_results(
+        config, dim_id, miss_files=classify.misses,
+        jsonl_path=jsonl, miss_keys=classify.miss_keys, cache=cache,
+    )
+
+    # If there are also cache hits, merge them into the JSONL and
+    # re-parse so the returned Evidence reflects the full picture.
+    if classify.cached_findings:
+        _write_findings(jsonl, classify.cached_findings, append=True)
+        return parse_evidence_from_jsonl(
+            config, dim_id, ctx, jsonl, files_read=len(files),
+        )
+
+    return miss_evidence

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -1,0 +1,395 @@
+"""process_dimension_with_cache — V2 dimension processor.
+
+Composes the B4 helpers (classify, persist, key) with the existing
+dispatcher boundary (process_dimension_with_subagents) into a
+cache-aware dimension runner.
+
+These tests pin down the orchestration:
+
+  - all-hits short-circuits dispatch entirely
+  - all-misses dispatches with the original file set
+  - partial dispatches with file filter restricted to misses
+  - missed-file findings are persisted to cache after dispatch
+  - cached findings are merged into final Evidence
+  - dispatcher returning None propagates without writing cache entries
+
+The dispatcher is patched at the boundary
+(process_dimension_with_subagents) so we don't need a real subagent
+pool. The runner's behaviour is fully observable through the cache
+state and the dispatcher call recorder.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig, _AnalysisContext
+from quodeq.analysis.cache import (
+    CacheEntry,
+    LocalFileBackend,
+    build_cache_key_for_file,
+)
+from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
+from quodeq.analysis.subagents.runner import DimensionCallbacks
+from quodeq.core.evidence.model import Evidence
+
+
+# ============================================================
+# Test scaffolding
+# ============================================================
+
+
+def _make_manifest(file_names: list[str]) -> SourceManifest:
+    """Manifest with a single Python target listing the given files."""
+    target = AnalysisTarget(
+        name="test", language="python",
+        source_files=sorted(file_names),
+        total_files=len(file_names),
+        language_stats={"py": len(file_names)},
+    )
+    return SourceManifest(targets=[target], total_files=len(file_names))
+
+
+def _make_config(
+    src: Path, *, work_dir: Path | None = None,
+    file_names: list[str] | None = None,
+) -> RunConfig:
+    return RunConfig(
+        src=src, language="python", standards_dir=None,
+        work_dir=work_dir or src,
+        options=AnalysisOptions(subagent_model="test-model"),
+        manifest=_make_manifest(file_names or []) if file_names is not None else None,
+    )
+
+
+def _write_files(root: Path, contents: dict[str, str]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for name, text in contents.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+
+def _setup(
+    tmp_path: Path, contents: dict[str, str] | None = None,
+) -> tuple[RunConfig, Path]:
+    """Create files + a config wired with a manifest. Returns (config, src)."""
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    if contents:
+        _write_files(src, contents)
+    config = _make_config(
+        src, work_dir=tmp_path / "work",
+        file_names=sorted(contents.keys()) if contents else [],
+    )
+    return config, src
+
+
+def _make_ctx() -> _AnalysisContext:
+    from quodeq.analysis._dimensions import DimensionsConfig
+    return _AnalysisContext(
+        dimensions_data=DimensionsConfig(dimensions={}),
+        date_str="2026-01-01",
+        template="",
+        subagent_template="",
+        total=1,
+    )
+
+
+def _make_callbacks() -> DimensionCallbacks:
+    """Real callbacks aren't needed when the dispatcher boundary is mocked."""
+    from quodeq.analysis._dimension_steps import (
+        _build_dimension_prompt,
+        _parse_dimension_evidence,
+        _run_dimension_analysis,
+    )
+    return DimensionCallbacks(
+        build_prompt=_build_dimension_prompt,
+        run_analysis=_run_dimension_analysis,
+        parse_evidence=_parse_dimension_evidence,
+    )
+
+
+class FakeDispatcher:
+    """Stand-in for process_dimension_with_subagents that writes a JSONL
+    and returns a synthetic Evidence — same contract as the real thing."""
+
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root
+        self.calls: list[RunConfig] = []
+
+    def __call__(
+        self, config: RunConfig, dim_id: str, idx: int, ctx, callbacks,
+    ) -> Evidence | None:
+        self.calls.append(config)
+        # Mirror what the real dispatcher does: write findings to JSONL
+        # for each file in the (filtered) file list. Findings are
+        # deterministic per file so we can assert on them.
+        evidence_dir = config.work_dir or config.src
+        jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        files_to_dispatch = (
+            sorted(config.options.incremental_file_filter)
+            if config.options.incremental_file_filter
+            else self._all_source_files()
+        )
+        with jsonl.open("a") as out:
+            for f in files_to_dispatch:
+                out.write(json.dumps({
+                    "file": f, "line": 1, "t": "violation", "w": f"v-{f}",
+                }) + "\n")
+        return _make_dummy_evidence(files_read=len(files_to_dispatch))
+
+    def _all_source_files(self) -> list[str]:
+        return sorted(
+            str(p.relative_to(self.project_root))
+            for p in self.project_root.rglob("*.py")
+        )
+
+
+def _make_dummy_evidence(*, files_read: int) -> Evidence:
+    """Minimal Evidence shape — the V2 runner re-parses from JSONL anyway,
+    so the dispatcher's exact return value isn't what matters."""
+    return Evidence(
+        repository="", language="python", date="2026-01-01",
+        source_file_count=files_read, files_read=files_read,
+        coverage_pct=100.0, principles={},
+    )
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+# ============================================================
+# Behavioural tests
+# ============================================================
+
+
+class TestAllHits:
+    def test_all_hits_skip_dispatch_entirely(self, tmp_path: Path, cache: LocalFileBackend):
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        # Pre-populate cache for both files.
+        for f, finding_text in [("a.py", "a-cached"), ("b.py", "b-cached")]:
+            key = build_cache_key_for_file(config, f, "security")
+            cache.put(key, CacheEntry(
+                key=key, schema_version=1,
+                findings=[{"file": f, "line": 1, "t": "violation", "w": finding_text}],
+                files_read=1, file_path=f, dimension="security",
+                model_id="test-model",
+            ))
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            ev = process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        # No dispatch happened.
+        assert dispatcher.calls == []
+        assert ev is not None
+
+        # Final JSONL contains exactly the cached findings.
+        jsonl = (tmp_path / "work" / "security_evidence.jsonl").read_text()
+        lines = [json.loads(l) for l in jsonl.splitlines() if l.strip()]
+        assert {l["w"] for l in lines} == {"a-cached", "b-cached"}
+
+
+class TestAllMisses:
+    def test_cold_cache_dispatches_all_files(self, tmp_path: Path, cache: LocalFileBackend):
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            ev = process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        # Dispatch happened with all files (file filter == all source files).
+        assert len(dispatcher.calls) == 1
+        dispatched = dispatcher.calls[0].options.incremental_file_filter
+        assert dispatched == {"a.py", "b.py"}
+        assert ev is not None
+
+        # Cache entries written for both files after dispatch.
+        for f in ["a.py", "b.py"]:
+            key = build_cache_key_for_file(config, f, "security")
+            entry = cache.get(key)
+            assert entry is not None, f"no cache entry for {f}"
+            assert entry.findings, f"empty findings for {f}"
+
+    def test_second_run_after_cold_is_all_hits(self, tmp_path: Path, cache: LocalFileBackend):
+        """Sanity end-to-end: cold run populates cache, second run hits."""
+        config, src = _setup(tmp_path, {"a.py": "x"})
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+            )
+            # Run 2 — should not dispatch.
+            dispatcher.calls.clear()
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+            )
+        assert dispatcher.calls == []
+
+
+class TestPartialHits:
+    def test_dispatches_only_misses(self, tmp_path: Path, cache: LocalFileBackend):
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y", "c.py": "z"})
+
+        # Pre-populate b.py only.
+        key_b = build_cache_key_for_file(config, "b.py", "security")
+        cache.put(key_b, CacheEntry(
+            key=key_b, schema_version=1,
+            findings=[{"file": "b.py", "line": 1, "t": "violation", "w": "b-cached"}],
+            files_read=1, file_path="b.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            ev = process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+            )
+
+        # Dispatcher saw only the misses.
+        assert len(dispatcher.calls) == 1
+        dispatched = dispatcher.calls[0].options.incremental_file_filter
+        assert dispatched == {"a.py", "c.py"}
+        assert ev is not None
+
+        # Final JSONL combines miss findings + cached findings.
+        jsonl = (tmp_path / "work" / "security_evidence.jsonl").read_text()
+        lines = [json.loads(l) for l in jsonl.splitlines() if l.strip()]
+        files_in_jsonl = {l["file"] for l in lines}
+        assert files_in_jsonl == {"a.py", "b.py", "c.py"}
+
+        # b.py's cached finding survived; a.py and c.py were freshly dispatched.
+        b_findings = [l for l in lines if l["file"] == "b.py"]
+        assert any(l["w"] == "b-cached" for l in b_findings)
+
+
+class TestDispatchFailure:
+    def test_dispatcher_returns_none_no_cache_writes(self, tmp_path: Path, cache: LocalFileBackend):
+        config, src = _setup(tmp_path, {"a.py": "x"})
+
+        def failing_dispatcher(*args, **kwargs):
+            return None
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=failing_dispatcher,
+        ):
+            ev = process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+            )
+        assert ev is None
+
+        # No cache entry was written for the failed dispatch.
+        key = build_cache_key_for_file(config, "a.py", "security")
+        assert cache.get(key) is None
+
+
+class TestNoSourceFiles:
+    def test_falls_through_to_dispatcher_when_no_files(self, tmp_path: Path, cache: LocalFileBackend):
+        # Empty src — the cache layer can't classify, defer to dispatcher.
+        config, src = _setup(tmp_path, {})
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), _make_callbacks(), cache=cache,
+            )
+        # Dispatcher was called (even with no files — same as V1 behaviour).
+        assert len(dispatcher.calls) == 1
+
+
+# ============================================================
+# Wiring smoke test
+# ============================================================
+
+
+class TestFlagWiring:
+    def test_v2_flag_routes_to_cache_runner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """When QUODEQ_CACHE_V2=1, _process_single_dimension dispatches
+        through the cache runner instead of calling subagents directly."""
+        from quodeq.analysis._dimension_ops import _process_single_dimension
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+
+        monkeypatch.setenv("QUODEQ_CACHE_V2", "1")
+
+        called_v2 = {"hit": False}
+        def fake_v2(config, dim_id, idx, ctx, callbacks, cache=None):
+            called_v2["hit"] = True
+            return _make_dummy_evidence(files_read=1)
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_cache",
+            new=fake_v2,
+        ), patch(
+            "quodeq.analysis._dimension_ops._save_dimension_fingerprint",
+        ):
+            _process_single_dimension(config, "security", 1, _make_ctx(), emit_log=False)
+
+        assert called_v2["hit"] is True
+
+    def test_v2_flag_off_routes_to_subagents_directly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Default behaviour: flag off → existing path, no V2 involvement."""
+        from quodeq.analysis._dimension_ops import _process_single_dimension
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+
+        monkeypatch.delenv("QUODEQ_CACHE_V2", raising=False)
+
+        called_v2 = {"hit": False}
+        called_v1 = {"hit": False}
+        def fake_v2(*args, **kwargs):
+            called_v2["hit"] = True
+            return _make_dummy_evidence(files_read=1)
+        def fake_v1(*args, **kwargs):
+            called_v1["hit"] = True
+            return _make_dummy_evidence(files_read=1)
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_cache",
+            new=fake_v2,
+        ), patch(
+            "quodeq.analysis._dimension_ops.process_dimension_with_subagents",
+            new=fake_v1,
+        ), patch(
+            "quodeq.analysis._dimension_ops._save_dimension_fingerprint",
+        ):
+            _process_single_dimension(config, "security", 1, _make_ctx(), emit_log=False)
+
+        assert called_v1["hit"] is True
+        assert called_v2["hit"] is False


### PR DESCRIPTION
## Summary

The wiring PR. Adds \`process_dimension_with_cache\` — the V2 dimension processor — and routes \`_process_single_dimension\` through it behind \`QUODEQ_CACHE_V2\`. **Default path is byte-identical to before.**

This is the first PR that touches the live pipeline. The diff to live code is intentionally minimal: a single \`if is_cache_v2_enabled()\` branch with a deferred import.

## The V2 flow

1. List source files (existing helper)
2. \`classify_files_via_cache\` → split into cache hits / misses
3. **All hits**: write cached findings to JSONL → parse Evidence → skip dispatch entirely
4. **Otherwise**: dispatch misses via \`process_dimension_with_subagents\` with \`incremental_file_filter\` restricted to the miss set
5. \`persist_dispatch_results\` writes per-file cache entries from the dispatch JSONL
6. If hits also exist, append cached findings and re-parse so the returned Evidence reflects the full picture

The cache supersedes V1's incrementality decisions but keeps the proven dispatch path intact. Existing carry-forward, fingerprint, and queue salvage logic still runs for dispatched files. That's a known minor limitation: a long-lived V1 install switching to V2 may see duplicate findings if V1's carry-forward surfaces files V2 has already cached. **B6 cleanup removes the V1 path entirely**, eliminating this edge case.

## Live-code diff

In \`_dimension_ops.py\`:
- One new import: \`is_cache_v2_enabled\`
- 7 added lines: flag check + deferred import + V2 branch
- Existing call site preserved verbatim in the \`else\` branch

\`\`\`python
callbacks = DimensionCallbacks(...)
if is_cache_v2_enabled():
    from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
    ev = process_dimension_with_cache(config, dimension, idx, ctx, callbacks)
else:
    ev = process_dimension_with_subagents(config, dimension, idx, ctx, callbacks)
\`\`\`

## TDD

Tests written first → \`ModuleNotFoundError\` on first run → implementation → first round of failures (Evidence constructor, manifest setup) → fixture fixes → green.

## Tests (8 new)

| Class | Coverage |
|---|---|
| \`TestAllHits\` | Pre-populated cache short-circuits dispatch entirely |
| \`TestAllMisses\` | Cold cache dispatches all files; second run is all hits |
| \`TestPartialHits\` | File filter restricted to misses; hit findings survive in final JSONL |
| \`TestDispatchFailure\` | Dispatcher returns None → no cache writes, None propagated |
| \`TestNoSourceFiles\` | Empty manifest → falls through to V1 path |
| \`TestFlagWiring\` | \`_process_single_dimension\` routes to V2 when flag set, V1 when unset |

The dispatcher is patched at the boundary (\`process_dimension_with_subagents\`) so tests run in milliseconds and don't require a real Claude CLI.

## Test plan

- [x] 8 new wiring tests pass
- [x] Full unit suite: 2820 passed (was 2812; +8)
- [x] Default behaviour unchanged (\`QUODEQ_CACHE_V2\` defaults off)
- [x] Reviewer note: the V1 carry-forward duplication risk is documented in \`dimension_runner.py\`. Real-world soak with V2 enabled before flipping the default is the next step.

## What's next (Phase B6)

1. Soak \`QUODEQ_CACHE_V2=1\` on a real evaluation — confirm cache hits/misses behave as expected, no duplicate findings, no regressions
2. Once green, flip the flag default on
3. Cleanup PR: delete the legacy \`_incr_*\` files, the \`if/else\` branch, and the V1 carry-forward / fingerprint scaffolding that the cache replaces