### PR TITLE
fix(analysis): BrokenPipe on success-log must not mark a successful dim as incomplete

### DIFF
--- a/src/quodeq/analysis/_dimension_ops.py
+++ b/src/quodeq/analysis/_dimension_ops.py
@@ -48,7 +48,18 @@ def _process_single_dimension(
         return None
 
     if emit_log:
-        _log_dimension_result(ev, dimension, idx, ctx.total)
+        # The dim has analytically succeeded at this point: subagent pool
+        # is done, JSONL is dedupped, evidence parsed cleanly. The success
+        # log line is observability only; if the dashboard's stdout pipe
+        # closed mid-evaluation, do NOT let a logging failure propagate
+        # out as if the analysis itself failed -- the loop's outer except
+        # would mark this dim INCOMPLETE despite all 18 files (or however
+        # many) having completed cleanly with findings on disk.
+        try:
+            _log_dimension_result(ev, dimension, idx, ctx.total)
+        except BrokenPipeError:
+            from quodeq.analysis._loops import _silence_broken_stdout
+            _silence_broken_stdout()
     return ev
 
 

--- a/tests/analysis/test_dimension_ops_broken_pipe.py
+++ b/tests/analysis/test_dimension_ops_broken_pipe.py
@@ -1,0 +1,122 @@
+"""BrokenPipeError on the success-log line must not mark a successful dim as incomplete.
+
+Regression: the dashboard's stdout pipe can close at any moment (parent
+restarting, kernel pipe-buffer pressure, etc.). When that happens between
+the dim's dispatch finishing and the success log line being written, the
+log call raises BrokenPipeError. Pre-fix, this propagated out of
+``_process_single_dimension`` and the loop's outer except branch caught
+it as if the dim itself had failed -- writing INCOMPLETE state, skipping
+``_score_dimension``, and erasing the dim from the run report despite
+the JSONL having all the findings on disk.
+
+Observed in the wild on a 3-dim run: flexibility ran clean (18 files,
+22v/1c), but the success log raised BrokenPipeError, and the run report
+showed only 2 dims (maintainability + performance) with 80 violations
+instead of the actual 113.
+
+The fix: ``_process_single_dimension`` swallows BrokenPipeError around
+the success-log call so a logging failure doesn't mask a successful
+analysis. Stdout/stderr are then redirected to /dev/null so the rest of
+the run can keep logging without compounding the error.
+"""
+from __future__ import annotations
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis._dimension_ops import _process_single_dimension
+from quodeq.core.evidence.model import Evidence
+
+
+def _make_evidence() -> Evidence:
+    return Evidence(
+        repository="", language="python", date="2026-01-01",
+        source_file_count=18, files_read=18, coverage_pct=100.0, principles={},
+    )
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.total = 3
+    return ctx
+
+
+class TestSuccessLogBrokenPipe:
+    def test_returns_evidence_when_log_raises(self):
+        """If _log_dimension_result raises BrokenPipeError, the function
+        still returns the Evidence. The dim is analytically successful;
+        a logging failure must not mask that."""
+        ev = _make_evidence()
+        with patch(
+            "quodeq.analysis._dimension_ops.process_dimension_with_cache",
+            return_value=ev,
+        ), patch(
+            "quodeq.analysis._dimension_ops._log_dimension_result",
+            side_effect=BrokenPipeError("dashboard pipe closed"),
+        ), patch(
+            "quodeq.analysis._loops._silence_broken_stdout",
+        ) as mock_silence:
+            result = _process_single_dimension(
+                MagicMock(), "flexibility", 3, _make_ctx(), emit_log=True,
+            )
+        assert result is ev, (
+            "BrokenPipeError on success-log must not propagate; the dim's "
+            "Evidence must still be returned to the caller"
+        )
+        mock_silence.assert_called_once()
+
+    def test_no_silence_when_log_succeeds(self):
+        """Sanity: the silence-stdout fallback only fires when logging
+        actually fails. Normal runs should not hit the BrokenPipeError
+        recovery path."""
+        ev = _make_evidence()
+        with patch(
+            "quodeq.analysis._dimension_ops.process_dimension_with_cache",
+            return_value=ev,
+        ), patch(
+            "quodeq.analysis._dimension_ops._log_dimension_result",
+        ), patch(
+            "quodeq.analysis._loops._silence_broken_stdout",
+        ) as mock_silence:
+            result = _process_single_dimension(
+                MagicMock(), "flexibility", 3, _make_ctx(), emit_log=True,
+            )
+        assert result is ev
+        mock_silence.assert_not_called()
+
+    def test_emit_log_false_skips_log_entirely(self):
+        """When emit_log=False (incremental fallback path), the success
+        log isn't called at all -- so the BrokenPipeError fallback must
+        not run either, and the original behaviour is unchanged."""
+        ev = _make_evidence()
+        with patch(
+            "quodeq.analysis._dimension_ops.process_dimension_with_cache",
+            return_value=ev,
+        ), patch(
+            "quodeq.analysis._dimension_ops._log_dimension_result",
+        ) as mock_log, patch(
+            "quodeq.analysis._loops._silence_broken_stdout",
+        ) as mock_silence:
+            result = _process_single_dimension(
+                MagicMock(), "flexibility", 3, _make_ctx(), emit_log=False,
+            )
+        assert result is ev
+        mock_log.assert_not_called()
+        mock_silence.assert_not_called()
+
+    def test_other_exceptions_still_propagate(self):
+        """A non-BrokenPipe exception in _log_dimension_result is a real
+        bug and must still propagate -- we're only swallowing the specific
+        BrokenPipeError case where the analysis itself succeeded."""
+        ev = _make_evidence()
+        with patch(
+            "quodeq.analysis._dimension_ops.process_dimension_with_cache",
+            return_value=ev,
+        ), patch(
+            "quodeq.analysis._dimension_ops._log_dimension_result",
+            side_effect=RuntimeError("real bug"),
+        ):
+            with pytest.raises(RuntimeError, match="real bug"):
+                _process_single_dimension(
+                    MagicMock(), "flexibility", 3, _make_ctx(), emit_log=True,
+                )


### PR DESCRIPTION
## What you saw

Run dashboard showed 2 dims (maintainability + performance, 80 violations), but the eval panel for the same run showed 3 dims completed with 113 violations:

| Source | Dims | Violations |
|---|---|---|
| Eval panel ('evaluation_complete', all green) | 3 | 113 |
| Dashboard | 2 | 80 |
| History row | "maintainability 5.3, performance 3.3" | — |

Flexibility was missing from the report despite the eval reporting it as complete.

## Root cause

Looked at the run dir for \`3fe691a1-...\`:

\`\`\`json
// dimensions.json
{
  "flexibility": { "state": "incomplete", "reason": "failed_exception" },
  "maintainability": { "state": "done" },
  "performance": { "state": "done" }
}
\`\`\`

Then run.log:
\`\`\`
Subagent pool done: 6/6 agents ran, 6 succeeded
Deduplicated flexibility_evidence.jsonl: 46 unique findings
[loop] completed iteration 3/3 for flexibility (skipped: broken pipe)
\`\`\`

The dim's analysis finished cleanly. What raised \`BrokenPipeError\` was the success log line (\`[SUCCESS] [3/3] flexibility — 18 files, 22v/1c\`) — the dashboard's stdout pipe had closed between the dispatch finishing and the log call. The loop's outer except branch caught BrokenPipeError as if \`process_fn\` itself had failed, wrote INCOMPLETE state, and skipped \`_score_dimension\`. No \`evaluation/flexibility.json\` ever landed.

Cascading effects:
- Dashboard reads \`evaluation/*.json\` files → sees only 2 dims.
- Violation count drops from 113 to 80.
- History row's "DIMENSIONS CHANGED" only lists the 2 done dims.

## Fix

Surgical: in \`_process_single_dimension\`, wrap \`_log_dimension_result\` in \`try/except BrokenPipeError\`. The dim is analytically complete by the time we reach the success log (pool done, JSONL dedupped, evidence parsed) — observability failure must not mask success. Falls back to \`_silence_broken_stdout\` so the rest of the run can keep logging.

## Other inconsistencies in the screenshots (not fixed here, flagged for follow-up)

- **Δ -0.1 with score 4.1 → 4.3 (up)**: pre-existing. The displayed score uses \`runNumericAverage\` (this run's own score) while Δ uses \`numericAverage\` (accumulated across all dims ever scored). Different bases, confusing UX.
- **+1.2 ↗ on maintainability and -1.5 ↘ on performance** in QUALITY_DIMENSIONS view: those are accumulated trend deltas. Behaviour is intentional but reads weirdly when only some dims were re-run.

## Test plan
- [x] 4 new tests in \`test_dimension_ops_broken_pipe.py\` pin: success-with-broken-log returns ev; silence-stdout fires only on broken pipe; emit_log=False skips entirely; non-BrokenPipe exceptions still propagate.
- [x] Full repo green (2788 passing).
- [x] After merge: re-run a 3-dim flexibility/maintainability/performance eval, confirm all three dims appear in the report and dimensions.json shows all three as 'done'.