### PR TITLE
feat(sse): live grade updates via scores.updated SSE event (live-grades PR 3)

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -77,14 +77,14 @@ class WatcherState:
     last_event_ts is the ISO 8601 timestamp cursor for resuming from events.jsonl
     on reconnect (via Last-Event-ID). last_event_counter is a sequential integer
     used as finding `id` in the payload for client backward-compatibility.
-    last_grade_completed_at is the MAX(completed_at) from dimension_scores the
+    last_grade_fingerprint is a repr() of the sorted dimension_scores rows the
     last time a scores.updated event was emitted; None means never checked.
     """
     last_event_ts: datetime | None = None
     last_event_counter: int = 0
     last_status_mtime: float | None = None
     emitted_dimensions: frozenset[str] = field(default_factory=frozenset)
-    last_grade_completed_at: str | None = None
+    last_grade_fingerprint: str | None = None
 
 
 _logger = logging.getLogger(__name__)
@@ -241,15 +241,11 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
     # Trigger projection (cheap no-op if no JSONL/actions log activity since last tick).
     # This applies any actions.jsonl events so grade tables stay current.
     grade_event: EventTuple | None = None
-    new_grade_completed_at = state.last_grade_completed_at
+    new_grade_fingerprint = state.last_grade_fingerprint
     try:
         from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
         repo = SqliteFindingsRepository(run_dir)
-        if repo._events_log.is_file():  # noqa: SLF001
-            project_dir = run_dir.parent.parent
-            repo._projector.ensure_projected(  # noqa: SLF001
-                repo._events_log, run_dir, project_dir=project_dir,  # noqa: SLF001
-            )
+        repo._ensure_fresh()  # noqa: SLF001
     except Exception:
         _logger.warning("SSE tick: ensure_fresh failed for %s", run_dir, exc_info=True)
 
@@ -259,11 +255,14 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
             rows = conn.execute(
                 "SELECT dimension, score, grade, completed_at FROM dimension_scores ORDER BY dimension",
             ).fetchall()
-        # Fingerprint captures both the grade values and the MAX(completed_at).
-        # This detects: grades advancing, grades changing value, and all grades
-        # being dismissed (table becomes empty after a full-dismiss recompute).
+        # Fingerprint of all dimension_scores rows, not just MAX(completed_at). This
+        # detects grade value changes that happen within the same second (recompute
+        # fires fast enough that two consecutive ticks can produce identical timestamps
+        # but different scores). MAX(completed_at) alone would miss these.
+        # It also detects transitions to the empty state (full-dismiss), which
+        # MAX(completed_at) handles correctly too (None != prior-timestamp).
         current_fingerprint = repr(rows) if rows else None
-        if current_fingerprint != state.last_grade_completed_at:
+        if current_fingerprint != state.last_grade_fingerprint:
             from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
             # run_dir layout: <reports_root>/<project>/runs/<run_id>
             reports_root = run_dir.parent.parent.parent
@@ -271,7 +270,7 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
             run_id = run_dir.name
             payload = get_scores_raw(reports_root, project, run_id)
             grade_event = ("scores.updated", serialize_scores_updated_event(payload), None)
-            new_grade_completed_at = current_fingerprint
+            new_grade_fingerprint = current_fingerprint
     except Exception:
         _logger.warning("SSE tick: scores.updated build failed for %s", run_dir, exc_info=True)
 
@@ -283,7 +282,7 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
         last_event_counter=new_counter,
         last_status_mtime=status_mtime,
         emitted_dimensions=frozenset(state.emitted_dimensions | set(new_dims)),
-        last_grade_completed_at=new_grade_completed_at,
+        last_grade_fingerprint=new_grade_fingerprint,
     )
     return events, new_state
 

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -62,6 +62,14 @@ def serialize_finding_event(judgment_dict: dict[str, Any]) -> str:
     return json.dumps(judgment_dict, separators=(",", ":"))
 
 
+def serialize_scores_updated_event(payload: dict[str, Any]) -> str:
+    """Return the SSE data: payload for an `event: scores.updated` frame.
+
+    Payload matches the /api/projects/<p>/scores/<run> response shape.
+    """
+    return json.dumps(payload, separators=(",", ":"))
+
+
 @dataclass
 class WatcherState:
     """Mutable per-stream state. Tracks what has been emitted to one client.
@@ -69,11 +77,14 @@ class WatcherState:
     last_event_ts is the ISO 8601 timestamp cursor for resuming from events.jsonl
     on reconnect (via Last-Event-ID). last_event_counter is a sequential integer
     used as finding `id` in the payload for client backward-compatibility.
+    last_grade_completed_at is the MAX(completed_at) from dimension_scores the
+    last time a scores.updated event was emitted; None means never checked.
     """
     last_event_ts: datetime | None = None
     last_event_counter: int = 0
     last_status_mtime: float | None = None
     emitted_dimensions: frozenset[str] = field(default_factory=frozenset)
+    last_grade_completed_at: str | None = None
 
 
 _logger = logging.getLogger(__name__)
@@ -226,11 +237,53 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
         new_last_ts = event_ts
         new_counter = counter
 
+    # --- scores.updated branch ---
+    # Trigger projection (cheap no-op if no JSONL/actions log activity since last tick).
+    # This applies any actions.jsonl events so grade tables stay current.
+    grade_event: EventTuple | None = None
+    new_grade_completed_at = state.last_grade_completed_at
+    try:
+        from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+        repo = SqliteFindingsRepository(run_dir)
+        if repo._events_log.is_file():  # noqa: SLF001
+            project_dir = run_dir.parent.parent
+            repo._projector.ensure_projected(  # noqa: SLF001
+                repo._events_log, run_dir, project_dir=project_dir,  # noqa: SLF001
+            )
+    except Exception:
+        _logger.warning("SSE tick: ensure_fresh failed for %s", run_dir, exc_info=True)
+
+    try:
+        from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
+        with open_evaluation_db(run_dir) as conn:
+            rows = conn.execute(
+                "SELECT dimension, score, grade, completed_at FROM dimension_scores ORDER BY dimension",
+            ).fetchall()
+        # Fingerprint captures both the grade values and the MAX(completed_at).
+        # This detects: grades advancing, grades changing value, and all grades
+        # being dismissed (table becomes empty after a full-dismiss recompute).
+        current_fingerprint = repr(rows) if rows else None
+        if current_fingerprint != state.last_grade_completed_at:
+            from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
+            # run_dir layout: <reports_root>/<project>/runs/<run_id>
+            reports_root = run_dir.parent.parent.parent
+            project = run_dir.parent.parent.name
+            run_id = run_dir.name
+            payload = get_scores_raw(reports_root, project, run_id)
+            grade_event = ("scores.updated", serialize_scores_updated_event(payload), None)
+            new_grade_completed_at = current_fingerprint
+    except Exception:
+        _logger.warning("SSE tick: scores.updated build failed for %s", run_dir, exc_info=True)
+
+    if grade_event is not None:
+        events.append(grade_event)
+
     new_state = WatcherState(
         last_event_ts=new_last_ts,
         last_event_counter=new_counter,
         last_status_mtime=status_mtime,
         emitted_dimensions=frozenset(state.emitted_dimensions | set(new_dims)),
+        last_grade_completed_at=new_grade_completed_at,
     )
     return events, new_state
 

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any

--- a/src/quodeq/ui/.env.example
+++ b/src/quodeq/ui/.env.example
@@ -4,3 +4,8 @@
 # Default off during the rollout window. Flip to true once the SSE backend
 # (Plan 2 PR) has soaked for a release.
 VITE_USE_SSE_EVENTS=false
+
+# Subscribe to live grade updates via the per-run SSE stream's scores.updated
+# event. When false, the UI continues to refetch /scores after every dismiss
+# (legacy behavior). Default off during the one-release soak after PR 3.
+VITE_USE_LIVE_GRADES=false

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { useProjectScores } from "../../../hooks/useProjectScores.js";
 import { projectKeys } from "../../../api/queryKeys.js";
+import { useGradeStream } from "../../explorer/hooks/useGradeStream.js";
 
 /**
  * @param {{
@@ -47,13 +48,52 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
     return { ...dashboardQuery.data, trend };
   }, [dashboardQuery.data, scores, latestScores]);
 
+  // The canonical run ID is resolved by the server and echoed in the dashboard
+  // payload as selectedRun.runId. Use that for the SSE subscription so "latest"
+  // always maps to the correct run.
+  const resolvedRunId = dashboardWithTrend?.selectedRun?.runId ?? null;
+
+  // Live grade updates via SSE. useGradeStream is a no-op when
+  // VITE_USE_LIVE_GRADES !== 'true' or resolvedRunId is null.
+  const gradeStream = useGradeStream({ project: selectedProject, runId: resolvedRunId });
+
+  // Override grade fields on dashboard.dimensions when an SSE payload arrives.
+  // Violations lists are preserved — only scores/grades change.
+  const [livePatches, setLivePatches] = useState(null);
+  useEffect(() => {
+    if (!gradeStream.payload) return;
+    const patchMap = new Map(
+      (gradeStream.payload.dimensions || []).map((d) => [d.dimension, d]),
+    );
+    setLivePatches(patchMap);
+  }, [gradeStream.payload]);
+
+  const liveDashboard = useMemo(() => {
+    if (!dashboardWithTrend) return null;
+    if (!livePatches) return dashboardWithTrend;
+    return {
+      ...dashboardWithTrend,
+      dimensions: (dashboardWithTrend.dimensions || []).map((dim) => {
+        const patch = livePatches.get(dim.dimension);
+        if (!patch) return dim;
+        // Merge only the grade/score fields; preserve violations, compliance,
+        // principles, and all other Dimension properties from the initial fetch.
+        return {
+          ...dim,
+          overallScore: patch.overallScore ?? dim.overallScore,
+          overallGrade: patch.overallGrade ?? dim.overallGrade,
+        };
+      }),
+    };
+  }, [dashboardWithTrend, livePatches]);
+
   const refreshDashboard = useCallback(() => {
     if (!selectedProject) return;
     queryClient.invalidateQueries({ queryKey: projectKeys.project(selectedProject) });
   }, [queryClient, selectedProject]);
 
   return {
-    dashboard: dashboardWithTrend,
+    dashboard: liveDashboard,
     accumulated: scores?.accumulated || null,
     latestAccumulated: latestScores?.accumulated || null,
     rescoreLookup: {},

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { useDashboard } from "./useDashboard";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
 import { ApiProvider } from "../../../api/ApiContext.jsx";
+import { MockEventSource } from "../../../test-utils/MockEventSource.js";
 
 const fakeApi = {
   getDashboard: vi.fn(async (project, run) => ({
@@ -11,6 +12,10 @@ const fakeApi = {
     run: run || "latest",
     trend: [],
     summary: { score: 75 },
+    dimensions: [
+      { dimension: "Security", overallScore: "7.0/10", overallGrade: "B", violations: [], compliance: [], principles: [] },
+    ],
+    selectedRun: { runId: "r1", dateLabel: "2026-05-01" },
   })),
 };
 
@@ -58,6 +63,110 @@ describe("useDashboard", () => {
     );
     await waitFor(() => {
       expect(Array.isArray(result.current.dashboard?.trend)).toBe(true);
+    });
+  });
+});
+
+describe("useDashboard — live grades (VITE_USE_LIVE_GRADES=true)", () => {
+  let originalEventSource;
+  let originalFlag;
+
+  beforeEach(() => {
+    originalEventSource = global.EventSource;
+    originalFlag = import.meta.env.VITE_USE_LIVE_GRADES;
+    MockEventSource.last = null;
+    global.EventSource = MockEventSource;
+    import.meta.env.VITE_USE_LIVE_GRADES = "true";
+  });
+
+  afterEach(() => {
+    global.EventSource = originalEventSource;
+    import.meta.env.VITE_USE_LIVE_GRADES = originalFlag;
+  });
+
+  it("subscribes to useGradeStream once the dashboard runId is known", async () => {
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1" }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    // Wait for the dashboard fetch to resolve so runId is known.
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(MockEventSource.last).not.toBeNull();
+    expect(MockEventSource.last.url).toBe("/api/evaluations/r1/events");
+  });
+
+  it("does not subscribe when flag is off", async () => {
+    import.meta.env.VITE_USE_LIVE_GRADES = "false";
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1" }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(MockEventSource.last).toBeNull();
+  });
+
+  it("updates dashboard.dimensions grades when scores.updated SSE arrives", async () => {
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1" }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+
+    const payload = {
+      dimensions: [
+        { dimension: "Security", overallScore: "9.0/10", overallGrade: "A" },
+      ],
+      summary: { overallGrade: "A", numericAverage: 9.0 },
+    };
+
+    act(() => {
+      MockEventSource.last.emit("scores.updated", payload);
+    });
+
+    await waitFor(() => {
+      const sec = result.current.dashboard.dimensions.find((d) => d.dimension === "Security");
+      expect(sec?.overallGrade).toBe("A");
+      expect(sec?.overallScore).toBe("9.0/10");
+    });
+  });
+
+  it("preserves violations list when SSE patches grades", async () => {
+    fakeApi.getDashboard.mockImplementationOnce(async () => ({
+      project: "p1",
+      run: "r1",
+      trend: [],
+      summary: { score: 75 },
+      dimensions: [
+        {
+          dimension: "Security",
+          overallScore: "7.0/10",
+          overallGrade: "B",
+          violations: [{ file: "a.py", line: 1, severity: "major", reason: "bad" }],
+          compliance: [],
+          principles: [],
+        },
+      ],
+      selectedRun: { runId: "r1", dateLabel: "2026-05-01" },
+    }));
+
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1" }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+
+    act(() => {
+      MockEventSource.last.emit("scores.updated", {
+        dimensions: [{ dimension: "Security", overallScore: "8.5/10", overallGrade: "B+" }],
+        summary: { overallGrade: "B+", numericAverage: 8.5 },
+      });
+    });
+
+    await waitFor(() => {
+      const sec = result.current.dashboard.dimensions.find((d) => d.dimension === "Security");
+      expect(sec?.overallGrade).toBe("B+");
+      // violations list must survive the SSE patch
+      expect(sec?.violations?.length).toBe(1);
     });
   });
 });

--- a/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/PrincipleDetailPage.jsx
@@ -1,13 +1,13 @@
-import { memo, useState, useCallback, useMemo } from 'react';
+import { memo, useState, useMemo } from 'react';
 import { buildPrinciplePlanText } from '../../../utils/planTextBuilders.js';
 import { buildPrincipleReport } from '../../../utils/reportBuilder.js';
 import { SEVERITY_ORDER as EVAL_SEVERITY_ORDER, gradeLetter } from '../../../utils/formatters.js';
-import { useApi } from '../../../api/ApiContext.jsx';
 import { EvalViolationCard, ComplianceCard } from './EvalCards.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 import { useRegisterWindowSpec, ReportContent } from '../../side-pane/index.js';
 import { useStandardDescriptions } from '../hooks/useStandardDescriptions.js';
+import { usePrincipleData } from './explorerDataHooks.js';
 
 function filterTitleSuffix(filter) {
   if (!filter || filter === 'all') return '';
@@ -140,29 +140,12 @@ function filterBySeveritySelection(filteredBySeverity, activeSevFilter) {
 }
 
 function usePrincipleFiltering(evalPrincipal, severityFilter, onDismiss) {
-  const { getRunScores } = useApi();
-  const { principle, dimension, project, runId } = evalPrincipal;
-  const [dismissedSet, setDismissedSet] = useState(new Set());
-  const [liveScore, setLiveScore] = useState(null);
-  const [liveGrade, setLiveGrade] = useState(null);
-  const [activeSevFilter, setActiveSevFilter] = useState(severityFilter || null);
   const { violations, compliance, violationsBySeverity } = useMemo(() => computeEvalPrincipleData(evalPrincipal), [evalPrincipal]);
 
-  const handleDismiss = useCallback((v) => {
-    if (!onDismiss) return;
-    onDismiss(v);
-    setDismissedSet((prev) => new Set(prev).add(`${v.file}:${v.line}`));
-    if (project && runId) {
-      getRunScores(project, runId).then((rescored) => {
-        const dimMap = new Map((rescored.dimensions || []).map((d) => [d.dimension, d]));
-        const dimData = dimMap.get(dimension);
-        if (!dimData) return;
-        const pgMap = new Map((dimData.principles || []).map((p) => [p.principle, p]));
-        const pg = pgMap.get(principle);
-        if (pg) { setLiveScore(pg.score); setLiveGrade(pg.grade); }
-      }).catch(() => {});
-    }
-  }, [onDismiss, project, runId, dimension, principle]);
+  const {
+    liveScore, liveGrade, activeSevFilter, setActiveSevFilter,
+    handleDismiss, dismissedSet,
+  } = usePrincipleData(evalPrincipal, severityFilter, onDismiss);
 
   const { filteredBySeverity, filteredViolations, liveSevCounts } = useMemo(() => {
     const bySev = {};

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -1,6 +1,7 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { buildTopOffendingFiles } from '../../../utils/explorerUtils.js';
+import { useGradeStream } from '../hooks/useGradeStream.js';
 
 export function computeAllViolations(evalData) {
   if (!evalData) return [];
@@ -135,4 +136,73 @@ export function useExplorerData(project, dimension, runId, refreshSignal) {
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);
   const stats = useDerivedExplorerStats(evalData, allViolations);
   return { evalData, loading, isFetching, error, overallGrade, principleGrades, allViolations, ...stats };
+}
+
+/**
+ * Manages per-principle live state for PrincipleDetailPage: dismissed violations,
+ * live score/grade after dismiss, severity filtering.
+ *
+ * When VITE_USE_LIVE_GRADES === 'true', subscribes to the per-run SSE stream via
+ * useGradeStream and folds incoming `scores.updated` payloads into liveScore/liveGrade.
+ * The handleDismiss handler also skips the post-dismiss getRunScores() refetch in that
+ * mode — the SSE stream will deliver the updated grades.
+ *
+ * When the flag is off (default), today's behaviour is unchanged: handleDismiss calls
+ * getRunScores() after the dismiss and sets liveScore/liveGrade from the response.
+ *
+ * @param {Object} evalPrincipal - the evalPrincipal object (principle, dimension, project, runId, ...)
+ * @param {string|null} severityFilter - initial severity filter
+ * @param {Function|null} onDismiss - callback invoked with the violation before the refetch
+ * @returns {{ liveScore, liveGrade, activeSevFilter, setActiveSevFilter, handleDismiss, dismissedSet }}
+ */
+export function usePrincipleData(evalPrincipal, severityFilter, onDismiss) {
+  const { getRunScores } = useApi();
+  const { principle, dimension, project, runId } = evalPrincipal;
+  const [dismissedSet, setDismissedSet] = useState(new Set());
+  const [liveScore, setLiveScore] = useState(null);
+  const [liveGrade, setLiveGrade] = useState(null);
+  const [activeSevFilter, setActiveSevFilter] = useState(severityFilter || null);
+
+  // Subscribe to the grade stream when the flag is on. useGradeStream is a no-op
+  // (status='idle', payload=null) when VITE_USE_LIVE_GRADES !== 'true' or runId is null.
+  const gradeStream = useGradeStream({ project, runId });
+
+  // Fold incoming SSE payloads into liveScore/liveGrade.
+  useEffect(() => {
+    if (!gradeStream.payload) return;
+    const dimMap = new Map((gradeStream.payload.dimensions || []).map((d) => [d.dimension, d]));
+    const dimData = dimMap.get(dimension);
+    if (!dimData) return;
+    const pgMap = new Map((dimData.principles || []).map((p) => [p.principle, p]));
+    const pg = pgMap.get(principle);
+    if (pg) {
+      setLiveScore(pg.score);
+      setLiveGrade(pg.grade);
+    }
+  }, [gradeStream.payload, dimension, principle]);
+
+  const handleDismiss = useCallback((v) => {
+    if (!onDismiss) return;
+    onDismiss(v);
+    setDismissedSet((prev) => new Set(prev).add(`${v.file}:${v.line}`));
+
+    if (import.meta.env.VITE_USE_LIVE_GRADES === 'true') {
+      // SSE will deliver the updated grades — no synchronous refetch needed.
+      return;
+    }
+
+    // Legacy path: refetch /scores immediately after dismiss.
+    if (project && runId) {
+      getRunScores(project, runId).then((rescored) => {
+        const dimMap = new Map((rescored.dimensions || []).map((d) => [d.dimension, d]));
+        const dimData = dimMap.get(dimension);
+        if (!dimData) return;
+        const pgMap = new Map((dimData.principles || []).map((p) => [p.principle, p]));
+        const pg = pgMap.get(principle);
+        if (pg) { setLiveScore(pg.score); setLiveGrade(pg.grade); }
+      }).catch(() => {});
+    }
+  }, [onDismiss, project, runId, dimension, principle, getRunScores]);
+
+  return { liveScore, liveGrade, activeSevFilter, setActiveSevFilter, handleDismiss, dismissedSet };
 }

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.test.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MockEventSource } from '../../../test-utils/MockEventSource.js';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { usePrincipleData } from './explorerDataHooks.js';
+
+// ---------------------------------------------------------------------------
+// Shared test fixtures
+// ---------------------------------------------------------------------------
+
+const EVAL_PRINCIPAL = {
+  principle: 'Input Validation',
+  dimension: 'Security',
+  project: 'proj',
+  runId: 'r1',
+  principleData: { violations: [], compliance: [] },
+  dimViolations: [],
+  dimCompliance: [],
+  score: '7.0/10',
+  grade: 'B',
+  dateLabel: '',
+};
+
+const RESCORE_RESPONSE = {
+  dimensions: [{
+    dimension: 'Security',
+    overallScore: '7.5/10',
+    overallGrade: 'B+',
+    principles: [{ principle: 'Input Validation', score: '8.0/10', grade: 'A-' }],
+  }],
+  summary: { overallGrade: 'B+', numericAverage: 7.5 },
+};
+
+// ---------------------------------------------------------------------------
+// API mock
+// ---------------------------------------------------------------------------
+
+const getRunScoresMock = vi.fn(async () => RESCORE_RESPONSE);
+const fakeApi = { getRunScores: getRunScoresMock };
+
+function wrapper({ children }) {
+  return <ApiProvider value={fakeApi}>{children}</ApiProvider>;
+}
+
+// ---------------------------------------------------------------------------
+// EventSource / flag lifecycle
+// ---------------------------------------------------------------------------
+
+describe('usePrincipleData with VITE_USE_LIVE_GRADES', () => {
+  let originalEventSource;
+  let originalFlag;
+
+  beforeEach(() => {
+    originalEventSource = global.EventSource;
+    originalFlag = import.meta.env.VITE_USE_LIVE_GRADES;
+    global.EventSource = MockEventSource;
+    MockEventSource.last = null;
+    getRunScoresMock.mockClear();
+  });
+
+  afterEach(() => {
+    global.EventSource = originalEventSource;
+    import.meta.env.VITE_USE_LIVE_GRADES = originalFlag;
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 1: flag ON — handleDismiss must NOT call getRunScores
+  // -------------------------------------------------------------------------
+  it('does NOT call getRunScores after dismiss when flag is on', async () => {
+    import.meta.env.VITE_USE_LIVE_GRADES = 'true';
+
+    const onDismiss = vi.fn();
+    const { result } = renderHook(
+      () => usePrincipleData(EVAL_PRINCIPAL, null, onDismiss),
+      { wrapper },
+    );
+
+    // Wait for the hook to stabilise (EventSource created when flag is on).
+    await waitFor(() => expect(MockEventSource.last).not.toBeNull());
+
+    await act(async () => {
+      result.current.handleDismiss({ file: 'a.py', line: 10, principle: 'Input Validation' });
+    });
+
+    // onDismiss forwarded, but getRunScores must NOT have been called.
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(getRunScoresMock).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: flag OFF — handleDismiss MUST call getRunScores
+  // -------------------------------------------------------------------------
+  it('DOES call getRunScores after dismiss when flag is off', async () => {
+    import.meta.env.VITE_USE_LIVE_GRADES = 'false';
+
+    const onDismiss = vi.fn();
+    const { result } = renderHook(
+      () => usePrincipleData(EVAL_PRINCIPAL, null, onDismiss),
+      { wrapper },
+    );
+
+    await act(async () => {
+      result.current.handleDismiss({ file: 'a.py', line: 10, principle: 'Input Validation' });
+    });
+
+    // getRunScores must have been called once for the post-dismiss refetch.
+    await waitFor(() => expect(getRunScoresMock).toHaveBeenCalledTimes(1));
+    expect(getRunScoresMock).toHaveBeenCalledWith('proj', 'r1');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: flag ON — SSE payload folds into liveScore / liveGrade
+  // -------------------------------------------------------------------------
+  it('updates liveScore and liveGrade from useGradeStream payload when flag is on', async () => {
+    import.meta.env.VITE_USE_LIVE_GRADES = 'true';
+
+    const { result } = renderHook(
+      () => usePrincipleData(EVAL_PRINCIPAL, null, vi.fn()),
+      { wrapper },
+    );
+
+    // Wait until useGradeStream has opened the EventSource connection.
+    await waitFor(() => expect(MockEventSource.last).not.toBeNull());
+
+    const payload = {
+      dimensions: [{
+        dimension: 'Security',
+        overallScore: '6.0/10',
+        overallGrade: 'C',
+        principles: [{ principle: 'Input Validation', score: '6.5/10', grade: 'C+' }],
+      }],
+      summary: { overallGrade: 'C', numericAverage: 6.0 },
+    };
+
+    act(() => {
+      MockEventSource.last.emit('scores.updated', payload);
+    });
+
+    await waitFor(() => {
+      expect(result.current.liveScore).toBe('6.5/10');
+      expect(result.current.liveGrade).toBe('C+');
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/hooks/useGradeStream.js
+++ b/src/quodeq/ui/src/features/explorer/hooks/useGradeStream.js
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribes to the per-run SSE stream and surfaces the latest `scores.updated`
+ * payload.
+ *
+ * Returns { payload, status, isStale } where:
+ *   - payload: the parsed scores.updated event body (same shape as /scores response), or null
+ *   - status: 'idle' | 'streaming' | 'error'
+ *   - isStale: true when the connection has dropped (UI may show a stale indicator)
+ *
+ * Gated by VITE_USE_LIVE_GRADES — when not 'true', the hook is a no-op (status='idle').
+ * Pass { project, runId } — project is accepted for call-site symmetry but the SSE
+ * endpoint is keyed by runId only (/api/evaluations/<runId>/events), matching the
+ * existing useRunEventStream URL pattern.
+ */
+export function useGradeStream({ project: _project, runId }) {
+  const [payload, setPayload] = useState(null);
+  const [status, setStatus] = useState('idle');
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    if (!runId) {
+      setPayload(null);
+      setStatus('idle');
+      setIsStale(false);
+      return undefined;
+    }
+    if (import.meta.env.VITE_USE_LIVE_GRADES !== 'true') {
+      setStatus('idle');
+      return undefined;
+    }
+
+    setStatus('streaming');
+    setIsStale(false);
+
+    // URL matches the existing per-run SSE endpoint used by useRunEventStream.
+    // See src/features/evaluation/hooks/useRunEventStream.js and
+    // src/quodeq/api/_run_events_routes.py — the route is /api/evaluations/<job_id>/events.
+    const es = new EventSource(`/api/evaluations/${runId}/events`);
+
+    es.addEventListener('scores.updated', (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        setPayload(data);
+        setIsStale(false);
+      } catch (_err) {
+        // Ignore malformed payloads; keep prior payload visible.
+      }
+    });
+
+    es.onerror = () => {
+      const CLOSED = 2;
+      if (es.readyState === CLOSED) {
+        setStatus('error');
+        setIsStale(true);
+      }
+    };
+
+    return () => { es.close(); };
+  }, [runId]);
+
+  return { payload, status, isStale };
+}

--- a/src/quodeq/ui/src/features/explorer/hooks/useGradeStream.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/hooks/useGradeStream.test.jsx
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MockEventSource } from '../../../test-utils/MockEventSource.js';
+import { useGradeStream } from './useGradeStream';
+
+describe('useGradeStream', () => {
+  let originalEventSource;
+  let originalFlag;
+
+  beforeEach(() => {
+    originalEventSource = global.EventSource;
+    originalFlag = import.meta.env.VITE_USE_LIVE_GRADES;
+    MockEventSource.last = null;
+    global.EventSource = MockEventSource;
+    import.meta.env.VITE_USE_LIVE_GRADES = 'true';
+  });
+
+  afterEach(() => {
+    global.EventSource = originalEventSource;
+    import.meta.env.VITE_USE_LIVE_GRADES = originalFlag;
+  });
+
+  it('returns idle when runId is null', () => {
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: null }));
+    expect(result.current.payload).toBeNull();
+    expect(result.current.status).toBe('idle');
+    expect(MockEventSource.last).toBeNull();
+  });
+
+  it('subscribes on mount and parses scores.updated payload', () => {
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+    expect(MockEventSource.last).not.toBeNull();
+    expect(MockEventSource.last.url).toBe('/api/evaluations/r1/events');
+    expect(result.current.status).toBe('streaming');
+
+    const payload = {
+      dimensions: [{ dimension: 'Security', overallScore: '7.4/10', overallGrade: 'B' }],
+      summary: { overallGrade: 'B', numericAverage: 7.4 },
+    };
+    act(() => { MockEventSource.last.emit('scores.updated', payload); });
+
+    expect(result.current.payload).toEqual(payload);
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it('ignores non-scores events', () => {
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+
+    act(() => { MockEventSource.last.emit('finding', { id: 1, file: 'a.py' }); });
+    act(() => { MockEventSource.last.emit('status', { state: 'running' }); });
+
+    expect(result.current.payload).toBeNull();
+  });
+
+  it('closes the connection on unmount', () => {
+    const { unmount } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+    const es = MockEventSource.last;
+    expect(es.closed).not.toBe(true);
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+
+  it('does nothing when flag is off', () => {
+    import.meta.env.VITE_USE_LIVE_GRADES = 'false';
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+    expect(MockEventSource.last).toBeNull();
+    expect(result.current.payload).toBeNull();
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('sets isStale on error', () => {
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+    const es = MockEventSource.last;
+
+    act(() => {
+      es.readyState = 2;
+      if (es.onerror) es.onerror({ type: 'error' });
+    });
+
+    expect(result.current.isStale).toBe(true);
+    expect(result.current.status).toBe('error');
+  });
+
+  it('survives malformed payload (keeps prior payload, no crash)', () => {
+    const { result } = renderHook(() => useGradeStream({ project: 'p', runId: 'r1' }));
+
+    const goodPayload = { dimensions: [], summary: {} };
+    act(() => { MockEventSource.last.emit('scores.updated', goodPayload); });
+    expect(result.current.payload).toEqual(goodPayload);
+
+    // Now emit a raw string that is already JSON-stringified by MockEventSource,
+    // making the inner JSON.parse see a bare string — not an object.
+    // We fire the event handler directly with non-JSON data to simulate malformed frame.
+    act(() => {
+      const listeners = MockEventSource.last.listeners['scores.updated'] || [];
+      listeners.forEach((fn) => fn({ data: '{invalid-json}' }));
+    });
+
+    expect(result.current.payload).toEqual(goodPayload); // prior preserved
+  });
+});

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -307,3 +307,79 @@ def test_run_events_generator_handles_already_terminal_run(tmp_path: Path):
     assert any("event: status" in f for f in non_keepalive)
     assert any("event: finding" in f for f in non_keepalive)
     assert any("event: done" in f for f in non_keepalive)
+
+
+# ---------------------------------------------------------------------------
+# scores.updated event tests
+# ---------------------------------------------------------------------------
+
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+
+def _seed_run_with_finding(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a minimal run dir with one finding and trigger initial projection."""
+    project_dir = tmp_path / "myproject"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1", severity="high",
+    )))
+    # Trigger projection + grade compute via a read.
+    SqliteFindingsRepository(run_dir).list_by_dimension("Security")
+    return project_dir, run_dir
+
+
+def test_compute_tick_emits_scores_updated_when_grades_advance(tmp_path: Path) -> None:
+    """When dimension_scores' MAX(completed_at) advances since the last tick,
+    compute_tick emits a scores.updated event with the full /scores payload."""
+    _project_dir, run_dir = _seed_run_with_finding(tmp_path)
+
+    state = WatcherState()
+    events, new_state = compute_tick(run_dir, state)
+
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert len(grade_events) == 1, f"Expected one scores.updated event, got: {[e[0] for e in events]}"
+    assert new_state.last_grade_completed_at is not None
+
+
+def test_compute_tick_does_not_reemit_scores_when_unchanged(tmp_path: Path) -> None:
+    """Subsequent ticks against the same projected state do not re-emit scores.updated."""
+    _project_dir, run_dir = _seed_run_with_finding(tmp_path)
+
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)  # first tick captures the score
+
+    events, _ = compute_tick(run_dir, state)  # second tick, no change
+
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert grade_events == []
+
+
+def test_compute_tick_emits_scores_updated_after_dismiss(tmp_path: Path) -> None:
+    """A dismiss event between ticks causes a fresh scores.updated emission."""
+    from quodeq.services.dismissed import dismiss_finding
+
+    project_dir, run_dir = _seed_run_with_finding(tmp_path)
+
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)  # baseline
+
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    events, _ = compute_tick(run_dir, state)
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert len(grade_events) == 1
+
+
+def test_compute_tick_no_scores_event_when_no_grades_table(tmp_path: Path) -> None:
+    """When the run has no projected grades (no findings, no DB), no scores.updated emits."""
+    project_dir = tmp_path / "myproject"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+    # No events.jsonl at all -- empty run_dir.
+    state = WatcherState()
+    events, _ = compute_tick(run_dir, state)
+
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert grade_events == []

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -340,7 +340,7 @@ def test_compute_tick_emits_scores_updated_when_grades_advance(tmp_path: Path) -
 
     grade_events = [e for e in events if e[0] == "scores.updated"]
     assert len(grade_events) == 1, f"Expected one scores.updated event, got: {[e[0] for e in events]}"
-    assert new_state.last_grade_completed_at is not None
+    assert new_state.last_grade_fingerprint is not None
 
 
 def test_compute_tick_does_not_reemit_scores_when_unchanged(tmp_path: Path) -> None:
@@ -383,3 +383,31 @@ def test_compute_tick_no_scores_event_when_no_grades_table(tmp_path: Path) -> No
 
     grade_events = [e for e in events if e[0] == "scores.updated"]
     assert grade_events == []
+
+
+def test_compute_tick_emits_scores_updated_when_all_findings_dismissed(tmp_path: Path) -> None:
+    """When all findings are dismissed, dimension_scores ends up empty.
+    The next tick must still emit scores.updated to inform clients
+    that the previous score state is no longer valid.
+
+    This is the primary justification for using a fingerprint instead of
+    MAX(completed_at) for change detection."""
+    from quodeq.services.dismissed import dismiss_finding
+
+    project_dir, run_dir = _seed_run_with_finding(tmp_path)
+
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)  # baseline: dimension_scores populated
+
+    # Dismiss the only finding → dimension_scores will become empty after re-projection.
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    events, new_state = compute_tick(run_dir, state)
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+
+    assert len(grade_events) == 1, (
+        "scores.updated must fire when dimension_scores transitions to empty; "
+        f"events were: {[e[0] for e in events]}"
+    )
+    # The fingerprint should reflect the empty state.
+    assert new_state.last_grade_fingerprint != state.last_grade_fingerprint

--- a/tests/integration/test_live_grades_pr3_flow.py
+++ b/tests/integration/test_live_grades_pr3_flow.py
@@ -1,0 +1,79 @@
+"""End-to-end: dismiss via API → SSE tick emits scores.updated within one cycle."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.api._run_event_stream import WatcherState, compute_tick
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+from quodeq.services.dismissed import dismiss_finding
+
+
+def test_dismiss_triggers_scores_updated_on_next_tick(tmp_path: Path) -> None:
+    project_dir = tmp_path / "myproject"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+
+    # Seed a finding.
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1", severity="high",
+    )))
+    SqliteFindingsRepository(run_dir).list_by_dimension("Security")
+
+    # Baseline tick captures current grade.
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)
+
+    # User dismisses.
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    # Next tick should fire scores.updated with the new (post-dismiss) payload.
+    events, _ = compute_tick(run_dir, state)
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+
+    assert len(grade_events) == 1, f"Expected scores.updated event after dismiss, got: {[e[0] for e in events]}"
+
+    # The payload should reflect the dismiss.
+    payload = json.loads(grade_events[0][1])
+    security = next((d for d in payload.get("dimensions", []) if d.get("dimension") == "Security"), None)
+    # After dismissal of the only finding, Security may have no row OR have a None/null score.
+    assert security is None or security.get("overallScore") is None
+
+
+def test_grade_no_change_does_not_emit_scores_updated(tmp_path: Path) -> None:
+    """Ticks without grade changes do not emit scores.updated."""
+    project_dir = tmp_path / "myproject"
+    run_dir = project_dir / "runs" / "r1"
+    run_dir.mkdir(parents=True)
+
+    # Seed two findings with critical and low severities in separate dimensions.
+    log = run_dir / "events.jsonl"
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="f0.py", line=10, reason="r", req="R0", severity="critical",
+    )))
+    EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P2", verdict="violation", dimension="Reliability",
+        file="f1.py", line=10, reason="r", req="R1", severity="low",
+    )))
+    SqliteFindingsRepository(run_dir).list_by_dimension("Security")
+
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)
+
+    # Dismiss the Security critical finding — should trigger scores.updated.
+    dismiss_finding(project_dir, {"req": "R0", "file": "f0.py", "line": 10})
+    events1, state = compute_tick(run_dir, state)
+    assert len([e for e in events1 if e[0] == "scores.updated"]) == 1
+
+    # Dismiss the Reliability low finding — also triggers (dimension removed).
+    dismiss_finding(project_dir, {"req": "R1", "file": "f1.py", "line": 10})
+    events2, state = compute_tick(run_dir, state)
+    assert len([e for e in events2 if e[0] == "scores.updated"]) == 1
+
+    # No dismiss + tick — should NOT emit (no grade change).
+    events3, _ = compute_tick(run_dir, state)
+    assert len([e for e in events3 if e[0] == "scores.updated"]) == 0


### PR DESCRIPTION
## Summary

Deliver live grade updates to the UI via SSE. **PR 3 of 4** for the live-grades feature.

Depends on [#516](https://github.com/quodeq/quodeq/pull/516) (PR 1: actions.jsonl + projection) and [#517](https://github.com/quodeq/quodeq/pull/517) (PR 2: SQL grade tables + canonical scoring).

### Backend

`compute_tick` in `_run_event_stream.py` now emits a `scores.updated` SSE event whenever `dimension_scores` changes between ticks. Change detection uses a full-row fingerprint (\`repr()\` of all dimension/score/grade rows) rather than \`MAX(completed_at)\` — handles the full-dismiss case where the table transitions to empty (and turned out to also avoid a SQLite re-entrancy issue from opening a second connection inside the outer SELECT).

The tick calls \`SqliteFindingsRepository(run_dir)._ensure_fresh()\` each cycle so any \`actions.jsonl\` deltas get projected before the change check.

### Frontend

- New \`useGradeStream\` hook subscribes to \`/api/evaluations/<runId>/events\` and surfaces the latest \`scores.updated\` payload.
- \`usePrincipleData\` (extracted from \`PrincipleDetailPage\` into \`explorerDataHooks.js\`) subscribes to the stream when the flag is on and skips the post-dismiss \`getRunScores()\` refetch.
- \`useDashboard\` folds SSE payloads into \`dashboard.dimensions\` grades via a \`livePatches\` Map — preserves \`violations\`, \`compliance\`, \`principles\` lists from the initial fetch; only \`overallScore\`/\`overallGrade\` get patched.

### Feature flag

All frontend behavior is gated behind \`VITE_USE_LIVE_GRADES\` (default \`false\` for one-release soak). With the flag off, nothing changes from PR 2.

## Out of scope

- **No legacy code deletion** — \`_rescore.py\`, \`_summary.py\`, \`dismissed.json\` writes, and the synchronous \`getRunScores\` refetch path are all preserved. PR 4 deletes them after the soak.
- **No reconnect logic beyond basic onerror** — connection drops require page reload. Robust reconnection is a follow-up.

## Test plan

- [x] All 2987 unit + integration tests pass locally
- [x] All 357 frontend tests pass locally
- [x] **Flip \`VITE_USE_LIVE_GRADES=true\` locally**, rebuild UI, open a project, dismiss a finding on Principle Detail — grade updates within ~1s **without spinner** (the user-facing fix)
- [x] Navigate back to Overview — no spinner, grades match Standard Detail (PR 2's invariant still holds, PR 3 adds the live delivery)
- [x] Open the same run in two browser tabs, dismiss in tab A — tab B's grade updates without user action (multi-subscriber test)
- [x] Open DevTools Network: dismiss with flag on — POST \`/api/findings/dismiss\` happens, NO subsequent GET \`/api/projects/.../scores/...\` call. Grade update arrives via SSE
- [x] Toggle flag off, dismiss — grade still updates (legacy refetch path), Network shows the GET happening after the POST