### PR TITLE
ui: tighten cancel button on running-eval header

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -26,12 +26,12 @@ function JobHeader({ job, projectLabel, onDismiss, onCancel }) {
           <button type="button" className="term-btn term-btn--ghost term-btn--sm" onClick={onCancel}>cancel</button>
         )}
         {!isRunning && isDone && (
-          <button type="button" className="term-btn term-btn--primary" onClick={() => onDismiss('view')}>
+          <button type="button" className="term-btn term-btn--primary term-btn--sm" onClick={() => onDismiss('view')}>
             <span aria-hidden="true">▸</span> view results
           </button>
         )}
         {!isRunning && (
-          <button type="button" className="term-btn term-btn--secondary" onClick={() => onDismiss('close')}>close</button>
+          <button type="button" className="term-btn term-btn--secondary term-btn--sm" onClick={() => onDismiss('close')}>close</button>
         )}
       </div>
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -23,7 +23,7 @@ function JobHeader({ job, projectLabel, onDismiss, onCancel }) {
       <TermHeader name={termNameForStatus(job.status)} sub={projectLabel || undefined} />
       <div className="evaluate-panel__top-actions">
         {isRunning && (
-          <button type="button" className="term-btn term-btn--ghost" onClick={onCancel}>cancel</button>
+          <button type="button" className="term-btn term-btn--ghost term-btn--sm" onClick={onCancel}>cancel</button>
         )}
         {!isRunning && isDone && (
           <button type="button" className="term-btn term-btn--primary" onClick={() => onDismiss('view')}>

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2248,6 +2248,15 @@ button.term-sev-badge--clickable:focus-visible {
   cursor: not-allowed;
 }
 
+/* Small size modifier — for secondary or destructive actions tucked into
+   corners (e.g. cancel during a running eval) where a full-size button
+   would overweight the layout. Composes with any variant. */
+.term-btn--sm {
+  font-size: 11px;
+  padding: 2px var(--term-space-2);
+  letter-spacing: 0.02em;
+}
+
 /* Filled variant — solid accent background. Compose with --primary,
    e.g. `term-btn term-btn--primary term-btn--filled`. Theme-safe via
    --color-on-accent (works in both light and dark themes). */


### PR DESCRIPTION
## What
Adds a small \`term-btn--sm\` modifier and applies it to the cancel button in the running-eval header. The full-size button was visually overweight against the progress card.

## Verified
Side-by-side comparison in the live preview:
- old: 13px font, 8x16 padding, ~128px wide
- new: 11px font, 2x8 padding, ~100px wide

Same height (35px), same variant (\`--ghost\`), same behaviour. Just less weight.

The modifier is generic -- composable with any variant. Could be used elsewhere for tucked-in secondary actions.