### PR TITLE
feat(ui): refresh History on tab open, not just on poll tick

### DIFF
--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
@@ -1,14 +1,18 @@
 /**
- * Background refresh while at least one run is in_progress.
+ * Keep History data fresh for the user. Two distinct refreshes:
  *
- * Mounted from the History page only — we deliberately don't put this
- * on the global score query. Other tabs (Overview, Standards, etc.)
- * shouldn't poll while the user is reading them; the History list is
- * the one place where the user is actively watching for the running
- * row to flip to "complete".
+ *   1. On mount — the user just navigated to History. Invalidate once so
+ *      the page reflects whatever just happened on disk (e.g. a dim that
+ *      finished while they were on another tab). Without this, the user
+ *      stares at a stale snapshot until the next poll tick fires.
  *
- * When the next refresh sees all runs terminal, the interval clears
- * itself: no runaway polling.
+ *   2. Background polling — while at least one run is in_progress, refresh
+ *      on a cadence so the running row flips to "complete" without a
+ *      manual reload. When all runs are terminal, the interval clears.
+ *
+ * Mounted from the History page only — we deliberately don't poll on
+ * Overview / Standards / etc. The History list is the one place where the
+ * user is actively watching for the running row to terminate.
  */
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -19,6 +23,17 @@ export function useRunningRunsRefresh({ selectedProject, availableRuns }) {
   const queryClient = useQueryClient();
   const interval = pollIntervalForRuns(availableRuns);
 
+  // (1) Mount-time refresh: invalidate once when the project changes (which
+  // includes initial mount). The user's act of opening History IS the
+  // signal that they want fresh data; don't wait for the polling tick.
+  useEffect(() => {
+    if (!selectedProject) return;
+    queryClient.invalidateQueries({
+      queryKey: projectKeys.project(selectedProject),
+    });
+  }, [queryClient, selectedProject]);
+
+  // (2) Background polling: only while in_progress runs exist.
   useEffect(() => {
     if (!selectedProject || !interval) return undefined;
     const id = setInterval(() => {

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
@@ -24,7 +24,10 @@ describe('useRunningRunsRefresh', () => {
     vi.useRealTimers();
   });
 
-  it('does not invalidate when every run is terminal', () => {
+  it('invalidates once on mount even when every run is terminal', () => {
+    // Mount-time refresh fires regardless of polling state -- the user just
+    // navigated to History and wants the latest data right now, not on the
+    // next poll tick (which never comes when nothing is in_progress).
     const { Wrapper, invalidateSpy } = makeWrapper();
     renderHook(
       () =>
@@ -34,13 +37,17 @@ describe('useRunningRunsRefresh', () => {
         }),
       { wrapper: Wrapper },
     );
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    invalidateSpy.mockClear();
+    // No further invalidations after mount -- nothing is in_progress, so
+    // the polling interval doesn't run.
     act(() => {
       vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 3);
     });
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
-  it('invalidates on each tick while a run is in_progress', () => {
+  it('invalidates on mount AND on each tick while a run is in_progress', () => {
     const { Wrapper, invalidateSpy } = makeWrapper();
     renderHook(
       () =>
@@ -53,16 +60,20 @@ describe('useRunningRunsRefresh', () => {
         }),
       { wrapper: Wrapper },
     );
+    // Mount-time refresh fires immediately.
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectKeys.project('p1'),
+    });
+    invalidateSpy.mockClear();
+    // Then polling: 2 ticks within the advanced window.
     act(() => {
       vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 2 + 50);
     });
     expect(invalidateSpy).toHaveBeenCalledTimes(2);
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: projectKeys.project('p1'),
-    });
   });
 
-  it('stops invalidating once all runs become terminal', () => {
+  it('stops polling once all runs become terminal (mount-refresh aside)', () => {
     const { Wrapper, invalidateSpy } = makeWrapper();
     const { rerender } = renderHook(
       ({ runs }) =>
@@ -74,16 +85,47 @@ describe('useRunningRunsRefresh', () => {
         },
       },
     );
+    // Mount-time invalidate (1) + first poll tick (1) = 2 within the window.
     act(() => {
       vi.advanceTimersByTime(IN_PROGRESS_POLL_MS + 50);
     });
-    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
     invalidateSpy.mockClear();
+    // Run terminates. Polling stops; selectedProject didn't change so the
+    // mount-effect doesn't re-fire.
     rerender({ runs: [{ runId: 'r1', status: 'complete' }] });
     act(() => {
       vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 5);
     });
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-invalidates when the user switches to a different project', () => {
+    // Navigating between projects (or back to History after viewing a
+    // different one) should re-trigger the mount-time refresh so the new
+    // project's data is current.
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    const { rerender } = renderHook(
+      ({ project }) =>
+        useRunningRunsRefresh({
+          selectedProject: project,
+          availableRuns: [{ runId: 'r1', status: 'complete' }],
+        }),
+      {
+        wrapper: Wrapper,
+        initialProps: { project: 'p1' },
+      },
+    );
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectKeys.project('p1'),
+    });
+    invalidateSpy.mockClear();
+    rerender({ project: 'p2' });
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectKeys.project('p2'),
+    });
   });
 
   it('does nothing without a selected project', () => {


### PR DESCRIPTION
## Why
The History page already polls while runs are in_progress, but the first poll tick can be 10-30s away. A user navigating to History saw a stale snapshot until the next tick, even though clicking the tab is a clear "I want fresh data now" signal.

## What
Add a mount-time invalidate as a separate effect in \`useRunningRunsRefresh\`. Fires once when \`selectedProject\` changes (which includes initial mount). The polling effect is untouched.

## Behaviour matrix
- User opens History — immediate refresh (mount-time).
- A run is in_progress — background polling continues at normal cadence.
- All runs terminal — polling stops; next time the user navigates away and back, the mount-refresh fires again.
- User switches projects — re-invalidates for the new project.

## Test plan
- [x] Hook tests rewritten: mount-time refresh always fires (even all-terminal); polling fires on top of mount while in_progress; project switch re-invalidates. 5/5 pass.
- [x] Live verification in browser preview: tab-click triggers \`/api/projects/<id>/dashboard\` and \`/scores\` fetches within ~50ms (deduped count = 4 in 500ms window, before any poll tick would have run).
- [x] After merge: navigate away from History, finish an eval in a separate process, come back to History — score row updates immediately instead of after the next poll.