### PR TITLE
fix(packaging): point QuodeqBar PyInstaller add-data at the new icon path

### DIFF
--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -45,7 +45,7 @@ uv run --with pyinstaller --with rumps pyinstaller \
     --specpath "$BUILD_DIR" \
     --hidden-import rumps \
     --collect-all rumps \
-    --add-data "$SCRIPT_DIR/icon.icns:." \
+    --add-data "$REPO_ROOT/src/quodeq/data/icons/icon.icns:." \
     --add-data "$SCRIPT_DIR/menubar_iconTemplate.png:." \
     --add-data "$SCRIPT_DIR/menubar_iconTemplate@2x.png:." \
     --add-data "$SCRIPT_DIR/menubar_icon_running.png:." \


### PR DESCRIPTION
The icon was moved to \`src/quodeq/data/icons/icon.icns\` in #494, but \`packaging/macos/build-dmg.sh:48\` still pointed at \`\$SCRIPT_DIR/icon.icns\` for the PyInstaller \`--add-data\` bundling. Result: the QuodeqBar build for v1.1.2 failed and the DMG was not uploaded to the release.

Every other icon reference in packaging is already on the new path; this is the one that was missed. The fix is one line.

QuodeqBar will be shipped in the next release.