### PR TITLE
fix(ui): stack overview score-history and dimensions on narrow viewports

### DIFF
--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -960,9 +960,12 @@ button.term-sev-badge--clickable:focus-visible {
 
 
 /* ------------------------------------------------------------
-   Responsive .history-panels-row — wrap chart + dimensions onto
-   two rows once combined min width is no longer available.
-   Each child keeps a soft floor so it doesn't collapse too thin.
+   Responsive .history-panels-row — chart + dimensions sit side by
+   side on wide viewports and stack on narrow ones. Mirrors the
+   media-query pattern used by .qd-top-grid on the detail page so
+   the behaviour is predictable across webview engines (the prior
+   min(100%, 500px) floor was fragile against history.css's
+   `> *` rule and didn't always trigger the wrap).
    ------------------------------------------------------------ */
 .history-panels-row {
   flex-wrap: wrap !important;
@@ -970,11 +973,18 @@ button.term-sev-badge--clickable:focus-visible {
 }
 .history-panels-row > .run-history-panel,
 .history-panels-row > .dim-score-panel {
-  /* Wrap sooner — below ~1040px combined, the two panels stack vertically
-     so each has full width rather than cramming side-by-side and clipping
-     the DIMENSIONS row numerics. */
-  flex: 1 1 500px !important;
-  min-width: min(100%, 500px) !important;
+  flex: 1 1 0 !important;
+  min-width: 0 !important;
+}
+@media (max-width: 1120px) {
+  .history-panels-row {
+    flex-direction: column !important;
+  }
+  .history-panels-row > .run-history-panel,
+  .history-panels-row > .dim-score-panel {
+    flex-basis: auto !important;
+    width: 100% !important;
+  }
 }
 
 /* ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the `flex-wrap` + `min(100%, 500px)` floor on `.history-panels-row` with a plain `@media (max-width: 1120px)` rule that flips the row to `flex-direction: column`.
- Matches the pattern already used by `.qd-top-grid` on the detail page (Explorer), so both pages now collapse to a single column the same way.
- Fixes the case where `SCORE_HISTORY` and `DIMENSIONS` stayed cramped side-by-side on narrow viewports because `history.css`'s `.history-panels-row > *` rule could undercut the terminal.css floor.

## Test plan
- [x] Open overview on a project with run history at 1440px viewport → panels side-by-side
- [x] Resize to 1280px → still side-by-side
- [x] Resize to 1100px → panels stack (SCORE_HISTORY on top, DIMENSIONS below)
- [x] Resize to 375px (mobile) → still stacked, no overflow
- [x] Detail page (Explorer) unchanged: still wraps at viewport ≤760px