### PR TITLE
fix(services): cancel waits for status.json terminal before returning

### DIFF
--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -309,6 +310,13 @@ class FsEvaluationMixin:
         report file already exists), so double-firing with the route-level
         scoring in ``_evaluation_routes`` is a no-op.
 
+        After ``cancel_job`` returns we wait briefly for the run lifecycle
+        handler in the subprocess to write ``status.json`` to a terminal
+        state. Without this wait, the API returns while observers reading
+        ``status.json`` (UI dashboard query, SSE stream, etc.) still see
+        the run as ``in_progress`` for a window of ~100ms-1s, producing
+        the "two running rows" UX after a cancel-then-start.
+
         When ``discard_partial`` is True we also wipe queue + fingerprint
         files for any dim that didn't complete scoring — the next run sees
         no salvageable state and starts fresh for those dims.
@@ -317,6 +325,8 @@ class FsEvaluationMixin:
         job = self.get_evaluation_status(job_id, reports_dir=reports_dir)
         ok = self._jobs.cancel_job(job_id, reports_root=reports_root)
         if ok and reports_dir and job:
+            run_dir = Path(reports_dir) / job.output_project / job.output_run_id
+            _wait_for_terminal_status(run_dir)
             _score_completed_evidence(reports_dir, {
                 "outputProject": job.output_project,
                 "outputRunId": job.output_run_id,
@@ -354,6 +364,46 @@ class FsEvaluationMixin:
         if states:
             jobs = [j for j in jobs if j.status in states]
         return jobs[:limit] if limit > 0 else jobs
+
+
+_TERMINAL_RUN_STATES = frozenset({"done", "failed", "cancelled"})
+_CANCEL_WAIT_TIMEOUT_S = 2.0
+_CANCEL_WAIT_POLL_S = 0.05
+
+
+def _wait_for_terminal_status(
+    run_dir: Path,
+    *,
+    timeout_s: float = _CANCEL_WAIT_TIMEOUT_S,
+    poll_interval_s: float = _CANCEL_WAIT_POLL_S,
+) -> bool:
+    """Block until ``run_dir/status.json`` reports a terminal state, or timeout.
+
+    Returns True when a terminal state ({done, failed, cancelled}) is
+    observed on disk; returns False on timeout. Best-effort: a False
+    return does not abort the calling cancel flow — downstream polling
+    or SSE will eventually catch up.
+
+    Bridges the async gap between ``JobManager.cancel_job`` returning
+    (in-memory state flipped, signal sent to subprocess) and the run
+    lifecycle handler in the subprocess flushing ``status.json`` to
+    terminal. Without this wait, observers reading from disk
+    immediately after the API returns can still see the run as
+    ``in_progress`` for ~100ms-1s, producing a window where a
+    follow-up "Start" surfaces two ``running`` rows in the UI.
+    """
+    deadline = time.monotonic() + timeout_s
+    status_path = run_dir / "status.json"
+    while True:
+        try:
+            data = json.loads(status_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and data.get("state") in _TERMINAL_RUN_STATES:
+                return True
+        except (OSError, ValueError):
+            pass
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(poll_interval_s)
 
 
 def _open_cache():

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -21,6 +21,7 @@ from quodeq.services.evaluation_mixin import (
     _read_queue_files_count,
     _register_project,
     _score_completed_evidence,
+    _wait_for_terminal_status,
 )
 
 
@@ -280,7 +281,8 @@ class TestCancelEvaluation:
             job_id="j1", status="running",
             output_project="proj", output_run_id="run1",
         )
-        with patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score:
+        with patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score, \
+             patch("quodeq.services.evaluation_mixin._wait_for_terminal_status"):
             result = m.cancel_evaluation("j1", reports_dir="/reports")
         assert result is True
         mock_score.assert_called_once()
@@ -315,7 +317,8 @@ class TestCancelEvaluation:
             output_project="proj-uuid", output_run_id="run-42",
         )
         with patch.object(FsEvaluationMixin, "get_evaluation_status", return_value=ext_snapshot), \
-             patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score:
+             patch("quodeq.services.evaluation_mixin._score_completed_evidence") as mock_score, \
+             patch("quodeq.services.evaluation_mixin._wait_for_terminal_status"):
             result = m.cancel_evaluation("ext-run-42", reports_dir="/reports")
         assert result is True
         mock_score.assert_called_once()
@@ -325,6 +328,99 @@ class TestCancelEvaluation:
         assert call_args.args[0] == "/reports"
         assert call_args.args[1]["outputProject"] == "proj-uuid"
         assert call_args.args[1]["outputRunId"] == "run-42"
+
+
+class TestWaitForTerminalStatus:
+    def test_returns_true_when_status_already_terminal(self, tmp_path: Path):
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "status.json").write_text(json.dumps({"state": "cancelled"}))
+        assert _wait_for_terminal_status(run_dir, timeout_s=0.2) is True
+
+    def test_recognizes_all_three_terminal_states(self, tmp_path: Path):
+        for state in ("done", "failed", "cancelled"):
+            run_dir = tmp_path / f"run-{state}"
+            run_dir.mkdir()
+            (run_dir / "status.json").write_text(json.dumps({"state": state}))
+            assert _wait_for_terminal_status(run_dir, timeout_s=0.2) is True
+
+    def test_returns_false_on_timeout_when_state_never_terminal(self, tmp_path: Path):
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "status.json").write_text(json.dumps({"state": "running"}))
+        assert _wait_for_terminal_status(
+            run_dir, timeout_s=0.1, poll_interval_s=0.02,
+        ) is False
+
+    def test_returns_false_on_timeout_when_status_missing(self, tmp_path: Path):
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        # No status.json file at all -- expected during the brief window
+        # before the lifecycle handler creates it.
+        assert _wait_for_terminal_status(
+            run_dir, timeout_s=0.1, poll_interval_s=0.02,
+        ) is False
+
+    def test_returns_false_on_malformed_status(self, tmp_path: Path):
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "status.json").write_text("not valid json")
+        assert _wait_for_terminal_status(
+            run_dir, timeout_s=0.1, poll_interval_s=0.02,
+        ) is False
+
+    def test_polls_until_terminal_appears(self, tmp_path: Path):
+        # Real-world scenario: status starts running, then the subprocess
+        # lifecycle handler flushes terminal a moment later. We expect
+        # _wait_for_terminal_status to bridge that gap.
+        import threading
+        import time as _time
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        status_path = run_dir / "status.json"
+        status_path.write_text(json.dumps({"state": "running"}))
+
+        def write_terminal() -> None:
+            _time.sleep(0.05)
+            status_path.write_text(json.dumps({"state": "cancelled"}))
+
+        threading.Thread(target=write_terminal, daemon=True).start()
+        assert _wait_for_terminal_status(
+            run_dir, timeout_s=1.0, poll_interval_s=0.02,
+        ) is True
+
+
+class TestCancelEvaluationWaitsForTerminal:
+    def test_cancel_calls_wait_for_terminal_status_after_cancel_job(self):
+        # Regression: pre-fix, cancel_evaluation returned before status.json
+        # was flushed to terminal, producing the "two running rows" UX
+        # window after cancel-then-start.
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        m._jobs.get_job.return_value = JobSnapshot(
+            job_id="j1", status="running",
+            output_project="proj", output_run_id="run1",
+        )
+        with patch("quodeq.services.evaluation_mixin._wait_for_terminal_status") as mock_wait, \
+             patch("quodeq.services.evaluation_mixin._score_completed_evidence"):
+            m.cancel_evaluation("j1", reports_dir="/reports")
+        mock_wait.assert_called_once()
+        run_dir_arg = mock_wait.call_args.args[0]
+        assert run_dir_arg == Path("/reports/proj/run1")
+
+    def test_cancel_skips_wait_when_no_reports_dir(self):
+        # When reports_dir is None there's no run_dir to watch; the wait
+        # is part of the same conditional block that gates _score and
+        # _discard, so it stays inert.
+        m = FsEvaluationMixin()
+        m._jobs = MagicMock()
+        m._jobs.cancel_job.return_value = True
+        m._jobs.get_job.return_value = JobSnapshot(job_id="j1", status="running")
+        with patch("quodeq.services.evaluation_mixin._wait_for_terminal_status") as mock_wait:
+            m.cancel_evaluation("j1")
+        mock_wait.assert_not_called()
 
 
 class TestCancelDiscardPartial:
@@ -338,6 +434,7 @@ class TestCancelDiscardPartial:
             output_project="proj", output_run_id="run1",
         )
         with patch("quodeq.services.evaluation_mixin._score_completed_evidence"), \
+             patch("quodeq.services.evaluation_mixin._wait_for_terminal_status"), \
              patch("quodeq.services.evaluation_mixin._discard_partial_dim_state") as mock_discard:
             m.cancel_evaluation("j1", reports_dir="/reports")
         mock_discard.assert_not_called()
@@ -351,6 +448,7 @@ class TestCancelDiscardPartial:
             output_project="proj", output_run_id="run1",
         )
         with patch("quodeq.services.evaluation_mixin._score_completed_evidence"), \
+             patch("quodeq.services.evaluation_mixin._wait_for_terminal_status"), \
              patch("quodeq.services.evaluation_mixin._discard_partial_dim_state") as mock_discard:
             m.cancel_evaluation("j1", reports_dir="/reports", discard_partial=True)
         mock_discard.assert_called_once()


### PR DESCRIPTION
## Summary
Closes the "two running rows" UX window after a cancel-then-start: backend `cancel_evaluation` now waits (best-effort, 2s cap) for `status.json` to reach a terminal state on disk before returning, so the very next dashboard refetch sees the run as `cancelled` rather than still `in_progress`.

## Why
`JobManager.cancel_job` flips the in-memory job state and signals the subprocess, then returns. The subprocess's run lifecycle handler writes `status.json` to terminal asynchronously — typically ~100ms–1s later. Observers reading the file in that window see the run as `in_progress`. With the recent live-History work ([quodeq#487](https://github.com/quodeq/quodeq/pull/487)) and cancel-invalidate fix ([quodeq#488](https://github.com/quodeq/quodeq/pull/488)), the immediate post-cancel refetch was hitting that stale state, so a follow-up Start surfaced two `running` rows until polling/SSE caught up.

## Approach
A small module-level helper `_wait_for_terminal_status(run_dir, *, timeout_s=2.0, poll_interval_s=0.05)` polls `run_dir/status.json` for `state in {done, failed, cancelled}`. `cancel_evaluation` calls it after `cancel_job` returns True, before `_score_completed_evidence` runs. Best-effort: a False return (timeout, missing or malformed file) is non-fatal — downstream polling/SSE catches up as before. With a real subprocess the wait typically resolves in ~50–200ms, well under the 2s cap.

## Why not a UI-side delayed retry
The retry approach would have hidden the race rather than fixing it — every other consumer of `cancel_evaluation` (the CLI, tests, future API clients) would have kept seeing the same window. Fixing the API contract once is the architecturally cleaner answer: "cancel_evaluation returns when the run is observably terminal."

## Test plan
- [x] `uv run pytest` — **2800 / 2800 pass**
- [x] `tests/services/test_evaluation_mixin.py::TestWaitForTerminalStatus` — 6 new cases covering happy path, all three terminal states, timeout-with-non-terminal, missing file, malformed JSON, and poll-until-terminal-appears (background-thread write).
- [x] `tests/services/test_evaluation_mixin.py::TestCancelEvaluationWaitsForTerminal` — 2 new cases covering "cancel calls wait with the right run_dir" and "cancel skips wait when reports_dir is None".
- [x] Manual: cancel a multi-dim run, immediately Start another; confirm History shows only one `running` row (the new run), not two.