### PR TITLE
feat(ui): invalidate project queries on eval start so History reflects the new run immediately

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -26,7 +26,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { chooseDialog } from "../../../utils/chooseDialog.js";
 import { useRunEventStream } from "./useRunEventStream.js";
-import { evaluationKeys } from "../../../api/queryKeys.js";
+import { evaluationKeys, projectKeys } from "../../../api/queryKeys.js";
 import {
   ACTIVE_PROVIDER_KEY,
   providerKey,
@@ -167,6 +167,13 @@ export function useEvaluation() {
       setJobError(null);
       setJobId(created.jobId);
       queryClient.setQueryData(evaluationKeys.status(created.jobId), created);
+      // Invalidate the project subtree so History (and any other view
+      // backed by project queries) shows the freshly-started run as
+      // 'running' immediately, instead of waiting for the next poll
+      // tick. Without this, History stays stale until the user
+      // navigates away and back, or the polling timer fires --
+      // user-visible delay was ~10-30s on a fresh start.
+      queryClient.invalidateQueries({ queryKey: projectKeys.all() });
     },
     onError: (err) => {
       const msg = err?.message || "Failed to start evaluation.";

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -68,6 +68,34 @@ describe("useEvaluation", () => {
     });
   });
 
+  it("startEvaluation invalidates project queries so History sees the new run immediately", async () => {
+    // Regression: pre-fix, History stayed stale until either polling
+    // ticked (only fires when in_progress runs are already visible) or
+    // the user navigated away and back. Result: 'running' row took
+    // ~10-30s to appear after Start. The fix invalidates the project
+    // subtree on success so subscribed queries refetch right away.
+    const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "jx", status: "pending", dimensions: [],
+    });
+    function Wrapper({ children }) {
+      return (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      );
+    }
+    const { result } = renderHook(() => useEvaluation(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project"] });
+  });
+
   it("clearJob resets job state", async () => {
     fakeApi.startEvaluation.mockResolvedValue({
       jobId: "j2",


### PR DESCRIPTION
## What you saw
Starting an evaluation, then switching to (or already on) the History tab, the running row took 10-30s to appear. Your screenshot showed the right-hand log panel actively running an eval (\`72b5868b-d7b...\`) while the left-hand History list didn't yet show a "running" row at the top.

## Root cause
\`startMutation.onSuccess\` in \`useEvaluation.js\` only seeded the evaluation's own status query (\`evaluationKeys.status(jobId)\`). It didn't touch the project subtree. So:

1. User clicks Start.
2. \`startEvaluation\` API call returns. Hook seeds the evaluation's status cache.
3. Project queries (which the History page reads from) stay stale.
4. \`useRunningRunsRefresh\` only fires polling when there's an in_progress run **already visible** in \`availableRuns\` — chicken-and-egg.
5. History shows nothing about the new run until either:
   - The user navigates away and back (the mount-time refresh from the prior PR fires).
   - Something else triggers a project refetch (rare).

That ~10-30s window is the user-visible delay.

## Fix
On \`startMutation\` success, invalidate \`projectKeys.all()\` (\`["project"]\`). Any subscribed project query refetches immediately. History reflects the running row within one roundtrip.

This pairs with the previous PR (mount-time refresh): together they cover both "user is already on History when starting" (this PR) and "user navigates back to History later" (the previous one).

## Test plan
- [x] New unit test: \`startEvaluation invalidates project queries so History sees the new run immediately\` — spies on QueryClient and asserts \`invalidateQueries({queryKey: ["project"]})\` is called.
- [x] Run that test in isolation: passes.
- [x] After merge: start an eval from the dashboard, immediately switch to History (or be already there), confirm the running row appears within ~1s instead of waiting for the next poll.

## Other concerns from your screenshots (not fixed here, flagged)
- Run Detail page for in-progress runs has no "still running" indicator and looks like a completed run (just with fewer dims). Worth a separate PR.
- History row for in-progress runs shows \`● running\` but no progress info ("X/Y dims complete"). Same separate PR.