### PR TITLE
perf(live-grades): cut dismiss latency on large projects

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -34,12 +34,45 @@ def _project_dir(evaluations_dir: str, project: str) -> Path:
     return resolved
 
 
+def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
+    """Drop violation/compliance arrays from the rescored payload.
+
+    The UI's dismiss handlers (PrincipleDetail, FileDetail, FindingDetail)
+    only need the per-dimension and per-principle ``score`` / ``grade``
+    fields to update local state. Returning the full payload meant 300+ KB
+    on large projects (quodeq: 322 KB → 543 B after slimming, a 600× cut),
+    which was the bulk of the perceived dismiss latency: parse + transfer +
+    re-render against violations the page already has from its initial fetch.
+    """
+    if not scores:
+        return scores
+    slim_dims = []
+    for dim in scores.get("dimensions", []) or []:
+        slim_principles = [
+            {
+                "principle": p.get("principle"),
+                "score": p.get("score"),
+                "grade": p.get("grade"),
+            }
+            for p in (dim.get("principles") or [])
+        ]
+        slim_dims.append({
+            "dimension": dim.get("dimension"),
+            "overallScore": dim.get("overallScore"),
+            "overallGrade": dim.get("overallGrade"),
+            "principles": slim_principles,
+        })
+    return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
+
+
 def _rescore_run(evaluations_dir: str, project: str, run_id: str | None) -> dict[str, Any] | None:
-    """Compute the rescored payload for the run referenced in a mutation body.
+    """Compute the slim rescored payload for the run referenced in a mutation body.
 
     Returns ``None`` when ``run_id`` is missing or the run directory cannot
-    be resolved. Callers fold the result into the response body so the UI
-    can apply the new scores without a follow-up GET.
+    be resolved. The payload omits per-finding arrays since dismiss handlers
+    only need score/grade fields — see ``_slim_scores`` for the rationale.
+    Callers fold the result into the response body so the UI can apply the
+    new scores without a follow-up GET.
     """
     if not run_id:
         return None
@@ -51,7 +84,7 @@ def _rescore_run(evaluations_dir: str, project: str, run_id: str | None) -> dict
 
     reports_root = Path(evaluations_dir).resolve()
     try:
-        return get_scores_raw(reports_root, project, run_id)
+        return _slim_scores(get_scores_raw(reports_root, project, run_id))
     except FileNotFoundError:
         return None
     except Exception:

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -53,7 +53,20 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
 
   const refreshDashboard = useCallback(() => {
     if (!selectedProject) return;
-    queryClient.invalidateQueries({ queryKey: projectKeys.project(selectedProject) });
+    // Mark project queries stale but DON'T trigger an immediate refetch.
+    // The dashboard payload is 10-20 MB on large projects (one run's full
+    // violation + compliance arrays × multiple dimensions); refetching on
+    // every dismiss froze the UI for 1-3 s while the browser parsed the
+    // JSON and React re-rendered. The dismiss POST already returned the
+    // rescored run for the active page (PrincipleDetail / FileDetail /
+    // FindingDetail) to apply locally — the dashboard rollup just needs
+    // to be eventually-correct, which React Query handles automatically:
+    // ``refetchType: 'none'`` marks the cache stale, the next mount
+    // refetches naturally on navigation.
+    queryClient.invalidateQueries({
+      queryKey: projectKeys.project(selectedProject),
+      refetchType: 'none',
+    });
   }, [queryClient, selectedProject]);
 
   return {


### PR DESCRIPTION
## Why

On the quodeq project (1200 violations across 6 dimensions, ~20 MB dashboard payload), Victor reported a "big delay between deletion and re-score". Profiling found two wasteful operations on every dismiss:

1. **19 MB dashboard refetch** triggered by ``invalidateQueries`` even though the user isn't on the dashboard (they're on the principle detail page). Browser parse + React reconcile of that 19 MB took 1-3 s per dismiss.
2. **322 KB POST response** carrying the full violation + compliance arrays even though dismiss handlers only read score/grade fields.

## Changes

1. ``refreshDashboard`` now uses ``refetchType: 'none'`` — marks the project queries stale but doesn't refetch. React Query refetches naturally on the next mount when the user navigates back to the dashboard. The dismiss POST already returned the rescored run, which the active detail page applies locally.
2. ``_rescore_run`` returns a **slim** scores payload via new ``_slim_scores`` helper. Drops violation + compliance arrays. quodeq goes from 322 KB → 543 B per dismiss response (~600× smaller).

## End-to-end measured on the actual quodeq run

| | Before | After |
|---|---|---|
| Dismiss POST response | 322 KB | **543 B** |
| Dashboard cache invalidation | Triggers 19 MB refetch + reparse + re-render | Marks stale; refetches on navigation |
| Click → visible score change | 1-3 s + freezes | **~600-900 ms** |

Score changes work as before: 9.4 → 9.3 visibly after one click, no more frozen UI.

## Test plan

- [x] 348 frontend tests pass
- [x] 2983 backend tests pass
- [x] End-to-end on quodeq: dismiss feels responsive, no big delays
- [x] Manual: open project Overview, see updated scores cascade after navigation

## Notes

The dashboard score still reflects the latest data when navigated to — React Query refetches on remount because the cache is marked stale. There's no behavior regression, only a deferred refetch. If a user dismisses then immediately jumps to Overview, they'll see the refetch happen there (with its own loading indicator) rather than as an invisible blocking operation on the dismiss page.

Builds on PR #531 (mutation-returns-result). Once #531 lands and this rebases onto develop, both fixes are in.