### PR TITLE
fix(ui): differentiate Adequate from Poor/Critical in daruma light

### DIFF
--- a/src/quodeq/ui/src/styles/tokens.css
+++ b/src/quodeq/ui/src/styles/tokens.css
@@ -307,8 +307,8 @@
   --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
   --color-grade-high-text:   #9ca0a8;
   --color-grade-high-bg:     color-mix(in srgb, #9ca0a8 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
+  --color-grade-mid-text:    #c0502a;
+  --color-grade-mid-bg:      color-mix(in srgb, #c0502a 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-900);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
   --color-grade-bottom-text: var(--primitive-crimson-600);
@@ -571,8 +571,8 @@ html[data-theme="light"]:root, [data-theme="light"] {
   --color-grade-top-bg:      color-mix(in srgb, #e0a800 14%, transparent);
   --color-grade-high-text:   #9ca0a8;
   --color-grade-high-bg:     color-mix(in srgb, #9ca0a8 12%, transparent);
-  --color-grade-mid-text:    var(--primitive-ired-800);
-  --color-grade-mid-bg:      color-mix(in srgb, var(--primitive-ired-800) 12%, transparent);
+  --color-grade-mid-text:    #c0502a;
+  --color-grade-mid-bg:      color-mix(in srgb, #c0502a 12%, transparent);
   --color-grade-low-text:    var(--primitive-ired-900);
   --color-grade-low-bg:      color-mix(in srgb, var(--primitive-ired-900) 12%, transparent);
   --color-grade-bottom-text: var(--primitive-crimson-600);


### PR DESCRIPTION
## Summary
- Adequate, Poor, and Critical were three close shades of dark red on light backgrounds, blending into one red mass in the daruma light theme.
- Shifts Adequate from `--primitive-ired-800` (#9a4040) to `#c0502a` so the bottom three tiers form distinguishable hues (orange → red → crimson).
- Applied to both the default `:root` and explicit `[data-theme="light"]` blocks. Other light themes (galadriel, ifrit, neo, deckard) untouched.

## Why not just port the dark-theme colors
The dark-theme legend differentiates by *lightness* (light pink → bright red → vivid red), which only works on a dark canvas — those values fail WCAG contrast on the light sand background. Hue-shift is the right move on light.

## Test plan
- [x] Map view → toggle Light → confirm Adequate (orange), Poor (red), Critical (crimson) are visually distinct in the legend
- [x] Confirm Adequate-grade files in the Circle Pack viz read as orange and pop from the surrounding red files
- [x] Map view → Dark mode unchanged
- [x] Other themes (galadriel-light, ifrit-light, neo-light, deckard-light) unchanged