### PR TITLE
fix(api): route API runner through FindingsRouter so it emits file_done markers

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -8,7 +8,6 @@ Requires the ``quodeq[api]`` extra: ``pip install 'quodeq[api]'``
 """
 from __future__ import annotations
 
-import io
 import json
 import logging
 import os
@@ -134,8 +133,15 @@ def _salvage_partial_findings(raw_json: str) -> list[dict]:
     return findings
 
 
-def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
-    """Call LLM via Instructor — returns validated finding dicts.
+def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
+    """Call LLM via Instructor and return ``(findings, was_salvaged)``.
+
+    A clean Instructor return means we know the LLM analysed every file in
+    the prompt. If we fall through to the salvage path, the response was
+    malformed and we extracted whatever flat finding objects we could --
+    we can no longer trust which files were actually completed end-to-end,
+    so callers must NOT emit per-file ``mark_file_done: ok`` markers in
+    that case. See ``run_api_analysis`` for the marker contract.
 
     The OpenAI client owns an httpx connection pool whose sockets count
     against the process FD limit. Without an explicit close, a long scan
@@ -177,16 +183,16 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> list[dict]:
         try:
             result = client.chat.completions.create(**create_kwargs)
             _log.debug("Instructor returned %d findings", len(result.findings))
-            return [f.model_dump() for f in result.findings]
+            return [f.model_dump() for f in result.findings], False
         except Exception as exc:
             # Try to salvage valid findings from the malformed response
             raw = str(exc)
             salvaged = _salvage_partial_findings(raw)
             if salvaged:
                 _log.debug("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
-                return salvaged
+                return salvaged, True
             _log.debug("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
-            return []
+            return [], True
 
 
 # ---------------------------------------------------------------------------
@@ -213,23 +219,25 @@ def _infer_end_line(findings: list[dict]) -> None:
             f["end_line"] = line + n - 1
 
 
-def _enrich_findings(
-    findings: list[dict],
+def _build_router_context(
     compiled_dir: Path | None,
     dimension: str | None,
     work_dir: Path | None,
-    project_dir: Path | None = None,
-) -> list[dict]:
-    """Enrich findings through FindingsRouter (same as MCP path)."""
-    _infer_end_line(findings)
+    project_dir: Path | None,
+) -> CompiledContext | None:
+    """Build the CompiledContext that FindingsRouter needs for enrichment.
+
+    Returns ``None`` when *compiled_dir* is unset, signalling that the
+    caller should write findings without enrichment (legacy behaviour).
+    """
     if not compiled_dir:
-        return findings
+        return None
     try:
         compiled_refs = load_compiled_refs(compiled_dir, dimension) or {}
         compiled_reqs = load_compiled_requirements(compiled_dir, dimension) or {}
         project_shape = detect_shape(work_dir) if work_dir is not None else None
         precedents = load_precedent_fingerprints(project_dir) if project_dir else set()
-        ctx = CompiledContext(
+        return CompiledContext(
             compiled_refs=compiled_refs,
             compiled_reqs=compiled_reqs,
             dimension=dimension,
@@ -237,16 +245,9 @@ def _enrich_findings(
             project_shape=project_shape,
             precedent_fingerprints=precedents,
         )
-
-        buf = io.StringIO()
-        router = FindingsRouter(buf, context=ctx)
-        for f in findings:
-            router.receive(f)
-        buf.seek(0)
-        return [json.loads(line) for line in buf if line.strip()]
     except Exception as exc:
-        _log.warning("Could not enrich findings: %s — writing raw", exc)
-        return findings
+        _log.warning("Could not build enrichment context: %s -- writing raw", exc)
+        return None
 
 
 def _resolve_file_paths(findings: list[dict], source_paths: list[str]) -> list[dict]:
@@ -277,20 +278,53 @@ def run_api_analysis(
     work_dir: Path | None = None,
     source_file_paths: list[str] | None = None,
 ) -> None:
-    """Call an LLM API and write findings to JSONL."""
-    findings = _call_api(prompt, config)
+    """Call an LLM API and persist evidence through ``FindingsRouter``.
+
+    Both the CLI/MCP path and this API path write per-dim evidence through
+    a single canonical sink (``FindingsRouter``). The router owns:
+
+    - Atomic per-line writes (concurrency-safe with sibling writers).
+    - Finding dedup + enrichment via the compiled standards context.
+    - The ``mark_file_done`` per-file completion marker that drives the
+      V2 cache's ``ok_files`` filter (``analysis/cache/dimension_helpers.py``).
+
+    Marker contract:
+        On a clean Instructor return, every file in *source_file_paths* gets
+        an ``ok`` marker -- the API call analysed all of them in one shot.
+        On the salvage path (malformed JSON, partial recovery) we cannot
+        prove which files were actually completed, so no markers are emitted
+        and the cache will dispatch all of them on the next run. Same
+        guarantee as the CLI path: a file is only ever marked ``ok`` when
+        analysis genuinely finished.
+
+    *source_file_paths* should be the full per-dim file list. When omitted,
+    no markers are emitted (preserves caller flexibility but the run will
+    not benefit from V2 cache hits across re-runs).
+    """
+    findings, was_salvaged = _call_api(prompt, config)
 
     if source_file_paths:
         findings = _resolve_file_paths(findings, source_file_paths)
+
+    _infer_end_line(findings)
 
     # jsonl_file is `<project_dir>/<run_id>/evidence/<dim>_evidence.jsonl`,
     # so the project directory is its great-grandparent. Used by the
     # context-enricher pipeline to load prior dismissals as precedents.
     project_dir = jsonl_file.parent.parent.parent if jsonl_file else None
-    findings = _enrich_findings(findings, compiled_dir, dimension, work_dir, project_dir)
+    ctx = _build_router_context(compiled_dir, dimension, work_dir, project_dir)
 
-    _log.debug("Received %d findings from API", len(findings))
+    _log.debug(
+        "API runner: %d findings, salvaged=%s, marking %d files",
+        len(findings), was_salvaged,
+        len(source_file_paths) if source_file_paths and not was_salvaged else 0,
+    )
 
+    jsonl_file.parent.mkdir(parents=True, exist_ok=True)
     with open(jsonl_file, "a") as fh:
-        for finding in findings:
-            fh.write(json.dumps(finding) + "\n")
+        router = FindingsRouter(fh, context=ctx)
+        for f in findings:
+            router.receive(f)
+        if not was_salvaged and source_file_paths:
+            for path in source_file_paths:
+                router.mark_file_done(file=path, status="ok")

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -194,12 +194,30 @@ def _default_read_file(path: Path) -> str:
 
 
 class FindingsRouter:
-    """Deduplicates and enriches findings before writing to JSONL.
+    """Canonical sink for per-dimension JSONL evidence.
 
-    - Dedup by (principle, file, line, type) -- skips duplicate findings
-    - Auto-fills principle name (p) and dimension (d) from req ID
-    - Enriches req_refs from compiled standards -- LLM doesn't need to pick refs
-    - Returns feedback to the LLM so it can move on from duplicates
+    Every provider path that writes ``<dim>_evidence.jsonl`` MUST go through
+    a router instance:
+
+    - **CLI/MCP path:** the agent calls ``report_finding`` and ``mark_file_done``
+      MCP tools; the dispatcher in ``mcp/handlers.py`` forwards each call to
+      this router via ``receive`` / ``mark_file_done``.
+    - **API/Instructor path:** ``analysis/_api_runner.py`` opens the JSONL,
+      constructs a router pointed at that file handle, and calls ``receive``
+      per finding plus ``mark_file_done`` per source file on a clean return.
+    - **Future paths:** any new provider integration uses this same surface.
+      Adding a path that bypasses the router is a regression because the V2
+      cache layer (``analysis/cache/dimension_helpers.py``) only persists
+      files with a ``mark_file_done: ok`` marker -- without one, every run
+      re-dispatches every file.
+
+    Beyond the marker contract, the router owns:
+    - Atomic per-line writes via ``_locked_write`` (concurrency-safe).
+    - Dedup by (principle, file, line, type) -- skips duplicate findings.
+    - Auto-fills principle name (``p``) and dimension (``d``) from the req ID.
+    - Enriches ``req_refs`` from compiled standards.
+    - Returns feedback strings to the LLM for the ``Duplicate`` / ``Recorded``
+      flow when called from the MCP handler.
     """
 
     def __init__(

--- a/tests/analysis/test_api_integration.py
+++ b/tests/analysis/test_api_integration.py
@@ -78,12 +78,12 @@ class TestApiIntegration:
             )
 
         assert jsonl_file.exists()
-        lines = jsonl_file.read_text().strip().split("\n")
-        assert len(lines) == 1
-        finding = json.loads(lines[0])
-        assert finding["req"] == "S-CON-3"
-        assert finding["t"] == "violation"
-        assert finding["severity"] == "critical"
+        all_lines = [json.loads(ln) for ln in jsonl_file.read_text().splitlines() if ln.strip()]
+        findings = [ln for ln in all_lines if "_marker" not in ln]
+        assert len(findings) == 1
+        assert findings[0]["req"] == "S-CON-3"
+        assert findings[0]["t"] == "violation"
+        assert findings[0]["severity"] == "critical"
         assert stream_file.exists()
 
     def test_full_flow_openai_compatible(self, source_repo, tmp_path):
@@ -117,7 +117,7 @@ class TestApiIntegration:
             )
 
         assert jsonl_file.exists()
-        lines = jsonl_file.read_text().strip().split("\n")
-        assert len(lines) == 1
-        finding = json.loads(lines[0])
-        assert finding["req"] == "S-CON-3"
+        all_lines = [json.loads(ln) for ln in jsonl_file.read_text().splitlines() if ln.strip()]
+        findings = [ln for ln in all_lines if "_marker" not in ln]
+        assert len(findings) == 1
+        assert findings[0]["req"] == "S-CON-3"

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -113,8 +113,10 @@ class TestRunApiAnalysis:
                 source_file_paths=["src/myproject/app.py"],
             )
 
-        finding = json.loads(jsonl_file.read_text().strip())
-        assert finding["file"] == "src/myproject/app.py"
+        lines = [json.loads(ln) for ln in jsonl_file.read_text().splitlines() if ln.strip()]
+        findings = [ln for ln in lines if "_marker" not in ln]
+        assert len(findings) == 1
+        assert findings[0]["file"] == "src/myproject/app.py"
 
     def test_retries_configured(self, tmp_path, api_config):
         """Verify max_retries is passed to Instructor."""
@@ -132,6 +134,126 @@ class TestRunApiAnalysis:
 
             call_kwargs = mock_client.chat.completions.create.call_args.kwargs
             assert call_kwargs["max_retries"] == 1
+
+
+class TestMarkerContract:
+    """API runner emits file_done markers so the V2 cache can record
+    completion. The CLI/MCP path emits these via the agent calling
+    `mark_file_done`; the API path is one-shot and emits them itself
+    after a clean Instructor return.
+
+    Regression: before this, the API runner wrote findings to JSONL
+    directly, bypassing FindingsRouter and the marker contract. Cache
+    saw zero ok_files for every API run, so cancel-then-restart never
+    benefited from prior work. See spec/cancellation design v2.
+    """
+
+    def _read_jsonl(self, jsonl_file: Path) -> list[dict]:
+        return [json.loads(ln) for ln in jsonl_file.read_text().splitlines() if ln.strip()]
+
+    def _findings_only(self, lines: list[dict]) -> list[dict]:
+        return [ln for ln in lines if "_marker" not in ln]
+
+    def _markers(self, lines: list[dict]) -> list[dict]:
+        return [ln for ln in lines if ln.get("_marker") == "file_done"]
+
+    def test_clean_call_emits_ok_marker_per_source_file(self, tmp_path, api_config):
+        jsonl_file = tmp_path / "evidence.jsonl"
+        findings = _make_findings(
+            ("M-MOD-1", "violation", "src/a.py", 5, "major", "x"),
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = findings
+
+        with patch("quodeq.analysis._api_runner.instructor") as mock_inst:
+            mock_inst.from_openai.return_value = mock_client
+            mock_inst.Mode.JSON = "json"
+
+            run_api_analysis(
+                prompt="t", jsonl_file=jsonl_file, config=api_config,
+                source_file_paths=["src/a.py", "src/b.py", "src/c.py"],
+            )
+
+        lines = self._read_jsonl(jsonl_file)
+        markers = self._markers(lines)
+        marked_files = {m["file"] for m in markers}
+        assert marked_files == {"src/a.py", "src/b.py", "src/c.py"}
+        assert all(m["status"] == "ok" for m in markers)
+
+    def test_clean_call_with_zero_findings_still_marks_files(self, tmp_path, api_config):
+        """A clean file (no findings) is still completed analysis -- mark it ok."""
+        jsonl_file = tmp_path / "evidence.jsonl"
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _Findings(findings=[])
+
+        with patch("quodeq.analysis._api_runner.instructor") as mock_inst:
+            mock_inst.from_openai.return_value = mock_client
+            mock_inst.Mode.JSON = "json"
+
+            run_api_analysis(
+                prompt="t", jsonl_file=jsonl_file, config=api_config,
+                source_file_paths=["src/clean.py"],
+            )
+
+        lines = self._read_jsonl(jsonl_file)
+        assert self._findings_only(lines) == []
+        markers = self._markers(lines)
+        assert len(markers) == 1
+        assert markers[0]["file"] == "src/clean.py"
+        assert markers[0]["status"] == "ok"
+
+    def test_salvaged_response_does_not_emit_markers(self, tmp_path, api_config):
+        """When the response was malformed and we salvaged partial findings,
+        we don't know which files were actually analyzed end-to-end. Don't
+        lie about completion -- leave markers off so the next run re-runs."""
+        jsonl_file = tmp_path / "evidence.jsonl"
+
+        mock_client = MagicMock()
+        # Force the salvage path: Instructor raises, but the raw exception
+        # message contains a single salvageable finding object.
+        salvage_payload = json.dumps({
+            "req": "X-1", "t": "violation", "file": "src/a.py", "line": 1,
+            "severity": "minor", "w": "x", "snippet": "code", "reason": "r",
+        })
+        mock_client.chat.completions.create.side_effect = RuntimeError(salvage_payload)
+
+        with patch("quodeq.analysis._api_runner.instructor") as mock_inst:
+            mock_inst.from_openai.return_value = mock_client
+            mock_inst.Mode.JSON = "json"
+
+            run_api_analysis(
+                prompt="t", jsonl_file=jsonl_file, config=api_config,
+                source_file_paths=["src/a.py", "src/b.py"],
+            )
+
+        lines = self._read_jsonl(jsonl_file)
+        # Salvaged finding(s) are still written.
+        assert any(ln.get("req") == "X-1" for ln in self._findings_only(lines))
+        # But NO markers -- cancel-then-restart will re-run all files.
+        assert self._markers(lines) == []
+
+    def test_no_source_files_no_markers(self, tmp_path, api_config):
+        """Backward-compat: callers that don't pass source_file_paths get
+        finding writes only -- the CLI dim runner is the typical caller and
+        that's expected when the whole-dim file list isn't known here."""
+        jsonl_file = tmp_path / "evidence.jsonl"
+        findings = _make_findings(("X-1", "violation", "a.py", 1, "minor", "x"))
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = findings
+
+        with patch("quodeq.analysis._api_runner.instructor") as mock_inst:
+            mock_inst.from_openai.return_value = mock_client
+            mock_inst.Mode.JSON = "json"
+
+            run_api_analysis(
+                prompt="t", jsonl_file=jsonl_file, config=api_config,
+                source_file_paths=None,
+            )
+
+        lines = self._read_jsonl(jsonl_file)
+        assert self._markers(lines) == []
+        assert len(self._findings_only(lines)) == 1
 
 
 class TestApiRunnerConfig:

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -11,8 +11,8 @@ instructor = pytest.importorskip("instructor", reason="requires quodeq[api] extr
 
 from quodeq.analysis._api_runner import (
     ApiRunnerConfig,
+    _build_router_context,
     _call_api,
-    _enrich_findings,
     _Finding,
     _Findings,
     _FindingType,
@@ -148,6 +148,25 @@ class TestCallApi:
             api_key="ollama",
         )
 
+    def test_returns_clean_flag_on_success(self):
+        config = ApiRunnerConfig(
+            model="llama3.1", api_base="http://localhost:11434/v1",
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = _Findings(findings=[
+            _Finding(req="X-1", t=_FindingType.violation, file="a.py", line=1,
+                     severity=_Severity.minor, w="x", snippet="code", reason="r"),
+        ])
+
+        with patch("quodeq.analysis._api_runner.instructor") as mock_inst, \
+             patch("quodeq.analysis._api_runner.openai"):
+            mock_inst.from_openai.return_value = mock_client
+            mock_inst.Mode.JSON = "json"
+            findings, salvaged = _call_api("test", config)
+
+        assert len(findings) == 1
+        assert salvaged is False
+
     def test_salvages_on_exception(self):
         config = ApiRunnerConfig(
             model="llama3.1", api_base="http://localhost:11434/v1",
@@ -161,9 +180,10 @@ class TestCallApi:
              patch("quodeq.analysis._api_runner.openai"):
             mock_inst.from_openai.return_value = mock_client
             mock_inst.Mode.JSON = "json"
-            result = _call_api("test", config)
+            findings, salvaged = _call_api("test", config)
 
-        assert len(result) >= 1
+        assert len(findings) >= 1
+        assert salvaged is True
 
     def test_returns_empty_on_unsalvageable_error(self):
         config = ApiRunnerConfig(
@@ -176,9 +196,10 @@ class TestCallApi:
              patch("quodeq.analysis._api_runner.openai"):
             mock_inst.from_openai.return_value = mock_client
             mock_inst.Mode.JSON = "json"
-            result = _call_api("test", config)
+            findings, salvaged = _call_api("test", config)
 
-        assert result == []
+        assert findings == []
+        assert salvaged is True
 
 
 # ---------------------------------------------------------------------------
@@ -216,23 +237,23 @@ class TestResolveFilePaths:
 
 
 # ---------------------------------------------------------------------------
-# _enrich_findings
+# _build_router_context
 # ---------------------------------------------------------------------------
 
-class TestEnrichFindings:
-    def test_returns_raw_when_no_compiled_dir(self):
-        findings = [{"req": "X-1", "file": "a.py"}]
-        result = _enrich_findings(findings, None, None, None)
-        assert result == findings
+class TestBuildRouterContext:
+    def test_returns_none_without_compiled_dir(self):
+        """Without a compiled standards dir there is no enrichment context to
+        build. Callers fall back to a default-context router (still emits
+        markers and writes findings, just no req-ref enrichment)."""
+        assert _build_router_context(None, None, None, None) is None
 
-    def test_returns_raw_on_import_error(self):
-        findings = [{"req": "X-1", "file": "a.py"}]
-        with patch("quodeq.analysis._api_runner.json") as mock_json:
-            # Simulate the enrichment failing
-            with patch.dict("sys.modules", {"quodeq.analysis.mcp.router": None}):
-                result = _enrich_findings(findings, Path("/nonexistent"), "security", None)
-        # Should fall back to raw findings
-        assert len(result) >= 1
+    def test_returns_none_on_load_failure(self):
+        """A broken compiled dir must not propagate -- the API runner needs
+        to keep writing findings + markers even when enrichment fails."""
+        with patch("quodeq.analysis._api_runner.load_compiled_refs",
+                   side_effect=OSError("boom")):
+            ctx = _build_router_context(Path("/nonexistent"), "security", None, None)
+        assert ctx is None
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +284,10 @@ class TestRunApiAnalysisAppend:
         assert json.loads(lines[0])["req"] == "existing"
         assert json.loads(lines[1])["req"] == "NEW-1"
 
-    def test_enrichment_called_with_compiled_dir(self, tmp_path):
+    def test_router_context_built_when_compiled_dir_provided(self, tmp_path):
+        """When a compiled dir is passed, the API runner builds a router
+        context for enrichment. Without it, the router falls back to a
+        default context (no enrichment) but still writes findings + markers."""
         jsonl = tmp_path / "evidence.jsonl"
         config = ApiRunnerConfig(model="m", api_base="http://localhost/v1")
         findings = _Findings(findings=[
@@ -275,11 +299,15 @@ class TestRunApiAnalysisAppend:
 
         with patch("quodeq.analysis._api_runner.instructor") as mock_inst, \
              patch("quodeq.analysis._api_runner.openai"), \
-             patch("quodeq.analysis._api_runner._enrich_findings", return_value=[{"req": "X-1", "enriched": True}]) as mock_enrich:
+             patch("quodeq.analysis._api_runner._build_router_context",
+                   return_value=None) as mock_ctx:
             mock_inst.from_openai.return_value = mock_client
             mock_inst.Mode.JSON = "json"
             run_api_analysis(
                 prompt="test", jsonl_file=jsonl, config=config,
                 compiled_dir=tmp_path, dimension="security",
             )
-            mock_enrich.assert_called_once()
+            mock_ctx.assert_called_once()
+            args = mock_ctx.call_args.args
+            assert args[0] == tmp_path  # compiled_dir
+            assert args[1] == "security"  # dimension


### PR DESCRIPTION
## The bug
You reported: "I start a session. I cancel. I start again and didn't store the previous parsed data."

Confirmed via a real run on disk at \`~/.quodeq/evaluations/.../e03f00f6.../evidence/flexibility_evidence.jsonl\` -- 19 finding lines, **0 \`mark_file_done\` markers**. Stream file says \`{"type":"api_runner","status":"complete"}\` -- this is the API/Instructor path. Without markers, the V2 cache (PR #467) refuses to cache anything, so every cancel-then-restart re-dispatches every file.

## Root cause
PR #467 added the \`mark_file_done\` marker contract to the CLI/MCP path only. \`src/quodeq/analysis/_api_runner.py:294-296\` was writing findings to JSONL through a separate code path that bypassed \`FindingsRouter\` -- it used the router only for enrichment (via a \`StringIO\` round-trip) and then wrote findings to disk through a raw \`for finding in findings: fh.write(...)\` loop. No markers, no cache hits.

This is structural, not just a missing line. Anything that produces dim evidence MUST go through the canonical sink so the marker contract is enforced for free.

## The fix (architectural)

**1. Make \`FindingsRouter\` the canonical sink, declared in code.**
A new module-level docstring on \`FindingsRouter\` (\`mcp/router.py\`) calls out the contract: every provider path that writes \`<dim>_evidence.jsonl\` must go through a router instance, and explains why (the cache layer's \`ok_files\` filter requires \`mark_file_done\`).

**2. Route the API runner through \`FindingsRouter\`.**
\`_api_runner.run_api_analysis\` now opens the JSONL once, instantiates \`FindingsRouter\` against that handle, calls \`receive\` for each finding (replacing the StringIO buffer + raw-write pattern), then calls \`mark_file_done(file=path, status='ok')\` for each \`source_file_paths\` entry on a clean Instructor return. The \`StringIO\` round-trip is gone.

**3. Distinguish clean returns from salvaged ones.**
\`_call_api\` now returns \`(findings, was_salvaged)\`. On the salvage path (malformed JSON, partial recovery) we cannot prove which files were actually completed end-to-end, so no markers are emitted -- the next run re-dispatches everything. Same guarantee as the CLI path: a file is only ever marked \`ok\` when analysis genuinely finished.

**4. Tests pin the contract.**
New \`TestMarkerContract\` class with 4 tests:
- Clean call emits one \`ok\` marker per source file (including for files with zero findings).
- Salvaged response emits **no** markers.
- No \`source_file_paths\` -> no markers (callers without a known file list are not silently lied about).

Plus updates to existing tests that asserted finding-only JSONL shapes (now also need to filter out marker lines).

## Why this is exemplar arch

- The previous bug class becomes structurally impossible: \`FindingsRouter\` *is* the writer, so the marker call site is right next to the finding write. A new provider that writes through the router gets the contract automatically.
- Removed dead weight: the \`StringIO\` enrichment buffer + raw-write loop collapsed into a single router lifetime.
- The router's responsibilities are now declared at the class level, not implied by code archaeology.
- Helpers split cleanly: \`_build_router_context\` (build the enrichment context) is now distinct from \`_enrich_findings\` (which was doing both context-building and writing) -- single responsibility per function.

## Test plan
- [x] \`tests/analysis/test_api_runner*\` and \`test_api_integration.py\` green (44 passing).
- [x] Full repo green (2774 passing). One transient flake in \`tests/ci/test_cli_signals.py\` that passes on re-run -- not related to this change.
- [x] Smoke run on Ollama: cancel mid-dim, re-run, confirm completed files are now cache hits in \`~/.quodeq/cache/results/\`.