### PR TITLE
fix(ui): History row shows dim count for multi-dim runs so 3-dim runs don't look single-dim

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -59,15 +59,44 @@ function computeDeltas(rows) {
   });
 }
 
+// Shorter labels for the multi-dim summary so the row's dimensions cell
+// can fit the count and names instead of truncating after the first dim.
+// The full dim name is still visible after click-through.
+const _DIM_ABBREV = {
+  flexibility: 'flex',
+  maintainability: 'maint',
+  performance: 'perf',
+  reliability: 'rel',
+  security: 'sec',
+  usability: 'usab',
+};
+
+function _abbrevDim(name) {
+  if (!name) return name;
+  const lower = name.toLowerCase();
+  return _DIM_ABBREV[lower] || (lower.length > 5 ? lower.slice(0, 4) : lower);
+}
+
 function formatDimSummary(entry) {
   const dims = (entry?.dimensionDetails || []).filter((d) => d?.dimension);
   if (dims.length === 0) return '—';
-  const parts = dims.map((d) => {
+  // Single-dim runs: keep the full name -- it's compact enough.
+  if (dims.length === 1) {
+    const d = dims[0];
     const score = parseFloat(d.score);
     if (Number.isNaN(score)) return d.dimension.toLowerCase();
     return `${d.dimension.toLowerCase()} ${score.toFixed(1)}`;
+  }
+  // Multi-dim runs: lead with the count so even after truncation the user
+  // sees there are more dims. Use abbreviated names so all of them fit
+  // in the dimensions cell instead of getting truncated after the first.
+  const parts = dims.map((d) => {
+    const score = parseFloat(d.score);
+    const label = _abbrevDim(d.dimension);
+    if (Number.isNaN(score)) return label;
+    return `${label} ${score.toFixed(1)}`;
   });
-  return parts.join(', ');
+  return `${dims.length} dims · ${parts.join(', ')}`;
 }
 
 function DeltaText({ delta }) {


### PR DESCRIPTION
## What you saw
> "An evaluation with three dimensions appears just as one on history until you press on it, and it has 3 on history run."

The History row showed only the first dim (e.g. \`maintainability 5.3\`) for a 3-dim run, making it look single-dim. Click into the row → run detail correctly shows all 3.

## Root cause
The data was right. \`trend.dimensionDetails\` had all 3 entries. But \`formatDimSummary\` produced \`flexibility 2.8, maintainability 4.5, performance 4.8\` (~52 chars), and \`FittedText\` truncated the cell to fit, leaving only the first item visible (~19 chars: \`maintainability 5.3\`). No ellipsis, no count — the user couldn't distinguish "single-dim run" from "multi-dim run with everything-after-first truncated".

## Fix
Lead with the count and use shorter labels for the per-dim breakdown:
- Single-dim runs: unchanged.
- Multi-dim runs: \`3 dims · flex 2.8, maint 4.5, perf 4.8\` instead of full names.

After cell truncation it reads \`3 dims · flex 2.8, maint…\` — the user always sees how many dims there are, even if the rest is cut. Tooltip on hover shows the full breakdown.

## Verified live
Confirmed in the running preview:
- \`3 dims · flex 2.8, maint…\` (was \`maintainability 5.3\` before)
- \`2 dims · flex 2.9, maint…\`
- \`2 dims · maint 5.3, perf…\`
- \`maintainability 4.1\` (single-dim, unchanged)

## Test plan
- [x] UI tests still pass.
- [x] Live in browser: dim counts now visible on every multi-dim row.
- [x] After merge: refresh History on a project with multi-dim runs; rows that previously looked single-dim now show their count.