### PR TITLE
feat(ui): live per-dim updates on History rows via SSE

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.js
@@ -19,13 +19,14 @@
  */
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { evaluationKeys } from "../../../api/queryKeys.js";
+import { evaluationKeys, projectKeys } from "../../../api/queryKeys.js";
 
 // Cap the per-job findings array so a long-running scan with tens of thousands
 // of findings does not grow the React Query cache without bound. The dashboard
 // renders aggregated counts and the most-recent slice; older entries are still
 // reachable through the scored evaluation/<dim>.json artifacts on disk.
 const MAX_FINDINGS_IN_CACHE = 5000;
+const TERMINAL_STATES = new Set(["done", "failed", "cancelled"]);
 
 function isSseEnabled() {
   return import.meta.env?.VITE_USE_SSE_EVENTS === "true";
@@ -58,6 +59,14 @@ export function useRunEventStream(jobId) {
       try {
         const data = JSON.parse(e.data);
         writeCache(evaluationKeys.status(jobId), data);
+        if (data && TERMINAL_STATES.has(data.state)) {
+          // Run just hit a terminal state -- the trend's view of this run is
+          // about to flip from "in-progress / partial" to "terminal / final".
+          // Invalidate the project subtree so the History row rerenders against
+          // the freshly-fetched trend instead of staying on the SSE-fed live
+          // dim cache for an unbounded time.
+          queryClient.invalidateQueries({ queryKey: projectKeys.all() });
+        }
       } catch {
         // ignore malformed frames; reconnect handles recovery via Last-Event-ID
       }

--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useQuery } from "@tanstack/react-query";
 import { useRunEventStream } from "./useRunEventStream";
-import { evaluationKeys } from "../../../api/queryKeys.js";
+import { evaluationKeys, projectKeys } from "../../../api/queryKeys.js";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 class MockEventSource {
   constructor(url) {
@@ -21,6 +22,18 @@ class MockEventSource {
       h({ data: JSON.stringify(data), lastEventId: data?.id }),
     );
   }
+}
+
+function renderStreamWithSpy(jobId) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  function Wrapper({ children }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  const utils = renderHook(() => useRunEventStream(jobId), { wrapper: Wrapper });
+  return { ...utils, invalidateSpy };
 }
 
 function renderStreamAndQuery(jobId, key) {
@@ -110,5 +123,44 @@ describe("useRunEventStream (cache-writer)", () => {
     import.meta.env.VITE_USE_SSE_EVENTS = "false";
     renderStreamAndQuery("job-1", evaluationKeys.status("job-1"));
     expect(MockEventSource.last).toBeNull();
+  });
+
+  it("invalidates project trend on terminal status (done)", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { invalidateSpy } = renderStreamWithSpy("job-term-1");
+    act(() => {
+      MockEventSource.last.emit("status", { state: "done" });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: projectKeys.all() });
+  });
+
+  it("invalidates project trend on terminal status (failed)", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { invalidateSpy } = renderStreamWithSpy("job-term-2");
+    act(() => {
+      MockEventSource.last.emit("status", { state: "failed" });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: projectKeys.all() });
+  });
+
+  it("invalidates project trend on terminal status (cancelled)", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { invalidateSpy } = renderStreamWithSpy("job-term-3");
+    act(() => {
+      MockEventSource.last.emit("status", { state: "cancelled" });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: projectKeys.all() });
+  });
+
+  it("does NOT invalidate project trend on non-terminal status", () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = "true";
+    const { invalidateSpy } = renderStreamWithSpy("job-running");
+    act(() => {
+      MockEventSource.last.emit("status", { state: "running" });
+    });
+    const sawProjectInvalidate = invalidateSpy.mock.calls.some(
+      ([arg]) => Array.isArray(arg?.queryKey) && arg.queryKey[0] === "project",
+    );
+    expect(sawProjectInvalidate).toBe(false);
   });
 });

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -3,6 +3,8 @@ import { gradeLabel, scoreColorClass } from '../../../utils/formatters.js';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
 import { useRunningRunsRefresh } from '../../../hooks/useRunningRunsRefresh.js';
+import { useHistoryRunLive } from '../hooks/useHistoryRunLive.js';
+import { formatLiveDimSummary } from '../utils/formatLiveDimSummary.js';
 const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
@@ -165,6 +167,48 @@ function HistoryRow({ className = '', onClick, cells, onDelete, title }) {
   );
 }
 
+/**
+ * Row variant for in-progress runs. Calls useHistoryRunLive at the top
+ * level (cannot be conditional inside .map()), reads live dim payloads
+ * from the SSE-fed cache, and renders a partial summary as soon as the
+ * first dim has scored. Falls back to the 'performing an evaluation...'
+ * placeholder while no dim has scored.
+ */
+function InProgressHistoryRow({ entry, onClick, onNotReadyClick }) {
+  const { liveDims, plannedDimensions } = useHistoryRunLive(entry.runId);
+  const liveCount = Object.values(liveDims || {}).filter((d) => d?.dimension).length;
+  const notReady = entry.hasScoredDims === false && liveCount === 0;
+  const { date } = formatDateParts(new Date().toISOString());
+  const liveText = liveCount === 0 ? '' : formatLiveDimSummary(liveDims, plannedDimensions);
+  const dimsCell = liveCount === 0
+    ? <span className="history-row__muted">performing an evaluation...</span>
+    : (
+      <span className="history-row__muted">
+        <FittedText text={liveText} mode="end" />
+      </span>
+    );
+  return (
+    <HistoryRow
+      className={`history-row--in-progress${notReady ? ' history-row--not-ready' : ''}`}
+      onClick={notReady ? () => onNotReadyClick() : () => onClick(entry.runId)}
+      title={notReady ? NOT_READY_MESSAGE : undefined}
+      cells={{
+        date,
+        time: (
+          <span className="history-row__running">
+            <span className="history-row__running-dot" aria-hidden="true" />
+            running
+          </span>
+        ),
+        grade: <span className="history-row__muted">—</span>,
+        score: <span className="history-row__muted">—</span>,
+        delta: <span className="history-delta history-delta--muted">—</span>,
+        dims: dimsCell,
+      }}
+    />
+  );
+}
+
 function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onDeleteRun, onNotReadyClick }) {
   return (
     <section className="history-evaluations panel">
@@ -186,39 +230,12 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
         {visible.map((entry, i) => {
           const isInProgress = entry.status === 'in_progress';
           if (isInProgress) {
-            const { date } = formatDateParts(new Date().toISOString());
-            // Stubs (hasScoredDims === false) have no completed standards yet
-            // and would land on an empty dashboard. Block the click and tell
-            // the user to wait. Runs that already have at least one scored
-            // dim remain clickable. We used to surface a partial dim summary
-            // here, but dimensionDetails only fills in once the umbrella run
-            // terminates -- so the cell sat empty for the whole run and then
-            // flipped to a finished summary at the very end. A flat
-            // 'performing an evaluation...' placeholder is honest about the
-            // state and avoids implying live per-dim progress.
-            const notReady = entry.hasScoredDims === false;
-            const dimsCell = (
-              <span className="history-row__muted">performing an evaluation...</span>
-            );
             return (
-              <HistoryRow
+              <InProgressHistoryRow
                 key={entry.runId}
-                className={`history-row--in-progress${notReady ? ' history-row--not-ready' : ''}`}
-                onClick={notReady ? () => onNotReadyClick() : () => onRunClick(entry.runId)}
-                title={notReady ? NOT_READY_MESSAGE : undefined}
-                cells={{
-                  date,
-                  time: (
-                    <span className="history-row__running">
-                      <span className="history-row__running-dot" aria-hidden="true" />
-                      running
-                    </span>
-                  ),
-                  grade: <span className="history-row__muted">—</span>,
-                  score: <span className="history-row__muted">—</span>,
-                  delta: <span className="history-delta history-delta--muted">—</span>,
-                  dims: dimsCell,
-                }}
+                entry={entry}
+                onClick={onRunClick}
+                onNotReadyClick={onNotReadyClick}
               />
             );
           }

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -13,6 +13,7 @@ import { TermHeader } from '../../../components/terminal/index.js';
 import EmptyState from '../../../components/EmptyState.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import FittedText from '../../../components/FittedText.jsx';
+import { abbrevDim } from '../utils/dimAbbrev.js';
 
 const TOAST_DISMISS_MS = 2600;
 const NOT_READY_MESSAGE = 'No standards fully evaluated yet. Try again once the first one finishes.';
@@ -59,23 +60,6 @@ function computeDeltas(rows) {
   });
 }
 
-// Shorter labels for the multi-dim summary so the row's dimensions cell
-// can fit the count and names instead of truncating after the first dim.
-// The full dim name is still visible after click-through.
-const _DIM_ABBREV = {
-  flexibility: 'flex',
-  maintainability: 'maint',
-  performance: 'perf',
-  reliability: 'rel',
-  security: 'sec',
-  usability: 'usab',
-};
-
-function _abbrevDim(name) {
-  if (!name) return name;
-  const lower = name.toLowerCase();
-  return _DIM_ABBREV[lower] || (lower.length > 5 ? lower.slice(0, 4) : lower);
-}
 
 function formatDimSummary(entry) {
   const dims = (entry?.dimensionDetails || []).filter((d) => d?.dimension);
@@ -92,7 +76,7 @@ function formatDimSummary(entry) {
   // in the dimensions cell instead of getting truncated after the first.
   const parts = dims.map((d) => {
     const score = parseFloat(d.score);
-    const label = _abbrevDim(d.dimension);
+    const label = abbrevDim(d.dimension);
     if (Number.isNaN(score)) return label;
     return `${label} ${score.toFixed(1)}`;
   });

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.js
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.js
@@ -1,0 +1,57 @@
+/**
+ * Live data for an in-progress History row.
+ *
+ * Mounts a per-row SSE subscription via useRunEventStream and reactively
+ * subscribes to the cache slots that subscription writes. Returns
+ *
+ *   { liveDims, plannedDimensions }
+ *
+ * where liveDims is a `{ [dim]: <evaluation/<dim>.json payload> }` map
+ * and plannedDimensions is the dim list the run was started against
+ * (sourced from the most recent status event).
+ *
+ * The render switch (placeholder vs partial summary) lives in the
+ * caller; this hook is just the data adapter.
+ *
+ * Gating: useRunEventStream itself is gated on VITE_USE_SSE_EVENTS,
+ * so when the flag is off this hook simply returns the empty defaults
+ * forever. No behavior change for the SSE-off path.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useRunEventStream } from '../../evaluation/hooks/useRunEventStream.js';
+import { evaluationKeys } from '../../../api/queryKeys.js';
+
+// queryFn never runs (enabled: false); the cache is populated only by
+// the SSE writer in useRunEventStream. useQuery is here for its
+// subscription -- when setQueryData fires, this component rerenders.
+const NEVER_QUERIED = () => {
+  throw new Error('cache slot is SSE-fed; queryFn must not run');
+};
+
+export function useHistoryRunLive(runId) {
+  useRunEventStream(runId);
+
+  const { data: liveDims = {} } = useQuery({
+    queryKey: runId
+      ? evaluationKeys.dimensions(runId)
+      : ['evaluation', '_none_', 'dimensions'],
+    queryFn: NEVER_QUERIED,
+    enabled: false,
+    staleTime: Infinity,
+  });
+
+  const { data: status } = useQuery({
+    queryKey: runId
+      ? evaluationKeys.status(runId)
+      : ['evaluation', '_none_', 'status'],
+    queryFn: NEVER_QUERIED,
+    enabled: false,
+    staleTime: Infinity,
+  });
+
+  const plannedDimensions = Array.isArray(status?.dimensions)
+    ? status.dimensions
+    : [];
+
+  return { liveDims, plannedDimensions };
+}

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useHistoryRunLive } from './useHistoryRunLive.js';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+
+class MockEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    MockEventSource.last = this;
+  }
+  addEventListener(event, handler) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(handler);
+  }
+  close() { this.closed = true; }
+  emit(event, data) {
+    (this.listeners[event] || []).forEach((h) =>
+      h({ data: JSON.stringify(data), lastEventId: data?.id }),
+    );
+  }
+}
+
+describe('useHistoryRunLive', () => {
+  beforeEach(() => {
+    global.EventSource = MockEventSource;
+    MockEventSource.last = null;
+    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+  });
+
+  it('returns empty defaults when no events have arrived', () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-empty'), { wrapper });
+    expect(result.current.liveDims).toEqual({});
+    expect(result.current.plannedDimensions).toEqual([]);
+  });
+
+  it('opens an EventSource scoped to the runId', () => {
+    const wrapper = withQueryClient();
+    renderHook(() => useHistoryRunLive('run-xyz'), { wrapper });
+    expect(MockEventSource.last.url).toBe('/api/evaluations/run-xyz/events');
+  });
+
+  it('surfaces dimension-completed events into liveDims', async () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-1'), { wrapper });
+    act(() => {
+      MockEventSource.last.emit('dimension-completed', {
+        dimension: 'security', score: 7.4,
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.liveDims).toEqual({
+        security: { dimension: 'security', score: 7.4 },
+      });
+    });
+  });
+
+  it('surfaces status.dimensions as plannedDimensions', async () => {
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-2'), { wrapper });
+    act(() => {
+      MockEventSource.last.emit('status', {
+        state: 'running',
+        dimensions: ['security', 'maintainability', 'performance'],
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.plannedDimensions).toEqual([
+        'security', 'maintainability', 'performance',
+      ]);
+    });
+  });
+
+  it('closes the EventSource on unmount', () => {
+    const wrapper = withQueryClient();
+    const { unmount } = renderHook(() => useHistoryRunLive('run-close'), { wrapper });
+    const source = MockEventSource.last;
+    unmount();
+    expect(source.closed).toBe(true);
+  });
+
+  it('does not open EventSource when runId is empty', () => {
+    const wrapper = withQueryClient();
+    renderHook(() => useHistoryRunLive(''), { wrapper });
+    expect(MockEventSource.last).toBeNull();
+  });
+
+  it('returns empty defaults and opens no EventSource when SSE is off', () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
+    const wrapper = withQueryClient();
+    const { result } = renderHook(() => useHistoryRunLive('run-sseoff'), { wrapper });
+    expect(MockEventSource.last).toBeNull();
+    expect(result.current.liveDims).toEqual({});
+    expect(result.current.plannedDimensions).toEqual([]);
+  });
+});

--- a/src/quodeq/ui/src/features/history/utils/dimAbbrev.js
+++ b/src/quodeq/ui/src/features/history/utils/dimAbbrev.js
@@ -1,0 +1,20 @@
+/**
+ * Shorter labels for dim summaries so the row's dimensions cell can fit
+ * the count and names instead of truncating after the first dim. Used
+ * by both the terminal `formatDimSummary` (HistoryPage.jsx) and the
+ * live `formatLiveDimSummary` so the truncation rules stay consistent.
+ */
+export const DIM_ABBREV = {
+  flexibility: 'flex',
+  maintainability: 'maint',
+  performance: 'perf',
+  reliability: 'rel',
+  security: 'sec',
+  usability: 'usab',
+};
+
+export function abbrevDim(name) {
+  if (!name) return name;
+  const lower = String(name).toLowerCase();
+  return DIM_ABBREV[lower] || (lower.length > 5 ? lower.slice(0, 4) : lower);
+}

--- a/src/quodeq/ui/src/features/history/utils/dimAbbrev.test.js
+++ b/src/quodeq/ui/src/features/history/utils/dimAbbrev.test.js
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { abbrevDim, DIM_ABBREV } from './dimAbbrev.js';
+
+test('abbreviates known dimensions to their canonical short forms', () => {
+  assert.equal(abbrevDim('security'), 'sec');
+  assert.equal(abbrevDim('Maintainability'), 'maint');
+  assert.equal(abbrevDim('PERFORMANCE'), 'perf');
+  assert.equal(abbrevDim('reliability'), 'rel');
+  assert.equal(abbrevDim('flexibility'), 'flex');
+  assert.equal(abbrevDim('usability'), 'usab');
+});
+
+test('passes short unknown dims through lowercased', () => {
+  assert.equal(abbrevDim('foo'), 'foo');
+  assert.equal(abbrevDim('AB'), 'ab');
+  assert.equal(abbrevDim('FIVES'), 'fives'); // exactly 5 chars: passthrough
+});
+
+test('truncates long unknown dims to 4 chars', () => {
+  assert.equal(abbrevDim('observability'), 'obse');
+  assert.equal(abbrevDim('SCALABILITY'), 'scal');
+});
+
+test('returns the input as-is for falsy values', () => {
+  assert.equal(abbrevDim(''), '');
+  assert.equal(abbrevDim(null), null);
+  assert.equal(abbrevDim(undefined), undefined);
+});
+
+test('DIM_ABBREV is exported and contains expected entries', () => {
+  assert.equal(DIM_ABBREV.security, 'sec');
+  assert.equal(DIM_ABBREV.maintainability, 'maint');
+});

--- a/src/quodeq/ui/src/features/history/utils/formatLiveDimSummary.js
+++ b/src/quodeq/ui/src/features/history/utils/formatLiveDimSummary.js
@@ -1,0 +1,32 @@
+/**
+ * Build the live dim-summary cell text for an in-progress History row.
+ *
+ * Inputs come from the SSE-fed TanStack Query cache:
+ *   liveDims          : { [dim]: <evaluation/<dim>.json payload> }
+ *   plannedDimensions : string[] from the latest status event's `dimensions`
+ *
+ * Empty `liveDims` → empty string (the caller renders the
+ * "performing an evaluation..." placeholder in that case). Otherwise the
+ * shape is `${done} / ${total} dims · ${abbrev1} ${score1}, ...`.
+ *
+ * If `plannedDimensions` is missing or empty (status not yet streamed),
+ * the total falls back to the number of completed dims, so we never
+ * render `1 / 0 dims`.
+ */
+import { abbrevDim } from './dimAbbrev.js';
+
+export function formatLiveDimSummary(liveDims, plannedDimensions) {
+  const entries = Object.values(liveDims || {}).filter((d) => d?.dimension);
+  if (entries.length === 0) return '';
+  const total = (plannedDimensions && plannedDimensions.length > 0)
+    ? plannedDimensions.length
+    : entries.length;
+  const parts = entries.map((d) => {
+    const raw = d.score ?? d.average_score;
+    const score = parseFloat(raw);
+    const label = abbrevDim(d.dimension);
+    if (raw === undefined || raw === null || Number.isNaN(score)) return label;
+    return `${label} ${score.toFixed(1)}`;
+  });
+  return `${entries.length} / ${total} dims · ${parts.join(', ')}`;
+}

--- a/src/quodeq/ui/src/features/history/utils/formatLiveDimSummary.test.js
+++ b/src/quodeq/ui/src/features/history/utils/formatLiveDimSummary.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatLiveDimSummary } from './formatLiveDimSummary.js';
+
+test('returns empty-state placeholder for empty live dims', () => {
+  assert.equal(formatLiveDimSummary({}, ['security', 'maintainability']), '');
+  assert.equal(formatLiveDimSummary(null, []), '');
+  assert.equal(formatLiveDimSummary(undefined, undefined), '');
+});
+
+test('formats a partial run (1 of 3 dims complete)', () => {
+  const live = { security: { dimension: 'security', score: 7.4 } };
+  const planned = ['security', 'maintainability', 'performance'];
+  assert.equal(formatLiveDimSummary(live, planned), '1 / 3 dims · sec 7.4');
+});
+
+test('formats two completed of three planned', () => {
+  const live = {
+    security: { dimension: 'security', score: 7.4 },
+    maintainability: { dimension: 'maintainability', score: 6.1 },
+  };
+  const planned = ['security', 'maintainability', 'performance'];
+  assert.equal(
+    formatLiveDimSummary(live, planned),
+    '2 / 3 dims · sec 7.4, maint 6.1',
+  );
+});
+
+test('formats all-complete-but-not-yet-terminal', () => {
+  const live = {
+    security: { dimension: 'security', score: 7.4 },
+    maintainability: { dimension: 'maintainability', score: 6.1 },
+  };
+  const planned = ['security', 'maintainability'];
+  assert.equal(
+    formatLiveDimSummary(live, planned),
+    '2 / 2 dims · sec 7.4, maint 6.1',
+  );
+});
+
+test('falls back to average_score when score field is missing', () => {
+  const live = {
+    security: { dimension: 'security', average_score: 8.25 },
+  };
+  assert.equal(formatLiveDimSummary(live, ['security']), '1 / 1 dims · sec 8.3');
+});
+
+test('renders dim without a score when both fields are missing', () => {
+  const live = { security: { dimension: 'security' } };
+  assert.equal(formatLiveDimSummary(live, ['security']), '1 / 1 dims · sec');
+});
+
+test('falls back to live count when plannedDimensions is missing', () => {
+  const live = { security: { dimension: 'security', score: 7.4 } };
+  assert.equal(formatLiveDimSummary(live, undefined), '1 / 1 dims · sec 7.4');
+  assert.equal(formatLiveDimSummary(live, []), '1 / 1 dims · sec 7.4');
+});
+
+test('skips entries that have no dimension name', () => {
+  const live = {
+    security: { dimension: 'security', score: 7.4 },
+    _: { score: 5 }, // malformed -- no dimension field
+  };
+  assert.equal(formatLiveDimSummary(live, ['security']), '1 / 1 dims · sec 7.4');
+});

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.js
@@ -19,6 +19,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { projectKeys } from '../api/queryKeys.js';
 import { pollIntervalForRuns } from '../utils/runPolling.js';
 
+const SSE_ENABLED = () => import.meta.env?.VITE_USE_SSE_EVENTS === 'true';
+
 export function useRunningRunsRefresh({ selectedProject, availableRuns }) {
   const queryClient = useQueryClient();
   const interval = pollIntervalForRuns(availableRuns);
@@ -33,9 +35,12 @@ export function useRunningRunsRefresh({ selectedProject, availableRuns }) {
     });
   }, [queryClient, selectedProject]);
 
-  // (2) Background polling: only while in_progress runs exist.
+  // (2) Background polling: only while in_progress runs exist AND SSE is off.
+  // With SSE on, terminal-status events drive the running -> terminal flip
+  // (see useRunEventStream); polling here would just double the request rate.
   useEffect(() => {
     if (!selectedProject || !interval) return undefined;
+    if (SSE_ENABLED()) return undefined;
     const id = setInterval(() => {
       queryClient.invalidateQueries({
         queryKey: projectKeys.project(selectedProject),

--- a/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
+++ b/src/quodeq/ui/src/hooks/useRunningRunsRefresh.test.jsx
@@ -19,6 +19,7 @@ function makeWrapper() {
 describe('useRunningRunsRefresh', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -142,5 +143,58 @@ describe('useRunningRunsRefresh', () => {
       vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 3);
     });
     expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('mount-time refresh fires regardless of VITE_USE_SSE_EVENTS', () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: 'p1',
+          availableRuns: [{ runId: 'r1', status: 'in_progress' }],
+        }),
+      { wrapper: Wrapper },
+    );
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: projectKeys.project('p1'),
+    });
+  });
+
+  it('suppresses recurring poll when VITE_USE_SSE_EVENTS=true', () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = 'true';
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: 'p1',
+          availableRuns: [{ runId: 'r1', status: 'in_progress' }],
+        }),
+      { wrapper: Wrapper },
+    );
+    invalidateSpy.mockClear(); // ignore the mount-time refresh
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 5);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('still polls when VITE_USE_SSE_EVENTS is not "true"', () => {
+    import.meta.env.VITE_USE_SSE_EVENTS = 'false';
+    const { Wrapper, invalidateSpy } = makeWrapper();
+    renderHook(
+      () =>
+        useRunningRunsRefresh({
+          selectedProject: 'p1',
+          availableRuns: [{ runId: 'r1', status: 'in_progress' }],
+        }),
+      { wrapper: Wrapper },
+    );
+    invalidateSpy.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(IN_PROGRESS_POLL_MS * 2 + 50);
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
Per-row SSE subscription on the History page: the in-progress dim cell fills score-by-score as each dim lands on disk, replacing the static `performing an evaluation...` placeholder shipped in #486. Trend cache is never patched — in-progress rows read from a side-channel SSE-fed cache (`evaluationKeys.dimensions`), terminal rows from the trend, and a single invalidate at terminal-status bridges them.

## Behavior
- **`VITE_USE_SSE_EVENTS=true`** — Row transitions `performing an evaluation...` → `1 / 3 dims · sec 7.4` → `2 / 3 dims · sec 7.4, maint 6.1` → final summary, with each step appearing within ~250ms of the dim landing on disk. Terminal status invalidates `projectKeys.all()`, the trend refetches once, and the row flips to its authoritative summary.
- **`VITE_USE_SSE_EVENTS=false` (default)** — Identical to `develop`: hook returns empty defaults forever, placeholder stays for the whole run, the existing recurring poll drives the running → terminal flip.

## Architecture
6 commits, each tested:
1. **Terminal-status invalidate** in `useRunEventStream` — foundation for the row-flip
2. **`dimAbbrev`** helper extracted for reuse between formatters
3. **`formatLiveDimSummary`** — pure formatter `{ [dim]: evalData } + plannedDimensions → "2 / 3 dims · ..."`
4. **`useHistoryRunLive`** hook — per-row data adapter
5. **`<InProgressHistoryRow>`** wires it into `HistoryPage.jsx` (extracted so the hook can be called per-row at top level)
6. **Polling gate** — recurring poll suppressed when SSE is on

Design doc: `docs/superpowers/specs/2026-05-10-history-row-sse-live-dims-design.md` (local).

## Side effect worth noting
`useRunEventStream` is also mounted by `useEvaluation` (the active eval pane). The new terminal-invalidate logic therefore fires there too, which means History/Dashboard will auto-refresh when an active eval finishes under SSE. This is the desired behavior and isn't a new request, but reviewers should know it's not scoped to History rows alone.

## Out of scope
- Live finding counts on the row (SSE delivers them but the row doesn't render them today).
- Multi-tab consolidation (each tab opens its own EventSource; backend is read-only with no per-client state).
- Removing the polling fallback entirely (kept for the SSE-off path).

## Test plan
- [x] `npm --prefix src/quodeq/ui run test:all` — 333 pass, 5 fail (pre-existing `useEvaluation.test.jsx` failures present on `develop`, unrelated and untouched here)
- [x] `npm --prefix src/quodeq/ui run build` — clean (148ms)
- [x] With `VITE_USE_SSE_EVENTS=true`, start a 3-dim eval; confirm the row transitions placeholder → `1 / 3 dims · ...` → `2 / 3 dims · ...` → final summary as each dim lands.
- [x] With `VITE_USE_SSE_EVENTS=false`, behavior matches `develop`: placeholder for the whole run, polling drives the running → terminal flip.
- [x] Cancel a run mid-dim; confirm the row flips to the terminal partial summary; SSE stream closes.