### PR TITLE
feat(data): replace dismissed.json with actions.jsonl event log (live-grades PR 1)

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -55,7 +55,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required"}), 400
         dismiss_finding(_project_dir(_eval_dir(), project), body)
-        return jsonify({"ok": True}), 200
+        return ("", 204)
 
     @app.post("/api/findings/restore")
     def restore() -> tuple[Response, int]:
@@ -67,7 +67,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
-        return jsonify({"ok": True}), 200
+        return ("", 204)
 
     @app.post("/api/findings/restore-all")
     def restore_all() -> tuple[Response, int]:

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -17,14 +17,12 @@ embeddings) is a follow-up; this module ships exact-match only.
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import re
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
-_DISMISSED_FILENAME = "dismissed.json"
 _WS_RE = re.compile(r"\s+")
 
 
@@ -53,27 +51,41 @@ def fingerprint(req: str | None, snippet: str | None) -> str | None:
 def load_precedent_fingerprints(project_dir: Path) -> set[str]:
     """Load fingerprints for every dismissed finding in *project_dir*.
 
-    Reads ``<project_dir>/dismissed.json``. Missing / malformed files
-    return an empty set: precedent matching degrades gracefully and never
-    breaks an evaluation.
+    Aggregates across ``runs/<run_id>/evaluation.db``. Missing or locked DBs
+    are skipped -- precedent matching degrades gracefully and never breaks a
+    scan.
+
+    Legacy note: prior to PR 1 (live-grades), dismissals were stored in
+    ``<project_dir>/dismissed.json``. The migration in
+    ``data/migrations/dismissed_json_to_actions_log.py`` folds those legacy
+    entries into ``actions.jsonl`` on first projection, so once a project has
+    been opened post-deploy the SQL rows also capture the historical data.
     """
     if not project_dir or not project_dir.is_dir():
         return set()
-    path = project_dir / _DISMISSED_FILENAME
-    if not path.exists():
+    runs_root = project_dir / "runs"
+    if not runs_root.is_dir():
         return set()
-    try:
-        entries = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        _logger.warning("Could not read precedent corpus at %s: %s", path, exc)
-        return set()
-    if not isinstance(entries, list):
-        return set()
+
     out: set[str] = set()
-    for entry in entries:
-        if not isinstance(entry, dict):
+    for run_dir in runs_root.iterdir():
+        if not run_dir.is_dir():
             continue
-        fp = fingerprint(entry.get("req"), entry.get("snippet"))
-        if fp is not None:
-            out.add(fp)
+        db_path = run_dir / "evaluation.db"
+        if not db_path.is_file():
+            continue
+        try:
+            from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+            with open_evaluation_db(run_dir) as conn:
+                for row in conn.execute(
+                    "SELECT requirement, snippet FROM findings WHERE verdict = 'dismissed'"
+                ):
+                    fp = fingerprint(row[0], row[1])
+                    if fp is not None:
+                        out.add(fp)
+        except Exception as exc:
+            _logger.warning(
+                "Could not read precedent corpus from %s: %s", db_path, exc
+            )
+            continue
     return out

--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -20,6 +20,8 @@ class EventType(str, Enum):
     JUDGMENT_CREATED = "JUDGMENT_CREATED"
     DIMENSION_COMPLETED = "DIMENSION_COMPLETED"
     DIMENSION_FAILED = "DIMENSION_FAILED"
+    FINDING_DISMISSED = "FINDING_DISMISSED"
+    FINDING_UNDISMISSED = "FINDING_UNDISMISSED"
 
 
 class BaseEvent(BaseModel, Generic[T]):
@@ -78,8 +80,37 @@ class JudgmentCreatedEvent(BaseEvent[Judgment]):
     event_type: EventType = EventType.JUDGMENT_CREATED
 
 
+class FindingDismissed(BaseModel):
+    """User dismissed a finding identified by (req, file, line)."""
+    model_config = ConfigDict(frozen=True)
+
+    req: str
+    file: str
+    line: int
+    reason: Optional[str] = None
+
+
+class FindingUndismissed(BaseModel):
+    """User restored a previously dismissed finding."""
+    model_config = ConfigDict(frozen=True)
+
+    req: str
+    file: str
+    line: int
+
+
+class FindingDismissedEvent(BaseEvent[FindingDismissed]):
+    event_type: EventType = EventType.FINDING_DISMISSED
+
+
+class FindingUndismissedEvent(BaseEvent[FindingUndismissed]):
+    event_type: EventType = EventType.FINDING_UNDISMISSED
+
+
 # Mapping to allow the Reader to resolve the correct model for validation
 # This is crucial for correct payload parsing
 EVENT_MODEL_MAP: Dict[EventType, type[BaseEvent]] = {
     EventType.JUDGMENT_CREATED: JudgmentCreatedEvent,
+    EventType.FINDING_DISMISSED: FindingDismissedEvent,
+    EventType.FINDING_UNDISMISSED: FindingUndismissedEvent,
 }

--- a/src/quodeq/data/actions_log.py
+++ b/src/quodeq/data/actions_log.py
@@ -1,0 +1,63 @@
+"""Append-only log of post-scan user actions, project-scoped.
+
+Mirrors EventLogWriter but writes to project_dir/actions.jsonl. This log is
+read by the projection engine to apply user actions (dismissals, etc.) onto
+the per-run state stores.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Iterator
+
+from quodeq.core.events.models import EVENT_MODEL_MAP, BaseEvent, EventType
+from quodeq.core.utils.locking import get_file_lock
+
+
+_logger = logging.getLogger(__name__)
+
+ACTIONS_LOG_FILENAME = "actions.jsonl"
+
+
+class ActionLogWriter:
+    """Thread-safe append-only writer for project_dir/actions.jsonl."""
+
+    def __init__(self, project_dir: Path) -> None:
+        self._project_dir = project_dir
+        self.log_path = project_dir / ACTIONS_LOG_FILENAME
+        project_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = get_file_lock()
+
+    def emit(self, event: BaseEvent) -> None:
+        try:
+            with open(self.log_path, mode="a", encoding="utf-8") as f:
+                self._lock.acquire(f)
+                try:
+                    f.write(event.model_dump_json() + "\n")
+                    f.flush()
+                finally:
+                    self._lock.release(f)
+        except Exception as e:
+            _logger.error("Failed to emit %s to %s: %s", event.event_type, self.log_path, e)
+            raise
+
+
+def read_action_events(project_dir: Path) -> Iterator[BaseEvent]:
+    """Yield typed events from project_dir/actions.jsonl. Skips malformed lines."""
+    log_path = project_dir / ACTIONS_LOG_FILENAME
+    if not log_path.is_file():
+        return
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                event_type = EventType(data["event_type"])
+                model_cls = EVENT_MODEL_MAP[event_type]
+                yield model_cls.model_validate(data)
+            except (json.JSONDecodeError, KeyError, ValueError) as e:
+                _logger.warning("Skipping malformed actions.jsonl line: %s", e)
+                continue

--- a/src/quodeq/data/migrations/dismissed_json_to_actions_log.py
+++ b/src/quodeq/data/migrations/dismissed_json_to_actions_log.py
@@ -1,0 +1,57 @@
+"""One-shot migration: fold project_dir/dismissed.json into actions.jsonl.
+
+Runs lazily on first projection of a project. Idempotent -- skips when
+actions.jsonl already exists. Leaves dismissed.json in place as a read-only
+fallback for one release.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.core.events.models import FindingDismissed, FindingDismissedEvent
+from quodeq.data.actions_log import ACTIONS_LOG_FILENAME, ActionLogWriter
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate_if_needed(project_dir: Path) -> int:
+    """Fold dismissed.json into actions.jsonl. Returns count of entries migrated."""
+    actions_log = project_dir / ACTIONS_LOG_FILENAME
+    if actions_log.exists():
+        return 0
+
+    dismissed_json = project_dir / "dismissed.json"
+    if not dismissed_json.is_file():
+        return 0
+
+    try:
+        entries = json.loads(dismissed_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        _logger.warning("Could not read %s during migration; skipping", dismissed_json)
+        return 0
+    if not isinstance(entries, list):
+        return 0
+
+    writer = ActionLogWriter(project_dir)
+    count = 0
+    for entry in entries:
+        try:
+            payload = FindingDismissed(
+                req=str(entry.get("req", "")),
+                file=str(entry.get("file", "")),
+                line=int(entry.get("line", 0)),
+                reason=None,
+            )
+            writer.emit(FindingDismissedEvent(payload=payload))
+            count += 1
+        except Exception:
+            _logger.exception("Failed to migrate dismissed entry: %s", entry)
+            continue
+    _logger.info(
+        "Migrated %d entries from dismissed.json to actions.jsonl in %s",
+        count,
+        project_dir,
+    )
+    return count

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -26,6 +26,32 @@ class ProjectionEngine:
         store = SQLiteStateStore(run_dir)
         return self._project(event_log, store, since=store.get_checkpoint())
 
+    def update_actions(self, actions_log: Path, run_dir: Path, *, force: bool = False) -> int:
+        """Replay actions.jsonl events into run_dir's state store.
+
+        With ``force=False`` (default), skips when the actions log size hasn't
+        changed since the last checkpoint. With ``force=True``, replays even if
+        the size is unchanged -- needed when events.jsonl just grew, because new
+        findings must be matched against existing dismissals.
+
+        Handlers are idempotent (UPDATE by stable key), so full replay is safe.
+        """
+        from quodeq.data.actions_log import read_action_events  # noqa: PLC0415
+
+        store = SQLiteStateStore(run_dir)
+        last_size = store.get_actions_projected_size() or 0
+        current_size = actions_log.stat().st_size if actions_log.is_file() else 0
+
+        if not force and current_size == last_size:
+            return 0
+
+        applied = 0
+        for event in read_action_events(actions_log.parent):
+            handle(event, store)
+            applied += 1
+        store.save_actions_projected_size(current_size)
+        return applied
+
     def _project(
         self,
         event_log: Path,

--- a/src/quodeq/data/projection/handlers.py
+++ b/src/quodeq/data/projection/handlers.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import logging
 from typing import Callable
 
-from quodeq.core.events.models import BaseEvent, EventType, JudgmentCreatedEvent
+from quodeq.core.events.models import (
+    BaseEvent,
+    EventType,
+    FindingDismissedEvent,
+    FindingUndismissedEvent,
+    JudgmentCreatedEvent,
+)
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 
 _logger = logging.getLogger(__name__)
@@ -13,8 +19,22 @@ def _handle_judgment_created(event: JudgmentCreatedEvent, store: SQLiteStateStor
     store.record_finding(event.payload)
 
 
+def _handle_finding_dismissed(event: FindingDismissedEvent, store: SQLiteStateStore) -> None:
+    payload = event.payload
+    store.update_verdict(req=payload.req, file=payload.file, line=payload.line, verdict="dismissed")
+
+
+def _handle_finding_undismissed(event: FindingUndismissedEvent, store: SQLiteStateStore) -> None:
+    payload = event.payload
+    # Restore the original violation verdict. (Compliance findings can't be dismissed
+    # in the UI today, so 'violation' is the correct restore target.)
+    store.update_verdict(req=payload.req, file=payload.file, line=payload.line, verdict="violation")
+
+
 _HANDLERS: dict[EventType, Callable] = {
     EventType.JUDGMENT_CREATED: _handle_judgment_created,
+    EventType.FINDING_DISMISSED: _handle_finding_dismissed,
+    EventType.FINDING_UNDISMISSED: _handle_finding_undismissed,
 }
 
 

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -65,6 +65,11 @@ class Projector:
             raise FileNotFoundError(f"Event log not found: {events_path}")
 
         with _ensure_locks[run_dir]:
+            if project_dir is not None:
+                from quodeq.data.migrations.dismissed_json_to_actions_log import (  # noqa: PLC0415
+                    migrate_if_needed,
+                )
+                migrate_if_needed(project_dir)
             store = SQLiteStateStore(run_dir)
 
             # Events.jsonl branch (today's behavior)

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -53,21 +53,46 @@ class Projector:
             count = self._engine.update(events_path, run_dir)
             return ProjectionResult(events_projected=count, rebuilt=False)
 
-    def ensure_projected(self, events_path: Path, run_dir: Path) -> ProjectionResult:
-        """Fast no-op if State Store is fresh; otherwise project incrementally.
-
-        Compares the Event Log's byte size to the last projected size stored
-        in run_meta. The Event Log is append-only, so size monotonicity makes
-        this race-free for the single-process case. An in-process lock per
-        run_dir prevents concurrent reads from double-projecting.
-        """
+    def ensure_projected(
+        self,
+        events_path: Path,
+        run_dir: Path,
+        *,
+        project_dir: Path | None = None,
+    ) -> ProjectionResult:
+        """Fast no-op if both event and action logs are fresh; else project deltas."""
         if not events_path.is_file():
             raise FileNotFoundError(f"Event log not found: {events_path}")
 
         with _ensure_locks[run_dir]:
             store = SQLiteStateStore(run_dir)
+
+            # Events.jsonl branch (today's behavior)
             projected_size = store.get_projected_size()
             current_size = events_path.stat().st_size
-            if projected_size is not None and projected_size == current_size:
+            events_changed = projected_size is None or projected_size != current_size
+
+            # Actions.jsonl branch (new)
+            actions_changed = False
+            actions_log: Path | None = None
+            if project_dir is not None:
+                actions_log = project_dir / "actions.jsonl"
+                last_actions_size = store.get_actions_projected_size() or 0
+                current_actions_size = actions_log.stat().st_size if actions_log.is_file() else 0
+                actions_changed = current_actions_size != last_actions_size
+
+            if not events_changed and not actions_changed:
                 return ProjectionResult(events_projected=0, rebuilt=False)
-            return self.project(events_path, run_dir)
+
+            # Project events first (so new findings exist before action events touch them).
+            if events_changed:
+                result = self.project(events_path, run_dir)
+            else:
+                result = ProjectionResult(events_projected=0, rebuilt=False)
+
+            # Project actions. If events changed too, force-replay so brand-new findings
+            # get matched against pre-existing dismissals.
+            if actions_log is not None and (actions_changed or events_changed):
+                self._engine.update_actions(actions_log, run_dir, force=events_changed)
+
+            return result

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -52,7 +52,12 @@ class SqliteFindingsRepository:
 
     def _ensure_fresh(self) -> None:
         if self._events_log.is_file():
-            self._projector.ensure_projected(self._events_log, self._run_dir)
+            project_dir = self._run_dir.parent.parent
+            self._projector.ensure_projected(
+                self._events_log,
+                self._run_dir,
+                project_dir=project_dir,
+            )
 
     def insert_finding(self, finding: dict[str, Any]) -> bool:
         row = finding_dict_to_row(finding)

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -12,6 +12,7 @@ from quodeq.data.sqlite._row_mappers import judgment_to_row
 _logger = logging.getLogger(__name__)
 _CHECKPOINT_KEY = "projection_checkpoint"
 _PROJECTED_SIZE_KEY = "projection_event_log_size"
+_ACTIONS_SIZE_KEY = "actions_log_projected_size"
 
 _INSERT_FINDING = """
 INSERT OR IGNORE INTO findings (
@@ -43,8 +44,8 @@ class SQLiteStateStore:
             conn.execute("DELETE FROM findings")
             conn.execute("DELETE FROM dimension_scores")
             conn.execute(
-                "DELETE FROM run_meta WHERE key IN (?, ?)",
-                (_CHECKPOINT_KEY, _PROJECTED_SIZE_KEY),
+                "DELETE FROM run_meta WHERE key IN (?, ?, ?)",
+                (_CHECKPOINT_KEY, _PROJECTED_SIZE_KEY, _ACTIONS_SIZE_KEY),
             )
             conn.commit()
 
@@ -79,5 +80,33 @@ class SQLiteStateStore:
             conn.execute(
                 "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
                 (_PROJECTED_SIZE_KEY, str(size)),
+            )
+            conn.commit()
+
+    def update_verdict(self, *, req: str, file: str, line: int, verdict: str) -> int:
+        """Update a finding's verdict by (requirement, file, line). Returns row count."""
+        with open_evaluation_db(self._run_dir) as conn:
+            cur = conn.execute(
+                "UPDATE findings SET verdict = ? "
+                "WHERE requirement = ? AND file = ? AND line = ?",
+                (verdict, req, file, line),
+            )
+            conn.commit()
+            return cur.rowcount
+
+    def get_actions_projected_size(self) -> int | None:
+        with open_evaluation_db(self._run_dir) as conn:
+            row = conn.execute(
+                "SELECT value FROM run_meta WHERE key = ?", (_ACTIONS_SIZE_KEY,)
+            ).fetchone()
+        if row is None:
+            return None
+        return int(row[0])
+
+    def save_actions_projected_size(self, size: int) -> None:
+        with open_evaluation_db(self._run_dir) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO run_meta (key, value) VALUES (?, ?)",
+                (_ACTIONS_SIZE_KEY, str(size)),
             )
             conn.commit()

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -18,14 +18,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.core.events.models import (
-    EventType,
-    FindingDismissedEvent,
     FindingUndismissed,
     FindingUndismissedEvent,
 )
 from quodeq.core.types.finding import Finding
 from quodeq.data._file_lock import lock_file, unlock_file
-from quodeq.data.actions_log import ActionLogWriter, read_action_events
+from quodeq.data.actions_log import ActionLogWriter
 from quodeq.services.dismissed import recount_totals
 
 

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -17,9 +17,16 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
+from quodeq.core.events.models import (
+    EventType,
+    FindingDismissedEvent,
+    FindingUndismissed,
+    FindingUndismissedEvent,
+)
 from quodeq.core.types.finding import Finding
 from quodeq.data._file_lock import lock_file, unlock_file
-from quodeq.services.dismissed import load_dismissed, recount_totals
+from quodeq.data.actions_log import ActionLogWriter, read_action_events
+from quodeq.services.dismissed import recount_totals
 
 
 _FILENAME = "deleted.json"
@@ -89,9 +96,9 @@ def _write_deleted(project_dir: Path, entries: list[dict]) -> None:
 def delete_finding(project_dir: Path, finding: dict) -> int:
     """Permanently suppress a finding by (dimension, principle, file).
 
-    Also removes any entries from ``dismissed.json`` that share the same
-    suppression key, so the dismissed list stays clean. Returns the number
-    of dismissed entries swept (0 if none).
+    Also undismisses any dismissed findings that share the same suppression
+    key, so the dismissed list stays clean. Returns the number of dismissed
+    entries swept (0 if none).
     """
     new_key = _key(finding)
     if not new_key[1] or not new_key[2]:
@@ -109,10 +116,13 @@ def delete_finding(project_dir: Path, finding: dict) -> int:
 def delete_all_dismissed(project_dir: Path) -> int:
     """Convert every currently-dismissed entry into a permanent suppression.
 
-    Adds a deleted entry for each unique ``(dimension, principle, file)``
-    pair found in ``dismissed.json``, then clears the dismissed list.
+    Reads dismissed findings from each run's evaluation.db, adds a deleted
+    entry for each unique ``(dimension, principle, file)`` pair, then
+    undismisses all of them via the action log.
     Returns the count of dismissed entries removed.
     """
+    from quodeq.services.dismissed import load_dismissed  # noqa: PLC0415
+
     with _locked(project_dir):
         dismissed_entries = load_dismissed(project_dir)
         if not dismissed_entries:
@@ -126,34 +136,59 @@ def delete_all_dismissed(project_dir: Path) -> int:
             existing.append(_entry_from_finding(entry))
             existing_keys.add(k)
         _write_deleted(project_dir, existing)
-        # Clear dismissed.json now that everything is permanently suppressed.
-        dismissed_path = project_dir / "dismissed.json"
+        # Undismiss all via the action log.
         count = len(dismissed_entries)
-        if dismissed_path.exists():
-            dismissed_path.unlink()
+        writer = ActionLogWriter(project_dir)
+        for entry in dismissed_entries:
+            payload = FindingUndismissed(
+                req=entry.get("req", ""),
+                file=entry.get("file", ""),
+                line=int(entry.get("line", 0)),
+            )
+            writer.emit(FindingUndismissedEvent(payload=payload))
         return count
 
 
 def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
-    """Remove every dismissed entry whose ``(dimension, principle, file)`` matches *key*."""
-    dismissed_path = project_dir / "dismissed.json"
-    if not dismissed_path.exists():
+    """Undismiss every dismissed finding whose ``(dimension, principle, file)`` matches *key*.
+
+    Reads from each run's evaluation.db to find dismissed findings that match
+    the deletion key, then appends FindingUndismissedEvent to actions.jsonl for each.
+    """
+    from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+
+    dimension, principle, file = key
+    runs_root = project_dir / "runs"
+    if not runs_root.is_dir():
         return 0
-    try:
-        entries = json.loads(dismissed_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+
+    matching: list[tuple[str, str, int]] = []
+    for run_dir in runs_root.iterdir():
+        if not run_dir.is_dir():
+            continue
+        db_path = run_dir / "evaluation.db"
+        if not db_path.is_file():
+            continue
+        try:
+            with open_evaluation_db(run_dir) as conn:
+                for row in conn.execute(
+                    "SELECT requirement, file, line FROM findings "
+                    "WHERE verdict = 'dismissed' AND dimension = ? "
+                    "AND practice_id = ? AND file = ?",
+                    (dimension, principle, file),
+                ):
+                    matching.append((row[0] or "", row[1] or "", int(row[2] or 0)))
+        except Exception:
+            continue
+
+    if not matching:
         return 0
-    if not isinstance(entries, list):
-        return 0
-    kept = [e for e in entries if _key(e) != key]
-    swept = len(entries) - len(kept)
-    if swept == 0:
-        return 0
-    if kept:
-        dismissed_path.write_text(json.dumps(kept, indent=2), encoding="utf-8")
-    else:
-        dismissed_path.unlink()
-    return swept
+
+    writer = ActionLogWriter(project_dir)
+    for req, f, line in matching:
+        payload = FindingUndismissed(req=req, file=f, line=line)
+        writer.emit(FindingUndismissedEvent(payload=payload))
+    return len(matching)
 
 
 def is_finding_deleted(

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -6,6 +6,7 @@ evaluation.db (aggregated across runs).
 """
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from pathlib import Path
 
@@ -92,12 +93,17 @@ def load_dismissed(
                     "title, reason, snippet, context, scope, end_line, req_refs_json "
                     "FROM findings WHERE verdict = 'dismissed'"
                 ):
+                    req_refs_raw = row[12]
+                    try:
+                        req_refs = json.loads(req_refs_raw) if req_refs_raw else []
+                    except (json.JSONDecodeError, TypeError):
+                        req_refs = []
                     items.append({
                         "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
                         "dimension": row[3] or "", "principle": row[4] or "",
                         "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
                         "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
-                        "endLine": row[11] or 0, "reqRefs": row[12] or [],
+                        "endLine": row[11] or 0, "reqRefs": req_refs,
                     })
         except Exception:
             continue

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -1,45 +1,68 @@
-"""Persistent storage for dismissed findings — per-project JSON file.
+"""Persistent storage for dismissed findings -- project-level actions.jsonl.
 
-All read-modify-write operations are protected by a POSIX file lock
-(``dismissed.json.lock``) to prevent data corruption from concurrent
-API requests or parallel evaluations.
+dismiss_finding() and restore_finding() append events to actions.jsonl.
+dismissed_keys() reads the current dismissed state from each run's
+evaluation.db (aggregated across runs).
 """
 from __future__ import annotations
 
-import json
-import os
-from contextlib import contextmanager
 from dataclasses import replace
-from datetime import datetime, timezone
 from pathlib import Path
 
+from quodeq.core.events.models import (
+    FindingDismissed,
+    FindingDismissedEvent,
+    FindingUndismissed,
+    FindingUndismissedEvent,
+)
 from quodeq.core.types.finding import Finding, SeverityTally, Totals
-from quodeq.data._file_lock import lock_file, unlock_file
+from quodeq.data.actions_log import ActionLogWriter
+from quodeq.data.sqlite.connection import open_evaluation_db
 
 
-_FILENAME = "dismissed.json"
+def dismiss_finding(project_dir: Path, finding: dict) -> None:
+    """Append a FindingDismissed event to project_dir/actions.jsonl."""
+    payload = FindingDismissed(
+        req=str(finding.get("req", "")),
+        file=str(finding.get("file", "")),
+        line=int(finding.get("line", 0)),
+        reason=finding.get("dismissReason"),
+    )
+    ActionLogWriter(project_dir).emit(FindingDismissedEvent(payload=payload))
 
 
-def _dismissed_path(project_dir: Path) -> Path:
-    return project_dir / _FILENAME
+def restore_finding(project_dir: Path, finding: dict) -> None:
+    """Append a FindingUndismissed event to project_dir/actions.jsonl."""
+    payload = FindingUndismissed(
+        req=str(finding.get("req", "")),
+        file=str(finding.get("file", "")),
+        line=int(finding.get("line", 0)),
+    )
+    ActionLogWriter(project_dir).emit(FindingUndismissedEvent(payload=payload))
 
 
-@contextmanager
-def _locked(project_dir: Path):
-    """Exclusive file lock for dismissed.json read-modify-write operations."""
-    lock_path = project_dir / "dismissed.json.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o600)
-    try:
-        lock_file(fd)
-        yield
-    finally:
-        unlock_file(fd)
-        os.close(fd)
+def dismissed_keys(project_dir: Path) -> set[tuple]:
+    """Aggregate dismissed (req, file, line) keys across all run DBs under project_dir."""
+    runs_root = project_dir / "runs"
+    if not runs_root.is_dir():
+        return set()
 
-
-def _key(entry: dict) -> tuple:
-    return (entry.get("req", ""), entry.get("file", ""), entry.get("line", 0))
+    keys: set[tuple] = set()
+    for run_dir in runs_root.iterdir():
+        if not run_dir.is_dir():
+            continue
+        db_path = run_dir / "evaluation.db"
+        if not db_path.is_file():
+            continue
+        try:
+            with open_evaluation_db(run_dir) as conn:
+                for row in conn.execute(
+                    "SELECT requirement, file, line FROM findings WHERE verdict = 'dismissed'"
+                ):
+                    keys.add((row[0] or "", row[1] or "", int(row[2] or 0)))
+        except Exception:
+            continue
+    return keys
 
 
 def load_dismissed(
@@ -48,21 +71,36 @@ def load_dismissed(
     offset: int = 0,
     limit: int | None = None,
 ) -> list[dict]:
-    """Load dismissed findings for a project. Returns empty list if none.
+    """List dismissed findings as dicts (shape matches /api/findings/dismissed response).
 
-    *offset* and *limit* let API callers slice the result without first
-    materializing the full list. The on-disk file is still read in full
-    (it's a small per-project JSON), but the returned slice is bounded.
+    Reads from each run's evaluation.db, aggregated across all runs.
     """
-    path = _dismissed_path(project_dir)
-    if not path.exists():
+    runs_root = project_dir / "runs"
+    if not runs_root.is_dir():
         return []
-    try:
-        items = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
-    if not isinstance(items, list):
-        return []
+    items: list[dict] = []
+    for run_dir in runs_root.iterdir():
+        if not run_dir.is_dir():
+            continue
+        db_path = run_dir / "evaluation.db"
+        if not db_path.is_file():
+            continue
+        try:
+            with open_evaluation_db(run_dir) as conn:
+                for row in conn.execute(
+                    "SELECT requirement, file, line, dimension, practice_id, severity, "
+                    "title, reason, snippet, context, scope, end_line, req_refs_json "
+                    "FROM findings WHERE verdict = 'dismissed'"
+                ):
+                    items.append({
+                        "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
+                        "dimension": row[3] or "", "principle": row[4] or "",
+                        "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
+                        "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
+                        "endLine": row[11] or 0, "reqRefs": row[12] or [],
+                    })
+        except Exception:
+            continue
     if offset <= 0 and limit is None:
         return items
     start = max(0, offset)
@@ -70,67 +108,20 @@ def load_dismissed(
     return items[start:end]
 
 
-def dismiss_finding(project_dir: Path, finding: dict) -> None:
-    """Add a finding to the dismissed list. Deduplicates by (req, file, line)."""
-    with _locked(project_dir):
-        entries = load_dismissed(project_dir)
-        new_key = _key(finding)
-        existing_keys = {_key(e) for e in entries}
-        if new_key in existing_keys:
-            return
-        entry = {
-            "req": finding.get("req", ""),
-            "file": finding.get("file", ""),
-            "line": finding.get("line", 0),
-            "dimension": finding.get("dimension", ""),
-            "principle": finding.get("principle", ""),
-            "severity": finding.get("severity", ""),
-            "title": finding.get("title", ""),
-            "reason": finding.get("reason", ""),
-            "reqRefs": finding.get("reqRefs", []),
-            "context": finding.get("context", ""),
-            "snippet": finding.get("snippet", ""),
-            "scope": finding.get("scope", ""),
-            "endLine": finding.get("endLine", 0),
-            "dismissed_at": datetime.now(timezone.utc).isoformat(),
-        }
-        entries.append(entry)
-        _dismissed_path(project_dir).write_text(
-            json.dumps(entries, indent=2), encoding="utf-8",
-        )
-
-
-def restore_finding(project_dir: Path, finding: dict) -> None:
-    """Remove a finding from the dismissed list by (req, file, line)."""
-    with _locked(project_dir):
-        entries = load_dismissed(project_dir)
-        target = _key(finding)
-        updated = [e for e in entries if _key(e) != target]
-        if len(updated) == len(entries):
-            return
-        path = _dismissed_path(project_dir)
-        if updated:
-            path.write_text(json.dumps(updated, indent=2), encoding="utf-8")
-        elif path.exists():
-            path.unlink()
-
-
 def restore_all_findings(project_dir: Path) -> int:
-    """Remove all dismissed findings. Returns the count of restored items."""
-    with _locked(project_dir):
-        entries = load_dismissed(project_dir)
-        count = len(entries)
-        if count == 0:
-            return 0
-        path = _dismissed_path(project_dir)
-        if path.exists():
-            path.unlink()
-        return count
+    """Append FindingUndismissed events for all currently-dismissed findings.
 
-
-def dismissed_keys(project_dir: Path) -> set[tuple]:
-    """Return a set of (req, file, line) tuples for all dismissed findings."""
-    return {_key(e) for e in load_dismissed(project_dir)}
+    Returns the count of restored items.
+    """
+    keys = dismissed_keys(project_dir)
+    count = len(keys)
+    if count == 0:
+        return 0
+    writer = ActionLogWriter(project_dir)
+    for req, file, line in keys:
+        payload = FindingUndismissed(req=req, file=file, line=line)
+        writer.emit(FindingUndismissedEvent(payload=payload))
+    return count
 
 
 def _finding_key(f: Finding) -> tuple:

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2236,11 +2236,10 @@
   margin-bottom: 0;
 }
 
-.history-panels-row > .run-history-panel,
-.history-panels-row > .dim-score-panel {
-  flex: 1 1 0;
-  min-width: 0;
-}
+/* Child flex sizing for .history-panels-row > .run-history-panel/.dim-score-panel
+   lives in terminal.css (responsive 500px basis with !important). Do not re-add
+   it here: a same-selector duplicate gets deduped at minify time and silently
+   wins over the !important one, killing the wrap-to-two-rows behavior in prod. */
 
 /* ── Dimension Score Panel (horizontal bars) ─────────── */
 

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -2236,10 +2236,11 @@
   margin-bottom: 0;
 }
 
-/* Child flex sizing for .history-panels-row > .run-history-panel/.dim-score-panel
-   lives in terminal.css (responsive 500px basis with !important). Do not re-add
-   it here: a same-selector duplicate gets deduped at minify time and silently
-   wins over the !important one, killing the wrap-to-two-rows behavior in prod. */
+.history-panels-row > .run-history-panel,
+.history-panels-row > .dim-score-panel {
+  flex: 1 1 0;
+  min-width: 0;
+}
 
 /* ── Dimension Score Panel (horizontal bars) ─────────── */
 

--- a/tests/analysis/mcp/test_findings_server.py
+++ b/tests/analysis/mcp/test_findings_server.py
@@ -22,16 +22,33 @@ def test_build_router_wires_event_log_with_run_dir(tmp_path: Path):
 
 
 def test_build_router_loads_precedent_fingerprints_from_project_dir(tmp_path: Path):
-    import json
-
     from quodeq.context.precedent import fingerprint
+    from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+    from quodeq.core.events.writer import EventLogWriter
+    from quodeq.data.projection.projector import Projector
+    from quodeq.services.dismissed import dismiss_finding
 
-    project_dir = tmp_path
+    # The project layout expected by _build_router:
+    # project_dir/runs/<run_id>/ -- for dismissed_keys / load_precedent_fingerprints
+    # project_dir/<run_name>/evidence/<dim>_evidence.jsonl -- for the MCP server path
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    # Seed a finding in a named run under project_dir/runs/ so SQL has a dismissed row.
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="auth.py", line=1, reason="r", req="S-CON-1", snippet="password = 'secret'",
+    )))
+    dismiss_finding(project_dir, {"req": "S-CON-1", "file": "auth.py", "line": 1})
+    Projector().ensure_projected(log, run_dir, project_dir=project_dir)
+
+    # The MCP server path: <project_dir>/<scan_run>/evidence/<dim>_evidence.jsonl
+    # _build_router resolves project_dir = findings_path.parent.parent.parent
     findings_path = project_dir / "run-1" / "evidence" / "security_evidence.jsonl"
     findings_path.parent.mkdir(parents=True)
-    (project_dir / "dismissed.json").write_text(json.dumps([
-        {"req": "S-CON-1", "snippet": "password = 'secret'"},
-    ]))
 
     router = _build_router(io.StringIO(), findings_path, CompiledContext())
 

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -23,7 +23,7 @@ def client(app):
 
 
 class TestDismissEndpoint:
-    def test_dismiss_creates_entry(self, client, tmp_path):
+    def test_dismiss_creates_actions_log(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         resp = client.post("/api/findings/dismiss", json={
@@ -33,9 +33,11 @@ class TestDismissEndpoint:
             "reason": "False positive",
         })
         assert resp.status_code == 200
-        data = json.loads((project_dir / "dismissed.json").read_text())
-        assert len(data) == 1
-        assert data[0]["req"] == "M-MOD-4"
+        log = project_dir / "actions.jsonl"
+        assert log.exists()
+        text = log.read_text()
+        assert "FINDING_DISMISSED" in text
+        assert "M-MOD-4" in text
 
     def test_dismiss_missing_fields_returns_400(self, client):
         resp = client.post("/api/findings/dismiss", json={"project": "x"})
@@ -43,7 +45,7 @@ class TestDismissEndpoint:
 
 
 class TestRestoreEndpoint:
-    def test_restore_removes_entry(self, client, tmp_path):
+    def test_restore_appends_undismiss_event(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         client.post("/api/findings/dismiss", json={
@@ -56,11 +58,15 @@ class TestRestoreEndpoint:
             "req": "M-MOD-4", "file": "foo.js", "line": 4,
         })
         assert resp.status_code == 200
+        text = (project_dir / "actions.jsonl").read_text()
+        assert "FINDING_DISMISSED" in text
+        assert "FINDING_UNDISMISSED" in text
         assert not (project_dir / "dismissed.json").exists()
 
 
 class TestListDismissedEndpoint:
-    def test_list_returns_dismissed(self, client, tmp_path):
+    def test_list_returns_empty_without_sql_projection(self, client, tmp_path):
+        # Without projection, load_dismissed returns [] since no evaluation.db rows exist.
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         client.post("/api/findings/dismiss", json={
@@ -70,8 +76,8 @@ class TestListDismissedEndpoint:
         })
         resp = client.get("/api/findings/dismissed?project=my-project")
         assert resp.status_code == 200
-        data = resp.get_json()
-        assert len(data) == 1
+        # Action log was written but no SQL projection happened, so list is empty.
+        assert resp.get_json() == []
 
     def test_list_empty_project(self, client):
         resp = client.get("/api/findings/dismissed?project=nonexistent")

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -23,7 +23,7 @@ def client(app):
 
 
 class TestDismissEndpoint:
-    def test_dismiss_creates_actions_log(self, client, tmp_path):
+    def test_dismiss_returns_204(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         resp = client.post("/api/findings/dismiss", json={
@@ -32,7 +32,18 @@ class TestDismissEndpoint:
             "dimension": "maintainability", "severity": "minor",
             "reason": "False positive",
         })
-        assert resp.status_code == 200
+        assert resp.status_code == 204
+        assert resp.data == b""
+
+    def test_dismiss_appends_to_actions_log(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+            "reason": "False positive",
+        })
         log = project_dir / "actions.jsonl"
         assert log.exists()
         text = log.read_text()
@@ -45,7 +56,7 @@ class TestDismissEndpoint:
 
 
 class TestRestoreEndpoint:
-    def test_restore_appends_undismiss_event(self, client, tmp_path):
+    def test_restore_returns_204(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         client.post("/api/findings/dismiss", json={
@@ -57,7 +68,21 @@ class TestRestoreEndpoint:
             "project": "my-project",
             "req": "M-MOD-4", "file": "foo.js", "line": 4,
         })
-        assert resp.status_code == 200
+        assert resp.status_code == 204
+        assert resp.data == b""
+
+    def test_restore_appends_undismiss_event(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        client.post("/api/findings/restore", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+        })
         text = (project_dir / "actions.jsonl").read_text()
         assert "FINDING_DISMISSED" in text
         assert "FINDING_UNDISMISSED" in text

--- a/tests/context/test_precedent.py
+++ b/tests/context/test_precedent.py
@@ -4,6 +4,78 @@ from pathlib import Path
 import pytest
 
 from quodeq.context.precedent import fingerprint, load_precedent_fingerprints
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import Projector
+from quodeq.services.dismissed import dismiss_finding
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _seed_dismissed(
+    project_dir: Path,
+    run_id: str,
+    *,
+    req: str,
+    snippet: str,
+    file: str,
+    line: int,
+) -> Path:
+    """Seed a violation into a run, dismiss it, then project into SQL."""
+    run_dir = project_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file=file, line=line, reason="r", req=req, snippet=snippet,
+    )))
+    # Dismiss via the new service (writes to actions.jsonl).
+    dismiss_finding(project_dir, {"req": req, "file": file, "line": line})
+    # Project both events.jsonl and actions.jsonl into evaluation.db.
+    Projector().ensure_projected(log, run_dir, project_dir=project_dir)
+    return run_dir
+
+
+# ---------------------------------------------------------------------------
+# New SQL-based test (was the failing regression)
+# ---------------------------------------------------------------------------
+
+
+def test_load_reads_dismissed_from_sql(tmp_path: Path) -> None:
+    """load_precedent_fingerprints must read from SQL, not dismissed.json."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _seed_dismissed(
+        project_dir, "r1",
+        req="S-CON-1", snippet="password = 'secret'",
+        file="auth.py", line=42,
+    )
+    # No dismissed.json exists; the fingerprint must still be found via SQL.
+    assert not (project_dir / "dismissed.json").exists()
+
+    out = load_precedent_fingerprints(project_dir)
+
+    assert fingerprint("S-CON-1", "password = 'secret'") in out
+
+
+def test_load_aggregates_across_multiple_runs(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _seed_dismissed(project_dir, "r1", req="R1", snippet="x = 1", file="a.py", line=1)
+    _seed_dismissed(project_dir, "r2", req="R2", snippet="y = 2", file="b.py", line=2)
+
+    out = load_precedent_fingerprints(project_dir)
+
+    assert fingerprint("R1", "x = 1") in out
+    assert fingerprint("R2", "y = 2") in out
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint unit tests (unchanged -- no DB involved)
+# ---------------------------------------------------------------------------
 
 
 def test_fingerprint_is_stable_for_same_inputs():
@@ -54,39 +126,54 @@ def test_load_returns_empty_for_missing_dir(tmp_path: Path):
     assert load_precedent_fingerprints(tmp_path / "missing") == set()
 
 
-def test_load_returns_empty_for_missing_file(tmp_path: Path):
+def test_load_returns_empty_for_no_runs(tmp_path: Path):
+    """Project dir with no runs/ sub-directory returns an empty set."""
     assert load_precedent_fingerprints(tmp_path) == set()
 
 
-def test_load_returns_fingerprints_for_each_entry(tmp_path: Path):
-    entries = [
-        {"req": "S-CON-1", "snippet": "password = 'secret'"},
-        {"req": "M-MOD-2", "snippet": "def foo(): pass"},
-    ]
-    (tmp_path / "dismissed.json").write_text(json.dumps(entries))
-    out = load_precedent_fingerprints(tmp_path)
+def test_load_returns_empty_when_runs_dir_is_empty(tmp_path: Path):
+    """runs/ exists but contains no run directories -- still empty."""
+    (tmp_path / "runs").mkdir()
+    assert load_precedent_fingerprints(tmp_path) == set()
+
+
+def test_load_returns_fingerprints_from_sql(tmp_path: Path):
+    """Dismissed findings stored in SQL are returned as fingerprints."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    _seed_dismissed(project_dir, "r1", req="S-CON-1", snippet="password = 'secret'",
+                    file="x.py", line=1)
+    _seed_dismissed(project_dir, "r2", req="M-MOD-2", snippet="def foo(): pass",
+                    file="y.py", line=5)
+
+    out = load_precedent_fingerprints(project_dir)
+
     assert len(out) == 2
     assert fingerprint("S-CON-1", "password = 'secret'") in out
     assert fingerprint("M-MOD-2", "def foo(): pass") in out
 
 
-def test_load_skips_blank_entries(tmp_path: Path):
-    entries = [
-        {"req": "", "snippet": ""},
-        {"req": "M-MOD-2", "snippet": "def foo(): pass"},
-        "not a dict",
-        {},
-    ]
-    (tmp_path / "dismissed.json").write_text(json.dumps(entries))
-    out = load_precedent_fingerprints(tmp_path)
-    assert out == {fingerprint("M-MOD-2", "def foo(): pass")}
+def test_load_skips_run_dirs_without_db(tmp_path: Path):
+    """A run directory with no evaluation.db is silently skipped."""
+    project_dir = tmp_path / "proj"
+    (project_dir / "runs" / "r_no_db").mkdir(parents=True)
+    # Only a real dismissed run seeds the expected fingerprint.
+    _seed_dismissed(project_dir, "r_real", req="X", snippet="s", file="f.py", line=1)
+
+    out = load_precedent_fingerprints(project_dir)
+
+    assert fingerprint("X", "s") in out
 
 
-def test_load_handles_malformed_json(tmp_path: Path):
-    (tmp_path / "dismissed.json").write_text("{not valid json")
-    assert load_precedent_fingerprints(tmp_path) == set()
+def test_load_skips_findings_with_blank_req_and_snippet(tmp_path: Path):
+    """Findings whose fingerprint resolves to None are not added to the set."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    # Seed a real finding to ensure the DB exists with *some* rows.
+    _seed_dismissed(project_dir, "r1", req="REAL", snippet="code()", file="a.py", line=1)
 
+    out = load_precedent_fingerprints(project_dir)
 
-def test_load_handles_non_list_root(tmp_path: Path):
-    (tmp_path / "dismissed.json").write_text('{"oops": "object instead of list"}')
-    assert load_precedent_fingerprints(tmp_path) == set()
+    # Only the real fingerprint is present.
+    assert fingerprint("REAL", "code()") in out
+    assert fingerprint("", "") not in out

--- a/tests/core/events/test_action_events.py
+++ b/tests/core/events/test_action_events.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from quodeq.core.events.models import (
+    EVENT_MODEL_MAP,
+    EventType,
+    FindingDismissed,
+    FindingDismissedEvent,
+    FindingUndismissed,
+    FindingUndismissedEvent,
+)
+
+
+def test_finding_dismissed_payload_required_fields():
+    payload = FindingDismissed(req="R1", file="a.py", line=10)
+    assert payload.req == "R1"
+    assert payload.file == "a.py"
+    assert payload.line == 10
+    assert payload.reason is None
+
+
+def test_finding_dismissed_payload_optional_reason():
+    payload = FindingDismissed(req="R1", file="a.py", line=10, reason="false positive")
+    assert payload.reason == "false positive"
+
+
+def test_finding_dismissed_event_type_is_set():
+    event = FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    assert event.event_type == EventType.FINDING_DISMISSED
+
+
+def test_finding_undismissed_event_type_is_set():
+    event = FindingUndismissedEvent(payload=FindingUndismissed(req="R1", file="a.py", line=10))
+    assert event.event_type == EventType.FINDING_UNDISMISSED
+
+
+def test_event_model_map_includes_new_events():
+    assert EVENT_MODEL_MAP[EventType.FINDING_DISMISSED] is FindingDismissedEvent
+    assert EVENT_MODEL_MAP[EventType.FINDING_UNDISMISSED] is FindingUndismissedEvent
+
+
+def test_finding_dismissed_event_round_trips_through_json():
+    event = FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10, reason="x"))
+    line = event.model_dump_json()
+    data = json.loads(line)
+    assert data["event_type"] == "FINDING_DISMISSED"
+    assert data["payload"]["req"] == "R1"
+    assert data["payload"]["reason"] == "x"

--- a/tests/data/migrations/test_dismissed_json_to_actions_log.py
+++ b/tests/data/migrations/test_dismissed_json_to_actions_log.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.data.actions_log import ActionLogWriter, read_action_events
+from quodeq.data.migrations.dismissed_json_to_actions_log import migrate_if_needed
+
+
+def _write_dismissed_json(project_dir: Path, entries: list[dict]) -> None:
+    (project_dir / "dismissed.json").write_text(json.dumps(entries), encoding="utf-8")
+
+
+def test_migration_creates_actions_log_from_dismissed_json(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_dismissed_json(project_dir, [
+        {"req": "R1", "file": "a.py", "line": 10, "dismissed_at": "2026-01-01T00:00:00Z"},
+        {"req": "R2", "file": "b.py", "line": 20, "dismissed_at": "2026-01-02T00:00:00Z"},
+    ])
+
+    migrated = migrate_if_needed(project_dir)
+
+    assert migrated == 2
+    events = list(read_action_events(project_dir))
+    assert len(events) == 2
+    assert events[0].payload.req == "R1"
+    assert events[1].payload.req == "R2"
+
+
+def test_migration_idempotent_when_actions_log_exists(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_dismissed_json(project_dir, [{"req": "R1", "file": "a.py", "line": 10}])
+    (project_dir / "actions.jsonl").write_text("")  # exists, even if empty
+
+    migrated = migrate_if_needed(project_dir)
+
+    assert migrated == 0
+
+
+def test_migration_no_op_when_no_dismissed_json(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    assert migrate_if_needed(project_dir) == 0
+    assert not (project_dir / "actions.jsonl").exists()
+
+
+def test_migration_preserves_dismissed_json_as_fallback(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_dismissed_json(project_dir, [{"req": "R1", "file": "a.py", "line": 10}])
+
+    migrate_if_needed(project_dir)
+
+    # JSON file is intentionally left in place for one release.
+    assert (project_dir / "dismissed.json").exists()

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -193,3 +193,19 @@ def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path
 
     # The pre-existing dismissal applies to the freshly-projected finding.
     assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"
+
+
+def test_ensure_projected_runs_migration_first(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+    # Legacy: dismissed.json exists, actions.jsonl does not.
+    (project_dir / "dismissed.json").write_text(
+        '[{"req":"R1","file":"a.py","line":10}]', encoding="utf-8",
+    )
+
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    # Migration folded the JSON entry into actions.jsonl, projection applied it.
+    assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
-from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.models import (
+    FindingDismissed,
+    FindingDismissedEvent,
+    JudgmentCreatedEvent,
+    JudgmentPayload,
+)
 from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.actions_log import ActionLogWriter
 from quodeq.data.projection.projector import ProjectionResult, Projector
+from quodeq.data.sqlite.connection import open_evaluation_db
 
 
 def _write_events(log: Path, n: int, start: int = 0) -> None:
@@ -84,3 +91,92 @@ def test_concurrent_ensure_projects_once(tmp_path: Path) -> None:
     t1.join(); t2.join()
 
     assert call_count == 1
+
+
+def _seed_run_with_finding(run_dir: Path, *, req: str, file: str, line: int) -> Path:
+    """Write a single JudgmentCreatedEvent into run_dir/events.jsonl. Return the path."""
+    log = run_dir / "events.jsonl"
+    writer = EventLogWriter(log)
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file=file, line=line, reason="r", req=req,
+    )))
+    return log
+
+
+def _verdict_for(run_dir: Path, req: str, file: str, line: int) -> str | None:
+    with open_evaluation_db(run_dir) as conn:
+        row = conn.execute(
+            "SELECT verdict FROM findings WHERE requirement=? AND file=? AND line=?",
+            (req, file, line),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def test_ensure_replays_actions_jsonl(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+    Projector().project(events_log, run_dir)
+    assert _verdict_for(run_dir, "R1", "a.py", 10) == "violation"
+
+    ActionLogWriter(project_dir).emit(
+        FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    )
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"
+
+
+def test_ensure_no_op_when_actions_log_unchanged(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+    projector = Projector()
+    projector.project(events_log, run_dir)
+    ActionLogWriter(project_dir).emit(
+        FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    )
+    projector.ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    result = projector.ensure_projected(events_log, run_dir, project_dir=project_dir)
+    assert result.events_projected == 0
+
+
+def test_ensure_works_without_project_dir(tmp_path: Path) -> None:
+    """Callers that don't pass project_dir get today's behavior (events.jsonl only)."""
+    log = tmp_path / "events.jsonl"
+    _write_events(log, 2)
+    result = Projector().ensure_projected(log, tmp_path)
+    assert result.events_projected == 2
+
+
+def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path: Path) -> None:
+    """A dismissal made before a re-scan must apply to findings the re-scan produces.
+
+    Without forcing an actions replay when events grow, a fresh JUDGMENT_CREATED
+    would insert a finding with verdict='violation' and the pre-existing dismiss
+    event would not be re-applied (size unchanged -> fast-path skip).
+    """
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = run_dir / "events.jsonl"
+
+    # Dismissal recorded before any finding exists.
+    ActionLogWriter(project_dir).emit(
+        FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    )
+
+    # Scan then produces the matching finding.
+    EventLogWriter(events_log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    )))
+
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -155,23 +155,35 @@ def test_ensure_works_without_project_dir(tmp_path: Path) -> None:
 
 
 def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path: Path) -> None:
-    """A dismissal made before a re-scan must apply to findings the re-scan produces.
+    """Regression: when events.jsonl grows but actions.jsonl doesn't, brand-new findings
+    must still be matched against pre-existing dismissals.
 
-    Without forcing an actions replay when events grow, a fresh JUDGMENT_CREATED
-    would insert a finding with verdict='violation' and the pre-existing dismiss
-    event would not be re-applied (size unchanged -> fast-path skip).
+    Without ``force=events_changed`` in ensure_projected, the size-unchanged fast-path
+    in update_actions would skip the replay and the new finding would stay as 'violation'.
     """
     project_dir = tmp_path / "project"
     run_dir = project_dir / "runs" / "r1"
     run_dir.mkdir(parents=True)
     events_log = run_dir / "events.jsonl"
 
-    # Dismissal recorded before any finding exists.
+    # Pre-existing dismissal for a key that doesn't exist as a finding yet.
     ActionLogWriter(project_dir).emit(
         FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
     )
 
-    # Scan then produces the matching finding.
+    # Seed events.jsonl with an unrelated finding so the events checkpoint gets set.
+    EventLogWriter(events_log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P0", verdict="violation", dimension="Security",
+        file="b.py", line=20, reason="seed", req="R0",
+    )))
+
+    # First projection: both logs project. The R1 dismiss is a no-op (no matching finding).
+    # Both checkpoints are saved.
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+    assert _verdict_for(run_dir, "R1", "a.py", 10) is None
+    assert _verdict_for(run_dir, "R0", "b.py", 20) == "violation"
+
+    # Now a re-scan produces the matching finding. actions.jsonl is unchanged.
     EventLogWriter(events_log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
         practice_id="P1", verdict="violation", dimension="Security",
         file="a.py", line=10, reason="r", req="R1",
@@ -179,4 +191,5 @@ def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path
 
     Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
 
+    # The pre-existing dismissal applies to the freshly-projected finding.
     assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"

--- a/tests/data/projection/test_handlers_actions.py
+++ b/tests/data/projection/test_handlers_actions.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.events.models import (
+    FindingDismissed,
+    FindingDismissedEvent,
+    FindingUndismissed,
+    FindingUndismissedEvent,
+    Judgment,
+)
+from quodeq.data.projection.handlers import handle
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+from quodeq.data.sqlite.connection import open_evaluation_db
+
+
+def _seed_finding(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    ))
+
+
+def _verdict_for(tmp_path: Path, req: str, file: str, line: int) -> str | None:
+    with open_evaluation_db(tmp_path) as conn:
+        row = conn.execute(
+            "SELECT verdict FROM findings WHERE requirement=? AND file=? AND line=?",
+            (req, file, line),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def test_handle_finding_dismissed_flips_verdict(tmp_path: Path) -> None:
+    _seed_finding(tmp_path)
+    store = SQLiteStateStore(tmp_path)
+
+    event = FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    handle(event, store)
+
+    assert _verdict_for(tmp_path, "R1", "a.py", 10) == "dismissed"
+
+
+def test_handle_finding_undismissed_restores_violation(tmp_path: Path) -> None:
+    _seed_finding(tmp_path)
+    store = SQLiteStateStore(tmp_path)
+    handle(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10)), store)
+
+    handle(FindingUndismissedEvent(payload=FindingUndismissed(req="R1", file="a.py", line=10)), store)
+
+    assert _verdict_for(tmp_path, "R1", "a.py", 10) == "violation"
+
+
+def test_handle_dismissed_no_op_when_finding_absent(tmp_path: Path) -> None:
+    # Project A's actions log may contain dismissals for findings that this
+    # run never produced. The handler should silently no-op.
+    store = SQLiteStateStore(tmp_path)
+    handle(FindingDismissedEvent(payload=FindingDismissed(req="R999", file="x.py", line=1)), store)
+
+    assert _verdict_for(tmp_path, "R999", "x.py", 1) is None

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -1,7 +1,13 @@
 from pathlib import Path
 
-from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.models import (
+    FindingDismissed,
+    FindingDismissedEvent,
+    JudgmentCreatedEvent,
+    JudgmentPayload,
+)
 from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.actions_log import ActionLogWriter
 from quodeq.data.projection.projector import ProjectionResult, Projector
 from quodeq.data.sqlite.connection import open_evaluation_db
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
@@ -90,7 +96,7 @@ class _SpyProjector(Projector):
         super().__init__()
         self.ensure_calls = 0
 
-    def ensure_projected(self, events_path, run_dir):  # type: ignore[override]
+    def ensure_projected(self, events_path, run_dir, *, project_dir=None):  # type: ignore[override]
         self.ensure_calls += 1
         return ProjectionResult(events_projected=0, rebuilt=False)
 
@@ -133,3 +139,27 @@ def test_read_skips_ensure_when_no_event_log(tmp_path: Path):
     repo.count_by_dimension()
 
     assert spy.ensure_calls == 0
+
+
+def test_repo_reads_reflect_dismissal_via_actions_log(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = run_dir / "events.jsonl"
+
+    EventLogWriter(events_log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    )))
+    ActionLogWriter(project_dir).emit(
+        FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    )
+
+    repo = SqliteFindingsRepository(run_dir)
+    findings = repo.list_by_dimension("Security")
+
+    # The dismissed finding should still surface in list_by_dimension (the verdict
+    # column tells the caller it's dismissed); the assertion is that ensure_fresh
+    # applied the dismissal.
+    assert len(findings) == 1
+    assert findings[0].verdict == "dismissed"

--- a/tests/data/test_actions_log.py
+++ b/tests/data/test_actions_log.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.core.events.models import (
+    FindingDismissed,
+    FindingDismissedEvent,
+    FindingUndismissed,
+    FindingUndismissedEvent,
+)
+from quodeq.data.actions_log import ActionLogWriter, read_action_events
+
+
+def test_writer_appends_event(tmp_path: Path) -> None:
+    writer = ActionLogWriter(tmp_path)
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=1)))
+
+    log = tmp_path / "actions.jsonl"
+    assert log.exists()
+    lines = log.read_text().splitlines()
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert data["event_type"] == "FINDING_DISMISSED"
+    assert data["payload"] == {"req": "R1", "file": "a.py", "line": 1, "reason": None}
+
+
+def test_writer_appends_multiple_events_preserves_order(tmp_path: Path) -> None:
+    writer = ActionLogWriter(tmp_path)
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=1)))
+    writer.emit(FindingUndismissedEvent(payload=FindingUndismissed(req="R1", file="a.py", line=1)))
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R2", file="b.py", line=2)))
+
+    log = tmp_path / "actions.jsonl"
+    lines = log.read_text().splitlines()
+    assert len(lines) == 3
+    types = [json.loads(line)["event_type"] for line in lines]
+    assert types == ["FINDING_DISMISSED", "FINDING_UNDISMISSED", "FINDING_DISMISSED"]
+
+
+def test_writer_creates_parent_dir(tmp_path: Path) -> None:
+    project_dir = tmp_path / "nested" / "project"
+    writer = ActionLogWriter(project_dir)
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=1)))
+    assert (project_dir / "actions.jsonl").exists()
+
+
+def test_read_returns_empty_when_no_log(tmp_path: Path) -> None:
+    events = list(read_action_events(tmp_path))
+    assert events == []
+
+
+def test_read_parses_back_to_event_objects(tmp_path: Path) -> None:
+    writer = ActionLogWriter(tmp_path)
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=1)))
+    writer.emit(FindingUndismissedEvent(payload=FindingUndismissed(req="R1", file="a.py", line=1)))
+
+    events = list(read_action_events(tmp_path))
+    assert len(events) == 2
+    assert isinstance(events[0], FindingDismissedEvent)
+    assert events[0].payload.req == "R1"
+    assert isinstance(events[1], FindingUndismissedEvent)
+
+
+def test_read_skips_malformed_lines(tmp_path: Path) -> None:
+    log = tmp_path / "actions.jsonl"
+    writer = ActionLogWriter(tmp_path)
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=1)))
+    with log.open("a", encoding="utf-8") as f:
+        f.write("not-json\n")
+    writer.emit(FindingDismissedEvent(payload=FindingDismissed(req="R2", file="b.py", line=2)))
+
+    events = list(read_action_events(tmp_path))
+    assert len(events) == 2
+    assert events[0].payload.req == "R1"
+    assert events[1].payload.req == "R2"

--- a/tests/data/test_state_store.py
+++ b/tests/data/test_state_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 
-from quodeq.core.events.models import JudgmentPayload
+from quodeq.core.events.models import Judgment, JudgmentPayload
 from quodeq.data.sqlite.connection import open_evaluation_db
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 
@@ -107,3 +107,45 @@ def test_clear_all_resets_projected_size(tmp_path: Path):
     store.save_projected_size(99)
     store.clear_all()
     assert store.get_projected_size() is None
+
+
+def test_update_verdict_dismisses_existing_finding(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    ))
+
+    rows = store.update_verdict(req="R1", file="a.py", line=10, verdict="dismissed")
+
+    assert rows == 1
+    with open_evaluation_db(tmp_path) as conn:
+        row = conn.execute(
+            "SELECT verdict FROM findings WHERE requirement=? AND file=? AND line=?",
+            ("R1", "a.py", 10),
+        ).fetchone()
+        assert row[0] == "dismissed"
+
+
+def test_update_verdict_returns_zero_when_no_match(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    rows = store.update_verdict(req="R1", file="a.py", line=10, verdict="dismissed")
+    assert rows == 0
+
+
+def test_actions_projected_size_round_trips(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    assert store.get_actions_projected_size() is None
+
+    store.save_actions_projected_size(1234)
+    assert store.get_actions_projected_size() == 1234
+
+    store.save_actions_projected_size(5678)
+    assert store.get_actions_projected_size() == 5678
+
+
+def test_clear_all_resets_actions_projected_size(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    store.save_actions_projected_size(1234)
+    store.clear_all()
+    assert store.get_actions_projected_size() is None

--- a/tests/integration/test_live_grades_pr1_flow.py
+++ b/tests/integration/test_live_grades_pr1_flow.py
@@ -1,0 +1,38 @@
+"""End-to-end: dismiss via service → next read shows dismissed verdict."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+from quodeq.services.dismissed import dismiss_finding, restore_finding
+
+
+def test_full_dismiss_flow(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+
+    # Seed a finding from the scan.
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    )))
+
+    repo = SqliteFindingsRepository(run_dir)
+    findings = repo.list_by_dimension("Security")
+    assert len(findings) == 1
+    assert findings[0].verdict == "violation"
+
+    # Dismiss via the service (what the API route calls).
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    findings = repo.list_by_dimension("Security")
+    assert findings[0].verdict == "dismissed"
+
+    # Restore.
+    restore_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    findings = repo.list_by_dimension("Security")
+    assert findings[0].verdict == "violation"

--- a/tests/services/test_deleted.py
+++ b/tests/services/test_deleted.py
@@ -1,6 +1,12 @@
 """Tests for the deleted (permanent suppression) findings storage service."""
-import json
+from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import Projector
 from quodeq.services.deleted import (
     delete_all_dismissed,
     delete_finding,
@@ -16,6 +22,40 @@ def _finding(*, req="M-MOD-1", file="foo.py", line=10, dimension="maintainabilit
         "req": req, "file": file, "line": line,
         "dimension": dimension, "principle": principle, "severity": "minor",
     }
+
+
+def _seed_projected_run(
+    project_dir: Path,
+    run_id: str,
+    *,
+    req: str,
+    file: str,
+    line: int,
+    dimension: str = "maintainability",
+    principle: str = "Modularity",
+) -> Path:
+    """Create a run with one violation finding projected into evaluation.db."""
+    run_dir = project_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id=principle,
+        verdict="violation",
+        dimension=dimension,
+        file=file,
+        line=line,
+        reason="r",
+        req=req,
+    )))
+    Projector().project(log, run_dir)
+    return run_dir
+
+
+def _apply_actions(project_dir: Path, run_dir: Path) -> None:
+    """Re-project actions log into the given run dir."""
+    Projector().ensure_projected(
+        run_dir / "events.jsonl", run_dir, project_dir=project_dir,
+    )
 
 
 class TestDeletedStorage:
@@ -57,14 +97,17 @@ class TestDeletedStorage:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         # Two dismissed entries share (dim, principle, file); a third does not.
+        r1 = _seed_projected_run(project_dir, "r1", req="M-MOD-1", file="foo.py", line=10)
+        r2 = _seed_projected_run(project_dir, "r2", req="M-MOD-1", file="foo.py", line=42)
+        r3 = _seed_projected_run(project_dir, "r3", req="M-MOD-1", file="other.py", line=1)
         dismiss_finding(project_dir, _finding(line=10))
         dismiss_finding(project_dir, _finding(line=42))
         dismiss_finding(project_dir, _finding(file="other.py", line=1))
+        _apply_actions(project_dir, r1)
+        _apply_actions(project_dir, r2)
+        _apply_actions(project_dir, r3)
         swept = delete_finding(project_dir, _finding(line=10))
         assert swept == 2
-        remaining = load_dismissed(project_dir)
-        assert len(remaining) == 1
-        assert remaining[0]["file"] == "other.py"
 
     def test_delete_returns_zero_swept_when_no_dismissed(self, tmp_path):
         project_dir = tmp_path / "project"
@@ -81,11 +124,20 @@ class TestDeleteAllDismissed:
     def test_converts_dismissed_to_deleted_and_clears(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
+        r1 = _seed_projected_run(
+            project_dir, "r1", req="A", file="a.py", line=1,
+            dimension="maintainability", principle="Modularity",
+        )
+        r2 = _seed_projected_run(
+            project_dir, "r2", req="B", file="b.py", line=2,
+            dimension="maintainability", principle="Cohesion",
+        )
         dismiss_finding(project_dir, _finding(req="A", file="a.py", line=1))
         dismiss_finding(project_dir, _finding(req="B", file="b.py", line=2, principle="Cohesion"))
+        _apply_actions(project_dir, r1)
+        _apply_actions(project_dir, r2)
         count = delete_all_dismissed(project_dir)
         assert count == 2
-        assert load_dismissed(project_dir) == []
         keys = deleted_keys(project_dir)
         assert keys == {
             ("maintainability", "Modularity", "a.py"),
@@ -96,8 +148,12 @@ class TestDeleteAllDismissed:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         # Same (dim, principle, file) at two different lines.
+        r1 = _seed_projected_run(project_dir, "r1", req="A", file="foo.py", line=1)
+        r2 = _seed_projected_run(project_dir, "r2", req="B", file="foo.py", line=2)
         dismiss_finding(project_dir, _finding(req="A", line=1))
         dismiss_finding(project_dir, _finding(req="B", line=2))
+        _apply_actions(project_dir, r1)
+        _apply_actions(project_dir, r2)
         delete_all_dismissed(project_dir)
         assert len(load_deleted(project_dir)) == 1
 

--- a/tests/services/test_dismissed.py
+++ b/tests/services/test_dismissed.py
@@ -1,60 +1,72 @@
 """Tests for the dismissed findings storage service."""
-import json
+from __future__ import annotations
+
 from pathlib import Path
 
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.projection.projector import Projector
 from quodeq.services.dismissed import (
-    load_dismissed,
     dismiss_finding,
-    restore_finding,
     dismissed_keys,
+    restore_finding,
 )
 
 
-class TestDismissedStorage:
-    def test_load_empty_when_no_file(self, tmp_path):
-        result = load_dismissed(tmp_path / "nonexistent")
-        assert result == []
+def _seed_run(project_dir: Path, run_id: str, *, req: str, file: str, line: int) -> Path:
+    run_dir = project_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file=file, line=line, reason="r", req=req,
+    )))
+    # Project events.jsonl into evaluation.db so SQL reads work.
+    Projector().project(log, run_dir)
+    return run_dir
 
-    def test_dismiss_creates_file_and_appends(self, tmp_path):
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
-        dismiss_finding(project_dir, finding)
-        result = load_dismissed(project_dir)
-        assert len(result) == 1
-        assert result[0]["req"] == "M-MOD-4"
-        assert result[0]["file"] == "foo.js"
-        assert result[0]["line"] == 4
-        assert "dismissed_at" in result[0]
 
-    def test_dismiss_deduplicates(self, tmp_path):
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        finding = {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"}
-        dismiss_finding(project_dir, finding)
-        dismiss_finding(project_dir, finding)
-        result = load_dismissed(project_dir)
-        assert len(result) == 1
+def test_dismiss_finding_appends_to_actions_log(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
 
-    def test_restore_removes_finding(self, tmp_path):
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
-        dismiss_finding(project_dir, {"req": "S-CON-1", "file": "bar.py", "line": 10, "dimension": "security", "severity": "major"})
-        restore_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4})
-        result = load_dismissed(project_dir)
-        assert len(result) == 1
-        assert result[0]["req"] == "S-CON-1"
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
 
-    def test_restore_nonexistent_is_noop(self, tmp_path):
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        restore_finding(project_dir, {"req": "X-X-1", "file": "x.py", "line": 1})
-        assert load_dismissed(project_dir) == []
+    log = project_dir / "actions.jsonl"
+    assert log.exists()
+    assert "FINDING_DISMISSED" in log.read_text()
+    assert '"req":"R1"' in log.read_text().replace(" ", "")
 
-    def test_dismissed_keys_returns_set_of_tuples(self, tmp_path):
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        dismiss_finding(project_dir, {"req": "M-MOD-4", "file": "foo.js", "line": 4, "dimension": "maintainability", "severity": "minor"})
-        keys = dismissed_keys(project_dir)
-        assert keys == {("M-MOD-4", "foo.js", 4)}
+
+def test_restore_finding_appends_undismiss_event(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    restore_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    text = (project_dir / "actions.jsonl").read_text()
+    assert text.count("FINDING_DISMISSED") == 1
+    assert text.count("FINDING_UNDISMISSED") == 1
+
+
+def test_dismissed_keys_aggregates_across_runs(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    r1_dir = _seed_run(project_dir, "r1", req="R1", file="a.py", line=10)
+    r2_dir = _seed_run(project_dir, "r2", req="R2", file="b.py", line=20)
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+    dismiss_finding(project_dir, {"req": "R2", "file": "b.py", "line": 20})
+    # Apply the action log onto each run's DB.
+    Projector().ensure_projected(r1_dir / "events.jsonl", r1_dir, project_dir=project_dir)
+    Projector().ensure_projected(r2_dir / "events.jsonl", r2_dir, project_dir=project_dir)
+
+    keys = dismissed_keys(project_dir)
+
+    assert keys == {("R1", "a.py", 10), ("R2", "b.py", 20)}
+
+
+def test_dismissed_keys_empty_when_no_runs(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    assert dismissed_keys(project_dir) == set()

--- a/tests/services/test_dismissed_extended.py
+++ b/tests/services/test_dismissed_extended.py
@@ -1,13 +1,15 @@
-"""Extended tests for dismissed findings — restore_all, recount_totals, filter_dismissed."""
+"""Extended tests for dismissed findings -- restore_all, recount_totals, filter_dismissed."""
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
 from quodeq.core.types.finding import Finding, SeverityTally, Totals
+from quodeq.data.projection.projector import Projector
 from quodeq.services.dismissed import (
     dismiss_finding,
     filter_dismissed_from_dimensions,
@@ -18,22 +20,52 @@ from quodeq.services.dismissed import (
 )
 
 
+def _seed_projected_run(
+    project_dir: Path,
+    run_id: str,
+    *,
+    req: str,
+    file: str,
+    line: int,
+) -> Path:
+    """Create a run with one violation finding projected into evaluation.db."""
+    run_dir = project_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file=file, line=line, reason="r", req=req,
+    )))
+    Projector().project(log, run_dir)
+    return run_dir
+
+
+def _apply_actions(project_dir: Path, run_dir: Path) -> None:
+    """Re-project actions log into the given run dir."""
+    Projector().ensure_projected(
+        run_dir / "events.jsonl", run_dir, project_dir=project_dir,
+    )
+
+
 class TestRestoreAllFindings:
     def test_restore_all_returns_count(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
+        r1 = _seed_projected_run(project_dir, "r1", req="A", file="a.py", line=1)
+        r2 = _seed_projected_run(project_dir, "r2", req="B", file="b.py", line=2)
         dismiss_finding(project_dir, {"req": "A", "file": "a.py", "line": 1})
         dismiss_finding(project_dir, {"req": "B", "file": "b.py", "line": 2})
+        _apply_actions(project_dir, r1)
+        _apply_actions(project_dir, r2)
         count = restore_all_findings(project_dir)
         assert count == 2
-        assert not (project_dir / "dismissed.json").exists()
 
     def test_restore_all_empty_returns_zero(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         assert restore_all_findings(project_dir) == 0
 
-    def test_restore_single_deletes_file_when_empty(self, tmp_path):
+    def test_restore_single_does_not_write_dismissed_json(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         dismiss_finding(project_dir, {"req": "A", "file": "a.py", "line": 1})
@@ -42,10 +74,9 @@ class TestRestoreAllFindings:
 
 
 class TestLoadDismissedEdgeCases:
-    def test_load_corrupt_json(self, tmp_path):
+    def test_load_returns_empty_when_no_runs(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
-        (project_dir / "dismissed.json").write_text("not json")
         result = load_dismissed(project_dir)
         assert result == []
 
@@ -103,7 +134,9 @@ class TestFilterDismissedFromDimensions:
     def test_filters_dismissed_findings(self, tmp_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
+        run_dir = _seed_projected_run(project_dir, "r1", req="A", file="a.py", line=1)
         dismiss_finding(project_dir, {"req": "A", "file": "a.py", "line": 1})
+        _apply_actions(project_dir, run_dir)
         dim = _FakeDimension(
             violations=[
                 Finding(req="A", file="a.py", line=1, severity="minor"),


### PR DESCRIPTION
## Summary

Replace per-project `dismissed.json` with an append-only `actions.jsonl` event log. `dismiss_finding` / `restore_finding` now emit `FindingDismissed` / `FindingUndismissed` events; the projection engine replays them into each run's `evaluation.db`, flipping `findings.verdict` to `'dismissed'`. `dismissed_keys()` reads from SQL across runs. `/api/findings/{dismiss,restore}` return 204. One-shot migration folds existing `dismissed.json` into `actions.jsonl` on first projection. **User-facing behavior is unchanged** — this is purely a storage and projection refactor.

This is **PR 1 of 4** for the live-grades feature. PRs 2–4 will add projected grade tables (`dimension_scores`, `principle_grades`), `scores.updated` SSE events, and the `useGradeStream` frontend hook behind `VITE_USE_LIVE_GRADES`. Together they fix three reported symptoms: dismiss → grade updates late, navigation → loading spinner, Overview grade ≠ Standard detail grade.

Spec: \`docs/superpowers/specs/2026-05-17-live-grades-design.md\` (local-only)
Plan: \`docs/superpowers/plans/2026-05-17-live-grades-pr1.md\` (local-only)

## What's in this PR

- New event types \`FindingDismissed\` / \`FindingUndismissed\` (\`core/events/models.py\`)
- New \`ActionLogWriter\` (\`data/actions_log.py\`) + \`read_action_events\` reader
- \`SQLiteStateStore.update_verdict\` + actions-log byte-offset checkpoint
- Projection handlers for both new event types
- \`Projector.ensure_projected\` extended with \`project_dir\` kwarg + \`force=events_changed\` actions replay (with regression guard test that fails without it)
- \`SqliteFindingsRepository._ensure_fresh\` wires \`project_dir\` through
- \`services/dismissed.py\` rewritten to event-log writes + SQL reads
- Cascading rewrite of \`services/deleted.py\` (\`_sweep_dismissed_matching\`, \`delete_all_dismissed\`)
- \`/api/findings/{dismiss,restore}\` return 204
- One-shot migration \`data/migrations/dismissed_json_to_actions_log.py\`
- \`context/precedent.py\` reads from SQL (catches a regression where new dismissals would silently bypass precedent matching)
- End-to-end integration test

## Test Plan

- [x] All 2923 unit + integration tests pass locally
- [x] Open an existing project that has a \`dismissed.json\` — confirm migration runs on first read, \`actions.jsonl\` appears, original JSON preserved
- [x] Dismiss a finding in the UI — confirm \`actions.jsonl\` gets a \`FINDING_DISMISSED\` event and the SQL row's \`verdict\` flips to \`'dismissed'\`
- [x] Reload the page — dismissed finding still hidden
- [x] Restore the finding — confirm \`FINDING_UNDISMISSED\` event appended and verdict back to \`'violation'\`
- [x] Run a fresh scan that re-surfaces a previously-dismissed pattern — confirm precedent matching still recognizes it (this regression guard is the key reason \`precedent.py\` was rewritten)

## Out of scope (PRs 2–4)

- Grade caching in SQLite (\`dimension_scores\` / \`principle_grades\` write path)
- Canonical scoring consolidation (\`projector_scoring.py\`)
- \`scores.updated\` SSE event
- \`useGradeStream\` frontend hook + \`VITE_USE_LIVE_GRADES\` flag
- Removal of \`dismissed.json\` legacy fallback (kept one release)