### PR TITLE
feat(dashboard): unified coverage line on dimension cards

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -9,45 +9,56 @@ import { splitScore, scoreGradeColorVar, complianceRatio, formatRunId } from '..
 import { dimensionGradeLabel } from './dimensionGradeLabel.js';
 
 /**
- * Decide whether a dimension run was partial (incomplete coverage).
+ * Build a coverage record for the gauge card's footer line.
  *
- * A run is considered "partial" when EITHER:
- *   - the analyzer read fewer files than the project's total source-file
- *     count (typically a deadline-truncated run), OR
- *   - the run's lifecycle exit_reason is anything other than "done"
- *     (e.g. "deadline", "failure_streak"). Legacy runs that lack any
- *     exit_reason at all are NOT flagged — we don't want to splash a
- *     "Partial" badge on every historical complete-but-pre-Phase-1 run.
+ * Every card with a date gets a footer line; `coveragePct` and `isPartial`
+ * are derived from the same signals as the old partial badge:
+ *   - "partial" when filesRead < sourceFileCount, OR
+ *   - "partial" when exitReason is set to anything other than 'done'.
+ * Legacy runs with neither signal end up complete-by-default.
  *
- * Returns null when there's no signal at all (no filesRead, no
- * sourceFileCount, no exitReason) — i.e. legacy runs.
+ * `coveragePct` is null when there are no file counts (legacy runs);
+ * in that case the footer renders the date only.
  */
-function computePartialInfo(filesRead, sourceFileCount, exitReason) {
-  const hasCoverageSignal =
-    typeof filesRead === 'number' && typeof sourceFileCount === 'number' && sourceFileCount > 0;
-  const coverageIncomplete = hasCoverageSignal && filesRead < sourceFileCount;
-  const exitIncomplete = typeof exitReason === 'string' && exitReason !== 'done';
-  if (!coverageIncomplete && !exitIncomplete) return null;
-  const coveragePct = hasCoverageSignal
+function computeCoverageInfo(filesRead, sourceFileCount, exitReason) {
+  const hasCounts =
+    typeof filesRead === 'number' &&
+    typeof sourceFileCount === 'number' &&
+    sourceFileCount > 0;
+  const coveragePct = hasCounts
     ? Math.round((filesRead / sourceFileCount) * 100)
     : null;
-  return { filesRead, sourceFileCount, coveragePct, exitReason };
+  const coverageIncomplete = hasCounts && filesRead < sourceFileCount;
+  const exitIncomplete = typeof exitReason === 'string' && exitReason !== 'done';
+  const isPartial = coverageIncomplete || exitIncomplete;
+  return { filesRead, sourceFileCount, coveragePct, exitReason, isPartial };
 }
 
-function PartialBadge({ info }) {
-  const { filesRead, sourceFileCount, coveragePct, exitReason } = info;
+function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
   const hasCounts =
-    typeof filesRead === 'number' && typeof sourceFileCount === 'number' && sourceFileCount > 0;
-  const label = hasCounts
-    ? `Partial — ${filesRead.toLocaleString()} of ${sourceFileCount.toLocaleString()} files (${coveragePct}%)`
-    : 'Partial';
+    typeof filesRead === 'number' &&
+    typeof sourceFileCount === 'number' &&
+    sourceFileCount > 0;
+  const parts = ['Partial run'];
+  if (hasCounts) {
+    parts.push(`${filesRead.toLocaleString()} of ${sourceFileCount.toLocaleString()} files`);
+  }
+  if (typeof exitReason === 'string') {
+    parts.push(`stopped: ${exitReason}`);
+  }
+  return parts.join(' · ');
+}
+
+function CoverageLine({ dateText, coveragePct, isPartial, tooltip }) {
+  if (!dateText) return null;
+  const label = coveragePct !== null ? `${dateText} · ${coveragePct}%` : dateText;
   return (
-    <span
-      className="dim-gauge-card__partial-badge"
-      title={exitReason ?? undefined}
+    <div
+      className="dim-gauge-card__coverage-line"
+      title={isPartial ? tooltip : undefined}
     >
       {label}
-    </span>
+    </div>
   );
 }
 
@@ -100,7 +111,8 @@ export default function DimensionGaugeCard({
   const activate = () => onDimensionClick?.(item, selectedRunId);
   const staleClass = evaluatedToday ? '' : 'dim-gauge-card--stale';
   const dateText = item.fromDateLabel || dateLabel || formatRunId(item.fromRunId || selectedRunId);
-  const partialInfo = computePartialInfo(item.filesRead, item.sourceFileCount, item.exitReason);
+  const coverage = computeCoverageInfo(item.filesRead, item.sourceFileCount, item.exitReason);
+  const partialTooltip = coverage.isPartial ? buildPartialTooltip(coverage) : undefined;
 
   return (
     <article
@@ -173,11 +185,12 @@ export default function DimensionGaugeCard({
         </>
       )}
 
-      {partialInfo && <PartialBadge info={partialInfo} />}
-
-      {!evaluatedToday && dateText && (
-        <div className="dim-gauge-card__stale-label">Older run · {dateText}</div>
-      )}
+      <CoverageLine
+        dateText={dateText}
+        coveragePct={coverage.coveragePct}
+        isPartial={coverage.isPartial}
+        tooltip={partialTooltip}
+      />
     </article>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -32,8 +32,10 @@ describe('DimensionGaugeCard', () => {
     expect(screen.queryByText(/VIOL/)).toBeNull();
   });
 
-  describe('partial badge', () => {
-    it("shows 'Partial — N of M files (P%)' when filesRead < sourceFileCount", () => {
+  describe('coverage line', () => {
+    const dateLabel = '13 May 2026';
+
+    it('shows "<date> · <pct>%" when filesRead < sourceFileCount', () => {
       render(
         <DimensionGaugeCard
           item={{
@@ -41,17 +43,37 @@ describe('DimensionGaugeCard', () => {
             filesRead: 850,
             sourceFileCount: 3037,
           }}
+          dateLabel={dateLabel}
           onDimensionClick={() => {}}
         />,
       );
-      const badge = screen.getByText(/Partial/i);
-      expect(badge).toBeInTheDocument();
-      expect(badge.textContent).toMatch(/850/);
-      expect(badge.textContent).toMatch(/3,?037/);
-      expect(badge.textContent).toMatch(/28%/);
+      const line = screen.getByText(`${dateLabel} · 28%`);
+      expect(line).toBeInTheDocument();
+      expect(line.getAttribute('title')).toBe(
+        'Partial run · 850 of 3,037 files',
+      );
     });
 
-    it("shows the badge when exitReason is 'deadline' even if file counts match", () => {
+    it('appends "stopped: <exitReason>" to the tooltip when exitReason is set', () => {
+      render(
+        <DimensionGaugeCard
+          item={{
+            ...baseItem,
+            filesRead: 850,
+            sourceFileCount: 3037,
+            exitReason: 'deadline',
+          }}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+      const line = screen.getByText(`${dateLabel} · 28%`);
+      expect(line.getAttribute('title')).toBe(
+        'Partial run · 850 of 3,037 files · stopped: deadline',
+      );
+    });
+
+    it('flags partial when exitReason is "deadline" even if file counts match', () => {
       render(
         <DimensionGaugeCard
           item={{
@@ -60,30 +82,70 @@ describe('DimensionGaugeCard', () => {
             sourceFileCount: 100,
             exitReason: 'deadline',
           }}
+          dateLabel={dateLabel}
           onDimensionClick={() => {}}
         />,
       );
-      expect(screen.getByText(/Partial/i)).toBeInTheDocument();
+      const line = screen.getByText(`${dateLabel} · 100%`);
+      expect(line.getAttribute('title')).toBe(
+        'Partial run · 100 of 100 files · stopped: deadline',
+      );
     });
 
-    it('does NOT show the badge when filesRead equals sourceFileCount and exitReason is null', () => {
+    it('shows "<date> · 100%" with no tooltip on a complete run', () => {
       render(
         <DimensionGaugeCard
           item={{
             ...baseItem,
             filesRead: 3037,
             sourceFileCount: 3037,
-            exitReason: null,
+            exitReason: 'done',
           }}
+          dateLabel={dateLabel}
           onDimensionClick={() => {}}
         />,
       );
-      expect(screen.queryByText(/Partial/i)).not.toBeInTheDocument();
+      const line = screen.getByText(`${dateLabel} · 100%`);
+      expect(line.getAttribute('title')).toBeNull();
     });
 
-    it('does NOT show the badge when neither filesRead nor exitReason is present (legacy run)', () => {
-      render(<DimensionGaugeCard item={baseItem} onDimensionClick={() => {}} />);
-      expect(screen.queryByText(/Partial/i)).not.toBeInTheDocument();
+    it('omits the "· %" suffix on legacy runs without file counts', () => {
+      render(
+        <DimensionGaugeCard
+          item={baseItem}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+      expect(screen.getByText(dateLabel)).toBeInTheDocument();
+      expect(screen.queryByText(/%/)).toBeNull();
+    });
+
+    it('builds a tooltip with no file counts when only an exit signal exists', () => {
+      render(
+        <DimensionGaugeCard
+          item={{ ...baseItem, exitReason: 'deadline' }}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+      const line = screen.getByText(dateLabel);
+      expect(line.getAttribute('title')).toBe(
+        'Partial run · stopped: deadline',
+      );
+    });
+
+    it('does NOT render the coverage line when there is no date to show', () => {
+      const { container } = render(
+        <DimensionGaugeCard
+          item={baseItem}
+          dateLabel=""
+          onDimensionClick={() => {}}
+        />,
+      );
+      expect(
+        container.querySelector('.dim-gauge-card__coverage-line'),
+      ).toBeNull();
     });
   });
 });

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -135,17 +135,5 @@ describe('DimensionGaugeCard', () => {
       );
     });
 
-    it('does NOT render the coverage line when there is no date to show', () => {
-      const { container } = render(
-        <DimensionGaugeCard
-          item={baseItem}
-          dateLabel=""
-          onDimensionClick={() => {}}
-        />,
-      );
-      expect(
-        container.querySelector('.dim-gauge-card__coverage-line'),
-      ).toBeNull();
-    });
   });
 });

--- a/src/quodeq/ui/src/styles/dim-gauge-card.css
+++ b/src/quodeq/ui/src/styles/dim-gauge-card.css
@@ -113,10 +113,13 @@
 .dim-gauge-card--stale:focus-visible {
   opacity: 0.85;
 }
-.dim-gauge-card__stale-label {
+/* Coverage line: `<date> · <pct>%` rendered under every dimension card.
+   When the card is for a non-active dimension, `.dim-gauge-card--stale`
+   applies opacity 0.6 to the whole card — that's the "older run" cue.
+   When the run is partial, the line carries a tooltip with full detail. */
+.dim-gauge-card__coverage-line {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
-  font-style: italic;
   text-align: center;
 }
 
@@ -132,22 +135,3 @@
   letter-spacing: 0.04em;
 }
 
-/* "Partial — N of M files (P%)" badge.
-   Surfaced when a run was deadline-truncated or otherwise didn't reach
-   exit_reason=done. Score is still rendered above — the badge is purely
-   informational, so users know the coverage was incomplete. */
-.dim-gauge-card__partial-badge {
-  display: inline-block;
-  align-self: center;
-  padding: 2px var(--space-2);
-  margin-top: var(--space-1);
-  border-radius: 4px;
-  background: var(--color-warning-bg);
-  color: var(--color-warning-text);
-  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, transparent);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: var(--text-xs);
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-  text-align: center;
-}


### PR DESCRIPTION
## Summary

Replace the dimension gauge card's separate "Partial — N of M files (P%)" warning badge **and** the "Older run · <date>" stale label with a single muted coverage line: `<date> · <pct>%`. Full partial-run detail moves into a hover tooltip.

| State | Label | Visual |
|---|---|---|
| Active + complete | `<date> · 100%` | normal text-xs muted |
| Active + partial  | `<date> · 44%`  | normal text-xs muted |
| Older + complete  | `<date> · 100%` | muted (via card opacity 0.6) |
| Older + partial   | `<date> · 44%`  | muted (via card opacity 0.6) |
| Legacy (no counts) | `<date>` (no `· %` suffix) | as above per state |

Tooltip (partial runs only):
- Default: `Partial run · 1,325 of 3,037 files · stopped: deadline`
- No `exitReason`: `Partial run · 1,325 of 3,037 files`
- No file counts: `Partial run · stopped: deadline`

No warning color anywhere — the percentage value (< 100%) is the only signal that a run was partial.

## Changes

- `src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx`
  - Replace `computePartialInfo` + `PartialBadge` with `computeCoverageInfo` + `CoverageLine`.
  - Drop the standalone "Older run · …" stale-label render.
- `src/quodeq/ui/src/styles/dim-gauge-card.css`
  - Drop `.dim-gauge-card__partial-badge` (warning-colored).
  - Replace `.dim-gauge-card__stale-label` with `.dim-gauge-card__coverage-line` (text-xs muted, no italic — card-level `opacity: 0.6` is the "older" cue).
- `src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx`
  - Rewrite the "partial badge" describe-block to assert the new label format and tooltip text (7 tests, all passing).

## Test plan

- [x] `npm run test:ui -- DimensionGaugeCard` passes (8/8).
- [x] Manual verification on the local dashboard at `localhost:7863` — coverage line renders correctly across active/older × complete/partial states; tooltip shows full detail on partial cards only.