### PR TITLE
chore(cleanup): remove legacy quodeq.provider stub package

### DIFF
--- a/src/quodeq/provider/__init__.py
+++ b/src/quodeq/provider/__init__.py
@@ -1,1 +1,0 @@
-"""Legacy provider package — all implementations live in quodeq.services."""

--- a/src/quodeq/provider/accumulated.py
+++ b/src/quodeq/provider/accumulated.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.accumulated instead."""

--- a/src/quodeq/provider/base.py
+++ b/src/quodeq/provider/base.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.base instead."""

--- a/src/quodeq/provider/dashboard.py
+++ b/src/quodeq/provider/dashboard.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.dashboard instead."""

--- a/src/quodeq/provider/evaluation_mixin.py
+++ b/src/quodeq/provider/evaluation_mixin.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.evaluation_mixin instead."""

--- a/src/quodeq/provider/filesystem.py
+++ b/src/quodeq/provider/filesystem.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.filesystem instead."""

--- a/src/quodeq/provider/jobs.py
+++ b/src/quodeq/provider/jobs.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.jobs instead."""

--- a/src/quodeq/provider/plugin_discovery.py
+++ b/src/quodeq/provider/plugin_discovery.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.plugin_discovery instead."""

--- a/src/quodeq/provider/tooling_mixin.py
+++ b/src/quodeq/provider/tooling_mixin.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.tooling_mixin instead."""

--- a/src/quodeq/provider/violation_context.py
+++ b/src/quodeq/provider/violation_context.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.violation_context instead."""

--- a/src/quodeq/provider/violations.py
+++ b/src/quodeq/provider/violations.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.violations instead."""

--- a/src/quodeq/provider/violations_parsing.py
+++ b/src/quodeq/provider/violations_parsing.py
@@ -1,1 +1,0 @@
-"""Legacy shim — use quodeq.services.violations_parsing instead."""

--- a/tests/services/test_accumulated.py
+++ b/tests/services/test_accumulated.py
@@ -1,4 +1,4 @@
-"""Tests for quodeq.provider.accumulated — cross-run aggregation logic."""
+"""Tests for quodeq.services.accumulated — cross-run aggregation logic."""
 from __future__ import annotations
 
 import json

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -1,4 +1,4 @@
-"""Tests for quodeq.provider.dashboard — dashboard construction logic."""
+"""Tests for quodeq.services.dashboard — dashboard construction logic."""
 from __future__ import annotations
 
 from typing import Any

--- a/tests/services/test_violations.py
+++ b/tests/services/test_violations.py
@@ -1,4 +1,4 @@
-"""Tests for quodeq.provider.violations — resolution and aggregation."""
+"""Tests for quodeq.services.violations — resolution and aggregation."""
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary

- Deletes `src/quodeq/provider/` — 12 one-line docstring shim files that pointed readers at `quodeq.services.X`. The migration to `quodeq.services` already completed; these stubs are vestigial.
- Fixes three stale test-file docstrings (`tests/services/test_{violations,dashboard,accumulated}.py`) that still referenced `quodeq.provider.*`. The actual imports already use `quodeq.services.*`.
- Completes the legacy-stubs portion of architectural item **#3C** from the 2026-05-16 `/improve-codebase-architecture` deepening review. The broader Provider interface redesign is deferred pending the `experimental/multi-provider-setup` branch; `src/quodeq/llm_bridge/` and `src/quodeq/analysis/subprocess.py` are intentionally untouched here.

## Safety check

Pre-deletion grep returned no functional dependencies:

```
grep -rn "from quodeq.provider\|import quodeq.provider" --include="*.py" src/ tests/
# (no matches)

grep -rn "quodeq\.provider\." --include="*.py" src/ tests/
# only 3 stale docstrings (fixed in this PR)

grep -rn "quodeq/provider\|quodeq\.provider" pyproject.toml
# (no matches — uv_build auto-discovers, no explicit package list)
```

## Test plan

- [x] `python -c "import quodeq"` succeeds
- [x] `python -c "from quodeq import services"` succeeds
- [x] `uv run pytest tests/ -x` — 2881 passed in 47.79s
- [x] CI green on develop merge target