### PR TITLE
feat: discard wipes V2 cache for incomplete dims

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -163,10 +163,18 @@ def process_dimension_with_cache(
     miss_options = replace(config.options, incremental_file_filter=set(classify.misses))
     miss_config = replace(config, options=miss_options)
 
+    # Persist the per-file cache keys to a sidecar so the discard path can
+    # locate this dim's V2 cache entries even after the process exits. Without
+    # this, a user clicking "discard partial findings" can't wipe entries that
+    # were written by the periodic-persist watcher above.
+    sidecar = _evidence_dir(config) / f"{dim_id}_dispatch_keys.json"
+    sidecar.parent.mkdir(parents=True, exist_ok=True)
+    sidecar.write_text(json.dumps(classify.miss_keys, indent=2), encoding="utf-8")
+
     # Periodic persist watcher: persists what's in JSONL every
     # _PERSIST_INTERVAL_S seconds. If the dispatch is cancelled (SIGTERM,
     # exception, etc.) the cache retains the work that completed before
-    # the cancel — instead of losing the entire dim's progress.
+    # the cancel - instead of losing the entire dim's progress.
     def _persist_now() -> None:
         persist_dispatch_results(
             config, dim_id, miss_files=classify.misses,

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -356,21 +356,32 @@ class FsEvaluationMixin:
         return jobs[:limit] if limit > 0 else jobs
 
 
+def _open_cache():
+    """Indirection so tests can swap in a fake backend."""
+    from quodeq.analysis.cache import LocalFileBackend
+    return LocalFileBackend()
+
+
 def _discard_partial_dim_state(reports_dir: str, job: dict) -> None:
-    """Wipe queue + fingerprint files for any dim that didn't finish scoring.
+    """Wipe queue + fingerprint + V2 cache + JSONL for any dim that didn't finish scoring.
 
     Invoked when the user opts to discard collected findings on cancel.
-    Dims with ``evaluation/<dim>.json`` (cleanly scored) are preserved —
+    Dims with ``evaluation/<dim>.json`` (cleanly scored) are preserved -
     only in-flight ones are reset, so partial work doesn't get accidentally
     discarded just because the umbrella run was stopped.
+
+    For dims marked ``incomplete`` in ``dimensions.json``, also wipes the V2
+    content-addressed cache entries (looked up via the ``<dim>_dispatch_keys.json``
+    sidecar written by the dim runner) and the dim's evidence JSONL.
     """
     project = job.get("outputProject")
     run_id = job.get("outputRunId")
     if not project or not run_id:
         return
 
-    evidence_dir = Path(reports_dir) / project / run_id / "evidence"
-    evaluation_dir = Path(reports_dir) / project / run_id / "evaluation"
+    run_dir = Path(reports_dir) / project / run_id
+    evidence_dir = run_dir / "evidence"
+    evaluation_dir = run_dir / "evaluation"
     if not evidence_dir.is_dir():
         return
 
@@ -390,6 +401,39 @@ def _discard_partial_dim_state(reports_dir: str, job: dict) -> None:
                 pass
             except OSError as exc:
                 _logger.warning("Could not discard %s: %s", victim, exc)
+
+    # V2 cache + JSONL wipe for dims explicitly marked incomplete.
+    from quodeq.shared.dimensions_state import read_dimensions
+    dim_states = read_dimensions(run_dir).get("dimensions", {})
+    cache = None
+    for dim_id, info in dim_states.items():
+        if info.get("state") != "incomplete":
+            continue
+        sidecar = evidence_dir / f"{dim_id}_dispatch_keys.json"
+        if sidecar.is_file():
+            try:
+                keys = json.loads(sidecar.read_text(encoding="utf-8"))
+                if cache is None:
+                    cache = _open_cache()
+                for key in keys.values():
+                    try:
+                        cache.delete(key)
+                    except Exception as exc:  # noqa: BLE001
+                        _logger.warning("Could not delete cache entry %s: %s", key, exc)
+            except (OSError, json.JSONDecodeError) as exc:
+                _logger.warning("Could not read sidecar %s: %s", sidecar, exc)
+        else:
+            _logger.warning(
+                "No dispatch-keys sidecar for incomplete dim %s; skipping cache wipe",
+                dim_id,
+            )
+        jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
+        try:
+            jsonl.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            _logger.warning("Could not delete %s: %s", jsonl, exc)
 
 
 def _read_queue_files_count(queue_path: Path) -> int:

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -359,3 +359,56 @@ class TestWiring:
             _process_single_dimension(config, "security", 1, _make_ctx(), emit_log=False)
 
         assert called["hit"] is True
+
+
+class TestDispatchKeysSidecar:
+    def test_sidecar_written_with_miss_keys(self, tmp_path: Path, cache):
+        from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        sidecar = (config.work_dir or config.src) / "security_dispatch_keys.json"
+        assert sidecar.is_file()
+        keys = json.loads(sidecar.read_text())
+        expected_keys = {
+            "a.py": build_cache_key_for_file(config, "a.py", "security"),
+            "b.py": build_cache_key_for_file(config, "b.py", "security"),
+        }
+        assert keys == expected_keys
+
+    def test_sidecar_skipped_when_all_hits(self, tmp_path: Path, cache):
+        """All-hits short-circuit returns before reaching the dispatch path,
+        so no sidecar is written. Discard for an all-hits dim has nothing
+        to wipe anyway."""
+        from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{"file": "a.py", "line": 1, "t": "violation", "w": "v"}],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        assert dispatcher.calls == []  # confirm we hit the all-hits path
+        sidecar = (config.work_dir or config.src) / "security_dispatch_keys.json"
+        assert not sidecar.exists()

--- a/tests/services/test_discard_wipes_v2_cache.py
+++ b/tests/services/test_discard_wipes_v2_cache.py
@@ -1,0 +1,112 @@
+"""Discard path wipes V2 cache entries + JSONL for incomplete dims."""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.cache import LocalFileBackend, CacheEntry
+from quodeq.shared.dimensions_state import DimState, write_dim_state
+
+
+def _seed_cache_entries(cache_root: Path, keys: list[str]) -> LocalFileBackend:
+    cache = LocalFileBackend(root=cache_root)
+    for k in keys:
+        cache.put(k, CacheEntry(
+            key=k, schema_version=2, findings=[],
+            files_read=1, file_path=f"{k}.py", dimension="d", model_id="m",
+        ))
+    return cache
+
+
+def _seed_run(tmp_path: Path) -> tuple[Path, Path]:
+    reports = tmp_path / "reports"
+    run = reports / "proj" / "run-1"
+    (run / "evidence").mkdir(parents=True)
+    (run / "evaluation").mkdir(parents=True)
+    return reports, run
+
+
+class TestDiscardWipesV2Cache:
+    def test_incomplete_dim_keys_deleted_done_dim_untouched(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        from quodeq.services.evaluation_mixin import _discard_partial_dim_state
+
+        reports, run = _seed_run(tmp_path)
+
+        # Two dims:
+        # - d_inc: incomplete, has 2 cache entries via sidecar
+        # - d_done: cleanly scored
+        (run / "evidence" / "d_inc_dispatch_keys.json").write_text(
+            json.dumps({"a.py": "kkkkk1", "b.py": "kkkkk2"}),
+        )
+        (run / "evidence" / "d_inc_evidence.jsonl").write_text('{"file":"a.py"}\n')
+        (run / "evidence" / "d_inc_queue.json").write_text("{}")
+        (run / "evidence" / "d_done_dispatch_keys.json").write_text(
+            json.dumps({"c.py": "kkkkk3"}),
+        )
+        (run / "evaluation" / "d_done.json").write_text("{}")
+
+        write_dim_state(run, "d_inc", DimState.PENDING)
+        write_dim_state(run, "d_inc", DimState.RUNNING)
+        write_dim_state(run, "d_inc", DimState.INCOMPLETE, reason="cancelled_by_user")
+        write_dim_state(run, "d_done", DimState.PENDING)
+        write_dim_state(run, "d_done", DimState.RUNNING)
+        write_dim_state(run, "d_done", DimState.DONE)
+
+        cache_root = tmp_path / "cache"
+        cache = _seed_cache_entries(cache_root, ["kkkkk1", "kkkkk2", "kkkkk3"])
+        monkeypatch.setattr(
+            "quodeq.services.evaluation_mixin._open_cache",
+            lambda: cache,
+        )
+
+        _discard_partial_dim_state(str(reports), {
+            "outputProject": "proj", "outputRunId": "run-1",
+        })
+
+        assert cache.get("kkkkk1") is None
+        assert cache.get("kkkkk2") is None
+        assert cache.get("kkkkk3") is not None  # done dim untouched
+        assert not (run / "evidence" / "d_inc_evidence.jsonl").exists()
+
+    def test_missing_sidecar_continues_and_wipes_jsonl(
+        self, tmp_path: Path,
+    ):
+        """A crash before the sidecar is written must not block discard."""
+        from quodeq.services.evaluation_mixin import _discard_partial_dim_state
+
+        reports, run = _seed_run(tmp_path)
+        # Dim is incomplete but no sidecar (e.g., crashed before writing it).
+        (run / "evidence" / "d_inc_evidence.jsonl").write_text('{"file":"a.py"}\n')
+        write_dim_state(run, "d_inc", DimState.PENDING)
+        write_dim_state(run, "d_inc", DimState.RUNNING)
+        write_dim_state(run, "d_inc", DimState.INCOMPLETE, reason="failed_exception")
+
+        # Should not raise even with no sidecar.
+        _discard_partial_dim_state(str(reports), {
+            "outputProject": "proj", "outputRunId": "run-1",
+        })
+
+        # JSONL still gets wiped despite the missing sidecar.
+        assert not (run / "evidence" / "d_inc_evidence.jsonl").exists()
+
+    def test_no_dim_states_file_falls_back_to_legacy_behavior(
+        self, tmp_path: Path,
+    ):
+        """Pre-Slice-2 runs (no dimensions.json) still work: only the
+        queue + fingerprint wipe runs, V2 cache is untouched."""
+        from quodeq.services.evaluation_mixin import _discard_partial_dim_state
+
+        reports, run = _seed_run(tmp_path)
+        (run / "evidence" / "d1_queue.json").write_text("{}")
+        (run / "evidence" / "d1_fingerprint.json").write_text("{}")
+
+        # No dimensions.json. Discard should not crash.
+        _discard_partial_dim_state(str(reports), {
+            "outputProject": "proj", "outputRunId": "run-1",
+        })
+
+        assert not (run / "evidence" / "d1_queue.json").exists()
+        assert not (run / "evidence" / "d1_fingerprint.json").exists()


### PR DESCRIPTION
## Summary
- Dim runner persists a `<dim>_dispatch_keys.json` sidecar at dispatch start, recording the per-file V2 cache keys.
- `_discard_partial_dim_state` reads the sidecar for any dim marked `incomplete` in `dimensions.json` and deletes those cache entries plus the dim's `<dim>_evidence.jsonl`.
- Cleanly-finished dims and runs without `dimensions.json` (pre-Slice-2) are untouched.
- Robust to missing sidecar (logs and continues, JSONL still wiped).

This is Slice 3 of the spec. Builds on Slice 1 (#467) and Slice 2 (#468).

## What this PR does NOT do (later slices)
- UI cancel popup with keep/discard buttons (Slice 4) - the API already accepts `?discard=true`.
- Consecutive-failure circuit breaker (Slice 5).
- End-to-end integration test (Slice 6).

## Test plan
- [x] `tests/analysis/cache/` and `tests/services/` green
- [x] Full repo test suite green (2754 passing)
- [x] Smoke run: cancel mid-dim with `DELETE /api/evaluations/<id>?discard=true`, confirm V2 cache for that dim is wiped and a re-run dispatches every file in the dim
- [x] Smoke run with `?discard=false` (the default for now): cache for completed-before-cancel files survives and re-run skips them