### PR TITLE
fix(cache): clean scan invalidates the cache up front

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -45,6 +45,7 @@ from quodeq.analysis.cache._failure_streak import (
 )
 from quodeq.analysis.cache.dimension_helpers import (
     ClassifyResult,
+    build_cache_key_for_file,
     classify_files_via_cache,
     persist_dispatch_results,
 )
@@ -138,9 +139,28 @@ def process_dimension_with_cache(
         # warning + single-agent fallback runs unchanged.
         return process_dimension_with_subagents(config, dim_id, idx, ctx, callbacks)
 
-    # Clean-scan (incremental=False) bypasses cache reads — fresh dispatch
-    # every time — but writes still happen below so the cache stays current.
+    # Clean-scan (incremental=False) means "I want fresh analysis." The user's
+    # mental model: cancelled clean-scan + retry should NOT short-circuit on
+    # stale entries that pre-date the clean-scan. So at clean-scan start, we
+    # delete the cache entries for this (dim, files) tuple BEFORE classify.
+    # If the run completes, the cache is naturally repopulated. If the run
+    # cancels mid-flight, the cache only contains what THIS run completed --
+    # never ghosts from before. Without this, "clean" only meant "bypass
+    # reads," and a cancelled clean run left the prior cache fully intact.
     bypass_reads = not config.options.incremental
+    if bypass_reads:
+        wiped = 0
+        for f in files:
+            key = build_cache_key_for_file(config, f, dim_id)
+            try:
+                cache.delete(key)
+                wiped += 1
+            except Exception as exc:  # noqa: BLE001
+                _logger.debug("[%s] cache delete failed for %s: %s", dim_id, f, exc)
+        _logger.info(
+            "[%s] cache: invalidated %d entries before clean-scan dispatch",
+            dim_id, wiped,
+        )
     classify = classify_files_via_cache(
         config, dim_id, files, cache, bypass_reads=bypass_reads,
     )
@@ -148,9 +168,9 @@ def process_dimension_with_cache(
     _logger.info(
         "[%s] cache: %d hits / %d misses (%d total)%s",
         dim_id, n_hits, len(classify.misses), len(files),
-        " — clean-scan refresh" if bypass_reads else "",
+        " - clean-scan invalidated" if bypass_reads else "",
     )
-    # Structured marker for the dashboard / SSE stream — one event per
+    # Structured marker for the dashboard / SSE stream - one event per
     # dim summarising hit/miss split. Per-file events would be too noisy
     # for a UI-level stream; per-dim is the right granularity.
     emit_marker(
@@ -159,7 +179,7 @@ def process_dimension_with_cache(
         hits=n_hits,
         misses=len(classify.misses),
         total=len(files),
-        mode="clean-scan-refresh" if bypass_reads else "incremental",
+        mode="clean-scan-invalidated" if bypass_reads else "incremental",
     )
 
     jsonl = _jsonl_path(config, dim_id)

--- a/tests/analysis/cache/test_clean_scan_honor.py
+++ b/tests/analysis/cache/test_clean_scan_honor.py
@@ -241,3 +241,128 @@ class TestDispatchBypassesCacheOnCleanScan:
         assert entry is not None
         assert any(f.get("w") == "fresh" for f in entry.findings)
         assert all(f.get("w") != "stale" for f in entry.findings)
+
+
+# ============================================================
+# Cache invalidation on clean scan (the "I want fresh" guarantee)
+# ============================================================
+#
+# Background: prior to this fix, a clean scan only set bypass_reads=True
+# (so the in-flight run ignored cache hits) but left existing entries
+# alone. If the user cancelled the clean scan mid-flight and re-ran
+# without --clean, the prior entries the user wanted refreshed were
+# still hits, producing the surprising "instant complete" behaviour.
+#
+# Now: clean scan deletes the (file, dim) cache entries up front. A
+# completing clean scan repopulates them; a cancelled clean scan leaves
+# the cache holding only what THIS run finished, never ghosts from
+# before.
+
+
+class TestCleanScanInvalidates:
+    def test_clean_scan_deletes_entries_for_this_dim_files(
+        self, tmp_path: Path, cache,
+    ):
+        """Pre-populated entries are gone after process_dimension_with_cache
+        runs with incremental=False, even if the dispatch is short-circuited."""
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+        config, src = _setup(
+            tmp_path, {"a.py": "x", "b.py": "y"}, incremental=False,
+        )
+        _populate_cache(cache, config, "security", ["a.py", "b.py"])
+
+        # Sanity: entries exist before.
+        for f in ("a.py", "b.py"):
+            assert cache.get(build_cache_key_for_file(config, f, "security")) is not None
+
+        from quodeq.core.evidence.model import Evidence
+        def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+            jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            # Worker emits a marker for a.py only -- b.py is "abandoned"
+            # mid-flight (simulating a cancel after a finished).
+            with jsonl.open("w") as out:
+                out.write(json.dumps({"file": "a.py", "line": 1, "t": "violation", "w": "fresh-a"}) + "\n")
+                out.write(json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n")
+            return Evidence(
+                repository="", language="python", date="2026-01-01",
+                source_file_count=2, files_read=1, coverage_pct=50.0, principles={},
+            )
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=fake_dispatch,
+        ):
+            from quodeq.analysis.subagents.runner import DimensionCallbacks
+            from quodeq.analysis._dimension_steps import (
+                _build_dimension_prompt, _parse_dimension_evidence, _run_dimension_analysis,
+            )
+            callbacks = DimensionCallbacks(
+                build_prompt=_build_dimension_prompt,
+                run_analysis=_run_dimension_analysis,
+                parse_evidence=_parse_dimension_evidence,
+            )
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), callbacks, cache=cache,
+            )
+
+        # a.py: re-dispatched, ok marker, repopulated under same key with FRESH content.
+        a_entry = cache.get(build_cache_key_for_file(config, "a.py", "security"))
+        assert a_entry is not None, "a.py should be re-cached after clean-scan"
+        assert any(f.get("w") == "fresh-a" for f in a_entry.findings)
+        assert all(f.get("w") != "cached-a.py" for f in a_entry.findings), (
+            "stale pre-clean-scan finding leaked through -- the wipe-then-rewrite contract is broken"
+        )
+
+        # b.py: invalidated up front, never got an ok marker -- entry is GONE.
+        b_entry = cache.get(build_cache_key_for_file(config, "b.py", "security"))
+        assert b_entry is None, (
+            "stale b.py entry survived a clean-scan that never re-completed it -- "
+            "next non-clean run would short-circuit on the ghost entry"
+        )
+
+    def test_incremental_run_does_not_invalidate(
+        self, tmp_path: Path, cache,
+    ):
+        """Sanity: invalidation is gated on bypass_reads. A normal
+        incremental run that happens to find no hits MUST NOT delete
+        anything."""
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+
+        config, src = _setup(
+            tmp_path, {"a.py": "x"}, incremental=True,
+        )
+        _populate_cache(cache, config, "security", ["a.py"])
+        key_before = build_cache_key_for_file(config, "a.py", "security")
+        entry_before = cache.get(key_before)
+        assert entry_before is not None
+
+        from quodeq.core.evidence.model import Evidence
+        def noop_dispatch(cfg, dim_id, idx, ctx, callbacks):
+            return Evidence(
+                repository="", language="python", date="2026-01-01",
+                source_file_count=1, files_read=1, coverage_pct=100.0, principles={},
+            )
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=noop_dispatch,
+        ):
+            from quodeq.analysis.subagents.runner import DimensionCallbacks
+            from quodeq.analysis._dimension_steps import (
+                _build_dimension_prompt, _parse_dimension_evidence, _run_dimension_analysis,
+            )
+            callbacks = DimensionCallbacks(
+                build_prompt=_build_dimension_prompt,
+                run_analysis=_run_dimension_analysis,
+                parse_evidence=_parse_dimension_evidence,
+            )
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(), callbacks, cache=cache,
+            )
+
+        # All-hits path; entry survives untouched.
+        entry_after = cache.get(key_before)
+        assert entry_after is not None
+        assert any(f.get("w") == "cached-a.py" for f in entry_after.findings)

--- a/tests/analysis/cache/test_telemetry.py
+++ b/tests/analysis/cache/test_telemetry.py
@@ -152,11 +152,12 @@ class TestCacheStatsMarker:
         assert payload["misses"] == 2
         assert payload["total"] == 3
 
-    def test_clean_scan_marks_refresh_mode(
+    def test_clean_scan_marks_invalidated_mode(
         self, tmp_path: Path, cache: LocalFileBackend,
     ):
         """Clean-scan runs include a 'mode' field so the dashboard can
-        distinguish 'fresh forced re-analysis' from a regular cold run."""
+        distinguish 'cache invalidated, forced re-analysis' from a
+        regular cold run."""
         config = _setup(tmp_path, {"a.py": "x"})
         config.options.incremental = False  # clean scan
 
@@ -190,7 +191,7 @@ class TestCacheStatsMarker:
         cache_stats = [(p, kw) for p, kw in markers if p == "cache_stats"]
         assert len(cache_stats) == 1
         _, payload = cache_stats[0]
-        assert payload["mode"] == "clean-scan-refresh"
+        assert payload["mode"] == "clean-scan-invalidated"
 
     def test_marker_payload_is_json_serializable(
         self, tmp_path: Path, cache: LocalFileBackend,


### PR DESCRIPTION
## What you observed
You ran a clean evaluation, cancelled it mid-flight, then started another flexibility eval (non-clean). It instantly jumped to "done" using cached results from the run BEFORE the clean evaluation. That's the opposite of what "clean" should mean.

## Why it happened
\`--clean-scan\` only set \`bypass_reads=True\` for the in-flight run. The prior cache entries the user asked to refresh were left fully intact. When the user cancelled and re-ran without \`--clean\`, those untouched entries served as cache hits, producing the surprising instant-complete behaviour.

The system's contract was "clean = ignore cache for THIS run, but keep prior entries." The user's contract was "clean = throw away the old opinions, I want fresh ones."

## The fix
At clean-scan start, the dim runner deletes the cache entries for every \`(file, dim)\` it's about to re-analyse. Three outcomes:

- **Clean scan completes normally:** entries naturally repopulated with fresh content (same as before).
- **Clean scan cancels mid-flight:** cache contains only the subset that completed during THIS run. The next attempt sees true misses for unfinished files.
- **Clean scan errors before any worker completes:** cache is empty for those files. Same.

In all three, the next run can no longer hit ghosts from before the clean scan. "Clean" now means clean.

Telemetry mode renamed \`clean-scan-refresh\` → \`clean-scan-invalidated\` so the dashboard / SSE stream can distinguish.

## Test plan
- [x] \`tests/analysis/cache/test_clean_scan_honor.py::TestCleanScanInvalidates\` -- two new tests pinning the contract (clean wipes; incremental does not).
- [x] Existing telemetry test updated for renamed mode.
- [x] Full repo green (2781 passing).
- [x] After merge: pull, run a clean flexibility eval, cancel mid-flight, run again non-clean, confirm it actually re-dispatches the unfinished files instead of short-circuiting.