### PR TITLE
fix(events): emit JUDGMENT_CREATED for cache-replayed findings

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -112,12 +112,61 @@ def _jsonl_path(config: RunConfig, dim_id: str) -> Path:
     return _evidence_dir(config) / f"{dim_id}_evidence.jsonl"
 
 
-def _write_findings(jsonl: Path, findings: list[dict], *, append: bool) -> None:
+def _events_log_path(jsonl: Path) -> Path:
+    """Return the run's events.jsonl path given a per-dim evidence JSONL.
+
+    Evidence files live at ``<run_dir>/evidence/<dim>_evidence.jsonl``; the
+    event log lives at ``<run_dir>/events.jsonl``. Centralising the join so
+    the two callers below can't drift apart.
+    """
+    return jsonl.parent.parent / "events.jsonl"
+
+
+def _emit_cached_findings(events_log: Path, findings: list[dict]) -> None:
+    """Emit cached findings as JUDGMENT_CREATED events to the run's event log.
+
+    Cached findings replayed by the V2 cache in incremental runs were
+    landing only in the per-dim JSONL and never reaching ``events.jsonl``.
+    The SQL projection runs off ``events.jsonl``, so the dashboard's grade
+    tables saw only the freshly-dispatched findings and produced scores
+    that disagreed with the CLI's JSON file (e.g. flexibility scoring 9.0
+    in the UI vs 7.7 from the CLI on the same run). Mirroring each cached
+    finding into the event log closes that gap.
+
+    Exceptions are caught per finding and logged — the JSONL write
+    already succeeded above, so an event-emit failure should not propagate
+    and roll back the cache restore.
+    """
+    if not findings:
+        return
+    from quodeq.core.events.models import JudgmentCreatedEvent  # noqa: PLC0415
+    from quodeq.core.events.writer import EventLogWriter  # noqa: PLC0415
+    from quodeq.core.finding_mappings import wire_dict_to_judgment  # noqa: PLC0415
+
+    writer = EventLogWriter(events_log)
+    for finding in findings:
+        try:
+            payload = wire_dict_to_judgment(finding)
+            writer.emit(JudgmentCreatedEvent(payload=payload))
+        except Exception:  # noqa: BLE001 — event-log emit must never break a cache replay
+            _logger.warning(
+                "cache replay: event emit failed for finding p=%r file=%r line=%r",
+                finding.get("p"), finding.get("file"), finding.get("line"),
+                exc_info=True,
+            )
+
+
+def _write_findings(
+    jsonl: Path, findings: list[dict], *, append: bool,
+    emit_events: bool = True,
+) -> None:
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
     with jsonl.open(mode) as out:
         for finding in findings:
             out.write(json.dumps(finding) + "\n")
+    if emit_events:
+        _emit_cached_findings(_events_log_path(jsonl), findings)
 
 
 def process_dimension_with_cache(

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -584,3 +584,132 @@ class TestCarryOrder:
         assert carry_idx < fresh_idx, (
             f"carry (index {carry_idx}) should appear before fresh (index {fresh_idx})"
         )
+
+
+class TestCachedFindingsReachEventLog:
+    """Pin that cache-replayed findings land in ``events.jsonl`` as
+    ``JUDGMENT_CREATED`` events, not only in the per-dim JSONL.
+
+    Without this, an incremental run's SQL projection (which reads
+    ``events.jsonl``) sees only the freshly-dispatched findings — the
+    dashboard grade tables disagree with the CLI's JSON output because
+    they're scoring different sets of findings. The user reported this as
+    "flexibility shows 7.7 in the CLI but 9.0 in the UI" on a real
+    incremental run; the gap was exactly the cache-restored findings.
+    """
+
+    def _read_events(self, events_log: Path) -> list[dict]:
+        if not events_log.exists():
+            return []
+        out = []
+        for line in events_log.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+        return out
+
+    def test_all_hits_run_emits_judgment_events_for_cache_replay(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        # Pre-populate cache for both files so the run short-circuits dispatch.
+        for f in ["a.py", "b.py"]:
+            key = build_cache_key_for_file(config, f, "security")
+            cache.put(key, CacheEntry(
+                key=key, schema_version=1,
+                findings=[{
+                    "file": f, "line": 7, "t": "violation",
+                    "w": f"cached-{f}", "p": "Confidentiality", "d": "security",
+                    "req": f"S-CON-{f}", "severity": "minor",
+                    "snippet": "s", "reason": "r",
+                }],
+                files_read=1, file_path=f, dimension="security",
+                model_id="test-model",
+            ))
+
+        dispatcher = FakeDispatcher(src)
+        # events.jsonl lives at <evidence_dir>/.. which is <work_dir>/..
+        # The runner derives this from the per-dim JSONL path internally.
+        events_log = (config.work_dir or config.src).parent / "events.jsonl"
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        assert dispatcher.calls == [], "all-hits path must not dispatch"
+
+        events = self._read_events(events_log)
+        # Every cached finding must produce a JUDGMENT_CREATED event so the
+        # SQL projection sees it. Without the fix this list would be empty.
+        judgments = [e for e in events if e.get("event_type") == "JUDGMENT_CREATED"]
+        files_in_events = {e["payload"]["file"] for e in judgments}
+        assert files_in_events == {"a.py", "b.py"}, (
+            f"events.jsonl must contain a JUDGMENT_CREATED per cached finding; "
+            f"got {files_in_events}"
+        )
+
+    def test_partial_run_emits_judgment_events_for_carried_findings(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        """Mixed run: one cached hit (a.py) + one dispatched miss (b.py).
+
+        The cached carry was the silently-dropped path — pin that it shows
+        up in events.jsonl alongside the dispatcher's own emit.
+        """
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[{
+                "file": "a.py", "line": 1, "t": "violation",
+                "w": "carry-a", "p": "Confidentiality", "d": "security",
+                "req": "S-CON-A", "severity": "minor",
+                "snippet": "x", "reason": "r",
+            }],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+
+        events_log = (config.work_dir or config.src).parent / "events.jsonl"
+
+        def fake_dispatch(cfg, dim_id, idx, ctx, callbacks):
+            # The dispatcher in production routes through FindingsRouter,
+            # which emits events. This fake only writes JSONL — we're
+            # specifically testing the cache-replay side.
+            jsonl = (cfg.work_dir or cfg.src) / f"{dim_id}_evidence.jsonl"
+            jsonl.parent.mkdir(parents=True, exist_ok=True)
+            with jsonl.open("a") as out:
+                out.write(json.dumps({
+                    "file": "b.py", "line": 1, "t": "violation",
+                    "w": "fresh-b", "p": "Confidentiality", "d": "security",
+                    "req": "S-CON-B", "severity": "minor",
+                    "snippet": "y", "reason": "r",
+                }) + "\n")
+            return _make_dummy_evidence(files_read=1)
+
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=fake_dispatch,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+
+        events = self._read_events(events_log)
+        carry_files = {
+            e["payload"]["file"] for e in events
+            if e.get("event_type") == "JUDGMENT_CREATED"
+        }
+        assert "a.py" in carry_files, (
+            f"cached carry for a.py must emit a JUDGMENT_CREATED event; "
+            f"got {carry_files}"
+        )


### PR DESCRIPTION
## Summary

Incremental runs reuse findings from prior runs via the V2 cache. Those replays wrote straight to `<dim>_evidence.jsonl` via `_write_findings`, **bypassing `FindingsRouter`** and so never emitting `JUDGMENT_CREATED` events. The SQL projection runs off `events.jsonl`, so the dashboard's grade tables saw only the freshly-dispatched findings while the CLI's evaluation JSON described the full (cached + fresh) set. Result: dashboard scores diverged from the CLI's own report on any incremental run with cache hits.

Symptom reported by the user on a real flexibility run:

| Source | Violations / Compliance | Score |
|---|---|---|
| CLI (`evaluation/flexibility.json`) | 26 / 147 | 7.7/10 Good |
| Dashboard (SQL-projection) | 14 / 70 (events.jsonl only) | 9.0/10 Exemplary |

The 89 cache-replayed findings never reached `events.jsonl` — that's the entire gap.

## Fix

`_write_findings` now emits a `JudgmentCreatedEvent` per cached finding via `EventLogWriter` pointed at the run's `events.jsonl`. Both callers (all-hits short-circuit + pre-write before dispatch) pick it up automatically. Per-finding emit failures are caught and logged — the JSONL write already succeeded, so an event-log emit problem shouldn't roll back a legitimate cache replay.

The events.jsonl path is derived from the per-dim JSONL location (`<run_dir>/evidence/<dim>_evidence.jsonl` → `<run_dir>/events.jsonl`), centralised in a new `_events_log_path` helper so the two callers can't drift apart.

## What this doesn't fix

The remaining dashboard-vs-`/scores` divergence (the SQL projector's `compute_principle_grade` doesn't apply the CLI's confidence-level check, so principles with thin evidence score `10.0 Exemplary` instead of `Insufficient`) is a separate scoring-formula bug. The right architectural fix is to emit `PRINCIPLE_GRADED` / `DIMENSION_GRADED` events at end-of-run with the CLI's `(score, grade, confidence_level)` and have the projector skip its own math — tracked for a follow-up PR.

## Tests

`tests/analysis/cache/test_dimension_runner.py` gains `TestCachedFindingsReachEventLog` (2 tests):

- all-hits short-circuit must emit `JUDGMENT_CREATED` for every cached finding
- partial run must emit `JUDGMENT_CREATED` for cached carries (the previously-silent path)

Both tests fail against `develop` without this change — verified via `git stash` round-trip. **2992 backend tests pass.**

## Test plan

- [x] Full backend suite green (2992 tests)
- [x] New regression tests fail against base without the fix (verified)
- [x] End-to-end on user's real run (selectives-android `db9b0ded…`) after backfilling 89 missing events via the new emit path: `/api/projects/<p>/scores` returns flexibility `7.7/10 Good` with Installability + Scalability marked `Insufficient` — exact parity with the CLI's `evaluation/flexibility.json`.