### PR TITLE
feat: per-dim incomplete state and scoring guard

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -8,6 +8,7 @@ import time
 from copy import copy
 from dataclasses import replace
 from collections.abc import Callable
+from pathlib import Path
 
 from quodeq.analysis._dimension_ops import _run_dimension_incremental as run_dimension_incremental
 from quodeq.analysis._types import RunConfig, _AnalysisContext
@@ -16,6 +17,49 @@ from quodeq.core.evidence.model import Evidence
 from quodeq.engine._runner_markers import emit_marker
 # NOTE: logging in inner layer — tracked for middleware extraction
 from quodeq.shared.logging import log_info, log_warning
+from quodeq.shared import cancellation
+from quodeq.shared.dimensions_state import DimState, write_dim_state, IllegalDimTransitionError
+
+
+def _safe_write_dim_state(
+    run_dir: Path | None, dim: str, state: DimState, *, reason: str | None = None,
+) -> None:
+    """Best-effort dim-state write. Never raises into the loop.
+
+    Tests that mock RunConfig don't have a real work_dir, and we don't
+    want state I/O failures to crash the loop. Logged at WARNING for
+    visibility. Lifecycle errors (illegal transition) are also swallowed:
+    if the state machine rejects the transition, that's a bug we want to
+    see in logs but not crash on.
+    """
+    if run_dir is None:
+        return
+    try:
+        run_dir = Path(run_dir)
+    except (TypeError, ValueError):
+        return
+    try:
+        write_dim_state(run_dir, dim, state, reason=reason)
+    except IllegalDimTransitionError as exc:
+        log_warning(f"[loop] dim-state transition rejected: {exc}")
+    except (OSError, AttributeError, TypeError) as exc:
+        log_warning(f"[loop] dim-state write failed for {dim}: {exc}")
+
+
+def _run_dir_for(config: RunConfig) -> Path | None:
+    work_dir = getattr(config, "work_dir", None)
+    src = getattr(config, "src", None)
+    candidate = work_dir or src
+    if candidate is None:
+        return None
+    try:
+        return Path(candidate)
+    except (TypeError, ValueError):
+        return None
+
+
+def _interruption_reason() -> str:
+    return "cancelled_signal" if cancellation.is_cancelled() else "failed_exception"
 
 
 def _silence_broken_stdout() -> None:
@@ -57,7 +101,7 @@ def check_zero_findings(
         raise EvaluationError(
             f"Evaluation produced 0 findings across {len(result)} dimensions{skip_msg}. "
             f"This usually means the AI CLI could not read files or report findings "
-            f"\u2014 check tool permissions and MCP configuration."
+            "— check tool permissions and MCP configuration."
         )
 
 
@@ -85,8 +129,10 @@ def run_incremental_loop(
         if deadline is not None and time.monotonic() >= deadline:
             log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
             break
+        run_dir = _run_dir_for(config)
+        _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)
         emit_marker("analyzing", dimension=dimension)
-        log_info(f"\u2192 [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
+        log_info(f"→ [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
         ev: Evidence | None = None
         try:
             ev = run_dimension_incremental(config, dimension, idx, ctx)
@@ -94,7 +140,7 @@ def run_incremental_loop(
             _silence_broken_stdout()
             ev = None
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
-            log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 incremental failed: {exc}, falling back to full")
+            log_warning(f"[{idx}/{ctx.total}] {dimension} — incremental failed: {exc}, falling back to full")
             fallback_options = copy(config.options)
             fallback_options.incremental_file_filter = None
             fallback_config = replace(config, options=fallback_options)
@@ -110,14 +156,15 @@ def run_incremental_loop(
             # so subsequent dims still run; the surfaced log line gives us
             # the trail we need next time this happens.
             log_warning(
-                f"[loop] {dimension} \u2014 unexpected exception "
-                f"{type(exc).__name__}: {exc} \u2014 skipping dim, continuing loop",
+                f"[loop] {dimension} — unexpected exception "
+                f"{type(exc).__name__}: {exc} — skipping dim, continuing loop",
             )
             ev = None
         # log_result_fn / on_dimension_done are caller-provided (e.g., the
-        # dashboard's scoring callback). Wrap them too \u2014 an exception in a
+        # dashboard's scoring callback). Wrap them too — an exception in a
         # callback shouldn't drop the next iteration on the floor.
         if ev:
+            _safe_write_dim_state(run_dir, dimension, DimState.DONE)
             try:
                 log_result_fn(ev, dimension, idx, ctx.total)
                 result[dimension] = ev
@@ -128,7 +175,7 @@ def run_incremental_loop(
                 # stderr, then retry the callback once: scoring callbacks like
                 # ``_score_dimension`` write evaluation/<dim>.json to disk and
                 # are idempotent (overwrite). The previous "result kept"
-                # message was misleading \u2014 only the in-memory Evidence stayed,
+                # message was misleading — only the in-memory Evidence stayed,
                 # the persistent file write was lost with the exception.
                 _silence_broken_stdout()
                 result.setdefault(dimension, ev)
@@ -136,22 +183,24 @@ def run_incremental_loop(
                     try:
                         on_dimension_done(dimension, ev)
                         log_warning(
-                            f"[loop] {dimension} \u2014 callback broken pipe, "
+                            f"[loop] {dimension} — callback broken pipe, "
                             f"retried after silencing stdout, result persisted",
                         )
                     except Exception as exc:  # noqa: BLE001
                         log_warning(
-                            f"[loop] {dimension} \u2014 callback retry after broken pipe raised "
-                            f"{type(exc).__name__}: {exc} \u2014 result NOT persisted, continuing loop",
+                            f"[loop] {dimension} — callback retry after broken pipe raised "
+                            f"{type(exc).__name__}: {exc} — result NOT persisted, continuing loop",
                         )
                 else:
-                    log_warning(f"[loop] {dimension} \u2014 callback broken pipe, no retry needed, continuing loop")
+                    log_warning(f"[loop] {dimension} — callback broken pipe, no retry needed, continuing loop")
             except Exception as exc:  # noqa: BLE001
                 log_warning(
-                    f"[loop] {dimension} \u2014 callback raised "
-                    f"{type(exc).__name__}: {exc} \u2014 result kept, continuing loop",
+                    f"[loop] {dimension} — callback raised "
+                    f"{type(exc).__name__}: {exc} — result kept, continuing loop",
                 )
                 result.setdefault(dimension, ev)
+        else:
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
         log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (ev={'set' if ev else 'None'})")
     log_info(
         f"[loop] incremental finished: processed {len(result)} of {len(dimensions)} dim(s) "
@@ -187,18 +236,23 @@ def run_per_dimension_loop(
         deadline = getattr(config.options, "deadline_at", None)
         if deadline is not None and time.monotonic() >= deadline:
             log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
+            # Remaining dims stay in PENDING (they were never RUNNING). No write needed.
             break
+        run_dir = _run_dir_for(config)
+        _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)
         ev: Evidence | None = None
         try:
             ev = process_fn(config, dimension, idx, ctx)
         except BrokenPipeError:
             _silence_broken_stdout()
             skipped_count += 1
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: broken pipe)")
             continue
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
-            log_warning(f"[{idx}/{ctx.total}] {dimension} \u2014 failed: {exc}")
+            log_warning(f"[{idx}/{ctx.total}] {dimension} — failed: {exc}")
             skipped_count += 1
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: {type(exc).__name__})")
             continue
         except Exception as exc:  # noqa: BLE001
@@ -209,12 +263,16 @@ def run_per_dimension_loop(
                 f"{type(exc).__name__}: {exc} — skipping dim, continuing loop",
             )
             skipped_count += 1
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: unexpected)")
             continue
         if ev is None:
             skipped_count += 1
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: ev=None)")
             continue
+        # ev is set — dim succeeded analytically.
+        _safe_write_dim_state(run_dir, dimension, DimState.DONE)
         try:
             result[dimension] = ev
             if on_dimension_done:

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -1,4 +1,4 @@
-"""Dimension loop orchestrators — run dimensions sequentially or incrementally."""
+"""Dimension loop orchestrators - run dimensions sequentially or incrementally."""
 from __future__ import annotations
 
 import json
@@ -15,7 +15,7 @@ from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.errors import EvaluationError
 from quodeq.core.evidence.model import Evidence
 from quodeq.engine._runner_markers import emit_marker
-# NOTE: logging in inner layer — tracked for middleware extraction
+# NOTE: logging in inner layer - tracked for middleware extraction
 from quodeq.shared.logging import log_info, log_warning
 from quodeq.shared import cancellation
 from quodeq.shared.dimensions_state import DimState, write_dim_state, IllegalDimTransitionError
@@ -74,11 +74,11 @@ def _silence_broken_stdout() -> None:
 
     Once the parent has closed its end of the pipe every subsequent write to
     stdout/stderr raises BrokenPipeError. The actual analysis work (evidence
-    files, MCP calls, etc.) doesn't depend on those streams — only logging
+    files, MCP calls, etc.) doesn't depend on those streams - only logging
     does. Swapping the streams to /dev/null lets remaining dimensions run.
     """
     try:
-        devnull = open(os.devnull, "w")  # noqa: SIM115 — long-lived
+        devnull = open(os.devnull, "w")  # noqa: SIM115 - long-lived
         sys.stdout = devnull
         sys.stderr = devnull
     except OSError:
@@ -93,7 +93,7 @@ def check_zero_findings(
 
     When *incremental_filter_active* is True, zero findings is a legitimate
     outcome (PR-diff / incremental mode deliberately narrows the scan to a
-    changed-file set that may contain none of the dimension's language) —
+    changed-file set that may contain none of the dimension's language) -
     skip the check. Otherwise a genuinely empty result is almost always a
     symptom of a broken AI CLI tool loop, not a clean codebase.
     """
@@ -108,7 +108,7 @@ def check_zero_findings(
         raise EvaluationError(
             f"Evaluation produced 0 findings across {len(result)} dimensions{skip_msg}. "
             f"This usually means the AI CLI could not read files or report findings "
-            "— check tool permissions and MCP configuration."
+            "- check tool permissions and MCP configuration."
         )
 
 
@@ -139,7 +139,7 @@ def run_incremental_loop(
         run_dir = _run_dir_for(config)
         _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)
         emit_marker("analyzing", dimension=dimension)
-        log_info(f"→ [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
+        log_info(f"-> [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
         ev: Evidence | None = None
         try:
             ev = run_dimension_incremental(config, dimension, idx, ctx)
@@ -147,7 +147,7 @@ def run_incremental_loop(
             _silence_broken_stdout()
             ev = None
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
-            log_warning(f"[{idx}/{ctx.total}] {dimension} — incremental failed: {exc}, falling back to full")
+            log_warning(f"[{idx}/{ctx.total}] {dimension} - incremental failed: {exc}, falling back to full")
             fallback_options = copy(config.options)
             fallback_options.incremental_file_filter = None
             fallback_config = replace(config, options=fallback_options)
@@ -163,12 +163,12 @@ def run_incremental_loop(
             # so subsequent dims still run; the surfaced log line gives us
             # the trail we need next time this happens.
             log_warning(
-                f"[loop] {dimension} — unexpected exception "
-                f"{type(exc).__name__}: {exc} — skipping dim, continuing loop",
+                f"[loop] {dimension} - unexpected exception "
+                f"{type(exc).__name__}: {exc} - skipping dim, continuing loop",
             )
             ev = None
         # log_result_fn / on_dimension_done are caller-provided (e.g., the
-        # dashboard's scoring callback). Wrap them too — an exception in a
+        # dashboard's scoring callback). Wrap them too - an exception in a
         # callback shouldn't drop the next iteration on the floor.
         if ev:
             _safe_write_dim_state(run_dir, dimension, DimState.DONE)
@@ -182,7 +182,7 @@ def run_incremental_loop(
                 # stderr, then retry the callback once: scoring callbacks like
                 # ``_score_dimension`` write evaluation/<dim>.json to disk and
                 # are idempotent (overwrite). The previous "result kept"
-                # message was misleading — only the in-memory Evidence stayed,
+                # message was misleading - only the in-memory Evidence stayed,
                 # the persistent file write was lost with the exception.
                 _silence_broken_stdout()
                 result.setdefault(dimension, ev)
@@ -190,20 +190,20 @@ def run_incremental_loop(
                     try:
                         on_dimension_done(dimension, ev)
                         log_warning(
-                            f"[loop] {dimension} — callback broken pipe, "
+                            f"[loop] {dimension} - callback broken pipe, "
                             f"retried after silencing stdout, result persisted",
                         )
                     except Exception as exc:  # noqa: BLE001
                         log_warning(
-                            f"[loop] {dimension} — callback retry after broken pipe raised "
-                            f"{type(exc).__name__}: {exc} — result NOT persisted, continuing loop",
+                            f"[loop] {dimension} - callback retry after broken pipe raised "
+                            f"{type(exc).__name__}: {exc} - result NOT persisted, continuing loop",
                         )
                 else:
-                    log_warning(f"[loop] {dimension} — callback broken pipe, no retry needed, continuing loop")
+                    log_warning(f"[loop] {dimension} - callback broken pipe, no retry needed, continuing loop")
             except Exception as exc:  # noqa: BLE001
                 log_warning(
-                    f"[loop] {dimension} — callback raised "
-                    f"{type(exc).__name__}: {exc} — result kept, continuing loop",
+                    f"[loop] {dimension} - callback raised "
+                    f"{type(exc).__name__}: {exc} - result kept, continuing loop",
                 )
                 result.setdefault(dimension, ev)
         else:
@@ -257,7 +257,7 @@ def run_per_dimension_loop(
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: broken pipe)")
             continue
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
-            log_warning(f"[{idx}/{ctx.total}] {dimension} — failed: {exc}")
+            log_warning(f"[{idx}/{ctx.total}] {dimension} - failed: {exc}")
             skipped_count += 1
             _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: {type(exc).__name__})")
@@ -266,8 +266,8 @@ def run_per_dimension_loop(
             # Don't let an exotic exception class drop the rest of the loop
             # silently. Log + count as skipped + continue so we get the trail.
             log_warning(
-                f"[loop] {dimension} — unexpected exception "
-                f"{type(exc).__name__}: {exc} — skipping dim, continuing loop",
+                f"[loop] {dimension} - unexpected exception "
+                f"{type(exc).__name__}: {exc} - skipping dim, continuing loop",
             )
             skipped_count += 1
             _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
@@ -278,7 +278,7 @@ def run_per_dimension_loop(
             _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: ev=None)")
             continue
-        # ev is set — dim succeeded analytically.
+        # ev is set - dim succeeded analytically.
         _safe_write_dim_state(run_dir, dimension, DimState.DONE)
         try:
             result[dimension] = ev
@@ -294,20 +294,20 @@ def run_per_dimension_loop(
                 try:
                     on_dimension_done(dimension, ev)
                     log_warning(
-                        f"[loop] {dimension} — callback broken pipe, "
+                        f"[loop] {dimension} - callback broken pipe, "
                         f"retried after silencing stdout, result persisted",
                     )
                 except Exception as exc:  # noqa: BLE001
                     log_warning(
-                        f"[loop] {dimension} — callback retry after broken pipe raised "
-                        f"{type(exc).__name__}: {exc} — result NOT persisted, continuing loop",
+                        f"[loop] {dimension} - callback retry after broken pipe raised "
+                        f"{type(exc).__name__}: {exc} - result NOT persisted, continuing loop",
                     )
             else:
-                log_warning(f"[loop] {dimension} — callback broken pipe, no retry needed, continuing loop")
+                log_warning(f"[loop] {dimension} - callback broken pipe, no retry needed, continuing loop")
         except Exception as exc:  # noqa: BLE001
             log_warning(
-                f"[loop] {dimension} — callback raised "
-                f"{type(exc).__name__}: {exc} — result kept, continuing loop",
+                f"[loop] {dimension} - callback raised "
+                f"{type(exc).__name__}: {exc} - result kept, continuing loop",
             )
         log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (ev=set)")
     log_info(

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -47,10 +47,17 @@ def _safe_write_dim_state(
 
 
 def _run_dir_for(config: RunConfig) -> Path | None:
+    """Resolve the run directory for dim-state writes.
+
+    Only accepts a real ``Path`` or ``str`` candidate. Mocked configs
+    (whose ``work_dir`` / ``src`` are ``MagicMock`` instances) return
+    ``None`` so tests don't create stray ``<MagicMock id=...>``
+    directories in the CWD when they exercise the dim loops.
+    """
     work_dir = getattr(config, "work_dir", None)
     src = getattr(config, "src", None)
-    candidate = work_dir or src
-    if candidate is None:
+    candidate = work_dir if work_dir is not None else src
+    if not isinstance(candidate, (str, Path)):
         return None
     try:
         return Path(candidate)

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 from http import HTTPStatus
+from pathlib import Path
+from typing import Any
 
 from flask import Flask, Response, jsonify, request
 
@@ -19,8 +21,22 @@ from quodeq.api.routes import _reports_dir
 from quodeq.services.base import ActionProvider
 from quodeq.services.evaluation_mixin import _score_completed_evidence
 from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
+from quodeq.shared.dimensions_state import read_dimensions
 
 _logger = logging.getLogger(__name__)
+
+
+def _read_dim_states(job: Any) -> dict[str, dict[str, Any]]:
+    """Read dimensions.json for *job*'s run dir, returning the dimensions map.
+
+    Empty dict on missing/corrupt file (read_dimensions handles that).
+    """
+    project = getattr(job, "output_project", None)
+    run_id = getattr(job, "output_run_id", None)
+    if not project or not run_id:
+        return {}
+    run_dir = Path(_reports_dir()) / project / run_id
+    return read_dimensions(run_dir).get("dimensions", {})
 
 # Cap on /api/evaluations ?limit= so a client cannot ask the server to materialize
 # an unbounded list. limit=0 still means "no client cap" but we clamp the actual
@@ -112,7 +128,9 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
                 })
             except Exception as exc:
                 _logger.debug("Could not score cancelled dimension for %s: %s", job_id, exc)
-        return jsonify(to_camel_dict(job))
+        payload = to_camel_dict(job)
+        payload["dimStates"] = _read_dim_states(job)
+        return jsonify(payload)
 
     @app.get("/api/evaluations/<job_id>/progress")
     def get_evaluation_progress(job_id: str) -> Response | tuple[Response, int]:

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -454,11 +454,17 @@ def _score_completed_evidence(reports_dir: str, job: dict) -> None:
     evaluation_dir.mkdir(parents=True, exist_ok=True)
     source_file_count = _read_project_source_file_count(reports_dir, project)
 
+    from quodeq.shared.dimensions_state import read_dimensions
+    dim_states = read_dimensions(Path(reports_dir) / project / run_id).get("dimensions", {})
+
     for jsonl_path in evidence_dir.glob("*_evidence.jsonl"):
         dim_id = jsonl_path.name.replace("_evidence.jsonl", "")
         eval_file = evaluation_dir / f"{dim_id}.json"
         if eval_file.exists():
             continue  # already scored
+        if dim_states.get(dim_id, {}).get("state") == "incomplete":
+            _logger.info("Skipping scoring for incomplete dim %s", dim_id)
+            continue
         if jsonl_path.stat().st_size == 0:
             continue  # no findings
         # Only score dimensions that passed verification (analysis queue exists)

--- a/src/quodeq/shared/dimensions_state.py
+++ b/src/quodeq/shared/dimensions_state.py
@@ -1,0 +1,96 @@
+"""Per-dimension lifecycle state for an evaluation run.
+
+Mirrors run_status.py for the per-dim layer. Lives in a sibling
+dimensions.json so per-dim writers don't contend with the run-level
+status writer's lock.
+"""
+from __future__ import annotations
+
+import enum
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+FILENAME = "dimensions.json"
+
+
+class DimState(str, enum.Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    INCOMPLETE = "incomplete"
+
+
+_TERMINAL = frozenset({DimState.DONE, DimState.INCOMPLETE})
+
+_ALLOWED: dict[DimState, frozenset[DimState]] = {
+    DimState.PENDING: frozenset({DimState.RUNNING, DimState.INCOMPLETE}),
+    DimState.RUNNING: frozenset({DimState.DONE, DimState.INCOMPLETE}),
+    DimState.DONE: frozenset(),
+    DimState.INCOMPLETE: frozenset(),
+}
+
+
+class IllegalDimTransitionError(RuntimeError):
+    pass
+
+
+_lock = threading.Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def read_dimensions(run_dir: Path) -> dict[str, Any]:
+    path = run_dir / FILENAME
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, FileNotFoundError, json.JSONDecodeError):
+        return {"schema_version": SCHEMA_VERSION, "dimensions": {}}
+
+
+def write_dim_state(
+    run_dir: Path, dimension: str, state: DimState,
+    *, reason: str | None = None,
+) -> None:
+    """Transition *dimension* to *state* atomically.
+
+    Validates the transition against the state machine. Initial writes
+    (no prior entry) are allowed regardless of *state* -- callers can seed
+    in any state, but typically use PENDING first.
+    """
+    with _lock:
+        data = read_dimensions(run_dir)
+        existing = data["dimensions"].get(dimension)
+        if existing is not None:
+            try:
+                prev = DimState(existing["state"])
+            except ValueError:
+                prev = DimState.PENDING
+            if state not in _ALLOWED[prev]:
+                raise IllegalDimTransitionError(
+                    f"{dimension}: {prev.value} -> {state.value} not permitted",
+                )
+        entry: dict[str, Any] = {"state": state.value}
+        if state == DimState.RUNNING:
+            entry["started_at"] = _now_iso()
+        elif state == DimState.DONE:
+            entry["completed_at"] = _now_iso()
+        elif state == DimState.INCOMPLETE:
+            entry["interrupted_at"] = _now_iso()
+            if reason:
+                entry["reason"] = reason
+        data["dimensions"][dimension] = entry
+        data["schema_version"] = SCHEMA_VERSION
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+        tmp = run_dir / (FILENAME + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(run_dir / FILENAME)

--- a/src/quodeq/shared/dimensions_state.py
+++ b/src/quodeq/shared/dimensions_state.py
@@ -27,8 +27,6 @@ class DimState(str, enum.Enum):
     INCOMPLETE = "incomplete"
 
 
-_TERMINAL = frozenset({DimState.DONE, DimState.INCOMPLETE})
-
 _ALLOWED: dict[DimState, frozenset[DimState]] = {
     DimState.PENDING: frozenset({DimState.RUNNING, DimState.INCOMPLETE}),
     DimState.RUNNING: frozenset({DimState.DONE, DimState.INCOMPLETE}),
@@ -73,6 +71,10 @@ def write_dim_state(
             try:
                 prev = DimState(existing["state"])
             except ValueError:
+                _logger.warning(
+                    "dimensions.json: corrupt state %r for %s; treating as pending",
+                    existing.get("state"), dimension,
+                )
                 prev = DimState.PENDING
             if state not in _ALLOWED[prev]:
                 raise IllegalDimTransitionError(

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -76,6 +76,7 @@ class RunLifecycleContext:
     def __enter__(self) -> "RunLifecycleContext":
         cancellation.reset()
         self._write(RunState.PENDING)
+        self._seed_dimension_states()
         self._install_signal_handlers()
         atexit.register(self._finalize_on_atexit)
         self._atexit_registered = True
@@ -157,6 +158,15 @@ class RunLifecycleContext:
             exit_reason=exit_reason,
             deadline_at=self._deadline_at,
         )
+
+    def _seed_dimension_states(self) -> None:
+        """Initialise dimensions.json with one PENDING entry per dim."""
+        from quodeq.shared.dimensions_state import DimState, write_dim_state
+        for dim in self._dimensions:
+            try:
+                write_dim_state(self._run_dir, dim, DimState.PENDING)
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning("failed to seed dim state for %s: %s", dim, exc)
 
     def _install_signal_handlers(self) -> None:
         def _handle(signum: int, frame: Any) -> None:

--- a/tests/analysis/test_dim_state_transitions.py
+++ b/tests/analysis/test_dim_state_transitions.py
@@ -1,0 +1,180 @@
+"""Per-dim state transitions in the analysis loops."""
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.analysis._loops import run_per_dimension_loop, run_incremental_loop
+from quodeq.analysis._types import RunConfig, AnalysisOptions
+from quodeq.shared import cancellation
+from quodeq.shared.dimensions_state import read_dimensions
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+def _mk_config(work_dir: Path):
+    config = MagicMock()
+    config.options.deadline_at = None
+    config.options.incremental_file_filter = None
+    config.options.skip_scoring = True
+    config.options.incremental = False
+    config.source_file_count = 10
+    config.work_dir = work_dir
+    config.src = work_dir
+    return config
+
+
+class TestPerDimensionLoopTransitions:
+    def test_successful_dim_marked_done(self, tmp_path: Path):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+        ev = MagicMock()
+        process_fn = MagicMock(return_value=ev)
+
+        run_per_dimension_loop(config, ["security"], ctx, process_fn=process_fn)
+
+        states = read_dimensions(tmp_path)["dimensions"]
+        assert states["security"]["state"] == "done"
+
+    def test_exception_marks_incomplete_failed(self, tmp_path: Path):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+        process_fn = MagicMock(side_effect=RuntimeError("boom"))
+
+        run_per_dimension_loop(config, ["security"], ctx, process_fn=process_fn)
+
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "incomplete"
+        assert entry["reason"] == "failed_exception"
+
+    def test_cancelled_marks_incomplete_signal(self, tmp_path: Path):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+
+        def cancel_then_raise(*_a, **_kw):
+            cancellation.request_cancel()
+            raise RuntimeError("cancelled mid-flight")
+
+        run_per_dimension_loop(
+            config, ["security"], ctx,
+            process_fn=MagicMock(side_effect=cancel_then_raise),
+        )
+
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "incomplete"
+        assert entry["reason"] == "cancelled_signal"
+
+    def test_ev_none_marks_incomplete(self, tmp_path: Path):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+        process_fn = MagicMock(return_value=None)
+
+        run_per_dimension_loop(config, ["security"], ctx, process_fn=process_fn)
+
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "incomplete"
+
+    def test_mixed_success_and_failure(self, tmp_path: Path):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=2)
+        ev = MagicMock()
+
+        def proc(_cfg, dim, _idx, _ctx):
+            if dim == "security":
+                return ev
+            raise RuntimeError("boom")
+
+        run_per_dimension_loop(
+            config, ["security", "reliability"], ctx,
+            process_fn=MagicMock(side_effect=proc),
+        )
+
+        states = read_dimensions(tmp_path)["dimensions"]
+        assert states["security"]["state"] == "done"
+        assert states["reliability"]["state"] == "incomplete"
+
+
+class TestIncrementalLoopTransitions:
+    def test_successful_dim_marked_done(self, tmp_path: Path, monkeypatch):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+        ev = MagicMock()
+        # Patch the incremental dispatcher so we don't go down the fallback path.
+        monkeypatch.setattr(
+            "quodeq.analysis._loops.run_dimension_incremental",
+            lambda *a, **k: ev,
+        )
+        process_fn = MagicMock()
+        log_result_fn = MagicMock()
+
+        run_incremental_loop(
+            config, ["security"], ctx,
+            process_fn=process_fn, log_result_fn=log_result_fn,
+        )
+
+        assert read_dimensions(tmp_path)["dimensions"]["security"]["state"] == "done"
+
+    def test_incremental_fallback_success_marks_done(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        # The incremental loop uses dataclasses.replace(config, ...) on the
+        # fallback path, so config must be a real RunConfig dataclass instance.
+        options = AnalysisOptions(
+            deadline_at=None,
+            incremental_file_filter=None,
+            skip_scoring=True,
+            incremental=False,
+        )
+        config = RunConfig(src=tmp_path, language="python", work_dir=tmp_path, options=options)
+        ctx = MagicMock(total=1)
+        ev = MagicMock()
+        # Incremental fails, fallback succeeds.
+        monkeypatch.setattr(
+            "quodeq.analysis._loops.run_dimension_incremental",
+            MagicMock(side_effect=RuntimeError("inc failed")),
+        )
+        process_fn = MagicMock(return_value=ev)
+        log_result_fn = MagicMock()
+
+        run_incremental_loop(
+            config, ["security"], ctx,
+            process_fn=process_fn, log_result_fn=log_result_fn,
+        )
+
+        assert read_dimensions(tmp_path)["dimensions"]["security"]["state"] == "done"
+
+    def test_incremental_unexpected_exception_marks_incomplete(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        config = _mk_config(tmp_path)
+        ctx = MagicMock(total=1)
+        # Raise something that's NOT in the (OSError, KeyError, ValueError, RuntimeError) tuple.
+        monkeypatch.setattr(
+            "quodeq.analysis._loops.run_dimension_incremental",
+            MagicMock(side_effect=KeyboardInterrupt("user ctrl-c")),
+        )
+        process_fn = MagicMock()
+        log_result_fn = MagicMock()
+
+        # KeyboardInterrupt would actually propagate -- but the bare Exception
+        # handler catches `except Exception`, which doesn't include KeyboardInterrupt.
+        # Use TypeError instead to test the bare handler.
+        monkeypatch.setattr(
+            "quodeq.analysis._loops.run_dimension_incremental",
+            MagicMock(side_effect=TypeError("unexpected")),
+        )
+
+        run_incremental_loop(
+            config, ["security"], ctx,
+            process_fn=process_fn, log_result_fn=log_result_fn,
+        )
+
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "incomplete"
+        assert entry["reason"] == "failed_exception"

--- a/tests/api/test_evaluation_status_dim_states.py
+++ b/tests/api/test_evaluation_status_dim_states.py
@@ -1,0 +1,110 @@
+"""GET /api/evaluations/<id> surfaces the per-dim state map."""
+from __future__ import annotations
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.services.base import ActionProvider, EvaluationOptions
+from quodeq.services._job_model import JobSnapshot
+from quodeq.shared.dimensions_state import DimState, write_dim_state
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth(monkeypatch):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+
+
+@pytest.fixture()
+def reports_root(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmp:
+        monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", tmp)
+        yield Path(tmp)
+
+
+class _Provider(ActionProvider):
+    """Minimal provider exposing one running job tied to a real run dir."""
+
+    def list_projects(self, reports_dir: str):
+        return {"projects": []}
+
+    def get_project_info(self, reports_dir: str, project: str):
+        return {"project": project}
+
+    def get_dashboard(self, reports_dir: str, project: str, run: str):
+        return {}
+
+    def get_accumulated(self, reports_dir: str, project: str, as_of):
+        return {"summary": {"dimensionCount": 0}}
+
+    def get_dimension_eval(self, reports_dir: str, project: str, run_id: str, dimension: str):
+        return {}
+
+    def get_run_plan(self, reports_dir: str, project: str, run_id: str):
+        return {}
+
+    def get_violations(self, reports_dir: str, project: str, run_id: str):
+        return {"total": 0, "critical": 0, "major": 0, "minor": 0, "files": []}
+
+    def start_evaluation(self, repo, reports_dir, options):
+        return {"jobId": "job-1", "status": "running", "logs": []}
+
+    def get_evaluation_status(self, job_id, reports_dir=None):
+        if job_id != "job-1":
+            return None
+        return JobSnapshot(
+            job_id="job-1", status="running", logs=[],
+            output_project="proj", output_run_id="run-1",
+        )
+
+    def cancel_evaluation(self, job_id, reports_dir=None, *, discard_partial=False):
+        return False
+
+    def list_evaluations(self, *, limit=0, reports_dir=None, states=None):
+        return []
+
+    def delete_project(self, reports_dir, project):
+        return False
+
+    def browse_repo(self, path=None):
+        return {"current": "/", "parent": None, "directories": [], "isGitRepo": False}
+
+    def get_ai_clients(self):
+        return {"clients": []}
+
+    def get_client_models(self, client_id):
+        return {"models": []}
+
+
+@pytest.fixture()
+def client():
+    return create_app(_Provider()).test_client()
+
+
+def test_dim_states_present_in_response(client, reports_root: Path):
+    run_dir = reports_root / "proj" / "run-1"
+    run_dir.mkdir(parents=True)
+    write_dim_state(run_dir, "security", DimState.PENDING)
+    write_dim_state(run_dir, "security", DimState.RUNNING)
+    write_dim_state(run_dir, "security", DimState.DONE)
+    write_dim_state(run_dir, "reliability", DimState.PENDING)
+    write_dim_state(run_dir, "reliability", DimState.RUNNING)
+    write_dim_state(run_dir, "reliability", DimState.INCOMPLETE, reason="cancelled_by_user")
+
+    response = client.get("/api/evaluations/job-1")
+    assert response.status_code == 200
+    payload = response.get_json()
+    states = payload["dimStates"]
+    assert states["security"]["state"] == "done"
+    assert states["reliability"]["state"] == "incomplete"
+    assert states["reliability"]["reason"] == "cancelled_by_user"
+
+
+def test_dim_states_empty_when_run_dir_missing(client):
+    response = client.get("/api/evaluations/job-1")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["dimStates"] == {}

--- a/tests/services/test_score_skips_incomplete_dims.py
+++ b/tests/services/test_score_skips_incomplete_dims.py
@@ -1,0 +1,86 @@
+"""Scoring path skips dims marked incomplete in dimensions.json."""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from quodeq.shared.dimensions_state import DimState, write_dim_state
+
+
+def _seed_run(tmp_path: Path) -> tuple[Path, Path]:
+    reports = tmp_path / "reports"
+    run = reports / "proj" / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evaluation").mkdir(parents=True)
+    return reports, run
+
+
+def _write_evidence_with_marker(run: Path, dim: str, file: str = "a.py") -> None:
+    p = run / "evidence" / f"{dim}_evidence.jsonl"
+    lines = [
+        {"file": file, "req": "R-1", "t": "violation", "line": 1,
+         "severity": "minor", "w": "w", "reason": "r",
+         "p": "Modularity", "d": "maintainability"},
+        {"_marker": "file_done", "file": file, "status": "ok"},
+    ]
+    p.write_text("".join(json.dumps(line) + "\n" for line in lines))
+
+
+def _write_queue(run: Path, dim: str) -> None:
+    queue = run / "evidence" / f"{dim}_queue.json"
+    queue.write_text(json.dumps({
+        "version": 2, "pending": [], "taken": [{"files": ["a.py"], "agent": "a1", "ts": 0}],
+    }))
+
+
+def _write_scan_json(reports: Path, project: str) -> None:
+    scan = reports / project / "scan.json"
+    scan.parent.mkdir(parents=True, exist_ok=True)
+    scan.write_text(json.dumps({"sourceFileCount": 1}))
+
+
+def test_done_dim_scored_incomplete_skipped(tmp_path: Path):
+    from quodeq.services.evaluation_mixin import _score_completed_evidence
+
+    reports, run = _seed_run(tmp_path)
+    _write_scan_json(reports, "proj")
+    _write_evidence_with_marker(run, "d1")
+    _write_evidence_with_marker(run, "d2")
+    _write_queue(run, "d1")
+    _write_queue(run, "d2")
+
+    write_dim_state(run, "d1", DimState.PENDING)
+    write_dim_state(run, "d1", DimState.RUNNING)
+    write_dim_state(run, "d1", DimState.DONE)
+    write_dim_state(run, "d2", DimState.PENDING)
+    write_dim_state(run, "d2", DimState.RUNNING)
+    write_dim_state(run, "d2", DimState.INCOMPLETE, reason="cancelled_by_user")
+
+    _score_completed_evidence(str(reports), {
+        "outputProject": "proj", "outputRunId": "run-1",
+    })
+
+    assert (run / "evaluation" / "d1.json").exists()
+    assert not (run / "evaluation" / "d2.json").exists()
+
+
+def test_idempotent_does_not_rescore(tmp_path: Path):
+    from quodeq.services.evaluation_mixin import _score_completed_evidence
+
+    reports, run = _seed_run(tmp_path)
+    _write_scan_json(reports, "proj")
+    _write_evidence_with_marker(run, "d1")
+    _write_queue(run, "d1")
+    write_dim_state(run, "d1", DimState.PENDING)
+    write_dim_state(run, "d1", DimState.RUNNING)
+    write_dim_state(run, "d1", DimState.DONE)
+
+    _score_completed_evidence(str(reports), {
+        "outputProject": "proj", "outputRunId": "run-1",
+    })
+    first_mtime = (run / "evaluation" / "d1.json").stat().st_mtime_ns
+
+    _score_completed_evidence(str(reports), {
+        "outputProject": "proj", "outputRunId": "run-1",
+    })
+    second_mtime = (run / "evaluation" / "d1.json").stat().st_mtime_ns
+    assert first_mtime == second_mtime

--- a/tests/shared/test_dimensions_state.py
+++ b/tests/shared/test_dimensions_state.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.shared.dimensions_state import (
+    DimState,
+    IllegalDimTransitionError,
+    read_dimensions,
+    write_dim_state,
+)
+
+
+class TestStateMachine:
+    def test_initial_state_is_pending(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        data = read_dimensions(tmp_path)
+        assert data["dimensions"]["security"]["state"] == "pending"
+
+    def test_pending_to_running_to_done(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.DONE)
+        assert read_dimensions(tmp_path)["dimensions"]["security"]["state"] == "done"
+
+    def test_running_to_incomplete_with_reason(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.INCOMPLETE, reason="cancelled_by_user")
+        entry = read_dimensions(tmp_path)["dimensions"]["security"]
+        assert entry["state"] == "incomplete"
+        assert entry["reason"] == "cancelled_by_user"
+
+    def test_done_is_terminal(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "security", DimState.DONE)
+        with pytest.raises(IllegalDimTransitionError):
+            write_dim_state(tmp_path, "security", DimState.RUNNING)
+
+    def test_pending_to_done_illegal(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        with pytest.raises(IllegalDimTransitionError):
+            write_dim_state(tmp_path, "security", DimState.DONE)
+
+    def test_multiple_dims_independent(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        write_dim_state(tmp_path, "security", DimState.RUNNING)
+        write_dim_state(tmp_path, "reliability", DimState.PENDING)
+        data = read_dimensions(tmp_path)
+        assert data["dimensions"]["security"]["state"] == "running"
+        assert data["dimensions"]["reliability"]["state"] == "pending"
+
+    def test_atomic_write_rename(self, tmp_path: Path):
+        write_dim_state(tmp_path, "security", DimState.PENDING)
+        # No leftover .tmp files.
+        assert not (tmp_path / "dimensions.json.tmp").exists()
+
+
+class TestRead:
+    def test_missing_file_returns_empty(self, tmp_path: Path):
+        assert read_dimensions(tmp_path) == {"schema_version": 1, "dimensions": {}}
+
+    def test_corrupt_file_returns_empty(self, tmp_path: Path):
+        (tmp_path / "dimensions.json").write_text("{not json")
+        assert read_dimensions(tmp_path) == {"schema_version": 1, "dimensions": {}}

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -123,3 +123,13 @@ def test_transition_methods(tmp_path: Path) -> None:
         status = read_status(tmp_path)
         assert status["phase"] == "analyzing"
         assert status["current_dimension"] == "security"
+
+
+def test_lifecycle_seeds_dimensions_pending(tmp_path: Path) -> None:
+    """RunLifecycleContext seeds dimensions.json with PENDING entries on enter."""
+    from quodeq.shared.dimensions_state import read_dimensions
+
+    with RunLifecycleContext(run_dir=tmp_path, job_id="j1", dimensions=["a", "b"]):
+        data = read_dimensions(tmp_path)
+        assert data["dimensions"]["a"]["state"] == "pending"
+        assert data["dimensions"]["b"]["state"] == "pending"


### PR DESCRIPTION
## Summary
- New `src/quodeq/shared/dimensions_state.py` per-dim state machine + sibling `dimensions.json` (states: `pending|running|done|incomplete`).
- Lifecycle seeds each dim's state to `pending` on enter; analysis loops write `running` on dispatch start, `done` on success, `incomplete` (with `cancelled_signal` or `failed_exception` reason) on cancel/exception.
- Scoring path (`_score_completed_evidence`) skips dims with `state=incomplete`, so half-finished dims no longer get a `<dim>.json` report on cancel/fail.
- API surfaces a `dimStates` map in `GET /api/evaluations/<id>` so the UI can render incomplete badges.

This is Slice 2 of the spec at `docs/superpowers/specs/2026-05-09-robust-evaluation-cancellation-design.md`. Builds on Slice 1 (#467, merged).

## What this PR does NOT do (later slices)
- Discard wipes V2 cache for incomplete dims (Slice 3)
- UI cancel popup + history badge (Slice 4)
- Consecutive-failure circuit breaker (Slice 5)
- End-to-end integration test (Slice 6)

## Test plan
- [x] `tests/shared/`, `tests/analysis/`, `tests/services/`, `tests/api/` green
- [x] Full repo test suite green (2749 passing)
- [x] Smoke run a real evaluation, confirm `dimensions.json` appears in the run dir with the expected transitions
- [x] Cancel a real evaluation mid-dim, confirm: run report omits the interrupted dim, the API status response shows it as `incomplete`