### PR TITLE
refactor(ui): extract MockEventSource to shared test util

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useRunEventStream.test.jsx
@@ -4,25 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useRunEventStream } from "./useRunEventStream";
 import { evaluationKeys, projectKeys } from "../../../api/queryKeys.js";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
+import { MockEventSource } from "../../../test-utils/MockEventSource.js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-class MockEventSource {
-  constructor(url) {
-    this.url = url;
-    this.listeners = {};
-    MockEventSource.last = this;
-  }
-  addEventListener(event, handler) {
-    if (!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event].push(handler);
-  }
-  close() { this.closed = true; }
-  emit(event, data) {
-    (this.listeners[event] || []).forEach((h) =>
-      h({ data: JSON.stringify(data), lastEventId: data?.id }),
-    );
-  }
-}
 
 function renderStreamWithSpy(jobId) {
   const client = new QueryClient({

--- a/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
+++ b/src/quodeq/ui/src/features/history/hooks/useHistoryRunLive.test.jsx
@@ -2,24 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useHistoryRunLive } from './useHistoryRunLive.js';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
-
-class MockEventSource {
-  constructor(url) {
-    this.url = url;
-    this.listeners = {};
-    MockEventSource.last = this;
-  }
-  addEventListener(event, handler) {
-    if (!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event].push(handler);
-  }
-  close() { this.closed = true; }
-  emit(event, data) {
-    (this.listeners[event] || []).forEach((h) =>
-      h({ data: JSON.stringify(data), lastEventId: data?.id }),
-    );
-  }
-}
+import { MockEventSource } from '../../../test-utils/MockEventSource.js';
 
 describe('useHistoryRunLive', () => {
   beforeEach(() => {

--- a/src/quodeq/ui/src/test-utils/MockEventSource.js
+++ b/src/quodeq/ui/src/test-utils/MockEventSource.js
@@ -1,0 +1,28 @@
+/**
+ * Test-only stand-in for the browser `EventSource` API.
+ *
+ * Assign to `global.EventSource` in a test's `beforeEach` so hooks under test
+ * pick it up instead of the real implementation. The most recently constructed
+ * instance is recorded on `MockEventSource.last`, so tests can grab it without
+ * threading the reference through the hook. Use `emit(name, dataObj)` to fire
+ * a named event synchronously — `dataObj` is JSON-stringified into `event.data`
+ * and its `id` (if any) is exposed as `event.lastEventId`, mirroring the real
+ * SSE message shape.
+ */
+export class MockEventSource {
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    MockEventSource.last = this;
+  }
+  addEventListener(event, handler) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(handler);
+  }
+  close() { this.closed = true; }
+  emit(event, data) {
+    (this.listeners[event] || []).forEach((h) =>
+      h({ data: JSON.stringify(data), lastEventId: data?.id }),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- The `MockEventSource` class was duplicated verbatim in `useRunEventStream.test.jsx` and `useHistoryRunLive.test.jsx`. Both copies recorded the latest instance on `MockEventSource.last`, buffered handlers via `addEventListener`, and exposed a synchronous `emit(name, data)` helper.
- Extracted to `src/quodeq/ui/src/test-utils/MockEventSource.js` with a JSDoc explaining the contract. Both tests now import the shared class.
- Pure refactor — no behavior change. If the mock ever needs to grow (e.g., `onerror`, `readyState`, `Last-Event-ID` reconnect), it'll change in one place.

## Test plan
- [x] `npm --prefix src/quodeq/ui run test:ui` — 62 files, 339 tests pass
- [x] Targeted run of the two affected files — 18 tests pass (11 + 7), counts unchanged