### PR TITLE
fix(cache): pre-write cached findings before dispatch (carries first, single dedup)

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -183,6 +183,19 @@ def process_dimension_with_cache(
     miss_options = replace(config.options, incremental_file_filter=set(classify.misses))
     miss_config = replace(config, options=miss_options)
 
+    # Pre-write cached findings to the JSONL BEFORE dispatch. Two reasons:
+    # (1) Ordering: carries (prior runs' findings) appear first in the JSONL,
+    #     fresh dispatch findings appear after. The final report reads
+    #     foundation-then-new instead of "new findings, oh by the way here
+    #     are the carries tacked on at the end."
+    # (2) Single dedup pass: the dispatcher's internal dedup at the end of
+    #     its evidence collector runs on the merged JSONL, so the user sees
+    #     ONE final "Deduplicated ...: N unique findings" log line. Pre-fix
+    #     the user saw two confusing counts -- "27 unique" (dispatch only)
+    #     followed by "55 unique" (after we appended cached findings).
+    if classify.cached_findings:
+        _write_findings(jsonl, classify.cached_findings, append=True)
+
     # Persist the per-file cache keys to a sidecar so the discard path can
     # locate this dim's V2 cache entries even after the process exits. Without
     # this, a user clicking "discard partial findings" can't wipe entries that
@@ -234,20 +247,19 @@ def process_dimension_with_cache(
         raise CircuitBreakerError("circuit_breaker")
 
     if miss_evidence is None:
-        # Dispatch returned None — final persist already ran via the
-        # watcher, so any partial completion is preserved.
+        # Dispatch returned None - final persist already ran via the
+        # watcher, so any partial completion is preserved. If we have
+        # cached findings already in the JSONL (pre-written above), parse
+        # them so the run still has SOMETHING to score; otherwise None.
+        if classify.cached_findings and jsonl.exists():
+            return parse_evidence_from_jsonl(
+                config, dim_id, ctx, jsonl, files_read=len(files),
+            )
         return None
 
-    # If there are also cache hits, merge them into the JSONL and
-    # re-parse so the returned Evidence reflects the full picture.
-    # Dedup handles overlap with anything earlier phases may have written.
-    if classify.cached_findings:
-        from quodeq.analysis.subagents.jsonl_utils import deduplicate_jsonl
-        _write_findings(jsonl, classify.cached_findings, append=True)
-        if jsonl.exists():
-            deduplicate_jsonl(jsonl)
-        return parse_evidence_from_jsonl(
-            config, dim_id, ctx, jsonl, files_read=len(files),
-        )
-
-    return miss_evidence
+    # Re-parse the JSONL so files_read reflects the total (hits + misses),
+    # not just len(misses) which is what the dispatcher's Evidence carries.
+    # The dispatcher already deduped on its way out, so no extra dedup here.
+    return parse_evidence_from_jsonl(
+        config, dim_id, ctx, jsonl, files_read=len(files),
+    )

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -501,3 +501,86 @@ class TestCircuitBreakerWiring:
             assert not cancellation.is_cancelled()
         finally:
             cancellation.reset()
+
+
+# ============================================================
+# Carry order: cached findings appear FIRST in the JSONL
+# ============================================================
+#
+# Pre-fix, cached findings were appended AFTER dispatch wrote its fresh
+# findings, producing two effects users complained about:
+#  1. The merged JSONL ordered fresh-then-cached, so the final report
+#     read "new findings, then carries" -- the opposite of how a user
+#     thinks about it ("carries are foundation, fresh is on top").
+#  2. The dispatcher's internal dedup ran BEFORE we appended cached
+#     findings, producing two log lines like "Deduplicated ...: 27"
+#     followed by "Deduplicated ...: 55", visibly confusing.
+#
+# Now: cached findings are pre-written to the JSONL BEFORE dispatch.
+# Dispatch's internal dedup sees the merged set in one pass.
+
+
+class TestCarryOrder:
+    def test_cached_findings_appear_before_fresh(self, tmp_path: Path, cache):
+        """Pre-populate cache for one file. Dispatch a different file. The
+        JSONL should have the cached file's findings BEFORE the dispatched
+        file's findings (carries first, then fresh)."""
+        from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+        from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        # Cache a.py with a recognizable finding.
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{"file": "a.py", "line": 1, "t": "violation",
+                       "w": "carry-a", "p": "P1", "d": "security",
+                       "req": "X-1", "severity": "minor",
+                       "snippet": "x", "reason": "r"}],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        # b.py is a miss -- fake dispatcher writes a fresh finding for it.
+        def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+            jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                out.write(json.dumps({
+                    "file": "b.py", "line": 1, "t": "violation",
+                    "w": "fresh-b", "p": "P2", "d": "security",
+                    "req": "X-2", "severity": "minor",
+                    "snippet": "y", "reason": "r",
+                }) + "\n")
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": "b.py", "status": "ok",
+                }) + "\n")
+            return _make_dummy_evidence(files_read=1)
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=fake_dispatch,
+        ):
+            process_dimension_with_cache(
+                config, "security", 1, _make_ctx(),
+                _make_callbacks(), cache=cache,
+            )
+
+        jsonl_path = (config.work_dir or config.src) / "security_evidence.jsonl"
+        lines = [json.loads(ln) for ln in jsonl_path.read_text().splitlines() if ln.strip()]
+        # Filter to actual finding lines (not markers).
+        findings = [ln for ln in lines if "_marker" not in ln]
+        # Carry comes first; fresh comes second.
+        assert findings[0]["w"] == "carry-a", (
+            f"expected carry-a first, got {[f.get('w') for f in findings]}"
+        )
+        assert any(f.get("w") == "fresh-b" for f in findings), (
+            "fresh dispatch finding missing from JSONL"
+        )
+        # Specifically: the carry comes before the fresh in JSONL order.
+        carry_idx = next(i for i, f in enumerate(findings) if f.get("w") == "carry-a")
+        fresh_idx = next(i for i, f in enumerate(findings) if f.get("w") == "fresh-b")
+        assert carry_idx < fresh_idx, (
+            f"carry (index {carry_idx}) should appear before fresh (index {fresh_idx})"
+        )


### PR DESCRIPTION
## What you saw
\`\`\`
[flexibility] cache: 9 hits / 9 misses (18 total)
...
Deduplicated flexibility_evidence.jsonl: 27 unique findings
Deduplicated flexibility_evidence.jsonl: 55 unique findings
[1/1] flexibility — 18 files, 44v/2c
\`\`\`

Two confusing things at once:
1. Two dedup messages with different counts -- visibly looks like the system bolted on more findings AFTER it was already done.
2. The cached findings (carries from prior runs) appeared at the END of the merged JSONL, after the fresh dispatch findings -- the opposite of how a user thinks about it.

## Root cause
The dim runner appended cached findings to the JSONL AFTER the dispatcher had already finished and deduped its own output. So:
- Dispatcher's internal dedup ran on its own 9-file output → "27 unique findings"
- We appended the 9 cached files' findings → unique count jumped to 55
- We deduped a second time → "55 unique findings"

## The fix
Pre-write cached findings to the JSONL BEFORE dispatch runs. Two effects:

1. **Carries first**: prior runs' findings appear at the top of the JSONL; fresh dispatch findings come after. The final report reads as the user's mental model has it -- prior opinions are foundation, fresh is on top.
2. **Single dedup pass**: the dispatcher's internal dedup at the end of \`_evidence_collector.py\` runs on the merged JSONL. ONE log line with the final unique-finding count. No more 27-then-55 confusion.

Also dropped the redundant post-dispatch dedup pass and always re-parse the JSONL with \`files_read=len(files)\` so the returned Evidence's \`files_read\` reflects total = hits + misses.

## Test plan
- [x] New \`TestCarryOrder::test_cached_findings_appear_before_fresh\` -- pre-populate cache for a.py, dispatch b.py, assert carry-a appears before fresh-b in the JSONL.
- [x] All 116 cache tests pass.
- [x] Full repo green (2780 passing).
- [x] After merge: re-run your flexibility scenario, confirm only ONE dedup log line and the final count matches what the report shows.