### PR TITLE
fix(events): coerce legacy bare-string req_refs (unblocks projection)

### DIFF
--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 from uuid import uuid4, UUID
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 from quodeq.core.types.req_ref import ReqRef
 
@@ -63,6 +63,32 @@ class Judgment(BaseModel):
     req: Optional[str] = None
     req_refs: List[ReqRef] = Field(default_factory=list)
     cwe: Optional[str] = None
+
+    @field_validator("req_refs", mode="before")
+    @classmethod
+    def _coerce_legacy_req_refs(cls, value: Any) -> Any:
+        """Accept the legacy bare-string format for ``req_refs``.
+
+        Historical events.jsonl files stored req_refs as a list of bare
+        strings (e.g. ``["CWE-89", "CISQ"]``) before the ReqRef struct was
+        introduced. Strict validation rejected the whole event, which made
+        EventLogReader silently skip it — producing empty grade tables and
+        nonsensical scores for any pre-refactor run.
+
+        Coerce strings to ``ReqRef(label=<string>, url="")`` so legacy events
+        round-trip cleanly. The empty url means the UI's filterValidRefs()
+        drops them from links (it requires http(s)://), which is the right
+        behaviour: there is no URL to recover.
+        """
+        if not isinstance(value, list):
+            return value
+        coerced = []
+        for item in value:
+            if isinstance(item, str):
+                coerced.append(ReqRef(label=item, url=""))
+            else:
+                coerced.append(item)
+        return coerced
 
     def is_violation(self) -> bool:
         return self.verdict == "violation"

--- a/tests/core/test_judgment_req_refs_compat.py
+++ b/tests/core/test_judgment_req_refs_compat.py
@@ -1,0 +1,81 @@
+"""Regression: Judgment.req_refs must accept the legacy bare-string format.
+
+Historical events.jsonl files (pre-ReqRef-struct refactor) stored req_refs as
+a list of bare strings:
+
+    {"req_refs": ["CWE-89", "CISQ", "ASVS V5.3.5"], ...}
+
+The current Judgment model declares ``req_refs: List[ReqRef]`` and pydantic
+rejects bare strings during validation. The EventLogReader then silently
+skips the entire event, which means whole runs project as zero findings —
+the UI shows the violations from the dimension JSON file, but the score is
+computed off an empty SQL DB and renders 10.0 grade A regardless of how
+many violations exist.
+
+The fix coerces bare strings to ``ReqRef(label=<string>, url="")`` so old
+events round-trip cleanly through the reader. This pins that contract.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.core.events.models import JudgmentCreatedEvent
+from quodeq.core.events.reader import EventLogReader
+
+
+_LEGACY_EVENT_JSON = {
+    "event_id": "00000000-0000-0000-0000-000000000001",
+    "timestamp": "2026-05-17T19:20:00+00:00",
+    "event_type": "JUDGMENT_CREATED",
+    "payload": {
+        "practice_id": "Integrity",
+        "verdict": "violation",
+        "dimension": "security",
+        "file": "auth.py",
+        "line": 10,
+        "reason": "Use of weak cryptographic hash (MD5)",
+        "severity": "major",
+        "req": "Integrity.MD5",
+        # Legacy format: bare strings rather than {label, url} dicts.
+        "req_refs": ["CWE-327", "CISQ"],
+    },
+}
+
+
+def test_judgment_model_accepts_bare_string_req_refs() -> None:
+    """Judgment validation must coerce ['CWE-327', 'CISQ'] to ReqRef objects."""
+    event = JudgmentCreatedEvent.model_validate(_LEGACY_EVENT_JSON)
+    refs = event.payload.req_refs
+    assert len(refs) == 2, f"Expected 2 ReqRefs, got {refs}"
+    labels = [r.label for r in refs]
+    assert labels == ["CWE-327", "CISQ"], (
+        f"Bare-string req_refs not coerced into ReqRef.label. Got: {labels}"
+    )
+    # url defaults to empty for the legacy format; the references are kept
+    # so the UI's filterValidRefs() drops them gracefully (it requires url
+    # to start with http(s)://).
+    urls = [r.url for r in refs]
+    assert urls == ["", ""], f"Expected empty urls, got: {urls}"
+
+
+def test_event_log_reader_does_not_drop_legacy_req_refs(tmp_path: Path) -> None:
+    """End-to-end: a JSONL file of legacy events must project every event,
+    not silently skip them on ValidationError."""
+    log_path = tmp_path / "events.jsonl"
+    with log_path.open("w") as f:
+        for i in range(5):
+            ev = json.loads(json.dumps(_LEGACY_EVENT_JSON))
+            ev["event_id"] = f"00000000-0000-0000-0000-00000000000{i + 1}"
+            ev["payload"]["line"] = 10 + i
+            f.write(json.dumps(ev) + "\n")
+
+    reader = EventLogReader(log_path)
+    events = list(reader.stream())
+
+    assert len(events) == 5, (
+        f"EventLogReader dropped {5 - len(events)} legacy events on ValidationError. "
+        f"This silently corrupts every old run — projection produces an empty DB "
+        f"and the scoring engine returns 10.0 / Exemplary while the UI lists real "
+        f"violations from the dimension JSON file."
+    )


### PR DESCRIPTION
## Summary

Root cause of the **10.0 / grade A with 11 visible violations** symptom that's been confusing for weeks.

Pre-refactor events.jsonl files stored ``req_refs`` as bare strings (``["CWE-89", "CISQ"]``), before the ReqRef struct landed. The current ``Judgment`` model declares ``req_refs: List[ReqRef]`` and pydantic rejects the whole event during validation. ``EventLogReader`` catches ``ValidationError``, logs at ERROR, and continues — so for any old run, **every JUDGMENT_CREATED event silently dropped**. The DB projected as zero findings. The scoring engine read an empty DB and returned 10.0 / Exemplary for every principle, while the UI listed the real violations from the dimension JSON file.

## Fix

``field_validator(mode="before")`` on ``Judgment.req_refs`` coerces bare strings to ``ReqRef(label=<string>, url="")``. The empty url is intentional: the UI's ``filterValidRefs()`` already drops refs without ``http(s)://`` urls, which is the correct behaviour when there is no URL to recover. Labels still surface in the report.

## End-to-end verification on a real run

| | Before | After |
|---|---|---|
| Events projected | 0 | 51 |
| security overall | 10.0 / Exemplary | 1.9 / Critical |
| Integrity principle | 10.0 / Exemplary, 0 findings | 1.8 / Critical, 10 findings |

## Test plan

- [x] Regression test ``tests/core/test_judgment_req_refs_compat.py`` pins both the model contract and the EventLogReader behaviour. Fails on develop, passes here.
- [x] Full backend suite: 1305 tests pass
- [x] Manual: open a previously-broken run in the UI and verify the principle detail page shows a score consistent with its violations

## Related

- PR #525 fixes the SSE flakiness layer (sits on top of this). Order does not matter for merge — they touch disjoint files.