### PR TITLE
feat: consecutive-failure circuit breaker

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -65,7 +65,17 @@ def _run_dir_for(config: RunConfig) -> Path | None:
         return None
 
 
-def _interruption_reason() -> str:
+def _interruption_reason(exc: BaseException | None = None) -> str:
+    """Map a process state and optional exception to a dim-state reason.
+
+    - Circuit-breaker trip: returns 'circuit_breaker' (recognised so the
+      lifecycle exit handler can map to exit_reason=failure_streak).
+    - Cancellation flag set (signal or breaker-via-flag): 'cancelled_signal'.
+    - Otherwise: 'failed_exception'.
+    """
+    from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+    if isinstance(exc, CircuitBreakerError):
+        return "circuit_breaker"
     return "cancelled_signal" if cancellation.is_cancelled() else "failed_exception"
 
 
@@ -141,20 +151,27 @@ def run_incremental_loop(
         emit_marker("analyzing", dimension=dimension)
         log_info(f"-> [{idx}/{ctx.total}] Analyzing {dimension} (incremental)")
         ev: Evidence | None = None
+        last_exc: BaseException | None = None
         try:
             ev = run_dimension_incremental(config, dimension, idx, ctx)
-        except BrokenPipeError:
+        except BrokenPipeError as exc:
             _silence_broken_stdout()
+            last_exc = exc
             ev = None
         except (OSError, KeyError, ValueError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} - incremental failed: {exc}, falling back to full")
+            last_exc = exc
             fallback_options = copy(config.options)
             fallback_options.incremental_file_filter = None
             fallback_config = replace(config, options=fallback_options)
             try:
                 ev = process_fn(fallback_config, dimension, idx, ctx)
-            except BrokenPipeError:
+            except BrokenPipeError as inner_exc:
                 _silence_broken_stdout()
+                last_exc = inner_exc
+                ev = None
+            except Exception as inner_exc:  # noqa: BLE001
+                last_exc = inner_exc
                 ev = None
         except Exception as exc:  # noqa: BLE001
             # Loop-level diagnostic: an unanticipated exception class would
@@ -166,6 +183,7 @@ def run_incremental_loop(
                 f"[loop] {dimension} - unexpected exception "
                 f"{type(exc).__name__}: {exc} - skipping dim, continuing loop",
             )
+            last_exc = exc
             ev = None
         # log_result_fn / on_dimension_done are caller-provided (e.g., the
         # dashboard's scoring callback). Wrap them too - an exception in a
@@ -207,7 +225,7 @@ def run_incremental_loop(
                 )
                 result.setdefault(dimension, ev)
         else:
-            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason(last_exc))
         log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (ev={'set' if ev else 'None'})")
     log_info(
         f"[loop] incremental finished: processed {len(result)} of {len(dimensions)} dim(s) "
@@ -250,16 +268,16 @@ def run_per_dimension_loop(
         ev: Evidence | None = None
         try:
             ev = process_fn(config, dimension, idx, ctx)
-        except BrokenPipeError:
+        except BrokenPipeError as exc:
             _silence_broken_stdout()
             skipped_count += 1
-            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason(exc))
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: broken pipe)")
             continue
         except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as exc:
             log_warning(f"[{idx}/{ctx.total}] {dimension} - failed: {exc}")
             skipped_count += 1
-            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason(exc))
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: {type(exc).__name__})")
             continue
         except Exception as exc:  # noqa: BLE001
@@ -270,7 +288,7 @@ def run_per_dimension_loop(
                 f"{type(exc).__name__}: {exc} - skipping dim, continuing loop",
             )
             skipped_count += 1
-            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason())
+            _safe_write_dim_state(run_dir, dimension, DimState.INCOMPLETE, reason=_interruption_reason(exc))
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: unexpected)")
             continue
         if ev is None:

--- a/src/quodeq/analysis/_types.py
+++ b/src/quodeq/analysis/_types.py
@@ -39,6 +39,10 @@ class AnalysisOptions:
     # persistence and scoring are suppressed — PR runs are evidence-only.
     diff_from: str | None = None
     skip_scoring: bool = False
+    # Consecutive `file_done: error` markers that trip the dim-runner's
+    # circuit breaker. 0 disables. The QUODEQ_FAILURE_STREAK env var,
+    # when set, overrides this default at runtime.
+    failure_streak_threshold: int = 5
 
 
 @dataclass

--- a/src/quodeq/analysis/cache/_failure_streak.py
+++ b/src/quodeq/analysis/cache/_failure_streak.py
@@ -1,0 +1,132 @@
+"""Consecutive-failure circuit breaker for the dim runner.
+
+Tails the dim's evidence JSONL for file_done markers, counts consecutive
+errors, signals run-wide cancellation when the threshold trips. Reuses
+the same cancellation event that SIGTERM triggers, so workers and the
+existing dispatch teardown handle the rest.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from quodeq.shared import cancellation
+
+_logger = logging.getLogger(__name__)
+
+# How often the watcher re-reads the JSONL to find new lines. Small
+# enough that a trip happens within ~poll_interval of the threshold-th
+# error, large enough that we don't spin.
+_POLL_INTERVAL_S = 0.5
+
+
+class CircuitBreakerError(Exception):
+    """Raised by the dim runner when the failure-streak watcher trips.
+
+    Carries the breaker reason so RunLifecycleContext.__exit__ can map
+    it to exit_reason='failure_streak' on the run-level status.
+    """
+
+    def __init__(self, reason: str = "circuit_breaker") -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class FileError:
+    file: str
+    reason: str
+
+
+@dataclass
+class TripEvent:
+    streak: int
+    recent: list[FileError] = field(default_factory=list)
+
+
+class FailureStreakWatcher:
+    """Background watcher that trips cancellation on N consecutive errors."""
+
+    def __init__(self, jsonl_path: Path, *, threshold: int):
+        self._jsonl_path = jsonl_path
+        self._threshold = threshold
+        self._stop = threading.Event()
+        self._tripped = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.trip_event: TripEvent | None = None
+
+    def start(self) -> None:
+        if self._threshold <= 0:
+            # Still start a no-op thread so callers can rely on stop_and_join.
+            self._thread = threading.Thread(target=self._noop, daemon=True)
+        else:
+            self._thread = threading.Thread(
+                target=self._run, daemon=True,
+                name=f"failure-streak-{self._jsonl_path.stem}",
+            )
+        self._thread.start()
+
+    def stop_and_join(self, *, timeout: float = 5.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def wait_for_trip(self, *, timeout: float) -> bool:
+        return self._tripped.wait(timeout=timeout)
+
+    def _noop(self) -> None:
+        self._stop.wait()
+
+    def _run(self) -> None:
+        offset = 0
+        streak = 0
+        recent: list[FileError] = []
+        while not self._stop.is_set():
+            offset, streak, recent = self._scan_once(offset, streak, recent)
+            if streak >= self._threshold and self.trip_event is None:
+                if not cancellation.is_cancelled():
+                    event = TripEvent(streak=streak, recent=list(recent[-self._threshold:]))
+                    self.trip_event = event
+                    _logger.error(
+                        "failure-streak breaker tripped: %d consecutive errors; recent=%s",
+                        streak, [(e.file, e.reason) for e in event.recent],
+                    )
+                    cancellation.request_cancel()
+                self._tripped.set()
+                return  # one trip, then we're done
+            self._stop.wait(timeout=_POLL_INTERVAL_S)
+
+    def _scan_once(
+        self, offset: int, streak: int, recent: list[FileError],
+    ) -> tuple[int, int, list[FileError]]:
+        try:
+            with self._jsonl_path.open("rb") as f:
+                f.seek(offset)
+                chunk = f.read()
+                new_offset = f.tell()
+        except FileNotFoundError:
+            return offset, streak, recent
+        for raw in chunk.splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+            if entry.get("_marker") != "file_done":
+                continue
+            status = entry.get("status")
+            if status == "ok":
+                streak = 0
+                recent = []
+            elif status == "error":
+                streak += 1
+                recent.append(FileError(
+                    file=str(entry.get("file", "?")),
+                    reason=str(entry.get("reason", "")),
+                ))
+        return new_offset, streak, recent

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -30,14 +30,19 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
 from quodeq.analysis._evidence_parser import parse_evidence_from_jsonl
-from quodeq.analysis._types import RunConfig, _AnalysisContext
+from quodeq.analysis._types import AnalysisOptions, RunConfig, _AnalysisContext
 from quodeq.analysis.cache.backend import CacheBackend
+from quodeq.analysis.cache._failure_streak import (
+    CircuitBreakerError,
+    FailureStreakWatcher,
+)
 from quodeq.analysis.cache.dimension_helpers import (
     ClassifyResult,
     classify_files_via_cache,
@@ -59,6 +64,21 @@ _logger = logging.getLogger(__name__)
 # normal runs. 30s is a pragmatic default — at typical model dispatch
 # speeds (~10-30s per file), each tick covers a handful of completed files.
 _PERSIST_INTERVAL_S = 30.0
+
+
+def _resolve_failure_streak_threshold(opts: AnalysisOptions) -> int:
+    """Return the effective breaker threshold.
+
+    Priority: ``QUODEQ_FAILURE_STREAK`` env var > options field. Negative or
+    non-integer env values fall back to the options field. 0 disables.
+    """
+    raw = os.environ.get("QUODEQ_FAILURE_STREAK")
+    if raw is not None:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return max(0, opts.failure_streak_threshold)
 
 
 def _periodic_persist(
@@ -182,6 +202,11 @@ def process_dimension_with_cache(
     )
     watcher.start()
 
+    breaker = FailureStreakWatcher(
+        jsonl, threshold=_resolve_failure_streak_threshold(config.options),
+    )
+    breaker.start()
+
     try:
         miss_evidence = process_dimension_with_subagents(
             miss_config, dim_id, idx, ctx, callbacks,
@@ -192,6 +217,13 @@ def process_dimension_with_cache(
         # returned cleanly or raised.
         stop_event.set()
         watcher.join(timeout=5.0)
+        breaker.stop_and_join(timeout=5.0)
+
+    if breaker.trip_event is not None:
+        # The breaker tripped. Surface a typed exception so the pipeline
+        # layer can mark this dim's state with reason=circuit_breaker and
+        # the lifecycle layer can record exit_reason=failure_streak.
+        raise CircuitBreakerError("circuit_breaker")
 
     if miss_evidence is None:
         # Dispatch returned None — final persist already ran via the

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -115,6 +115,12 @@ class RunLifecycleContext:
                 if self._current_state != RunState.FINALIZING:
                     self._transition(RunState.FINALIZING)
                 self._transition(RunState.DONE)
+        elif self._is_circuit_breaker_error(exc_type):
+            # Circuit breaker tripped — auto-protection, not user cancel.
+            # Distinct exit_reason makes the History entry distinguishable
+            # from regular failures so the UI can surface it differently.
+            if self._current_state not in TERMINAL_STATES:
+                self._transition(RunState.FAILED, exit_reason="failure_streak")
         else:
             # Any other exception → failed.
             if self._current_state not in TERMINAL_STATES:
@@ -167,6 +173,21 @@ class RunLifecycleContext:
                 write_dim_state(self._run_dir, dim, DimState.PENDING)
             except Exception as exc:  # noqa: BLE001
                 _logger.warning("failed to seed dim state for %s: %s", dim, exc)
+
+    @staticmethod
+    def _is_circuit_breaker_error(exc_type: type[BaseException] | None) -> bool:
+        """Detect CircuitBreakerError without a hard import dependency.
+
+        Lifecycle is a shared/low-level module; importing from analysis.cache
+        would invert the dependency graph. Class-name match is enough since
+        we control both ends.
+        """
+        if exc_type is None:
+            return False
+        for cls in exc_type.__mro__:
+            if cls.__name__ == "CircuitBreakerError":
+                return True
+        return False
 
     def _install_signal_handlers(self) -> None:
         def _handle(signum: int, frame: Any) -> None:

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -21,6 +21,7 @@ state and the dispatcher call recorder.
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -359,3 +360,91 @@ class TestWiring:
             _process_single_dimension(config, "security", 1, _make_ctx(), emit_log=False)
 
         assert called["hit"] is True
+
+
+# ============================================================
+# Circuit breaker (Slice 5)
+# ============================================================
+
+
+class TestCircuitBreakerWiring:
+    def test_breaker_trips_and_raises(self, tmp_path: Path, cache, monkeypatch):
+        """Threshold=2 + dispatcher emits 2 error markers => CircuitBreakerError."""
+        from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+        from quodeq.shared import cancellation
+        cancellation.reset()
+
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y", "c.py": "z"})
+        config = replace(config, options=replace(config.options, failure_streak_threshold=2))
+
+        evidence_dir = config.work_dir or config.src
+
+        def err_dispatcher(config, dim_id, idx, ctx, callbacks):
+            jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": "a.py",
+                    "status": "error", "reason": "token_limit",
+                }) + "\n")
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": "b.py",
+                    "status": "error", "reason": "token_limit",
+                }) + "\n")
+            # Give the watcher's poll loop time to read both errors and trip.
+            import time as _time
+            _time.sleep(1.0)
+            return _make_dummy_evidence(files_read=2)
+
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=err_dispatcher,
+            ):
+                with pytest.raises(CircuitBreakerError) as excinfo:
+                    process_dimension_with_cache(
+                        config, "security", idx=1, ctx=_make_ctx(),
+                        callbacks=_make_callbacks(), cache=cache,
+                    )
+            assert excinfo.value.reason == "circuit_breaker"
+            assert cancellation.is_cancelled()
+        finally:
+            cancellation.reset()
+
+    def test_breaker_disabled_when_threshold_zero(
+        self, tmp_path: Path, cache, monkeypatch,
+    ):
+        """threshold=0 disables the breaker even with many error markers."""
+        from quodeq.shared import cancellation
+        cancellation.reset()
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        config = replace(config, options=replace(config.options, failure_streak_threshold=0))
+
+        evidence_dir = config.work_dir or config.src
+
+        def err_dispatcher(config, dim_id, idx, ctx, callbacks):
+            jsonl = evidence_dir / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                for i in range(10):
+                    out.write(json.dumps({
+                        "_marker": "file_done", "file": f"f{i}.py",
+                        "status": "error",
+                    }) + "\n")
+            return _make_dummy_evidence(files_read=10)
+
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=err_dispatcher,
+            ):
+                # Should NOT raise CircuitBreakerError.
+                ev = process_dimension_with_cache(
+                    config, "security", idx=1, ctx=_make_ctx(),
+                    callbacks=_make_callbacks(), cache=cache,
+                )
+            assert ev is not None
+            assert not cancellation.is_cancelled()
+        finally:
+            cancellation.reset()

--- a/tests/analysis/cache/test_failure_streak_breaker.py
+++ b/tests/analysis/cache/test_failure_streak_breaker.py
@@ -1,0 +1,99 @@
+"""Consecutive-failure circuit breaker for the dim runner."""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.shared import cancellation
+from quodeq.analysis.cache._failure_streak import (
+    FailureStreakWatcher,
+    TripEvent,
+    CircuitBreakerError,
+)
+
+
+def _append(jsonl: Path, line: dict) -> None:
+    with jsonl.open("a") as f:
+        f.write(json.dumps(line) + "\n")
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+class TestFailureStreakBreaker:
+    def test_no_trip_with_streak_below_threshold(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        watcher.start()
+        for _ in range(4):
+            _append(jsonl, {"_marker": "file_done", "file": "x", "status": "error", "reason": "token_limit"})
+        _append(jsonl, {"_marker": "file_done", "file": "x", "status": "ok"})
+        for _ in range(4):
+            _append(jsonl, {"_marker": "file_done", "file": "x", "status": "error", "reason": "token_limit"})
+        watcher.stop_and_join(timeout=5.0)
+        assert not cancellation.is_cancelled()
+        assert watcher.trip_event is None
+
+    def test_trip_at_threshold(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        watcher.start()
+        for i in range(5):
+            _append(jsonl, {"_marker": "file_done", "file": f"f{i}.py", "status": "error", "reason": "token_limit"})
+        watcher.wait_for_trip(timeout=5.0)
+        watcher.stop_and_join(timeout=5.0)
+        assert cancellation.is_cancelled()
+        assert isinstance(watcher.trip_event, TripEvent)
+        assert watcher.trip_event.streak == 5
+        assert len(watcher.trip_event.recent) == 5
+        assert watcher.trip_event.recent[0].reason == "token_limit"
+
+    def test_threshold_zero_disables(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        watcher = FailureStreakWatcher(jsonl, threshold=0)
+        watcher.start()
+        for _ in range(100):
+            _append(jsonl, {"_marker": "file_done", "file": "x", "status": "error"})
+        watcher.stop_and_join(timeout=5.0)
+        assert not cancellation.is_cancelled()
+
+    def test_threshold_one_trips_immediately(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        watcher = FailureStreakWatcher(jsonl, threshold=1)
+        watcher.start()
+        _append(jsonl, {"_marker": "file_done", "file": "x", "status": "error", "reason": "parse_error"})
+        watcher.wait_for_trip(timeout=5.0)
+        watcher.stop_and_join(timeout=5.0)
+        assert cancellation.is_cancelled()
+
+    def test_already_cancelled_does_not_double_trip(self, tmp_path: Path):
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+        cancellation.request_cancel()
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        watcher.start()
+        for _ in range(10):
+            _append(jsonl, {"_marker": "file_done", "file": "x", "status": "error"})
+        watcher.stop_and_join(timeout=5.0)
+        # The watcher sees cancellation already set and does not record a trip event.
+        assert watcher.trip_event is None
+
+
+class TestCircuitBreakerError:
+    def test_error_has_reason(self):
+        exc = CircuitBreakerError("circuit_breaker")
+        assert str(exc) == "circuit_breaker"
+        assert exc.reason == "circuit_breaker"
+
+    def test_default_reason(self):
+        exc = CircuitBreakerError()
+        assert exc.reason == "circuit_breaker"

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -133,3 +133,22 @@ def test_lifecycle_seeds_dimensions_pending(tmp_path: Path) -> None:
         data = read_dimensions(tmp_path)
         assert data["dimensions"]["a"]["state"] == "pending"
         assert data["dimensions"]["b"]["state"] == "pending"
+
+
+def test_breaker_exit_writes_failed_with_reason(tmp_path: Path) -> None:
+    """CircuitBreakerError raised from inside the lifecycle context maps
+    to state=failed with exit_reason=failure_streak."""
+    from quodeq.analysis.cache._failure_streak import CircuitBreakerError
+
+    raised = False
+    try:
+        with RunLifecycleContext(run_dir=tmp_path, job_id="j1", dimensions=["a"]):
+            raise CircuitBreakerError("circuit_breaker")
+    except CircuitBreakerError:
+        raised = True
+
+    assert raised
+    status = read_status(tmp_path)
+    assert status is not None
+    assert status["state"] == "failed"
+    assert status["exit_reason"] == "failure_streak"


### PR DESCRIPTION
## Summary
Adds an automatic stop when a dimension's worker abandons N files in a row. Default threshold = 5, configurable via \`AnalysisOptions.failure_streak_threshold\` and the \`QUODEQ_FAILURE_STREAK\` env var (0 disables).

- New \`FailureStreakWatcher\` thread (`src/quodeq/analysis/cache/_failure_streak.py`) tails the dim's evidence JSONL by byte offset, counts consecutive \`file_done: error\` markers, calls \`cancellation.request_cancel()\` on trip and stores a \`TripEvent\` with the recent file/reason pairs for diagnostics.
- New \`CircuitBreakerError\` exception is raised by \`process_dimension_with_cache\` when the trip is detected, so the analysis loop and the lifecycle layer can write the right reason.
- \`_loops.py\` maps \`CircuitBreakerError\` to dim-state \`reason=circuit_breaker\` (vs \`cancelled_signal\` / \`failed_exception\`).
- \`run_lifecycle.py\` recognises the exception by class name (no import-graph inversion) and writes run-level \`state=failed\` with \`exit_reason=failure_streak\`. Cancel-by-user (\`SystemExit\` from the signal handler) still wins if it fires first.
- Subsequent dims naturally skip because the cancellation flag is sticky within a run, leaving them in PENDING state.

This is Slice 5 of the spec at \`docs/superpowers/specs/2026-05-09-robust-evaluation-cancellation-design.md\`. Builds on Slices 1+2 (#467, #468 merged). PRs #469 and #470 are independent.

## What this PR does NOT do
- End-to-end integration test (Slice 6) - the unit-level breaker tests are in this PR (\`tests/analysis/cache/test_failure_streak_breaker.py\`); the e2e composition test follows.
- UI badge for breaker-tripped runs - "Auto-stopped: N file failures in a row" - is deferred per the spec ("lower priority than the core fix; can land in a follow-up").

## Test plan
- [x] \`tests/analysis/cache/test_failure_streak_breaker.py\` - 7 tests for the watcher in isolation
- [x] \`tests/analysis/cache/test_dimension_runner.py\` - 2 new tests for the breaker wired into the dim runner (trips on threshold; \`threshold=0\` disables)
- [x] \`tests/shared/test_run_lifecycle.py\` - new test that the lifecycle exit handler maps \`CircuitBreakerError\` to \`failed\` + \`exit_reason=failure_streak\`
- [x] Full repo test suite green (2759 passing)
- [x] Smoke run: configure a model that fails on every file, set \`QUODEQ_FAILURE_STREAK=3\`, confirm the run stops after 3 errors with run state \`failed\` and \`exit_reason=failure_streak\`