### PR TITLE
fix(live-grades): emit SSE on principle change, subscribe more pages

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -252,16 +252,30 @@ def compute_tick(run_dir: Path, state: WatcherState) -> tuple[list[EventTuple], 
     try:
         from quodeq.data.sqlite.connection import open_evaluation_db  # noqa: PLC0415
         with open_evaluation_db(run_dir) as conn:
-            rows = conn.execute(
-                "SELECT dimension, score, grade, completed_at FROM dimension_scores ORDER BY dimension",
+            dim_rows = conn.execute(
+                "SELECT dimension, score, grade FROM dimension_scores ORDER BY dimension",
             ).fetchall()
-        # Fingerprint of all dimension_scores rows, not just MAX(completed_at). This
-        # detects grade value changes that happen within the same second (recompute
-        # fires fast enough that two consecutive ticks can produce identical timestamps
-        # but different scores). MAX(completed_at) alone would miss these.
-        # It also detects transitions to the empty state (full-dismiss), which
-        # MAX(completed_at) handles correctly too (None != prior-timestamp).
-        current_fingerprint = repr(rows) if rows else None
+            principle_rows = conn.execute(
+                "SELECT dimension, principle_id, score, grade, finding_count, dismissed_count "
+                "FROM principle_grades ORDER BY dimension, principle_id",
+            ).fetchall()
+        # Fingerprint covers BOTH grade tables (dimension and principle), and excludes
+        # ``completed_at``. Two design points:
+        #
+        # 1. Including principle_grades catches dismisses that change a principle's
+        #    finding_count / dismissed_count even when the rolled-up dimension score
+        #    happens to round to the same value. Without this, the SSE silently
+        #    swallowed real per-principle changes — the UI's `usePrincipleData` hook
+        #    would never see the dismiss and the detail-page grade stayed stale.
+        # 2. Excluding completed_at because SQLite ``CURRENT_TIMESTAMP`` has 1-second
+        #    resolution. Two recomputes within the same second produced identical
+        #    timestamps, neutralising completed_at as a tiebreaker. Letting score +
+        #    grade + finding_count + dismissed_count drive the fingerprint is both
+        #    more correct (it tracks actual content) and avoids spurious events when
+        #    nothing semantic changed.
+        current_fingerprint = (
+            repr((dim_rows, principle_rows)) if (dim_rows or principle_rows) else None
+        )
         if current_fingerprint != state.last_grade_fingerprint:
             from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
             # run_dir layout: <reports_root>/<project>/<run_id>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -134,7 +134,7 @@ function renderEvalPrincipleDetail(params, props) {
       severityFilter={params.severity || null}
       onDismiss={(v) => {
         props.dismissFinding(selectedProject, buildDismissPayload(v, evalPrincipal.dimension))
-          .then(() => props.refreshDashboard?.())
+          .then(() => { props.refreshDashboard?.(); props.bumpDismissRefresh?.(); })
           .catch((e) => console.error('[Dismiss] failed:', e));
       }}
     />
@@ -204,6 +204,7 @@ function ViolationsRoute({ params, props }) {
         projectName: props.dashboardData.selectedDisplayName,
         loading: props.dashboardData.loading,
         isFetching: props.dashboardData.isFetching,
+        dismissRefreshKey: props.dismissRefreshKey,
       }}
       callbacks={{
         onDimensionClick: (dim) => nav('explorer', { dimension: dim.dimension, runId: dim.fromRunId, dateLabel: dim.fromDateLabel, fromProject: dim.fromProject, sourceTab: 'violations' }),
@@ -301,7 +302,7 @@ const ROUTE_RENDERERS = {
       severityFilter={params.severityFilter || params.severity || null}
       onDismiss={(v) => {
         props.dismissFinding(props.navigation.selectedProject, buildDismissPayload(v))
-          .then(() => props.refreshDashboard?.())
+          .then(() => { props.refreshDashboard?.(); props.bumpDismissRefresh?.(); })
           .catch((e) => console.error('[Dismiss] failed:', e));
       }}
     />
@@ -315,7 +316,7 @@ const ROUTE_RENDERERS = {
       dimension={params.dimension}
       onDismiss={(v) => {
         props.dismissFinding(props.navigation.selectedProject, buildDismissPayload(v, params.dimension))
-          .then(() => props.refreshDashboard?.())
+          .then(() => { props.refreshDashboard?.(); props.bumpDismissRefresh?.(); })
           .catch((e) => console.error('[Dismiss] failed:', e));
       }}
     />
@@ -378,6 +379,13 @@ export default function App() {
   const selectedProjectInfo = state.projects?.find((p) => (p.id || p.name) === state.selectedProject) || null;
   const [sidebarPinned, setSidebarPinned] = useState(false);
   const [wizardEntry, setWizardEntry] = useState(null);
+  // Incremented after every successful dismiss POST so the violations
+  // page's dismissed sub-tab knows to refetch its list. Without this, a
+  // dismiss made on the principle / file detail page never appeared in the
+  // dismissed list until the user switched projects — the list was only
+  // fetched once on mount.
+  const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
+  const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's
@@ -523,6 +531,8 @@ export default function App() {
     settings: state.settings,
     refreshDashboard: state.refreshDashboard,
     dismissFinding,
+    bumpDismissRefresh,
+    dismissRefreshKey,
   };
 
   // Resolve the project's friendly name. Until the /api/projects response

--- a/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
+++ b/src/quodeq/ui/src/features/explorer/components/explorerDataHooks.js
@@ -131,6 +131,20 @@ export function useExplorerData(project, dimension, runId, refreshSignal) {
     }).catch(() => {});
   }, [refreshSignal]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Live updates via SSE. When a user dismisses a finding on the principle
+  // detail page (or anywhere else in the same run), the backend's SSE tick
+  // emits `scores.updated` with the rescored payload. We fold the matching
+  // dimension into evalData using the same merge helper as the manual
+  // refreshSignal path — so the standard-detail page reflects dismisses
+  // within ~250 ms instead of waiting on a full refetch.
+  const gradeStream = useGradeStream({ project, runId });
+  useEffect(() => {
+    if (!gradeStream.payload) return;
+    const dimData = (gradeStream.payload.dimensions || []).find((d) => d.dimension === dimension);
+    if (!dimData) return;
+    setEvalData((prev) => mergeRescoreIntoEval(prev, dimData));
+  }, [gradeStream.payload, dimension]);
+
   const overallGrade = useMemo(() => (evalData?.principleGrades || []).find((pg) => pg.isOverall || pg.principle?.includes('Overall')), [evalData]);
   const principleGrades = useMemo(() => (evalData?.principleGrades || []).filter((pg) => !pg.isOverall && !pg.principle?.includes('Overall')), [evalData]);
   const allViolations = useMemo(() => computeAllViolations(evalData), [evalData]);

--- a/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
+++ b/src/quodeq/ui/src/features/violations/components/ViolationsPage.jsx
@@ -97,7 +97,7 @@ function FileSubTab({ dimensions, onFileClick, currentPath, setCurrentPath }) {
   );
 }
 
-function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, initialSubTab, initialFilePath }) {
+function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, initialSubTab, initialFilePath, dismissRefreshKey }) {
   const [activeSubTab, _setActiveSubTab] = useState(initialSubTab);
   const setActiveSubTab = (v) => {
     writeCachedState('violations', selectedProject, { activeSubTab: v });
@@ -110,7 +110,12 @@ function useViolationsData({ accumulatedDimensions, selectedProject, onRefresh, 
   };
 
   const [restoreError, setRestoreError] = useState(null);
-  const { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll } = useDismissedFindings(selectedProject, onRefresh, setRestoreError);
+  // dismissRefreshKey is bumped by App.jsx after a dismiss POST elsewhere.
+  // useDismissedFindings refetches when this changes, so the dismissed
+  // sub-tab reflects new entries without needing the user to re-open the
+  // page or switch projects.
+  const { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll } =
+    useDismissedFindings(selectedProject, onRefresh, setRestoreError, dismissRefreshKey);
 
   const visibleDimensions = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
@@ -179,7 +184,7 @@ function ViolationsSubTabContent(props) {
 }
 
 export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 0 }) {
-  const { accumulatedDimensions = [], selectedProject } = data;
+  const { accumulatedDimensions = [], selectedProject, dismissRefreshKey = 0 } = data;
   const { projects = [], projectsLoaded, projectName, loading, isFetching } = data;
   const { onNavigate, onRefresh } = callbacks;
 
@@ -214,6 +219,7 @@ export default function ViolationsPage({ data, callbacks, isDirectNav, tabKey = 
     onRefresh,
     initialSubTab: cached.activeSubTab,
     initialFilePath: cached.fileCurrentPath,
+    dismissRefreshKey,
   });
 
   if (!projectsLoaded) return <LoadingScreen />;

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -8,13 +8,17 @@ import {
 } from '../../../api/index.js';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
 
-export function useDismissedFindings(selectedProject, onRefresh, setRestoreError) {
+export function useDismissedFindings(selectedProject, onRefresh, setRestoreError, refreshKey = 0) {
   const [dismissed, setDismissed] = useState([]);
 
+  // refreshKey lets the parent force a refetch when something dismissed an
+  // entry elsewhere (e.g. the principle-detail page). Without it, the
+  // dismissed sub-tab only fetched on mount, so dismisses made on other
+  // pages never appeared until the user switched projects.
   useEffect(() => {
     if (!selectedProject) return;
     listDismissedFindings(selectedProject).then(setDismissed).catch(() => setDismissed([]));
-  }, [selectedProject]);
+  }, [selectedProject, refreshKey]);
 
   const handleRestore = useCallback(async (d) => {
     try {

--- a/tests/integration/test_dismiss_sse_principle_payload.py
+++ b/tests/integration/test_dismiss_sse_principle_payload.py
@@ -1,0 +1,117 @@
+"""Regression: SSE scores.updated payload carries per-principle score+grade
+in the shape the UI expects, and fires whenever per-principle state changes
+— not only when the dimension's overall score changes.
+
+The UI's `usePrincipleData` hook looks up the live principle score with:
+
+    pgMap = new Map(dimData.principles.map(p => [p.principle, p]))
+    pgMap.get(evalPrincipal.principle)
+
+where `evalPrincipal.principle` is the principle *name* (e.g. "Adaptability")
+read from `evalData.principleGrades[].principle`. The latter is produced by
+`parse_eval_from_json` from the JSON file's `principles[].name` field.
+
+Two contracts pinned here:
+
+1. **Shape**: SSE payload's `principles[].principle` MUST equal that
+   human-readable principle name — not an opaque id or slug.
+
+2. **Liveness**: SSE `scores.updated` MUST fire when a dismiss changes
+   per-principle state, even if the dimension's rolled-up score happens to
+   stay the same (rounding / low-data / current-scoring-engine quirks).
+   Before this regression, the fingerprint only looked at
+   ``dimension_scores`` and missed principle-level changes silently.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.api._run_event_stream import WatcherState, compute_tick
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+from quodeq.services.dismissed import dismiss_finding
+
+
+def _seed(
+    run_dir: Path, *, practice_id: str, req: str, file: str, line: int,
+    dimension: str = "Maintainability", verdict: str = "violation",
+    severity: str = "high",
+) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id=practice_id, verdict=verdict, dimension=dimension,
+        file=file, line=line, reason="r", req=req, severity=severity,
+    )))
+
+
+def test_scores_updated_fires_on_principle_change_even_if_dimension_score_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Dismissing a finding must trigger scores.updated whenever per-principle
+    state changes — not only when the dimension's overall score changes.
+
+    With the current scoring engine, a single-principle dimension can keep the
+    same overall score after one violation is dismissed (because the score
+    rounds to the same bucket, or because the scorer doesn't penalise enough
+    for low-data cases). The SSE fingerprint must still observe the change so
+    the UI's `usePrincipleData` gets the updated principle row.
+    """
+    eval_dir = tmp_path / "evaluations"
+    project_dir = eval_dir / "proj1"
+    run_dir = project_dir / "run1"
+
+    # Two violations + one compliance, all "Adaptability". Dismissing R1 leaves
+    # the principle row alive (R2 + R3) with different finding_count.
+    _seed(run_dir, practice_id="Adaptability", req="R1", file="a.py", line=10)
+    _seed(run_dir, practice_id="Adaptability", req="R2", file="b.py", line=20)
+    _seed(
+        run_dir, practice_id="Adaptability", req="R3", file="c.py", line=30,
+        verdict="compliance",
+    )
+
+    # Project so initial grade rows exist.
+    SqliteFindingsRepository(run_dir).list_by_dimension("Maintainability")
+
+    # Baseline tick — primes fingerprint with the un-dismissed state.
+    state = WatcherState()
+    _, state = compute_tick(run_dir, state)
+
+    # Dismiss one finding.
+    dismiss_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    # Force projection so finding.verdict is flipped and grades recomputed.
+    SqliteFindingsRepository(run_dir).list_by_dimension("Maintainability")
+
+    events, _ = compute_tick(run_dir, state)
+    grade_events = [e for e in events if e[0] == "scores.updated"]
+    assert len(grade_events) == 1, (
+        "Expected scores.updated after dismiss because principle_grades changed "
+        f"(finding_count 2 -> 1, dismissed_count 0 -> 1). Got events: "
+        f"{[e[0] for e in events]}. This means the SSE fingerprint only watches "
+        f"dimension_scores and swallowed a real per-principle change — the UI's "
+        f"usePrincipleData will never see the dismiss."
+    )
+
+    payload = json.loads(grade_events[0][1])
+    maint = next(
+        (d for d in payload.get("dimensions", []) if d.get("dimension") == "Maintainability"),
+        None,
+    )
+    assert maint is not None, f"Maintainability dimension missing from payload: {payload}"
+
+    principles = maint.get("principles") or []
+    assert len(principles) > 0, (
+        f"payload.dimensions[].principles is empty — UI cannot look up live score. "
+        f"Dimension dict: {maint}"
+    )
+
+    # Critical contract: principle field equals the human-readable name the UI
+    # uses on the detail page (evalPrincipal.principle).
+    principle_names = [p.get("principle") for p in principles]
+    assert "Adaptability" in principle_names, (
+        f"SSE payload principles[].principle = {principle_names!r}, but UI looks up "
+        f"'Adaptability' (the principle name). This is the silent merge-fail that "
+        f"makes the principle-detail-page grade stay stale after a dismiss."
+    )


### PR DESCRIPTION
## Summary

Two stacked bugs were making post-dismiss UX feel flaky.

**1. SSE fingerprint blind spot.** The tick hashed only ``dimension_scores`` rows. When a dismiss changed per-principle ``finding_count`` / ``dismissed_count`` but the rolled-up dimension score rounded to the same value, no ``scores.updated`` was emitted. Compounded by ``completed_at``'s 1-second SQLite resolution: two recomputes in the same second produced identical timestamps. Fingerprint now covers both grade tables (sans ``completed_at``).

**2. Pages not subscribing.** Only the dashboard and principle detail page listened to the SSE stream. ExplorerPage (standard detail) waited for ``refreshSignal``, and the violations dismissed sub-tab only fetched once on mount.

- ``useExplorerData`` now subscribes via ``useGradeStream``.
- ``useDismissedFindings`` accepts a ``dismissRefreshKey``; ``App.jsx`` bumps it after every successful dismiss POST and threads it through ``ViolationsPage``.

## Test plan

- [x] New regression test ``tests/integration/test_dismiss_sse_principle_payload.py`` fails on develop, passes with the fingerprint fix
- [x] Existing dismiss flow tests still pass (``test_dismiss_flow_prod_layout.py``)
- [x] Full backend suite: 1056 tests pass
- [x] Full frontend suite: 354 tests pass
- [x] Manual verification in dev server: grade on principle detail updates within a second after dismiss
- [x] Manual: standard detail page reflects a dismiss without navigating away
- [x] Manual: dismissed sub-tab on Violations shows a new dismiss without project switch

## Out of scope

Independent ticket: ``evaluation.db`` projection silently drops findings vs. ``events.jsonl`` (each dimension affected, security 52 -> 31). Affects scoring correctness but is separate from live-update plumbing. Tracking separately.