### PR TITLE
feat: per-file completion marker contract

### DIFF
--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -130,28 +130,42 @@ def classify_files_via_cache(
     )
 
 
-def _group_findings_by_file(jsonl_path: Path) -> dict[str, list[dict]]:
-    """Read a JSONL of findings and group lines by their ``file`` field."""
+def _group_findings_by_file(jsonl_path: Path) -> tuple[dict[str, list[dict]], set[str]]:
+    """Read a JSONL of findings + markers and return (grouped_findings, ok_files).
+
+    Marker lines are recognised by the ``_marker`` key and excluded from the
+    grouped findings. ``ok_files`` contains the set of files whose *most
+    recent* file_done marker has status='ok'. Files whose latest marker is
+    'error' (or have no marker at all) are not in the set.
+    """
     grouped: dict[str, list[dict]] = {}
+    last_status: dict[str, str] = {}
     if not jsonl_path.is_file():
-        return grouped
+        return grouped, set()
     try:
         text = jsonl_path.read_text(encoding="utf-8")
     except OSError as exc:
         _logger.warning("failed to read JSONL %s: %s", jsonl_path, exc)
-        return grouped
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
+        return grouped, set()
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw:
             continue
         try:
-            entry = json.loads(line)
+            entry = json.loads(raw)
         except json.JSONDecodeError:
+            continue
+        if entry.get("_marker") == "file_done":
+            f = entry.get("file")
+            status = entry.get("status")
+            if isinstance(f, str) and status in ("ok", "error"):
+                last_status[f] = status
             continue
         f = entry.get("file")
         if isinstance(f, str) and f:
             grouped.setdefault(f, []).append(entry)
-    return grouped
+    ok_files = {f for f, s in last_status.items() if s == "ok"}
+    return grouped, ok_files
 
 
 def persist_dispatch_results(

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -39,7 +39,10 @@ from quodeq.analysis.fingerprint import _hash_file, _hash_prompts_map, _hash_sta
 _logger = logging.getLogger(__name__)
 
 # Bumped on any breaking change to key composition or entry format.
-_SCHEMA_VERSION = 1
+# v1 -> v2: file_done marker contract; entries written without marker
+# filtering are no longer trusted, so old entries naturally invalidate
+# on the next input change.
+_SCHEMA_VERSION = 2
 
 
 @dataclass(frozen=True)

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -172,23 +172,20 @@ def persist_dispatch_results(
     config: RunConfig, dimension: str, *, miss_files: list[str],
     jsonl_path: Path, miss_keys: dict[str, str], cache: CacheBackend,
 ) -> None:
-    """Write per-file cache entries from a dispatch run's JSONL output.
+    """Write per-file cache entries for files with a file_done='ok' marker.
 
-    A successful dispatch that produced no findings for a given file
-    still writes an empty entry — the next run hits instead of
-    re-dispatching. If the JSONL doesn't exist (dispatch crashed before
-    writing), no entries are written: we don't fabricate "no findings"
-    when there's no evidence the analysis ran.
+    Files in *miss_files* that lack an ok marker (worker crashed, token-out,
+    abandoned) are NOT cached, so the next run re-dispatches them.
     """
     if not jsonl_path.is_file():
-        # Dispatch failed before writing; let the next run retry.
         return
-    grouped = _group_findings_by_file(jsonl_path)
+    grouped, ok_files = _group_findings_by_file(jsonl_path)
     model_id = _model_id_from(config)
     for f in miss_files:
+        if f not in ok_files:
+            continue
         key = miss_keys.get(f)
         if key is None:
-            # Caller error: missed file with no key. Skip rather than fabricate.
             _logger.debug("persist_dispatch_results: no key for %s; skipping", f)
             continue
         entry = CacheEntry(

--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -14,6 +14,9 @@ from quodeq.analysis.mcp.schemas import (
     GET_NEXT_FILES_DESC,
     GET_NEXT_FILES_NAME,
     GET_NEXT_FILES_SCHEMA,
+    MARK_FILE_DONE_DESC,
+    MARK_FILE_DONE_NAME,
+    MARK_FILE_DONE_SCHEMA,
     REPORT_FINDING_DESC,
     REPORT_FINDING_NAME,
     REPORT_FINDING_SCHEMA,
@@ -65,6 +68,11 @@ def handle_tools_list(request_id: object, *, has_queue: bool = False) -> dict:
             "description": GET_NEXT_FILES_DESC,
             "inputSchema": GET_NEXT_FILES_SCHEMA,
         })
+    tools.append({
+        "name": MARK_FILE_DONE_NAME,
+        "description": MARK_FILE_DONE_DESC,
+        "inputSchema": MARK_FILE_DONE_SCHEMA,
+    })
     return _ok(request_id, {"tools": tools})
 
 
@@ -101,6 +109,26 @@ def handle_tools_call(
         file_list = "\n".join(files)
         return _ok(request_id, {
             "content": [{"type": "text", "text": f"{len(files)} files to analyse:\n{file_list}"}],
+        })
+
+    if name == MARK_FILE_DONE_NAME:
+        file = args.get("file")
+        status = args.get("status")
+        reason = args.get("reason") or None
+        if not isinstance(file, str) or not isinstance(status, str):
+            return _ok(request_id, {
+                "content": [{"type": "text", "text": "mark_file_done requires 'file' (string) and 'status' (\"ok\"|\"error\")"}],
+                "isError": True,
+            })
+        try:
+            router.mark_file_done(file=file, status=status, reason=reason)
+        except ValueError as exc:
+            return _ok(request_id, {
+                "content": [{"type": "text", "text": str(exc)}],
+                "isError": True,
+            })
+        return _ok(request_id, {
+            "content": [{"type": "text", "text": "marked"}],
         })
 
     return _ok(request_id, {

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -284,7 +284,7 @@ class FindingsRouter:
         if status not in ("ok", "error"):
             raise ValueError(f"mark_file_done: status must be 'ok' or 'error', got {status!r}")
         payload: dict = {"_marker": "file_done", "file": file, "status": status}
-        if reason:
+        if reason is not None:
             payload["reason"] = reason
         line = json.dumps(payload) + "\n"
         _locked_write(self._fh, line)

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -274,3 +274,17 @@ class FindingsRouter:
                 )
         self.counter += 1
         return f"Finding #{self.counter} recorded.", False
+
+    def mark_file_done(self, *, file: str, status: str, reason: str | None = None) -> None:
+        """Append a per-file completion marker to the JSONL.
+
+        Used by the cache layer to decide which files are safely cached.
+        Lines without a matching ok marker are not persisted as cache hits.
+        """
+        if status not in ("ok", "error"):
+            raise ValueError(f"mark_file_done: status must be 'ok' or 'error', got {status!r}")
+        payload: dict = {"_marker": "file_done", "file": file, "status": status}
+        if reason:
+            payload["reason"] = reason
+        line = json.dumps(payload) + "\n"
+        _locked_write(self._fh, line)

--- a/src/quodeq/analysis/mcp/schemas.py
+++ b/src/quodeq/analysis/mcp/schemas.py
@@ -1,7 +1,7 @@
 """MCP tool schemas and constants for the findings server.
 
 Defines the JSON-RPC tool names, descriptions, and input schemas
-for ``report_finding`` and ``get_next_files``.
+for ``report_finding``, ``get_next_files``, and ``mark_file_done``.
 """
 from __future__ import annotations
 

--- a/src/quodeq/analysis/mcp/schemas.py
+++ b/src/quodeq/analysis/mcp/schemas.py
@@ -44,3 +44,22 @@ GET_NEXT_FILES_SCHEMA = {
         },
     },
 }
+
+MARK_FILE_DONE_NAME = "mark_file_done"
+MARK_FILE_DONE_DESC = (
+    "Call this exactly once after you have finished analysing a file, "
+    "successfully or not. Pass status='ok' if you analysed the file end-to-end "
+    "(even if there were no findings). Pass status='error' if you abandoned the file "
+    "(token limit, parse error, retry budget exhausted). The server uses this to "
+    "decide which files are safe to cache as 'done'; without it the file will be "
+    "re-analysed on the next run."
+)
+MARK_FILE_DONE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "file": {"type": "string", "description": "Repo-relative file path that was just analysed"},
+        "status": {"type": "string", "enum": ["ok", "error"], "description": "ok if analysis completed, error if abandoned"},
+        "reason": {"type": "string", "description": "Short stable code when status=error: token_limit | parse_error | retry_exhausted | subprocess_error | timeout"},
+    },
+    "required": ["file", "status"],
+}

--- a/src/quodeq/data/prompts/cli_consolidated_prompt.md
+++ b/src/quodeq/data/prompts/cli_consolidated_prompt.md
@@ -11,12 +11,16 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 ## Workflow
 
 1. Call `get_next_files()` to receive your next batch of files
-2. Read each file using the Read tool
-3. Evaluate against ALL dimension checklists below
-4. Call `report_finding()` for every violation and compliance you confirm
-5. Repeat from step 1 until `get_next_files` returns no more files
+2. For each file in the batch:
+   a. Read the file using the Read tool
+   b. Evaluate against ALL dimension checklists below
+   c. Call `report_finding()` for every violation and compliance you confirm
+   d. Call `mark_file_done(file=..., status='ok')` once you are done with this file (even if there were no findings). If you cannot finish (e.g. file too large, parse error), call `mark_file_done(file=..., status='error', reason=...)` instead. Reason values: `token_limit`, `parse_error`, `retry_exhausted`, `timeout`.
+3. Repeat from step 1 until `get_next_files` returns no more files
 
-**IMPORTANT:** When `get_next_files` returns "DONE" or "no more files", stop immediately.
+**IMPORTANT:** When `get_next_files` returns "DONE" or "no more files", stop immediately. Do not re-read files, do not summarize, do not call any more tools. Your work is complete.
+
+**Why mark_file_done matters:** the server only caches files that you've explicitly marked as `ok`. Skipping the call means the file will be re-analysed on the next run.
 
 ## report_finding parameters
 

--- a/src/quodeq/data/prompts/cli_subagent_prompt.md
+++ b/src/quodeq/data/prompts/cli_subagent_prompt.md
@@ -11,12 +11,16 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 ## Workflow
 
 1. Call `get_next_files()` to receive your next batch of files
-2. Read each file using the Read tool
-3. Evaluate against the standards checklist below
-4. Call `report_finding()` for every violation and compliance you confirm
-5. Repeat from step 1 until `get_next_files` returns no more files
+2. For each file in the batch:
+   a. Read the file using the Read tool
+   b. Evaluate against the standards checklist below
+   c. Call `report_finding()` for every violation and compliance you confirm
+   d. Call `mark_file_done(file=..., status='ok')` once you are done with this file (even if there were no findings). If you cannot finish (e.g. file too large, parse error), call `mark_file_done(file=..., status='error', reason=...)` instead. Reason values: `token_limit`, `parse_error`, `retry_exhausted`, `timeout`.
+3. Repeat from step 1 until `get_next_files` returns no more files
 
 **IMPORTANT:** When `get_next_files` returns "DONE" or "no more files", stop immediately. Do not re-read files, do not summarize, do not call any more tools. Your work is complete.
+
+**Why mark_file_done matters:** the server only caches files that you've explicitly marked as `ok`. Skipping the call means the file will be re-analysed on the next run.
 
 ## report_finding parameters
 

--- a/tests/analysis/cache/test_clean_scan_honor.py
+++ b/tests/analysis/cache/test_clean_scan_honor.py
@@ -155,6 +155,9 @@ class TestDispatchBypassesCacheOnCleanScan:
                     out.write(json.dumps({
                         "file": f, "line": 1, "t": "violation", "w": f"fresh-{f}",
                     }) + "\n")
+                    out.write(json.dumps({
+                        "_marker": "file_done", "file": f, "status": "ok",
+                    }) + "\n")
             return Evidence(
                 repository="", language="python", date="2026-01-01",
                 source_file_count=len(files), files_read=len(files),
@@ -205,6 +208,9 @@ class TestDispatchBypassesCacheOnCleanScan:
             with jsonl.open("a") as out:
                 out.write(json.dumps({
                     "file": "a.py", "line": 1, "t": "violation", "w": "fresh",
+                }) + "\n")
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": "a.py", "status": "ok",
                 }) + "\n")
             return Evidence(
                 repository="", language="python", date="2026-01-01",

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -222,6 +222,8 @@ class TestPersist:
             json.dumps({"file": "a.py", "line": 1, "t": "violation", "w": "a-issue"}) + "\n"
             + json.dumps({"file": "b.py", "line": 2, "t": "compliance", "w": "b-ok"}) + "\n"
             + json.dumps({"file": "a.py", "line": 5, "t": "violation", "w": "a-issue-2"}) + "\n"
+            + json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+            + json.dumps({"_marker": "file_done", "file": "b.py", "status": "ok"}) + "\n"
         )
 
         persist_dispatch_results(
@@ -246,8 +248,10 @@ class TestPersist:
 
         jsonl = tmp_path / "work" / "security_evidence.jsonl"
         jsonl.parent.mkdir(parents=True, exist_ok=True)
-        # No findings for clean.py — JSONL is empty.
-        jsonl.write_text("")
+        # No findings for clean.py — just the ok marker to confirm it completed.
+        jsonl.write_text(
+            json.dumps({"_marker": "file_done", "file": "clean.py", "status": "ok"}) + "\n"
+        )
 
         persist_dispatch_results(
             config, "security", miss_files=files,
@@ -271,6 +275,7 @@ class TestPersist:
         jsonl.write_text(
             json.dumps({"file": "a.py", "line": 1}) + "\n"
             + json.dumps({"file": "carried.py", "line": 2}) + "\n"
+            + json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
         )
 
         persist_dispatch_results(
@@ -320,6 +325,8 @@ class TestRoundTrip:
         jsonl.write_text(
             json.dumps({"file": "a.py", "line": 1, "t": "violation"}) + "\n"
             + json.dumps({"file": "b.py", "line": 2, "t": "compliance"}) + "\n"
+            + json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+            + json.dumps({"_marker": "file_done", "file": "b.py", "status": "ok"}) + "\n"
         )
 
         # Persist results.

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -142,6 +142,9 @@ class FakeDispatcher:
                 out.write(json.dumps({
                     "file": f, "line": 1, "t": "violation", "w": f"v-{f}",
                 }) + "\n")
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": f, "status": "ok",
+                }) + "\n")
         return _make_dummy_evidence(files_read=len(files_to_dispatch))
 
     def _all_source_files(self) -> list[str]:

--- a/tests/analysis/cache/test_file_done_markers.py
+++ b/tests/analysis/cache/test_file_done_markers.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from quodeq.analysis.cache.dimension_helpers import _group_findings_by_file
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.write_text("".join(json.dumps(l) + "\n" for l in lines))
+
+
+class TestGroupFindingsByFile:
+    def test_returns_tuple_of_grouped_and_ok_files(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"file": "a.py", "req": "X-1", "t": "violation"},
+            {"_marker": "file_done", "file": "a.py", "status": "ok"},
+        ])
+        grouped, ok_files = _group_findings_by_file(jsonl)
+        assert ok_files == {"a.py"}
+        assert "a.py" in grouped and len(grouped["a.py"]) == 1
+
+    def test_marker_not_included_in_findings(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"file": "a.py", "req": "X-1", "t": "violation"},
+            {"_marker": "file_done", "file": "a.py", "status": "ok"},
+        ])
+        grouped, _ = _group_findings_by_file(jsonl)
+        assert all("_marker" not in f for f in grouped["a.py"])
+
+    def test_legacy_jsonl_yields_empty_ok_set(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"file": "a.py", "req": "X-1", "t": "violation"},
+            {"file": "b.py", "req": "X-2", "t": "violation"},
+        ])
+        _, ok_files = _group_findings_by_file(jsonl)
+        assert ok_files == set()
+
+    def test_error_marker_does_not_add_to_ok_set(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"_marker": "file_done", "file": "a.py", "status": "error", "reason": "token_limit"},
+        ])
+        _, ok_files = _group_findings_by_file(jsonl)
+        assert ok_files == set()
+
+    def test_ok_then_later_error_treated_as_error(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"_marker": "file_done", "file": "a.py", "status": "ok"},
+            {"_marker": "file_done", "file": "a.py", "status": "error", "reason": "parse_error"},
+        ])
+        _, ok_files = _group_findings_by_file(jsonl)
+        assert ok_files == set()  # last-write-wins, error overrides ok
+
+    def test_malformed_marker_ignored(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"_marker": "file_done"},  # missing file/status
+            {"file": "a.py", "req": "X-1", "t": "violation"},
+            {"_marker": "file_done", "file": "a.py", "status": "ok"},
+        ])
+        grouped, ok_files = _group_findings_by_file(jsonl)
+        assert ok_files == {"a.py"}
+        assert len(grouped["a.py"]) == 1
+
+    def test_missing_jsonl_returns_empty_pair(self, tmp_path: Path):
+        grouped, ok_files = _group_findings_by_file(tmp_path / "missing.jsonl")
+        assert grouped == {}
+        assert ok_files == set()

--- a/tests/analysis/cache/test_marker_overhead.py
+++ b/tests/analysis/cache/test_marker_overhead.py
@@ -1,0 +1,32 @@
+"""Performance microbenchmark for the marker-aware grouping function.
+
+Catches O(n^2) regressions in `_group_findings_by_file`. The 500ms budget
+is loose to avoid CI flakes; the point is order-of-magnitude correctness,
+not micro-optimisation.
+"""
+from __future__ import annotations
+import json
+import time
+from pathlib import Path
+
+from quodeq.analysis.cache.dimension_helpers import _group_findings_by_file
+
+
+def test_grouping_overhead_under_budget(tmp_path: Path):
+    lines = []
+    for i in range(10_000):
+        lines.append({
+            "file": f"src/f{i % 1000}.py", "req": "X-1", "t": "violation",
+            "line": i, "severity": "minor", "w": "w", "reason": "r",
+        })
+    for i in range(1_000):
+        lines.append({"_marker": "file_done", "file": f"src/f{i}.py", "status": "ok"})
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text("".join(json.dumps(line) + "\n" for line in lines))
+
+    t0 = time.perf_counter()
+    grouped, ok_files = _group_findings_by_file(jsonl)
+    elapsed = time.perf_counter() - t0
+    assert len(ok_files) == 1000
+    assert sum(len(v) for v in grouped.values()) == 10_000
+    assert elapsed < 0.5, f"grouping took {elapsed*1000:.0f}ms (budget 500ms)"

--- a/tests/analysis/cache/test_periodic_persist.py
+++ b/tests/analysis/cache/test_periodic_persist.py
@@ -97,6 +97,7 @@ class TestWatcherStartsAndStops:
             jsonl.parent.mkdir(parents=True, exist_ok=True)
             jsonl.write_text(
                 '{"file": "a.py", "line": 1, "t": "violation", "w": "found"}\n'
+                + '{"_marker": "file_done", "file": "a.py", "status": "ok"}\n'
             )
             time.sleep(0.3)  # let the watcher tick
             return Evidence(
@@ -124,18 +125,18 @@ class TestWatcherStartsAndStops:
 
 
 class TestWatcherSurvivesDispatchException:
-    def test_dispatch_raises_watcher_still_does_final_persist(
+    def test_dispatch_raises_orphan_findings_not_cached(
         self, tmp_path: Path, cache: LocalFileBackend,
     ):
-        """If the dispatch raises mid-run, the watcher's final persist must
-        still run. The lost-work window is the persist interval, not the
-        whole dim."""
+        """If the dispatch raises without emitting a file_done=ok marker, the
+        file must NOT be cached — the worker crashed mid-file so we can't trust
+        the findings are complete. The next run will re-dispatch."""
         config = _setup(tmp_path, {"a.py": "x"})
 
         def crashing_dispatcher(cfg, dim_id, idx, ctx, callbacks):
             jsonl = cfg.work_dir / f"{dim_id}_evidence.jsonl"
             jsonl.parent.mkdir(parents=True, exist_ok=True)
-            # Write findings that completed before the crash.
+            # Write partial findings with no ok marker (worker died mid-file).
             jsonl.write_text(
                 '{"file": "a.py", "line": 1, "t": "violation", "w": "completed"}\n'
             )
@@ -153,11 +154,10 @@ class TestWatcherSurvivesDispatchException:
                     cache=cache,
                 )
 
-        # Final persist in the finally block must have written a.py's entry.
+        # No ok marker emitted → orphaned findings must NOT be cached.
         key = build_cache_key_for_file(config, "a.py", "security")
         entry = cache.get(key)
-        assert entry is not None, "final persist did not run after dispatch raise"
-        assert any(f.get("w") == "completed" for f in entry.findings)
+        assert entry is None, "orphaned findings without ok marker must not be cached"
 
 
 class TestNoWatcherWhenNoMisses:

--- a/tests/analysis/cache/test_persist_dispatch_results_markers.py
+++ b/tests/analysis/cache/test_persist_dispatch_results_markers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._types import AnalysisOptions, RunConfig
+from quodeq.analysis.cache import LocalFileBackend
+from quodeq.analysis.cache.dimension_helpers import persist_dispatch_results
+
+
+def _make_config(src: Path) -> RunConfig:
+    return RunConfig(
+        src=src, language="python", standards_dir=None,
+        work_dir=src, options=AnalysisOptions(subagent_model="m"),
+    )
+
+
+def _write_jsonl(path: Path, lines: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(l) + "\n" for l in lines))
+
+
+@pytest.fixture
+def cache(tmp_path: Path) -> LocalFileBackend:
+    return LocalFileBackend(root=tmp_path / "cache")
+
+
+class TestPersistFiltersByOkMarker:
+    def test_only_ok_files_persisted(self, tmp_path: Path, cache: LocalFileBackend):
+        src = tmp_path / "src"; src.mkdir()
+        for f in ("a.py", "b.py", "c.py"):
+            (src / f).write_text("x")
+        config = _make_config(src)
+        jsonl = tmp_path / "dim_evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"file": "a.py", "req": "X-1", "t": "violation", "line": 1, "severity": "minor", "w": "w", "reason": "r"},
+            {"_marker": "file_done", "file": "a.py", "status": "ok"},
+            # b.py: no marker (worker crashed mid-file)
+            # c.py: explicit error
+            {"_marker": "file_done", "file": "c.py", "status": "error", "reason": "token_limit"},
+        ])
+        miss_keys = {f: f"key-{f}" for f in ("a.py", "b.py", "c.py")}
+        persist_dispatch_results(
+            config, "security", miss_files=["a.py", "b.py", "c.py"],
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+        assert cache.get("key-a.py") is not None
+        assert cache.get("key-b.py") is None
+        assert cache.get("key-c.py") is None
+
+    def test_clean_file_with_ok_marker_is_cached_empty(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        src = tmp_path / "src"; src.mkdir()
+        (src / "clean.py").write_text("x")
+        config = _make_config(src)
+        jsonl = tmp_path / "dim_evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"_marker": "file_done", "file": "clean.py", "status": "ok"},
+        ])
+        persist_dispatch_results(
+            config, "security", miss_files=["clean.py"],
+            jsonl_path=jsonl, miss_keys={"clean.py": "key-clean"}, cache=cache,
+        )
+        entry = cache.get("key-clean")
+        assert entry is not None
+        assert entry.findings == []
+
+    def test_orphan_findings_without_marker_not_cached(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Findings exist but no ok marker: worker wrote some findings then died.
+        src = tmp_path / "src"; src.mkdir()
+        (src / "x.py").write_text("x")
+        config = _make_config(src)
+        jsonl = tmp_path / "dim_evidence.jsonl"
+        _write_jsonl(jsonl, [
+            {"file": "x.py", "req": "X-1", "t": "violation", "line": 1, "severity": "minor", "w": "w", "reason": "r"},
+        ])
+        persist_dispatch_results(
+            config, "security", miss_files=["x.py"],
+            jsonl_path=jsonl, miss_keys={"x.py": "key-x"}, cache=cache,
+        )
+        assert cache.get("key-x") is None
+
+    def test_missing_jsonl_writes_nothing(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        src = tmp_path / "src"; src.mkdir()
+        config = _make_config(src)
+        persist_dispatch_results(
+            config, "security", miss_files=["a.py"],
+            jsonl_path=tmp_path / "missing.jsonl",
+            miss_keys={"a.py": "key-a"}, cache=cache,
+        )
+        assert cache.get("key-a") is None

--- a/tests/analysis/mcp/test_handlers_marker.py
+++ b/tests/analysis/mcp/test_handlers_marker.py
@@ -37,12 +37,23 @@ class TestToolsCallDispatchesMarker:
         )
         router.mark_file_done.assert_called_once_with(file="b.py", status="error", reason="token_limit")
 
-    def test_invalid_args_returns_error_response(self):
+    def test_router_value_error_returns_error_response(self):
         router = MagicMock()
-        router.mark_file_done.side_effect = ValueError("bogus")
+        router.mark_file_done.side_effect = ValueError("status must be ok or error")
         result = handle_tools_call(
             request_id=1,
             params={"name": "mark_file_done", "arguments": {"file": "b.py", "status": "bogus"}},
             router=router,
         )
         assert result["result"].get("isError") is True
+        router.mark_file_done.assert_called_once()
+
+    def test_non_string_args_short_circuit_without_calling_router(self):
+        router = MagicMock()
+        result = handle_tools_call(
+            request_id=1,
+            params={"name": "mark_file_done", "arguments": {"file": 123, "status": "ok"}},
+            router=router,
+        )
+        assert result["result"].get("isError") is True
+        router.mark_file_done.assert_not_called()

--- a/tests/analysis/mcp/test_handlers_marker.py
+++ b/tests/analysis/mcp/test_handlers_marker.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from unittest.mock import MagicMock
+
+from quodeq.analysis.mcp.handlers import handle_tools_list, handle_tools_call
+
+
+class TestToolsListIncludesMarker:
+    def test_marker_listed(self):
+        result = handle_tools_list(request_id=1, has_queue=True)
+        names = {t["name"] for t in result["result"]["tools"]}
+        assert "mark_file_done" in names
+
+    def test_marker_listed_even_without_queue(self):
+        # The marker tool is independent of the queue — single-agent paths
+        # still want to mark per-file completion.
+        result = handle_tools_list(request_id=1, has_queue=False)
+        names = {t["name"] for t in result["result"]["tools"]}
+        assert "mark_file_done" in names
+
+
+class TestToolsCallDispatchesMarker:
+    def test_ok_marker_routed_to_router(self):
+        router = MagicMock()
+        handle_tools_call(
+            request_id=1,
+            params={"name": "mark_file_done", "arguments": {"file": "a.py", "status": "ok"}},
+            router=router,
+        )
+        router.mark_file_done.assert_called_once_with(file="a.py", status="ok", reason=None)
+
+    def test_error_marker_with_reason_routed(self):
+        router = MagicMock()
+        handle_tools_call(
+            request_id=1,
+            params={"name": "mark_file_done", "arguments": {"file": "b.py", "status": "error", "reason": "token_limit"}},
+            router=router,
+        )
+        router.mark_file_done.assert_called_once_with(file="b.py", status="error", reason="token_limit")
+
+    def test_invalid_args_returns_error_response(self):
+        router = MagicMock()
+        router.mark_file_done.side_effect = ValueError("bogus")
+        result = handle_tools_call(
+            request_id=1,
+            params={"name": "mark_file_done", "arguments": {"file": "b.py", "status": "bogus"}},
+            router=router,
+        )
+        assert result["result"].get("isError") is True

--- a/tests/analysis/mcp/test_router_marker.py
+++ b/tests/analysis/mcp/test_router_marker.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.mcp.router import FindingsRouter
+
+
+def _make_router(fh: io.StringIO) -> FindingsRouter:
+    return FindingsRouter(fh)
+
+
+def _read_lines(fh: io.StringIO) -> list[dict]:
+    return [json.loads(l) for l in fh.getvalue().splitlines() if l.strip()]
+
+
+class TestMarkFileDone:
+    def test_writes_ok_marker(self):
+        fh = io.StringIO()
+        router = _make_router(fh)
+        router.mark_file_done(file="src/foo.py", status="ok")
+        lines = _read_lines(fh)
+        assert len(lines) == 1
+        assert lines[0]["_marker"] == "file_done"
+        assert lines[0]["file"] == "src/foo.py"
+        assert lines[0]["status"] == "ok"
+
+    def test_writes_error_marker_with_reason(self):
+        fh = io.StringIO()
+        router = _make_router(fh)
+        router.mark_file_done(file="src/bar.py", status="error", reason="token_limit")
+        lines = _read_lines(fh)
+        assert lines[0]["status"] == "error"
+        assert lines[0]["reason"] == "token_limit"
+
+    def test_marker_does_not_dedupe_with_findings(self):
+        fh = io.StringIO()
+        router = _make_router(fh)
+        router.receive({
+            "req": "M-MOD-1", "t": "violation", "file": "src/foo.py",
+            "line": 10, "severity": "minor", "w": "x", "reason": "y",
+        })
+        router.mark_file_done(file="src/foo.py", status="ok")
+        lines = _read_lines(fh)
+        assert len(lines) == 2
+        assert "_marker" not in lines[0]
+        assert lines[1]["_marker"] == "file_done"
+
+    def test_invalid_status_rejected(self):
+        fh = io.StringIO()
+        router = _make_router(fh)
+        with pytest.raises(ValueError):
+            router.mark_file_done(file="src/foo.py", status="bogus")

--- a/tests/analysis/mcp/test_router_marker.py
+++ b/tests/analysis/mcp/test_router_marker.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import io
 import json
-from pathlib import Path
 
 import pytest
 
@@ -13,7 +12,7 @@ def _make_router(fh: io.StringIO) -> FindingsRouter:
 
 
 def _read_lines(fh: io.StringIO) -> list[dict]:
-    return [json.loads(l) for l in fh.getvalue().splitlines() if l.strip()]
+    return [json.loads(ln) for ln in fh.getvalue().splitlines() if ln.strip()]
 
 
 class TestMarkFileDone:

--- a/tests/analysis/mcp/test_schemas.py
+++ b/tests/analysis/mcp/test_schemas.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from quodeq.analysis.mcp.schemas import (
+    MARK_FILE_DONE_NAME,
+    MARK_FILE_DONE_DESC,
+    MARK_FILE_DONE_SCHEMA,
+)
+
+
+class TestMarkFileDoneSchema:
+    def test_name_is_stable(self):
+        assert MARK_FILE_DONE_NAME == "mark_file_done"
+
+    def test_required_fields(self):
+        assert set(MARK_FILE_DONE_SCHEMA["required"]) == {"file", "status"}
+
+    def test_status_enum(self):
+        assert MARK_FILE_DONE_SCHEMA["properties"]["status"]["enum"] == ["ok", "error"]
+
+    def test_reason_is_optional_free_string(self):
+        reason = MARK_FILE_DONE_SCHEMA["properties"]["reason"]
+        assert reason["type"] == "string"
+        assert "reason" not in MARK_FILE_DONE_SCHEMA["required"]
+
+    def test_description_mentions_per_file_completion(self):
+        assert "after" in MARK_FILE_DONE_DESC.lower()
+        assert "file" in MARK_FILE_DONE_DESC.lower()

--- a/tests/analysis/test_consolidated_prompt_marker_step.py
+++ b/tests/analysis/test_consolidated_prompt_marker_step.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pathlib import Path
+
+
+PROMPT = Path("src/quodeq/data/prompts/cli_consolidated_prompt.md").read_text()
+
+
+def test_workflow_mentions_mark_file_done():
+    # The prompt instructs the agent to call mark_file_done after each file.
+    assert "mark_file_done" in PROMPT
+
+
+def test_workflow_step_is_in_workflow_section():
+    workflow_idx = PROMPT.index("## Workflow")
+    next_section_idx = PROMPT.index("\n## ", workflow_idx + 1)
+    workflow_section = PROMPT[workflow_idx:next_section_idx]
+    assert "mark_file_done" in workflow_section
+
+
+def test_status_values_documented():
+    assert "status='ok'" in PROMPT or 'status="ok"' in PROMPT
+    assert "status='error'" in PROMPT or 'status="error"' in PROMPT

--- a/tests/analysis/test_subagent_prompt_marker_step.py
+++ b/tests/analysis/test_subagent_prompt_marker_step.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from pathlib import Path
+
+
+PROMPT = Path("src/quodeq/data/prompts/cli_subagent_prompt.md").read_text()
+
+
+def test_workflow_mentions_mark_file_done():
+    # The prompt instructs the agent to call mark_file_done after each file.
+    assert "mark_file_done" in PROMPT
+
+
+def test_workflow_step_is_in_workflow_section():
+    workflow_idx = PROMPT.index("## Workflow")
+    next_section_idx = PROMPT.index("\n## ", workflow_idx + 1)
+    workflow_section = PROMPT[workflow_idx:next_section_idx]
+    assert "mark_file_done" in workflow_section
+
+
+def test_status_values_documented():
+    assert "status='ok'" in PROMPT or 'status="ok"' in PROMPT
+    assert "status='error'" in PROMPT or 'status="error"' in PROMPT

--- a/tests/engine/test_mcp_findings.py
+++ b/tests/engine/test_mcp_findings.py
@@ -47,9 +47,11 @@ class TestToolsList:
             findings_file,
         )
         tools = responses[0]["result"]["tools"]
-        assert len(tools) == 1
-        assert tools[0]["name"] == "report_finding"
-        assert "inputSchema" in tools[0]
+        names = {tool["name"] for tool in tools}
+        assert "report_finding" in names
+        assert "mark_file_done" in names
+        report_tool = next(tool for tool in tools if tool["name"] == "report_finding")
+        assert "inputSchema" in report_tool
 
 
 class TestToolsCall:


### PR DESCRIPTION
## Summary
- Adds `mark_file_done` MCP tool — subagents call it after every file (`status='ok'` or `status='error'` with a stable `reason`).
- Cache writer (`persist_dispatch_results`) only persists files with an `ok` marker; orphan/abandoned files are re-dispatched on the next run instead of silently being treated as "done."
- Schema bump (v1 → v2) invalidates pre-marker entries naturally on next input change.

This is Slice 1 of the spec at `docs/superpowers/specs/2026-05-09-robust-evaluation-cancellation-design.md` (full plan at `docs/superpowers/plans/2026-05-09-robust-evaluation-cancellation.md`). It fixes the root cause that ties together cancel/fail/token-out/retry-exhausted leaks: there was no per-file completion signal, so any file appearing in the JSONL was treated as cached-done.

## What this PR does NOT do (later slices)
- Per-dim incomplete state + scoring guard (Slice 2)
- Discard wipes V2 cache for incomplete dims (Slice 3)
- UI cancel popup (Slice 4)
- Consecutive-failure circuit breaker (Slice 5)
- End-to-end integration test (Slice 6)

## Test plan
- [x] `tests/analysis/cache/` green (104 passing)
- [x] `tests/analysis/mcp/` green (27 passing including new marker tests)
- [x] Full repo test suite green (2727 passing)
- [x] Smoke run a real evaluation, confirm cache entries written only for files where the agent emitted `mark_file_done(status='ok')`
- [x] Cancel a real evaluation mid-dim, confirm uncompleted files are re-analysed on next run