### PR TITLE
feat(ui): clarify history partial-run tooltip

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -230,7 +230,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
                     {isPartial && (
                       <span
                         className="chip small history-row__partial-chip"
-                        title="Run was cancelled — some dimensions completed, others didn't"
+                        title="Run cancelled. Some dimensions completed; re-run to finish the rest."
                       >
                         partial
                       </span>


### PR DESCRIPTION
## Summary
Slice 4 of the spec at \`docs/superpowers/specs/2026-05-09-robust-evaluation-cancellation-design.md\`. Most of the planned UI work was already in place from earlier dashboard improvements:

- **Cancel popup (planned S4.A) — already shipped.** \`useEvaluation.js:204\` opens a \`confirmDialog\` with a "Discard collected findings" checkbox; the API client already appends \`?discard=true\`. End-to-end cancel-with-keep / cancel-with-discard works once the backend in PR #469 lands.
- **History incomplete-dim treatment (planned S4.B) — partial chip already exists.** \`HistoryPage.jsx\` shows a "partial" chip on cancelled runs. This PR sharpens the tooltip wording to match the spec ("Run cancelled. Some dimensions completed; re-run to finish the rest.") so the user understands the recovery path.

## What this PR does NOT do (deferred)
A count-based badge (e.g. "2 incomplete") would require extending the run-listing endpoint to surface \`dimStates\` per run. The single-run \`GET /api/evaluations/<id>\` already exposes \`dimStates\` (Slice 2), but the listing endpoint that feeds the History page does not. Tracked as a follow-up.

## Test plan
- [x] Cancel a run mid-dim with "Discard collected findings" checked - verify the next run dispatches every file in the cancelled dim
- [x] Cancel without checking - verify the next run skips the files that completed before cancel
- [x] History row for a cancelled run shows the "partial" chip with the new tooltip on hover