### PR TITLE
fix(schema): allow 'major' severity (was silently dropping every major)

### DIFF
--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -39,9 +39,107 @@ def _upgrade_v2_to_v3(conn: sqlite3.Connection) -> None:
     """)
 
 
+def _upgrade_v3_to_v4(conn: sqlite3.Connection) -> None:
+    """Allow 'major' in the findings.severity CHECK constraint.
+
+    The v3 schema's CHECK only permitted ``critical/high/medium/low/minor``.
+    The scoring engine and event log emit ``major`` for the middle severity
+    bucket, so ``INSERT OR IGNORE`` silently dropped every major finding —
+    making principle scores look correct only as long as no critical was
+    dismissed. After dismissing all criticals the score jumped to 10.0
+    because the DB had no remaining violations.
+
+    SQLite cannot ALTER a CHECK in place, so rebuild the table. Existing
+    rows (all of which already pass the new, wider CHECK by construction)
+    copy over unchanged, then the FTS5 index and triggers are recreated.
+
+    Note: ``user_version`` is bumped by ``apply_evaluation_schema`` after
+    this function returns.
+    """
+    conn.executescript("""
+        -- Drop triggers and FTS index that reference the old table by name.
+        DROP TRIGGER IF EXISTS findings_ai;
+        DROP TRIGGER IF EXISTS findings_ad;
+        DROP TRIGGER IF EXISTS findings_au;
+        DROP TABLE IF EXISTS findings_fts;
+
+        ALTER TABLE findings RENAME TO findings_old_v3;
+
+        CREATE TABLE findings (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            schema_version  INTEGER NOT NULL DEFAULT 1,
+            practice_id     TEXT NOT NULL,
+            dimension       TEXT NOT NULL DEFAULT '',
+            requirement     TEXT,
+            verdict         TEXT NOT NULL CHECK (verdict IN ('violation','compliance','dismissed')),
+            severity        TEXT NOT NULL CHECK (severity IN ('critical','major','high','medium','low','minor')),
+            file            TEXT NOT NULL DEFAULT '',
+            line            INTEGER NOT NULL DEFAULT 0,
+            end_line        INTEGER NOT NULL DEFAULT 0,
+            title           TEXT NOT NULL DEFAULT '',
+            reason          TEXT NOT NULL DEFAULT '',
+            snippet         TEXT NOT NULL DEFAULT '',
+            violation_type  TEXT NOT NULL DEFAULT '',
+            context         TEXT NOT NULL DEFAULT '',
+            scope           TEXT NOT NULL DEFAULT '',
+            req_refs_json   TEXT,
+            dedup_key       TEXT NOT NULL UNIQUE,
+            confidence      INTEGER NOT NULL DEFAULT 100,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        INSERT INTO findings (
+            id, schema_version, practice_id, dimension, requirement, verdict,
+            severity, file, line, end_line, title, reason, snippet,
+            violation_type, context, scope, req_refs_json, dedup_key,
+            confidence, created_at
+        )
+        SELECT
+            id, schema_version, practice_id, dimension, requirement, verdict,
+            severity, file, line, end_line, title, reason, snippet,
+            violation_type, context, scope, req_refs_json, dedup_key,
+            confidence, created_at
+        FROM findings_old_v3;
+
+        DROP TABLE findings_old_v3;
+
+        CREATE INDEX idx_findings_dimension   ON findings(dimension);
+        CREATE INDEX idx_findings_severity    ON findings(severity);
+        CREATE INDEX idx_findings_verdict     ON findings(verdict);
+        CREATE INDEX idx_findings_file        ON findings(file);
+        CREATE INDEX idx_findings_requirement ON findings(requirement);
+        CREATE INDEX idx_findings_practice    ON findings(practice_id);
+
+        CREATE VIRTUAL TABLE findings_fts USING fts5(
+            reason, snippet,
+            content='findings', content_rowid='id', tokenize='porter'
+        );
+
+        -- Backfill FTS for any rows copied over.
+        INSERT INTO findings_fts(rowid, reason, snippet)
+            SELECT id, reason, snippet FROM findings;
+
+        CREATE TRIGGER findings_ai AFTER INSERT ON findings BEGIN
+            INSERT INTO findings_fts(rowid, reason, snippet)
+            VALUES (new.id, new.reason, new.snippet);
+        END;
+        CREATE TRIGGER findings_ad AFTER DELETE ON findings BEGIN
+            INSERT INTO findings_fts(findings_fts, rowid, reason, snippet)
+            VALUES ('delete', old.id, old.reason, old.snippet);
+        END;
+        CREATE TRIGGER findings_au AFTER UPDATE ON findings BEGIN
+            INSERT INTO findings_fts(findings_fts, rowid, reason, snippet)
+            VALUES ('delete', old.id, old.reason, old.snippet);
+            INSERT INTO findings_fts(rowid, reason, snippet)
+            VALUES (new.id, new.reason, new.snippet);
+        END;
+    """)
+
+
 _UPGRADES = {
     1: _upgrade_v1_to_v2,
     2: _upgrade_v2_to_v3,
+    3: _upgrade_v3_to_v4,
 }
 
 

--- a/src/quodeq/data/sqlite/_schema.py
+++ b/src/quodeq/data/sqlite/_schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 EVALUATION_DDL = """
-PRAGMA user_version = 3;
+PRAGMA user_version = 4;
 
 CREATE TABLE findings (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -11,7 +11,13 @@ CREATE TABLE findings (
     dimension       TEXT NOT NULL DEFAULT '',
     requirement     TEXT,
     verdict         TEXT NOT NULL CHECK (verdict IN ('violation','compliance','dismissed')),
-    severity        TEXT NOT NULL CHECK (severity IN ('critical','high','medium','low','minor')),
+    -- Severity buckets used by the scoring engine, eval JSON, and UI are
+    -- 'critical' / 'major' / 'minor'. The legacy 'high' / 'medium' / 'low'
+    -- values remain accepted so older DBs round-trip cleanly. Without
+    -- 'major' here, INSERT OR IGNORE silently dropped every major-severity
+    -- finding on insert, which made principle scores jump to 10.0 after
+    -- the criticals were dismissed (the majors were never in the DB).
+    severity        TEXT NOT NULL CHECK (severity IN ('critical','major','high','medium','low','minor')),
     file            TEXT NOT NULL DEFAULT '',
     line            INTEGER NOT NULL DEFAULT 0,
     end_line        INTEGER NOT NULL DEFAULT 0,
@@ -87,4 +93,4 @@ CREATE TABLE principle_grades (
 CREATE INDEX idx_principle_grades_dimension ON principle_grades(dimension);
 """
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4

--- a/tests/data/sqlite/test_schema.py
+++ b/tests/data/sqlite/test_schema.py
@@ -26,8 +26,8 @@ def test_evaluation_ddl_includes_confidence_column():
     assert "confidence" in _schema.EVALUATION_DDL
 
 
-def test_schema_version_is_3() -> None:
-    assert SCHEMA_VERSION == 3
+def test_schema_version_is_4() -> None:
+    assert SCHEMA_VERSION == 4
 
 
 def test_principle_grades_table_exists(tmp_path: Path) -> None:

--- a/tests/data/sqlite/test_severity_major_persists.py
+++ b/tests/data/sqlite/test_severity_major_persists.py
@@ -1,0 +1,78 @@
+"""Regression: 'major' severity findings must persist to evaluation.db.
+
+The scoring engine, eval JSON files, and UI all use the severity bucket
+'major' (between 'critical' and 'minor'). The evaluation.db schema's
+CHECK constraint historically only allowed
+``('critical','high','medium','low','minor')`` — 'major' was missing.
+
+Combined with ``INSERT OR IGNORE`` in record_finding, every major-severity
+event was silently dropped at insert time. The DB ended up with only
+critical + minor rows, and recompute_grades scored against the partial
+data. When a user dismissed all the criticals, the principle's score
+jumped to 10.0 because the major-severity violations were never recorded
+in the DB to begin with.
+
+This test pins the contract: a Judgment with severity='major' must
+land in the findings table.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.events.models import Judgment
+from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def test_major_severity_finding_persists(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    store = SQLiteStateStore(run_dir)
+    judgment = Judgment(
+        practice_id="Integrity",
+        verdict="violation",
+        dimension="security",
+        file="auth.py",
+        line=10,
+        reason="weak crypto hash",
+        severity="major",
+    )
+    store.record_finding(judgment)
+
+    with open_evaluation_db(run_dir) as conn:
+        rows = conn.execute(
+            "SELECT severity, file, line FROM findings WHERE practice_id='Integrity'",
+        ).fetchall()
+
+    assert rows == [("major", "auth.py", 10)], (
+        f"'major' severity finding did not persist. The schema CHECK on the "
+        f"severity column rejected it, and INSERT OR IGNORE swallowed the "
+        f"error silently. DB rows for Integrity: {rows}. "
+        f"This explains why dismissing critical findings on the UI made "
+        f"principle scores jump to 10.0 — the majors were never in the DB."
+    )
+
+
+def test_all_canonical_severities_persist(tmp_path: Path) -> None:
+    """Every severity the scoring engine and UI use must round-trip."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    store = SQLiteStateStore(run_dir)
+    for i, sev in enumerate(["critical", "major", "minor"]):
+        store.record_finding(Judgment(
+            practice_id="P", verdict="violation", dimension="d",
+            file=f"f{i}.py", line=i + 1, reason="r", severity=sev,
+        ))
+
+    with open_evaluation_db(run_dir) as conn:
+        counts = dict(
+            conn.execute(
+                "SELECT severity, COUNT(*) FROM findings GROUP BY severity",
+            ).fetchall(),
+        )
+
+    assert counts == {"critical": 1, "major": 1, "minor": 1}, (
+        f"Not all canonical severities persisted: {counts}"
+    )


### PR DESCRIPTION
## Summary

Final piece of the "score jumps to 10.0/A despite visible majors" symptom.

The ``findings.severity`` CHECK constraint only permitted ``critical/high/medium/low/minor``. The scoring engine, event log, and UI all use ``major`` for the middle bucket. Combined with ``INSERT OR IGNORE`` in ``record_finding``, every major-severity event was silently dropped on insert.

Principles read as Critical while at least one critical existed. The moment a user dismissed all the criticals, the score jumped to 10.0 — the majors were never in the DB.

PR #526 (req_refs coercion) unblocked validation for legacy logs so events could reach the SQL layer in the first place; this PR makes the SQL layer actually accept them.

## Fix

- Add ``'major'`` to the CHECK alongside the legacy ``high/medium/low`` so existing rows round-trip.
- Schema version 3 -> 4.
- v3 -> v4 migration: SQLite cannot ALTER a CHECK in place, so rename the table, recreate with the wider CHECK, copy rows, rebuild FTS5 index and triggers (with backfill).

## Verification on real data

| | Before | After |
|---|---|---|
| Integrity findings in DB | 13 (10 critical + 3 compliance) | **24** (10 critical + 11 major + 3 compliance) |
| Integrity score | 10.0 / Exemplary (after dismissing criticals) | 1.3 / Critical |
| Security dimension | 4.9 / Poor | 3.4 / Poor |

The principle score (1.3) now matches the eval JSON exactly.

## Test plan

- [x] Regression tests in ``tests/data/sqlite/test_severity_major_persists.py``: ``major`` finding persists; all canonical severities round-trip
- [x] v3 -> v4 migration verified on a synthetically-created v3 DB with pre-existing data
- [x] Full backend suite: 1308 tests pass
- [x] Manual: open the same project after merge, verify principle scores reflect violations (no more 10.0 with visible majors)

## Cleanup follow-ups (independent, not in this PR)

- ``INSERT OR IGNORE`` swallowing CHECK violations silently is the meta-bug here. Worth logging at WARN when ``cursor.rowcount == 0`` after an insert. Separate ticket.
- Legacy severities ``high/medium/low`` are accepted but unused by anything that writes today. Consider deprecating once any old DB is past its useful life.