### PR TITLE
feat(provider): add omlx as a local Apple Silicon AI provider

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from enum import Enum as _Enum
 from pathlib import Path
 
+import httpx
 import instructor
 import openai
 from pydantic import BaseModel, Field
@@ -32,6 +33,8 @@ _log = logging.getLogger(__name__)
 _MAX_RETRIES = 1
 _OLLAMA_DEFAULT_BASE = "http://localhost:11434/v1"
 _OLLAMA_DEFAULT_API_KEY = "ollama"
+_OPENAI_API_HOST = "api.openai.com"
+_LOCAL_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=10.0)
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +154,10 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     if config.api_base and config.api_base != _OLLAMA_DEFAULT_BASE:
         validate_url_safe(config.api_base, allow_private=True)
 
-    extra_body: dict = {"reasoning_effort": "none"}
+    is_openai = _OPENAI_API_HOST in (config.api_base or "")
+    extra_body: dict = {}
+    if is_openai:
+        extra_body["reasoning_effort"] = "none"
     ctx_size = config.context_size
     if ctx_size <= 0:
         env_val = os.environ.get("QUODEQ_CONTEXT_SIZE", "").strip()
@@ -169,15 +175,18 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         ],
         temperature=config.temperature,
         max_retries=_MAX_RETRIES,
-        extra_body=extra_body,
     )
+    if extra_body:
+        create_kwargs["extra_body"] = extra_body
     if config.max_tokens is not None:
         create_kwargs["max_tokens"] = config.max_tokens
 
+    timeout = None if is_openai else _LOCAL_TIMEOUT
     _log.debug("Calling %s model=%s via Instructor", config.api_base, config.model)
     with openai.OpenAI(
         base_url=config.api_base,
         api_key=config.api_key or _OLLAMA_DEFAULT_API_KEY,
+        timeout=timeout,
     ) as oa_client:
         client = instructor.from_openai(oa_client, mode=instructor.Mode.JSON)
         try:

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -182,13 +182,17 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         create_kwargs["max_tokens"] = config.max_tokens
 
     timeout = None if is_openai else _LOCAL_TIMEOUT
-    _log.debug("Calling %s model=%s via Instructor", config.api_base, config.model)
+    # Local providers (omlx DMG, llamacpp, etc.) don't support structured
+    # output constraints. MD_JSON uses prompt engineering instead of
+    # response_format, so it works on any provider.
+    mode = instructor.Mode.JSON if is_openai else instructor.Mode.MD_JSON
+    _log.debug("Calling %s model=%s via Instructor mode=%s", config.api_base, config.model, mode)
     with openai.OpenAI(
         base_url=config.api_base,
         api_key=config.api_key or _OLLAMA_DEFAULT_API_KEY,
         timeout=timeout,
     ) as oa_client:
-        client = instructor.from_openai(oa_client, mode=instructor.Mode.JSON)
+        client = instructor.from_openai(oa_client, mode=mode)
         try:
             result = client.chat.completions.create(**create_kwargs)
             _log.debug("Instructor returned %d findings", len(result.findings))

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -158,6 +158,13 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     extra_body: dict = {}
     if is_openai:
         extra_body["reasoning_effort"] = "none"
+    else:
+        # Disable chat-template-driven thinking on reasoning-mode local models
+        # (Gemma 4, Qwen3). Without this, the model spends 1000s of tokens on
+        # reasoning_content before emitting the JSON we asked for, which can
+        # push per-batch latency from seconds into minutes. Unknown to models
+        # that don't support thinking — they simply ignore it.
+        extra_body["chat_template_kwargs"] = {"enable_thinking": False}
     ctx_size = config.context_size
     if ctx_size <= 0:
         env_val = os.environ.get("QUODEQ_CONTEXT_SIZE", "").strip()

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -240,6 +240,9 @@ def _resolve_provider_config(cfg: AnalysisConfig) -> tuple[str, str, str]:
     api_base = provider_cfg.get("api_base", "")
     api_key_env = provider_cfg.get("api_key_env", "")
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""
+    if not api_key and ai_cmd == "omlx":
+        from quodeq.llm_bridge._omlx import _read_omlx_api_key
+        api_key = _read_omlx_api_key()
 
     if not model:
         raise AnalysisError(

--- a/src/quodeq/api/_evaluation_helpers.py
+++ b/src/quodeq/api/_evaluation_helpers.py
@@ -112,6 +112,8 @@ def _build_evaluation_options(payload: dict) -> "EvaluationOptions":
         context_size=max(0, min(_MAX_CONTEXT_SIZE, _coerce_int(payload.get("contextSize"), 0))),
         branch=payload.get("branch") or None,
         scope_path=payload.get("scopePath") or None,
+        provider_api_key=str(payload.get("apiKey") or ""),
+        provider_api_base=str(payload.get("apiBase") or ""),
     )
 
 

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -13,6 +13,9 @@ from quodeq.llm_bridge import (
     get_llamacpp_status,
     list_llamacpp_models,
     run_llamacpp_concurrency_test,
+    get_omlx_status,
+    list_omlx_models,
+    run_omlx_concurrency_test,
     get_known_models,
     get_provider_configs,
     check_cloud_connection,
@@ -66,6 +69,25 @@ def register_llm_bridge_routes(app: Flask) -> None:
         if "\\" in model or ".." in model or "\0" in model:
             return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
         result = run_llamacpp_concurrency_test(model)
+        return jsonify(result)
+
+    @app.get("/api/omlx/status")
+    def omlx_status() -> Response:
+        return jsonify(get_omlx_status())
+
+    @app.get("/api/omlx/models")
+    def omlx_models() -> Response:
+        return jsonify({"models": list_omlx_models()})
+
+    @app.post("/api/omlx/test-concurrency")
+    def omlx_test_concurrency() -> Response:
+        data = request.get_json() or {}
+        model = data.get("model", "")
+        if not isinstance(model, str):
+            return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
+        if "\\" in model or ".." in model or "\0" in model:
+            return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
+        result = run_omlx_concurrency_test(model)
         return jsonify(result)
 
     @app.post("/api/provider/test")

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -73,11 +73,14 @@ def register_llm_bridge_routes(app: Flask) -> None:
 
     @app.get("/api/omlx/status")
     def omlx_status() -> Response:
-        return jsonify(get_omlx_status())
+        base_url = request.args.get("base_url", "").strip() or None
+        return jsonify(get_omlx_status(base_url=base_url))
 
     @app.get("/api/omlx/models")
     def omlx_models() -> Response:
-        return jsonify({"models": list_omlx_models()})
+        base_url = request.args.get("base_url", "").strip() or None
+        api_key = request.args.get("api_key", "").strip() or None
+        return jsonify({"models": list_omlx_models(base_url=base_url, api_key=api_key)})
 
     @app.post("/api/omlx/test-concurrency")
     def omlx_test_concurrency() -> Response:
@@ -87,7 +90,9 @@ def register_llm_bridge_routes(app: Flask) -> None:
             return jsonify({"error": "model must be a string", "code": "INVALID_PARAM"}), 400
         if "\\" in model or ".." in model or "\0" in model:
             return jsonify({"error": "Invalid model name", "code": "INVALID_PARAM"}), 400
-        result = run_omlx_concurrency_test(model)
+        base_url = data.get("base_url", "").strip() or None
+        api_key = data.get("api_key", "").strip() or None
+        result = run_omlx_concurrency_test(model, base_url=base_url, api_key=api_key)
         return jsonify(result)
 
     @app.post("/api/provider/test")

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -5,6 +5,13 @@
     "model": "gemma4:26b",
     "api_base": "http://localhost:11434/v1"
   },
+  "omlx": {
+    "type": "api",
+    "order": 1,
+    "model": "",
+    "api_base": "http://localhost:8000/v1",
+    "requires_platform": "darwin-arm64"
+  },
   "llamacpp": {
     "type": "api",
     "order": 5,

--- a/src/quodeq/llm_bridge/__init__.py
+++ b/src/quodeq/llm_bridge/__init__.py
@@ -19,6 +19,11 @@ from quodeq.llm_bridge._llamacpp import (
     list_llamacpp_models,
     run_concurrency_test as run_llamacpp_concurrency_test,
 )
+from quodeq.llm_bridge._omlx import (
+    get_omlx_status,
+    list_omlx_models,
+    run_concurrency_test as run_omlx_concurrency_test,
+)
 from quodeq.llm_bridge._cloud import check_cloud_connection
 from quodeq.llm_bridge._models import get_known_models
 
@@ -33,6 +38,9 @@ __all__ = [
     "get_llamacpp_status",
     "list_llamacpp_models",
     "run_llamacpp_concurrency_test",
+    "get_omlx_status",
+    "list_omlx_models",
+    "run_omlx_concurrency_test",
     "check_cloud_connection",
     "get_known_models",
 ]

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -63,8 +63,26 @@ def get_omlx_status(base_url: str | None = None) -> dict:
         return {"running": False, "error": "Connection failed"}
 
 
+def _list_model_dirs() -> list[dict]:
+    """Read ~/.omlx/models/ and return one entry per directory (follows symlinks)."""
+    models_dir = Path.home() / ".omlx" / "models"
+    try:
+        return [
+            {"name": entry.name, "size": 0, "quantization": "", "family": ""}
+            for entry in sorted(models_dir.iterdir())
+            if entry.is_dir()  # is_dir() follows symlinks
+        ]
+    except OSError:
+        return []
+
+
 def list_omlx_models(base_url: str | None = None, api_key: str | None = None) -> list[dict]:
-    """List models available on the omlx server."""
+    """List models available on the omlx server.
+
+    Tries GET /v1/models first. Falls back to reading ~/.omlx/models/ directly
+    when the API returns nothing, which handles symlinked model directories that
+    omlx does not enumerate via the OpenAI-compatible endpoint.
+    """
     root = _normalize_base(base_url or _OMLX_BASE)
     try:
         req = urllib.request.Request(f"{root}/v1/models")
@@ -74,19 +92,16 @@ def list_omlx_models(base_url: str | None = None, api_key: str | None = None) ->
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             entries = data.get("data", []) or []
-            return [
-                {
-                    "name": m.get("id", ""),
-                    "size": 0,
-                    "quantization": "",
-                    "family": "",
-                }
+            models = [
+                {"name": m.get("id", ""), "size": 0, "quantization": "", "family": ""}
                 for m in entries
                 if m.get("id")
             ]
+            if models:
+                return models
     except (urllib.error.URLError, ConnectionRefusedError, OSError, ValueError) as exc:
         _log.warning("Could not list omlx models: %s", exc)
-        return []
+    return _list_model_dirs()
 
 
 def run_concurrency_test(model: str, base_url: str | None = None, api_key: str | None = None) -> dict:

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -1,0 +1,102 @@
+"""omlx-specific integration: server status, model list, VRAM estimation.
+
+omlx is an Apple Silicon-only inference server that serves MLX-format models
+with a FastAPI HTTP server. It exposes an OpenAI-compatible API at /v1 and
+supports multiple concurrently loaded models.
+
+Endpoints used:
+  - GET /health         — omlx health check
+  - GET /v1/models      — OpenAI-compatible model list
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+import urllib.error
+
+from quodeq.llm_bridge._ollama import _detect_memory, estimate_max_agents
+
+_log = logging.getLogger(__name__)
+
+_OMLX_BASE = os.environ.get("OMLX_BASE_URL", "http://localhost:8000")
+_TIMEOUT_S = 3
+
+
+def _normalize_base(base_url: str) -> str:
+    """Strip trailing /v1 so /health and /v1/models both work."""
+    stripped = base_url.rstrip("/")
+    if stripped.endswith("/v1"):
+        stripped = stripped[: -len("/v1")]
+    return stripped
+
+
+def get_omlx_status(base_url: str = _OMLX_BASE) -> dict:
+    """Check if an omlx server is running and reachable."""
+    root = _normalize_base(base_url)
+    try:
+        req = urllib.request.Request(f"{root}/health")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read() or b"{}")
+            return {
+                "running": True,
+                "status": data.get("status", "ok"),
+                "address": root.replace("http://", ""),
+            }
+    except (urllib.error.URLError, ConnectionRefusedError, OSError, ValueError) as exc:
+        _log.warning("omlx status check failed: %s", exc)
+        return {"running": False, "error": "Connection failed"}
+
+
+def list_omlx_models(base_url: str = _OMLX_BASE) -> list[dict]:
+    """List models available on the omlx server."""
+    root = _normalize_base(base_url)
+    try:
+        req = urllib.request.Request(f"{root}/v1/models")
+        with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
+            data = json.loads(resp.read())
+            entries = data.get("data", []) or []
+            return [
+                {
+                    "name": m.get("id", ""),
+                    "size": 0,
+                    "quantization": "",
+                    "family": "",
+                }
+                for m in entries
+                if m.get("id")
+            ]
+    except (urllib.error.URLError, ConnectionRefusedError, OSError, ValueError) as exc:
+        _log.warning("Could not list omlx models: %s", exc)
+        return []
+
+
+def run_concurrency_test(model: str, base_url: str = _OMLX_BASE) -> dict:
+    """Estimate max parallel agents for the omlx server."""
+    gpu_memory = _detect_memory()
+    models = list_omlx_models(base_url)
+    if not models:
+        return {
+            "recommended": 1,
+            "vram_per_context": 0,
+            "gpu_memory": gpu_memory,
+            "reason": "omlx is not running or no models available",
+        }
+
+    if gpu_memory <= 0:
+        vram_per_context = 1
+        return {
+            "recommended": 1,
+            "vram_per_context": vram_per_context,
+            "gpu_memory": gpu_memory,
+            "reason": "Could not detect host memory",
+        }
+
+    vram_per_context = max(int(gpu_memory * 0.5), 1)
+    result = estimate_max_agents(model_size=vram_per_context, gpu_memory=gpu_memory)
+    return {
+        "recommended": result["estimate"],
+        "vram_per_context": vram_per_context,
+        "gpu_memory": gpu_memory,
+    }

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -46,9 +46,9 @@ def _normalize_base(base_url: str) -> str:
     return stripped
 
 
-def get_omlx_status(base_url: str = _OMLX_BASE) -> dict:
+def get_omlx_status(base_url: str | None = None) -> dict:
     """Check if an omlx server is running and reachable."""
-    root = _normalize_base(base_url)
+    root = _normalize_base(base_url or _OMLX_BASE)
     try:
         req = urllib.request.Request(f"{root}/health")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
@@ -63,14 +63,14 @@ def get_omlx_status(base_url: str = _OMLX_BASE) -> dict:
         return {"running": False, "error": "Connection failed"}
 
 
-def list_omlx_models(base_url: str = _OMLX_BASE) -> list[dict]:
+def list_omlx_models(base_url: str | None = None, api_key: str | None = None) -> list[dict]:
     """List models available on the omlx server."""
-    root = _normalize_base(base_url)
+    root = _normalize_base(base_url or _OMLX_BASE)
     try:
         req = urllib.request.Request(f"{root}/v1/models")
-        api_key = _read_omlx_api_key()
-        if api_key:
-            req.add_header("Authorization", f"Bearer {api_key}")
+        key = api_key if api_key is not None else _read_omlx_api_key()
+        if key:
+            req.add_header("Authorization", f"Bearer {key}")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             entries = data.get("data", []) or []
@@ -89,10 +89,10 @@ def list_omlx_models(base_url: str = _OMLX_BASE) -> list[dict]:
         return []
 
 
-def run_concurrency_test(model: str, base_url: str = _OMLX_BASE) -> dict:
+def run_concurrency_test(model: str, base_url: str | None = None, api_key: str | None = None) -> dict:
     """Estimate max parallel agents for the omlx server."""
     gpu_memory = _detect_memory()
-    models = list_omlx_models(base_url)
+    models = list_omlx_models(base_url, api_key)
     if not models:
         return {
             "recommended": 1,

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -16,12 +16,26 @@ import os
 import urllib.request
 import urllib.error
 
+from pathlib import Path
+
 from quodeq.llm_bridge._ollama import _detect_memory, estimate_max_agents
 
 _log = logging.getLogger(__name__)
 
 _OMLX_BASE = os.environ.get("OMLX_BASE_URL", "http://localhost:8000")
 _TIMEOUT_S = 3
+
+
+def _read_omlx_api_key() -> str:
+    """Return the omlx API key from OMLX_API_KEY env var or ~/.omlx/settings.json."""
+    env_key = os.environ.get("OMLX_API_KEY", "")
+    if env_key:
+        return env_key
+    try:
+        cfg = json.loads((Path.home() / ".omlx" / "settings.json").read_text())
+        return cfg.get("auth", {}).get("api_key", "")
+    except (OSError, json.JSONDecodeError):
+        return ""
 
 
 def _normalize_base(base_url: str) -> str:
@@ -54,6 +68,9 @@ def list_omlx_models(base_url: str = _OMLX_BASE) -> list[dict]:
     root = _normalize_base(base_url)
     try:
         req = urllib.request.Request(f"{root}/v1/models")
+        api_key = _read_omlx_api_key()
+        if api_key:
+            req.add_header("Authorization", f"Bearer {api_key}")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read())
             entries = data.get("data", []) or []

--- a/src/quodeq/services/base.py
+++ b/src/quodeq/services/base.py
@@ -30,6 +30,8 @@ class EvaluationOptions:
     branch: str | None = None
     scope_path: str | None = None
     context_size: int = 0
+    provider_api_key: str = ""
+    provider_api_base: str = ""
 
 
 class ProjectActions(Protocol):

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -260,6 +260,11 @@ class FsEvaluationMixin:
             built_env["QUODEQ_NO_CONSOLIDATE"] = "1"
         if options.context_size > 0:
             built_env["QUODEQ_CONTEXT_SIZE"] = str(options.context_size)
+        if options.ai_cmd == "omlx":
+            if options.provider_api_key:
+                built_env["OMLX_API_KEY"] = options.provider_api_key
+            if options.provider_api_base:
+                built_env["OMLX_BASE_URL"] = options.provider_api_base
         return built_env
 
     def start_evaluation(self, repo: str, reports_dir: str, options: EvaluationOptions) -> JobSnapshot:

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import platform as _platform_module
 import shutil
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -71,6 +73,13 @@ def get_allowed_client_ids(env: dict[str, str] | None = None) -> frozenset[str]:
         if cfg.get("type") == "api"
     )
     return _DEFAULT_CLIENT_IDS | api_ids
+
+
+def _platform_matches(requires: str) -> bool:
+    """Return True if the current platform satisfies the requires_platform constraint."""
+    if requires == "darwin-arm64":
+        return sys.platform == "darwin" and _platform_module.machine() == "arm64"
+    return True
 
 
 class FsToolingMixin:
@@ -212,6 +221,9 @@ class FsToolingMixin:
         api_label_overrides = {"llamacpp": "llama.cpp"}
         for provider_id, cfg in provider_configs.items():
             if cfg.get("type") == "api" and provider_id != "custom":
+                requires = cfg.get("requires_platform", "")
+                if requires and not _platform_matches(requires):
+                    continue
                 if not any(c["id"] == provider_id for c in clients):
                     clients.append({
                         "id": provider_id,

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -259,21 +259,26 @@ export function testLlamacppConcurrency(model) {
 }
 
 /** @returns {Promise<Object>} omlx connection status */
-export function getOmlxStatus() {
-  return request('/omlx/status');
+export function getOmlxStatus(baseUrl) {
+  const params = baseUrl ? `?base_url=${encodeURIComponent(baseUrl)}` : '';
+  return request(`/omlx/status${params}`);
 }
 
 /** @returns {Promise<Object[]>} Available omlx models */
-export async function getOmlxModels() {
-  const data = await request('/omlx/models');
+export async function getOmlxModels(baseUrl, apiKey) {
+  const params = new URLSearchParams();
+  if (baseUrl) params.set('base_url', baseUrl);
+  if (apiKey) params.set('api_key', apiKey);
+  const qs = params.toString() ? `?${params}` : '';
+  const data = await request(`/omlx/models${qs}`);
   return data?.models ?? [];
 }
 
 /** @returns {Promise<Object>} Concurrency test results for the given model */
-export function testOmlxConcurrency(model) {
+export function testOmlxConcurrency(model, baseUrl, apiKey) {
   return request('/omlx/test-concurrency', {
     method: 'POST',
-    body: JSON.stringify({ model }),
+    body: JSON.stringify({ model, base_url: baseUrl || undefined, api_key: apiKey || undefined }),
   });
 }
 

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -258,6 +258,25 @@ export function testLlamacppConcurrency(model) {
   });
 }
 
+/** @returns {Promise<Object>} omlx connection status */
+export function getOmlxStatus() {
+  return request('/omlx/status');
+}
+
+/** @returns {Promise<Object[]>} Available omlx models */
+export async function getOmlxModels() {
+  const data = await request('/omlx/models');
+  return data?.models ?? [];
+}
+
+/** @returns {Promise<Object>} Concurrency test results for the given model */
+export function testOmlxConcurrency(model) {
+  return request('/omlx/test-concurrency', {
+    method: 'POST',
+    body: JSON.stringify({ model }),
+  });
+}
+
 /** @returns {Promise<Object>} Connection test result for the provider */
 export function testProviderConnection({ provider, apiBase, model, apiKey }) {
   return request('/provider/test', {

--- a/src/quodeq/ui/src/api/queryKeys.js
+++ b/src/quodeq/ui/src/api/queryKeys.js
@@ -31,6 +31,7 @@ export const systemKeys = {
   health: () => ["system", "health"],
   ollama: () => ["system", "ollama"],
   llamacpp: () => ["system", "llamacpp"],
+  omlx: () => ["system", "omlx"],
 };
 
 export const standardsKeys = {
@@ -46,4 +47,5 @@ export const settingsKeys = {
   knownModels: (providerId) => ["settings", "knownModels", providerId],
   ollamaModels: () => ["settings", "ollamaModels"],
   llamacppModels: () => ["settings", "llamacppModels"],
+  omlxModels: () => ["settings", "omlxModels"],
 };

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -71,6 +71,10 @@ function preparePayload(payload, storage = localStorage) {
   };
   if (get("per-dimension") === "true") result.perDimension = true;
   if (get("verify") === "false") result.verifyFindings = false;
+  const apiKey = get("api-key");
+  if (apiKey) result.apiKey = apiKey;
+  const apiBase = get("api-base");
+  if (apiBase) result.apiBase = apiBase;
   return result;
 }
 

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -41,7 +41,7 @@ const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
 const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
-const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp"]);
+const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp", "omlx"]);
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)

--- a/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
@@ -110,32 +110,6 @@ export default function OmlxTab({ state, update }) {
       )}
       <div className="settings-row">
         <div className="settings-row-label">
-          <span className="settings-label">Server address</span>
-          <span className="settings-description">Leave blank to use the default (<code>http://localhost:8000</code>).</span>
-        </div>
-        <input
-          type="text"
-          className="settings-model-input"
-          placeholder="http://localhost:8000"
-          value={apiBase}
-          onChange={(e) => update('api-base', e.target.value)}
-        />
-      </div>
-      <div className="settings-row">
-        <div className="settings-row-label">
-          <span className="settings-label">API key</span>
-          <span className="settings-description">Leave blank to use the key from <code>~/.omlx/settings.json</code>.</span>
-        </div>
-        <input
-          type="password"
-          className="settings-model-input"
-          placeholder="sk-..."
-          value={apiKey}
-          onChange={(e) => update('api-key', e.target.value)}
-        />
-      </div>
-      <div className="settings-row">
-        <div className="settings-row-label">
           <span className="settings-label-row">
             <span className="settings-label">Model</span>
             <HelpHint label="Model help">{OMLX_MODEL_HINT}</HelpHint>
@@ -148,6 +122,32 @@ export default function OmlxTab({ state, update }) {
       <details className="settings-advanced">
         <summary className="settings-advanced-toggle">Advanced</summary>
         <div className="settings-advanced-content">
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label">Server address</span>
+              <span className="settings-description">Leave blank to use the default (<code>http://localhost:8000</code>).</span>
+            </div>
+            <input
+              type="text"
+              className="settings-model-input"
+              placeholder="http://localhost:8000"
+              value={apiBase}
+              onChange={(e) => update('api-base', e.target.value)}
+            />
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label">API key</span>
+              <span className="settings-description">Leave blank to use the key from <code>~/.omlx/settings.json</code> (default <code>1234</code>).</span>
+            </div>
+            <input
+              type="password"
+              className="settings-model-input"
+              placeholder="1234"
+              value={apiKey}
+              onChange={(e) => update('api-key', e.target.value)}
+            />
+          </div>
           <div className="settings-row">
             <div className="settings-row-label">
               <span className="settings-label-row">

--- a/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { MIN_SUBAGENTS, MAX_SUBAGENTS } from '../../../constants.js';
+import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
+import HelpHint from '../../../components/HelpHint.jsx';
+import { useOmlxServerStatus } from '../hooks/useOmlxServerStatus.js';
+import { TimeLimitSetting, AdvancedAnalysisSettings, SUBAGENTS_HINT_OLLAMA } from './ProviderSettings.jsx';
+import { settingsKeys } from '../../../api/queryKeys.js';
+
+const OMLX_MODEL_HINT = (
+  <>
+    This list comes from your local omlx server. To add a model, use the omlx admin UI at{' '}
+    <code>http://localhost:8000/admin</code> or pull a model with the omlx CLI. Models show up here as soon as they are downloaded.
+  </>
+);
+
+function ModelSelector({ value, models, onChange }) {
+  const needsModel = !value;
+  return (
+    <div className="settings-model-field">
+      <select
+        className={`settings-model-input${needsModel ? ' settings-model-input--required' : ''}`}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="">Pick a model</option>
+        {models.map((m) => (
+          <option key={m.name} value={m.name}>{m.name}</option>
+        ))}
+      </select>
+      {needsModel && (
+        <span className="settings-model-hint">
+          You&apos;ll need a model before you can run an evaluation.
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function OmlxTab({ state, update }) {
+  const { getOmlxModels, testOmlxConcurrency } = useApi();
+  const omlxStatus = useOmlxServerStatus();
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
+  const [testError, setTestError] = useState(null);
+
+  const queryClient = useQueryClient();
+  const { data: models = [], error: modelsQueryError } = useQuery({
+    queryKey: settingsKeys.omlxModels(),
+    queryFn: () => getOmlxModels(),
+  });
+  const modelsError = modelsQueryError
+    ? 'We couldn’t load your omlx models. Make sure omlx is running.'
+    : null;
+
+  const prevStatusRef = useRef(omlxStatus?.status ?? 'offline');
+  useEffect(() => {
+    const status = omlxStatus?.status ?? 'offline';
+    if (prevStatusRef.current !== 'online' && status === 'online') {
+      queryClient.invalidateQueries({ queryKey: settingsKeys.omlxModels() });
+    }
+    prevStatusRef.current = status;
+  }, [omlxStatus?.status, queryClient]);
+
+  const runTest = async () => {
+    if (!state.model) return;
+    setTesting(true);
+    try {
+      const result = await testOmlxConcurrency(state.model);
+      setTestResult(result);
+      if (result.recommended) update('subagents', String(result.recommended));
+    } catch (err) {
+      console.warn('omlx concurrency test failed', err);
+      setTestResult(null);
+      setTestError('The concurrency test didn’t finish. Make sure omlx is running and your model is loaded.');
+    }
+    setTesting(false);
+  };
+
+  return (
+    <>
+      <ServerStatusPill
+        status={omlxStatus?.status ?? 'offline'}
+        address={omlxStatus?.address}
+        offlineMessage={
+          <span>
+            omlx isn&apos;t running. Start it with <code>omlx serve</code>, or open the omlx menu bar app.
+          </span>
+        }
+      />
+      {modelsError && (
+        <div className="settings-row">
+          <span className="settings-error">We couldn&apos;t load your omlx models. Make sure omlx is running.</span>
+        </div>
+      )}
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label-row">
+            <span className="settings-label">Model</span>
+            <HelpHint label="Model help">{OMLX_MODEL_HINT}</HelpHint>
+          </span>
+          <span className="settings-description">This model handles every step of your evaluation.</span>
+        </div>
+        <ModelSelector value={state.model} models={models} onChange={(v) => update('model', v)} />
+      </div>
+      <TimeLimitSetting state={state} update={update} providerType="local-api" />
+      <details className="settings-advanced">
+        <summary className="settings-advanced-toggle">Advanced</summary>
+        <div className="settings-advanced-content">
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label-row">
+                <span className="settings-label">Max parallel agents</span>
+                <HelpHint label="Max parallel agents help">{SUBAGENTS_HINT_OLLAMA}</HelpHint>
+              </span>
+              <span className="settings-description">We make a guess based on your unified memory. Run a quick test for a more accurate number.</span>
+            </div>
+            <div className="settings-budget-control">
+              <input
+                type="number"
+                className="settings-model-input"
+                min={MIN_SUBAGENTS}
+                max={MAX_SUBAGENTS}
+                value={state.subagents}
+                onChange={(e) => update('subagents', e.target.value)}
+              />
+              <button
+                type="button"
+                className="settings-action-btn"
+                onClick={runTest}
+                disabled={testing || !state.model}
+              >
+                {testing ? 'Testing...' : 'Auto-detect'}
+              </button>
+            </div>
+            {testResult && <span className="settings-description">Recommended: {testResult.recommended} agents</span>}
+            {testError && <span className="settings-error">{testError}</span>}
+          </div>
+          <AdvancedAnalysisSettings state={state} update={update} />
+        </div>
+      </details>
+    </>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
@@ -6,7 +6,6 @@ import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
 import { useOmlxServerStatus } from '../hooks/useOmlxServerStatus.js';
 import { TimeLimitSetting, AdvancedAnalysisSettings, SUBAGENTS_HINT_OLLAMA } from './ProviderSettings.jsx';
-import { settingsKeys } from '../../../api/queryKeys.js';
 
 const OMLX_MODEL_HINT = (
   <>
@@ -40,25 +39,27 @@ function ModelSelector({ value, models, onChange }) {
 
 export default function OmlxTab({ state, update }) {
   const { getOmlxModels, testOmlxConcurrency } = useApi();
-  const omlxStatus = useOmlxServerStatus();
+  const apiBase = state['api-base'] || '';
+  const apiKey = state['api-key'] || '';
+  const omlxStatus = useOmlxServerStatus(apiBase || undefined);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState(null);
   const [testError, setTestError] = useState(null);
 
   const queryClient = useQueryClient();
   const { data: models = [], error: modelsQueryError } = useQuery({
-    queryKey: settingsKeys.omlxModels(),
-    queryFn: () => getOmlxModels(),
+    queryKey: ['settings', 'omlxModels', apiBase, apiKey],
+    queryFn: () => getOmlxModels(apiBase || undefined, apiKey || undefined),
   });
   const modelsError = modelsQueryError
-    ? 'We couldn’t load your omlx models. Make sure omlx is running.'
+    ? "We couldn’t load your omlx models. Make sure omlx is running."
     : null;
 
   const prevStatusRef = useRef(omlxStatus?.status ?? 'offline');
   useEffect(() => {
     const status = omlxStatus?.status ?? 'offline';
     if (prevStatusRef.current !== 'online' && status === 'online') {
-      queryClient.invalidateQueries({ queryKey: settingsKeys.omlxModels() });
+      queryClient.invalidateQueries({ queryKey: ['settings', 'omlxModels'] });
     }
     prevStatusRef.current = status;
   }, [omlxStatus?.status, queryClient]);
@@ -67,13 +68,13 @@ export default function OmlxTab({ state, update }) {
     if (!state.model) return;
     setTesting(true);
     try {
-      const result = await testOmlxConcurrency(state.model);
+      const result = await testOmlxConcurrency(state.model, apiBase || undefined, apiKey || undefined);
       setTestResult(result);
       if (result.recommended) update('subagents', String(result.recommended));
     } catch (err) {
       console.warn('omlx concurrency test failed', err);
       setTestResult(null);
-      setTestError('The concurrency test didn’t finish. Make sure omlx is running and your model is loaded.');
+      setTestError("The concurrency test didn't finish. Make sure omlx is running and your model is loaded.");
     }
     setTesting(false);
   };
@@ -94,6 +95,32 @@ export default function OmlxTab({ state, update }) {
           <span className="settings-error">We couldn&apos;t load your omlx models. Make sure omlx is running.</span>
         </div>
       )}
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Server address</span>
+          <span className="settings-description">Leave blank to use the default (<code>http://localhost:8000</code>).</span>
+        </div>
+        <input
+          type="text"
+          className="settings-model-input"
+          placeholder="http://localhost:8000"
+          value={apiBase}
+          onChange={(e) => update('api-base', e.target.value)}
+        />
+      </div>
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">API key</span>
+          <span className="settings-description">Leave blank to use the key from <code>~/.omlx/settings.json</code>.</span>
+        </div>
+        <input
+          type="password"
+          className="settings-model-input"
+          placeholder="sk-..."
+          value={apiKey}
+          onChange={(e) => update('api-key', e.target.value)}
+        />
+      </div>
       <div className="settings-row">
         <div className="settings-row-label">
           <span className="settings-label-row">

--- a/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/OmlxTab.jsx
@@ -16,21 +16,34 @@ const OMLX_MODEL_HINT = (
 
 function ModelSelector({ value, models, onChange }) {
   const needsModel = !value;
+  const hasModels = models.length > 0;
   return (
     <div className="settings-model-field">
-      <select
-        className={`settings-model-input${needsModel ? ' settings-model-input--required' : ''}`}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-      >
-        <option value="">Pick a model</option>
-        {models.map((m) => (
-          <option key={m.name} value={m.name}>{m.name}</option>
-        ))}
-      </select>
+      {hasModels ? (
+        <select
+          className={`settings-model-input${needsModel ? ' settings-model-input--required' : ''}`}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">Pick a model</option>
+          {models.map((m) => (
+            <option key={m.name} value={m.name}>{m.name}</option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type="text"
+          className={`settings-model-input${needsModel ? ' settings-model-input--required' : ''}`}
+          placeholder="mlx-community/gemma-3-4b-it-4bit"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
       {needsModel && (
         <span className="settings-model-hint">
-          You&apos;ll need a model before you can run an evaluation.
+          {hasModels
+            ? "You'll need a model before you can run an evaluation."
+            : "omlx didn't return any models. Enter the model name directly (e.g. from your omlx admin UI)."}
         </span>
       )}
     </div>

--- a/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ProviderTabs.jsx
@@ -5,6 +5,7 @@ import useProviderSettings from '../hooks/useProviderSettings.js';
 import { classifyProvider } from './providerUtils.js';
 import OllamaTab from './OllamaTab.jsx';
 import LlamaCppTab from './LlamaCppTab.jsx';
+import OmlxTab from './OmlxTab.jsx';
 import CliProviderTab from './CliProviderTab.jsx';
 import CloudProviderTab from './CloudProviderTab.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
@@ -39,6 +40,7 @@ const INSTALL_INSTRUCTIONS = {
 const CLI_DEFAULTS = { 'subagents': String(DEFAULT_MAX_SUBAGENTS), 'time-limit': String(DEFAULT_TIME_LIMIT_S) };
 const OLLAMA_DEFAULTS = { 'time-limit': '0' };
 const LLAMACPP_DEFAULTS = { 'time-limit': '0' };
+const OMLX_DEFAULTS = { 'time-limit': '0' };
 const CLOUD_DEFAULTS_BY_ID = {
   openrouter: { 'time-limit': String(DEFAULT_TIME_LIMIT_S), 'model': 'baidu/cobuddy:free' },
 };
@@ -57,7 +59,11 @@ const LEGACY_SETTING_MIGRATIONS = {
 
 function TabContent({ provider, providerConfig }) {
   const classification = classifyProvider(provider.id, provider.type, providerConfig);
-  const localApiDefaults = provider.id === 'llamacpp' ? LLAMACPP_DEFAULTS : OLLAMA_DEFAULTS;
+  const localApiDefaults = provider.id === 'llamacpp'
+    ? LLAMACPP_DEFAULTS
+    : provider.id === 'omlx'
+      ? OMLX_DEFAULTS
+      : OLLAMA_DEFAULTS;
   const defaults = classification === 'cli'
     ? CLI_DEFAULTS
     : classification === 'local-api'
@@ -68,6 +74,9 @@ function TabContent({ provider, providerConfig }) {
   if (classification === 'local-api') {
     if (provider.id === 'llamacpp') {
       return <LlamaCppTab state={state} update={update} />;
+    }
+    if (provider.id === 'omlx') {
+      return <OmlxTab state={state} update={update} />;
     }
     return <OllamaTab state={state} update={update} />;
   }

--- a/src/quodeq/ui/src/features/settings/hooks/useOmlxServerStatus.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useOmlxServerStatus.js
@@ -6,18 +6,17 @@
  */
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '../../../api/ApiContext.jsx';
-import { systemKeys } from '../../../api/queryKeys.js';
 
 const POLL_MS = 5000;
 
-export function useOmlxServerStatus() {
+export function useOmlxServerStatus(baseUrl) {
   const { getOmlxStatus } = useApi();
 
   const { data } = useQuery({
-    queryKey: systemKeys.omlx(),
+    queryKey: ['system', 'omlx', baseUrl || ''],
     queryFn: async () => {
       try {
-        const result = await getOmlxStatus();
+        const result = await getOmlxStatus(baseUrl || undefined);
         if (result?.running) {
           return { status: 'online', address: result.address ?? null };
         }

--- a/src/quodeq/ui/src/features/settings/hooks/useOmlxServerStatus.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useOmlxServerStatus.js
@@ -1,0 +1,34 @@
+/**
+ * useOmlxServerStatus - TanStack Query poll for omlx server status.
+ *
+ * Polls every 5s and reports { status: 'online' | 'offline', address }.
+ * A fetch rejection is treated as offline.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { systemKeys } from '../../../api/queryKeys.js';
+
+const POLL_MS = 5000;
+
+export function useOmlxServerStatus() {
+  const { getOmlxStatus } = useApi();
+
+  const { data } = useQuery({
+    queryKey: systemKeys.omlx(),
+    queryFn: async () => {
+      try {
+        const result = await getOmlxStatus();
+        if (result?.running) {
+          return { status: 'online', address: result.address ?? null };
+        }
+        return { status: 'offline', address: null };
+      } catch {
+        return { status: 'offline', address: null };
+      }
+    },
+    refetchInterval: POLL_MS,
+    refetchOnWindowFocus: false,
+  });
+
+  return data ?? null;
+}

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { providerKey } from '../../../constants.js';
 
-const SETTINGS = ['model', 'model-analysis', 'model-fast', 'model-balanced', 'model-thorough', 'subagents', 'time-limit', 'per-dimension', 'verify'];
+const SETTINGS = ['model', 'model-analysis', 'model-fast', 'model-balanced', 'model-thorough', 'subagents', 'time-limit', 'per-dimension', 'verify', 'api-key', 'api-base'];
 const DEFAULTS = {
   'model': '',
   'model-analysis': '',
@@ -12,6 +12,8 @@ const DEFAULTS = {
   'time-limit': '0',
   'per-dimension': 'true',
   'verify': 'true',
+  'api-key': '',
+  'api-base': '',
 };
 
 // Legacy storage key fallback, only consulted when the new key has no value.

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -11,7 +11,7 @@ instructor = pytest.importorskip("instructor", reason="requires quodeq[api] extr
 
 from quodeq.analysis._api_runner import (
     run_api_analysis, ApiRunnerConfig,
-    _Finding, _Findings, _FindingType, _Severity,
+    _Finding, _Findings, _FindingType, _Severity, _LOCAL_TIMEOUT,
 )
 
 
@@ -80,6 +80,7 @@ class TestRunApiAnalysis:
             mock_openai.OpenAI.assert_called_once_with(
                 base_url="http://localhost:8000/v1",
                 api_key="test-key",
+                timeout=_LOCAL_TIMEOUT,
             )
 
     def test_handles_empty_findings(self, tmp_path, api_config):

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -11,6 +11,7 @@ instructor = pytest.importorskip("instructor", reason="requires quodeq[api] extr
 
 from quodeq.analysis._api_runner import (
     ApiRunnerConfig,
+    _LOCAL_TIMEOUT,
     _build_router_context,
     _call_api,
     _Finding,
@@ -94,7 +95,7 @@ class TestCallApi:
             _call_api("test", config)
 
         kwargs = mock_client.chat.completions.create.call_args.kwargs
-        assert "num_ctx" not in kwargs["extra_body"]
+        assert "num_ctx" not in kwargs.get("extra_body", {})
 
     def test_includes_max_tokens_when_set(self):
         config = ApiRunnerConfig(
@@ -146,6 +147,7 @@ class TestCallApi:
         mock_openai.OpenAI.assert_called_once_with(
             base_url="http://localhost:11434/v1",
             api_key="ollama",
+            timeout=_LOCAL_TIMEOUT,
         )
 
     def test_returns_clean_flag_on_success(self):

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -12,6 +12,7 @@ from quodeq.analysis.subprocess import (
     _get_provider_type,
     _load_standards_text,
     _render_standards_grouped,
+    _resolve_provider_config,
     _run_api_analysis_bridge,
     _run_cli_analysis,
     count_files_from_stream,
@@ -277,6 +278,40 @@ class TestRunApiAnalysisBridge:
             _run_api_analysis_bridge(tmp_path, "test", stream, cfg)
             mock_api.assert_called_once()
             assert stream.read_text().strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# run_analysis dispatch
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# _resolve_provider_config
+# ---------------------------------------------------------------------------
+
+class TestResolveProviderConfig:
+    def test_reads_api_key_from_env(self, monkeypatch):
+        provider = {"myprovider": {"type": "api", "model": "m", "api_base": "http://x", "api_key_env": "MY_KEY"}}
+        monkeypatch.setenv("MY_KEY", "secret")
+        cfg = AnalysisConfig(ai_cmd="myprovider", ai_model="m")
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
+            _, _, key = _resolve_provider_config(cfg)
+        assert key == "secret"
+
+    def test_omlx_falls_back_to_read_omlx_api_key(self):
+        provider = {"omlx": {"type": "api", "model": "m", "api_base": "http://localhost:8000/v1"}}
+        cfg = AnalysisConfig(ai_cmd="omlx", ai_model="m")
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
+             patch("quodeq.llm_bridge._omlx._read_omlx_api_key", return_value="omlx-key"):
+            _, _, key = _resolve_provider_config(cfg)
+        assert key == "omlx-key"
+
+    def test_omlx_empty_key_when_not_configured(self):
+        provider = {"omlx": {"type": "api", "model": "m", "api_base": "http://localhost:8000/v1"}}
+        cfg = AnalysisConfig(ai_cmd="omlx", ai_model="m")
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider), \
+             patch("quodeq.llm_bridge._omlx._read_omlx_api_key", return_value=""):
+            _, _, key = _resolve_provider_config(cfg)
+        assert key == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/llm_bridge/test_omlx.py
+++ b/tests/llm_bridge/test_omlx.py
@@ -108,6 +108,34 @@ class TestListOmlxModels:
         with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError):
             assert list_omlx_models() == []
 
+    def test_sends_auth_header_when_key_available(self):
+        mock_data = {"object": "list", "data": [{"id": "gemma-4-26B", "object": "model"}]}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp) as mock_open, \
+             patch("quodeq.llm_bridge._omlx._read_omlx_api_key", return_value="test-key"):
+            list_omlx_models()
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer test-key"
+
+    def test_no_auth_header_when_no_key(self):
+        mock_data = {"object": "list", "data": []}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp) as mock_open, \
+             patch("quodeq.llm_bridge._omlx._read_omlx_api_key", return_value=""):
+            list_omlx_models()
+
+        req = mock_open.call_args[0][0]
+        assert req.get_header("Authorization") is None
+
 
 class TestConcurrency:
     def test_no_models_available(self):

--- a/tests/llm_bridge/test_omlx.py
+++ b/tests/llm_bridge/test_omlx.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, MagicMock
 
 from quodeq.llm_bridge._omlx import (
     _normalize_base,
+    _list_model_dirs,
     get_omlx_status,
     list_omlx_models,
     run_concurrency_test,
@@ -94,19 +95,36 @@ class TestListOmlxModels:
         assert len(models) == 1
         assert models[0]["name"] == "mlx-community/valid-model"
 
-    def test_empty_list(self):
+    def test_empty_api_response_falls_back_to_dirs(self):
+        mock_data = {"data": []}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        dir_models = [{"name": "mlx-community/gemma-3-4b-it-4bit", "size": 0, "quantization": "", "family": ""}]
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp), \
+             patch("quodeq.llm_bridge._omlx._list_model_dirs", return_value=dir_models):
+            result = list_omlx_models()
+
+        assert result == dir_models
+
+    def test_empty_api_and_no_dirs(self):
         mock_data = {"data": []}
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps(mock_data).encode()
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp), \
+             patch("quodeq.llm_bridge._omlx._list_model_dirs", return_value=[]):
             assert list_omlx_models() == []
 
-    def test_server_offline(self):
-        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError):
-            assert list_omlx_models() == []
+    def test_server_offline_falls_back_to_dirs(self):
+        dir_models = [{"name": "my-model", "size": 0, "quantization": "", "family": ""}]
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError), \
+             patch("quodeq.llm_bridge._omlx._list_model_dirs", return_value=dir_models):
+            assert list_omlx_models() == dir_models
 
     def test_sends_auth_header_when_key_available(self):
         mock_data = {"object": "list", "data": [{"id": "gemma-4-26B", "object": "model"}]}
@@ -135,6 +153,30 @@ class TestListOmlxModels:
 
         req = mock_open.call_args[0][0]
         assert req.get_header("Authorization") is None
+
+
+class TestListModelDirs:
+    def test_returns_directories_including_symlinks(self, tmp_path):
+        models_dir = tmp_path / ".omlx" / "models"
+        models_dir.mkdir(parents=True)
+        (models_dir / "real-model").mkdir()
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        (models_dir / "symlinked-model").symlink_to(target)
+
+        with patch("quodeq.llm_bridge._omlx.Path") as mock_path_cls:
+            mock_path_cls.home.return_value = tmp_path
+            result = _list_model_dirs()
+
+        names = [m["name"] for m in result]
+        assert "real-model" in names
+        assert "symlinked-model" in names
+
+    def test_returns_empty_when_dir_missing(self, tmp_path):
+        with patch("quodeq.llm_bridge._omlx.Path") as mock_path_cls:
+            mock_path_cls.home.return_value = tmp_path  # no .omlx/models subdir
+            result = _list_model_dirs()
+        assert result == []
 
 
 class TestConcurrency:

--- a/tests/llm_bridge/test_omlx.py
+++ b/tests/llm_bridge/test_omlx.py
@@ -1,0 +1,134 @@
+"""Tests for omlx integration in llm_bridge."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+from quodeq.llm_bridge._omlx import (
+    _normalize_base,
+    get_omlx_status,
+    list_omlx_models,
+    run_concurrency_test,
+)
+
+
+class TestNormalizeBase:
+    def test_strips_v1_suffix(self):
+        assert _normalize_base("http://localhost:8000/v1") == "http://localhost:8000"
+
+    def test_strips_trailing_slash(self):
+        assert _normalize_base("http://localhost:8000/") == "http://localhost:8000"
+
+    def test_leaves_root_alone(self):
+        assert _normalize_base("http://localhost:8000") == "http://localhost:8000"
+
+
+class TestGetOmlxStatus:
+    def test_running(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b'{"status":"ok"}'
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            result = get_omlx_status("http://localhost:8000")
+
+        assert result["running"] is True
+        assert result["status"] == "ok"
+        assert "8000" in result["address"]
+
+    def test_running_with_v1_suffix(self):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"{}"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            get_omlx_status("http://localhost:8000/v1")
+
+        called_url = mock_open.call_args[0][0].full_url
+        assert called_url.endswith("/health")
+        assert "/v1/health" not in called_url
+
+    def test_not_running(self):
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            result = get_omlx_status()
+
+        assert result["running"] is False
+        assert "error" in result
+
+
+class TestListOmlxModels:
+    def test_returns_models(self):
+        mock_data = {
+            "object": "list",
+            "data": [
+                {"id": "mlx-community/gemma-3-4b-it-4bit", "object": "model"},
+                {"id": "mlx-community/Qwen3-8B-4bit", "object": "model"},
+            ],
+        }
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            models = list_omlx_models()
+
+        assert len(models) == 2
+        assert models[0]["name"] == "mlx-community/gemma-3-4b-it-4bit"
+        assert models[0]["size"] == 0
+        assert models[0]["quantization"] == ""
+        assert models[0]["family"] == ""
+
+    def test_skips_entries_without_id(self):
+        mock_data = {"data": [{"object": "model"}, {"id": "mlx-community/valid-model"}]}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            models = list_omlx_models()
+
+        assert len(models) == 1
+        assert models[0]["name"] == "mlx-community/valid-model"
+
+    def test_empty_list(self):
+        mock_data = {"data": []}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(mock_data).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", return_value=mock_resp):
+            assert list_omlx_models() == []
+
+    def test_server_offline(self):
+        with patch("quodeq.llm_bridge._omlx.urllib.request.urlopen", side_effect=ConnectionRefusedError):
+            assert list_omlx_models() == []
+
+
+class TestConcurrency:
+    def test_no_models_available(self):
+        with patch("quodeq.llm_bridge._omlx.list_omlx_models", return_value=[]), \
+             patch("quodeq.llm_bridge._omlx._detect_memory", return_value=48e9):
+            result = run_concurrency_test("any")
+        assert result["recommended"] == 1
+        assert "reason" in result
+
+    def test_estimates_with_models_available(self):
+        mock_models = [{"name": "mlx-community/gemma-3-4b-it-4bit", "size": 0}]
+        with patch("quodeq.llm_bridge._omlx.list_omlx_models", return_value=mock_models), \
+             patch("quodeq.llm_bridge._omlx._detect_memory", return_value=128e9):
+            result = run_concurrency_test("mlx-community/gemma-3-4b-it-4bit")
+        assert result["recommended"] >= 1
+        assert result["gpu_memory"] == 128e9
+
+    def test_no_host_memory_detected(self):
+        mock_models = [{"name": "mlx-community/gemma-3-4b-it-4bit", "size": 0}]
+        with patch("quodeq.llm_bridge._omlx.list_omlx_models", return_value=mock_models), \
+             patch("quodeq.llm_bridge._omlx._detect_memory", return_value=0):
+            result = run_concurrency_test("mlx-community/gemma-3-4b-it-4bit")
+        assert result["recommended"] == 1
+        assert "reason" in result

--- a/tests/services/test_tooling_api_clients.py
+++ b/tests/services/test_tooling_api_clients.py
@@ -59,3 +59,44 @@ class TestGetAiClientsIncludesApiProviders:
         claude = next((c for c in result["clients"] if c["id"] == "claude"), None)
         assert claude is not None
         assert claude["installed"] is False
+
+
+class TestRequiresPlatformFiltering:
+    """Providers with requires_platform are hidden on non-matching platforms."""
+
+    def test_excluded_when_platform_mismatches(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg, \
+             patch("quodeq.services.tooling_mixin._platform_matches", return_value=False):
+            mock_cfg.return_value = {
+                "omlx": {"type": "api", "order": 1, "model": "", "api_base": "http://localhost:8000/v1", "requires_platform": "darwin-arm64"},
+                "ollama": {"type": "api", "order": 0, "model": "", "api_base": "http://localhost:11434/v1"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "omlx" not in client_ids
+        assert "ollama" in client_ids
+
+    def test_included_when_platform_matches(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg, \
+             patch("quodeq.services.tooling_mixin._platform_matches", return_value=True):
+            mock_cfg.return_value = {
+                "omlx": {"type": "api", "order": 1, "model": "", "api_base": "http://localhost:8000/v1", "requires_platform": "darwin-arm64"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "omlx" in client_ids
+
+    def test_provider_without_requires_always_included(self):
+        mixin = FsToolingMixin()
+        with patch("quodeq.services.tooling_mixin.get_provider_configs") as mock_cfg:
+            mock_cfg.return_value = {
+                "ollama": {"type": "api", "order": 0, "model": "", "api_base": "http://localhost:11434/v1"},
+            }
+            with patch("shutil.which", return_value=None):
+                result = mixin.get_ai_clients()
+        client_ids = [c["id"] for c in result["clients"]]
+        assert "ollama" in client_ids


### PR DESCRIPTION
## Summary

Adds **omlx** as a first-class AI provider — an Apple Silicon-only inference server that serves MLX-format models with an OpenAI-compatible API.

- **Backend** (`quodeq.llm_bridge._omlx`): server status, model listing (with symlinked-model fallback), VRAM/concurrency estimation, API-key auto-read from `~/.omlx/settings.json`
- **Provider config**: new `omlx` entry in `ai_providers.json` with `requires_platform: darwin-arm64`
- **HTTP routes**: `/api/omlx/status`, `/api/omlx/models`, `/api/omlx/test-concurrency`
- **Settings UI**: dedicated OmlxTab with model picker + server status; advanced block holds server address, API key, parallel agents
- **Evaluation env wiring**: `OMLX_API_KEY` / `OMLX_BASE_URL` propagate from UI → service options → subprocess env → analysis runner

## Compatibility fixes uncovered while bringing this online

omlx (and reasoning-mode local models in general) exposed gaps in `_api_runner.py` that also benefit existing local providers (Ollama, llamacpp):

- **MD_JSON mode** for non-OpenAI providers. `Mode.JSON` requests `response_format: json_object` — a structured-output constraint that omlx's DMG build can't satisfy and that caused requests to hang.
- **Explicit HTTP timeouts** (10s connect / 300s read / 30s write) on non-OpenAI clients. Previously a slow local model could block indefinitely.
- **Disable Gemma 4 / Qwen3 thinking mode** via `chat_template_kwargs.enable_thinking=false`. The thinking trace generates thousands of tokens before the actual JSON output — pushed per-batch latency from seconds to minutes. Verified locally: a 3-finding analysis prompt returns in ~22 s vs. several minutes before.
- **Restrict `reasoning_effort: \"none\"`** to OpenAI endpoints only (it's an o-series-specific field).
- **Classify `omlx` as a local-api provider** in `useEvaluation.js` so it inherits the unlimited time-limit / 1-agent defaults — without this it picked up the 10 min CLI deadline and was killed before any file finished.

## Test plan

- [x] Unit tests: `tests/llm_bridge/test_omlx.py` (18 tests) covers status, model list, symlink fallback, auth header propagation, concurrency estimation
- [x] Unit tests: `tests/services/test_tooling_api_clients.py` and `tests/analysis/test_subprocess_coverage.py` cover the API key chain (env → settings.json fallback)
- [x] Unit tests: `tests/analysis/test_api_runner*.py` updated for the new timeout/extra_body shape
- [x] Full suite green: `uv run pytest` → 2881 passed
- [x] Manual end-to-end: live evaluation against `gemma-4-26B-A4B-it-OptiQ-4bit` on omlx produced real findings (SQL injection, weak hashes, resource leaks, type-hint gaps) with sub-second per-token output and findings landing in `evidence/<dim>_evidence.jsonl` + projecting into `evaluation.db`