### PR TITLE
fix(tests): make 3 cache-root tests pass on Windows CI

### DIFF
--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -280,9 +280,14 @@ class TestSyncCacheWrite:
         (src_root / "Foo.kt").write_text("class Foo")
 
         # build_cache_writer hardcodes Path.home() / ".quodeq/cache/results",
-        # so redirect HOME to keep this test self-contained.
-        monkeypatch.setenv("HOME", str(tmp_path / "home"))
-        cache_root = tmp_path / "home" / ".quodeq" / "cache" / "results"
+        # so redirect the user-home lookup to keep this test self-contained.
+        # POSIX's expanduser reads HOME; Windows' reads USERPROFILE first and
+        # ignores HOME when USERPROFILE is set (which it always is on CI).
+        # Setting both keeps the test cross-platform.
+        fake_home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
+        cache_root = fake_home / ".quodeq" / "cache" / "results"
 
         run_config = RunConfig(
             src=src_root,

--- a/tests/analysis/test_command_coverage.py
+++ b/tests/analysis/test_command_coverage.py
@@ -246,9 +246,13 @@ class TestBuildMcpServerArgs:
         assert args[model_idx + 1] == "sonnet"
         lang_idx = args.index("--language")
         assert args[lang_idx + 1] == "kotlin"
-        # Cache root defaults to ~/.quodeq/cache/results
+        # Cache root defaults to ~/.quodeq/cache/results. Compare via
+        # Path so the assertion is platform-agnostic — on Windows the
+        # produced path uses backslashes, so a literal forward-slash
+        # tail check would fail there.
         cr_idx = args.index("--cache-root")
-        assert args[cr_idx + 1].endswith(".quodeq/cache/results")
+        expected_tail = str(Path(".quodeq") / "cache" / "results")
+        assert args[cr_idx + 1].endswith(expected_tail)
 
     def test_cache_flags_fall_back_when_no_run_config(self, tmp_path):
         """Without a RunConfig carrier, --cache-root is still emitted, model_id

--- a/tests/analysis/test_mcp_config_coverage.py
+++ b/tests/analysis/test_mcp_config_coverage.py
@@ -125,8 +125,12 @@ class TestCreateMcpConfig:
             assert args[model_idx + 1] == "sonnet"
             lang_idx = args.index("--language")
             assert args[lang_idx + 1] == "kotlin"
+            # Cache root path uses platform-native separators (backslash
+            # on Windows); compare via Path so the tail check holds on
+            # every OS.
             cr_idx = args.index("--cache-root")
-            assert args[cr_idx + 1].endswith(".quodeq/cache/results")
+            expected_tail = str(Path(".quodeq") / "cache" / "results")
+            assert args[cr_idx + 1].endswith(expected_tail)
         finally:
             config_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
The Windows leg of CI has been red on `develop` ever since the `--cache-root / --model-id / --language` plumbing landed in #538. All three failures are POSIX-only assumptions in the tests, not bugs in the production code.

## Failing tests (pre-existing on develop)

| Test | Cause |
|---|---|
| [`test_api_path_writes_cache_synchronously_when_file_done_ok`](tests/analysis/test_api_runner.py#L317) | `monkeypatch.setenv("HOME", ...)` doesn't redirect `Path.home()` on Windows — Python's `os.path.expanduser` reads `USERPROFILE` first and ignores `HOME` when `USERPROFILE` is set (always true on CI). The synchronous cache write landed at the runner's real `C:\Users\runneradmin\...` instead of the test's tmp_path, and the assertion saw zero entries. |
| [`test_includes_cache_root_model_id_language`](tests/analysis/test_command_coverage.py#L251) (×2 — also in `test_mcp_config_coverage.py`) | Asserted `args[cr_idx + 1].endswith(".quodeq/cache/results")`. On Windows the produced path uses backslashes, so the literal forward-slash tail never matched. |

## Fix

Two-line test changes, no production code touched:

- **HOME / USERPROFILE:** set both env vars to the same fake home. POSIX reads `HOME`, Windows reads `USERPROFILE`, both point at tmp_path. Cross-platform self-contained.
- **Path-aware tail:** build the expected tail via `Path(".quodeq") / "cache" / "results"` so the separator matches the platform (`/` on POSIX, `\` on Windows). Test stays a tail assertion; no functional change.

## Test plan

- [x] All 3 previously failing tests pass on macOS: `pytest tests/analysis/test_api_runner.py::TestSyncCacheWrite tests/analysis/test_command_coverage.py::TestBuildMcpServerArgs::test_includes_cache_root_model_id_language tests/analysis/test_mcp_config_coverage.py::TestCreateMcpConfig::test_includes_cache_root_model_id_language` → 3 passed
- [x] Full suite on macOS: 3045 passed (no regression).
- [x] Windows CI on this PR: expected to drop from 3 fails to 0.
- Once green, #541's Windows CI should also clean up (the `test_standards_change_invalidates` fix already lives there).