### PR TITLE
fix(ui): tighten History poll cadence to 5s for live dim updates

### DIFF
--- a/src/quodeq/ui/src/utils/runPolling.js
+++ b/src/quodeq/ui/src/utils/runPolling.js
@@ -2,18 +2,24 @@
  * Polling cadence + predicate for "is any run still alive?".
  *
  * Used by the History page to refresh the run list while at least one
- * run is in progress, so the row's running indicator and the
- * overview pick up the freshly-completed dims without the user
- * manually refreshing. Polling is intentionally scoped to the History
- * page (not the global score query) so the rest of the app doesn't
- * fire periodic requests while the user is reading other tabs.
+ * run is in progress, so per-dim scores appear in the row as each dim
+ * finishes, not only when the umbrella run terminates. Polling is
+ * intentionally scoped to the History page (not the global score query)
+ * so the rest of the app doesn't fire periodic requests while the user
+ * is reading other tabs.
  *
- * 15 seconds: a finishing run takes minutes, so 15s is plenty tight
- * to update the row visibly soon after the umbrella run terminates,
- * while keeping background load near-zero (4 requests/min while a
- * run is alive, none otherwise).
+ * 5 seconds: a single dim takes minutes, so 5s catches a dim completion
+ * within roughly 5s of it landing on disk -- feels live to the user.
+ * Backend cost is small (12 requests/min while a run is alive, none
+ * otherwise), and the dim cache is now self-healing (PR #484) so each
+ * fetch reflects on-disk truth.
+ *
+ * The proper next step is per-evaluation SSE (we already have
+ * ``useRunEventStream`` for the active job's evaluation pane) so dim
+ * updates push to the History row instead of being polled. Until that
+ * lands, polling is the simple knob.
  */
-export const IN_PROGRESS_POLL_MS = 15000;
+export const IN_PROGRESS_POLL_MS = 5000;
 
 /**
  * Return the poll interval for `useQuery.refetchInterval`, or `false`

--- a/src/quodeq/ui/src/utils/runPolling.test.js
+++ b/src/quodeq/ui/src/utils/runPolling.test.js
@@ -25,13 +25,15 @@ test('returns the poll interval when at least one run is in_progress', () => {
   assert.equal(pollIntervalForRuns(runs), IN_PROGRESS_POLL_MS);
 });
 
-test('IN_PROGRESS_POLL_MS is in the 10-30 second range', () => {
-  // Background-poll cadence: tight enough to flip the row within
-  // seconds of the umbrella run terminating, loose enough that a
-  // local server with one running scan barely notices. Polling is
-  // History-page-only, not global. If this constant moves outside
-  // the band, revisit the UX/perf tradeoff.
-  assert.ok(IN_PROGRESS_POLL_MS >= 10000 && IN_PROGRESS_POLL_MS <= 30000);
+test('IN_PROGRESS_POLL_MS is in the 3-15 second range', () => {
+  // Background-poll cadence: tight enough that a dim landing on disk
+  // shows up in the History row within a handful of seconds (live
+  // feel), loose enough that a local server with one running scan
+  // barely notices. Polling is History-page-only, not global. If this
+  // constant moves outside the band, revisit the UX/perf tradeoff -
+  // the proper next step is per-evaluation SSE so updates push instead
+  // of being polled.
+  assert.ok(IN_PROGRESS_POLL_MS >= 3000 && IN_PROGRESS_POLL_MS <= 15000);
 });
 
 test('treats missing status as not in_progress (defensive)', () => {


### PR DESCRIPTION
## Summary
- Drop `IN_PROGRESS_POLL_MS` from 15s to 5s so per-dim scores appear in the History row within seconds of each dim finishing, not only when the umbrella run terminates.
- Update the bound assertion in `runPolling.test.js` to match the new 3-15s acceptable band, and refresh the rationale comments in both the constant's docstring and the test.

## Why
A 15s cadence felt stale during a running multi-dim scan -- dims could complete one-by-one and the row would only flip up to 15s after each one landed on disk. The dim cache became self-healing in PR #484 (it evicts when the in-memory cache disagrees with the on-disk eval/ count), so each poll fetch now reflects truth -- the cadence is the only knob holding us back from a live feel.

Cost is small: 12 req/min while a run is alive, zero otherwise. Polling is scoped to the History page (not the global score query) so the rest of the app stays quiet while the user is reading other tabs.

## Future work
The proper architectural answer is per-evaluation SSE for History rows -- we already have `useRunEventStream` driving the active job's evaluation pane. Pushing dim/finding events to History instead of polling would drop request count to zero and remove the cadence trade-off entirely. Polling at 5s is the simple stopgap until that lands.

## Test plan
- [x] `node --test src/quodeq/ui/src/utils/runPolling.test.js` passes locally (5/5)
- [x] Start a multi-dim eval and verify the row flips within ~5s of each dim completing
- [ ] Confirm no extra polling kicks in once the umbrella run terminates (interval should be `false`)