### PR TITLE
feat(ui): side-pane Report and Fix Plan react to severity filter

### DIFF
--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -12,6 +12,11 @@ import { TermHeader, StatStrip, Stat, SevBadge } from '../../../components/termi
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 
+function filterTitleSuffix(filter) {
+  if (!filter || filter === 'all') return '';
+  return ` (${filter})`;
+}
+
 const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
   const { addWindow } = useSidePane();
   const { filePath, line } = parseFileRef(v.file, v.line);
@@ -290,32 +295,34 @@ const FileDetailPage = memo(function FileDetailPage({ file, runId, dateLabel, on
 
   const reportSpec = useMemo(() => {
     if (!file?.file) return null;
-    const buildMarkdown = () => buildFileReport(file);
+    const buildMarkdown = () => buildFileReport(file, activeFilter);
     const filenameLabel = file.file.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    const baseTitle = `${file.file.split('/').pop()} report`;
     return {
       id: `report:file:${file.file}`,
       type: 'report',
-      title: `${file.file.split('/').pop()} report`,
+      title: `${baseTitle}${filterTitleSuffix(activeFilter)}`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `file-${filenameLabel}-report.md`, body: buildMarkdown() }),
     };
-  }, [file]);
+  }, [file, activeFilter]);
   useRegisterWindowSpec('report', reportSpec);
 
   const fixPlanSpec = useMemo(() => {
     if (!file?.file || (file.total || 0) === 0) return null;
-    const buildMarkdown = () => buildFilePlanText(file);
+    const buildMarkdown = () => buildFilePlanText(file, activeFilter);
     const filenameLabel = file.file.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
+    const baseTitle = `${file.file.split('/').pop()} fix plan`;
     return {
       id: `fixplan:file:${file.file}`,
       type: 'fixplan',
-      title: `${file.file.split('/').pop()} fix plan`,
+      title: `${baseTitle}${filterTitleSuffix(activeFilter)}`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `file-${filenameLabel}-fix-plan.md`, body: buildMarkdown() }),
     };
-  }, [file]);
+  }, [file, activeFilter]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
   const renderItem = (item) => {

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -9,6 +9,11 @@ import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../co
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
 
+function filterTitleSuffix(filter) {
+  if (!filter || filter === 'all') return '';
+  return ` (${filter})`;
+}
+
 // Off-screen rows skip layout/paint via CSS `content-visibility: auto` on
 // `.vdetail-row` (see styles/explorer.css), so no JS virtualizer or
 // "Show all" pagination is needed. Rows render naturally inside the app's
@@ -190,8 +195,7 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
   const principleDescription = principleDescriptions[principle] || '';
 
   const {
-    violations, compliance, violationsBySeverity,
-    liveScore, liveGrade, activeSevFilter, setActiveSevFilter,
+    compliance, liveScore, liveGrade, activeSevFilter, setActiveSevFilter,
     handleDismiss, filteredViolations, liveSevCounts, displayedBySeverity,
   } = usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss);
 
@@ -200,34 +204,48 @@ const PrincipleDetailPage = memo(function PrincipleDetailPage({ evalPrincipal, s
     const buildMarkdown = () => buildPrincipleReport({
       principle, dimension,
       score: liveScore ?? score, grade: liveGrade ?? grade,
-      violations: filteredViolations, violationsBySeverity: displayedBySeverity,
+      violations: filteredViolations,
       compliance, principleData, runId,
+      severityFilter: activeSevFilter,
     });
     const slug = `${(dimension || 'dim')}-${principle}`.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
     return {
       id: `report:principle:${dimension || 'dim'}:${principle}:${runId || 'current'}`,
       type: 'report',
-      title: `${principle} report`,
+      title: `${principle} report${filterTitleSuffix(activeSevFilter)}`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `principle-${slug}-report.md`, body: buildMarkdown() }),
     };
-  }, [principle, dimension, runId, score, grade, liveScore, liveGrade, filteredViolations, displayedBySeverity, compliance, principleData]);
+  }, [principle, dimension, runId, score, grade, liveScore, liveGrade, filteredViolations, compliance, principleData, activeSevFilter]);
   useRegisterWindowSpec('report', reportSpec);
 
   const fixPlanSpec = useMemo(() => {
     if (!principle || filteredViolations.length === 0) return null;
-    const buildMarkdown = () => buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData);
+    const buildBySeverity = () => {
+      const bucket = {};
+      for (const sev of EVAL_SEVERITY_ORDER) {
+        bucket[sev] = filteredViolations.filter((v) => (v.severity || 'minor').toLowerCase() === sev);
+      }
+      return bucket;
+    };
+    const buildMarkdown = () => buildPrinciplePlanText(
+      principle,
+      filteredViolations,
+      buildBySeverity(),
+      principleData,
+      activeSevFilter,
+    );
     const slug = `${(dimension || 'dim')}-${principle}`.replace(/[^a-z0-9-]+/gi, '-').toLowerCase();
     return {
       id: `fixplan:principle:${dimension || 'dim'}:${principle}:${runId || 'current'}`,
       type: 'fixplan',
-      title: `${principle} fix plan`,
+      title: `${principle} fix plan${filterTitleSuffix(activeSevFilter)}`,
       render: () => <ReportContent markdown={buildMarkdown()} />,
       copy: () => buildMarkdown(),
       download: () => ({ filename: `principle-${slug}-fix-plan.md`, body: buildMarkdown() }),
     };
-  }, [principle, dimension, runId, violations, violationsBySeverity, principleData, filteredViolations.length]);
+  }, [principle, dimension, runId, filteredViolations, principleData, activeSevFilter]);
   useRegisterWindowSpec('fixplan', fixPlanSpec);
 
   return (

--- a/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneProvider.jsx
@@ -105,6 +105,7 @@ export function SidePaneProvider({ children }) {
     setWindows((prev) => {
       const idx = prev.findIndex((w) => w.id === spec.id);
       if (idx === -1) return prev;
+      if (prev[idx] === spec) return prev;
       const next = prev.slice();
       next[idx] = spec;
       return next;

--- a/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.js
+++ b/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.js
@@ -10,7 +10,7 @@ import { useSidePane } from './SidePaneContext.jsx';
  */
 export function useRegisterWindowSpec(type, spec) {
   const ctx = useSidePane();
-  const { registerSpec, unregisterSpec, hasWindow, toggleWindow, windows, MAX_WINDOWS } = ctx;
+  const { registerSpec, unregisterSpec, replaceWindow, hasWindow, toggleWindow, windows, MAX_WINDOWS } = ctx;
 
   useEffect(() => {
     if (!spec) {
@@ -18,8 +18,11 @@ export function useRegisterWindowSpec(type, spec) {
       return undefined;
     }
     registerSpec(type, spec);
+    if (hasWindow(spec.id)) {
+      replaceWindow(spec);
+    }
     return () => unregisterSpec(type);
-  }, [type, spec, registerSpec, unregisterSpec]);
+  }, [type, spec, registerSpec, unregisterSpec, replaceWindow, hasWindow]);
 
   const isInDock = spec ? hasWindow(spec.id) : false;
   const isAtCap = windows.length >= MAX_WINDOWS;

--- a/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
@@ -164,4 +164,39 @@ describe('useRegisterWindowSpec', () => {
     fireEvent.click(screen.getByTestId('bump'));
     expect(screen.getByTestId('dock-body')).toHaveTextContent('empty');
   });
+
+  it('re-registering the same spec reference does not trigger a render cascade', () => {
+    let renderCount = 0;
+    function CountingPage({ spec }) {
+      useRegisterWindowSpec('report', spec);
+      renderCount += 1;
+      return null;
+    }
+    function Harness() {
+      const spec = useMemo(
+        () => ({ id: 'r1', type: 'report', title: 'v1', render: () => <p>body</p> }),
+        [],
+      );
+      const { addWindow } = useSidePane();
+      return (
+        <>
+          <CountingPage spec={spec} />
+          <button data-testid="open" onClick={() => addWindow(spec)}>open</button>
+        </>
+      );
+    }
+    render(
+      <SidePaneProvider>
+        <Harness />
+      </SidePaneProvider>,
+    );
+    const before = renderCount;
+    fireEvent.click(screen.getByTestId('open'));
+    const after = renderCount;
+    // Opening the window should cause at most one extra render of the page
+    // (the windows state changes once). If replaceWindow does not short-
+    // circuit on identity, this triggers an unbounded cascade and the diff
+    // will be much larger.
+    expect(after - before).toBeLessThanOrEqual(2);
+  });
 });

--- a/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
@@ -105,4 +105,63 @@ describe('useRegisterWindowSpec', () => {
     fireEvent.click(screen.getByTestId('null-btn'));
     expect(screen.getByTestId('dock')).toHaveTextContent('empty');
   });
+
+  function VersionedPage({ id, version }) {
+    const spec = useMemo(
+      () => ({ id, type: 'report', title: `v${version}`, render: () => <p>{`body:${version}`}</p> }),
+      [id, version],
+    );
+    useRegisterWindowSpec('report', spec);
+    return null;
+  }
+
+  function VersionedHarness() {
+    const [version, setVersion] = useState(1);
+    return (
+      <>
+        <VersionedPage id="r1" version={version} />
+        <button data-testid="bump" onClick={() => setVersion((n) => n + 1)}>bump</button>
+      </>
+    );
+  }
+
+  function DockBody() {
+    const { windows } = useSidePane();
+    return <div data-testid="dock-body">{windows.map((w) => `${w.id}:${w.title}`).join(',') || 'empty'}</div>;
+  }
+
+  it('re-registering an updated spec updates the docked window in place', () => {
+    function Adder() {
+      const { addWindow } = useSidePane();
+      return (
+        <button
+          data-testid="open"
+          onClick={() => addWindow({ id: 'r1', type: 'report', title: 'v1', render: () => <p>body:1</p> })}
+        >open</button>
+      );
+    }
+    render(
+      <SidePaneProvider>
+        <Adder />
+        <VersionedHarness />
+        <DockBody />
+      </SidePaneProvider>,
+    );
+    fireEvent.click(screen.getByTestId('open'));
+    expect(screen.getByTestId('dock-body')).toHaveTextContent('r1:v1');
+    fireEvent.click(screen.getByTestId('bump'));
+    expect(screen.getByTestId('dock-body')).toHaveTextContent('r1:v2');
+  });
+
+  it('re-registering a spec when no matching window is docked does not add a window', () => {
+    render(
+      <SidePaneProvider>
+        <VersionedHarness />
+        <DockBody />
+      </SidePaneProvider>,
+    );
+    expect(screen.getByTestId('dock-body')).toHaveTextContent('empty');
+    fireEvent.click(screen.getByTestId('bump'));
+    expect(screen.getByTestId('dock-body')).toHaveTextContent('empty');
+  });
 });

--- a/src/quodeq/ui/src/utils/planTextBuilders.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.js
@@ -6,12 +6,20 @@ const addEntryTitle = (v) => ({ ...v, _entryTitle: v.principle || 'Violation' })
 /**
  * Build a copy-friendly plan text summarising violations for a single file.
  * @param {{ file: string, violationsBySeverity: Object }} file - File object with violation data.
+ * @param {string} [severityFilter] - Optional severity to filter by ('all', 'critical', 'major', 'minor', 'compliance').
  * @returns {string} Formatted plan text.
  */
-export function buildFilePlanText(file) {
+export function buildFilePlanText(file, severityFilter) {
+  if (severityFilter === 'compliance') {
+    return '_No violations match the current filter._';
+  }
   const allViolations = [];
   const violationsBySeverity = {};
   for (const sev of SEVERITY_ORDER) {
+    if (severityFilter && severityFilter !== 'all' && severityFilter !== sev) {
+      violationsBySeverity[sev] = [];
+      continue;
+    }
     const mapped = (file.violationsBySeverity?.[sev] || []).map(addEntryTitle);
     violationsBySeverity[sev] = mapped;
     allViolations.push(...mapped);

--- a/src/quodeq/ui/src/utils/planTextBuilders.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.js
@@ -46,9 +46,28 @@ export function buildFilePlanText(file, severityFilter) {
  * @param {Object} [principleData] - Optional extra data (e.g. `.findings`) for convention 1.
  * @returns {string} Formatted plan text.
  */
-export function buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData) {
+export function buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData, severityFilter) {
   if (violations !== undefined) {
-    return buildGroupPlanText({ title: principle, violations, violationsBySeverity, context: principleData?.findings || undefined });
+    if (severityFilter === 'compliance') {
+      return '_No violations match the current filter._';
+    }
+    let filteredViolations = violations;
+    let filteredBySeverity = violationsBySeverity;
+    if (severityFilter && severityFilter !== 'all') {
+      filteredViolations = (violations || []).filter(
+        (v) => (v.severity || 'minor').toLowerCase() === severityFilter,
+      );
+      filteredBySeverity = {};
+      for (const sev of SEVERITY_ORDER) {
+        filteredBySeverity[sev] = sev === severityFilter ? (violationsBySeverity?.[sev] || []) : [];
+      }
+    }
+    return buildGroupPlanText({
+      title: principle,
+      violations: filteredViolations,
+      violationsBySeverity: filteredBySeverity,
+      context: principleData?.findings || undefined,
+    });
   }
   const allViolations = principle.violations || [];
   const bySeverity = {};

--- a/src/quodeq/ui/src/utils/planTextBuilders.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.js
@@ -44,6 +44,9 @@ export function buildFilePlanText(file, severityFilter) {
  * @param {Array} [violations] - Flat array of violation objects (convention 1 only).
  * @param {Object} [violationsBySeverity] - Violations keyed by severity (convention 1 only).
  * @param {Object} [principleData] - Optional extra data (e.g. `.findings`) for convention 1.
+ * @param {string} [severityFilter] - Optional severity filter; values: null/'all' (no filter),
+ *   'critical'/'major'/'minor' (only that bucket), or 'compliance' (returns the empty-state
+ *   string `_No violations match the current filter._`). Split form only.
  * @returns {string} Formatted plan text.
  */
 export function buildPrinciplePlanText(principle, violations, violationsBySeverity, principleData, severityFilter) {

--- a/src/quodeq/ui/src/utils/planTextBuilders.test.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildFilePlanText, buildPrinciplePlanText } from './planTextBuilders.js';
+
+const fileFixture = {
+  file: 'src/foo/bar.js',
+  violationsBySeverity: {
+    critical: [{ severity: 'critical', principle: 'SRP', reason: 'Crit-1 reason', file: 'src/foo/bar.js', line: 1 }],
+    major:    [{ severity: 'major',    principle: 'DRY', reason: 'Maj-1 reason', file: 'src/foo/bar.js', line: 2 }],
+    minor:    [{ severity: 'minor',    principle: 'Style', reason: 'Min-1 reason', file: 'src/foo/bar.js', line: 3 }],
+  },
+};
+
+test('buildFilePlanText with no severityFilter includes all severities', () => {
+  const md = buildFilePlanText(fileFixture);
+  assert.match(md, /Crit-1 reason/);
+  assert.match(md, /Maj-1 reason/);
+  assert.match(md, /Min-1 reason/);
+  assert.match(md, /\*\*Total violations:\*\* 3/);
+});
+
+test("buildFilePlanText with severityFilter='critical' includes only critical", () => {
+  const md = buildFilePlanText(fileFixture, 'critical');
+  assert.match(md, /Crit-1 reason/);
+  assert.doesNotMatch(md, /Maj-1 reason/);
+  assert.doesNotMatch(md, /Min-1 reason/);
+  assert.match(md, /\*\*Total violations:\*\* 1/);
+});
+
+test("buildFilePlanText with severityFilter='all' equals no filter", () => {
+  assert.equal(buildFilePlanText(fileFixture, 'all'), buildFilePlanText(fileFixture));
+});
+
+test("buildFilePlanText with severityFilter='compliance' returns the empty-state body", () => {
+  const md = buildFilePlanText(fileFixture, 'compliance');
+  assert.equal(md, '_No violations match the current filter._');
+});

--- a/src/quodeq/ui/src/utils/planTextBuilders.test.js
+++ b/src/quodeq/ui/src/utils/planTextBuilders.test.js
@@ -35,3 +35,50 @@ test("buildFilePlanText with severityFilter='compliance' returns the empty-state
   const md = buildFilePlanText(fileFixture, 'compliance');
   assert.equal(md, '_No violations match the current filter._');
 });
+
+const principleViolations = [
+  { severity: 'critical', principle: 'SRP', reason: 'P-Crit', file: 'a.js', line: 1 },
+  { severity: 'major',    principle: 'SRP', reason: 'P-Maj',  file: 'b.js', line: 2 },
+  { severity: 'minor',    principle: 'SRP', reason: 'P-Min',  file: 'c.js', line: 3 },
+];
+const principleBySeverity = {
+  critical: [principleViolations[0]],
+  major:    [principleViolations[1]],
+  minor:    [principleViolations[2]],
+};
+
+test('buildPrinciplePlanText with no severityFilter includes all severities (object form)', () => {
+  const md = buildPrinciplePlanText({ principle: 'SRP', violations: principleViolations });
+  assert.match(md, /P-Crit/);
+  assert.match(md, /P-Maj/);
+  assert.match(md, /P-Min/);
+});
+
+test("buildPrinciplePlanText with severityFilter='critical' includes only critical (split form)", () => {
+  const md = buildPrinciplePlanText('SRP', principleViolations, principleBySeverity, undefined, 'critical');
+  assert.match(md, /P-Crit/);
+  assert.doesNotMatch(md, /P-Maj/);
+  assert.doesNotMatch(md, /P-Min/);
+  assert.match(md, /\*\*Total violations:\*\* 1/);
+});
+
+test("buildPrinciplePlanText with severityFilter='all' equals no filter (split form)", () => {
+  const a = buildPrinciplePlanText('SRP', principleViolations, principleBySeverity, undefined, 'all');
+  const b = buildPrinciplePlanText('SRP', principleViolations, principleBySeverity);
+  assert.equal(a, b);
+});
+
+test("buildPrinciplePlanText with severityFilter='compliance' returns the empty-state body", () => {
+  const md = buildPrinciplePlanText('SRP', principleViolations, principleBySeverity, undefined, 'compliance');
+  assert.equal(md, '_No violations match the current filter._');
+});
+
+test("buildPrinciplePlanText object form ignores severityFilter (it's split-form only)", () => {
+  // The object form does not take a positional severityFilter; consumers
+  // using the object form pre-filter their input. This pins down that
+  // calling the object form does not crash and renders all the violations
+  // it was given.
+  const md = buildPrinciplePlanText({ principle: 'SRP', violations: principleViolations.slice(0, 1) });
+  assert.match(md, /P-Crit/);
+  assert.doesNotMatch(md, /P-Maj/);
+});

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -267,8 +267,8 @@ export function buildRunReport({ dashboard, runSummary, projectName }) {
   return lines.join('\n');
 }
 
-export function buildPrincipleReport({ principle, dimension, score, grade, violations, violationsBySeverity, compliance, principleData, runId, dateLabel }) {
-  const violationsList = violations || [];
+export function buildPrincipleReport({ principle, dimension, score, grade, violations, violationsBySeverity, compliance, principleData, runId, dateLabel, severityFilter }) {
+  const rawViolations = violations || [];
   const complianceList = (compliance || []).filter((c) => c.file || c.reason || c.snippet);
   const date = dateLabel || formatDate();
   const ridSuffix = runId ? ` · **Run:** ${runId.slice(0, 8)}` : '';
@@ -294,14 +294,25 @@ export function buildPrincipleReport({ principle, dimension, score, grade, viola
     lines.push('');
   }
 
-  const bySeverity = violationsBySeverity || groupBySeverity(violationsList);
-  lines.push(`## Violations (${violationsList.length})`);
+  const showCompliance = !severityFilter || severityFilter === 'all' || severityFilter === 'compliance';
+  const showViolationEntries = severityFilter !== 'compliance';
+
+  const filteredViolations = (severityFilter && severityFilter !== 'all' && severityFilter !== 'compliance')
+    ? rawViolations.filter((v) => (v.severity || 'minor').toLowerCase() === severityFilter)
+    : rawViolations;
+  const bySeverity = (violationsBySeverity && (!severityFilter || severityFilter === 'all'))
+    ? violationsBySeverity
+    : groupBySeverity(filteredViolations);
+
+  const visibleCount = showViolationEntries ? filteredViolations.length : 0;
+  lines.push(`## Violations (${visibleCount})`);
   lines.push('');
-  if (violationsList.length === 0) {
+  if (visibleCount === 0) {
     lines.push('No violations found.');
     lines.push('');
   } else {
     for (const sev of SEVERITY_ORDER) {
+      if (severityFilter && severityFilter !== 'all' && severityFilter !== sev) continue;
       const vs = bySeverity[sev] || [];
       if (vs.length === 0) continue;
       lines.push(`### ${sev.charAt(0).toUpperCase() + sev.slice(1)} (${vs.length})`);
@@ -310,7 +321,9 @@ export function buildPrincipleReport({ principle, dimension, score, grade, viola
     }
   }
 
-  lines.push(...buildComplianceSection(complianceList));
+  if (showCompliance) {
+    lines.push(...buildComplianceSection(complianceList));
+  }
 
   return lines.join('\n');
 }

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -294,7 +294,7 @@ export function buildPrincipleReport({ principle, dimension, score, grade, viola
     lines.push('');
   }
 
-  const showViolations = !severityFilter || severityFilter === 'all' || severityFilter !== 'compliance';
+  const showViolations = severityFilter !== 'compliance';
   const showCompliance = !severityFilter || severityFilter === 'all' || severityFilter === 'compliance';
 
   const filteredViolations = (showViolations && severityFilter && severityFilter !== 'all')

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -329,9 +329,11 @@ function buildFileSummarySection(file, totalViolations, totalCompliance) {
   return lines;
 }
 
-function buildFileViolationsSection(file) {
+function buildFileViolationsSection(file, severityFilter) {
   const lines = [];
-  const allViolations = SEVERITY_ORDER.flatMap((sev) => file.violationsBySeverity?.[sev] || []);
+  const allViolations = SEVERITY_ORDER
+    .filter((sev) => !severityFilter || severityFilter === 'all' || severityFilter === sev)
+    .flatMap((sev) => file.violationsBySeverity?.[sev] || []);
   lines.push(`## Violations (${allViolations.length})`);
   lines.push('');
   if (allViolations.length === 0) {
@@ -340,6 +342,7 @@ function buildFileViolationsSection(file) {
     return lines;
   }
   for (const sev of SEVERITY_ORDER) {
+    if (severityFilter && severityFilter !== 'all' && severityFilter !== sev) continue;
     const vs = file.violationsBySeverity?.[sev] || [];
     if (vs.length === 0) continue;
     lines.push(`### ${sev.charAt(0).toUpperCase() + sev.slice(1)} (${vs.length})`);
@@ -349,7 +352,7 @@ function buildFileViolationsSection(file) {
   return lines;
 }
 
-export function buildFileReport(file) {
+export function buildFileReport(file, severityFilter) {
   const filePath = file?.file || 'unknown';
   const totalViolations = file?.total || 0;
   const totalCompliance = file?.compliance?.length || 0;
@@ -362,8 +365,11 @@ export function buildFileReport(file) {
   lines.push('');
 
   lines.push(...buildFileSummarySection(file, totalViolations, totalCompliance));
-  lines.push(...buildFileViolationsSection(file));
-  lines.push(...buildComplianceSection(file?.compliance || []));
+
+  const showCompliance = !severityFilter || severityFilter === 'all' || severityFilter === 'compliance';
+
+  lines.push(...buildFileViolationsSection(file, severityFilter));
+  if (showCompliance) lines.push(...buildComplianceSection(file?.compliance || []));
 
   return lines.join('\n');
 }

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -294,20 +294,19 @@ export function buildPrincipleReport({ principle, dimension, score, grade, viola
     lines.push('');
   }
 
+  const showViolations = !severityFilter || severityFilter === 'all' || severityFilter !== 'compliance';
   const showCompliance = !severityFilter || severityFilter === 'all' || severityFilter === 'compliance';
-  const showViolationEntries = severityFilter !== 'compliance';
 
-  const filteredViolations = (severityFilter && severityFilter !== 'all' && severityFilter !== 'compliance')
+  const filteredViolations = (showViolations && severityFilter && severityFilter !== 'all')
     ? rawViolations.filter((v) => (v.severity || 'minor').toLowerCase() === severityFilter)
-    : rawViolations;
+    : (showViolations ? rawViolations : []);
   const bySeverity = (violationsBySeverity && (!severityFilter || severityFilter === 'all'))
     ? violationsBySeverity
     : groupBySeverity(filteredViolations);
 
-  const visibleCount = showViolationEntries ? filteredViolations.length : 0;
-  lines.push(`## Violations (${visibleCount})`);
+  lines.push(`## Violations (${filteredViolations.length})`);
   lines.push('');
-  if (visibleCount === 0) {
+  if (filteredViolations.length === 0) {
     lines.push('No violations found.');
     lines.push('');
   } else {

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -91,6 +91,59 @@ test('buildFileReport with no violations shows "No violations found"', () => {
   assert.match(md, /No violations found\./);
 });
 
+const fileFixture = {
+  file: 'src/foo/bar.js',
+  total: 3,
+  critical: 1,
+  major: 1,
+  minor: 1,
+  dimensionsCount: 2,
+  compliance: [{ principle: 'Naming', file: 'src/foo/bar.js' }],
+  violationsBySeverity: {
+    critical: [{ severity: 'critical', principle: 'SRP', title: 'Crit-1', file: 'src/foo/bar.js', line: 12 }],
+    major:    [{ severity: 'major',    principle: 'DRY', title: 'Maj-1', file: 'src/foo/bar.js' }],
+    minor:    [{ severity: 'minor',    principle: 'Style', title: 'Min-1', file: 'src/foo/bar.js' }],
+  },
+};
+
+test('buildFileReport with no severityFilter renders all severities and compliance', () => {
+  const md = buildFileReport(fileFixture);
+  assert.match(md, /Crit-1/);
+  assert.match(md, /Maj-1/);
+  assert.match(md, /Min-1/);
+  assert.match(md, /## Compliance Summary/);
+});
+
+test("buildFileReport with severityFilter='critical' shows only critical and omits compliance", () => {
+  const md = buildFileReport(fileFixture, 'critical');
+  assert.match(md, /Crit-1/);
+  assert.doesNotMatch(md, /Maj-1/);
+  assert.doesNotMatch(md, /Min-1/);
+  assert.doesNotMatch(md, /## Compliance Summary/);
+  assert.match(md, /## Violations \(1\)/);
+});
+
+test("buildFileReport with severityFilter='major' shows only major and omits compliance", () => {
+  const md = buildFileReport(fileFixture, 'major');
+  assert.doesNotMatch(md, /Crit-1/);
+  assert.match(md, /Maj-1/);
+  assert.doesNotMatch(md, /Min-1/);
+  assert.doesNotMatch(md, /## Compliance Summary/);
+});
+
+test("buildFileReport with severityFilter='compliance' omits violations and shows compliance", () => {
+  const md = buildFileReport(fileFixture, 'compliance');
+  assert.match(md, /## Violations \(0\)/);
+  assert.match(md, /No violations found\./);
+  assert.match(md, /## Compliance Summary \(1\)/);
+});
+
+test("buildFileReport with severityFilter='all' is identical to no filter", () => {
+  const filtered = buildFileReport(fileFixture, 'all');
+  const unfiltered = buildFileReport(fileFixture);
+  assert.equal(filtered, unfiltered);
+});
+
 test('buildPrincipleReport includes principle, score, findings, and violations', () => {
   const md = buildPrincipleReport({
     principle: 'Single Responsibility',

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -177,6 +177,48 @@ test('buildPrincipleReport with no violations shows "No violations found"', () =
   assert.match(md, /No violations found\./);
 });
 
+const principleFixture = {
+  principle: 'SRP',
+  dimension: 'maintainability',
+  score: '7.5/10',
+  grade: 'B',
+  violations: [
+    { severity: 'critical', principle: 'SRP', title: 'P-Crit', reason: 'reason-c', file: 'a.js' },
+    { severity: 'major',    principle: 'SRP', title: 'P-Maj',  reason: 'reason-m', file: 'b.js' },
+    { severity: 'minor',    principle: 'SRP', title: 'P-Min',  reason: 'reason-n', file: 'c.js' },
+  ],
+  compliance: [{ principle: 'SRP', file: 'd.js', reason: 'ok' }],
+};
+
+test('buildPrincipleReport with no severityFilter renders all severities and compliance', () => {
+  const md = buildPrincipleReport(principleFixture);
+  assert.match(md, /P-Crit/);
+  assert.match(md, /P-Maj/);
+  assert.match(md, /P-Min/);
+  assert.match(md, /## Compliance Summary/);
+});
+
+test("buildPrincipleReport with severityFilter='critical' shows only critical, no compliance", () => {
+  const md = buildPrincipleReport({ ...principleFixture, severityFilter: 'critical' });
+  assert.match(md, /P-Crit/);
+  assert.doesNotMatch(md, /P-Maj/);
+  assert.doesNotMatch(md, /P-Min/);
+  assert.doesNotMatch(md, /## Compliance Summary/);
+  assert.match(md, /## Violations \(1\)/);
+});
+
+test("buildPrincipleReport with severityFilter='compliance' omits violations and shows compliance", () => {
+  const md = buildPrincipleReport({ ...principleFixture, severityFilter: 'compliance' });
+  assert.match(md, /## Violations \(0\)/);
+  assert.match(md, /## Compliance Summary \(1\)/);
+});
+
+test("buildPrincipleReport with severityFilter='all' equals no filter", () => {
+  const filtered = buildPrincipleReport({ ...principleFixture, severityFilter: 'all' });
+  const unfiltered = buildPrincipleReport(principleFixture);
+  assert.equal(filtered, unfiltered);
+});
+
 test('existing buildOverviewReport and buildDimensionReport still produce output', () => {
   const acc = { summary: { numericAverage: 8.0, overallGrade: 'B', totalViolations: 3, totalCompliance: 1, severity: { critical: 1, major: 1, minor: 1 } } };
   const md1 = buildOverviewReport(acc, dimensions, 'MyApp');

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -129,6 +129,7 @@ test("buildFileReport with severityFilter='major' shows only major and omits com
   assert.match(md, /Maj-1/);
   assert.doesNotMatch(md, /Min-1/);
   assert.doesNotMatch(md, /## Compliance Summary/);
+  assert.match(md, /## Violations \(1\)/);
 });
 
 test("buildFileReport with severityFilter='compliance' omits violations and shows compliance", () => {

--- a/src/quodeq/ui/src/utils/reportBuilder.test.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.test.js
@@ -210,6 +210,7 @@ test("buildPrincipleReport with severityFilter='critical' shows only critical, n
 test("buildPrincipleReport with severityFilter='compliance' omits violations and shows compliance", () => {
   const md = buildPrincipleReport({ ...principleFixture, severityFilter: 'compliance' });
   assert.match(md, /## Violations \(0\)/);
+  assert.match(md, /No violations found\./);
   assert.match(md, /## Compliance Summary \(1\)/);
 });
 


### PR DESCRIPTION
## Summary

- The dock-side **Report** and **Fix Plan** windows on `FileDetailPage` and `PrincipleDetailPage` now honour the active severity filter pill. Picking *Critical* gives a report and fix plan containing only critical entries; picking *Compliance* shows only the compliance section in the report and an empty-state line in the fix plan.
- The open dock window updates in place when the user changes the filter — no need to close and re-open. The window title gains a `(critical)` / `(compliance)` suffix so the active filter is obvious.
- The principle detail's fix plan now also honours dismiss state (it previously ignored both dismiss and the severity filter).

## How it works

- Optional `severityFilter` parameter added to four markdown builders: `buildFileReport`, `buildFilePlanText`, `buildPrincipleReport`, `buildPrinciplePlanText`. Existing one-arg callers are unaffected.
- `useRegisterWindowSpec` now calls the existing `replaceWindow(spec)` when the spec object identity changes and the spec is already docked. A one-line ref-equality short-circuit in `SidePaneProvider.replaceWindow` closes a re-render loop that the new path would otherwise have introduced.
- Spec `id`s stay stable across filter changes so the dock window updates in place rather than opening duplicates.

## Test plan

- [x] `cd src/quodeq/ui && npm run test:all` — 165/165 node + 322/322 vitest, all green
- [x] `cd src/quodeq/ui && npm run build` — clean build, no warnings
- [x] Manual smoke (file detail): open Report, click *Critical* / *Major* / *Minor* / *Compliance* — body and title update
- [x] Manual smoke (file detail): open Fix plan, click *Compliance* — body shows `_No violations match the current filter._`
- [x] Manual smoke (principle detail): same matrix as above