### PR TITLE
refactor(data): self-ensure projection at the State Store read seam

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -348,8 +348,7 @@ def run_api_analysis(
         len(source_file_paths) if source_file_paths and not was_salvaged else 0,
     )
 
-    run_dir = jsonl_file.parent.parent
-    events_log = run_dir / "events.jsonl"
+    events_log = jsonl_file.parent.parent / "events.jsonl"
 
     jsonl_file.parent.mkdir(parents=True, exist_ok=True)
     from quodeq.core.events.writer import EventLogWriter  # noqa: PLC0415
@@ -361,10 +360,3 @@ def run_api_analysis(
         if not was_salvaged and source_file_paths:
             for path in source_file_paths:
                 router.mark_file_done(file=path, status="ok")
-
-    if events_log.is_file():
-        try:
-            from quodeq.data.projection.engine import ProjectionEngine  # noqa: PLC0415
-            ProjectionEngine().update(events_log, run_dir)
-        except Exception:
-            _log.warning("API runner: incremental projection failed for %s", run_dir, exc_info=True)

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -191,18 +191,6 @@ def _read_new_findings_from_events(
         return []
 
 
-def _update_sqlite_projection(run_dir: Path) -> None:
-    """Incrementally project events.jsonl → evaluation.db so polling clients see live data."""
-    events_log = run_dir / "events.jsonl"
-    if not events_log.is_file():
-        return
-    try:
-        from quodeq.data.projection.engine import ProjectionEngine  # noqa: PLC0415
-        ProjectionEngine().update(events_log, run_dir)
-    except Exception:  # noqa: BLE001
-        _logger.warning("SSE tick: incremental projection failed for %s", run_dir, exc_info=True)
-
-
 def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], WatcherState]:
     """Single tick: read artifacts, return (events, new_state).
 
@@ -231,8 +219,6 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
     new_findings = _read_new_findings_from_events(
         run_dir, state.last_event_ts, state.last_event_counter,
     )
-    if new_findings:
-        _update_sqlite_projection(run_dir)
     new_last_ts = state.last_event_ts
     new_counter = state.last_event_counter
     for event_ts, counter, judgment_dict in new_findings:

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -50,5 +50,6 @@ class ProjectionEngine:
                 )
         if last_ts is not None:
             store.save_checkpoint(last_ts)
+            store.save_projected_size(event_log.stat().st_size)
         _logger.info("Projected %d events from %s", count, event_log)
         return count

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -11,6 +13,9 @@ from quodeq.data.sqlite.state_store import SQLiteStateStore
 class ProjectionResult:
     events_projected: int
     rebuilt: bool
+
+
+_ensure_locks: dict[Path, threading.Lock] = defaultdict(threading.Lock)
 
 
 class Projector:
@@ -47,3 +52,22 @@ class Projector:
         else:
             count = self._engine.update(events_path, run_dir)
             return ProjectionResult(events_projected=count, rebuilt=False)
+
+    def ensure_projected(self, events_path: Path, run_dir: Path) -> ProjectionResult:
+        """Fast no-op if State Store is fresh; otherwise project incrementally.
+
+        Compares the Event Log's byte size to the last projected size stored
+        in run_meta. The Event Log is append-only, so size monotonicity makes
+        this race-free for the single-process case. An in-process lock per
+        run_dir prevents concurrent reads from double-projecting.
+        """
+        if not events_path.is_file():
+            raise FileNotFoundError(f"Event log not found: {events_path}")
+
+        with _ensure_locks[run_dir]:
+            store = SQLiteStateStore(run_dir)
+            projected_size = store.get_projected_size()
+            current_size = events_path.stat().st_size
+            if projected_size is not None and projected_size == current_size:
+                return ProjectionResult(events_projected=0, rebuilt=False)
+            return self.project(events_path, run_dir)

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from quodeq.core.types.finding import Finding
+from quodeq.data.projection.projector import Projector
 from quodeq.data.sqlite._row_mappers import (
     finding_dict_to_row,
     row_to_finding,
@@ -31,10 +32,27 @@ _SELECT_COLUMNS = (
 
 
 class SqliteFindingsRepository:
-    """Per-run findings store backed by evaluation.db in run_dir."""
+    """Per-run findings store backed by evaluation.db in run_dir.
 
-    def __init__(self, run_dir: Path):
+    Reads self-ensure the State Store is fresh against the Event Log
+    (``events.jsonl``) before returning rows, so callers above the data
+    layer never need to project explicitly. Writes do not trigger projection.
+    """
+
+    def __init__(
+        self,
+        run_dir: Path,
+        *,
+        projector: Projector | None = None,
+        events_log: Path | None = None,
+    ) -> None:
         self._run_dir = run_dir
+        self._projector = projector or Projector()
+        self._events_log = events_log or (run_dir / "events.jsonl")
+
+    def _ensure_fresh(self) -> None:
+        if self._events_log.is_file():
+            self._projector.ensure_projected(self._events_log, self._run_dir)
 
     def insert_finding(self, finding: dict[str, Any]) -> bool:
         row = finding_dict_to_row(finding)
@@ -44,6 +62,7 @@ class SqliteFindingsRepository:
             return cur.rowcount == 1
 
     def list_by_dimension(self, dimension: str) -> list[Finding]:
+        self._ensure_fresh()
         with open_evaluation_db(self._run_dir) as conn:
             conn.row_factory = _dict_row
             rows = conn.execute(
@@ -53,6 +72,7 @@ class SqliteFindingsRepository:
         return [row_to_finding(r) for r in rows]
 
     def count_by_dimension(self) -> dict[str, int]:
+        self._ensure_fresh()
         with open_evaluation_db(self._run_dir) as conn:
             rows = conn.execute(
                 "SELECT dimension, COUNT(*) FROM findings GROUP BY dimension",
@@ -60,6 +80,7 @@ class SqliteFindingsRepository:
         return {dim: n for dim, n in rows}
 
     def search(self, query: str, limit: int = 100) -> list[Finding]:
+        self._ensure_fresh()
         fts_query = _quote_fts_query(query)
         with open_evaluation_db(self._run_dir) as conn:
             conn.row_factory = _dict_row

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -11,6 +11,7 @@ from quodeq.data.sqlite._row_mappers import judgment_to_row
 
 _logger = logging.getLogger(__name__)
 _CHECKPOINT_KEY = "projection_checkpoint"
+_PROJECTED_SIZE_KEY = "projection_event_log_size"
 
 _INSERT_FINDING = """
 INSERT OR IGNORE INTO findings (
@@ -42,7 +43,8 @@ class SQLiteStateStore:
             conn.execute("DELETE FROM findings")
             conn.execute("DELETE FROM dimension_scores")
             conn.execute(
-                "DELETE FROM run_meta WHERE key = ?", (_CHECKPOINT_KEY,)
+                "DELETE FROM run_meta WHERE key IN (?, ?)",
+                (_CHECKPOINT_KEY, _PROJECTED_SIZE_KEY),
             )
             conn.commit()
 
@@ -60,5 +62,22 @@ class SQLiteStateStore:
             conn.execute(
                 "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
                 (_CHECKPOINT_KEY, ts.isoformat()),
+            )
+            conn.commit()
+
+    def get_projected_size(self) -> int | None:
+        with open_evaluation_db(self._run_dir) as conn:
+            row = conn.execute(
+                "SELECT value FROM run_meta WHERE key = ?", (_PROJECTED_SIZE_KEY,)
+            ).fetchone()
+        if row is None:
+            return None
+        return int(row[0])
+
+    def save_projected_size(self, size: int) -> None:
+        with open_evaluation_db(self._run_dir) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
+                (_PROJECTED_SIZE_KEY, str(size)),
             )
             conn.commit()

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import ProjectionResult, Projector
+
+
+def _write_events(log: Path, n: int, start: int = 0) -> None:
+    writer = EventLogWriter(log)
+    for i in range(start, start + n):
+        payload = JudgmentPayload(
+            practice_id=f"P{i}", verdict="violation", dimension="Security",
+            file=f"f{i}.py", line=i + 1, reason="r",
+        )
+        writer.emit(JudgmentCreatedEvent(payload=payload))
+
+
+def test_ensure_no_op_when_size_matches(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    _write_events(log, 3)
+    projector = Projector()
+    projector.project(log, tmp_path)
+
+    result = projector.ensure_projected(log, tmp_path)
+
+    assert result == ProjectionResult(events_projected=0, rebuilt=False)
+
+
+def test_ensure_projects_when_size_grows(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    _write_events(log, 2)
+    projector = Projector()
+    projector.project(log, tmp_path)
+
+    _write_events(log, 3, start=2)
+    result = projector.ensure_projected(log, tmp_path)
+
+    assert result.events_projected == 3
+    assert result.rebuilt is False
+
+
+def test_ensure_bootstrap_when_no_size_stored(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    _write_events(log, 4)
+
+    result = Projector().ensure_projected(log, tmp_path)
+
+    assert result.events_projected == 4
+    assert result.rebuilt is True
+
+
+def test_concurrent_ensure_projects_once(tmp_path: Path) -> None:
+    log = tmp_path / "events.jsonl"
+    _write_events(log, 3)
+    # Prime once so both threads see a stored size that doesn't match yet.
+    Projector().project(log, tmp_path)
+    _write_events(log, 2, start=3)
+
+    projector = Projector()
+    call_count = 0
+    real_project = projector.project
+    call_lock = threading.Lock()
+
+    def spy(*args, **kwargs):
+        nonlocal call_count
+        with call_lock:
+            call_count += 1
+        return real_project(*args, **kwargs)
+
+    projector.project = spy  # type: ignore[method-assign]
+
+    barrier = threading.Barrier(2)
+
+    def run() -> None:
+        barrier.wait()
+        projector.ensure_projected(log, tmp_path)
+
+    t1 = threading.Thread(target=run)
+    t2 = threading.Thread(target=run)
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    assert call_count == 1

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import ProjectionResult, Projector
 from quodeq.data.sqlite.connection import open_evaluation_db
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 
@@ -78,3 +81,55 @@ def test_search_respects_limit(tmp_path: Path):
         repo.insert_finding(_finding(p=f"P{i}", line=i, reason="duplicate text"))
     hits = repo.search("duplicate", limit=3)
     assert len(hits) == 3
+
+
+class _SpyProjector(Projector):
+    """Projector that records ensure_projected invocations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ensure_calls = 0
+
+    def ensure_projected(self, events_path, run_dir):  # type: ignore[override]
+        self.ensure_calls += 1
+        return ProjectionResult(events_projected=0, rebuilt=False)
+
+
+def _write_event(log: Path, practice_id: str = "P1") -> None:
+    writer = EventLogWriter(log)
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id=practice_id, verdict="violation", dimension="dim",
+        file="x.py", line=1, reason="r",
+    )))
+
+
+def test_read_triggers_ensure(tmp_path: Path):
+    _write_event(tmp_path / "events.jsonl")
+    spy = _SpyProjector()
+    repo = SqliteFindingsRepository(tmp_path, projector=spy)
+
+    repo.list_by_dimension("dim")
+    repo.count_by_dimension()
+    repo.search("r")
+
+    assert spy.ensure_calls == 3
+
+
+def test_write_does_not_trigger_ensure(tmp_path: Path):
+    _write_event(tmp_path / "events.jsonl")
+    spy = _SpyProjector()
+    repo = SqliteFindingsRepository(tmp_path, projector=spy)
+
+    repo.insert_finding(_finding(p="P1"))
+    repo.set_verdict(practice_id="P1", file="x.py", line=1, verdict="dismissed")
+
+    assert spy.ensure_calls == 0
+
+
+def test_read_skips_ensure_when_no_event_log(tmp_path: Path):
+    spy = _SpyProjector()
+    repo = SqliteFindingsRepository(tmp_path, projector=spy)
+
+    repo.count_by_dimension()
+
+    assert spy.ensure_calls == 0

--- a/tests/data/test_state_store.py
+++ b/tests/data/test_state_store.py
@@ -90,3 +90,20 @@ def test_clear_all_resets_checkpoint(tmp_path: Path):
     store.save_checkpoint(datetime(2026, 5, 15, 10, 0, 0, tzinfo=timezone.utc))
     store.clear_all()
     assert store.get_checkpoint() is None
+
+
+def test_projected_size_is_none_when_not_set(tmp_path: Path):
+    assert SQLiteStateStore(tmp_path).get_projected_size() is None
+
+
+def test_projected_size_round_trip(tmp_path: Path):
+    store = SQLiteStateStore(tmp_path)
+    store.save_projected_size(1234)
+    assert store.get_projected_size() == 1234
+
+
+def test_clear_all_resets_projected_size(tmp_path: Path):
+    store = SQLiteStateStore(tmp_path)
+    store.save_projected_size(99)
+    store.clear_all()
+    assert store.get_projected_size() is None


### PR DESCRIPTION
## Summary

Move projection freshness from ad-hoc writer callers to the read-side repository. The State Store now self-ensures it is current before serving each read; callers above the data layer stop knowing that an Event Log and State Store are separate things.

- `SqliteFindingsRepository` calls `Projector.ensure_projected` before `list_by_dimension`, `count_by_dimension`, and `search`. Writes (`insert_finding`, `set_verdict`) do not trigger projection.
- Freshness is detected by comparing `events.jsonl` byte size to a new `projection_event_log_size` row in `run_meta`. The Event Log is append-only, so size monotonicity is race-free; an in-process `threading.Lock` per `run_dir` prevents concurrent reads from double-projecting.
- `ProjectionEngine._project` now records the projected size alongside the checkpoint, both in the same store, so both metadata updates are coherent.
- `SQLiteStateStore.clear_all` also resets `projection_event_log_size` so a `force_rebuild` won't leave the freshness marker pointing at a stale size.
- The two ad-hoc projection blocks in `analysis/_api_runner.py` and `api/_run_event_stream.py` (including the `_update_sqlite_projection` helper) are removed. The post-run hook (`services/_post_run_hook.py`) stays as a warm-up but is no longer load-bearing.

Completes architectural improvement #2 from the 2026-05-16 deepening review.

## ADR

ADR 0001 was updated locally with an Implementation note dated 2026-05-17 (covers the lazy-on-stale-read trigger, the byte-size freshness check, and the in-process lock). `docs/` is in `.gitignore` so the change is not part of this PR.

## Follow-up (not in this PR)

There is a naming smell worth recording: `CONTEXT.md` defines "State Store" as the read API, but `SQLiteStateStore` is the projection write-sink and `SqliteFindingsRepository` is the read API. Two reasonable later resolutions:
- Rename code (`SQLiteStateStore` → `ProjectionSink`; `SqliteFindingsRepository` → `SQLiteStateStore`).
- Update `CONTEXT.md` to say the State Store has two faces in code.

Out of scope here.

## Test plan

- [x] `pytest tests/data/ tests/analysis/test_api_runner.py tests/api/` → 429 passed
- [x] `pytest tests/integration/test_sqlite_dual_write_e2e.py tests/shared/test_sqlite_kill_switch.py` → 12 passed
- [x] Full suite: `pytest` → 2892 passed
- [x] Grep `ProjectionEngine().update` returns no production hits
- [x] Sanity-check end-to-end: run an evaluation on a small fixture; confirm dashboard sees findings (read self-ensures); confirm `events.jsonl` and `evaluation.db` are consistent after the run