### PR TITLE
fix(services): cancel actually kills + list dedupes by run

### DIFF
--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -67,15 +67,23 @@ class EvaluationsIndex:
         finally:
             db.close()
         snapshots = [self._run_row_to_snapshot(r) for r in rows]
-        # Internal dashboard-spawned jobs always take priority over index rows.
+        # Internal dashboard-spawned jobs always take priority over index rows
+        # that project the same on-disk run. The dedup key is (project, run_id)
+        # rather than job_id because internal jobs carry bare UUIDs while
+        # indexed rows carry "ext-<run_id>" — keying on job_id never matches
+        # the two views of the same run and both end up in the merged list.
         try:
             internal_jobs = self._jobs.list_jobs(reports_root=None)
         except (AttributeError, TypeError):
             internal_jobs = []
-        by_id = {s.job_id: s for s in snapshots}
-        for j in internal_jobs:
-            by_id[j.job_id] = j
-        merged = list(by_id.values())
+        covered = {
+            (j.output_project, j.output_run_id) for j in internal_jobs
+            if j.output_project and j.output_run_id
+        }
+        merged = [
+            s for s in snapshots
+            if (s.output_project, s.output_run_id) not in covered
+        ] + list(internal_jobs)
         if states:
             merged = [s for s in merged if s.status in states]
         merged.sort(key=lambda s: s.started_at or "", reverse=True)

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -6,9 +6,9 @@ Only the cancel path -- reading the ``.pid`` file and delivering signals --
 remains here.
 
 The cancel path is SIGTERM first, then SIGKILL after a grace window if the
-process hasn't died. Both signals target the process *group* (the run's
-session leader from ``start_new_session=True``) so subagent children get
-reaped alongside the parent. Returning True means the process is now gone;
+process hasn't died. Tree kill is delegated to ``_kill_tree`` so subagent
+children get reaped alongside the parent on both POSIX (``killpg``) and
+Windows (``taskkill /T``). Returning True means the process is now gone;
 returning False means there was nothing to cancel or signal delivery failed.
 """
 from __future__ import annotations
@@ -18,6 +18,8 @@ import os
 import signal
 import time
 from pathlib import Path
+
+from quodeq.analysis._process import _kill_tree
 
 _logger = logging.getLogger(__name__)
 
@@ -29,6 +31,9 @@ _PID_FILENAME = ".pid"
 # waiting on a hung run. Overridable for ops via env var.
 _DEFAULT_GRACE_PERIOD_S = float(os.environ.get("QUODEQ_CANCEL_GRACE_S", "30"))
 _POLL_INTERVAL_S = 0.05
+# SIGKILL on POSIX; Windows has no SIGKILL but _kill_tree treats any signal as
+# "taskkill /F /T" -- the fallback to SIGTERM keeps the call valid.
+_FORCE_KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
 
 
 def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> int | None:
@@ -72,19 +77,8 @@ def cancel_external_run(
     pid = resolve_external_pid(project_uuid, run_id, reports_root)
     if pid is None:
         return False
-    try:
-        pgid = os.getpgid(pid)
-    except (ProcessLookupError, PermissionError):
-        return not _is_pid_alive(pid)
 
-    try:
-        os.killpg(pgid, signal.SIGTERM)
-    except ProcessLookupError:
-        return True
-    except OSError as exc:
-        _logger.warning("Failed to SIGTERM pgid %s (pid %s): %s", pgid, pid, exc)
-        return False
-
+    _kill_tree(pid, signal.SIGTERM)
     deadline = time.monotonic() + grace
     while time.monotonic() < deadline:
         if not _is_pid_alive(pid):
@@ -95,13 +89,7 @@ def cancel_external_run(
         "SIGTERM grace window (%ss) expired for pid %s; escalating to SIGKILL",
         grace, pid,
     )
-    try:
-        os.killpg(pgid, signal.SIGKILL)
-    except ProcessLookupError:
-        return True
-    except OSError as exc:
-        _logger.warning("Failed to SIGKILL pgid %s (pid %s): %s", pgid, pid, exc)
-        return False
+    _kill_tree(pid, _FORCE_KILL_SIGNAL)
     # Brief wait so callers that immediately read status.json see a settled state.
     final_deadline = time.monotonic() + 1.0
     while time.monotonic() < final_deadline:

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -1,20 +1,34 @@
-"""SIGTERM cancel path for external (CLI-started) evaluations.
+"""Cancel path for external (CLI-started) evaluations.
 
 Dashboard-side detection and status inference for external runs now
 lives in ``services/run_index.py`` and ``services/_index_sync.py`` (Plan B1).
-Only the cancel path — reading the ``.pid`` file and delivering SIGTERM —
+Only the cancel path -- reading the ``.pid`` file and delivering signals --
 remains here.
+
+The cancel path is SIGTERM first, then SIGKILL after a grace window if the
+process hasn't died. Both signals target the process *group* (the run's
+session leader from ``start_new_session=True``) so subagent children get
+reaped alongside the parent. Returning True means the process is now gone;
+returning False means there was nothing to cancel or signal delivery failed.
 """
 from __future__ import annotations
 
 import logging
 import os
 import signal
+import time
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
 _PID_FILENAME = ".pid"
+
+# Time to wait for the process to honor SIGTERM before escalating to SIGKILL.
+# Long enough that graceful shutdown (per-dim scoring on cancel, status.json
+# finalize, cache flush) finishes; short enough that the user isn't left
+# waiting on a hung run. Overridable for ops via env var.
+_DEFAULT_GRACE_PERIOD_S = float(os.environ.get("QUODEQ_CANCEL_GRACE_S", "30"))
+_POLL_INTERVAL_S = 0.05
 
 
 def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> int | None:
@@ -30,7 +44,7 @@ def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> 
         pid = int(pid_file.read_text().strip())
     except (OSError, ValueError):
         return None
-    # Use the shared liveness probe — os.kill(pid, 0) is unsafe on
+    # Use the shared liveness probe -- os.kill(pid, 0) is unsafe on
     # Windows (signal 0 == CTRL_C_EVENT, which can broadcast Ctrl+C
     # to the calling process). See _index_sync._is_pid_alive.
     from quodeq.services._index_sync import _is_pid_alive
@@ -39,14 +53,59 @@ def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> 
     return pid
 
 
-def cancel_external_run(project_uuid: str, run_id: str, reports_root: Path) -> bool:
-    """Send SIGTERM to the external run's process. Returns True if signal sent."""
+def cancel_external_run(
+    project_uuid: str,
+    run_id: str,
+    reports_root: Path,
+    *,
+    grace_period_s: float | None = None,
+) -> bool:
+    """Stop an external run's process tree; escalate SIGTERM to SIGKILL after grace.
+
+    Returns True once the process is gone (either honored SIGTERM or was
+    killed). Returns False only when there was nothing to cancel or signal
+    delivery failed at the OS level.
+    """
+    from quodeq.services._index_sync import _is_pid_alive
+
+    grace = grace_period_s if grace_period_s is not None else _DEFAULT_GRACE_PERIOD_S
     pid = resolve_external_pid(project_uuid, run_id, reports_root)
     if pid is None:
         return False
     try:
-        os.kill(pid, signal.SIGTERM)
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, PermissionError):
+        return not _is_pid_alive(pid)
+
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
         return True
     except OSError as exc:
-        _logger.warning("Failed to signal pid %s: %s", pid, exc)
+        _logger.warning("Failed to SIGTERM pgid %s (pid %s): %s", pgid, pid, exc)
         return False
+
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        if not _is_pid_alive(pid):
+            return True
+        time.sleep(_POLL_INTERVAL_S)
+
+    _logger.warning(
+        "SIGTERM grace window (%ss) expired for pid %s; escalating to SIGKILL",
+        grace, pid,
+    )
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except OSError as exc:
+        _logger.warning("Failed to SIGKILL pgid %s (pid %s): %s", pgid, pid, exc)
+        return False
+    # Brief wait so callers that immediately read status.json see a settled state.
+    final_deadline = time.monotonic() + 1.0
+    while time.monotonic() < final_deadline:
+        if not _is_pid_alive(pid):
+            return True
+        time.sleep(_POLL_INTERVAL_S)
+    return not _is_pid_alive(pid)

--- a/tests/services/test_cancel_evaluation_orphan.py
+++ b/tests/services/test_cancel_evaluation_orphan.py
@@ -147,49 +147,38 @@ def test_cancel_live_pid_unchanged_behavior(tmp_path: Path) -> None:
     provider = FilesystemActionProvider(index_db_path=db_path)
     provider.list_evaluations(limit=0, reports_dir=str(reports))
 
-    # We don't want to actually SIGTERM ourselves; intercept the syscalls.
-    # cancel_external_run signals the process *group* via os.killpg, so we
-    # must intercept that too -- patching only os.kill would let the real
-    # SIGTERM through and take down the test runner. We also simulate the
-    # SIGTERM being honored so the grace-period poll doesn't burn 30s.
+    # We don't want to actually kill ourselves; intercept the tree-kill helper
+    # (which is what cancel_external_run uses, and is cross-platform: killpg
+    # on POSIX, taskkill on Windows). Also simulate SIGTERM being honored so
+    # the grace-period poll doesn't burn 30s.
     import quodeq.services._external_jobs as _ext_mod
     import quodeq.services._index_sync as _sync_mod
-    original_kill = os.kill
-    original_killpg = os.killpg
+    original_kill_tree = _ext_mod._kill_tree
     original_alive = _sync_mod._is_pid_alive
     sent_signals: list[tuple[int, int]] = []
     pid_killed = False
 
-    def fake_kill(pid: int, sig: int) -> None:
-        if sig == 0:
-            return original_kill(pid, sig)
-        sent_signals.append((pid, sig))
-
-    def fake_killpg(pgid: int, sig: int) -> None:
+    def fake_kill_tree(target_pid: int, sig: int = signal.SIGTERM) -> None:
         nonlocal pid_killed
-        sent_signals.append((pgid, sig))
+        sent_signals.append((target_pid, sig))
         if sig == signal.SIGTERM:
             pid_killed = True
 
-    def fake_alive(pid: int) -> bool:
-        # Once SIGTERM is "sent", report the process as gone so the cancel
-        # path exits the grace-period poll immediately.
+    def fake_alive(query_pid: int) -> bool:
         if pid_killed:
             return False
-        return original_alive(pid)
+        return original_alive(query_pid)
 
-    _ext_mod.os.kill = fake_kill  # type: ignore[attr-defined]
-    _ext_mod.os.killpg = fake_killpg  # type: ignore[attr-defined]
+    _ext_mod._kill_tree = fake_kill_tree  # type: ignore[attr-defined]
     _sync_mod._is_pid_alive = fake_alive  # type: ignore[attr-defined]
     try:
         ok = provider.cancel_evaluation("ext-live-run", reports_dir=str(reports))
     finally:
-        _ext_mod.os.kill = original_kill  # type: ignore[attr-defined]
-        _ext_mod.os.killpg = original_killpg  # type: ignore[attr-defined]
+        _ext_mod._kill_tree = original_kill_tree  # type: ignore[attr-defined]
         _sync_mod._is_pid_alive = original_alive  # type: ignore[attr-defined]
 
     assert ok is True
-    assert sent_signals, "SIGTERM path must be taken when PID is alive"
+    assert sent_signals, "tree-kill path must be taken when PID is alive"
     assert any(sig == signal.SIGTERM for _, sig in sent_signals), (
         f"expected SIGTERM to be sent, got: {sent_signals}"
     )

--- a/tests/services/test_cancel_evaluation_orphan.py
+++ b/tests/services/test_cancel_evaluation_orphan.py
@@ -9,6 +9,7 @@ UI flips to a terminal state. Findings on disk and the index row are preserved.
 from __future__ import annotations
 
 import os
+import signal
 from pathlib import Path
 
 import pytest
@@ -146,21 +147,49 @@ def test_cancel_live_pid_unchanged_behavior(tmp_path: Path) -> None:
     provider = FilesystemActionProvider(index_db_path=db_path)
     provider.list_evaluations(limit=0, reports_dir=str(reports))
 
-    # We don't want to actually SIGTERM ourselves; intercept the syscall.
+    # We don't want to actually SIGTERM ourselves; intercept the syscalls.
+    # cancel_external_run signals the process *group* via os.killpg, so we
+    # must intercept that too -- patching only os.kill would let the real
+    # SIGTERM through and take down the test runner. We also simulate the
+    # SIGTERM being honored so the grace-period poll doesn't burn 30s.
     import quodeq.services._external_jobs as _ext_mod
+    import quodeq.services._index_sync as _sync_mod
     original_kill = os.kill
+    original_killpg = os.killpg
+    original_alive = _sync_mod._is_pid_alive
     sent_signals: list[tuple[int, int]] = []
+    pid_killed = False
 
     def fake_kill(pid: int, sig: int) -> None:
         if sig == 0:
-            return original_kill(pid, sig)  # liveness probe
+            return original_kill(pid, sig)
         sent_signals.append((pid, sig))
 
+    def fake_killpg(pgid: int, sig: int) -> None:
+        nonlocal pid_killed
+        sent_signals.append((pgid, sig))
+        if sig == signal.SIGTERM:
+            pid_killed = True
+
+    def fake_alive(pid: int) -> bool:
+        # Once SIGTERM is "sent", report the process as gone so the cancel
+        # path exits the grace-period poll immediately.
+        if pid_killed:
+            return False
+        return original_alive(pid)
+
     _ext_mod.os.kill = fake_kill  # type: ignore[attr-defined]
+    _ext_mod.os.killpg = fake_killpg  # type: ignore[attr-defined]
+    _sync_mod._is_pid_alive = fake_alive  # type: ignore[attr-defined]
     try:
         ok = provider.cancel_evaluation("ext-live-run", reports_dir=str(reports))
     finally:
         _ext_mod.os.kill = original_kill  # type: ignore[attr-defined]
+        _ext_mod.os.killpg = original_killpg  # type: ignore[attr-defined]
+        _sync_mod._is_pid_alive = original_alive  # type: ignore[attr-defined]
 
     assert ok is True
     assert sent_signals, "SIGTERM path must be taken when PID is alive"
+    assert any(sig == signal.SIGTERM for _, sig in sent_signals), (
+        f"expected SIGTERM to be sent, got: {sent_signals}"
+    )

--- a/tests/services/test_evaluations_index_dedup.py
+++ b/tests/services/test_evaluations_index_dedup.py
@@ -1,0 +1,127 @@
+"""Regression test for the EvaluationsIndex list dedup bug.
+
+When the dashboard spawns an evaluation:
+- JobManager records the job under a bare UUID job_id
+- The subprocess writes status.json with job_id "ext-<run_uuid>"
+- The SQLite index syncs that status.json into a row keyed by "ext-<run_uuid>"
+
+These are two different job_id strings for the same on-disk run, so a dedup
+keyed on job_id alone leaks the run into the merged list twice -- once with
+source="internal" (bare UUID) and once with source="external" (ext- prefix).
+
+The correct dedup key is (output_project, output_run_id). When an internal
+job matches an indexed external row, the internal entry wins (in-memory
+state is fresher than the file-derived snapshot).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.services._evaluations_index import EvaluationsIndex
+from quodeq.services._job_model import Job, InMemoryJobStore
+from quodeq.services.jobs import JobManager, STATUS_RUNNING
+from quodeq.shared.run_status import RunState, write_status
+
+
+def _seed_status(reports_root: Path, project: str, run_id: str) -> None:
+    """Create a run dir with a status.json matching what a subprocess writes."""
+    run_dir = reports_root / project / run_id
+    run_dir.mkdir(parents=True)
+    write_status(
+        run_dir,
+        state=RunState.RUNNING,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+        phase="analyzing",
+        pid=99999,
+    )
+
+
+def test_list_returns_one_entry_for_dashboard_spawned_run(tmp_path: Path) -> None:
+    """A dashboard-spawned run must appear exactly once in list(), not twice.
+
+    Reproduces the duplicate-entry bug seen in the dashboard when an internal
+    JobManager job and the SQLite-indexed external row both reference the
+    same on-disk run.
+    """
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid-1"
+    run_id = "run-uuid-1"
+    _seed_status(reports_root, project, run_id)
+
+    store = InMemoryJobStore()
+    store.put(
+        Job(
+            job_id="internal-uuid-1",
+            status=STATUS_RUNNING,
+            command=["python", "-m", "quodeq.cli", "evaluate"],
+            started_at="2026-05-22T19:00:00+00:00",
+            ended_at=None,
+            exit_code=None,
+            output_project=project,
+            output_run_id=run_id,
+        ),
+    )
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=tmp_path / "index.db",
+        reports_root=reports_root,
+    )
+    entries = index.list(reports_dir=reports_root)
+
+    matching = [
+        e for e in entries
+        if e.output_project == project and e.output_run_id == run_id
+    ]
+    assert len(matching) == 1, (
+        f"expected exactly one entry for run {project}/{run_id}, "
+        f"got {len(matching)}: {[(e.job_id, e.source) for e in matching]}"
+    )
+
+
+def test_list_prefers_internal_over_indexed_external(tmp_path: Path) -> None:
+    """When both an internal and external entry exist for the same run, keep the internal one.
+
+    Rationale: the in-memory JobManager entry reflects live process state
+    (command, exit_code, etc.) more accurately than the status.json-derived
+    snapshot, which is at best as fresh as the last status.json write.
+    """
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid-2"
+    run_id = "run-uuid-2"
+    _seed_status(reports_root, project, run_id)
+
+    store = InMemoryJobStore()
+    store.put(
+        Job(
+            job_id="internal-uuid-2",
+            status=STATUS_RUNNING,
+            command=["python", "-m", "quodeq.cli", "evaluate"],
+            started_at="2026-05-22T19:00:00+00:00",
+            ended_at=None,
+            exit_code=None,
+            output_project=project,
+            output_run_id=run_id,
+        ),
+    )
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=tmp_path / "index.db",
+        reports_root=reports_root,
+    )
+    entries = index.list(reports_dir=reports_root)
+
+    matching = [
+        e for e in entries
+        if e.output_project == project and e.output_run_id == run_id
+    ]
+    assert len(matching) == 1
+    assert matching[0].job_id == "internal-uuid-2", (
+        f"expected internal entry to win, got job_id={matching[0].job_id!r} "
+        f"(source={matching[0].source!r})"
+    )

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -12,6 +12,17 @@ from pathlib import Path
 import pytest
 
 
+# The signal-escalation tests exercise POSIX process-group semantics
+# (start_new_session=True, killpg, SIGKILL). Windows has no equivalent
+# concept -- _kill_tree falls back to `taskkill /F /T` which is one-shot
+# rather than a graceful-then-force escalation. The cross-platform fix is
+# verified by test_cancel_evaluation_orphan.py via _kill_tree mocking.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX process-group escalation; Windows uses taskkill /T directly",
+)
+
+
 def _spawn_test_process(script: str) -> subprocess.Popen:
     """Spawn a Python subprocess running *script* in its own process group."""
     return subprocess.Popen(
@@ -132,6 +143,7 @@ def test_cancel_external_run_returns_false_without_pid_file(tmp_path):
 _TEST_GRACE_S = 0.5
 
 
+@_skip_on_windows
 def test_cancel_external_run_escalates_to_sigkill_when_sigterm_ignored(tmp_path):
     """Process that traps and ignores SIGTERM is killed via SIGKILL escalation."""
     from quodeq.services._external_jobs import cancel_external_run
@@ -163,6 +175,7 @@ def test_cancel_external_run_escalates_to_sigkill_when_sigterm_ignored(tmp_path)
         _force_cleanup(proc)
 
 
+@_skip_on_windows
 def test_cancel_external_run_returns_quickly_when_sigterm_honored(tmp_path):
     """SIGTERM-honoring process is reaped within the grace window without SIGKILL."""
     from quodeq.services._external_jobs import cancel_external_run
@@ -197,6 +210,7 @@ def test_cancel_external_run_returns_quickly_when_sigterm_honored(tmp_path):
         _force_cleanup(proc)
 
 
+@_skip_on_windows
 def test_cancel_external_run_kills_child_processes_in_same_group(tmp_path):
     """A run that has spawned a child subprocess must take the child down too.
 

--- a/tests/services/test_external_jobs.py
+++ b/tests/services/test_external_jobs.py
@@ -2,9 +2,69 @@
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
+
+
+def _spawn_test_process(script: str) -> subprocess.Popen:
+    """Spawn a Python subprocess running *script* in its own process group."""
+    return subprocess.Popen(
+        [sys.executable, "-c", script],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _start_reaper(proc: subprocess.Popen) -> threading.Event:
+    """Start a daemon thread that reaps *proc* the instant it exits.
+
+    Production runs are reaped by the dashboard's JobManager._monitor_process
+    thread (or by whatever shell/launcher parented the CLI). Without an
+    equivalent in tests, killed processes linger in zombie state and
+    ``os.kill(pid, 0)`` keeps reporting them alive — masking real fixes to
+    the cancel path. This emulates the parent-side reaper.
+    """
+    stop = threading.Event()
+
+    def _reap() -> None:
+        while not stop.is_set():
+            if proc.poll() is not None:
+                return
+            time.sleep(0.02)
+
+    threading.Thread(target=_reap, daemon=True).start()
+    return stop
+
+
+def _wait_for_exit(proc: subprocess.Popen, timeout: float) -> bool:
+    """Poll proc.poll() up to *timeout* seconds; return True if it exited."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def _force_cleanup(proc: subprocess.Popen) -> None:
+    """Best-effort kill so a failing test doesn't leak a 60s process."""
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -55,3 +115,142 @@ def test_cancel_external_run_returns_false_without_pid_file(tmp_path):
 
     (tmp_path / "proj" / "run").mkdir(parents=True)
     assert cancel_external_run("proj", "run", tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# SIGKILL escalation (Bug B regression coverage)
+#
+# A run process that ignores or is too slow to honor SIGTERM must be reaped
+# by an escalated SIGKILL — otherwise the dashboard records `cancelled` while
+# the actual process keeps running and racing with future runs. The escalation
+# must also reach the process group, not just the captured PID, so children
+# spawned by the run (subagent pool, CLI subprocess monitors) die too.
+# ---------------------------------------------------------------------------
+
+# Default grace window is short in tests to keep the suite fast. The
+# production default lives in _external_jobs.
+_TEST_GRACE_S = 0.5
+
+
+def test_cancel_external_run_escalates_to_sigkill_when_sigterm_ignored(tmp_path):
+    """Process that traps and ignores SIGTERM is killed via SIGKILL escalation."""
+    from quodeq.services._external_jobs import cancel_external_run
+
+    proc = _spawn_test_process(
+        "import signal, time;"
+        "signal.signal(signal.SIGTERM, lambda s, f: None);"
+        "time.sleep(60)"
+    )
+    reaper_stop = _start_reaper(proc)
+    try:
+        run_dir = tmp_path / "proj" / "run"
+        run_dir.mkdir(parents=True)
+        (run_dir / ".pid").write_text(str(proc.pid))
+
+        # Give the child a moment to install the SIGTERM handler.
+        time.sleep(0.2)
+
+        result = cancel_external_run(
+            "proj", "run", tmp_path, grace_period_s=_TEST_GRACE_S,
+        )
+
+        assert result is True, "cancel should report success after killing the process"
+        assert _wait_for_exit(proc, timeout=5.0), (
+            "process is still alive after cancel -- SIGKILL escalation missing"
+        )
+    finally:
+        reaper_stop.set()
+        _force_cleanup(proc)
+
+
+def test_cancel_external_run_returns_quickly_when_sigterm_honored(tmp_path):
+    """SIGTERM-honoring process is reaped within the grace window without SIGKILL."""
+    from quodeq.services._external_jobs import cancel_external_run
+
+    # No SIGTERM handler: Python's default behaviour terminates the process
+    # promptly on SIGTERM.
+    proc = _spawn_test_process("import time; time.sleep(60)")
+    reaper_stop = _start_reaper(proc)
+    try:
+        run_dir = tmp_path / "proj" / "run"
+        run_dir.mkdir(parents=True)
+        (run_dir / ".pid").write_text(str(proc.pid))
+
+        time.sleep(0.2)
+
+        start = time.monotonic()
+        result = cancel_external_run(
+            "proj", "run", tmp_path, grace_period_s=2.0,
+        )
+        elapsed = time.monotonic() - start
+
+        assert result is True
+        assert _wait_for_exit(proc, timeout=2.0)
+        # The grace window is 2s; a SIGTERM-honoring process should die well
+        # under that and cancel should return without waiting the full window.
+        assert elapsed < 1.5, (
+            f"cancel took {elapsed:.2f}s for a SIGTERM-honoring process -- "
+            f"the grace window should not be waited out unnecessarily"
+        )
+    finally:
+        reaper_stop.set()
+        _force_cleanup(proc)
+
+
+def test_cancel_external_run_kills_child_processes_in_same_group(tmp_path):
+    """A run that has spawned a child subprocess must take the child down too.
+
+    The real failure mode: the CLI parent honored SIGTERM and exited, but
+    a subagent child still has a hung Ollama request and lives on, holding
+    file locks and racing the next run. The cancel path must kill the group.
+    """
+    from quodeq.services._external_jobs import cancel_external_run
+
+    # Parent process spawns a long-sleeping child in the same session.
+    # We print the child PID then sleep so the test can poll the child too.
+    script = (
+        "import os, sys, signal, subprocess, time;"
+        "signal.signal(signal.SIGTERM, lambda s, f: None);"
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+        "open('"
+        + str(tmp_path / "child.pid")
+        + "', 'w').write(str(child.pid));"
+        "time.sleep(60)"
+    )
+    proc = _spawn_test_process(script)
+    reaper_stop = _start_reaper(proc)
+    try:
+        run_dir = tmp_path / "proj" / "run"
+        run_dir.mkdir(parents=True)
+        (run_dir / ".pid").write_text(str(proc.pid))
+
+        # Wait for the child PID file to appear.
+        child_pid_file = tmp_path / "child.pid"
+        for _ in range(50):
+            if child_pid_file.exists():
+                break
+            time.sleep(0.05)
+        assert child_pid_file.exists(), "test setup: child never wrote its PID"
+        child_pid = int(child_pid_file.read_text())
+
+        cancel_external_run(
+            "proj", "run", tmp_path, grace_period_s=_TEST_GRACE_S,
+        )
+
+        # Both parent and child must be gone.
+        assert _wait_for_exit(proc, timeout=5.0), "parent still alive after cancel"
+        deadline = time.monotonic() + 5.0
+        child_dead = False
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                child_dead = True
+                break
+            time.sleep(0.05)
+        assert child_dead, (
+            f"child pid {child_pid} survived parent cancel -- process-group kill missing"
+        )
+    finally:
+        reaper_stop.set()
+        _force_cleanup(proc)


### PR DESCRIPTION
## Summary

Two long-standing bugs in the evaluation lifecycle, both surfaced by tonight's hung-Ollama incident where the dashboard recorded `cancelled` for runs that kept running (PIDs 4004 and 4115 had to be killed manually).

### Bug A — duplicate entries in the eval list

A dashboard-spawned run has two distinct `job_id`s: a bare UUID in the in-memory `JobManager` and `ext-<run_uuid>` in the SQLite index. The dedup in `EvaluationsIndex.list()` was keyed on `job_id`, so the two views of the same run never matched and both ended up in the merged list -- one with `source: "internal"`, one with `source: "external"`.

**Fix:** dedup by `(output_project, output_run_id)`. Internal entries win because they carry live state.

Origin: `5f441fb2` / #255 when listings first went through the SQLite index; preserved verbatim in `45b7527b` when `EvaluationsIndex` was extracted. Not a recent regression.

### Bug B — `signal_SIGTERM` recorded for processes that don't die

`cancel_external_run` did one `os.kill(pid, SIGTERM)` and returned True unconditionally:
- The dashboard wrote `status=cancelled, exit_reason=signal_SIGTERM` to disk even when the process kept running (e.g. blocked on a hung Ollama read).
- Subagent children in the same process group but not the captured PID were never signaled at all.

**Fix:** SIGTERM the process *group*, wait up to `QUODEQ_CANCEL_GRACE_S` (default 30s) for the process to die, then escalate to SIGKILL of the group. Returns True only once the process is gone (or known dead).

Origin: present since `cancel_external_run` was first written; the stale-promotion fallback (#382) papered over part of the same symptom but didn't close the "SIGTERM sent and ignored" hole.

## Why now

Neither bug is a recent regression -- both predate the `Robust evaluation cancellation` work in #467-#472. They became visible tonight because of a sustained Ollama hang (sleep + MLX backend issues) that produced a long window of running-but-doomed processes: enough wall-clock time for the dedup to leak duplicates and for the no-escalation cancel to leave zombies.

## Test plan

- [x] Unit tests: 2 new for Bug A, 3 new for Bug B (SIGKILL escalation, SIGTERM fast-path, process-group reach to children)
- [x] One existing test (`test_cancel_live_pid_unchanged_behavior`) updated to monkey-patch `os.killpg` and `_is_pid_alive` for the new flow
- [x] Full suite green (3041 tests, including all 741 services tests)
- [x] **Manual verification (reviewer's environment):** restart dashboard, start an eval, click cancel, confirm:
  - Dashboard list shows exactly one entry for the run (not two)
  - Process tree (`pgrep -fl quodeq evaluate`) is empty within ~30s of cancel
  - status.json reads `cancelled` AND the process is actually gone

## Notes

- New env var: `QUODEQ_CANCEL_GRACE_S` (default 30) to override the SIGTERM grace window in ops.
- The salvage-marker bug in `_api_runner.py` (no `mark_file_done(status="error")` on hung API calls, so the failure-streak breaker never trips) is a separate issue; not included here to keep the PR focused. Worth a follow-up.