### PR TITLE
docs(scoring): document dimension weights as aspirational, not applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@ __pycache__/
 .venv/
 evaluations/
 
-docs/
+docs/*
+!docs/adr/
 specs/
 reports/
 src/tmp/

--- a/docs/adr/0001-dimension-level-weighting-not-yet-applied.md
+++ b/docs/adr/0001-dimension-level-weighting-not-yet-applied.md
@@ -1,0 +1,142 @@
+# ADR 0001: Dimension-level weighting is not yet applied
+
+## Status
+
+Accepted (documents existing behavior). Bootstraps `docs/adr/`.
+
+## Context
+
+`src/quodeq/data/config/dimensions.json` declares a `weight` field on every
+entry in `applies`, with values that look deliberately tuned:
+
+| Dimension       | Weight |
+| --------------- | ------ |
+| security        | 1.2    |
+| reliability     | 1.0    |
+| maintainability | 1.0    |
+| performance     | 0.8    |
+| usability       | 0.6    |
+| flexibility     | 0.6    |
+| clean-architecture | 1.0 |
+| domain-driven-design | 1.0 |
+
+The `iso_25010` and `source` fields point at ISO/IEC 25010:2023 as the
+underlying model. `dimensions_schema.json` lists `weight` as required and
+`tests/engine/test_universal_dimensions.py::test_all_dimensions_have_weight`
+enforces it. The weight is also read by Python:
+
+* `services/_standards_io.py::build_builtin_meta` reads `dim["weight"]`
+  into `StandardMeta.weight`.
+* `services/_standards_io.py::get_builtin_weight` is called by
+  `services/_standards_queries.py::get_standard` to populate
+  `StandardDetail.weight`.
+* `core/types/standard.py` carries `weight: float` on both
+  `StandardMeta` (line 20) and `StandardDetail` (line 36).
+* The custom-standards CRUD path round-trips `weight` through
+  `services/_standards_crud.py::duplicate` and the API.
+
+So the field is present, validated, populated, and surfaced through the API.
+
+### What it does NOT do
+
+No scoring path multiplies any score by this weight. Both
+dimension-to-run aggregators take a plain unweighted mean:
+
+* Legacy: `data/fs/report_parser/_summary.py::summarize_dimensions`
+  computes `sum(numeric_scores) / len(numeric_scores)`.
+* SQL projection: `services/scoring/projector_scoring.py::compute_run_score`
+  computes `sum(scored) / len(scored)`, and the mirror read path
+  `data/sqlite/state_store.py::read_run_score_from_dim_scores` does the
+  same.
+
+The only weighted aggregation in the scoring stack is `weighted_overall`
+in `core/scoring/overall.py`, which uses *principle-level*
+`PrincipleScore.weight` (a multiplier label like `"High (x3)"`). That is a
+separate concept from the `dimensions.json` weights.
+
+### What the UI tells users
+
+`src/quodeq/ui/src/features/help/components/HelpSections.jsx:252` reads:
+
+> Each dimension is scored 0 to 10 with a letter grade. The project grade
+> is a weighted average across enabled dimensions. See *Philosophy* for the
+> full Q² formula.
+
+This sentence is currently misleading: the project grade is a plain mean,
+not a weighted average. The Philosophy section describes principle-level
+scoring honestly and does not claim dimension-level weighting.
+
+## Decision
+
+Treat the per-dimension `weight` field as **aspirational, not applied**.
+
+Keep the field, the schema requirement, the test, and the round-trip
+through `StandardMeta` / `StandardDetail`. Document the state of play
+inline with a top-level `_note` field in `dimensions.json` so the next
+reader does not have to grep the codebase to figure out whether the
+weights are live.
+
+This avoids a breaking change to:
+
+* the dimensions schema and validator,
+* the custom-standards JSON contract (uploaded standards carry `weight`),
+* the API shape consumed by the standards UI.
+
+## Consequences
+
+* The next person opening `dimensions.json` sees the note and knows the
+  weights are not yet applied.
+* Anyone planning to ship dimension-level weighting now has a checklist
+  of touch points (see below) and a heads-up that grades will shift.
+* The misleading help-copy sentence stays in place for now, since fixing
+  it commits us to either landing weighting soon or removing the field.
+  It is called out as a follow-up in the PR that introduces this ADR.
+
+## Implementing weighted aggregation later
+
+A future "apply dimension weights" PR would need to touch:
+
+1. `data/fs/report_parser/_summary.py::summarize_dimensions`. The
+   function currently does not receive weights. Either pass a weight
+   lookup from the caller, or look up weights via the standards service.
+2. `services/scoring/projector_scoring.py::compute_run_score` and the
+   mirror reader `data/sqlite/state_store.py::read_run_score_from_dim_scores`.
+   Both currently compute a plain mean over the `dim_scores` projection.
+   Decide whether the weight lives in the SQL projection (denormalised
+   into the dim row) or is joined in at read time.
+3. The parity logger in PR2 of the live-grades work needs to be re-run
+   after the change, because legacy vs SQL parity is currently exact
+   *only because* both paths ignore weights identically. Once weights
+   are applied, both paths must agree on the same weight source and the
+   same formula.
+4. `CHANGELOG.md`: document that project-level grades will shift for
+   evaluations that mix high-weight and low-weight dimensions. Existing
+   stored run scores in `evaluation.db` are a frozen projection of the
+   old formula and can stay as is, but the next scoring run will produce
+   different values for the same findings.
+5. `src/quodeq/ui/src/features/help/components/HelpSections.jsx:252` is
+   already correct text for the post-change world; no edit needed.
+6. The Philosophy section may want a short mention of the dimension
+   weight table so the help copy is no longer the only place the user
+   encounters the concept.
+
+## Alternatives considered
+
+* **Delete the field**. Tempting, but the values look deliberate and the
+  field is part of the on-disk schema for custom standards. Deleting
+  would be a breaking change for users who have uploaded standards with
+  `weight` set.
+* **Rename to `weight_planned`**. Same breaking-change problem, and it
+  fragments the `StandardMeta.weight` round-trip path.
+* **Apply the weights now**. Out of scope for a docs/cleanup pass, and
+  would shift every grade quietly without a parity-logger sweep.
+
+## References
+
+* `src/quodeq/data/config/dimensions.json`
+* `src/quodeq/analysis/plugins/schemas/dimensions_schema.json`
+* `src/quodeq/services/_standards_io.py`
+* `src/quodeq/services/scoring/projector_scoring.py`
+* `src/quodeq/data/fs/report_parser/_summary.py`
+* `src/quodeq/core/types/standard.py`
+* `src/quodeq/ui/src/features/help/components/HelpSections.jsx`

--- a/src/quodeq/analysis/plugins/schemas/dimensions_schema.json
+++ b/src/quodeq/analysis/plugins/schemas/dimensions_schema.json
@@ -4,6 +4,7 @@
   "type": "object",
   "required": ["applies"],
   "properties": {
+    "_note": { "type": "string" },
     "applies": {
       "type": "array",
       "items": {

--- a/src/quodeq/data/config/dimensions.json
+++ b/src/quodeq/data/config/dimensions.json
@@ -1,4 +1,5 @@
 {
+  "_note": "The per-dimension 'weight' field is declared but NOT yet applied to scoring. Both aggregation paths (legacy summarize_dimensions and SQL compute_run_score) take a plain unweighted mean of dimension scores. The values here are aspirational, retained for a future weighted-aggregation feature. See docs/adr/0001-dimension-level-weighting-not-yet-applied.md.",
   "applies": [
     {
       "id": "security",


### PR DESCRIPTION
## Summary

Same change as [#519](https://github.com/quodeq/quodeq/pull/519), retargeted onto `develop`. The original PR merged into `feat/live-grades-pr2`, but [#517](https://github.com/quodeq/quodeq/pull/517) had already merged that branch into `develop` an hour earlier, so my change never reached `develop`. Cherry-picked `898fed8d` onto a fresh branch off `origin/develop`.

Flagged during architectural review of `compute_run_score` while planning PR2 of the live-grades work: every entry in [src/quodeq/data/config/dimensions.json](src/quodeq/data/config/dimensions.json) declares a `weight` (security=1.2, performance=0.8, usability/flexibility=0.6, others=1.0), but no scoring path applies them. This PR documents the gap without changing scoring logic.

## What I found

**Classification: aspirational**, with a derivative live issue in user-facing copy.

The field is **read by Python**, just not in aggregation:

- [`build_builtin_meta`](src/quodeq/services/_standards_io.py:81) reads `dim["weight"]` into [`StandardMeta.weight`](src/quodeq/core/types/standard.py:20).
- [`get_builtin_weight`](src/quodeq/services/_standards_io.py:102) is called from [`get_standard`](src/quodeq/services/_standards_queries.py:76) to populate [`StandardDetail.weight`](src/quodeq/core/types/standard.py:36).
- Custom standards round-trip `weight` through [`duplicate`](src/quodeq/services/_standards_crud.py:80) and the API, and the UI seeds new custom standards with `weight: 1.0` in [`useStandardDetail.js:99`](src/quodeq/ui/src/features/standards/hooks/useStandardDetail.js:99).

But **no aggregation uses it**:

- Legacy: [`summarize_dimensions`](src/quodeq/data/fs/report_parser/_summary.py:25) computes `sum(numeric_scores) / len(numeric_scores)`.
- SQL projection: [`compute_run_score`](src/quodeq/services/scoring/projector_scoring.py:110) and the mirror reader `read_run_score_from_dim_scores` both do the same plain mean.

The only weighted aggregator in the scoring stack is [`weighted_overall`](src/quodeq/core/scoring/overall.py) which uses **principle-level** `PrincipleScore.weight` (a `"High (x3)"` style label), a separate concept.

### Evidence this was deliberate, not vestigial

- The schema requires `weight` ([dimensions_schema.json:11](src/quodeq/analysis/plugins/schemas/dimensions_schema.json:11)) and a test enforces it (`test_all_dimensions_have_weight`).
- Values match ISO/IEC 25010 prioritization (risk-bearing dimensions weighted higher than usability/flexibility), not random defaults.
- The field has been carried forward intact since the universal-analysis refactor in March 2026.

## Derivative live issue (not fixed here)

[`HelpSections.jsx:252`](src/quodeq/ui/src/features/help/components/HelpSections.jsx:252) tells users:

> The project grade is a weighted average across enabled dimensions.

The project grade is currently a plain mean. The copy is either correct for the future weighted-aggregation world (consistent with the aspirational classification) or wrong today. Left in place; called out so a future PR can decide whether to ship weighting or correct the copy.

## What this PR does

- Adds a top-level `_note` to `dimensions.json` so the next reader sees the status inline.
- Updates `dimensions_schema.json` to permit the new top-level property.
- Adds [docs/adr/0001-dimension-level-weighting-not-yet-applied.md](docs/adr/0001-dimension-level-weighting-not-yet-applied.md) with the full story, a checklist of touch points for a future weighted-aggregation PR, and the alternatives considered.
- Whitelists `docs/adr/` in `.gitignore` (was `docs/`, now `docs/*` + `!docs/adr/`) so ADRs ship with the repo while the rest of `docs/` stays local-only.

Intentionally **not** touched:

- `StandardMeta.weight` / `StandardDetail.weight` (still used for API round-trip).
- Any scoring logic.
- The `HelpSections.jsx` copy.

## Test plan

- [x] `pytest tests/engine/test_universal_dimensions.py tests/engine/test_schema_validator.py tests/services/test_standards_service.py` (26 passed) confirms loader + schema still happy with the new `_note` field.
- [x] `load_universal_dimensions` smoke-loaded against the modified file: 8 dims, `_note` present, no validation errors.
- [x] CI green on this PR.