### PR TITLE
fix(cache): honor --clean-scan in V2 cache layer (B5c)

### DIFF
--- a/src/quodeq/analysis/_incremental_orchestrator.py
+++ b/src/quodeq/analysis/_incremental_orchestrator.py
@@ -57,7 +57,13 @@ def _try_v2_full_hit(
 
     Also writes a V1-compatible fingerprint so flipping the flag off later
     doesn't trigger a needless full re-analysis.
+
+    Honors ``config.options.incremental``: a clean-scan run (incremental=False)
+    must not serve fast-path hits — that's the whole user intent.
     """
+    if not config.options.incremental:
+        return None
+
     files = _list_all_source_files(config, dimension)
     if not files:
         return None

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -104,14 +104,21 @@ def build_cache_key_for_file(config: RunConfig, file_path: str, dimension: str) 
 def classify_files_via_cache(
     config: RunConfig, dimension: str, files: list[str],
     cache: CacheBackend,
+    *, bypass_reads: bool = False,
 ) -> ClassifyResult:
-    """Split ``files`` into cache hits (findings) and misses (need dispatch)."""
+    """Split ``files`` into cache hits (findings) and misses (need dispatch).
+
+    When ``bypass_reads`` is True (e.g. honoring ``--clean-scan``), every
+    file is forced into the misses bucket regardless of cache state. The
+    miss_keys map is still populated so callers can write fresh entries
+    after dispatch — clean-scan refreshes the cache rather than ignoring it.
+    """
     cached_findings: list[dict] = []
     misses: list[str] = []
     miss_keys: dict[str, str] = {}
     for f in files:
         key = build_cache_key_for_file(config, f, dimension)
-        hit = cache.get(key)
+        hit = None if bypass_reads else cache.get(key)
         if hit is None:
             misses.append(f)
             miss_keys[f] = key

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -87,11 +87,17 @@ def process_dimension_with_cache(
         # warning + single-agent fallback runs unchanged.
         return process_dimension_with_subagents(config, dim_id, idx, ctx, callbacks)
 
-    classify = classify_files_via_cache(config, dim_id, files, cache)
+    # Clean-scan (incremental=False) bypasses cache reads — fresh dispatch
+    # every time — but writes still happen below so the cache stays current.
+    bypass_reads = not config.options.incremental
+    classify = classify_files_via_cache(
+        config, dim_id, files, cache, bypass_reads=bypass_reads,
+    )
     n_hits = len(files) - len(classify.misses)
     _logger.info(
-        "[%s] cache: %d hits / %d misses (%d total)",
+        "[%s] cache: %d hits / %d misses (%d total)%s",
         dim_id, n_hits, len(classify.misses), len(files),
+        " — clean-scan refresh" if bypass_reads else "",
     )
 
     jsonl = _jsonl_path(config, dim_id)

--- a/tests/analysis/cache/test_clean_scan_honor.py
+++ b/tests/analysis/cache/test_clean_scan_honor.py
@@ -1,0 +1,257 @@
+"""Clean-scan honoring at the V2 cache layer.
+
+When the user requests a clean scan (config.options.incremental=False),
+V2 must not serve cache hits — that's the whole point of the flag. But
+fresh dispatch results SHOULD still be written to the cache so future
+incremental runs benefit from the refresh.
+
+Three boundaries are tested here:
+
+  1. classify_files_via_cache(bypass_reads=True): every file goes to
+     misses regardless of cache state. The miss_keys map is still
+     populated so persist_dispatch_results can write entries.
+
+  2. _try_v2_full_hit (orchestrator-level fast-path): returns None
+     when incremental=False so V1's clean-scan path takes over.
+
+  3. process_dimension_with_cache (dispatch-level): bypasses cache
+     reads when incremental=False, dispatches all files, writes
+     fresh results to the cache.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig, _AnalysisContext
+from quodeq.analysis.cache import (
+    CacheEntry,
+    LocalFileBackend,
+    build_cache_key_for_file,
+    classify_files_via_cache,
+)
+from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
+
+
+# ============================================================
+# Shared fixtures
+# ============================================================
+
+
+def _make_manifest(file_names: list[str]) -> SourceManifest:
+    target = AnalysisTarget(
+        name="test", language="python",
+        source_files=sorted(file_names),
+        total_files=len(file_names),
+        language_stats={"py": len(file_names)},
+    )
+    return SourceManifest(targets=[target], total_files=len(file_names))
+
+
+def _setup(
+    tmp_path: Path, contents: dict[str, str], *, incremental: bool = True,
+) -> tuple[RunConfig, Path]:
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    for name, text in contents.items():
+        (src / name).write_text(text)
+    config = RunConfig(
+        src=src, language="python", standards_dir=None,
+        work_dir=tmp_path / "work",
+        options=AnalysisOptions(subagent_model="test-model", incremental=incremental),
+        manifest=_make_manifest(sorted(contents.keys())),
+    )
+    return config, src
+
+
+def _make_ctx() -> _AnalysisContext:
+    from quodeq.analysis._dimensions import DimensionsConfig
+    return _AnalysisContext(
+        dimensions_data=DimensionsConfig(dimensions={}),
+        date_str="2026-01-01", template="", subagent_template="", total=1,
+    )
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache_v2")
+
+
+def _populate_cache(cache, config, dim, files: list[str]) -> None:
+    for f in files:
+        key = build_cache_key_for_file(config, f, dim)
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{"file": f, "line": 1, "t": "violation", "w": f"cached-{f}"}],
+            files_read=1, file_path=f, dimension=dim, model_id="test-model",
+        ))
+
+
+# ============================================================
+# 1. classify_files_via_cache(bypass_reads=True)
+# ============================================================
+
+
+class TestClassifyBypassReads:
+    def test_bypass_reads_all_miss_despite_full_cache(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        config, _ = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+        _populate_cache(cache, config, "security", ["a.py", "b.py"])
+
+        result = classify_files_via_cache(
+            config, "security", ["a.py", "b.py"], cache,
+            bypass_reads=True,
+        )
+        assert result.cached_findings == []
+        assert sorted(result.misses) == ["a.py", "b.py"]
+        # miss_keys must still be populated so writeback works.
+        assert set(result.miss_keys.keys()) == {"a.py", "b.py"}
+
+    def test_default_reads_normally(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        """Sanity: bypass_reads defaults to False and existing behaviour holds."""
+        config, _ = _setup(tmp_path, {"a.py": "x"})
+        _populate_cache(cache, config, "security", ["a.py"])
+
+        result = classify_files_via_cache(config, "security", ["a.py"], cache)
+        assert result.misses == []
+        assert len(result.cached_findings) == 1
+
+
+# ============================================================
+# 2. _try_v2_full_hit honors incremental=False
+# ============================================================
+
+
+class TestOrchestratorFastPathHonorsCleanScan:
+    def test_clean_scan_returns_none_despite_full_cache(
+        self, tmp_path: Path, cache: LocalFileBackend,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """incremental=False means V2 must not serve fast-path hits."""
+        config, _ = _setup(tmp_path, {"a.py": "x"}, incremental=False)
+        _populate_cache(cache, config, "security", ["a.py"])
+
+        monkeypatch.setenv("QUODEQ_CACHE_V2", "1")
+
+        from quodeq.analysis._incremental_orchestrator import _try_v2_full_hit
+
+        with patch(
+            "quodeq.analysis._incremental_orchestrator.LocalFileBackend",
+            return_value=cache,
+        ):
+            ev = _try_v2_full_hit(config, "security", _make_ctx())
+        assert ev is None
+
+
+# ============================================================
+# 3. process_dimension_with_cache honors incremental=False
+# ============================================================
+
+
+class TestDispatchBypassesCacheOnCleanScan:
+    def test_clean_scan_dispatches_all_files_despite_full_cache(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        config, _ = _setup(tmp_path, {"a.py": "x", "b.py": "y"}, incremental=False)
+        _populate_cache(cache, config, "security", ["a.py", "b.py"])
+
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+        from quodeq.core.evidence.model import Evidence
+
+        dispatched_files: list[str] = []
+        def fake_dispatcher(cfg, dim_id, idx, ctx, callbacks):
+            files = sorted(cfg.options.incremental_file_filter or set())
+            dispatched_files.extend(files)
+            jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                for f in files:
+                    out.write(json.dumps({
+                        "file": f, "line": 1, "t": "violation", "w": f"fresh-{f}",
+                    }) + "\n")
+            return Evidence(
+                repository="", language="python", date="2026-01-01",
+                source_file_count=len(files), files_read=len(files),
+                coverage_pct=100.0, principles={},
+            )
+
+        from quodeq.analysis._dimension_steps import (
+            _build_dimension_prompt, _parse_dimension_evidence, _run_dimension_analysis,
+        )
+        from quodeq.analysis.subagents.runner import DimensionCallbacks
+        callbacks = DimensionCallbacks(
+            build_prompt=_build_dimension_prompt,
+            run_analysis=_run_dimension_analysis,
+            parse_evidence=_parse_dimension_evidence,
+        )
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=fake_dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), callbacks, cache=cache,
+            )
+
+        # All files re-dispatched, NOT served from cache.
+        assert sorted(dispatched_files) == ["a.py", "b.py"]
+
+    def test_clean_scan_still_writes_fresh_results_to_cache(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        """Clean scan bypasses reads but writes — the cache stays current."""
+        config, _ = _setup(tmp_path, {"a.py": "x"}, incremental=False)
+        # Pre-populate with a stale entry that should be overwritten.
+        old_key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(old_key, CacheEntry(
+            key=old_key, schema_version=1,
+            findings=[{"file": "a.py", "line": 1, "t": "violation", "w": "stale"}],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+        from quodeq.core.evidence.model import Evidence
+
+        def fake_dispatcher(cfg, dim_id, idx, ctx, callbacks):
+            jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                out.write(json.dumps({
+                    "file": "a.py", "line": 1, "t": "violation", "w": "fresh",
+                }) + "\n")
+            return Evidence(
+                repository="", language="python", date="2026-01-01",
+                source_file_count=1, files_read=1, coverage_pct=100.0,
+                principles={},
+            )
+
+        from quodeq.analysis._dimension_steps import (
+            _build_dimension_prompt, _parse_dimension_evidence, _run_dimension_analysis,
+        )
+        from quodeq.analysis.subagents.runner import DimensionCallbacks
+        callbacks = DimensionCallbacks(
+            build_prompt=_build_dimension_prompt,
+            run_analysis=_run_dimension_analysis,
+            parse_evidence=_parse_dimension_evidence,
+        )
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=fake_dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), callbacks, cache=cache,
+            )
+
+        # Cache entry was overwritten with the fresh dispatch result.
+        entry = cache.get(old_key)
+        assert entry is not None
+        assert any(f.get("w") == "fresh" for f in entry.findings)
+        assert all(f.get("w") != "stale" for f in entry.findings)


### PR DESCRIPTION
## Summary

**Stacked on #453.** Fixes a real semantic bug surfaced during your live soak: pressing "clean scan" returned cached results.

\`AnalysisOptions.incremental=False\` (set by \`--clean-scan\` or the dashboard's clean-scan button) was not propagating to V2 — both the orchestrator-level fast-path (B5b #453) and the dispatch-level cache reads (B5 #452) ran regardless of the flag.

User intent: *"I want fresh analysis, ignore the cache."* Bug: V2 served hits anyway. The cache is content-keyed so the findings are "correct" in a strict sense, but ignoring user intent erodes trust and hides LLM non-determinism that clean-scan exists to surface.

## The semantic: read-skip, write-keep

When \`incremental=False\`:
- **Reads bypassed**: every file is forced into the misses bucket → all dispatched
- **Writes kept**: fresh dispatch results land in the cache
- **Net**: user gets fresh analysis, cache stays current, future incremental runs benefit from the refresh

This is the best-of-both: clean-scan respects user intent without throwing away the cache infrastructure.

## Three surgical changes

| Change | File | Effect |
|---|---|---|
| Add \`bypass_reads\` kwarg | \`cache/dimension_helpers.py\` | When True, all files → misses; \`miss_keys\` still populated for writeback |
| \`return None\` when not incremental | \`_incremental_orchestrator._try_v2_full_hit\` | V1's clean-scan path takes over |
| Derive \`bypass_reads\` from \`config.options.incremental\` | \`cache/dimension_runner.process_dimension_with_cache\` | Clean-scan dispatches all files; new findings still cached |

## Log signature

Clean-scan run now produces a distinguishable line:

\`\`\`
[security] cache: 0 hits / 18 misses (18 total) — clean-scan refresh
\`\`\`

Versus the normal incremental run:

\`\`\`
[security] cache: 18 hits / 0 misses (18 total) — V2 fast-path
\`\`\`

## Tests (5 new), TDD red→green

| Test | Pin |
|---|---|
| \`bypass_reads=True\` all-miss despite full cache | The new helper kwarg |
| Default reads work normally | Regression guard for non-clean-scan |
| \`_try_v2_full_hit\` returns None on \`incremental=False\` | Orchestrator-level honor |
| Clean-scan dispatches all files despite cached entries | Dispatch-level honor |
| Stale cache entries overwritten with fresh results | Write-side correctness |

## Test plan

- [x] 5 new tests pass
- [x] Full unit suite: 2829 passed (was 2824; +5)
- [x] Default behaviour unchanged for non-clean-scan runs
- [x] **Live verify**: with this stack merged + \`QUODEQ_CACHE_V2=1\`, clicking clean-scan in the dashboard should now actually re-dispatch (you'll see "clean-scan refresh" in the logs and the run will take meaningful time again)

## Merge order

This PR targets #453 (B5b). Once #453 merges to develop, I'll retarget this to develop.