### PR TITLE
fix(ui): cancel invalidates project trend so History flips immediately

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -189,6 +189,12 @@ export function useEvaluation() {
       if (jobId) {
         queryClient.invalidateQueries({ queryKey: evaluationKeys.evaluation(jobId) });
       }
+      // Mirror startMutation: refresh the project subtree so History's
+      // availableRuns drops the cancelled run from the in-progress list
+      // immediately. Without this, the History row stays on the
+      // 'performing an evaluation...' placeholder until the next polling
+      // tick (or, under SSE, the terminal-status event from the stream).
+      queryClient.invalidateQueries({ queryKey: projectKeys.all() });
     },
     onError: (err) => {
       // The backend returns 409 when the job is no longer cancellable

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.test.jsx
@@ -9,6 +9,13 @@ vi.mock("../../../utils/confirmDialog.js", () => ({
   confirmDialog: vi.fn().mockResolvedValue({ ok: true, checked: false }),
 }));
 
+// chooseDialog renders a real DOM dialog and waits for a click; in jsdom
+// that never resolves and the mutation never fires. Auto-resolve to a
+// non-destructive choice so cancel-flow tests can drive cancelMutation.
+vi.mock("../../../utils/chooseDialog.js", () => ({
+  chooseDialog: vi.fn().mockResolvedValue("preserve"),
+}));
+
 const fakeApi = {
   getEvaluation: vi.fn(),
   startEvaluation: vi.fn(),
@@ -132,6 +139,41 @@ describe("useEvaluation", () => {
         aiModel: "llama3.1",
       }),
     );
+  });
+
+  it("cancelEvaluation invalidates project queries so History drops the cancelled run immediately", async () => {
+    // Regression: pre-fix, after cancel the History row stayed on the
+    // 'performing an evaluation...' placeholder until either polling
+    // ticked or (under SSE) the terminal-status event arrived. Mirrors
+    // startMutation's existing project-subtree invalidate.
+    const { QueryClient, QueryClientProvider } = await import("@tanstack/react-query");
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    fakeApi.startEvaluation.mockResolvedValue({
+      jobId: "j-cancel-1", status: "running", dimensions: [],
+    });
+    fakeApi.cancelEvaluation.mockResolvedValue({ ok: true });
+    function Wrapper({ children }) {
+      return (
+        <QueryClientProvider client={client}>
+          <ApiProvider value={fakeApi}>{children}</ApiProvider>
+        </QueryClientProvider>
+      );
+    }
+    const { result } = renderHook(() => useEvaluation(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.startEvaluation({ repo: "x", dimensions: [] });
+    });
+    await waitFor(() => expect(result.current.job?.jobId).toBe("j-cancel-1"));
+    // Spy AFTER start so we only observe cancel's invalidations.
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    await act(async () => {
+      await result.current.cancelEvaluation();
+    });
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project"] });
+    });
   });
 
   it("cancelEvaluation surfaces an error and clears the job when the API rejects", async () => {


### PR DESCRIPTION
## Summary
Pre-existing bug exposed by [quodeq#487](https://github.com/quodeq/quodeq/pull/487): cancelling an evaluation left the History row stuck on `performing an evaluation...` because `cancelMutation`'s `onSuccess` only invalidated `evaluationKeys.evaluation(jobId)` -- never `projectKeys.*`. So `availableRuns` kept the cancelled run as `in_progress` until either polling ticked (~15s) or the SSE terminal-status event arrived. Mirror what `startMutation` already does on success: also invalidate `projectKeys.all()` so the History view drops the cancelled run from the in-progress list right away.

## Bonus: 5 pre-existing test failures fixed
While writing the regression test for the cancel path, I traced the 5 long-standing `useEvaluation.test.jsx` failures to a missing mock: `chooseDialog` is DOM-based, and in jsdom it just hangs waiting for a click that never comes. The unmounted dialogs leaked between tests, cascading failures into unrelated specs (provider-error path, mount-time resume, etc.). Adding a `vi.mock` for `chooseDialog` (auto-resolves to `'preserve'`) unblocks all 12 tests in the file.

## Test plan
- [x] `npm --prefix src/quodeq/ui run test:all` — **339 / 339 pass** (was 333 passing + 5 broken; +1 new test, +5 unstuck = 339)
- [x] With `VITE_USE_SSE_EVENTS=false` (default), start an eval, cancel mid-dim; confirm the History row flips out of `performing an evaluation...` immediately.
- [x] With `VITE_USE_SSE_EVENTS=true`, same scenario; confirm immediate flip via the terminal-status invalidate (the SSE path also picks this up, but the explicit cancel-success invalidate makes it unconditional).