### PR TITLE
fix(ui): show 'performing an evaluation...' on running History rows

### DIFF
--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -205,18 +205,17 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
             const { date } = formatDateParts(new Date().toISOString());
             // Stubs (hasScoredDims === false) have no completed standards yet
             // and would land on an empty dashboard. Block the click and tell
-            // the user to wait. Running runs that ARE in trend (i.e. already
-            // have at least one scored dim) remain clickable, and we surface
-            // the dims that *have* completed instead of a generic
-            // "in progress" placeholder.
+            // the user to wait. Runs that already have at least one scored
+            // dim remain clickable. We used to surface a partial dim summary
+            // here, but dimensionDetails only fills in once the umbrella run
+            // terminates -- so the cell sat empty for the whole run and then
+            // flipped to a finished summary at the very end. A flat
+            // 'performing an evaluation...' placeholder is honest about the
+            // state and avoids implying live per-dim progress.
             const notReady = entry.hasScoredDims === false;
-            const dimsCell = notReady
-              ? <span className="history-row__muted">no scores yet</span>
-              : (
-                <span className="history-row__muted">
-                  <FittedText text={formatDimSummary(entry)} mode="end" />
-                </span>
-              );
+            const dimsCell = (
+              <span className="history-row__muted">performing an evaluation...</span>
+            );
             return (
               <HistoryRow
                 key={entry.runId}


### PR DESCRIPTION
## Summary
- Replace the partial-dim summary cell on in-progress History rows with a flat `performing an evaluation...` placeholder.
- Drop the `notReady` branching for the dim cell -- both stub and trend-known in-progress rows render the same placeholder. Click-blocking on `notReady` rows still works.

## Why
The dim summary was supposed to surface scores as each dim completed, but `dimensionDetails` only fills in once the umbrella run terminates. So during a multi-dim run the cell sat empty for minutes and then flipped to a finished summary at the very end -- implying live per-dim progress that isn't actually happening.

A flat placeholder is honest about the state (the run is in progress, no dim-level info to show yet) and gets out of the way visually until the row flips to a terminal state.

## Future work
If we want a true live feel here, the architectural answer is per-evaluation SSE for History rows -- pushing dim/finding events the same way `useRunEventStream` drives the active job's evaluation pane. Out of scope for this PR.

## Test plan
- [x] Start a multi-dim eval; confirm the row shows `performing an evaluation...` for the duration of the run, then flips to the final dim summary on completion.
- [x] Confirm `notReady` rows (no scores yet) still block click and show the toast.