### PR TITLE
chore(gitignore): revert docs/adr whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,7 @@ __pycache__/
 .venv/
 evaluations/
 
-docs/*
-!docs/adr/
+docs/
 specs/
 reports/
 src/tmp/


### PR DESCRIPTION
## Summary

[#521](https://github.com/quodeq/quodeq/pull/521) changed `.gitignore` from `docs/` to `docs/*` + `!docs/adr/` so the new ADR could be tracked. Side effect: pre-existing local-only files under `docs/adr/` (e.g. `0001-event-sourcing-for-persistence.md`) also stopped being ignored and started showing up as untracked.

This PR reverts that line to `docs/`.

The ADR added in #521 (`docs/adr/0001-dimension-level-weighting-not-yet-applied.md`) stays tracked because `.gitignore` does not untrack files already in the index. Future ADRs intended to ship will need to live outside `docs/`, or be force-added.

## Test plan

- [x] `git check-ignore -v docs/adr/0001-event-sourcing-for-persistence.md` confirms it is ignored again (matches `docs/` rule).
- [x] `git ls-files docs/` still lists `docs/adr/0001-dimension-level-weighting-not-yet-applied.md`.