### PR TITLE
feat(ui): clickable violation drill-downs + virtualized file detail

### DIFF
--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@chenglou/pretext": "^0.0.6",
         "@tanstack/react-query": "^5.100.9",
+        "@tanstack/react-virtual": "^3.13.24",
         "d3-hierarchy": "^3.1.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",
@@ -753,6 +754,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.100.9",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@chenglou/pretext": "^0.0.6",
     "@tanstack/react-query": "^5.100.9",
+    "@tanstack/react-virtual": "^3.13.24",
     "d3-hierarchy": "^3.1.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -25,6 +25,7 @@ import { ACTIVE_PROVIDER_KEY, providerKey } from './constants.js';
 import ProjectHeader from './components/ProjectHeader.jsx';
 import { useAppState, formatDayLabel } from './hooks/useAppState.js';
 import { readVisibleStandardIds } from './utils/visibleStandards.js';
+import { buildProjectRootFile } from './utils/explorerUtils.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
 import { SidePane, useSidePane } from './features/side-pane/index.js';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -177,7 +178,19 @@ function ViolationsRoute({ params, props }) {
   function navigateToDimension(row, severity) {
     const dim = row.raw || dimMap.get(row.dimension);
     if (!dim) return;
-    nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject, severity, sourceTab: 'violations' });
+    // Cell clicks on a dimension row (numeric severity columns or the
+    // "violations" total) drill into the dimension's findings — match the
+    // project/run pattern by handing FileDetailPage a synthetic file
+    // aggregated from the dimension, with the chosen severity preselected.
+    const dimFile = buildProjectRootFile([dim], dim.dimension);
+    const severityFilter = severity || 'all';
+    nav('file', {
+      file: dimFile,
+      severityFilter,
+      runId: dim.fromRunId,
+      dateLabel: dim.fromDateLabel,
+      sourceTab: 'violations',
+    });
   }
 
   return (
@@ -194,7 +207,7 @@ function ViolationsRoute({ params, props }) {
       }}
       callbacks={{
         onDimensionClick: (dim) => nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject, sourceTab: 'violations' }),
-        onFileClick: (fileObj) => nav('file', { file: fileObj, sourceTab: 'violations' }),
+        onFileClick: (fileObj, opts) => nav('file', { file: fileObj, sourceTab: 'violations', severityFilter: opts?.severity || null }),
         onCellClick: ({ row, severity }) => {
           if (row.type === 'principle' && row.principleObj) {
             navigateToPrinciple(row.principleObj, severity);
@@ -285,6 +298,7 @@ const ROUTE_RENDERERS = {
       file={params.file}
       runId={params.runId}
       dateLabel={params.dateLabel}
+      severityFilter={params.severityFilter || params.severity || null}
       onDismiss={(v) => {
         props.dismissFinding(props.navigation.selectedProject, buildDismissPayload(v))
           .then(() => props.refreshDashboard?.())

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -1,13 +1,10 @@
 import { useState } from 'react';
-import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_SETTINGS, ICON_STANDARDS, ICON_HELP } from '../constants/navigation.jsx';
+import { ICON_OVERVIEW, ICON_VIOLATIONS, ICON_MAP, ICON_HISTORY, ICON_EVALUATE, ICON_SETTINGS, ICON_STANDARDS, ICON_HELP, ICON_FOLDER as BASE_ICON_FOLDER } from '../constants/navigation.jsx';
+import { cloneElement } from 'react';
 
-// Folder glyph for the REPOSITORY row — visually distinct from the list-style
-// ICON_PROJECTS so the repo context reads as a folder even on the collapsed rail.
-const ICON_FOLDER = (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
-  </svg>
-);
+// Folder glyph for the REPOSITORY row — same outline used in the file/folder
+// table on FileDetailPage, just sized up for the sidebar rail.
+const ICON_FOLDER = cloneElement(BASE_ICON_FOLDER, { width: 18, height: 18 });
 
 function Logo() {
   return (

--- a/src/quodeq/ui/src/components/terminal/SevBadge.jsx
+++ b/src/quodeq/ui/src/components/terminal/SevBadge.jsx
@@ -18,24 +18,54 @@ const SHORT = { critical: 'CRIT', major: 'MAJ', minor: 'MIN' };
 const LONG = { critical: 'critical', major: 'major', minor: 'minor' };
 const ABBR = { critical: 'crit', major: 'maj', minor: 'min' };
 
-export default function SevBadge({ level, format = 'short', count }) {
+export default function SevBadge({ level, format = 'short', count, onClick, ariaLabel }) {
   if (!level || !(level in SHORT)) return null;
 
+  const baseClass = `term-sev-badge term-sev-badge--${level}`;
+
   if (format === 'count-abbr') {
-    return (
-      <span className={`term-sev-badge term-sev-badge--${level} term-sev-badge--count-abbr`}>
+    const className = `${baseClass} term-sev-badge--count-abbr${onClick ? ' term-sev-badge--clickable' : ''}`;
+    const content = (
+      <>
         {count != null ? count : ''}
         {count != null ? ' ' : ''}
         {ABBR[level]}
-      </span>
+      </>
     );
+    if (onClick) {
+      return (
+        <button
+          type="button"
+          className={className}
+          onClick={(e) => { e.stopPropagation(); onClick(); }}
+          aria-label={ariaLabel || `${level} severity`}
+        >
+          {content}
+        </button>
+      );
+    }
+    return <span className={className}>{content}</span>;
   }
 
   const text = format === 'short' ? SHORT[level] : LONG[level];
-  return (
-    <span className={`term-sev-badge term-sev-badge--${level}`}>
+  const className = `${baseClass}${onClick ? ' term-sev-badge--clickable' : ''}`;
+  const content = (
+    <>
       {text}
       {count != null && <span className="term-sev-badge__count"> {count}</span>}
-    </span>
+    </>
   );
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className={className}
+        onClick={(e) => { e.stopPropagation(); onClick(); }}
+        aria-label={ariaLabel || `${level} severity`}
+      >
+        {content}
+      </button>
+    );
+  }
+  return <span className={className}>{content}</span>;
 }

--- a/src/quodeq/ui/src/components/terminal/StatStrip.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.jsx
@@ -29,15 +29,24 @@ export function StatStrip({ children, cards = false }) {
  * @param {React.ReactNode} [props.trailing] Right-aligned accessory slot (badges, delta).
  * @param {string} [props.tone] One of "default" | "success" | "warning" | "critical".
  */
-export function Stat({ label, value, hint, trailing, tone = 'default' }) {
-  return (
-    <div className={`term-stat term-stat--${tone}`}>
+export function Stat({ label, value, hint, trailing, tone = 'default', onClick, ariaLabel }) {
+  const className = `term-stat term-stat--${tone}${onClick ? ' term-stat--clickable' : ''}`;
+  const content = (
+    <>
       <div className="term-stat__label">{label}</div>
       <div className="term-stat__value-row">
         <span className="term-stat__value">{value}</span>
         {trailing != null && <span className="term-stat__trailing">{trailing}</span>}
       </div>
       {hint != null && <div className="term-stat__hint">{hint}</div>}
-    </div>
+    </>
   );
+  if (onClick) {
+    return (
+      <button type="button" className={className} onClick={onClick} aria-label={ariaLabel || label}>
+        {content}
+      </button>
+    );
+  }
+  return <div className={className}>{content}</div>;
 }

--- a/src/quodeq/ui/src/constants/navigation.jsx
+++ b/src/quodeq/ui/src/constants/navigation.jsx
@@ -85,3 +85,9 @@ export const ICON_STAR_FILLED = (
     <path d="M12 2l3 7h7l-5.5 4 2 7L12 16l-6.5 4 2-7L2 9h7l3-7z" />
   </svg>
 );
+
+export const ICON_FOLDER = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
+  </svg>
+);

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -6,7 +6,7 @@ import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGroupin
 const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
-import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+import { buildTopOffendingFiles, buildProjectRootFile } from '../../../utils/explorerUtils.js';
 import { withDimensionsStr } from '../../../utils/dimensionUtils.js';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 import LastFetchedLine from '../../../components/LastFetchedLine.jsx';
@@ -52,14 +52,15 @@ function computeAccumulatedStats(accumulated, accumulatedDimensions, dailyTrend,
 // Sub-components
 // ---------------------------------------------------------------------------
 
-function SeverityBadgeRow({ severity }) {
+function SeverityBadgeRow({ severity, onSeverityClick }) {
   const sev = severity || {};
   if (!(sev.critical || sev.major || sev.minor)) return null;
+  const onClickFor = (level) => onSeverityClick ? () => onSeverityClick(level) : undefined;
   return (
     <span className="acc-eval-sev-row">
-      {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} format="count-abbr" />}
-      {sev.major > 0    && <SevBadge level="major"    count={sev.major}    format="count-abbr" />}
-      {sev.minor > 0    && <SevBadge level="minor"    count={sev.minor}    format="count-abbr" />}
+      {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} format="count-abbr" onClick={onClickFor('critical')} />}
+      {sev.major > 0    && <SevBadge level="major"    count={sev.major}    format="count-abbr" onClick={onClickFor('major')} />}
+      {sev.minor > 0    && <SevBadge level="minor"    count={sev.minor}    format="count-abbr" onClick={onClickFor('minor')} />}
     </span>
   );
 }
@@ -76,7 +77,7 @@ function buildLanguageSub(projectInfo) {
     .join('  ');
 }
 
-function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulatedDimensions, projectName, projectInfo }) {
+function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulatedDimensions, projectName, projectInfo, onCardNavigate }) {
   const summary = accumulated?.summary;
   const scoreNum = parseFloat(summary?.numericAverage);
   const scoreDisplay = isNaN(scoreNum) ? '—' : scoreNum.toFixed(1);
@@ -85,6 +86,10 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
   const compliance = summary?.totalCompliance || 0;
   const totalChecks = violations + compliance;
   const ratio = complianceRatio(violations, compliance);
+
+  const handleViolations = onCardNavigate ? () => onCardNavigate('violations') : undefined;
+  const handleCompliance = onCardNavigate && compliance > 0 ? () => onCardNavigate('compliance') : undefined;
+  const handleSeverity = onCardNavigate ? (level) => onCardNavigate(level) : undefined;
 
   return (
     <section className="acc-eval-panel acc-eval-panel--terminal">
@@ -105,12 +110,16 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
         <Stat
           label="VIOLATIONS"
           value={violations}
-          hint={<SeverityBadgeRow severity={summary?.severity} />}
+          hint={<SeverityBadgeRow severity={summary?.severity} onSeverityClick={handleSeverity} />}
+          onClick={violations > 0 ? handleViolations : undefined}
+          ariaLabel={violations > 0 ? 'Show all violations' : undefined}
         />
         <Stat
           label="COMPLIANCE"
           value={compliance}
           hint={totalChecks > 0 ? `passing / ${totalChecks} checks` : null}
+          onClick={handleCompliance}
+          ariaLabel={compliance > 0 ? 'Show compliance entries' : undefined}
         />
         <Stat
           label="RATIO"
@@ -215,6 +224,15 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
   }, [hasReportData, reportProjectName, filteredAccumulated, filteredDimensions]);
   useRegisterWindowSpec('report', reportSpec);
 
+  const onCardNavigate = useMemo(() => {
+    if (!onNavigate) return undefined;
+    return (kind) => {
+      const projectFile = buildProjectRootFile(filteredDimensions || [], reportProjectName);
+      const severityFilter = kind === 'violations' ? 'all' : kind;
+      onNavigate('file', { file: projectFile, severityFilter });
+    };
+  }, [onNavigate, filteredDimensions, reportProjectName]);
+
   return (
     <>
       <AccumulatedHeroSection
@@ -224,6 +242,7 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
         accumulatedDimensions={filteredDimensions}
         projectName={data.selectedProject}
         projectInfo={data.projectInfo}
+        onCardNavigate={onCardNavigate}
       />
 
       <div className="history-panels-row">

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -40,6 +40,7 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
         projectName={projectInfo?.displayName || projectInfo?.name || selectedProject}
         onDimensionClick={onDimensionCardClick}
         onFileClick={onFileClick}
+        onNavigate={onNavigate}
       />
     );
   }

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -4,7 +4,7 @@ import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 
-import { buildTopOffendingFiles, buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
+import { buildTopOffendingFiles, buildDimensionPlanFromViolations, buildProjectRootFile } from '../../../utils/explorerUtils.js';
 import { buildRunReport } from '../../../utils/reportBuilder.js';
 import { formatRunId, gradeLetter, complianceRatio } from '../../../utils/formatters.js';
 import { withDimensionsStr } from '../../../utils/dimensionUtils.js';
@@ -40,19 +40,20 @@ function RunDimensionsGrid({ dimensions, selectedRunId, dateLabel, onDimensionCl
 // Run-specific overview panel
 // ---------------------------------------------------------------------------
 
-function SeverityBadgeRow({ severity }) {
+function SeverityBadgeRow({ severity, onSeverityClick }) {
   const sev = severity || {};
   if (!(sev.critical || sev.major || sev.minor)) return null;
+  const onClickFor = (level) => onSeverityClick ? () => onSeverityClick(level) : undefined;
   return (
     <span className="acc-eval-sev-row">
-      {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} format="count-abbr" />}
-      {sev.major > 0    && <SevBadge level="major"    count={sev.major}    format="count-abbr" />}
-      {sev.minor > 0    && <SevBadge level="minor"    count={sev.minor}    format="count-abbr" />}
+      {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} format="count-abbr" onClick={onClickFor('critical')} />}
+      {sev.major > 0    && <SevBadge level="major"    count={sev.major}    format="count-abbr" onClick={onClickFor('major')} />}
+      {sev.minor > 0    && <SevBadge level="minor"    count={sev.minor}    format="count-abbr" onClick={onClickFor('minor')} />}
     </span>
   );
 }
 
-function RunHeroSection({ dashboard, selectedRunId, runSummary }) {
+function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNavigate }) {
   const dateLabel = dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId);
   const scoreNum = parseFloat(runSummary.numericAverage);
   const scoreDisplay = isNaN(scoreNum) ? '—' : scoreNum.toFixed(1);
@@ -61,6 +62,10 @@ function RunHeroSection({ dashboard, selectedRunId, runSummary }) {
   const compliance = runSummary.totalCompliance || 0;
   const totalChecks = violations + compliance;
   const ratio = complianceRatio(violations, compliance);
+
+  const handleViolations = onCardNavigate && violations > 0 ? () => onCardNavigate('violations') : undefined;
+  const handleCompliance = onCardNavigate && compliance > 0 ? () => onCardNavigate('compliance') : undefined;
+  const handleSeverity = onCardNavigate ? (level) => onCardNavigate(level) : undefined;
 
   return (
     <section className="acc-eval-panel acc-eval-panel--terminal">
@@ -76,12 +81,16 @@ function RunHeroSection({ dashboard, selectedRunId, runSummary }) {
         <Stat
           label="VIOLATIONS"
           value={violations}
-          hint={<SeverityBadgeRow severity={runSummary.severity} />}
+          hint={<SeverityBadgeRow severity={runSummary.severity} onSeverityClick={handleSeverity} />}
+          onClick={handleViolations}
+          ariaLabel={violations > 0 ? 'Show all violations for this run' : undefined}
         />
         <Stat
           label="COMPLIANCE"
           value={compliance}
           hint={totalChecks > 0 ? `passing / ${totalChecks} checks` : null}
+          onClick={handleCompliance}
+          ariaLabel={compliance > 0 ? 'Show compliance entries for this run' : undefined}
         />
         <Stat
           label="RATIO"
@@ -106,9 +115,20 @@ function RunFileViolations({ runTopFiles, onFileClick }) {
   );
 }
 
-export default function RunOverviewPanel({ dashboard, selectedRunId, projectName, onDimensionClick, onFileClick }) {
+export default function RunOverviewPanel({ dashboard, selectedRunId, projectName, onDimensionClick, onFileClick, onNavigate }) {
   const runSummary = useMemo(() => buildRunSummary(dashboard?.dimensions), [dashboard]);
   const runTopFiles = useMemo(() => withDimensionsStr(buildTopOffendingFiles(dashboard?.dimensions || [])), [dashboard]);
+  const runDateLabel = dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId);
+
+  const onCardNavigate = useMemo(() => {
+    if (!onNavigate) return undefined;
+    return (kind) => {
+      const label = `${projectName || 'project'} · ${runDateLabel || 'run'}`;
+      const projectFile = buildProjectRootFile(dashboard?.dimensions || [], label);
+      const severityFilter = kind === 'violations' ? 'all' : kind;
+      onNavigate('file', { file: projectFile, severityFilter, runId: selectedRunId, dateLabel: runDateLabel });
+    };
+  }, [onNavigate, dashboard, projectName, runDateLabel, selectedRunId]);
 
   const reportSpec = useMemo(() => {
     if (!dashboard?.dimensions) return null;
@@ -170,7 +190,7 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, projectName
         <div className="run-overview-spinner"><LoadingScreen /></div>
       ) : (
         <>
-          <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} runSummary={runSummary} />
+          <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} runSummary={runSummary} onCardNavigate={onCardNavigate} />
           <section className="quality-dimensions" aria-label="Quality dimensions">
             <div className="quality-dimensions__head">
               <SectionLabel>quality_dimensions · {dimCount}</SectionLabel>

--- a/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/ExplorerPage.jsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useEffect } from 'react';
 import TopOffendingFilesTable from '../../dashboard/components/TopOffendingFilesTable.jsx';
 import { complianceRatio } from '../../../utils/formatters.js';
-import { buildDimensionPlanFromViolations } from '../../../utils/explorerUtils.js';
+import { buildDimensionPlanFromViolations, buildProjectRootFile } from '../../../utils/explorerUtils.js';
 import { buildDimensionReport } from '../../../utils/reportBuilder.js';
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useExplorerData, buildEvalPrincipalFn } from './explorerDataHooks.js';
@@ -133,6 +133,24 @@ export default function ExplorerPage({
   const sev = d.severityCounts;
   const isRefreshing = d.isFetching && !!d.evalData;
 
+  // Synthetic file for the dimension lets the VIOLATIONS / COMPLIANCE cards
+  // (and severity badges) navigate into a FileDetailPage scoped to this
+  // standard, mirroring the project / run / by-dimension-row pattern.
+  const allCompliance = [];
+  if (d.complianceByPrinciple) {
+    for (const items of d.complianceByPrinciple.values()) allCompliance.push(...items);
+  }
+  const dimFile = buildProjectRootFile(
+    [{ dimension: d.evalData.dimension, violations: d.allViolations, compliance: allCompliance }],
+    d.evalData.dimension,
+  );
+  const handleCardNavigate = (kind) => {
+    if (!onNavigate) return;
+    const severityFilter = kind === 'violations' ? 'all' : kind;
+    onNavigate('file', { file: dimFile, severityFilter, runId: activeRunId, dateLabel: activeDateLabel });
+  };
+  const onSeverityBadge = (level) => () => handleCardNavigate(level);
+
   return (
     <div className={`explorer-page dashboard-fade${isRefreshing ? ' dashboard-refreshing' : ''}`}>
       <TermHeader name={dim} description={standardDescription} sub={activeDateLabel || activeRunId || null} />
@@ -150,16 +168,20 @@ export default function ExplorerPage({
               value={d.allViolations.length}
               hint={(sev.critical || sev.major || sev.minor) ? (
                 <span className="principle-detail-sev-row">
-                  {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} />}
-                  {sev.major    > 0 && <SevBadge level="major"    count={sev.major} />}
-                  {sev.minor    > 0 && <SevBadge level="minor"    count={sev.minor} />}
+                  {sev.critical > 0 && <SevBadge level="critical" count={sev.critical} onClick={onNavigate ? onSeverityBadge('critical') : undefined} />}
+                  {sev.major    > 0 && <SevBadge level="major"    count={sev.major}    onClick={onNavigate ? onSeverityBadge('major') : undefined} />}
+                  {sev.minor    > 0 && <SevBadge level="minor"    count={sev.minor}    onClick={onNavigate ? onSeverityBadge('minor') : undefined} />}
                 </span>
               ) : null}
+              onClick={onNavigate && d.allViolations.length > 0 ? () => handleCardNavigate('violations') : undefined}
+              ariaLabel={d.allViolations.length > 0 ? 'Show all violations' : undefined}
             />
             <Stat
               label="COMPLIANCE"
               value={d.totalCompliant}
               hint={`passing / ${d.totalCompliant + d.allViolations.length} checks`}
+              onClick={onNavigate && d.totalCompliant > 0 ? () => handleCardNavigate('compliance') : undefined}
+              ariaLabel={d.totalCompliant > 0 ? 'Show compliance entries' : undefined}
             />
             <Stat
               label="RATIO"

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { buildFilePlanText } from '../../../utils/planTextBuilders.js';
 import { buildFileReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER, parseFileRef, complianceRatio } from '../../../utils/formatters.js';
@@ -9,12 +10,9 @@ import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { ComplianceCard } from './EvalCards.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge } from '../../../components/terminal/index.js';
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
-import LowConfidenceGroup, { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
+import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 
-const ANIM_DELAY_PER_ITEM_MS = 30;
-const ANIM_MAX_DELAY_MS = 300;
-
-function ViolationCard({ v, index, onDismiss }) {
+const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
   const { addWindow } = useSidePane();
   const { filePath, line } = parseFileRef(v.file, v.line);
   const filename = filePath ? filePath.split('/').pop() : null;
@@ -23,7 +21,7 @@ function ViolationCard({ v, index, onDismiss }) {
   const display = line != null ? `${filename}:${range}` : filename;
   const linkedRefs = v.reqRefs?.filter(r => r.url && /^https?:\/\//.test(r.url)) || [];
   return (
-    <div className={`vdetail-row vdetail-row--${v.severity}`} style={{ animationDelay: `${Math.min(index * ANIM_DELAY_PER_ITEM_MS, ANIM_MAX_DELAY_MS)}ms` }}>
+    <div className={`vdetail-row vdetail-row--${v.severity}`}>
       <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
         {v.dimension && <span className="vrow-label">[{v.dimension}]</span>}
@@ -73,7 +71,7 @@ function ViolationCard({ v, index, onDismiss }) {
       </div>
     </div>
   );
-}
+});
 
 function FileSevBadgeRow({ sevCounts }) {
   if (!(sevCounts.critical || sevCounts.major || sevCounts.minor)) return null;
@@ -119,29 +117,102 @@ function FileHeader({ file, sevCounts, totalViolations, totalCompliance, dimensi
   );
 }
 
-
-function SeverityGroup({ sev, violations, onDismiss }) {
-  if (violations.length === 0) return null;
+function GroupHeader({ title, count }) {
   return (
-    <div>
-      <div className="violation-group-header">
-        <span className="violation-group-title">{sev.charAt(0).toUpperCase() + sev.slice(1)}</span>
-        <span className="violation-group-count">{violations.length}</span>
-      </div>
-      <div className="vlive-violations-group">
-        {violations.map((v, idx) => (
-          <ViolationCard key={idx} v={v} index={idx} onDismiss={onDismiss} />
-        ))}
-      </div>
+    <div className="violation-group-header">
+      <span className="violation-group-title">{title}</span>
+      <span className="violation-group-count">{count}</span>
     </div>
   );
 }
 
-const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, onDismiss }) {
+function LowConfidenceToggle({ count, expanded, onToggle }) {
+  return (
+    <button
+      type="button"
+      className="violation-group-header low-confidence-group-header"
+      aria-expanded={expanded}
+      onClick={onToggle}
+    >
+      <span className="violation-group-title">Low confidence</span>
+      <span className="violation-group-count">{count}</span>
+      <span className="low-confidence-group-hint">
+        {expanded ? 'Hide' : 'Show'} likely false positives
+      </span>
+    </button>
+  );
+}
+
+// Virtualizer extracted into its own component so the parent can remount it
+// (via `key={activeFilter}`) when the filter changes. A fresh virtualizer
+// starts with empty measurement caches, sidestepping the class of bugs
+// where stale heights at recycled indices cause row overlap.
+function VirtualList({ items, scrollElement, renderItem }) {
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: (i) => {
+      const item = items[i];
+      if (!item) return 140;
+      if (item.kind === 'sev-header' || item.kind === 'compliance-header') return 36;
+      if (item.kind === 'low-conf-toggle') return 36;
+      return 160;
+    },
+    overscan: 6,
+    getItemKey: (i) => {
+      const item = items[i];
+      if (!item) return i;
+      if (item.kind === 'sev-header') return `h-${item.sev}`;
+      if (item.kind === 'compliance-header') return 'h-compliance';
+      if (item.kind === 'low-conf-toggle') return 'h-lowconf';
+      if (item.kind === 'violation') {
+        return `v-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
+      }
+      if (item.kind === 'low-conf-row') {
+        return `lc-${item.v.dimension || ''}:${item.v.file || ''}:${item.v.line ?? ''}:${item.v.principle || ''}:${item.v.title || ''}`;
+      }
+      if (item.kind === 'compliance') {
+        return `c-${item.c.dimension || ''}:${item.c.file || ''}:${item.c.line ?? ''}:${item.c.principle || ''}`;
+      }
+      return i;
+    },
+  });
+
+  const totalSize = virtualizer.getTotalSize();
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div className="vlive-violations-virtual" style={{ position: 'relative', width: '100%', height: totalSize }}>
+      {virtualItems.map((virtualRow) => {
+        const item = items[virtualRow.index];
+        if (!item) return null;
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={virtualizer.measureElement}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            {renderItem(item)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, onDismiss, severityFilter }) {
   const totalCompliance = file.compliance?.length || 0;
   const dimensionsCount = file.dimensionsCount || 0;
-  const [activeFilter, setActiveFilter] = useState(null);
+  const [activeFilter, setActiveFilter] = useState(severityFilter || null);
   const [dismissedSet, setDismissedSet] = useState(new Set());
+  const [lowConfExpanded, setLowConfExpanded] = useState(false);
 
   const dismissKey = (v) => `${v.file}:${v.line}`;
 
@@ -176,6 +247,47 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
   const showCompliance = !activeFilter || activeFilter === 'all' || activeFilter === 'compliance';
   const showViolations = activeFilter !== 'compliance';
 
+  // Flatten everything into a single virtualizable items array. Mixing
+  // headers + rows in one list lets us virtualize the whole page with one
+  // scroller; React never holds more than ~30 row instances at once even on
+  // 3k-violation projects.
+  const items = useMemo(() => {
+    const arr = [];
+    if (showViolations) {
+      for (const sev of SEVERITY_ORDER) {
+        const bucket = highConfidenceBySeverity[sev] || [];
+        if (bucket.length === 0) continue;
+        if (activeFilter && activeFilter !== 'all' && activeFilter !== sev) continue;
+        arr.push({ kind: 'sev-header', sev, count: bucket.length });
+        for (const v of bucket) arr.push({ kind: 'violation', v });
+      }
+      if ((!activeFilter || activeFilter === 'all') && lowConfidenceViolations.length > 0) {
+        arr.push({ kind: 'low-conf-toggle', count: lowConfidenceViolations.length, expanded: lowConfExpanded });
+        if (lowConfExpanded) {
+          for (const v of lowConfidenceViolations) arr.push({ kind: 'low-conf-row', v });
+        }
+      }
+    }
+    if (showCompliance && totalCompliance > 0) {
+      arr.push({ kind: 'compliance-header', count: totalCompliance });
+      for (const c of file.compliance) arr.push({ kind: 'compliance', c });
+    }
+    return arr;
+  }, [showViolations, showCompliance, activeFilter, highConfidenceBySeverity, lowConfidenceViolations, lowConfExpanded, file.compliance, totalCompliance]);
+
+  // The dashboard's main column owns vertical scroll; tanstack-virtual needs
+  // a ref to that ancestor to track scroll position.
+  const [scrollElement, setScrollElement] = useState(null);
+  useLayoutEffect(() => {
+    setScrollElement(document.querySelector('.app-shell__main-column > .dashboard'));
+  }, []);
+
+  // Snap to top whenever the filter changes so a giant list doesn't dump the
+  // user mid-scroll into a freshly-mounted virtualizer.
+  useEffect(() => {
+    if (scrollElement) scrollElement.scrollTop = 0;
+  }, [activeFilter, scrollElement]);
+
   const reportSpec = useMemo(() => {
     if (!file?.file) return null;
     const buildMarkdown = () => buildFileReport(file);
@@ -206,6 +318,30 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
   }, [file]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
+  const renderItem = (item) => {
+    switch (item.kind) {
+      case 'sev-header':
+        return <GroupHeader title={item.sev.charAt(0).toUpperCase() + item.sev.slice(1)} count={item.count} />;
+      case 'compliance-header':
+        return <GroupHeader title="Compliance" count={item.count} />;
+      case 'low-conf-toggle':
+        return <LowConfidenceToggle count={item.count} expanded={item.expanded} onToggle={() => setLowConfExpanded((v) => !v)} />;
+      case 'violation':
+      case 'low-conf-row':
+        return <ViolationCard v={item.v} onDismiss={onDismiss ? handleDismiss : undefined} />;
+      case 'compliance':
+        return <ComplianceCard c={item.c} principle={item.c.principle} index={0} />;
+      default:
+        return null;
+    }
+  };
+
+  // Remount the virtualizer whenever the items collection changes shape.
+  // A fresh useVirtualizer call begins with no cached heights, so the row
+  // wrappers re-measure from scratch — eliminating overlap caused by stale
+  // measurements lingering from a previous filter or dismiss state.
+  const virtualKey = `${activeFilter ?? 'all'}-${dismissedSet.size}-${lowConfExpanded ? 'lc' : ''}-${file?.file || ''}`;
+
   return (
     <>
       <FileHeader
@@ -227,31 +363,7 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
         />
       )}
 
-      {showViolations && SEVERITY_ORDER.map((sev) => {
-        if (activeFilter && activeFilter !== 'all' && activeFilter !== sev) return null;
-        return <SeverityGroup key={sev} sev={sev} violations={highConfidenceBySeverity[sev] || []} onDismiss={onDismiss ? handleDismiss : undefined} />;
-      })}
-
-      {showViolations && (!activeFilter || activeFilter === 'all') && (
-        <LowConfidenceGroup
-          violations={lowConfidenceViolations}
-          renderViolation={(v, idx) => <ViolationCard key={`lc-${idx}`} v={v} index={idx} onDismiss={onDismiss ? handleDismiss : undefined} />}
-        />
-      )}
-
-      {showCompliance && totalCompliance > 0 && (
-        <div>
-          <div className="violation-group-header">
-            <span className="violation-group-title">Compliance</span>
-            <span className="violation-group-count">{totalCompliance}</span>
-          </div>
-          <div className="vlive-violations-group">
-            {file.compliance.map((c, idx) => (
-              <ComplianceCard key={idx} c={c} principle={c.principle} index={idx} />
-            ))}
-          </div>
-        </div>
-      )}
+      <VirtualList key={virtualKey} items={items} scrollElement={scrollElement} renderItem={renderItem} />
     </>
   );
 });

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import HeatGridCells from './HeatGridCells.jsx';
+import { ICON_FOLDER } from '../../../../constants/navigation.jsx';
 
 const COL_NAME = 'name';
 const COL_CRITICAL = 'critical';
@@ -87,7 +88,8 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
                     onKeyDown={(e) => e.key === 'Enter' && (canDrill ? onDrillDown(row.path) : row.isFile && onFileClick?.(row))}
                     title={row.path}
                   >
-                    {row.isFile ? '' : '\uD83D\uDCC1 '}{row.name}
+                    {row.isFile ? null : <span className="heat-grid-folder-icon" aria-hidden="true">{ICON_FOLDER}</span>}
+                    {row.name}
                   </div>
                 </td>
                 <HeatGridCells row={row} onCellClick={onCellClick} variant={variant} />

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -83,8 +83,10 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
   }, [onFileClick]);
 
   const handleCellClick = useCallback(({ row, severity }) => {
-    // Navigate to file/folder detail filtered by severity
-    onFileClick?.(treeNodeToFileObj(row, { severity: severity || undefined }));
+    // Pass the full file object and let FileDetailPage apply the filter, so
+    // the severity-filter pill reflects the user's choice (rather than the
+    // file silently arriving pre-filtered).
+    onFileClick?.(treeNodeToFileObj(row), { severity: severity || undefined });
   }, [onFileClick]);
 
   return (

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2288,6 +2288,22 @@ button.eval-provider-badge--clickable:focus-visible {
   contain-intrinsic-size: auto 180px;
 }
 
+/* Inside JS-virtualized lists (FileDetailPage) the virtualizer already
+ * skips off-screen rows. Layering `content-visibility: auto` on top causes
+ * the wrapper's ResizeObserver to cache the intrinsic-size placeholder as
+ * the final height, producing overlapping rows after scroll. Drop it for
+ * virtualized rows and disable the per-row enter animation, which would
+ * otherwise replay every time a row scrolls into the overscan window.
+ * `!important` because the base `.vdetail-row` rule sets these properties
+ * directly and we need to win against any future override that adds them
+ * back. */
+.vlive-violations-virtual .vdetail-row {
+  content-visibility: visible !important;
+  contain-intrinsic-size: auto !important;
+  contain: none !important;
+  animation: none !important;
+}
+
 .vdetail-row-main {
   display: flex;
   align-items: center;

--- a/src/quodeq/ui/src/styles/map.css
+++ b/src/quodeq/ui/src/styles/map.css
@@ -343,6 +343,15 @@
   word-break: break-word;
 }
 
+.heat-grid-folder-icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 8px;
+  color: var(--color-text-muted);
+  vertical-align: middle;
+}
+.heat-grid-file.clickable:hover .heat-grid-folder-icon { color: var(--color-accent); }
+
 .heat-grid-file.clickable {
   cursor: pointer;
 }
@@ -427,9 +436,12 @@
 }
 
 /* Severity/health cells in the flat variant: no fill, no border, just
-   colored text (color comes from inline style in HeatGridCells). */
+   colored text (color comes from inline style in HeatGridCells). Block
+   layout so the full table cell is the hit target — matches the
+   VIOLATIONS column's heat-grid-num and gives a consistent click area
+   across all numeric columns. */
 .heat-grid--flat .heat-grid-cell {
-  display: inline-block;
+  display: block;
   min-width: 0;
   height: auto;
   padding: 0;
@@ -438,6 +450,7 @@
   box-shadow: none;
   font-weight: var(--weight-medium);
   font-size: 13px;
+  text-align: right;
   transition: color 120ms ease;
 }
 .heat-grid--flat .heat-grid-cell.empty {

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -136,6 +136,24 @@
 .term-stat--warning .term-stat__value { color: var(--color-warning); }
 .term-stat--critical .term-stat__value { color: var(--color-sev-critical-text); }
 
+/* Clickable variant — used when a Stat doubles as a navigation affordance. */
+button.term-stat--clickable {
+  appearance: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+button.term-stat--clickable:hover {
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
+}
+button.term-stat--clickable:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* ------------------------------------------------------------
    FlagPill: `--flag` toggle
    ------------------------------------------------------------ */
@@ -210,6 +228,19 @@
   color: var(--color-sev-minor-text);
   background: var(--color-sev-minor-bg);
   border-color: var(--color-sev-minor-border);
+}
+button.term-sev-badge--clickable {
+  appearance: none;
+  font: inherit;
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+button.term-sev-badge--clickable:hover {
+  filter: brightness(1.15);
+}
+button.term-sev-badge--clickable:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* ------------------------------------------------------------

--- a/src/quodeq/ui/src/utils/explorerUtils.js
+++ b/src/quodeq/ui/src/utils/explorerUtils.js
@@ -123,6 +123,51 @@ export function buildTopOffendingFiles(dimensions = [], filters = {}, limit = DE
     .slice(0, limit);
 }
 
+/**
+ * Build a synthetic "project root" file object from the same dimensions
+ * structure that powers buildTopOffendingFiles. The result has the same
+ * shape FileDetailPage expects (violationsBySeverity / compliance / counts),
+ * so the project itself can be navigated to as if it were a file.
+ */
+export function buildProjectRootFile(dimensions = [], projectName = 'project') {
+  const violationsBySeverity = { critical: [], major: [], minor: [], unknown: [] };
+  const compliance = [];
+  const dims = new Set();
+  const principles = new Set();
+  let total = 0;
+
+  for (const dim of dimensions) {
+    const dimName = dim.dimension || '';
+    for (const v of dim.violations || []) {
+      const sev = normalizeSeverity(v.severity);
+      const enriched = { ...v, dimension: v.dimension || dimName };
+      (violationsBySeverity[sev] || violationsBySeverity.unknown).push(enriched);
+      total += 1;
+      if (enriched.dimension) dims.add(enriched.dimension);
+      if (enriched.principle) principles.add(enriched.principle);
+    }
+    for (const c of dim.compliance || []) {
+      compliance.push({ ...c, dimension: c.dimension || dimName });
+      if (dimName) dims.add(dimName);
+      if (c.principle) principles.add(c.principle);
+    }
+  }
+
+  return {
+    file: projectName || 'project',
+    total,
+    critical: violationsBySeverity.critical.length,
+    major: violationsBySeverity.major.length,
+    minor: violationsBySeverity.minor.length,
+    unknown: violationsBySeverity.unknown.length,
+    dimensions: Array.from(dims).sort((a, b) => a.localeCompare(b)),
+    dimensionsCount: dims.size,
+    principlesCount: principles.size,
+    violationsBySeverity,
+    compliance,
+  };
+}
+
 export function pickValidProject(projects = [], selectedProject = '') {
   if (!Array.isArray(projects) || projects.length === 0) {
     return '';


### PR DESCRIPTION
## Summary
- Stat cards on the overview, history-run, and dimension explorer now navigate into a file-detail view scoped to the project / run / dimension. Per-severity badges (CRIT / MAJ / MIN) drill in with the matching filter pre-selected.
- The by-dimension table on the violations tab now drills into the same file-detail synthetic view on cell clicks (was sending users to the explorer overview); name clicks still go to the standard's overview.
- The by-file table now passes severity as a nav param so the file-detail's filter pill reflects the choice instead of arriving silently pre-filtered.
- File detail is now virtualized with `@tanstack/react-virtual` (~10 KB gzip). Single flat list mixes headers, violations, low-confidence (collapsible), and compliance rows. About ~30 React instances exist at any time, regardless of project size.
- Virtualizer is remounted on filter / dismiss / file change so stale row measurements can't cause overlap. `content-visibility: auto` and the per-row enter animation are disabled inside the virtualized container for the same reason.
- `📁` emoji in the file / folder table replaced with the same SVG icon the sidebar uses.
- Numeric cells in the by-dimension table are block-level so the whole cell is the click target (matching the existing VIOLATIONS column).

## Test plan
- [x] **Overview** — click VIOLATIONS, COMPLIANCE, and each sev badge on the project hero. Verify each lands on file detail with the correct filter.
- [x] **History run** — same as above, but on a per-run dashboard.
- [x] **Dimension explorer (standard detail)** — click VIOLATIONS, COMPLIANCE, sev badges. Verify drill-down is scoped to that dimension.
- [x] **Violations tab → by dimension table** — click CRITICAL / MAJOR / MINOR / VIOLATIONS on a dimension row. Verify the filter is pre-applied and the entire cell is clickable. Click the dimension name and confirm it still goes to the explorer.
- [x] **Violations tab → by file table** — click a severity cell. Verify the file-detail filter pill activates with the chosen severity.
- [x] **Big project** (e.g. growstuff with 3k+ violations) — confirm the file detail opens instantly. Switch filter all → critical → major → all repeatedly and confirm rows never overlap or jump.
- [x] **Dismiss** — dismiss a violation on file detail; confirm the row disappears, header counts update, no overlap.
- [x] **Folder icon** — confirm the file/folder table uses the same SVG icon as the sidebar (no emoji).