### PR TITLE
fix(live-grades): dismiss + grade updates broken on prod layout

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -264,9 +264,9 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
         current_fingerprint = repr(rows) if rows else None
         if current_fingerprint != state.last_grade_fingerprint:
             from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
-            # run_dir layout: <reports_root>/<project>/runs/<run_id>
-            reports_root = run_dir.parent.parent.parent
-            project = run_dir.parent.parent.name
+            # run_dir layout: <reports_root>/<project>/<run_id>
+            reports_root = run_dir.parent.parent
+            project = run_dir.parent.name
             run_id = run_dir.name
             payload = get_scores_raw(reports_root, project, run_id)
             grade_event = ("scores.updated", serialize_scores_updated_event(payload), None)

--- a/src/quodeq/context/precedent.py
+++ b/src/quodeq/context/precedent.py
@@ -51,9 +51,9 @@ def fingerprint(req: str | None, snippet: str | None) -> str | None:
 def load_precedent_fingerprints(project_dir: Path) -> set[str]:
     """Load fingerprints for every dismissed finding in *project_dir*.
 
-    Aggregates across ``runs/<run_id>/evaluation.db``. Missing or locked DBs
-    are skipped -- precedent matching degrades gracefully and never breaks a
-    scan.
+    Aggregates across ``<run_id>/evaluation.db`` under *project_dir*. Missing
+    or locked DBs are skipped -- precedent matching degrades gracefully and
+    never breaks a scan.
 
     Legacy note: prior to PR 1 (live-grades), dismissals were stored in
     ``<project_dir>/dismissed.json``. The migration in
@@ -63,12 +63,9 @@ def load_precedent_fingerprints(project_dir: Path) -> set[str]:
     """
     if not project_dir or not project_dir.is_dir():
         return set()
-    runs_root = project_dir / "runs"
-    if not runs_root.is_dir():
-        return set()
 
     out: set[str] = set()
-    for run_dir in runs_root.iterdir():
+    for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
         db_path = run_dir / "evaluation.db"

--- a/src/quodeq/data/projection/projector.py
+++ b/src/quodeq/data/projection/projector.py
@@ -77,6 +77,12 @@ class Projector:
             current_size = events_path.stat().st_size
             events_changed = projected_size is None or projected_size != current_size
 
+            # Pre-PR-1 DBs have a checkpoint (older code projected them) but no
+            # ``projection_event_log_size`` key (added in PR 1). Their findings
+            # may be missing columns the current mappers write (e.g. requirement).
+            # Force a full rebuild on first contact so every column is correct.
+            pre_pr1_db = projected_size is None and store.get_checkpoint() is not None
+
             # Actions.jsonl branch (new)
             actions_changed = False
             actions_log: Path | None = None
@@ -91,7 +97,7 @@ class Projector:
 
             # Project events first (so new findings exist before action events touch them).
             if events_changed:
-                result = self.project(events_path, run_dir)
+                result = self.project(events_path, run_dir, force_rebuild=pre_pr1_db)
             else:
                 result = ProjectionResult(events_projected=0, rebuilt=False)
 

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -52,7 +52,7 @@ class SqliteFindingsRepository:
 
     def _ensure_fresh(self) -> None:
         if self._events_log.is_file():
-            project_dir = self._run_dir.parent.parent
+            project_dir = self._run_dir.parent
             self._projector.ensure_projected(
                 self._events_log,
                 self._run_dir,

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -181,26 +181,41 @@ class EvaluationsIndex:
             db.close()
 
     def get_log_run_dir(self, job_id: str) -> Path | None:
-        """Return the run_dir for *job_id*, or None if unknown."""
-        if job_id.startswith("ext-"):
-            run_id = job_id[len("ext-"):]
-            reports_root = self._resolve_reports_root()
-            if reports_root is None or not reports_root.is_dir():
-                return None
-            for project_dir in reports_root.iterdir():
-                if not project_dir.is_dir():
-                    continue
-                candidate = project_dir / run_id
-                if candidate.is_dir():
-                    return candidate
-            return None
-        snapshot = self._jobs.get_job(job_id)
-        if snapshot is None or snapshot.output_project is None or snapshot.output_run_id is None:
-            return None
+        """Return the run_dir for *job_id*, or None if unknown.
+
+        Accepts either a bare run_id ("d5b8a421-...") or an "ext-<run_id>"
+        form. For active jobs we look up output_project/output_run_id via the
+        jobs index (efficient); for completed runs without a job entry we fall
+        back to a filesystem scan so the SSE endpoint keeps working for any
+        run that exists on disk.
+        """
+        run_id = job_id[len("ext-"):] if job_id.startswith("ext-") else job_id
+
+        # Active-job fast path: trust the jobs index when present.
+        if not job_id.startswith("ext-"):
+            snapshot = self._jobs.get_job(job_id)
+            if (
+                snapshot is not None
+                and snapshot.output_project is not None
+                and snapshot.output_run_id is not None
+            ):
+                reports_root = self._resolve_reports_root()
+                if reports_root is not None:
+                    candidate = reports_root / snapshot.output_project / snapshot.output_run_id
+                    if candidate.is_dir():
+                        return candidate
+
+        # Filesystem fallback: scan reports_root for <project>/<run_id>/.
         reports_root = self._resolve_reports_root()
-        if reports_root is None:
+        if reports_root is None or not reports_root.is_dir():
             return None
-        return reports_root / snapshot.output_project / snapshot.output_run_id
+        for project_dir in reports_root.iterdir():
+            if not project_dir.is_dir():
+                continue
+            candidate = project_dir / run_id
+            if candidate.is_dir():
+                return candidate
+        return None
 
     def rebuild(self, reports_root: Path | None = None) -> tuple[int, int]:
         """Rebuild the index from scratch by walking *reports_root*.

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -376,7 +376,7 @@ def _apply_sql_grade_override(
     from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
     from quodeq.data.sqlite.state_store import SQLiteStateStore  # noqa: PLC0415
 
-    run_dir = reports_root / project / "runs" / run_id
+    run_dir = reports_root / project / run_id
     if not run_dir.is_dir():
         return payload
 

--- a/src/quodeq/services/deleted.py
+++ b/src/quodeq/services/deleted.py
@@ -156,12 +156,11 @@ def _sweep_dismissed_matching(project_dir: Path, key: tuple) -> int:
     from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
 
     dimension, principle, file = key
-    runs_root = project_dir / "runs"
-    if not runs_root.is_dir():
+    if not project_dir.is_dir():
         return 0
 
     matching: list[tuple[str, str, int]] = []
-    for run_dir in runs_root.iterdir():
+    for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
         db_path = run_dir / "evaluation.db"

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -44,12 +44,11 @@ def restore_finding(project_dir: Path, finding: dict) -> None:
 
 def dismissed_keys(project_dir: Path) -> set[tuple]:
     """Aggregate dismissed (req, file, line) keys across all run DBs under project_dir."""
-    runs_root = project_dir / "runs"
-    if not runs_root.is_dir():
+    if not project_dir.is_dir():
         return set()
 
     keys: set[tuple] = set()
-    for run_dir in runs_root.iterdir():
+    for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
         db_path = run_dir / "evaluation.db"
@@ -76,11 +75,10 @@ def load_dismissed(
 
     Reads from each run's evaluation.db, aggregated across all runs.
     """
-    runs_root = project_dir / "runs"
-    if not runs_root.is_dir():
+    if not project_dir.is_dir():
         return []
     items: list[dict] = []
-    for run_dir in runs_root.iterdir():
+    for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
         db_path = run_dir / "evaluation.db"

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -244,7 +244,7 @@ def get_scores_raw(
     Reads from SQL grade tables after projection. Returns an empty shape when
     grade tables are empty (run not yet projected or has no findings).
     """
-    run_dir = reports_root / project / "runs" / run_id
+    run_dir = reports_root / project / run_id
     if not run_dir.is_dir():
         raise FileNotFoundError(f"Run directory not found: {run_dir}")
 

--- a/tests/analysis/mcp/test_findings_server.py
+++ b/tests/analysis/mcp/test_findings_server.py
@@ -29,13 +29,13 @@ def test_build_router_loads_precedent_fingerprints_from_project_dir(tmp_path: Pa
     from quodeq.services.dismissed import dismiss_finding
 
     # The project layout expected by _build_router:
-    # project_dir/runs/<run_id>/ -- for dismissed_keys / load_precedent_fingerprints
+    # project_dir/<run_id>/ -- for dismissed_keys / load_precedent_fingerprints
     # project_dir/<run_name>/evidence/<dim>_evidence.jsonl -- for the MCP server path
     project_dir = tmp_path / "project"
     project_dir.mkdir()
 
-    # Seed a finding in a named run under project_dir/runs/ so SQL has a dismissed row.
-    run_dir = project_dir / "runs" / "r1"
+    # Seed a finding in a named run under project_dir/ so SQL has a dismissed row.
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -319,7 +319,7 @@ from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
 def _seed_run_with_finding(tmp_path: Path) -> tuple[Path, Path]:
     """Create a minimal run dir with one finding and trigger initial projection."""
     project_dir = tmp_path / "myproject"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
         practice_id="P1", verdict="violation", dimension="Security",
@@ -375,7 +375,7 @@ def test_compute_tick_emits_scores_updated_after_dismiss(tmp_path: Path) -> None
 def test_compute_tick_no_scores_event_when_no_grades_table(tmp_path: Path) -> None:
     """When the run has no projected grades (no findings, no DB), no scores.updated emits."""
     project_dir = tmp_path / "myproject"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     # No events.jsonl at all -- empty run_dir.
     state = WatcherState()

--- a/tests/api/test_scores_routes.py
+++ b/tests/api/test_scores_routes.py
@@ -28,7 +28,7 @@ def _seed_run(
     project_after: bool = True,
 ) -> Path:
     """Create run directory, write events.jsonl, optionally trigger projection."""
-    run_dir = reports_root / project / "runs" / run_id
+    run_dir = reports_root / project / run_id
     run_dir.mkdir(parents=True)
     log = run_dir / "events.jsonl"
     writer = EventLogWriter(log)
@@ -82,7 +82,7 @@ def test_get_scores_raw_uses_sql_when_grades_present(tmp_path: Path, monkeypatch
 
 def test_get_scores_raw_returns_empty_shape_when_no_findings(tmp_path: Path) -> None:
     """When a run has no findings, get_scores_raw returns the empty shape."""
-    run_dir = tmp_path / "myproject" / "runs" / "r1"
+    run_dir = tmp_path / "myproject" / "r1"
     run_dir.mkdir(parents=True)
     # Create an empty events log (no findings emitted).
     (run_dir / "events.jsonl").touch()
@@ -93,7 +93,7 @@ def test_get_scores_raw_returns_empty_shape_when_no_findings(tmp_path: Path) -> 
 
 def test_get_scores_raw_raises_file_not_found_for_missing_run(tmp_path: Path) -> None:
     """FileNotFoundError raised when run directory does not exist."""
-    (tmp_path / "myproject" / "runs").mkdir(parents=True)
+    (tmp_path / "myproject").mkdir(parents=True)
     with pytest.raises(FileNotFoundError):
         get_scores_raw(tmp_path, "myproject", "nonexistent-run")
 
@@ -166,7 +166,7 @@ def test_get_scores_raw_reflects_dismissal_via_sql(tmp_path: Path) -> None:
     from quodeq.services.dismissed import dismiss_finding  # noqa: PLC0415
     project_dir = tmp_path / "myproject"
     dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     Projector().ensure_projected(run_dir / "events.jsonl", run_dir, project_dir=project_dir)
 
     after = get_scores_raw(tmp_path, "myproject", "r1")

--- a/tests/context/test_precedent.py
+++ b/tests/context/test_precedent.py
@@ -25,7 +25,7 @@ def _seed_dismissed(
     line: int,
 ) -> Path:
     """Seed a violation into a run, dismiss it, then project into SQL."""
-    run_dir = project_dir / "runs" / run_id
+    run_dir = project_dir / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
@@ -126,14 +126,14 @@ def test_load_returns_empty_for_missing_dir(tmp_path: Path):
     assert load_precedent_fingerprints(tmp_path / "missing") == set()
 
 
-def test_load_returns_empty_for_no_runs(tmp_path: Path):
-    """Project dir with no runs/ sub-directory returns an empty set."""
+def test_load_returns_empty_for_project_with_no_runs(tmp_path: Path):
+    """Project dir with no run sub-directories returns an empty set."""
     assert load_precedent_fingerprints(tmp_path) == set()
 
 
-def test_load_returns_empty_when_runs_dir_is_empty(tmp_path: Path):
-    """runs/ exists but contains no run directories -- still empty."""
-    (tmp_path / "runs").mkdir()
+def test_load_skips_subdirs_without_db(tmp_path: Path):
+    """Subdirectories without an evaluation.db are silently skipped."""
+    (tmp_path / "r_no_db").mkdir()
     assert load_precedent_fingerprints(tmp_path) == set()
 
 
@@ -156,7 +156,7 @@ def test_load_returns_fingerprints_from_sql(tmp_path: Path):
 def test_load_skips_run_dirs_without_db(tmp_path: Path):
     """A run directory with no evaluation.db is silently skipped."""
     project_dir = tmp_path / "proj"
-    (project_dir / "runs" / "r_no_db").mkdir(parents=True)
+    (project_dir / "r_no_db").mkdir(parents=True)
     # Only a real dismissed run seeds the expected fingerprint.
     _seed_dismissed(project_dir, "r_real", req="X", snippet="s", file="f.py", line=1)
 

--- a/tests/data/projection/test_ensure_projected.py
+++ b/tests/data/projection/test_ensure_projected.py
@@ -115,7 +115,7 @@ def _verdict_for(run_dir: Path, req: str, file: str, line: int) -> str | None:
 
 def test_ensure_replays_actions_jsonl(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
 
     events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
@@ -132,7 +132,7 @@ def test_ensure_replays_actions_jsonl(tmp_path: Path) -> None:
 
 def test_ensure_no_op_when_actions_log_unchanged(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
     projector = Projector()
@@ -162,7 +162,7 @@ def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path
     in update_actions would skip the replay and the new finding would stay as 'violation'.
     """
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = run_dir / "events.jsonl"
 
@@ -197,7 +197,7 @@ def test_ensure_applies_existing_dismissals_to_freshly_scanned_findings(tmp_path
 
 def test_ensure_projected_runs_migration_first(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
     # Legacy: dismissed.json exists, actions.jsonl does not.
@@ -213,7 +213,7 @@ def test_ensure_projected_runs_migration_first(tmp_path: Path) -> None:
 
 def test_ensure_projected_populates_grade_tables(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
 
@@ -225,9 +225,44 @@ def test_ensure_projected_populates_grade_tables(tmp_path: Path) -> None:
     assert len(store.read_principle_grades()) == 1
 
 
+def test_ensure_force_rebuilds_pre_pr1_db(tmp_path: Path) -> None:
+    """Pre-PR-1 DBs were projected by older code that left ``findings.requirement``
+    empty. They have a checkpoint but no ``projection_event_log_size`` key. On
+    first contact, ensure_projected must force a rebuild so the new mappers
+    populate every column (otherwise dismissals via UPDATE WHERE requirement=?
+    match zero rows and silently no-op).
+    """
+    project_dir = tmp_path / "project"
+    run_dir = project_dir / "r1"
+    run_dir.mkdir(parents=True)
+    events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
+
+    # Project normally so the DB has rows.
+    Projector().project(events_log, run_dir)
+    # Simulate the pre-PR-1 state: requirement was never written, and the
+    # projection_event_log_size key (added in PR 1) is absent.
+    with open_evaluation_db(run_dir) as conn:
+        conn.execute("UPDATE findings SET requirement = ''")
+        conn.execute(
+            "DELETE FROM run_meta WHERE key = 'projection_event_log_size'"
+        )
+        conn.commit()
+    assert _verdict_for(run_dir, "R1", "a.py", 10) is None  # match-by-req fails
+
+    # Dismiss the finding via the action log.
+    ActionLogWriter(project_dir).emit(
+        FindingDismissedEvent(payload=FindingDismissed(req="R1", file="a.py", line=10))
+    )
+
+    Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)
+
+    # Force-rebuild rewrites requirement from events.jsonl, then the dismiss applies.
+    assert _verdict_for(run_dir, "R1", "a.py", 10) == "dismissed"
+
+
 def test_ensure_projected_grade_updates_after_dismiss(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = _seed_run_with_finding(run_dir, req="R1", file="a.py", line=10)
     Projector().ensure_projected(events_log, run_dir, project_dir=project_dir)

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -143,7 +143,7 @@ def test_read_skips_ensure_when_no_event_log(tmp_path: Path):
 
 def test_repo_reads_reflect_dismissal_via_actions_log(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
     events_log = run_dir / "events.jsonl"
 

--- a/tests/integration/test_dismiss_flow_prod_layout.py
+++ b/tests/integration/test_dismiss_flow_prod_layout.py
@@ -1,0 +1,90 @@
+"""Regression: dismiss flow works with the production directory layout.
+
+Production stores runs at ``<eval_dir>/<project>/<run_id>/`` (no ``runs/``
+subdir). An earlier refactor mistakenly assumed ``<project>/runs/<run_id>/``
+which silently broke dismiss + live-grade updates in production while
+unit tests (which used the ``runs/`` layout) still passed.
+
+These tests pin the real layout end-to-end so the divergence cannot recur.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.api._run_event_stream import WatcherState, compute_tick
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+from quodeq.services.dismissed import dismiss_finding, dismissed_keys, load_dismissed
+
+
+def _seed_finding(run_dir: Path, *, req: str, file: str, line: int, dimension: str = "Security") -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension=dimension,
+        file=file, line=line, reason="r", req=req, severity="high",
+    )))
+    # Project events into evaluation.db so the finding exists in SQL.
+    SqliteFindingsRepository(run_dir).list_by_dimension(dimension)
+
+
+def test_dismiss_sticks_in_sql_under_prod_layout(tmp_path: Path) -> None:
+    """Production layout: dismiss must flip findings.verdict to 'dismissed'."""
+    eval_dir = tmp_path / "evaluations"
+    project_dir = eval_dir / "proj1"
+    run_dir = project_dir / "run1"  # NO `runs/` segment
+    _seed_finding(run_dir, req="R1", file="a.py", line=10)
+
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    # Re-listing must trigger projection of actions.jsonl.
+    SqliteFindingsRepository(run_dir).list_by_dimension("Security")
+
+    keys = dismissed_keys(project_dir)
+    assert keys == {("R1", "a.py", 10)}, (
+        f"Dismissal did not project to SQL under prod layout. "
+        f"actions.jsonl exists at {project_dir / 'actions.jsonl'}, "
+        f"but dismissed_keys returned {keys}"
+    )
+
+
+def test_load_dismissed_returns_entries_under_prod_layout(tmp_path: Path) -> None:
+    """Production layout: load_dismissed must surface dismissed entries."""
+    eval_dir = tmp_path / "evaluations"
+    project_dir = eval_dir / "proj1"
+    run_dir = project_dir / "run1"
+    _seed_finding(run_dir, req="R1", file="a.py", line=10)
+
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+    SqliteFindingsRepository(run_dir).list_by_dimension("Security")
+
+    items = load_dismissed(project_dir)
+    assert len(items) == 1
+    assert items[0]["req"] == "R1"
+    assert items[0]["file"] == "a.py"
+    assert items[0]["line"] == 10
+
+
+def test_dismiss_emits_scores_updated_under_prod_layout(tmp_path: Path) -> None:
+    """Production layout: SSE tick must emit scores.updated after dismiss."""
+    eval_dir = tmp_path / "evaluations"
+    project_dir = eval_dir / "proj1"
+    run_dir = project_dir / "run1"
+    _seed_finding(run_dir, req="R1", file="a.py", line=10)
+
+    # Baseline tick.
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)
+
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    events, _ = compute_tick(run_dir, state)
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert len(grade_events) == 1, (
+        f"Expected scores.updated after dismiss under prod layout, got: "
+        f"{[e[0] for e in events]}"
+    )
+    payload = json.loads(grade_events[0][1])
+    security = next((d for d in payload.get("dimensions", []) if d.get("dimension") == "Security"), None)
+    assert security is None or security.get("overallScore") is None

--- a/tests/integration/test_live_grades_pr1_flow.py
+++ b/tests/integration/test_live_grades_pr1_flow.py
@@ -11,7 +11,7 @@ from quodeq.services.dismissed import dismiss_finding, restore_finding
 
 def test_full_dismiss_flow(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
 
     # Seed a finding from the scan.

--- a/tests/integration/test_live_grades_pr2_flow.py
+++ b/tests/integration/test_live_grades_pr2_flow.py
@@ -12,7 +12,7 @@ from quodeq.services.dismissed import dismiss_finding
 
 def test_full_grade_flow(tmp_path: Path) -> None:
     project_dir = tmp_path / "project"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
 
     # Two findings in Security (varied severity), one in Reliability.

--- a/tests/integration/test_live_grades_pr3_flow.py
+++ b/tests/integration/test_live_grades_pr3_flow.py
@@ -13,7 +13,7 @@ from quodeq.services.dismissed import dismiss_finding
 
 def test_dismiss_triggers_scores_updated_on_next_tick(tmp_path: Path) -> None:
     project_dir = tmp_path / "myproject"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
 
     # Seed a finding.
@@ -46,7 +46,7 @@ def test_dismiss_triggers_scores_updated_on_next_tick(tmp_path: Path) -> None:
 def test_grade_no_change_does_not_emit_scores_updated(tmp_path: Path) -> None:
     """Ticks without grade changes do not emit scores.updated."""
     project_dir = tmp_path / "myproject"
-    run_dir = project_dir / "runs" / "r1"
+    run_dir = project_dir / "r1"
     run_dir.mkdir(parents=True)
 
     # Seed two findings with critical and low severities in separate dimensions.

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -511,7 +511,7 @@ class TestDashboardSqlGradeOverride:
 
         project = "myproject"
         run_id = "r1"
-        run_dir = tmp_path / project / "runs" / run_id
+        run_dir = tmp_path / project / run_id
         run_dir.mkdir(parents=True)
 
         # Seed SQL grade tables with a post-dismissal grade.
@@ -555,7 +555,7 @@ class TestDashboardSqlGradeOverride:
 
         project = "myproject"
         run_id = "r1"
-        run_dir = tmp_path / project / "runs" / run_id
+        run_dir = tmp_path / project / run_id
         run_dir.mkdir(parents=True)
         # No SQL rows seeded — grade tables are empty.
 
@@ -617,7 +617,7 @@ class TestDashboardSqlGradeOverride:
 
         project = "myproject"
         run_id = "r1"
-        run_dir = tmp_path / project / "runs" / run_id
+        run_dir = tmp_path / project / run_id
         run_dir.mkdir(parents=True)
 
         store = SQLiteStateStore(run_dir)
@@ -666,7 +666,7 @@ class TestDashboardSqlGradeOverride:
         project = "myproject"
         run_id = "r1"
         project_dir = tmp_path / project
-        run_dir = project_dir / "runs" / run_id
+        run_dir = project_dir / run_id
         run_dir.mkdir(parents=True)
 
         # Seed 3 findings: 2 in Security (varied severity), 1 in Reliability.
@@ -737,16 +737,16 @@ class TestDashboardSqlGradeOverride:
                 f"scores={scores_dims[dim_name]['overallScore']}"
             )
 
-    def test_dashboard_override_fires_with_runs_subdir(
+    def test_dashboard_override_fires_with_flat_run_layout(
         self, tmp_path: Path,
     ) -> None:
         """Regression guard: _apply_sql_grade_override must resolve the run
-        directory as reports_root / project / 'runs' / run_id, not the old
-        (wrong) reports_root / project / run_id path.
+        directory as reports_root / project / run_id (the production layout).
 
-        If the path were wrong, the 'not run_dir.is_dir()' guard would bail out
-        and the SQL override would silently never fire — the dashboard would
-        return the stale FS grade instead of the SQL-backed grade.
+        Earlier code mistakenly inserted a `runs/` segment, so the
+        ``not run_dir.is_dir()`` guard always bailed out and the SQL override
+        silently never fired — the dashboard returned the stale FS grade
+        instead of the SQL-backed grade.
         """
         from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
         from quodeq.core.events.writer import EventLogWriter
@@ -755,8 +755,8 @@ class TestDashboardSqlGradeOverride:
 
         project = "myproject"
         run_id = "r1"
-        # Correct path: reports_root / project / "runs" / run_id
-        run_dir = tmp_path / project / "runs" / run_id
+        # Production layout: reports_root / project / run_id (no `runs/` segment).
+        run_dir = tmp_path / project / run_id
         run_dir.mkdir(parents=True)
 
         # Seed one finding so the projector creates grade tables.

--- a/tests/services/test_deleted.py
+++ b/tests/services/test_deleted.py
@@ -35,7 +35,7 @@ def _seed_projected_run(
     principle: str = "Modularity",
 ) -> Path:
     """Create a run with one violation finding projected into evaluation.db."""
-    run_dir = project_dir / "runs" / run_id
+    run_dir = project_dir / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(

--- a/tests/services/test_dismissed.py
+++ b/tests/services/test_dismissed.py
@@ -14,7 +14,7 @@ from quodeq.services.dismissed import (
 
 
 def _seed_run(project_dir: Path, run_id: str, *, req: str, file: str, line: int) -> Path:
-    run_dir = project_dir / "runs" / run_id
+    run_dir = project_dir / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(

--- a/tests/services/test_dismissed_extended.py
+++ b/tests/services/test_dismissed_extended.py
@@ -29,7 +29,7 @@ def _seed_projected_run(
     line: int,
 ) -> Path:
     """Create a run with one violation finding projected into evaluation.db."""
-    run_dir = project_dir / "runs" / run_id
+    run_dir = project_dir / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     log = run_dir / "events.jsonl"
     EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(

--- a/tests/services/test_filesystem_log_resolution.py
+++ b/tests/services/test_filesystem_log_resolution.py
@@ -22,6 +22,26 @@ def test_get_log_run_dir_external_not_found(tmp_path: Path) -> None:
     assert provider.get_log_run_dir("ext-run-nonexistent") is None
 
 
+def test_get_log_run_dir_bare_run_id_falls_back_to_filesystem(tmp_path: Path) -> None:
+    """A bare run_id (no ext- prefix, no job entry) must still resolve.
+
+    The UI subscribes to the per-run SSE stream using the plain run UUID. For
+    completed runs without an active job entry, falling back to a filesystem
+    scan keeps live-grade updates working.
+    """
+    project = tmp_path / "proj-1"
+    run = project / "run-A"
+    run.mkdir(parents=True)
+    (run / "evidence").mkdir()
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.get_log_run_dir("run-A") == run
+
+
+def test_get_log_run_dir_bare_run_id_unknown_returns_none(tmp_path: Path) -> None:
+    provider = FilesystemActionProvider(reports_root=tmp_path)
+    assert provider.get_log_run_dir("run-nonexistent") is None
+
+
 def test_is_job_complete_external_when_scan_present(tmp_path: Path) -> None:
     project = tmp_path / "p"
     run = project / "r"


### PR DESCRIPTION
## Summary

Three bugs in the live-grades refactor (#516–#520) combined to break dismissals and live grade updates. Reported symptom: violations disappear from the screen (optimistic UI) but the grade doesn't move and the dismissal doesn't stick on reload.

## Three bugs, one PR

**1. Path layout mismatch.** 8 sites assumed `<project>/runs/<run_id>/`, but production layout is `<project>/<run_id>/`. The SSE tick read `actions.jsonl` from the wrong directory, projection silently skipped, verdict never flipped, grades never recomputed.

Sites fixed:
- [findings_repository.py:55](src/quodeq/data/sqlite/findings_repository.py) — `parent.parent` → `parent`
- [_run_event_stream.py:267-270](src/quodeq/api/_run_event_stream.py) — fixed reports_root / project derivation
- [services/dismissed.py:47,79](src/quodeq/services/dismissed.py) — iterate `project_dir` directly
- [services/deleted.py:159](src/quodeq/services/deleted.py)
- [context/precedent.py:66](src/quodeq/context/precedent.py)
- [services/dashboard.py:379](src/quodeq/services/dashboard.py)
- [services/scoring/__init__.py:247](src/quodeq/services/scoring/__init__.py)

**2. Stale DBs.** Pre-refactor evaluations have an empty `findings.requirement` column, so `UPDATE WHERE requirement=?` matched zero rows even after the path fix. [projector.py](src/quodeq/data/projection/projector.py) now detects pre-PR-1 DBs (checkpoint present, the new `projection_event_log_size` key missing) and force-rebuilds them so the current mappers populate every column.

**3. SSE endpoint resolution.** UI subscribes via the bare run UUID, but [`get_log_run_dir`](src/quodeq/services/_evaluations_index.py) only handled `ext-` prefix or active job entries. For 393 runs vs 106 mostly-stale jobs in a typical setup, completed runs returned 404 and the EventSource failed silently — no `scores.updated` ever delivered. Falls back to a filesystem scan now.

## Why tests didn't catch it

`tests/services/test_dismissed.py` and friends seeded runs at `project_dir/"runs"/run_id` — encoding the **wrong** layout. One test was even named `test_dashboard_override_fires_with_runs_subdir` and explicitly "guarded" the broken assumption. Tests and broken code agreed; production disagreed silently.

All 13 affected test files updated to use production layout. The misleading guard renamed and flipped to protect the correct layout.

## New regression tests

- [test_dismiss_flow_prod_layout.py](tests/integration/test_dismiss_flow_prod_layout.py) — end-to-end dismiss → SQL verdict update → SSE `scores.updated` under production layout
- [test_ensure_force_rebuilds_pre_pr1_db](tests/data/projection/test_ensure_projected.py) — simulates pre-PR-1 DB state, asserts force-rebuild
- [test_get_log_run_dir_bare_run_id_falls_back_to_filesystem](tests/services/test_filesystem_log_resolution.py) — SSE endpoint resolves bare run UUID

## Test plan

- [x] All 2983 tests pass locally
- [x] Reviewer: restart your dashboard, dismiss a violation, confirm:
  - Violation disappears immediately (optimistic UI)
  - Grade updates within ~250ms (SSE tick interval) without any refetch / loading state
  - Dismissed view shows the entry
  - Reload — dismissal sticks
- [x] Existing dismissals written to `actions.jsonl` before this fix will project on first dashboard load — verify no double-counting or weird state