### PR TITLE
fix(live-grades): runId threading + load_dismissed legacy fallback + rate-limit exemption

### DIFF
--- a/src/quodeq/api/_rate_limit_config.py
+++ b/src/quodeq/api/_rate_limit_config.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 import os
 
 _DEFAULT_RATE_LIMIT_WINDOW = 60
-_DEFAULT_RATE_LIMIT_MAX = 60
+# 60/min was too tight for the dashboard's bulk-dismiss UX — burst-dismissing
+# 60+ findings in a minute (a normal user flow on a large project) hit the
+# cap, returned 429, and the frontend rolled back its optimistic update so
+# violations appeared to "come back". A 10× bump still bounds runaway clients
+# but absorbs realistic UI bursts. Hardened deployments can tighten this via
+# QUODEQ_RATE_LIMIT_MAX.
+_DEFAULT_RATE_LIMIT_MAX = 600
 _RATE_STORE_MAX_IPS = 10_000  # max tracked IPs to prevent unbounded memory growth
 _PRUNE_THRESHOLD_MULTIPLIER = 2  # prune per-IP list when it exceeds max_requests * this
 

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -65,14 +65,52 @@ def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
     return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
 
 
-def _rescore_run(evaluations_dir: str, project: str, run_id: str | None) -> dict[str, Any] | None:
+def _project_all_runs(project_dir: Path) -> None:
+    """Trigger projection across every run dir of the project.
+
+    Used as a safety net when the dismiss POST didn't carry a usable
+    ``run_id`` (callers from the Violations / Map pages don't always have
+    one in hand). Without this, the action lands in ``actions.jsonl`` but
+    no run's SQL ``findings`` table is updated, so the dismissed-tab list
+    — which reads ``WHERE verdict = 'dismissed'`` from each run's
+    evaluation.db — stays empty until the user navigates somewhere that
+    happens to trigger projection for the right run.
+
+    Projection is incremental (gated by checkpoint + log-size), so this is
+    cheap in steady state; the first call after a fresh dismiss replays only
+    the actions-log delta.
+    """
+    if not project_dir.is_dir():
+        return
+    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+
+    for run_dir in project_dir.iterdir():
+        if not run_dir.is_dir():
+            continue
+        if not (run_dir / "events.jsonl").is_file():
+            continue
+        try:
+            SqliteFindingsRepository(run_dir)._ensure_fresh()  # noqa: SLF001
+        except Exception:
+            _logger.warning("Projection after mutation failed for %s", run_dir, exc_info=True)
+
+
+def _rescore_run(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any] | None:
     """Compute the slim rescored payload for the run referenced in a mutation body.
 
     Returns ``None`` when ``run_id`` is missing or the run directory cannot
-    be resolved. The payload omits per-finding arrays since dismiss handlers
-    only need score/grade fields — see ``_slim_scores`` for the rationale.
-    Callers fold the result into the response body so the UI can apply the
-    new scores without a follow-up GET.
+    be resolved. When it returns ``None``, the caller also calls
+    ``_project_all_runs`` so the action still lands in SQL — otherwise the
+    dismissed-tab list (which reads ``WHERE verdict='dismissed'`` from each
+    run's evaluation.db) wouldn't see the entry until the user happened to
+    trigger projection some other way.
+
+    The payload omits per-finding arrays since dismiss handlers only need
+    score/grade fields — see ``_slim_scores`` for the rationale. Callers
+    fold the result into the response body so the UI can apply the new
+    scores without a follow-up GET.
     """
     if not run_id:
         return None
@@ -100,6 +138,23 @@ def register_findings_routes(app: Flask) -> None:
 
     def _eval_dir() -> str:
         return app.config.get("EVALUATIONS_DIR") or get_evaluations_dir()
+
+    def _scores_with_fallback(
+        project: str, run_id: str | None,
+    ) -> dict[str, Any] | None:
+        """Rescore the requested run, falling back to a project-wide projection.
+
+        When the caller can't supply a usable ``run_id`` (Violations / Map
+        nav paths don't carry one today), ``_rescore_run`` returns ``None`` —
+        but the action *must* still propagate to SQL or the dismissed-tab
+        list won't see it. Project every run as the fallback so the entry
+        becomes visible without forcing the UI to retry.
+        """
+        evaluations_dir = _eval_dir()
+        scores = _rescore_run(evaluations_dir, project, run_id)
+        if scores is None:
+            _project_all_runs(_project_dir(evaluations_dir, project))
+        return scores
 
     @app.get("/api/findings/dismissed")
     def list_dismissed() -> Response:
@@ -129,7 +184,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required"}), 400
         dismiss_finding(_project_dir(_eval_dir(), project), body)
-        scores = _rescore_run(_eval_dir(), project, run_id)
+        scores = _scores_with_fallback(project, run_id)
         return jsonify({"scores": scores}), 200
 
     @app.post("/api/findings/restore")
@@ -143,7 +198,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project or not req or not file or line is None:
             return jsonify({"error": "project, req, file, and line are required"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
-        scores = _rescore_run(_eval_dir(), project, run_id)
+        scores = _scores_with_fallback(project, run_id)
         return jsonify({"scores": scores}), 200
 
     @app.post("/api/findings/restore-all")
@@ -154,7 +209,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project:
             return jsonify({"error": "project is required"}), 400
         count = restore_all_findings(_project_dir(_eval_dir(), project))
-        scores = _rescore_run(_eval_dir(), project, run_id)
+        scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "restored": count, "scores": scores}), 200
 
     @app.post("/api/findings/delete")
@@ -168,7 +223,7 @@ def register_findings_routes(app: Flask) -> None:
         if not project or not dimension or not principle or not file:
             return jsonify({"error": "project, dimension, principle, and file are required"}), 400
         swept = delete_finding(_project_dir(_eval_dir(), project), body)
-        scores = _rescore_run(_eval_dir(), project, run_id)
+        scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "swept": swept, "scores": scores}), 200
 
     @app.post("/api/findings/delete-all")
@@ -179,5 +234,5 @@ def register_findings_routes(app: Flask) -> None:
         if not project:
             return jsonify({"error": "project is required"}), 400
         count = delete_all_dismissed(_project_dir(_eval_dir(), project))
-        scores = _rescore_run(_eval_dir(), project, run_id)
+        scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "deleted": count, "scores": scores}), 200

--- a/src/quodeq/api/security.py
+++ b/src/quodeq/api/security.py
@@ -15,6 +15,16 @@ _logger = logging.getLogger(__name__)
 
 _HEALTH_PATH = "/api/health"
 _RATE_LIMITED_GET_PATHS = frozenset({"/api/browse"})
+# Per-finding user actions are idempotent and don't trigger expensive work
+# server-side. Burst-dismissing is a normal user flow on large projects; a
+# rate limit there just rolls back the optimistic UI update, which the user
+# experiences as "violations come back". The global limit still applies to
+# everything else (e.g. /api/evaluations/start).
+_RATE_LIMIT_EXEMPT_PATHS = frozenset({
+    "/api/findings/dismiss",
+    "/api/findings/restore",
+    "/api/findings/delete",
+})
 _LOCALHOST_ADDRS = {"127.0.0.1", "::1"}
 
 
@@ -59,6 +69,8 @@ def _check_csrf() -> Response | tuple[Response, int] | None:
 def _check_rate_limit(store: RateLimitStore) -> Response | tuple[Response, int] | None:
     """Enforce rate limiting on state-changing requests and sensitive GET endpoints."""
     if request.method in ("GET", "HEAD", "OPTIONS") and request.path not in _RATE_LIMITED_GET_PATHS:
+        return None
+    if request.path in _RATE_LIMIT_EXEMPT_PATHS:
         return None
     ip = request.remote_addr or "unknown"
     now = time.monotonic()

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -7,6 +7,7 @@ evaluation.db (aggregated across runs).
 from __future__ import annotations
 
 import json
+import sqlite3
 from dataclasses import replace
 from pathlib import Path
 
@@ -72,6 +73,87 @@ def dismissed_keys(project_dir: Path) -> set[tuple]:
     return keys
 
 
+def _enrich_from_sql(run_dir: Path, keys: set[tuple], out: dict[tuple, dict]) -> None:
+    """Add finding detail from a run's SQL findings table for any dismissed key not yet enriched.
+
+    Modern runs (those with an ``events.jsonl`` projected into ``findings``)
+    expose the full Judgment row here. We look up by the canonical (req,
+    file, line) tuple — the SQL ``verdict`` column is ignored because we
+    treat ``actions.jsonl`` as the source of truth for *which* findings
+    are dismissed, and the SQL row only for *what* the finding was.
+    """
+    db_path = run_dir / "evaluation.db"
+    if not db_path.is_file():
+        return
+    try:
+        with open_evaluation_db(run_dir) as conn:
+            cursor = conn.execute(
+                "SELECT requirement, file, line, dimension, practice_id, severity, "
+                "title, reason, snippet, context, scope, end_line, req_refs_json "
+                "FROM findings"
+            )
+            for row in cursor:
+                key = (str(row[0] or ""), str(row[1] or ""), int(row[2] or 0))
+                if key not in keys or key in out:
+                    continue
+                req_refs_raw = row[12]
+                try:
+                    req_refs = json.loads(req_refs_raw) if req_refs_raw else []
+                except (json.JSONDecodeError, TypeError):
+                    req_refs = []
+                out[key] = {
+                    "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
+                    "dimension": row[3] or "", "principle": row[4] or "",
+                    "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
+                    "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
+                    "endLine": row[11] or 0, "reqRefs": req_refs,
+                }
+    except sqlite3.DatabaseError:
+        # Corrupt evaluation.db — skip rather than fail the whole list.
+        return
+
+
+def _enrich_from_json_eval(run_dir: Path, keys: set[tuple], out: dict[tuple, dict]) -> None:
+    """Add finding detail from a run's ``evaluation/<dim>.json`` files.
+
+    Used for legacy runs that pre-date the event-log scoring engine and so
+    never produced a SQL ``findings`` table. The JSON files carry every
+    field the Dismissed tab needs (principle, severity, title, reason,
+    snippet, context, req_refs); ``dimension`` comes from the filename so
+    the entry stays linked to its standard for the restore/delete flows.
+    """
+    eval_dir = run_dir / "evaluation"
+    if not eval_dir.is_dir():
+        return
+    for path in eval_dir.iterdir():
+        if path.suffix != ".json":
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        dimension = path.stem
+        for v in (data.get("violations") or []):
+            req = str(v.get("req") or "")
+            file = str(v.get("file") or "")
+            try:
+                line = int(v.get("line") or 0)
+            except (TypeError, ValueError):
+                line = 0
+            key = (req, file, line)
+            if key not in keys or key in out:
+                continue
+            out[key] = {
+                "req": req, "file": file, "line": line,
+                "dimension": dimension, "principle": v.get("principle") or "",
+                "severity": v.get("severity") or "", "title": v.get("title") or "",
+                "reason": v.get("reason") or "", "snippet": v.get("snippet") or "",
+                "context": v.get("context") or "", "scope": v.get("scope") or "",
+                "endLine": int(v.get("end_line") or v.get("endLine") or 0),
+                "reqRefs": v.get("req_refs") or v.get("reqRefs") or [],
+            }
+
+
 def load_dismissed(
     project_dir: Path,
     *,
@@ -80,38 +162,48 @@ def load_dismissed(
 ) -> list[dict]:
     """List dismissed findings as dicts (shape matches /api/findings/dismissed response).
 
-    Reads from each run's evaluation.db, aggregated across all runs.
+    ``actions.jsonl`` is the source of truth for *which* findings are
+    dismissed (via ``dismissed_keys``). The original finding detail is
+    looked up from each run's SQL ``findings`` table when the run has been
+    projected, with a JSON-eval-file fallback for legacy runs that never
+    produced an ``events.jsonl``. Without that fallback, the Dismissed tab
+    was permanently empty for any project whose runs pre-date the event-log
+    scoring engine — even though the rescore + dismissed-set math always
+    worked because both go through ``actions.jsonl``.
     """
     if not project_dir.is_dir():
         return []
-    items: list[dict] = []
+    keys = dismissed_keys(project_dir)
+    if not keys:
+        return []
+
+    details: dict[tuple, dict] = {}
     for run_dir in project_dir.iterdir():
         if not run_dir.is_dir():
             continue
-        db_path = run_dir / "evaluation.db"
-        if not db_path.is_file():
-            continue
-        try:
-            with open_evaluation_db(run_dir) as conn:
-                for row in conn.execute(
-                    "SELECT requirement, file, line, dimension, practice_id, severity, "
-                    "title, reason, snippet, context, scope, end_line, req_refs_json "
-                    "FROM findings WHERE verdict = 'dismissed'"
-                ):
-                    req_refs_raw = row[12]
-                    try:
-                        req_refs = json.loads(req_refs_raw) if req_refs_raw else []
-                    except (json.JSONDecodeError, TypeError):
-                        req_refs = []
-                    items.append({
-                        "req": row[0] or "", "file": row[1] or "", "line": row[2] or 0,
-                        "dimension": row[3] or "", "principle": row[4] or "",
-                        "severity": row[5] or "", "title": row[6] or "", "reason": row[7] or "",
-                        "snippet": row[8] or "", "context": row[9] or "", "scope": row[10] or "",
-                        "endLine": row[11] or 0, "reqRefs": req_refs,
-                    })
-        except Exception:
-            continue
+        if len(details) >= len(keys):
+            break
+        _enrich_from_sql(run_dir, keys, details)
+        if len(details) >= len(keys):
+            break
+        _enrich_from_json_eval(run_dir, keys, details)
+
+    items: list[dict] = []
+    for req, file, line in keys:
+        match = details.get((req, file, line))
+        if match is not None:
+            items.append(match)
+        else:
+            # Couldn't find the original finding anywhere — surface a minimal
+            # stub so the user can still see (and restore/delete) the entry.
+            items.append({
+                "req": req, "file": file, "line": line,
+                "dimension": "", "principle": "",
+                "severity": "", "title": "", "reason": "",
+                "snippet": "", "context": "", "scope": "",
+                "endLine": 0, "reqRefs": [],
+            })
+
     if offset <= 0 and limit is None:
         return items
     start = max(0, offset)

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -147,7 +147,11 @@ function renderEvalPrincipleDetail(params, props) {
   );
 }
 
-function buildEvalPrincipal(principleObj, principleGrade) {
+// Exported so unit tests can pin the runId-threading contract without having
+// to mount the whole App. Callers from the Violations page must pass the
+// dimension's ``fromRunId`` — see ``ViolationsRoute.navigateToPrinciple`` for
+// the regression history.
+export function buildEvalPrincipal(principleObj, principleGrade, runId) {
   const violations = principleObj.violations || [];
   const compliance = principleObj.compliance || [];
   return {
@@ -155,6 +159,7 @@ function buildEvalPrincipal(principleObj, principleGrade) {
     score: principleGrade?.score || null,
     grade: principleGrade?.grade || null,
     dimension: principleObj.dimension || '',
+    runId: runId || '',
     principleData: {
       name: principleObj.principle,
       grade: principleGrade?.grade || null,
@@ -178,7 +183,16 @@ function ViolationsRoute({ params, props }) {
   function navigateToPrinciple(principleObj, severity) {
     const dim = dimMap.get(principleObj.dimension);
     const pg = principleMap.get(`${principleObj.dimension}\0${principleObj.principle}`);
-    nav('evalprinciple', { evalPrincipal: buildEvalPrincipal(principleObj, pg), severity, sourceTab: 'violations' });
+    // dim.fromRunId is the run whose data populated this accumulated entry;
+    // threading it through lets the dismiss POST carry a real run id so the
+    // backend can rescore and project the action into SQL — without this the
+    // PrincipleDetail score never moves on dismiss and the entry never lands
+    // on the Dismissed tab.
+    nav('evalprinciple', {
+      evalPrincipal: buildEvalPrincipal(principleObj, pg, dim?.fromRunId),
+      severity,
+      sourceTab: 'violations',
+    });
   }
 
   function navigateToDimension(row, severity) {

--- a/src/quodeq/ui/src/App.test.jsx
+++ b/src/quodeq/ui/src/App.test.jsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvalPrincipal } from './App.jsx';
+
+// Pins the contract that App.jsx's ``buildEvalPrincipal`` threads the
+// dimension's run id into ``evalPrincipal.runId``. Without it, the dismiss
+// POST from PrincipleDetail (when navigated from the Violations or Map
+// pages) lands at the backend with no usable ``run_id`` — the rescore
+// returns ``null`` and the grade never updates.
+
+describe('buildEvalPrincipal', () => {
+  const principleObj = {
+    principle: 'Input Validation',
+    dimension: 'Security',
+    violations: [],
+    compliance: [],
+  };
+  const principleGrade = { score: '7.0/10', grade: 'B' };
+
+  it('threads runId from the originating accumulated dimension', () => {
+    const result = buildEvalPrincipal(principleObj, principleGrade, 'run-abc');
+    expect(result.runId).toBe('run-abc');
+  });
+
+  it('falls back to empty string when no runId is provided', () => {
+    const result = buildEvalPrincipal(principleObj, principleGrade);
+    expect(result.runId).toBe('');
+  });
+
+  it('preserves principle, dimension, score, and grade fields', () => {
+    const result = buildEvalPrincipal(principleObj, principleGrade, 'run-abc');
+    expect(result.principle).toBe('Input Validation');
+    expect(result.dimension).toBe('Security');
+    expect(result.score).toBe('7.0/10');
+    expect(result.grade).toBe('B');
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewInfo.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewInfo.jsx
@@ -127,6 +127,10 @@ export function computeLevelInfo(scene, nav, projectName, onNavigate, navRef) {
             score: p.rawScore || (p.score != null ? p.score.toFixed(1) : null),
             grade: p.grade,
             dimension: d.name,
+            // Carry the originating run id so PrincipleDetail's dismiss POST
+            // sends a real run_id — without it the backend can't rescore and
+            // the dismissed entry never lands on the Dismissed tab.
+            runId: d._raw?.fromRunId || '',
             principleData: { name: p.name, grade: p.grade, violations: p._rawViolations, compliance: p._rawCompliance },
             dimViolations: p._rawViolations,
             dimCompliance: p._rawCompliance,

--- a/tests/api/test_findings_rate_limit_exempt.py
+++ b/tests/api/test_findings_rate_limit_exempt.py
@@ -1,0 +1,114 @@
+"""Regression: findings-mutation endpoints must not be rate-limited.
+
+The user's UX is to burst-dismiss many findings in quick succession on
+large projects. The legacy 60/min/IP cap turned the 61st click into a 429,
+which the frontend handled by rolling back its optimistic update — so
+violations appeared to "come back" to the user after several were dismissed
+rapidly. These tests pin the new behaviour:
+
+* ``/api/findings/dismiss`` / ``restore`` / ``delete`` are exempt from
+  rate limiting entirely (they're idempotent user actions).
+* Other state-changing POSTs still hit the global limit.
+"""
+from __future__ import annotations
+
+import os
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.api._rate_limit_store import InMemoryRateLimitStore
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth(monkeypatch):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """Full Flask app stack with a *tight* rate limit so the burst test is fast."""
+    monkeypatch.setenv("QUODEQ_RATE_LIMIT_MAX", "5")
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+    # Use a fresh in-memory store with the same tight cap so the test
+    # doesn't depend on environment-reading inside the factory.
+    store = InMemoryRateLimitStore(window=60, max_requests=5)
+    app = create_app(rate_limit_store=store)
+    return app.test_client()
+
+
+_DISMISS_BODY = {
+    "project": "p",
+    "req": "R1",
+    "file": "a.py",
+    "line": 1,
+    "dimension": "security",
+    "severity": "minor",
+}
+
+
+def test_dismiss_endpoint_is_exempt_from_rate_limit(client):
+    """Bursting more dismisses than the rate-limit cap must NOT return 429."""
+    # The cap is 5/min via the fixture — fire 20 dismisses in a row.
+    for i in range(20):
+        body = {**_DISMISS_BODY, "line": i}
+        resp = client.post(
+            "/api/findings/dismiss",
+            json=body,
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 200, (
+            f"dismiss #{i} returned {resp.status_code} {resp.data!r} — "
+            f"findings-mutation endpoints must be exempt from rate limiting"
+        )
+
+
+def test_restore_endpoint_is_exempt_from_rate_limit(client):
+    for i in range(20):
+        resp = client.post(
+            "/api/findings/restore",
+            json={"project": "p", "req": "R1", "file": "a.py", "line": i},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 200, (
+            f"restore #{i} returned {resp.status_code}"
+        )
+
+
+def test_delete_endpoint_is_exempt_from_rate_limit(client):
+    for i in range(20):
+        resp = client.post(
+            "/api/findings/delete",
+            json={
+                "project": "p",
+                "dimension": "security",
+                "principle": "Integrity",
+                "file": f"a-{i}.py",
+            },
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 200, (
+            f"delete #{i} returned {resp.status_code}"
+        )
+
+
+def test_non_findings_post_still_rate_limited(client):
+    """Other state-changing POSTs still respect the global cap.
+
+    Pins that the exemption doesn't accidentally disable rate limiting for
+    everything — e.g. ``/api/projects/<p>`` DELETE or ``/api/evaluations``
+    POST should still hit 429 after the cap.
+    """
+    # 6th call past the cap-of-5 should return 429.
+    last_status = None
+    for _ in range(10):
+        resp = client.post(
+            "/api/evaluations",
+            json={},
+            headers={"Origin": "http://localhost"},
+        )
+        last_status = resp.status_code
+        if last_status == 429:
+            break
+    assert last_status == 429, (
+        f"Expected /api/evaluations to be rate-limited after the cap, got {last_status}"
+    )

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -133,8 +133,13 @@ class TestRestoreEndpoint:
 
 
 class TestListDismissedEndpoint:
-    def test_list_returns_empty_without_sql_projection(self, client, tmp_path):
-        # Without projection, load_dismissed returns [] since no evaluation.db rows exist.
+    def test_list_returns_minimal_stub_when_finding_detail_is_unavailable(
+        self, client, tmp_path,
+    ):
+        """With no run dirs, ``load_dismissed`` can't enrich from SQL or JSON
+        eval files — but the dismiss still happened, so we must surface a
+        minimal stub (req/file/line) so the user can see and restore it.
+        """
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()
         client.post("/api/findings/dismiss", json={
@@ -144,8 +149,140 @@ class TestListDismissedEndpoint:
         })
         resp = client.get("/api/findings/dismissed?project=my-project")
         assert resp.status_code == 200
-        # Action log was written but no SQL projection happened, so list is empty.
-        assert resp.get_json() == []
+        body = resp.get_json()
+        assert len(body) == 1
+        assert body[0]["req"] == "M-MOD-4"
+        assert body[0]["file"] == "foo.js"
+        assert body[0]["line"] == 4
+
+    def test_dismiss_without_run_id_still_populates_dismissed_list(
+        self, client, tmp_path,
+    ):
+        """Dismiss without ``run_id`` must still update each run's SQL findings.
+
+        The Violations and Map pages navigate into PrincipleDetail without
+        knowing the originating run id today, so their dismiss POSTs arrive
+        either with no ``run_id`` or with ``run_id='latest'`` (a sentinel,
+        not a real directory). Without a fallback projection the action
+        lands in actions.jsonl but never reaches each run's evaluation.db,
+        so the dismissed-tab list (which reads
+        ``WHERE verdict='dismissed'``) stays empty — the user-visible
+        symptom that motivated this regression.
+        """
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+
+        run_dir = tmp_path / "my-project" / "run-A"
+        run_dir.mkdir(parents=True)
+        EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="Integrity", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1", severity="critical",
+        )))
+
+        # No run_id supplied (Violations-page nav path).
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "R1", "file": "a.py", "line": 10,
+            "dimension": "security", "severity": "critical",
+        })
+        assert resp.status_code == 200
+        assert resp.get_json() == {"scores": None}
+
+        listed = client.get("/api/findings/dismissed?project=my-project").get_json()
+        assert len(listed) == 1
+        assert listed[0]["req"] == "R1"
+        assert listed[0]["file"] == "a.py"
+        assert listed[0]["line"] == 10
+
+    def test_dismiss_with_latest_sentinel_still_populates_dismissed_list(
+        self, client, tmp_path,
+    ):
+        """``run_id='latest'`` is a UI sentinel, not a real run dir.
+
+        ``selectedRun`` defaults to ``'latest'`` in the React app; when nav
+        paths forget to override it, the dismiss POST carries that string
+        verbatim. The backend must treat it the same as a missing run id —
+        rescore returns None, the projection-all-runs fallback kicks in.
+        """
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+
+        run_dir = tmp_path / "my-project" / "run-A"
+        run_dir.mkdir(parents=True)
+        EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="Integrity", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1", severity="critical",
+        )))
+
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "R1", "file": "a.py", "line": 10,
+            "dimension": "security", "severity": "critical",
+            "run_id": "latest",
+        })
+        assert resp.status_code == 200
+        assert resp.get_json() == {"scores": None}
+
+        listed = client.get("/api/findings/dismissed?project=my-project").get_json()
+        assert len(listed) == 1
+
+    def test_list_enriches_legacy_runs_from_json_eval_files(
+        self, client, tmp_path,
+    ):
+        """Legacy runs (no events.jsonl, no SQL findings table) must still
+        appear on the Dismissed tab with full detail (principle, severity,
+        title, reason, snippet).
+
+        This was the real-world regression: every run in the user's
+        installation pre-dated the event-log scoring engine, so projection
+        had nothing to write — and ``load_dismissed`` (reading SQL
+        ``WHERE verdict='dismissed'``) returned an empty list for every
+        dismiss. The fallback path reads from ``evaluation/<dim>.json``
+        which exists for every legacy run.
+        """
+        run_dir = tmp_path / "my-project" / "run-A"
+        eval_dir = run_dir / "evaluation"
+        eval_dir.mkdir(parents=True)
+        (eval_dir / "security.json").write_text(json.dumps({
+            "violations": [
+                {
+                    "req": "S-INT-9",
+                    "file": "feature/foo.kt",
+                    "line": 173,
+                    "principle": "Integrity",
+                    "severity": "minor",
+                    "title": "API host hardcoded",
+                    "reason": "host value comes from a literal constant",
+                    "snippet": "val host = \"prod.example.com\"",
+                    "context": "...",
+                    "req_refs": [{"label": "CWE-20", "url": "https://cwe.mitre.org/20"}],
+                },
+            ],
+        }))
+
+        # No events.jsonl, no evaluation.db — pure legacy layout.
+        assert not (run_dir / "events.jsonl").exists()
+        assert not (run_dir / "evaluation.db").exists()
+
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "S-INT-9", "file": "feature/foo.kt", "line": 173,
+            "dimension": "security", "severity": "minor",
+        })
+
+        listed = client.get("/api/findings/dismissed?project=my-project").get_json()
+        assert len(listed) == 1
+        entry = listed[0]
+        assert entry["req"] == "S-INT-9"
+        assert entry["file"] == "feature/foo.kt"
+        assert entry["line"] == 173
+        assert entry["dimension"] == "security"
+        assert entry["principle"] == "Integrity"
+        assert entry["severity"] == "minor"
+        assert entry["title"] == "API host hardcoded"
+        assert entry["reason"] == "host value comes from a literal constant"
+        assert entry["snippet"] == "val host = \"prod.example.com\""
+        assert entry["reqRefs"] == [{"label": "CWE-20", "url": "https://cwe.mitre.org/20"}]
 
     def test_list_empty_project(self, client):
         resp = client.get("/api/findings/dismissed?project=nonexistent")


### PR DESCRIPTION
## Summary

Three correctness bugs in the dismiss flow, all reported in the same session:

1. **Grade didn't move on dismiss from Violations/Map → PrincipleDetail.** The navigation dropped `runId`, so the dismiss POST sent `run_id='latest'`. Backend couldn't resolve that to a real run dir → returned `{scores: null}` → optimistic UI had no rescored payload to apply.
2. **Dismissed tab was permanently empty on legacy runs.** `load_dismissed` read `WHERE verdict='dismissed'` from each run's `evaluation.db`, but runs that pre-date the event-log scoring engine (no `events.jsonl`) never produced a `findings` table — so the query was always empty even though `actions.jsonl` had the entries.
3. **Burst-dismissing 60+ findings hit a 429 wall.** Global rate limiter capped state-changing POSTs at 60/min/IP; the optimistic dismiss rolled back on failure, so violations appeared to "come back" after rapid clicks.

## Fixes (two commits, two concerns)

**[fix(live-grades)](https://github.com/quodeq/quodeq/commit/43581c61)** — runId threading + dismissed list enrichment

- `buildEvalPrincipal(principleObj, principleGrade, runId)` now accepts and threads a runId; `ViolationsRoute.navigateToPrinciple` passes `dim?.fromRunId`; the galaxy map→principle nav passes `d._raw?.fromRunId`.
- `_rescore_run` now triggers `_project_all_runs` as a safety net when run_id is missing/invalid — actions still land in SQL for modern runs even if a future caller forgets to pass one.
- `load_dismissed` treats `actions.jsonl` as the source of truth (`dismissed_keys()`) and enriches each entry from SQL findings when available, falling back to `evaluation/<dim>.json` for legacy runs. Minimal stub if neither source has the original — user can still see and restore.

**[fix(rate-limit)](https://github.com/quodeq/quodeq/commit/b835c076)** — exempt findings mutations; bump default cap

- `/api/findings/dismiss`, `/restore`, `/delete` exempt from the global limiter (idempotent user-data mutations; not abuse vectors).
- Default global cap raised 60 → 600/min. Other endpoints (e.g. `/api/evaluations`) still respect the limit; `QUODEQ_RATE_LIMIT_MAX` still overrides.

## Tests

- `tests/api/test_routes_findings.py`: dismiss with no run_id / with the `'latest'` sentinel both populate the Dismissed list; legacy-JSON path surfaces full detail (severity, principle, title, reason, snippet, CWE refs).
- `tests/api/test_findings_rate_limit_exempt.py` (new, 4 tests): each mutation endpoint does 20 calls in a row with cap=5; `/api/evaluations` is verified to still 429 after the cap.
- `src/quodeq/ui/src/App.test.jsx` (new): pins `buildEvalPrincipal`'s runId-threading contract.

**Backend: 2990 tests pass. Frontend: 351 tests pass.**

## Test plan

Verified end-to-end against the user's `selectives-android` dataset (51 legacy runs, no `events.jsonl`):

- [x] Violations → Integrity → dismiss first finding: score moves 4.6 → 5.0, grade D → C, no `{scores: null}` response.
- [x] Dismissed tab on Violations populates with 106 enriched entries (severity, principle, title, reason, CWE refs).
- [x] Burst-clicked 150 dismiss buttons on Time Behaviour: 150/150 returned 200, violation count 185 → 35, score 0.0 → 8.4 grade B, zero rollbacks.