### PR TITLE
fix(ui): keep Overview visible during evaluations

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -9,10 +9,13 @@ import EmptyState from '../../../components/EmptyState.jsx';
 function NoCompletedEvalPanel({ availableRuns = [], onNavigate }) {
   const hasRunning = availableRuns.some((r) => r?.status === 'in_progress');
   if (hasRunning) {
+    // First-ever evaluation is still running. There's no prior data to
+    // show, but we still avoid claiming the project has "no" evaluations
+    // — they just haven't finished yet.
     return (
       <EmptyState
-        title="Evaluation in progress"
-        description="Results will appear here once the evaluation finishes. You can watch dimensions complete one by one in the History tab."
+        title="First evaluation in progress"
+        description="The overview will fill in once a run finishes. You can watch dimensions complete in History."
         actionLabel="Open history"
         onAction={() => onNavigate?.('history')}
       />

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -23,16 +23,6 @@ import { projectKeys } from "../api/queryKeys.js";
  */
 export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true }) {
   const queryClient = useQueryClient();
-  const asOf = selectedRun && selectedRun !== "latest" ? selectedRun : null;
-
-  const scoresQuery = useQuery({
-    queryKey: projectKeys.scores(selectedProject || "_none_", asOf),
-    queryFn: () => getProjectScores(selectedProject, asOf),
-    enabled: !!selectedProject,
-    staleTime: 60_000,
-    // Keep prior scores visible while switching runs — see useDashboard for rationale.
-    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
-  });
 
   const latestQuery = useQuery({
     queryKey: projectKeys.scores(selectedProject || "_none_", null),
@@ -42,6 +32,34 @@ export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder
     // Latest scores are project-wide (no per-run swap), so prev-data
     // flashing isn't a concern — keep placeholder unconditionally.
     placeholderData: (prev) => prev,
+  });
+
+  // Overview is anchored on completed runs. If selectedRun points at an
+  // in-progress run (or one that hasn't shown up in availableRuns yet),
+  // fall back to 'latest' so the cards keep showing the last finished
+  // evaluation instead of going blank mid-flight. Resolution waits for
+  // latestQuery so we never fire the scoped query with a stale asOf.
+  const isLatestSelection = !selectedRun || selectedRun === "latest";
+  const asOf = useMemo(() => {
+    if (isLatestSelection) return null;
+    const runs = latestQuery.data?.availableRuns;
+    if (!runs) return null;
+    const match = runs.find((r) => r.runId === selectedRun);
+    if (!match) return null;
+    if (match.status === "in_progress") return null;
+    return selectedRun;
+  }, [isLatestSelection, selectedRun, latestQuery.data]);
+
+  const scoresQuery = useQuery({
+    queryKey: projectKeys.scores(selectedProject || "_none_", asOf),
+    queryFn: () => getProjectScores(selectedProject, asOf),
+    // Wait for the latest run-status list before issuing a scoped fetch —
+    // otherwise we'd briefly call with the raw selectedRun and only later
+    // correct it, leaking a stale-asOf request.
+    enabled: !!selectedProject && (isLatestSelection || latestQuery.isSuccess),
+    staleTime: 60_000,
+    // Keep prior scores visible while switching runs — see useDashboard for rationale.
+    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
   });
 
   const availableRuns = useMemo(() => {

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useProjectScores } from "./useProjectScores";
 import { withQueryClient } from "../test-utils/withQueryClient.jsx";
+import { getProjectScores } from "../api/index.js";
 
 vi.mock("../api/index.js", () => ({
   getProjectScores: vi.fn(async (project, asOf) => {
@@ -9,16 +10,26 @@ vi.mock("../api/index.js", () => ({
       return {
         accumulated: { score: 80 },
         trend: [{ runId: asOf }],
-        availableRuns: [],
+        availableRuns: [
+          { runId: "r9", status: "complete" },
+          { runId: "r1", status: "complete" },
+        ],
       };
     }
     return {
       accumulated: { score: 90 },
       trend: [],
-      availableRuns: [{ runId: "r1" }],
+      availableRuns: [
+        { runId: "r9", status: "complete" },
+        { runId: "r1", status: "complete" },
+      ],
     };
   }),
 }));
+
+beforeEach(() => {
+  getProjectScores.mockClear();
+});
 
 describe("useProjectScores", () => {
   it("returns null when project is empty", () => {
@@ -47,8 +58,69 @@ describe("useProjectScores", () => {
       { wrapper: withQueryClient() },
     );
     await waitFor(() => {
-      expect(result.current.availableRuns).toEqual([{ runId: "r1" }]);
+      expect(result.current.availableRuns.map((r) => r.runId)).toEqual(["r9", "r1"]);
     });
+  });
+
+  it("falls back to latest when selectedRun points at an in_progress run", async () => {
+    // Latest query returns availableRuns marking r_running as in_progress; the
+    // scoped query should NOT request asOf=r_running (would leak partial dims
+    // into Overview while the eval is alive). It re-uses the latest payload.
+    getProjectScores.mockImplementation(async (project, asOf) => ({
+      accumulated: { score: asOf ? 80 : 90 },
+      trend: [],
+      availableRuns: [
+        { runId: "r_running", status: "in_progress" },
+        { runId: "r_done", status: "complete" },
+      ],
+    }));
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: "r_running" }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current.scores?.accumulated?.score).toBe(90);
+    });
+    // Confirm the scoped call was never issued with asOf=r_running.
+    const asOfArgs = getProjectScores.mock.calls.map((c) => c[1]);
+    expect(asOfArgs).not.toContain("r_running");
+  });
+
+  it("falls back to latest when selectedRun is unknown (not in availableRuns)", async () => {
+    getProjectScores.mockImplementation(async (project, asOf) => ({
+      accumulated: { score: asOf ? 80 : 90 },
+      trend: [],
+      availableRuns: [{ runId: "r_done", status: "complete" }],
+    }));
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: "r_ghost" }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current.scores?.accumulated?.score).toBe(90);
+    });
+    const asOfArgs = getProjectScores.mock.calls.map((c) => c[1]);
+    expect(asOfArgs).not.toContain("r_ghost");
+  });
+
+  it("still scopes the query when selectedRun is a known completed run", async () => {
+    getProjectScores.mockImplementation(async (project, asOf) => ({
+      accumulated: { score: asOf ? 80 : 90 },
+      trend: [],
+      availableRuns: [
+        { runId: "r_done", status: "complete" },
+        { runId: "r_old", status: "complete" },
+      ],
+    }));
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: "r_old" }),
+      { wrapper: withQueryClient() },
+    );
+    await waitFor(() => {
+      expect(result.current.scores?.accumulated?.score).toBe(80);
+    });
+    const asOfArgs = getProjectScores.mock.calls.map((c) => c[1]);
+    expect(asOfArgs).toContain("r_old");
   });
 
 });


### PR DESCRIPTION
## Summary

- Clicking Overview while a run was in_progress could surface an "Evaluation in progress, go to history" empty state even when the project had prior completed runs. The scoped scores query was passing the in-progress runId as `asOf`, which the backend resolved to an empty set, blanking the cards.
- `useProjectScores` now resolves `asOf` against the latest run-status list and falls back to `null` whenever `selectedRun` is `in_progress` or not yet known. The scoped query is gated on `latestQuery` success so we never fire a stale-asOf request during the brief window before the run list arrives.
- `NoCompletedEvalPanel` in `DashboardPage` now only fires when the project genuinely has zero completed runs. Copy updated to "First evaluation in progress" since that is the only remaining trigger.
- Topbar continues to show the global "Evaluating…" pill, so no Overview-local indicator added.

## Test plan

- [x] `npx vitest run` (342 tests pass)
- [x] `npm run test` (178 node tests pass)
- [x] `uv run pytest tests/services/` (721 tests pass)
- [x] Manual: with an evaluation running on a project, click Overview. The page renders the prior completed run's stat strip, dimension cards, and history chart instead of the gating screen.
- [x] Reviewer sanity: click a bar in History to scope the accumulated to an older completed run. Should still work (regression check on the `asOf` path that's still in use).