### PR TITLE
fix(ui): break setState loop in useRegisterWindowSpec

### DIFF
--- a/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.js
+++ b/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSidePane } from './SidePaneContext.jsx';
 
 /**
@@ -12,17 +12,33 @@ export function useRegisterWindowSpec(type, spec) {
   const ctx = useSidePane();
   const { registerSpec, unregisterSpec, replaceWindow, hasWindow, toggleWindow, windows, MAX_WINDOWS } = ctx;
 
+  // The consumer's spec is typically a fresh object on every render — it
+  // closes over computed values (filteredAccumulated, activeFilter, etc.).
+  // Re-running this effect on every spec identity change would call
+  // registerSpec/replaceWindow on every render, looping with the provider's
+  // setState and pegging React's "Maximum update depth" warning.
+  //
+  // Instead, anchor the effect on the spec's visible identity (id + title)
+  // and read the current closures from a ref. This keeps the dock title in
+  // sync when it changes (e.g. file detail with a different filter) while
+  // ignoring closure-only churn from data updates.
+  const specRef = useRef(spec);
+  specRef.current = spec;
+  const specId = spec?.id ?? null;
+  const specTitle = spec?.title ?? null;
+
   useEffect(() => {
-    if (!spec) {
+    if (!specId) {
       unregisterSpec(type);
       return undefined;
     }
-    registerSpec(type, spec);
-    if (hasWindow(spec.id)) {
-      replaceWindow(spec);
+    const current = specRef.current;
+    registerSpec(type, current);
+    if (hasWindow(current.id)) {
+      replaceWindow(current);
     }
     return () => unregisterSpec(type);
-  }, [type, spec, registerSpec, unregisterSpec, replaceWindow, hasWindow]);
+  }, [type, specId, specTitle, registerSpec, unregisterSpec, replaceWindow, hasWindow]);
 
   const isInDock = spec ? hasWindow(spec.id) : false;
   const isAtCap = windows.length >= MAX_WINDOWS;

--- a/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/useRegisterWindowSpec.test.jsx
@@ -199,4 +199,44 @@ describe('useRegisterWindowSpec', () => {
     // will be much larger.
     expect(after - before).toBeLessThanOrEqual(2);
   });
+
+  it('a fresh spec object on every parent render does not loop the provider', () => {
+    // Mirrors the production hazard: AccumulatedOverviewPanel etc. recompute
+    // their spec on every render (it closes over filtered data refs that
+    // flip each render). The old hook called registerSpec/replaceWindow on
+    // every render, looping with SidePaneProvider's setState until React
+    // tripped its "Maximum update depth" guard.
+    let pageRenderCount = 0;
+    function ChurningPage() {
+      // Brand new object every render — no useMemo. Same id+title across renders.
+      const spec = { id: 'r1', type: 'report', title: 'stable', render: () => <p>body</p> };
+      useRegisterWindowSpec('report', spec);
+      pageRenderCount += 1;
+      return null;
+    }
+    function ParentBumper() {
+      const [, setN] = useState(0);
+      return (
+        <>
+          <ChurningPage />
+          <button data-testid="bump-parent" onClick={() => setN((n) => n + 1)}>bump</button>
+        </>
+      );
+    }
+    render(
+      <SidePaneProvider>
+        <ParentBumper />
+      </SidePaneProvider>,
+    );
+    const start = pageRenderCount;
+    // 5 parent re-renders. Each gives ChurningPage a new spec ref. If the
+    // hook re-registered on every spec change, every parent bump would
+    // ripple back as another render (and several more in StrictMode).
+    for (let i = 0; i < 5; i += 1) {
+      fireEvent.click(screen.getByTestId('bump-parent'));
+    }
+    const delta = pageRenderCount - start;
+    // 5 forced renders + at most ~1 extra per from StrictMode double-invoke.
+    expect(delta).toBeLessThanOrEqual(12);
+  });
 });


### PR DESCRIPTION
## Summary

- `useRegisterWindowSpec` was re-firing its effect on every consumer render. Consumers (`AccumulatedOverviewPanel`, `FileDetailPage`, `PrincipleDetailPage`, etc.) recompute the spec object each render because it closes over freshly-filtered data refs.
- With `spec` in the effect's deps, every render called `registerSpec` / `replaceWindow`, which set provider state, which re-rendered the consumer with another fresh spec, which... React floored renders to its "Maximum update depth" warning. The console flooded with 100+ entries per minute on Overview, History, Explorer.
- Side effect: the dock's `useMemo(() => spec.render(), [spec])` was invalidated every render, so the markdown body was being rebuilt on every commit even when nothing visible changed.

## Fix

Anchor the effect on the spec's visible identity (`id` + `title`) and read the latest closures from a ref. The dock title still updates when the consumer deliberately changes it (different file, different filter); pure closure-only churn from data updates no longer pings the provider.

## Test plan

- [x] New regression test: `a fresh spec object on every parent render does not loop the provider` — bumps the parent 5×, asserts consumer renders stayed bounded.
- [x] Existing tests for in-place title updates and unmount cleanup still pass.
- [x] `npx vitest run` (343 tests pass)
- [x] `npm run test` (178 node tests pass)
- [x] Manual: with an evaluation running on `quodeq`, open Overview and switch through Violations → Map → History. Console errors counter at 0 over 12s+.

## Diagnosis notes

Reproduced on `develop` with no local changes (instrumented `console.error` from `index.html` to bypass module load order). Bisected the loop to `useRegisterWindowSpec` via `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot` — the 20 commits before each warning all touched `SidePaneProvider → App → DashboardPage`, signalling a provider-state ping-pong rather than a query refetch.

The hypothesis was confirmed by inserting a counter inside the effect: 28 reg-calls in 5s before the fix, 4 after.

Originally flagged from PR #508's verification pass.