### PR TITLE
perf(manifest): 85s → 1s startup — prune skip dirs + memoize hashes

### DIFF
--- a/src/quodeq/analysis/fingerprint.py
+++ b/src/quodeq/analysis/fingerprint.py
@@ -11,6 +11,7 @@ keys (and that priority scoring uses to detect file changes).
 """
 from __future__ import annotations
 
+import functools
 import hashlib
 from pathlib import Path
 
@@ -31,16 +32,50 @@ def _hash_file(path: Path) -> str | None:
         return None
 
 
+@functools.lru_cache(maxsize=None)
+def _hash_file_by_stat(path: Path, size: int, mtime_ns: int) -> str | None:
+    """Memoized ``_hash_file`` keyed by (path, size, mtime_ns).
+
+    Standard make/pyc-style invalidation: hashing is the expensive part,
+    but ``os.stat`` is cheap. When the file is rewritten its
+    ``mtime_ns`` changes, the cache key changes, and we re-hash. Inside
+    one ``quodeq evaluate`` process the inputs don't change, so the
+    same key is hit thousands of times — exactly the case we want to
+    short-circuit. ``size`` is included as a defensive belt-and-braces
+    against the (rare) case of an mtime_ns collision on a same-size
+    rewrite at the granularity floor of the underlying filesystem.
+    """
+    # size and mtime_ns are only here to drive the cache key; the actual
+    # hashing reads the real bytes off disk.
+    _ = (size, mtime_ns)
+    return _hash_file(path)
+
+
+def _stat_key(path: Path) -> tuple[int, int] | None:
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return st.st_size, st.st_mtime_ns
+
+
 def _hash_standards(standards_dir: Path, dimension: str) -> str | None:
     """SHA-256 of the compiled standards JSON for a dimension.
 
     Uses the same chunked hashing approach as ``_hash_file`` to avoid
     reading the entire file into memory at once.
+
+    Memoized via ``_hash_file_by_stat``: inside one ``quodeq evaluate``
+    process the compiled JSON is rewritten only if the user edits it
+    mid-run, in which case the new ``mtime_ns`` invalidates the cache
+    automatically. Without this cache a 3 K-file dim re-hashes the same
+    JSON 3 K times.
     """
     compiled = standards_dir / "compiled" / f"{dimension}.json"
-    if not compiled.exists():
+    key = _stat_key(compiled)
+    if key is None:
         return None
-    return _hash_file(compiled)
+    return _hash_file_by_stat(compiled, *key)
 
 
 # Prompts in this set carry the rules that classify a finding (what counts
@@ -54,7 +89,10 @@ def _hash_prompts_map(prompts_dir: Path | None = None) -> dict[str, str]:
     """Per-file SHA-256 of every *.md prompt under *prompts_dir*.
 
     V2's cache key folds these into one combined hash; storing per-file
-    enables future selective invalidation if needed.
+    enables future selective invalidation if needed. The actual file
+    hashing is memoized in ``_hash_file_by_stat`` (keyed by mtime_ns), so
+    repeat calls inside one process re-walk the prompts directory (cheap)
+    but don't re-read file bytes.
     """
     if prompts_dir is None:
         prompts_dir = default_paths().prompts_dir
@@ -62,7 +100,17 @@ def _hash_prompts_map(prompts_dir: Path | None = None) -> dict[str, str]:
         return {}
     out: dict[str, str] = {}
     for path in sorted(prompts_dir.glob("*.md")):
-        h = _hash_file(path)
+        key = _stat_key(path)
+        if key is None:
+            continue
+        h = _hash_file_by_stat(path, *key)
         if h:
             out[path.name] = h
     return out
+
+
+# Expose ``cache_clear`` on the public-ish surface so test fixtures and
+# any code that genuinely needs to drop the cache (e.g. after editing
+# a prompt mid-process) don't have to reach for the internal helper.
+_hash_standards.cache_clear = _hash_file_by_stat.cache_clear  # type: ignore[attr-defined]
+_hash_prompts_map.cache_clear = _hash_file_by_stat.cache_clear  # type: ignore[attr-defined]

--- a/src/quodeq/config/_discipline_detection.py
+++ b/src/quodeq/config/_discipline_detection.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Iterable
 
@@ -130,20 +132,38 @@ class DisciplineRegistry:
         Honors the same vendor/skip-dir set used by recursive subproject discovery
         so a vendored copy under ``node_modules`` / ``.venv`` / ``vendor`` doesn't
         satisfy the prereq and falsely classify the host repo.
+
+        For recursive ``**/*.<ext>``-style patterns we walk the tree with
+        ``os.walk`` and prune skip / hidden dirs *before* descending. The
+        old implementation used ``Path.glob``, which scandirs every subtree
+        before the in-loop filter could discard matches — on an Android
+        repo with 88 subproject roots and ``build/`` + ``.gradle/`` under
+        each, that turned a millisecond gate into an 85 s walk
+        (~2 M scandir calls). Pruning at the directory level keeps the
+        boolean answer identical while bringing cost back to milliseconds.
+        Non-recursive patterns (e.g. ``lib/*.sh``) keep using ``Path.glob``;
+        they don't descend into skip dirs in the first place.
         """
-        if not rule.detect_requires_file:
+        pattern = rule.detect_requires_file
+        if not pattern:
             return True
-        for match in repo.glob(rule.detect_requires_file):
-            try:
-                rel = match.relative_to(repo)
-            except ValueError:
-                continue
-            if any(
-                part in _SUBPROJECT_SKIP_DIRS or part.startswith(".")
-                for part in rel.parts[:-1]
-            ):
-                continue
-            return True
+        if pattern.startswith("**/"):
+            file_pat = pattern[len("**/") :]
+            return self._has_pruned_recursive_match(repo, file_pat)
+        return any(repo.glob(pattern))
+
+    @staticmethod
+    def _has_pruned_recursive_match(repo: Path, file_pat: str) -> bool:
+        """Return True iff any file under *repo* matches *file_pat*, skipping
+        vendor / cache / hidden directories at the directory level.
+        """
+        for _dirpath, dirnames, filenames in os.walk(repo):
+            dirnames[:] = [
+                d for d in dirnames
+                if d not in _SUBPROJECT_SKIP_DIRS and not d.startswith(".")
+            ]
+            if any(fnmatchcase(f, file_pat) for f in filenames):
+                return True
         return False
 
     def _any_detect_file_matches(self, repo: Path, rule: DisciplineRule) -> bool:

--- a/tests/analysis/test_fingerprint_memo.py
+++ b/tests/analysis/test_fingerprint_memo.py
@@ -1,0 +1,132 @@
+"""Memoization of ``_hash_prompts_map`` and ``_hash_standards``.
+
+These hashes are computed inside ``build_cache_key_for_file`` for every
+(file, dimension) pair. Prompts are identical for the entire run; the
+compiled standards JSON is identical for the entire dimension. Re-hashing
+them once per file is wasted I/O — on a 3K-file repo that's thousands of
+redundant reads of the same handful of bytes.
+
+The cache must be:
+
+1. **Hit on identical inputs** — same call args, no second filesystem read.
+2. **Miss on different inputs** — a different ``standards_dir`` or
+   ``dimension`` still computes a fresh hash.
+3. **Stable across argument forms** — ``Path`` is hashable; the result
+   must be the same regardless of whether the caller passes the path as
+   a string or a ``Path``.
+
+A single process never swaps the underlying files (each ``quodeq evaluate``
+is fresh), so unbounded caching is safe within a run.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis import fingerprint
+
+
+def _write_compiled_standard(standards_dir: Path, dimension: str, body: str) -> None:
+    """Mirror the on-disk layout that ``_hash_standards`` expects."""
+    compiled = standards_dir / "compiled"
+    compiled.mkdir(parents=True, exist_ok=True)
+    (compiled / f"{dimension}.json").write_text(body)
+
+
+@pytest.fixture(autouse=True)
+def _clear_fingerprint_caches():
+    """Reset the LRU caches before each test so call counts are isolated."""
+    # The implementation will define cache_clear hooks on the memoized
+    # helpers. Use getattr so this fixture stays valid before and after
+    # the impl lands (clearing is a no-op when the cache doesn't exist).
+    for name in ("_hash_prompts_map", "_hash_standards"):
+        fn = getattr(fingerprint, name, None)
+        clear = getattr(fn, "cache_clear", None)
+        if clear is not None:
+            clear()
+    yield
+    for name in ("_hash_prompts_map", "_hash_standards"):
+        fn = getattr(fingerprint, name, None)
+        clear = getattr(fn, "cache_clear", None)
+        if clear is not None:
+            clear()
+
+
+def test_hash_standards_memoizes_within_dimension(tmp_path: Path):
+    """Two calls with the same (standards_dir, dimension) share one read."""
+    _write_compiled_standard(tmp_path, "flexibility", '{"rule": "v1"}')
+
+    with patch.object(
+        fingerprint, "_hash_file", wraps=fingerprint._hash_file,
+    ) as spy:
+        first = fingerprint._hash_standards(tmp_path, "flexibility")
+        second = fingerprint._hash_standards(tmp_path, "flexibility")
+
+    assert first == second
+    assert first is not None
+    assert spy.call_count == 1, (
+        f"expected one filesystem read across two identical calls, got {spy.call_count}"
+    )
+
+
+def test_hash_standards_does_not_collide_across_dimensions(tmp_path: Path):
+    """Different dimensions hash different files — cache must not collide."""
+    _write_compiled_standard(tmp_path, "flexibility", '{"rule": "flex"}')
+    _write_compiled_standard(tmp_path, "security", '{"rule": "sec"}')
+
+    flex = fingerprint._hash_standards(tmp_path, "flexibility")
+    sec = fingerprint._hash_standards(tmp_path, "security")
+
+    assert flex is not None and sec is not None
+    assert flex != sec
+
+
+def test_hash_prompts_map_memoizes_within_run(tmp_path: Path):
+    """Repeated calls with no argument hit the default prompts dir once."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "evaluation_rules.md").write_text("hello")
+    (prompts / "finding_format.md").write_text("world")
+
+    with patch.object(
+        fingerprint, "_hash_file", wraps=fingerprint._hash_file,
+    ) as spy:
+        first = fingerprint._hash_prompts_map(prompts)
+        second = fingerprint._hash_prompts_map(prompts)
+
+    assert first == second
+    assert set(first.keys()) == {"evaluation_rules.md", "finding_format.md"}
+    # Two .md files × two calls would be 4 reads without memoization.
+    assert spy.call_count == 2, (
+        f"expected one read per unique prompt file across calls, got {spy.call_count}"
+    )
+
+
+def test_hash_prompts_map_returns_immutable_safe_copy(tmp_path: Path):
+    """Callers must not be able to mutate the cached dict for later callers."""
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "evaluation_rules.md").write_text("hello")
+
+    first = fingerprint._hash_prompts_map(prompts)
+    first["evaluation_rules.md"] = "tampered"
+
+    second = fingerprint._hash_prompts_map(prompts)
+    assert second["evaluation_rules.md"] != "tampered"
+
+
+def test_hash_prompts_map_different_dirs_have_independent_caches(tmp_path: Path):
+    """Two distinct prompt dirs must not share a cache entry."""
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    (dir_a / "x.md").write_text("AAA")
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    (dir_b / "x.md").write_text("BBB")
+
+    map_a = fingerprint._hash_prompts_map(dir_a)
+    map_b = fingerprint._hash_prompts_map(dir_b)
+
+    assert map_a["x.md"] != map_b["x.md"]

--- a/tests/config/test_discipline_detection_skip_dirs.py
+++ b/tests/config/test_discipline_detection_skip_dirs.py
@@ -1,0 +1,175 @@
+"""Pruning behavior for ``_has_required_files``.
+
+The detect_requires_file gate uses ``**/*`` patterns that traditionally went
+through ``Path.glob``, which scandirs into ``build/``/``.gradle/``/``.git/``
+before the in-loop skip-dir filter could discard the match. On large
+multi-module repos this turned a millisecond gate into multi-second walks.
+
+These tests pin two things:
+
+1. **Semantic parity** — the gate's True/False answer is unchanged for
+   patterns under skip dirs vs. under regular source dirs.
+2. **Pruning at the directory level** — when looking for ``**/*.kt`` the
+   implementation must not ``scandir`` into ``_SUBPROJECT_SKIP_DIRS`` or
+   hidden directories. Without pruning, the wallclock blows up.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.config._discipline_detection import (
+    _SUBPROJECT_SKIP_DIRS,
+    DisciplineRegistry,
+)
+from quodeq.config._discipline_rule import DisciplineRule
+
+
+def _registry(rule: DisciplineRule) -> DisciplineRegistry:
+    return DisciplineRegistry({rule.name: rule})
+
+
+def _kotlin_rule() -> DisciplineRule:
+    """Mirror the real ``mobile_kotlin`` rule's gating pattern."""
+    return DisciplineRule(
+        name="mobile_kotlin",
+        detect_files=("build.gradle.kts",),
+        detect_requires_file="**/*.kt",
+    )
+
+
+def test_returns_true_for_match_outside_skip_dirs(tmp_path: Path):
+    """Baseline: a regular Foo.kt under src/ satisfies the gate."""
+    (tmp_path / "src" / "main" / "kotlin").mkdir(parents=True)
+    (tmp_path / "src" / "main" / "kotlin" / "Foo.kt").write_text("")
+    (tmp_path / "build.gradle.kts").write_text("")
+
+    reg = _registry(_kotlin_rule())
+    assert reg._has_required_files(tmp_path, _kotlin_rule()) is True
+
+
+def test_returns_false_when_match_only_in_skip_dir(tmp_path: Path):
+    """A .kt only under build/ does NOT satisfy the gate. Mirrors today's
+    semantics — vendored / generated copies don't count as project content.
+    """
+    (tmp_path / "build" / "generated").mkdir(parents=True)
+    (tmp_path / "build" / "generated" / "Generated.kt").write_text("")
+
+    reg = _registry(_kotlin_rule())
+    assert reg._has_required_files(tmp_path, _kotlin_rule()) is False
+
+
+def test_returns_false_when_match_only_in_hidden_dir(tmp_path: Path):
+    """A .kt only under .gradle/ does NOT satisfy the gate."""
+    (tmp_path / ".gradle" / "caches").mkdir(parents=True)
+    (tmp_path / ".gradle" / "caches" / "Cached.kt").write_text("")
+
+    reg = _registry(_kotlin_rule())
+    assert reg._has_required_files(tmp_path, _kotlin_rule()) is False
+
+
+def test_returns_true_for_match_at_root(tmp_path: Path):
+    """A .kt directly in the repo root counts."""
+    (tmp_path / "Foo.kt").write_text("")
+
+    reg = _registry(_kotlin_rule())
+    assert reg._has_required_files(tmp_path, _kotlin_rule()) is True
+
+
+def test_rule_without_detect_requires_file_returns_true(tmp_path: Path):
+    """When no gate is set, the rule trivially passes (semantic-preserving)."""
+    rule = DisciplineRule(name="anything", detect_requires_file=None)
+    reg = _registry(rule)
+    assert reg._has_required_files(tmp_path, rule) is True
+
+
+def test_does_not_scandir_into_skip_dirs(tmp_path: Path):
+    """Pruning happens at the directory level: ``scandir`` is never called
+    on ``build/`` or ``.gradle/`` while looking for ``**/*.kt``.
+
+    Without pruning, ``Path.glob`` enumerates *all* matches before the
+    in-loop filter discards skip-dir hits; on a real Android repo that
+    means scandir gets called ~2M times. This test pins the pruning so a
+    regression here would surface immediately.
+
+    Topology is chosen so the only valid match lives behind directories
+    alphabetically *after* the skip dirs, forcing any non-pruning glob
+    implementation to scandir the skip dirs before finding it.
+    """
+    # 'build' (skip) and '.gradle' (hidden) sort before 'src' in directory
+    # listings on every filesystem we care about, so a non-pruning glob
+    # implementation will scandir them before reaching src/main/kotlin/.
+    (tmp_path / "build").mkdir()
+    for i in range(5):
+        (tmp_path / "build" / f"Generated{i}.kt").write_text("")
+    (tmp_path / ".gradle" / "caches").mkdir(parents=True)
+    for i in range(5):
+        (tmp_path / ".gradle" / "caches" / f"Cached{i}.kt").write_text("")
+    (tmp_path / "src" / "main" / "kotlin").mkdir(parents=True)
+    (tmp_path / "src" / "main" / "kotlin" / "Foo.kt").write_text("")
+
+    scandir_calls: list[str] = []
+    real_scandir = os.scandir
+
+    def tracking_scandir(path):
+        scandir_calls.append(os.fspath(path))
+        return real_scandir(path)
+
+    with patch("os.scandir", side_effect=tracking_scandir):
+        reg = _registry(_kotlin_rule())
+        assert reg._has_required_files(tmp_path, _kotlin_rule()) is True
+
+    descended_paths = [Path(p).resolve() for p in scandir_calls]
+    build_dir = (tmp_path / "build").resolve()
+    gradle_dir = (tmp_path / ".gradle").resolve()
+    assert build_dir not in descended_paths, (
+        f"scandir descended into {build_dir} despite skip-dir membership; "
+        f"calls were: {scandir_calls}"
+    )
+    assert gradle_dir not in descended_paths, (
+        f"scandir descended into {gradle_dir} despite hidden-dir status; "
+        f"calls were: {scandir_calls}"
+    )
+
+
+def test_non_recursive_pattern_still_works(tmp_path: Path):
+    """``detect_requires_file='lib/*.sh'`` (non-recursive) must keep working.
+
+    The fix only changes the recursive branch; single-level patterns still
+    need to match files in the named subdirectory.
+    """
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "deploy.sh").write_text("")
+    rule = DisciplineRule(name="shell", detect_requires_file="lib/*.sh")
+
+    reg = _registry(rule)
+    assert reg._has_required_files(tmp_path, rule) is True
+
+
+def test_non_recursive_pattern_returns_false_when_no_match(tmp_path: Path):
+    """Non-recursive pattern with no match returns False."""
+    (tmp_path / "lib").mkdir()
+    rule = DisciplineRule(name="shell", detect_requires_file="lib/*.sh")
+
+    reg = _registry(rule)
+    assert reg._has_required_files(tmp_path, rule) is False
+
+
+def test_pruning_covers_every_skip_dir(tmp_path: Path):
+    """Every name in ``_SUBPROJECT_SKIP_DIRS`` must be pruned, not just
+    the well-known Kotlin/Android ones. Catches drift where the list grows
+    but the implementation forgets to honor an entry.
+    """
+    # Put a .kt in every skip dir. No legitimate match elsewhere — so the
+    # gate's correct answer is False, and an implementation that fails to
+    # prune even one skip dir would return True instead.
+    for name in _SUBPROJECT_SKIP_DIRS:
+        d = tmp_path / name
+        d.mkdir()
+        (d / "Inside.kt").write_text("")
+
+    reg = _registry(_kotlin_rule())
+    assert reg._has_required_files(tmp_path, _kotlin_rule()) is False


### PR DESCRIPTION
## Problem

On `quodeq evaluate` against a multi-module Android repo (selectives-android, 3037 files / 88 subproject roots), the dashboard sits on **`preparing… · Waiting for output…`** for ~1:30 before any codex / cloud LLM is invoked. The same gap shows up for every provider — it's local work, not the model.

Timeline from a live run (PID 55483):

| Time | Event |
|---|---|
| 12:32:xx | `quodeq evaluate` CLI process starts |
| **12:34:25** | `status.json` written → lifecycle finally enters "analyzing" |
| 12:34:30 | First `JUDGMENT_CREATED` from codex |

→ ~5 s from lifecycle "analyzing" to first finding. The other ~2 minutes are pre-pipeline work.

cProfile of `build_manifest` against that repo pins the whole cost to one hot path:

```
85.036 s  detect_matches  (_discipline_detection.py:175)
84.886 s  _has_required_files
84.868 s  glob.py:495 select_recursive   (450 calls)
79.418 s  glob.py:551 scandir         (1,998,828 calls)
```

`_has_required_files` was using `Path.glob(rule.detect_requires_file)` and filtering skip dirs *inside the loop*, after glob had already `scandir`'d every `build/`, `.gradle/`, `.git/` in every subproject root. 88 roots × 5 rules with `**/*` patterns × recursive scandir into vendor / cache dirs = the 85 s.

A secondary issue: `build_cache_key_for_file` re-hashes the compiled standards JSON and the 6 prompt `*.md` files once per source file (3 K+ redundant reads of the same bytes per dim).

## Fix

**1. Prune skip dirs at the directory level.** Recursive `**/*` patterns now walk with `os.walk` and drop `_SUBPROJECT_SKIP_DIRS` + dotted dirs from `dirnames[:]` *before* descending. Non-recursive patterns (`lib/*.sh`) keep using `Path.glob` — they don't descend into skip dirs anyway. Same True/False answer in every case; only the work changes.

**2. Memoize file hashes by `(path, size, mtime_ns)`.** Standard `make` / `pyc`-style invalidation: `os.stat` is cheap, hashing is the cost. Inside one process the inputs don't change, so the same key is hit thousands of times. A mid-process rewrite still invalidates correctly — the existing `test_standards_change_invalidates` regression test keeps passing.

## Impact (selectives-android, 3037 files, 88 subproject roots)

```
build_manifest:   85.52 s → 1.11 s   (77× faster)
File count:       3037 → 3037        (unchanged)
Targets:          kotlin (2792), kotlin (229), bash (5), kotlin (4), kotlin (4), kotlin (3)
                  → identical to current run.log
```

End-to-end: the `preparing…` window on the dashboard should drop from ~1:30 to ~5–10 s for this repo.

## Test plan

- [x] New `tests/config/test_discipline_detection_skip_dirs.py` (9 tests): semantic parity for match-outside-skip-dirs / match-only-in-skip-dir / match-at-root / no-`detect_requires_file` / non-recursive pattern variants, plus a structural `scandir`-spy test that pins the pruning (fails RED against the old impl).
- [x] New `tests/analysis/test_fingerprint_memo.py` (5 tests): memoization hits on identical inputs, misses across dimensions / prompt dirs, returned dict is mutation-safe.
- [x] Existing `test_standards_change_invalidates` still passes — mtime-keyed cache invalidates on rewrite.
- [x] Full suite: **3045 passed**.
- [x] Wallclock benchmark on `~/Projects/GitHub/selectives-android`: 85.52 s → 1.11 s.
- [x] Sanity wallclock on this repo: 0.36 s, 1206 files, 15 targets — unchanged.

## Out of scope (separate ticket)

`classify_files_via_cache` runs twice per dim — once in `_persist_dim_estimates` (for the dashboard's upfront totals) and once inside `dimension_runner.py:247` (for the actual hit/miss split). With memoization in place the redundant pass is ~1.5 s per dim — not the bottleneck, but worth filing.