### PR TITLE
feat(cache): remove zombie V1 fingerprint writes from subagent layer (B6.2a)

### DIFF
--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -12,7 +12,6 @@ from quodeq.core.evidence.model import Evidence
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence_by_dimension
 from quodeq.analysis.subagents.file_queue import FileQueue
 from quodeq.analysis.prompts.builder import PromptContext, build_consolidated_prompt
-from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint
 from quodeq.analysis.stream.counters import count_files_in_stream
 from quodeq.analysis.subagents.pool import PoolOptions, PoolPaths, SubagentPool
 from quodeq.analysis.subagents._pool_launcher import _default_subagent_model, _compute_files_per_agent
@@ -79,10 +78,9 @@ def _collect_consolidated_results(
         except (OSError, ValueError, KeyError):
             pass
 
-    # Save per-dimension fingerprints so incremental works after consolidated runs
-    for dim in run_ctx.dimensions:
-        fp = build_fingerprint(config.src, run_ctx.files, dim, config.standards_dir, analyzed_files=analyzed or None)
-        save_fingerprint(fp, paths.evidence_dir)
+    # V2 cache owns incremental state via per-file entries written
+    # during dispatch; the V1 per-dimension fingerprint write is no
+    # longer needed (B6.2).
 
     ev_ctx = EvidenceContext(
         language=config.language,

--- a/src/quodeq/analysis/subagents/_evidence_collector.py
+++ b/src/quodeq/analysis/subagents/_evidence_collector.py
@@ -1,4 +1,9 @@
-"""Evidence collection, deduplication, and parsing after subagent pool runs."""
+"""Evidence collection, deduplication, and parsing after subagent pool runs.
+
+Post-V2 (B6.2): the V1 per-dimension fingerprint write is gone. The
+V2 cache owns incremental state via per-file entries written during
+dispatch (see ``cache/dimension_helpers.py:persist_dispatch_results``).
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -9,7 +14,6 @@ from quodeq.analysis._types import RunConfig
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.analysis.subagents.pool import SubagentPool
-from quodeq.analysis.fingerprint import build_fingerprint, save_fingerprint as _default_save
 from quodeq.analysis.subagents._pool_launcher import _collect_all_evidence
 from quodeq.engine._runner_markers import cleanup_stream
 
@@ -20,29 +24,17 @@ class _CollectionContext:
     results: list[Any]
     ctx: Any
     files: list[str] | None = None
-    save_fingerprint_fn: Any = None
 
 
 def _collect_evidence(
     config: RunConfig, dim_id: str, evidence_dir: Path,
     collection: _CollectionContext,
 ) -> Evidence:
-    """Deduplicate JSONL, count files read, save fingerprint, and parse into Evidence.
-
-    *collection.save_fingerprint_fn* is an injectable ``(fingerprint, dir) -> None``
-    for persistence; defaults to ``analysis.fingerprint.save_fingerprint``.
-    """
-    _save = collection.save_fingerprint_fn or _default_save
-
+    """Deduplicate JSONL, count files read, and parse into Evidence."""
     merged_jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
     SubagentPool.deduplicate_jsonl(merged_jsonl)
 
     total_files_read = _collect_all_evidence(collection.results, cleanup_stream)
-
-    # Save fingerprint so next run can carry forward unchanged-file findings
-    if collection.files:
-        fp = build_fingerprint(config.src, collection.files, dim_id, config.standards_dir)
-        _save(fp, evidence_dir)
 
     compiled_dir = (config.standards_dir / "compiled") if config.standards_dir else None
     ev = parse_jsonl_to_evidence(

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from quodeq.analysis._types import RunConfig
-from quodeq.analysis.fingerprint import build_fingerprint, find_previous_fingerprint, save_fingerprint
+from quodeq.analysis.fingerprint import find_previous_fingerprint
 from quodeq.analysis.subagents._finding_classifier import classify_findings
 from quodeq.analysis.subagents.verify import (
     partition_findings_by_fingerprint, write_carry_forward_findings,
@@ -104,17 +104,9 @@ def _prepare_findings_and_queue(
     queue_path = dc.evidence_dir / f"{dc.dim_id}_queue.json"
     files_per_agent = _compute_files_per_agent(len(dc.files))
     FileQueue(queue_path, dc.files, max_files_per_agent=files_per_agent)
-    # Persist a fingerprint *now* — before any agent runs — so a crash or
-    # cancel mid-dim doesn't void the file_hashes / standards baseline.
-    # `analyzed_files` carries forward whatever the previous run analyzed
-    # (it'll be augmented by queue.taken on read in find_previous_fingerprint).
-    prev_fp_for_seed, _ = find_previous_fingerprint(dc.evidence_dir, dc.dim_id)
-    seed_analyzed = set(prev_fp_for_seed.get("analyzed_files", [])) if prev_fp_for_seed else set()
-    initial_fp = build_fingerprint(
-        config.src, dc.files, dc.dim_id, config.standards_dir,
-        analyzed_files=seed_analyzed or None,
-    )
-    save_fingerprint(initial_fp, dc.evidence_dir)
+    # V1's per-dimension fingerprint write is gone (B6.2). The V2 cache
+    # owns crash-safe state via per-file entries written by
+    # ``persist_dispatch_results`` (and the periodic-persist watcher).
     log_info(f"  [{dc.idx}/{dc.ctx.total}] {dc.dim_id} -- {len(dc.files)} files queued, {len(inline_findings)} inline findings")
 
     return _PoolExecutionParams(
@@ -135,15 +127,8 @@ def _execute_pool_and_collect(
     )
     pool, results = _launch_pool(config, dc.dim_id, params)
 
-    # Record what the queue actually dispatched. Without this, the saved
-    # fingerprint has analyzed_files=[], which combined with up-to-date
-    # file_hashes makes the next run's change detection skip everything.
-    queue_taken = set(FileQueue(pool_params.queue_path).all_taken_files())
-    fp = build_fingerprint(
-        config.src, dc.files, dc.dim_id, config.standards_dir,
-        analyzed_files=queue_taken or None,
-    )
-    save_fingerprint(fp, dc.evidence_dir)
+    # V2 owns post-dispatch state via per-file cache entries; the V1
+    # post-pool fingerprint write is no longer needed (B6.2).
 
     if pool_params.mini_verify_findings:
         verify_results = _dispatch_mini_verify(config, dc.dim_id, dc.evidence_dir, pool_params.mini_verify_findings)


### PR DESCRIPTION
## Summary

V2's per-file cache entries are now the only state quodeq persists for incremental analysis. The subagent layer was still writing **per-dim fingerprint files that nothing reads** — pure overhead. This PR removes those zombie writes.

## What was removed

| File | Removed |
|---|---|
| \`subagents/runner.py\` | Initial fingerprint write (before pool launch) + post-pool fingerprint write + the \`find_previous_fingerprint\` seed read + unused imports |
| \`subagents/_consolidated.py\` | Per-dim fingerprint loop after consolidated runs + unused imports |
| \`subagents/_evidence_collector.py\` | Post-collection fingerprint write + \`save_fingerprint_fn\` field on \`_CollectionContext\` + imports |

## What was kept

\`subagents/runner.py:_prepare_findings_and_queue\` still calls \`find_previous_fingerprint\` as input to \`partition_findings_by_fingerprint\` (the **verify-pool** logic). Removing that is **B6.2b** — bigger refactor since the verify-pool is a real V1 feature, not just a write. Splitting into its own PR.

## Why this matters

- **Stale V1 fingerprint files no longer accumulate** on disk
- One fewer source of confusion — V1 fingerprints were a recurring debugging point during the migration
- **Removes the duplicate-findings risk** noted as a known limitation in B5's docstring (V1 carry-forward + V2 cache hits could double-emit)

## Test plan

- [x] Full unit suite: 2757 passing (unchanged)
- [x] No public API change
- [x] No new behavior — the zombie writes were producing files nothing read
- [x] Live verify: after running an eval, no \`*_fingerprint.json\` files appear under the run's evidence dir

## What's next (B6.2b)

The verify-pool refactor: \`_prepare_findings_and_queue\` and \`_verification.py\` still use V1's \`find_previous_fingerprint\` + \`partition_findings_by_fingerprint\` to decide what previously-found findings need re-verification. Under V2 the cache hit/miss is the equivalent decision, so the verify-pool is structurally redundant. Removing it is ~200-400 lines of careful refactoring.

After B6.2b, \`fingerprint.py\` itself can be slimmed to just the hash helpers V2 uses (\`_hash_file\`, \`_hash_standards\`, \`_hash_prompts_map\`).