### PR TITLE
refactor(core): unify Judgment types and centralize Finding conversions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,8 +18,11 @@ The mutable, consolidated projection of the Event Log. It represents the "curren
 A specific axis of evaluation (e.g., Security, Reliability, Maintainability) based on ISO 25010.
 _Avoid_: Error, bug.
 
+**Judgment**:
+What the LLM produced about a single piece of code. Immutable, recorded in the Event Log. The canonical type. Verdict is "violation" or "compliance".
+
 **Finding/Violation**:
-An instance where the code fails to meet a requirement of a dimension, mapped to a CWE.
+A **Judgment** as the service layer sees it, after user preferences (dismiss/delete) and confidence enrichment apply. Verdict may additionally be "dismissed".
 _Avoid_: Error, bug.
 
 **Run**:

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -4,6 +4,14 @@ Calls LLM APIs directly via Instructor (Pydantic-based structured output)
 and writes findings as JSONL evidence -- the same format the CLI runner
 produces via MCP.
 
+``_Finding`` (below) is a lenient short-key variant of the canonical
+``Judgment`` (``quodeq.core.events.models``). Local models drop required
+fields and balk at long field names under load -- this type's short keys
+(``req``/``t``/``w``) and Field descriptions are tuned for that constraint,
+so the salvage path stays rare. The downstream wire-dict → Judgment lift
+happens via ``quodeq.core.finding_mappings.wire_dict_to_judgment`` after
+``FindingEnricher`` maps ``req`` to ``practice_id``.
+
 Requires the ``quodeq[api]`` extra: ``pip install 'quodeq[api]'``
 """
 from __future__ import annotations

--- a/src/quodeq/analysis/mcp/router.py
+++ b/src/quodeq/analysis/mcp/router.py
@@ -124,28 +124,9 @@ class FindingsRouter:
     def _emit_event(self, finding: dict) -> None:
         """Emit a JudgmentCreatedEvent to the event log. Never raises."""
         try:
-            from quodeq.core.events.models import JudgmentPayload, JudgmentCreatedEvent  # noqa: PLC0415
-            payload = JudgmentPayload(
-                practice_id=finding.get("p") or "",
-                verdict=finding.get("t") or "",
-                dimension=finding.get("d") or "",
-                file=finding.get("file") or "",
-                line=finding.get("line") or 0,
-                end_line=finding.get("end_line"),
-                snippet=finding.get("snippet"),
-                severity=finding.get("severity") or "medium",
-                violation_type=finding.get("violation_type"),
-                reason=finding.get("reason") or "",
-                title=finding.get("w"),
-                context=finding.get("context"),
-                scope=finding.get("scope"),
-                confidence=finding.get("confidence") or 100,
-                req_refs=[
-                    r["label"] if isinstance(r, dict) else str(r)
-                    for r in (finding.get("req_refs") or [])
-                ],
-                req=finding.get("req"),
-            )
+            from quodeq.core.events.models import JudgmentCreatedEvent  # noqa: PLC0415
+            from quodeq.core.finding_mappings import wire_dict_to_judgment  # noqa: PLC0415
+            payload = wire_dict_to_judgment(finding)
             self._event_log.emit(JudgmentCreatedEvent(payload=payload))
         except Exception:  # noqa: BLE001 — event log must never break JSONL durability
             _logger.warning("FindingsRouter: event log emit failed (JSONL succeeded)", exc_info=True)

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -140,7 +140,7 @@ def _read_dim_eval(run_dir: Path, dimension: str) -> dict[str, Any] | None:
 
 
 def _payload_as_sse_finding(payload: Any, finding_id: int) -> dict[str, Any]:
-    """Project a JudgmentPayload into the finding dict the SSE client expects."""
+    """Project a Judgment into the finding dict the SSE client expects."""
     return {
         "id": finding_id,
         "practice_id": payload.practice_id,

--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -7,6 +7,8 @@ from uuid import uuid4, UUID
 
 from pydantic import BaseModel, Field, ConfigDict
 
+from quodeq.core.types.req_ref import ReqRef
+
 
 T = TypeVar("T")
 
@@ -30,30 +32,48 @@ class BaseEvent(BaseModel, Generic[T]):
     payload: T
 
 
-class JudgmentPayload(BaseModel):
-    """Payload for JUDGMENT_CREATED event, expanded from the legacy JSONL structure."""
+class Judgment(BaseModel):
+    """What the LLM produced about a single piece of code.
+
+    Immutable. The canonical type for findings in the Event Log. Verdict is
+    "violation" or "compliance" -- "dismissed" is NOT a valid Judgment verdict;
+    that's a derived view-only state on Finding.
+    """
     model_config = ConfigDict(frozen=True)
 
+    # Required
     practice_id: str
     verdict: str  # "violation" | "compliance"
     dimension: str
     file: str
     line: int
+    reason: str
+
+    # Optional
     end_line: Optional[int] = None
     snippet: Optional[str] = None
     severity: str = "medium"
     violation_type: Optional[str] = None
-    reason: str
     title: Optional[str] = None
     context: Optional[str] = None
     scope: Optional[str] = None
     confidence: int = 100
-    req_refs: List[str] = Field(default_factory=list)
     req: Optional[str] = None
+    req_refs: List[ReqRef] = Field(default_factory=list)
     cwe: Optional[str] = None
 
+    def is_violation(self) -> bool:
+        return self.verdict == "violation"
 
-class JudgmentCreatedEvent(BaseEvent[JudgmentPayload]):
+    def is_compliance(self) -> bool:
+        return self.verdict == "compliance"
+
+
+# Deprecation alias -- remove in a follow-up PR once all callers migrate.
+JudgmentPayload = Judgment
+
+
+class JudgmentCreatedEvent(BaseEvent[Judgment]):
     """Event emitted whenever a new judgment is found and recorded."""
     event_type: EventType = EventType.JUDGMENT_CREATED
 

--- a/src/quodeq/core/evidence/__init__.py
+++ b/src/quodeq/core/evidence/__init__.py
@@ -1,2 +1,3 @@
-from quodeq.core.evidence.model import Evidence, PrincipleEvidence, Judgment
+from quodeq.core.events.models import Judgment
+from quodeq.core.evidence.model import Evidence, PrincipleEvidence
 from quodeq.core.evidence.merge import merge_evidence

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -8,7 +8,8 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 
 from quodeq.core.evidence._refs import enrich_judgment
-from quodeq.core.evidence.model import Judgment
+from quodeq.core.events.models import Judgment
+from quodeq.core.types.req_ref import ReqRef
 from quodeq.shared.utils import open_text
 
 _logger = logging.getLogger(__name__)
@@ -41,18 +42,24 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
     if not practice_id or verdict not in ("violation", "compliance"):
         return None
 
+    pre_resolved = obj.get("req_refs")
+    req_refs: list[ReqRef] = []
+    if isinstance(pre_resolved, list):
+        req_refs = [
+            ReqRef(label=r.get("label", ""), url=r.get("url", ""))
+            for r in pre_resolved if isinstance(r, dict)
+        ]
+
     j = Judgment(
         practice_id=practice_id, verdict=verdict, dimension=obj.get("d", ""),
-        file=obj.get("file", ""), line=obj.get("line", 0), end_line=obj.get("end_line", 0),
+        file=obj.get("file", ""), line=obj.get("line", 0), end_line=obj.get("end_line"),
         snippet=obj.get("snippet", ""), severity=obj.get("severity", "medium"),
-        violation_type=obj.get("vt", ""), reason=obj.get("reason", ""),
-        req=obj.get("req"), title=obj.get("w", ""),
-        context=obj.get("context", ""), scope=obj.get("scope", ""),
+        violation_type=obj.get("vt") or None, reason=obj.get("reason", ""),
+        req=obj.get("req"), title=obj.get("w") or None,
+        context=obj.get("context") or None, scope=obj.get("scope") or None,
         confidence=_jsonl_confidence(obj.get("confidence")),
+        req_refs=req_refs,
     )
-    pre_resolved = obj.get("req_refs")
-    if isinstance(pre_resolved, list) and pre_resolved:
-        j.req_refs = pre_resolved
     return j, obj.get("refs")
 
 
@@ -63,16 +70,19 @@ def judgment_to_dict(j: Judgment) -> dict:
                  "severity": j.severity, "violation_type": j.violation_type,
                  "context": j.context, "scope": j.scope}
     d.update({k: v for k, v in _optional.items() if v})
-    for key in ("req", "req_refs", "title", "reason"):
-        val = getattr(j, key, None)
-        if val:
-            d[key] = val
+    if j.req:
+        d["req"] = j.req
+    if j.req_refs:
+        d["req_refs"] = [{"label": r.label, "url": r.url} for r in j.req_refs]
+    if j.title:
+        d["title"] = j.title
+    if j.reason:
+        d["reason"] = j.reason
     # Carry confidence forward only when it's not the default 100. Keeps the
     # PrincipleEvidence dicts compact for the common case where every finding
     # has full confidence; producers writing < 100 surface in the output.
-    confidence = getattr(j, "confidence", 100)
-    if confidence != 100:
-        d["confidence"] = confidence
+    if j.confidence != 100:
+        d["confidence"] = j.confidence
     return d
 
 
@@ -84,7 +94,7 @@ def parse_judgments(lines: Iterable[str], compiled_dir: Path | None) -> list[Jud
         result = parse_jsonl_line(line)
         if result is not None:
             j, llm_refs = result
-            enrich_judgment(j, llm_refs, compiled_dir, req_refs_cache)
+            j = enrich_judgment(j, llm_refs, compiled_dir, req_refs_cache)
             judgments.append(j)
     return judgments
 

--- a/src/quodeq/core/evidence/_refs.py
+++ b/src/quodeq/core/evidence/_refs.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from quodeq.core.standards.refs import load_compiled_refs
+from quodeq.core.types.req_ref import ReqRef
+
+if TYPE_CHECKING:
+    from quodeq.core.events.models import Judgment
 
 _CWE_URL_TEMPLATE_DEFAULT = "https://cwe.mitre.org/data/definitions/{cwe_id}.html"
 
@@ -67,19 +72,26 @@ def resolve_llm_refs(
 
 
 def enrich_judgment(
-    j: "Judgment",  # noqa: F821 -- avoids circular import
+    j: "Judgment",
     llm_refs: list[str] | None,
     compiled_dir: Path | None,
     req_refs_cache: dict[str, dict[str, list[dict]]],
-) -> None:
-    """Resolve and attach req_refs to a Judgment in-place."""
+) -> "Judgment":
+    """Resolve req_refs for a Judgment, returning the (possibly new) Judgment.
+
+    Judgment is frozen (Pydantic), so we return a model_copy when we have
+    something new to attach. When the judgment already carries refs, or no
+    refs were resolved, the original instance is returned unchanged.
+    """
     if j.req_refs:
-        return  # MCP server already enriched
+        return j  # MCP server already enriched
     all_req_refs = None
     if compiled_dir and j.req and j.dimension:
         if j.dimension not in req_refs_cache:
             req_refs_cache[j.dimension] = build_req_refs_lookup(compiled_dir, j.dimension)
         all_req_refs = req_refs_cache[j.dimension].get(j.req)
     resolved = resolve_llm_refs(llm_refs, all_req_refs)
-    if resolved:
-        j.req_refs = resolved
+    if not resolved:
+        return j
+    refs = [ReqRef(label=r.get("label", ""), url=r.get("url", "")) for r in resolved]
+    return j.model_copy(update={"req_refs": refs})

--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -5,7 +5,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from quodeq.core.evidence.model import Judgment
+from quodeq.core.events.models import Judgment
 
 _SEV_RANKS = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -1,8 +1,16 @@
-"""Evidence model — dataclasses for judgments, principles, and evaluation output."""
+"""Evidence model — dataclasses for principles and evaluation output.
+
+Judgment is re-exported from quodeq.core.events.models, where the canonical
+type lives (the Event Log is the source of truth per ADR 0001).
+"""
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+
+# Re-exported for backward compatibility with callers that still import
+# Judgment from this module.
+from quodeq.core.events.models import Judgment as Judgment  # noqa: F401
 
 DEFAULT_WEIGHT = "Medium (x2)"
 _HIGH_CONFIDENCE_THRESHOLD = 10  # minimum total instances for "high" confidence
@@ -28,40 +36,6 @@ def compute_coverage_pct(files_read: int, source_file_count: int) -> float:
 
 _VALID_VERDICTS = frozenset({"violation", "compliance", "dismissed"})
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low", "minor"})
-
-
-@dataclass
-class Judgment:
-    """One LLM judgment per finding."""
-    practice_id: str
-    file: str = ""
-    line: int = 0
-    end_line: int = 0
-    snippet: str = ""
-    verdict: str = "violation"  # violation | compliance | dismissed
-    severity: str = "medium"
-    reason: str = ""
-    dimension: str = ""
-    req: str | None = None
-    req_refs: list[dict] | None = None
-    violation_type: str = ""
-    title: str = ""
-    context: str = ""
-    scope: str = ""
-    # 0-100 confidence score the scanner attaches to this finding. 100 means
-    # "no reason to doubt." Subsequent slices of the context-enricher plan
-    # populate values < 100 to downweight known false-positive patterns.
-    confidence: int = 100
-
-    def __post_init__(self) -> None:
-        if not self.practice_id:
-            raise ValueError("Judgment requires a practice_id")
-
-    def is_violation(self) -> bool:
-        return self.verdict == "violation"
-
-    def is_compliance(self) -> bool:
-        return self.verdict == "compliance"
 
 
 @dataclass

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from quodeq.core.evidence._jsonl import judgment_to_dict, parse_jsonl_line, read_judgments
 from quodeq.core.evidence._refs import build_req_refs_lookup, enrich_judgment, resolve_llm_refs
 from quodeq.shared.utils import open_text
+from quodeq.core.events.models import Judgment
 from quodeq.core.evidence._req_mapping import _GroupedJudgments, _group_judgments
-from quodeq.core.evidence.model import Evidence, Judgment, PrincipleEvidence, compute_coverage_pct
+from quodeq.core.evidence.model import Evidence, PrincipleEvidence, compute_coverage_pct
 
 # Re-export for backward compatibility (external code imports these from parser)
 __all__ = ["build_req_refs_lookup", "resolve_llm_refs", "EvidenceContext",
@@ -76,7 +77,7 @@ def parse_jsonl_to_evidence_by_dimension(
             result = parse_jsonl_line(line)
             if result is not None:
                 j, llm_refs = result
-                enrich_judgment(j, llm_refs, compiled_dir, req_refs_cache)
+                j = enrich_judgment(j, llm_refs, compiled_dir, req_refs_cache)
                 by_dim.setdefault(j.dimension or "unknown", []).append(j)
     if not by_dim:
         return {}

--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -1,0 +1,103 @@
+"""Centralized conversions between Finding-shape representations.
+
+This is the only module that knows how to convert between the LLM wire format,
+the canonical Judgment, the read-side Finding view, and the API response dict.
+SQL row mapping lives in data/sqlite/_row_mappers.py.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from quodeq.core.events.models import Judgment
+from quodeq.core.types.finding import Finding
+from quodeq.core.types.req_ref import ReqRef
+
+
+def _coerce_req_refs(raw: Any) -> list[ReqRef]:
+    if not isinstance(raw, list):
+        return []
+    refs: list[ReqRef] = []
+    for r in raw:
+        if isinstance(r, ReqRef):
+            refs.append(r)
+        elif isinstance(r, dict):
+            refs.append(ReqRef(label=r.get("label", ""), url=r.get("url", "")))
+    return refs
+
+
+def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
+    """Lift a short-key LLM/FindingsRouter wire dict into a Judgment.
+
+    The wire format uses short keys for LLM token economy: p=practice_id,
+    t=verdict, d=dimension, w=title. Missing required fields fall back to
+    empty strings / 0 so this never raises on malformed input -- the caller
+    decides whether to drop the result.
+    """
+    return Judgment(
+        practice_id=d.get("p") or "",
+        verdict=d.get("t") or "",
+        dimension=d.get("d") or "",
+        file=d.get("file") or "",
+        line=int(d.get("line") or 0),
+        end_line=d.get("end_line"),
+        snippet=d.get("snippet"),
+        severity=d.get("severity") or "medium",
+        violation_type=d.get("violation_type"),
+        reason=d.get("reason") or "",
+        title=d.get("w"),
+        context=d.get("context"),
+        scope=d.get("scope"),
+        confidence=int(d.get("confidence") if d.get("confidence") is not None else 100),
+        req=d.get("req"),
+        req_refs=_coerce_req_refs(d.get("req_refs")),
+        cwe=d.get("cwe"),
+    )
+
+
+def judgment_to_finding(j: Judgment, *, dismissed: bool = False) -> Finding:
+    """Project a Judgment into the read-side Finding view.
+
+    When *dismissed* is True the Finding's verdict becomes "dismissed" --
+    Judgment itself never carries that verdict; it's a derived view-only
+    state owned by service-layer user-preference logic.
+    """
+    return Finding(
+        practice_id=j.practice_id,
+        verdict="dismissed" if dismissed else j.verdict,
+        file=j.file,
+        line=j.line,
+        end_line=j.end_line,
+        title=j.title,
+        reason=j.reason,
+        snippet=j.snippet,
+        severity=j.severity or "minor",
+        cwe=j.cwe,
+        req=j.req,
+        req_refs=list(j.req_refs),
+        context=j.context,
+        dimension=j.dimension,
+        violation_type=j.violation_type,
+        scope=j.scope,
+        confidence=j.confidence,
+    )
+
+
+def finding_to_response_dict(f: Finding) -> dict[str, Any]:
+    """Render a Finding as the dict shape expected by SSE and REST clients."""
+    req_refs = (
+        [{"label": r.label, "url": r.url} for r in f.req_refs]
+        if f.req_refs else None
+    )
+    return {
+        "practice_id": f.practice_id,
+        "file": f.file,
+        "line": f.line,
+        "end_line": f.end_line,
+        "snippet": f.snippet,
+        "verdict": f.verdict,
+        "severity": f.severity,
+        "reason": f.reason,
+        "title": f.title,
+        "req": f.req,
+        "req_refs": req_refs,
+    }

--- a/src/quodeq/core/types/finding.py
+++ b/src/quodeq/core/types/finding.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from quodeq.core.types.req_ref import ReqRef as ReqRef
+
 
 @dataclass(frozen=True, slots=True)
 class SeverityTally:
@@ -16,12 +18,6 @@ class Totals:
     violation_count: int = 0
     compliance_count: int = 0
     severity: SeverityTally = field(default_factory=SeverityTally)
-
-
-@dataclass(frozen=True, slots=True)
-class ReqRef:
-    label: str
-    url: str
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/quodeq/core/types/req_ref.py
+++ b/src/quodeq/core/types/req_ref.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ReqRef:
+    label: str
+    url: str

--- a/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
+++ b/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from quodeq.core.finding_mappings import finding_to_response_dict
 from quodeq.data.fs.report_parser._date_utils import find_date_in_dir, normalize_date
 from quodeq.data.fs.report_parser._run_info import safe_read_dir
 from quodeq.data.sqlite.connection import EVALUATION_DB_FILENAME
@@ -73,8 +74,8 @@ def load_evidence_map_from_db(run_dir: Path) -> dict[str, dict[str, Any]]:
     result: dict[str, dict[str, Any]] = {}
     for dimension in counts:
         judgments = repo.list_by_dimension(dimension)
-        violations = [_judgment_to_finding_dict(j) for j in judgments if j.verdict == "violation"]
-        compliance = [_judgment_to_finding_dict(j) for j in judgments if j.verdict == "compliance"]
+        violations = [finding_to_response_dict(j) for j in judgments if j.verdict == "violation"]
+        compliance = [finding_to_response_dict(j) for j in judgments if j.verdict == "compliance"]
         principles: dict[str, dict[str, Any]] = {}
         for j in judgments:
             entry = principles.setdefault(j.practice_id, {
@@ -83,7 +84,7 @@ def load_evidence_map_from_db(run_dir: Path) -> dict[str, dict[str, Any]]:
                 "compliance": [],
             })
             target = entry["violations"] if j.verdict == "violation" else entry["compliance"]
-            target.append(_judgment_to_finding_dict(j))
+            target.append(finding_to_response_dict(j))
         result[dimension] = {
             "dimension": dimension,
             "principles": principles,
@@ -94,20 +95,3 @@ def load_evidence_map_from_db(run_dir: Path) -> dict[str, dict[str, Any]]:
             "discipline": run_metadata["discipline"],
         }
     return result
-
-
-def _judgment_to_finding_dict(j) -> dict[str, Any]:
-    req_refs = [{"label": r.label, "url": r.url} for r in j.req_refs] if j.req_refs else None
-    return {
-        "practice_id": j.practice_id,
-        "file": j.file,
-        "line": j.line,
-        "end_line": j.end_line,
-        "snippet": j.snippet,
-        "verdict": j.verdict,
-        "severity": j.severity,
-        "reason": j.reason,
-        "title": j.title,
-        "req": j.req,
-        "req_refs": req_refs,
-    }

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -1,17 +1,17 @@
 """Pure functions translating between FindingsRouter dicts, Judgment, and SQL rows.
 
 The JSONL write path (analysis/mcp/router.py) uses short keys for wire-size
-reasons. The runtime Judgment dataclass and the SQLite schema use long names.
-This module is the only place that knows about both naming conventions.
+reasons. The runtime Judgment and the SQLite schema use long names. This
+module is the only place that knows about both naming conventions.
 """
 from __future__ import annotations
 
 import json
 from typing import Any
 
-from quodeq.core.evidence.model import Judgment
-from quodeq.core.events.models import JudgmentPayload
-from quodeq.core.types.finding import Finding, ReqRef
+from quodeq.core.events.models import Judgment
+from quodeq.core.types.finding import Finding
+from quodeq.core.types.req_ref import ReqRef
 
 
 def _dedup_key(practice_id: str, file: str, line: int, verdict: str) -> str:
@@ -63,7 +63,12 @@ def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
 
 
 def judgment_to_row(j: Judgment) -> dict[str, Any]:
-    """Translate a Judgment dataclass into a row dict ready for SQL bind."""
+    """Translate a Judgment into a row dict ready for SQL bind."""
+    refs_json: str | None
+    if j.req_refs:
+        refs_json = json.dumps([{"label": r.label, "url": r.url} for r in j.req_refs])
+    else:
+        refs_json = "[]"
     return {
         "schema_version": 1,
         "practice_id": j.practice_id,
@@ -73,40 +78,16 @@ def judgment_to_row(j: Judgment) -> dict[str, Any]:
         "severity": j.severity,
         "file": j.file,
         "line": j.line,
-        "end_line": j.end_line,
-        "title": j.title,
+        "end_line": j.end_line or 0,
+        "title": j.title or "",
         "reason": j.reason,
-        "snippet": j.snippet,
-        "violation_type": j.violation_type,
-        "context": j.context,
-        "scope": j.scope,
-        "req_refs_json": json.dumps(j.req_refs) if j.req_refs is not None else None,
+        "snippet": j.snippet or "",
+        "violation_type": j.violation_type or "",
+        "context": j.context or "",
+        "scope": j.scope or "",
+        "req_refs_json": refs_json,
         "dedup_key": _dedup_key(j.practice_id, j.file, j.line, j.verdict),
-        "confidence": _coerce_confidence(getattr(j, "confidence", 100)),
-    }
-
-
-def finding_payload_to_row(p: JudgmentPayload) -> dict[str, Any]:
-    """Translate a JudgmentPayload event model into a SQL row dict."""
-    return {
-        "schema_version": 1,
-        "practice_id": p.practice_id,
-        "dimension": p.dimension,
-        "requirement": None,
-        "verdict": p.verdict,
-        "severity": p.severity,
-        "file": p.file,
-        "line": p.line,
-        "end_line": p.end_line or 0,
-        "title": p.title or "",
-        "reason": p.reason,
-        "snippet": p.snippet or "",
-        "violation_type": p.violation_type or "",
-        "context": p.context or "",
-        "scope": p.scope or "",
-        "req_refs_json": json.dumps(p.req_refs) if p.req_refs is not None else None,
-        "dedup_key": _dedup_key(p.practice_id, p.file, p.line, p.verdict),
-        "confidence": _coerce_confidence(p.confidence),
+        "confidence": _coerce_confidence(j.confidence),
     }
 
 

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from quodeq.core.events.models import JudgmentPayload
+from quodeq.core.events.models import Judgment
 from quodeq.data.sqlite.connection import open_evaluation_db
-from quodeq.data.sqlite._row_mappers import finding_payload_to_row
+from quodeq.data.sqlite._row_mappers import judgment_to_row
 
 _logger = logging.getLogger(__name__)
 _CHECKPOINT_KEY = "projection_checkpoint"
@@ -31,8 +31,8 @@ class SQLiteStateStore:
     def __init__(self, run_dir: Path) -> None:
         self._run_dir = run_dir
 
-    def record_finding(self, payload: JudgmentPayload) -> None:
-        row = finding_payload_to_row(payload)
+    def record_finding(self, payload: Judgment) -> None:
+        row = judgment_to_row(payload)
         with open_evaluation_db(self._run_dir) as conn:
             conn.execute(_INSERT_FINDING, row)
             conn.commit()

--- a/tests/core/test_finding_mappings.py
+++ b/tests/core/test_finding_mappings.py
@@ -1,0 +1,168 @@
+"""Tests for the centralized finding-shape conversions."""
+from __future__ import annotations
+
+from quodeq.core.events.models import Judgment
+from quodeq.core.finding_mappings import (
+    finding_to_response_dict,
+    judgment_to_finding,
+    wire_dict_to_judgment,
+)
+from quodeq.core.types.finding import Finding
+from quodeq.core.types.req_ref import ReqRef
+
+
+class TestWireDictToJudgment:
+    def test_short_keys_mapped_to_long_names(self):
+        d = {
+            "p": "P-TIM-1", "t": "violation", "d": "Timeliness",
+            "w": "Missed deadline", "file": "src/x.py", "line": 10,
+            "reason": "blocking call",
+        }
+        j = wire_dict_to_judgment(d)
+        assert j.practice_id == "P-TIM-1"
+        assert j.verdict == "violation"
+        assert j.dimension == "Timeliness"
+        assert j.title == "Missed deadline"
+        assert j.file == "src/x.py"
+        assert j.line == 10
+        assert j.reason == "blocking call"
+
+    def test_req_refs_dicts_converted_to_reqref_objects(self):
+        d = {
+            "p": "P1", "t": "violation", "d": "D", "file": "f.py", "line": 1,
+            "reason": "r",
+            "req_refs": [
+                {"label": "CWE-798", "url": "https://cwe.mitre.org/798"},
+                {"label": "OWASP-A1", "url": "https://owasp.org/A1"},
+            ],
+        }
+        j = wire_dict_to_judgment(d)
+        assert len(j.req_refs) == 2
+        assert isinstance(j.req_refs[0], ReqRef)
+        assert j.req_refs[0].label == "CWE-798"
+        assert j.req_refs[0].url == "https://cwe.mitre.org/798"
+
+    def test_missing_fields_get_safe_defaults(self):
+        j = wire_dict_to_judgment({"p": "P1", "t": "compliance"})
+        assert j.practice_id == "P1"
+        assert j.verdict == "compliance"
+        assert j.dimension == ""
+        assert j.file == ""
+        assert j.line == 0
+        assert j.severity == "medium"
+        assert j.confidence == 100
+        assert j.req_refs == []
+
+    def test_confidence_passed_through(self):
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "confidence": 50}
+        )
+        assert j.confidence == 50
+
+    def test_round_trip_via_judgment_dump(self):
+        """wire_dict → Judgment → dump preserves the long-name fields."""
+        d = {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "w": "T"}
+        j = wire_dict_to_judgment(d)
+        dumped = j.model_dump()
+        assert dumped["practice_id"] == "P1"
+        assert dumped["verdict"] == "violation"
+        assert dumped["title"] == "T"
+
+
+class TestJudgmentToFinding:
+    def _judgment(self, **overrides):
+        defaults = {
+            "practice_id": "P1", "verdict": "violation", "dimension": "Security",
+            "file": "src/auth.py", "line": 42, "reason": "hardcoded secret",
+        }
+        defaults.update(overrides)
+        return Judgment(**defaults)
+
+    def test_basic_projection(self):
+        j = self._judgment(title="Hardcoded secret", confidence=80)
+        f = judgment_to_finding(j)
+        assert isinstance(f, Finding)
+        assert f.practice_id == "P1"
+        assert f.verdict == "violation"
+        assert f.title == "Hardcoded secret"
+        assert f.confidence == 80
+
+    def test_dismissed_flag_overrides_verdict(self):
+        j = self._judgment()
+        f = judgment_to_finding(j, dismissed=True)
+        assert f.verdict == "dismissed"
+
+    def test_not_dismissed_preserves_verdict(self):
+        j = self._judgment(verdict="compliance")
+        f = judgment_to_finding(j, dismissed=False)
+        assert f.verdict == "compliance"
+
+    def test_req_refs_passed_through(self):
+        refs = [ReqRef(label="CWE-1", url="https://x")]
+        j = self._judgment(req_refs=refs)
+        f = judgment_to_finding(j)
+        assert f.req_refs == refs
+
+    def test_severity_falls_back_to_minor(self):
+        # Judgment defaults severity to "medium", but if some pathway produced
+        # an empty severity, Finding's default should kick in.
+        j = self._judgment(severity="")
+        f = judgment_to_finding(j)
+        assert f.severity == "minor"
+
+
+class TestFindingToResponseDict:
+    def _finding(self, **overrides):
+        defaults = {
+            "practice_id": "P1", "verdict": "violation", "file": "src/auth.py",
+            "line": 42, "reason": "hardcoded secret", "title": "Secret",
+            "severity": "high",
+        }
+        defaults.update(overrides)
+        return Finding(**defaults)
+
+    def test_shape_matches_legacy_evidence_dict(self):
+        f = self._finding(snippet="API_KEY = 'abc'", end_line=42)
+        d = finding_to_response_dict(f)
+        assert d["practice_id"] == "P1"
+        assert d["file"] == "src/auth.py"
+        assert d["line"] == 42
+        assert d["end_line"] == 42
+        assert d["snippet"] == "API_KEY = 'abc'"
+        assert d["verdict"] == "violation"
+        assert d["severity"] == "high"
+        assert d["title"] == "Secret"
+        assert d["reason"] == "hardcoded secret"
+
+    def test_req_refs_serialized_as_dicts(self):
+        refs = [ReqRef(label="CWE-798", url="https://x"),
+                ReqRef(label="OWASP", url="https://y")]
+        f = self._finding(req_refs=refs)
+        d = finding_to_response_dict(f)
+        assert d["req_refs"] == [
+            {"label": "CWE-798", "url": "https://x"},
+            {"label": "OWASP", "url": "https://y"},
+        ]
+
+    def test_empty_req_refs_render_as_none(self):
+        f = self._finding()
+        d = finding_to_response_dict(f)
+        assert d["req_refs"] is None
+
+
+class TestRoundTrip:
+    def test_wire_dict_to_finding_via_judgment(self):
+        d = {
+            "p": "P1", "t": "violation", "d": "Security",
+            "file": "auth.py", "line": 1, "reason": "r",
+            "w": "Title",
+            "req_refs": [{"label": "CWE-1", "url": "https://x"}],
+        }
+        j = wire_dict_to_judgment(d)
+        f = judgment_to_finding(j)
+        response = finding_to_response_dict(f)
+        assert response["practice_id"] == "P1"
+        assert response["title"] == "Title"
+        assert response["req_refs"] == [{"label": "CWE-1", "url": "https://x"}]

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -1,9 +1,7 @@
 import json
-from quodeq.core.evidence.model import Judgment
-from quodeq.core.events.models import JudgmentPayload
+from quodeq.core.events.models import Judgment
 from quodeq.data.sqlite._row_mappers import (
     finding_dict_to_row,
-    finding_payload_to_row,
     judgment_to_row,
     row_to_finding,
 )
@@ -74,6 +72,8 @@ def test_judgment_to_row_uses_long_names():
     row = judgment_to_row(j)
     assert row["practice_id"] == "P1"
     assert row["requirement"] == "R1"
+    assert row["title"] == "t"
+    assert row["snippet"] == "s"
     assert row["dedup_key"] == "P1|f.py|3|violation"
 
 
@@ -101,7 +101,9 @@ def test_finding_dict_to_row_treats_non_int_confidence_as_default():
 
 def test_judgment_to_row_propagates_confidence():
     j = Judgment(
-        practice_id="P1", verdict="violation", severity="medium", confidence=42,
+        practice_id="P1", verdict="violation", dimension="d",
+        file="f.py", line=1, reason="r",
+        severity="medium", confidence=42,
     )
     row = judgment_to_row(j)
     assert row["confidence"] == 42
@@ -125,8 +127,8 @@ def test_row_to_finding_preserves_explicit_confidence():
     assert row_to_finding(row).confidence == 30
 
 
-def test_finding_payload_to_row_maps_required_fields():
-    payload = JudgmentPayload(
+def test_judgment_to_row_maps_required_fields():
+    payload = Judgment(
         practice_id="P1",
         verdict="violation",
         dimension="Security",
@@ -134,7 +136,7 @@ def test_finding_payload_to_row_maps_required_fields():
         line=42,
         reason="hardcoded secret",
     )
-    row = finding_payload_to_row(payload)
+    row = judgment_to_row(payload)
     assert row["practice_id"] == "P1"
     assert row["verdict"] == "violation"
     assert row["dimension"] == "Security"
@@ -146,12 +148,12 @@ def test_finding_payload_to_row_maps_required_fields():
     assert row["end_line"] == 0
 
 
-def test_finding_payload_to_row_optional_fields_default():
-    payload = JudgmentPayload(
+def test_judgment_to_row_optional_fields_default():
+    payload = Judgment(
         practice_id="P2", verdict="compliance", dimension="Reliability",
         file="f.py", line=1, reason="ok",
     )
-    row = finding_payload_to_row(payload)
+    row = judgment_to_row(payload)
     assert row["title"] == ""
     assert row["snippet"] == ""
     assert row["context"] == ""

--- a/tests/engine/test_evidence.py
+++ b/tests/engine/test_evidence.py
@@ -4,11 +4,15 @@ from quodeq.core.evidence.model import Evidence, Judgment, PrincipleEvidence
 
 
 def test_judgment_defaults():
-    j = Judgment(practice_id="ts-001")
+    j = Judgment(
+        practice_id="ts-001", verdict="violation", dimension="security",
+        file="a.py", line=1, reason="r",
+    )
     assert j.verdict == "violation"
     assert j.severity == "medium"
-    assert j.line == 0
-    assert j.file == ""
+    assert j.confidence == 100
+    assert j.req_refs == []
+    assert j.is_violation() is True
 
 
 def test_principle_evidence_compute_metrics():

--- a/tests/engine/test_evidence_parser_line.py
+++ b/tests/engine/test_evidence_parser_line.py
@@ -69,7 +69,7 @@ class TestParseJsonlLine:
         result = _parse_jsonl_line(_evidence_line(req_refs=refs))
         assert result is not None
         j, llm_refs = result
-        assert j.req_refs == refs
+        assert [{"label": r.label, "url": r.url} for r in j.req_refs] == refs
         assert llm_refs is None  # no LLM refs field
 
     def test_pre_resolved_req_refs_empty_list_ignored(self):
@@ -77,4 +77,4 @@ class TestParseJsonlLine:
         result = _parse_jsonl_line(_evidence_line(req_refs=[]))
         assert result is not None
         j, _ = result
-        assert j.req_refs is None  # not set
+        assert j.req_refs == []


### PR DESCRIPTION
## Summary

- Collapses the four-to-six representations of a Finding into a single canonical `Judgment` (Pydantic, frozen) living in `core/events/models.py`, aligned with ADR 0001 -- the Event Log is the source of truth.
- Extracts `ReqRef` to its own module (`core/types/req_ref.py`) and re-exports from `core/types/finding.py` so legacy imports keep working.
- Fixes the `req_refs: list[str]` vs `list[dict]` divergence -- the runtime shape always carried URLs, so the `list[str]` declaration was lossy.
- New `core/finding_mappings.py` owns the three Finding-shape conversions:
  - `wire_dict_to_judgment` (LLM/FindingsRouter dict → Judgment)
  - `judgment_to_finding` (Judgment → read-side Finding view, with optional `dismissed` override)
  - `finding_to_response_dict` (Finding → SSE/REST client dict)
- Migrates inline conversions in `analysis/mcp/router.py` and `data/fs/report_parser/_evidence_sqlite.py` to the new module.
- Collapses `judgment_to_row` + `finding_payload_to_row` in `data/sqlite/_row_mappers.py` into a single function; updates `SQLiteStateStore` accordingly.
- Keeps `_Finding` in `analysis/_api_runner.py` as a lenient short-key variant for Instructor structured output (local models depend on tuned field descriptions and short keys for token economy). Rationale documented at the file header.
- Updates `CONTEXT.md` with the `Judgment` vs `Finding/Violation` terminology.
- `JudgmentPayload` stays as a deprecation alias to `Judgment` so older test imports keep working; can be removed in a follow-up.

Completes architectural improvement #4 from the 2026-05-16 deepening review, including the parts undersold by yesterday's 2026-05-15 review.

## Out of scope (separate PRs)

- Lazy-projection refactor.
- DimensionRunner shim cleanup.
- `SQLiteStateStore` vs `SqliteFindingsRepository` naming smell.
- Removing the short-key wire format (stays for token economy).

## Verification

- `grep -rn "JudgmentPayload" src/` only shows the deprecation alias.
- `grep -rn "from quodeq.core.evidence.model import Judgment" src/` is empty -- all callers route through `core.events.models`.

## Test plan

- [x] `pytest tests/ --timeout=30` -- 2895 passed
- [x] New `tests/core/test_finding_mappings.py` covers the three conversions plus a wire_dict -> Judgment -> Finding -> response_dict round trip.
- [x] Updated `tests/data/sqlite/test_row_mappers.py` to drop the removed `finding_payload_to_row` and exercise `judgment_to_row` with required fields.
- [x] Updated `tests/engine/test_evidence.py` to construct `Judgment` with the now-required fields.
- [x] Updated `tests/engine/test_evidence_parser_line.py` to assert `ReqRef` objects instead of raw dicts.
- [x] Sanity-check end-to-end: run an evaluation on a small fixture and confirm findings flow through correctly to the dashboard.