### PR TITLE
fix(dashboard): self-heal stale dim cache by validating against on-disk eval file count

### DIFF
--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -150,6 +150,22 @@ def _make_run_dimension_fetcher(
     )
 
 
+def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
+    """Count ``evaluation/*.json`` files on disk for a run.
+
+    Used to detect a stale cache: if the cached dim list has a different
+    count from what's currently on disk, the cache is wrong and must be
+    evicted. One ``listdir`` per cached lookup -- cheap.
+    """
+    eval_dir = reports_root / project / run_id / "evaluation"
+    if not eval_dir.is_dir():
+        return 0
+    try:
+        return sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
+    except OSError:
+        return 0
+
+
 def _make_status_aware_fetcher(
     reports_root: Path,
     project: str,
@@ -158,25 +174,46 @@ def _make_status_aware_fetcher(
     lock: threading.Lock | None = None,
     max_size: int | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
-    """Return a fetcher that bypasses the LRU cache for in_progress runs.
+    """Return a fetcher with two self-healing properties on top of the LRU cache.
 
-    The shared cache is correct for terminal runs ("runs are immutable once
-    finalized" -- see _SHARED_RUN_DIM_CACHE comment) but WRONG for in_progress
-    runs whose ``evaluation/<dim>.json`` set grows as dims finish mid-run.
-    Without this bypass, the History page renders the partial dim set from
-    the first read forever, never picking up new dims that complete later.
+    1. **In-progress bypass.** Runs with status=in_progress have a mutable
+       on-disk evaluation/ set as dims finish. We read directly from disk
+       and don't write to cache, so the next request also reads fresh.
 
-    Cancelled and failed runs go through the cache normally -- they're
-    terminal too. Only ``in_progress`` is treated as mutable.
+    2. **On-disk count validation for terminal runs.** Even after a run
+       completes, the cache may hold a stale partial dim set -- e.g. if
+       it was populated by a request that fired between dims being scored
+       (a window opened by the BrokenPipe-during-success-log regression
+       PR #481 fixed). On lookup, we count evaluation/*.json files and
+       compare against the cached length. Mismatch -> evict, re-read.
+
+    Cost: one extra ``listdir`` per cached lookup. Cheap (eval/ is small).
     """
+    resolved_cache = cache if cache is not None else _SHARED_RUN_DIM_CACHE
+    resolved_lock = lock if lock is not None else _SHARED_RUN_DIM_LOCK
     cached = _make_run_dimension_fetcher(
-        reports_root, project, cache=cache, lock=lock, max_size=max_size,
+        reports_root, project,
+        cache=resolved_cache, lock=resolved_lock, max_size=max_size,
     )
     status_by_id = {r.run_id: r.status for r in runs}
 
     def fetch(run_id: str) -> list[DimensionResult]:
         if status_by_id.get(run_id) == "in_progress":
             return read_run_data(reports_root, project, run_id)
+        # Validate any cached entry against the on-disk count. If they
+        # disagree, the cache is stale -- evict so the cached() call below
+        # re-reads from disk and re-caches with the correct value. We only
+        # validate when an actual evaluation/ directory exists on disk:
+        # without that anchor we'd evict every test stub that pre-seeds
+        # the cache without creating disk state.
+        key = (reports_root, project, run_id)
+        if key in resolved_cache:
+            eval_dir = reports_root / project / run_id / "evaluation"
+            if eval_dir.is_dir():
+                on_disk = _count_eval_files(reports_root, project, run_id)
+                if len(resolved_cache[key]) != on_disk:
+                    with resolved_lock:
+                        resolved_cache.pop(key, None)
         return cached(run_id)
 
     return fetch

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -353,3 +353,132 @@ class TestStatusAwareFetcher:
         # contract pinned here is: no exception, no infinite-loop, no
         # stale-bypass behaviour from the prior snapshot.
         assert len(calls) in (1, 2)
+
+
+class TestStaleCacheSelfHeal:
+    """Even for terminal runs, the cache CAN go stale -- e.g. when an
+    earlier request populated it from a partial on-disk state because a
+    dim file landed late. Without self-heal, the dashboard renders the
+    stale dim count forever; the user sees a 3-dim run as 1-dim.
+
+    The fix: count evaluation/*.json files on disk and compare to the
+    cached length on every lookup. Mismatch -> evict, re-read.
+
+    Observed in production after PR #481's BrokenPipe regression: dashboard
+    cached a 1-dim entry for a 3-dim run because the broken-pipe path had
+    skipped scoring 2 dims when the cache was first populated.
+    """
+
+    def test_count_eval_files_counts_json_only(self, tmp_path):
+        from quodeq.services.dashboard import _count_eval_files
+
+        eval_dir = tmp_path / "proj" / "r1" / "evaluation"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "flexibility.json").write_text("{}")
+        (eval_dir / "performance.json").write_text("{}")
+        (eval_dir / "security.json").write_text("{}")
+        # A non-json file should NOT be counted.
+        (eval_dir / "notes.txt").write_text("ignore me")
+
+        assert _count_eval_files(tmp_path, "proj", "r1") == 3
+
+    def test_count_returns_zero_when_eval_dir_missing(self, tmp_path):
+        from quodeq.services.dashboard import _count_eval_files
+        assert _count_eval_files(tmp_path, "proj", "missing") == 0
+
+    def test_stale_cache_evicted_when_dim_count_mismatches_disk(
+        self, tmp_path, monkeypatch,
+    ):
+        from collections import OrderedDict
+        from quodeq.services.dashboard import _make_status_aware_fetcher
+        from quodeq.data.fs.report_parser import RunInfo as _RI
+
+        # Build a real on-disk eval/ with 3 files for r-stale.
+        eval_dir = tmp_path / "proj" / "r-stale" / "evaluation"
+        eval_dir.mkdir(parents=True)
+        for d in ("flexibility", "reliability", "security"):
+            (eval_dir / f"{d}.json").write_text("{}")
+
+        runs = [
+            _RI(run_id="r-stale", date_iso="2024-01-01", date_label="2024-01-01", status="complete"),
+        ]
+
+        # Pre-populate the cache with a STALE 1-dim entry (simulates the
+        # bug: cache was populated when only 1 dim was on disk, even though
+        # disk now has 3).
+        cache = OrderedDict()
+        cache[(tmp_path, "proj", "r-stale")] = [_dim("security", "F", "2.0")]
+
+        # Fresh disk read should return all 3 dims.
+        read_calls = []
+        def fake_read(reports_root, project, run_id):
+            read_calls.append(run_id)
+            return [
+                _dim("flexibility", "C", "5.0"),
+                _dim("reliability", "B", "7.0"),
+                _dim("security", "F", "2.0"),
+            ]
+        monkeypatch.setattr(
+            "quodeq.services.dashboard.read_run_data", fake_read,
+        )
+        monkeypatch.setattr(
+            "quodeq.services._cache.read_run_data", fake_read,
+        )
+
+        fetcher = _make_status_aware_fetcher(
+            tmp_path, "proj", runs, cache=cache,
+        )
+        result = fetcher("r-stale")
+
+        # Cache had 1 dim, disk has 3 -- fetcher must self-heal: evict,
+        # re-read, return 3 dims.
+        assert len(result) == 3, (
+            f"expected self-heal to fresh-read 3 dims, got {len(result)}"
+        )
+        # And the cache should have been evicted (then repopulated by the
+        # cached() call that follows the eviction).
+        assert read_calls == ["r-stale"], (
+            f"expected exactly one fresh read after eviction, got {read_calls}"
+        )
+
+    def test_cache_serves_when_count_matches_disk(
+        self, tmp_path, monkeypatch,
+    ):
+        """Sanity gate: when the cached entry's count matches disk, we
+        DO use the cache and don't re-read. Without this, every lookup
+        would always re-read, defeating the cache."""
+        from collections import OrderedDict
+        from quodeq.services.dashboard import _make_status_aware_fetcher
+        from quodeq.data.fs.report_parser import RunInfo as _RI
+
+        eval_dir = tmp_path / "proj" / "r-fresh" / "evaluation"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "security.json").write_text("{}")
+
+        runs = [
+            _RI(run_id="r-fresh", date_iso="2024-01-01", date_label="2024-01-01", status="complete"),
+        ]
+
+        cache = OrderedDict()
+        cache[(tmp_path, "proj", "r-fresh")] = [_dim("security", "B", "7.0")]
+
+        read_calls = []
+        def fake_read(reports_root, project, run_id):
+            read_calls.append(run_id)
+            return [_dim("security", "B", "7.0")]
+        monkeypatch.setattr(
+            "quodeq.services.dashboard.read_run_data", fake_read,
+        )
+        monkeypatch.setattr(
+            "quodeq.services._cache.read_run_data", fake_read,
+        )
+
+        fetcher = _make_status_aware_fetcher(
+            tmp_path, "proj", runs, cache=cache,
+        )
+        fetcher("r-fresh")
+        fetcher("r-fresh")
+
+        assert read_calls == [], (
+            f"expected no disk reads (cache hit), got {read_calls}"
+        )


### PR DESCRIPTION
## What you saw
A 3-dim run showed up in the History row as if it ran just one dim (\`security 2.0\`). Click through to the run detail → all 3 dims correctly displayed (\`flexibility 2.8\`, \`reliability 4.5\`, \`security 2.0\`).

I confirmed live:
\`\`\`
$ ls ~/.quodeq/evaluations/.../6e02e1a7-.../evaluation/
flexibility.json reliability.json security.json     # 3 dim files on disk

$ curl '/api/projects/.../dashboard?run=latest' | jq .trend[0]
{"runId": "6e02e1a7", "dimensions": ["security"]}    # API returns 1
\`\`\`

3× the same request returned the same wrong count. Stale cache, no self-heal.

## Root cause
PR #479 made the dim cache bypass for in_progress runs. But once a run hits a terminal status, the fetcher trusts the cache fully — and the cache could have been seeded with a partial dim set during a narrow window (e.g. the BrokenPipe-during-success-log regression PR #481 fixed left some dims unscored at first; subsequent dim files landing on disk did NOT invalidate the cache). The bad entry was served forever.

## Fix
On every cached lookup for a non-in_progress run, count \`evaluation/*.json\` on disk and compare to the cached dim count. Mismatch ⇒ evict so the next call re-reads fresh. One \`listdir\` per cached lookup — cheap (eval/ holds at most a handful of files).

Validation gate: only fires when the \`evaluation/\` directory exists on disk. Without that anchor we'd evict every test stub that pre-seeds the cache without creating filesystem state, and break the existing in_progress-bypass tests.

## Test plan
- [x] New \`TestStaleCacheSelfHeal\` (4 tests): \`_count_eval_files\` counts only \`*.json\`; returns 0 when missing; stale 1-dim cache + disk-has-3 → evict + re-read returns 3; cache matches disk → serve cache (sanity gate, prevents always-evict regression).
- [x] Existing tests (24 dashboard tests, 706+ services tests) still green.
- [x] Full repo green (2792 passing).
- [x] After merge + backend restart: refresh History on a project with a multi-dim run that previously rendered as single-dim; the count + breakdown should now appear correctly.

## Note on workaround
You may need to **restart your dashboard** (kill process on :7863 and re-run) for the fix to take effect — the running backend instance is holding the stale cache in process memory. Once restarted with the fixed code, this self-heals on every future request automatically.