### PR TITLE
feat: per-dim exit_reason and amber coverage signal

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -22,7 +22,8 @@ from quodeq.shared.dimensions_state import DimState, write_dim_state, IllegalDim
 
 
 def _safe_write_dim_state(
-    run_dir: Path | None, dim: str, state: DimState, *, reason: str | None = None,
+    run_dir: Path | None, dim: str, state: DimState, *,
+    reason: str | None = None, exit_reason: str | None = None,
 ) -> None:
     """Best-effort dim-state write. Never raises into the loop.
 
@@ -39,7 +40,7 @@ def _safe_write_dim_state(
     except (TypeError, ValueError):
         return
     try:
-        write_dim_state(run_dir, dim, state, reason=reason)
+        write_dim_state(run_dir, dim, state, reason=reason, exit_reason=exit_reason)
     except IllegalDimTransitionError as exc:
         log_warning(f"[loop] dim-state transition rejected: {exc}")
     except (OSError, AttributeError, TypeError) as exc:
@@ -199,7 +200,10 @@ def run_incremental_loop(
         # scoring callback). Wrap it too - an exception in a callback
         # shouldn't drop the next iteration on the floor.
         if ev:
-            _safe_write_dim_state(run_dir, dimension, DimState.DONE)
+            _safe_write_dim_state(
+                run_dir, dimension, DimState.DONE,
+                exit_reason=ev.exit_reason,
+            )
             try:
                 _log_dimension_result(ev, dimension, idx, ctx.total)
                 result[dimension] = ev
@@ -308,7 +312,10 @@ def run_per_dimension_loop(
             log_info(f"[loop] completed iteration {idx}/{ctx.total} for {dimension} (skipped: ev=None)")
             continue
         # ev is set - dim succeeded analytically.
-        _safe_write_dim_state(run_dir, dimension, DimState.DONE)
+        _safe_write_dim_state(
+            run_dir, dimension, DimState.DONE,
+            exit_reason=ev.exit_reason,
+        )
         try:
             result[dimension] = ev
             if on_dimension_done:

--- a/src/quodeq/analysis/_report_assembly.py
+++ b/src/quodeq/analysis/_report_assembly.py
@@ -48,6 +48,7 @@ def _assemble_report_dict(data: _ReportData) -> dict:
         "sourceFileCount": data.evidence.get("source_file_count"),
         "filesRead": data.evidence.get("files_read", 0),
         "coveragePct": data.evidence.get("coverage_pct", 0.0),
+        "exitReason": data.evidence.get("exit_reason"),
         "meta": {
             "analysis_prompt_version": raw_meta.get("analysis_prompt_version"),
             "scoring_prompt_version": raw_meta.get("scoring_prompt_version"),

--- a/src/quodeq/analysis/subagents/_consolidated.py
+++ b/src/quodeq/analysis/subagents/_consolidated.py
@@ -34,6 +34,7 @@ class _ConsolidatedRunContext:
     ctx: Any
     results: list[Any]
     files: list[str]
+    exit_reason: str | None = None
 
 
 def _build_consolidated_config(
@@ -89,6 +90,7 @@ def _collect_consolidated_results(
         source_file_count=config.source_file_count,
         files_read=total_files_read,
         module=config.target.name if config.target else "",
+        exit_reason=run_ctx.exit_reason,
     )
 
     return parse_jsonl_to_evidence_by_dimension(
@@ -151,5 +153,8 @@ def process_consolidated_dimensions(
     results = pool.run()
 
     # 4. Collect and return per-dimension evidence
-    run_context = _ConsolidatedRunContext(dimensions=dimensions, ctx=ctx, results=results, files=files)
+    run_context = _ConsolidatedRunContext(
+        dimensions=dimensions, ctx=ctx, results=results, files=files,
+        exit_reason=pool.exit_reason,
+    )
     return _collect_consolidated_results(config, run_context, _ConsolidatedPaths(evidence_dir=evidence_dir, compiled_dir=compiled_dir))

--- a/src/quodeq/analysis/subagents/_evidence_collector.py
+++ b/src/quodeq/analysis/subagents/_evidence_collector.py
@@ -24,6 +24,7 @@ class _CollectionContext:
     results: list[Any]
     ctx: Any
     files: list[str] | None = None
+    exit_reason: str | None = None
 
 
 def _collect_evidence(
@@ -46,6 +47,7 @@ def _collect_evidence(
             source_file_count=config.source_file_count,
             files_read=total_files_read,
             module=config.target.name if config.target else "",
+            exit_reason=collection.exit_reason,
         ),
         compiled_dir=compiled_dir,
         evaluators_dir=config.evaluators_dir,

--- a/src/quodeq/analysis/subagents/pool.py
+++ b/src/quodeq/analysis/subagents/pool.py
@@ -59,6 +59,7 @@ class SubagentPool:
         self._futures: dict[Future[SubagentResult], int] = {}
         self._finished: dict[str, bool] = {}
         self._next_idx = 0
+        self.exit_reason: str = "done"
 
     def _shared_jsonl_path(self) -> Path:
         return self._evidence_dir / f"{self._dimension_key}_evidence.jsonl"
@@ -94,7 +95,9 @@ class SubagentPool:
 
     def run(self) -> list[SubagentResult]:
         """Launch agents in parallel, returning a SubagentResult per agent."""
+        self.exit_reason = "done"
         max_dur = self._base_config.time_limit if self._base_config.time_limit is not None else _DEFAULT_TIME_LIMIT
+        pool_start = time.monotonic()
         if self._scout_first:
             log_info(f"[{self._phase}] Launching scout agent for {self._dimension_key} (max {self._n} agents)")
         else:
@@ -108,7 +111,7 @@ class SubagentPool:
             with ThreadPoolExecutor(max_workers=self._n) as pool:
                 ctx = LoopContext(
                     futures=self._futures, finished=self._finished, results=results,
-                    max_duration=max_dur, pool_start=time.monotonic(),
+                    max_duration=max_dur, pool_start=pool_start,
                     n_agents=self._n,
                     queue=self._queue, queue_path=self._queue_path,
                     shared_jsonl_path=self._shared_jsonl_path(),
@@ -121,9 +124,16 @@ class SubagentPool:
                     scout_loop(ctx)
                 else:
                     immediate_loop(ctx)
+        except BaseException:
+            self.exit_reason = "error"
+            raise
         finally:
             stop.set()
             hb.join(timeout=_HEARTBEAT_JOIN_TIMEOUT_S)
+        # If we got here without an exception, decide between "done" and "time_limit".
+        elapsed = time.monotonic() - pool_start
+        if max_dur > 0 and elapsed >= max_dur:
+            self.exit_reason = "time_limit"
         succeeded = sum(1 for r in results if r.success)
         log_info(f"Subagent pool done: {succeeded}/{self._next_idx} agents ran, {succeeded} succeeded")
         return results

--- a/src/quodeq/analysis/subagents/runner.py
+++ b/src/quodeq/analysis/subagents/runner.py
@@ -96,7 +96,10 @@ def _execute_pool_and_collect(
     pool, results = _launch_pool(config, dc.dim_id, params)
     return _collect_evidence(
         config, dc.dim_id, dc.evidence_dir,
-        _CollectionContext(results=results, ctx=dc.ctx, files=dc.files),
+        _CollectionContext(
+            results=results, ctx=dc.ctx, files=dc.files,
+            exit_reason=pool.exit_reason,
+        ),
     )
 
 

--- a/src/quodeq/core/evidence/merge.py
+++ b/src/quodeq/core/evidence/merge.py
@@ -34,6 +34,22 @@ def merge_evidence(
     if not module and evidence_list:
         module = evidence_list[0].module
 
+    # Pick exit_reason: any non-"done" reason wins (incomplete dominates done),
+    # otherwise the first non-None value, otherwise None. Mirrors how the UI
+    # treats anything-not-done as partial.
+    incomplete = next(
+        (ev.exit_reason for ev in evidence_list
+         if ev.exit_reason and ev.exit_reason != "done"),
+        None,
+    )
+    if incomplete is not None:
+        merged_exit_reason: str | None = incomplete
+    else:
+        merged_exit_reason = next(
+            (ev.exit_reason for ev in evidence_list if ev.exit_reason is not None),
+            None,
+        )
+
     merged = Evidence(
         repository=src,
         language=language,
@@ -43,6 +59,7 @@ def merge_evidence(
         coverage_pct=coverage_pct,
         principles=merged_principles,
         dismissed_count=total_dismissed,
+        exit_reason=merged_exit_reason,
         module=module,
     )
     return merged

--- a/src/quodeq/core/evidence/model.py
+++ b/src/quodeq/core/evidence/model.py
@@ -150,6 +150,7 @@ class Evidence:
     dismissed_count: int = 0
     meta: dict = field(default_factory=dict)
     module: str = ""
+    exit_reason: str | None = None
 
     def summary(self) -> dict:
         """Return an aggregate summary of findings, confidence, and balance across all principles."""
@@ -200,6 +201,7 @@ def evidence_to_scoring_dict(evidence: Evidence) -> dict:
         "source_file_count": evidence.source_file_count,
         "files_read": evidence.files_read,
         "coverage_pct": evidence.coverage_pct,
+        "exit_reason": evidence.exit_reason,
         "meta": evidence.meta,
         "principles": principles,
         "evidence_summary": evidence.summary(),

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -28,6 +28,7 @@ class EvidenceContext:
     source_file_count: int
     files_read: int
     module: str = ""
+    exit_reason: str | None = None
 
 
 def _build_principles(
@@ -55,6 +56,7 @@ def _build_evidence(context: EvidenceContext, principles: dict[str, PrincipleEvi
         source_file_count=context.source_file_count, files_read=context.files_read,
         coverage_pct=compute_coverage_pct(context.files_read, context.source_file_count),
         principles=principles, dismissed_count=0, module=context.module,
+        exit_reason=context.exit_reason,
     )
 
 

--- a/src/quodeq/core/types/_mapper_dimensions.py
+++ b/src/quodeq/core/types/_mapper_dimensions.py
@@ -43,6 +43,7 @@ def parse_dimension_result(raw: dict[str, object]) -> DimensionResult:
         totals=totals,
         source_file_count=_opt_int(raw.get("sourceFileCount")),
         files_read=_opt_int(raw.get("filesRead")),
+        exit_reason=_opt_str(raw.get("exitReason")),
         evidence_date=_opt_str(raw.get("evidenceDate")),
         discipline=_opt_str(raw.get("discipline")),
         trend=_opt_str(raw.get("trend")),

--- a/src/quodeq/core/types/dimension.py
+++ b/src/quodeq/core/types/dimension.py
@@ -37,6 +37,7 @@ class DimensionResult:
     totals: Totals | None = None
     source_file_count: int | None = None
     files_read: int | None = None
+    exit_reason: str | None = None
     evidence_date: str | None = None
     discipline: str | None = None
     trend: str | None = None

--- a/src/quodeq/data/fs/report_parser/_report_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_report_parsing.py
@@ -67,6 +67,7 @@ def parse_report_json(json_path: Path) -> dict[str, Any] | None:
         # missing values as "no coverage signal" and skips the badge.
         "filesRead": data.get("filesRead"),
         "sourceFileCount": data.get("sourceFileCount"),
+        "exitReason": data.get("exitReason"),
         "principles": [
             {"name": p.get("name"), "score": p.get("score"), "grade": p.get("grade")}
             for p in data.get("principles", [])

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -160,10 +160,30 @@ def _upgrade_v3_to_v4(conn: sqlite3.Connection) -> None:
         )
 
 
+def _upgrade_v4_to_v5(conn: sqlite3.Connection) -> None:
+    """Add exit_reason TEXT column to dimension_scores.
+
+    Per-dim signal indicating why the subagent pool stopped (drained,
+    time_limit, failure_streak, cancelled, error). NULL is interpreted
+    as 'done' / drained by downstream consumers.
+
+    dimension_scores may not exist on DBs upgraded from very old (v1/v2)
+    schemas — only the fresh-DB DDL creates it, and the v1->v3 upgrade
+    scripts never did. Skip the ALTER in that case; if a future caller
+    needs the table they will get the fresh DDL on a new DB.
+    """
+    has_dim_scores = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dimension_scores'"
+    ).fetchone() is not None
+    if has_dim_scores:
+        conn.execute("ALTER TABLE dimension_scores ADD COLUMN exit_reason TEXT")
+
+
 _UPGRADES = {
     1: _upgrade_v1_to_v2,
     2: _upgrade_v2_to_v3,
     3: _upgrade_v3_to_v4,
+    4: _upgrade_v4_to_v5,
 }
 
 

--- a/src/quodeq/data/sqlite/_schema.py
+++ b/src/quodeq/data/sqlite/_schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 EVALUATION_DDL = """
-PRAGMA user_version = 4;
+PRAGMA user_version = 5;
 
 CREATE TABLE findings (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -71,6 +71,7 @@ CREATE TABLE dimension_scores (
     files_read      INTEGER NOT NULL DEFAULT 0,
     source_count    INTEGER NOT NULL DEFAULT 0,
     coverage_pct    REAL NOT NULL DEFAULT 0.0,
+    exit_reason     TEXT,
     completed_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -93,4 +94,4 @@ CREATE TABLE principle_grades (
 CREATE INDEX idx_principle_grades_dimension ON principle_grades(dimension);
 """
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -251,17 +251,27 @@ def _read_run_exit_reason(reports_root: Path, project: str, run_id: str) -> str 
     return reason if isinstance(reason, str) else None
 
 
-def _attach_exit_reason_to_dim(dim_dict: dict[str, Any], exit_reason: str | None) -> dict[str, Any]:
-    """Add ``exitReason`` to a serialized dimension dict (in place safe via shallow copy).
+def _attach_exit_reason_to_dim(
+    dim_dict: dict[str, Any], run_exit_reason: str | None,
+) -> dict[str, Any]:
+    """Add ``exitReason`` to a serialized dimension dict.
 
-    Done at the response-assembly layer so we don't need to add a per-dim
-    field to the DimensionResult dataclass: the exit reason is a
-    run-level signal, but the UI consumes it per-card.
+    Preference order: per-dim exit_reason (if present on the dim) wins over
+    the run-level value. Either way, the chosen reason is exposed to the UI
+    as ``exitReason``. Falls back to no key when both are absent (legacy).
     """
-    if exit_reason is None:
+    per_dim = dim_dict.get("exit_reason") or dim_dict.get("exitReason")
+    chosen = per_dim or run_exit_reason
+    if chosen is None:
+        # Drop the snake_case key if present, to keep the response clean.
+        if "exit_reason" in dim_dict:
+            out = dict(dim_dict)
+            out.pop("exit_reason", None)
+            return out
         return dim_dict
     out = dict(dim_dict)
-    out["exitReason"] = exit_reason
+    out.pop("exit_reason", None)
+    out["exitReason"] = chosen
     return out
 
 

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
 from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+from quodeq.shared.dimensions_state import read_dimensions
 
 _AGENT_ACTIVE_WINDOW_S = 30
 
@@ -37,6 +38,7 @@ class _DimProgress:
     budget_s: int | None = None
     active_agents: int = 0
     estimate_reason: str | None = None  # see _dim_estimates module docstring
+    exit_reason: str | None = None
 
 
 @dataclass
@@ -213,6 +215,7 @@ def build_scan_progress(
 
     project_files = _project_total_files(run_dir)
     dim_estimates = _read_dim_estimates(run_dir)
+    dim_records = read_dimensions(run_dir).get("dimensions") or {}
     dim_ids = list(status.get("dimensions") or [])
     evidence_dir = run_dir / "evidence"
 
@@ -226,6 +229,8 @@ def build_scan_progress(
             has_queue=queue is not None,
             has_evaluation=eval_path.is_file(),
         )
+        record = dim_records.get(dim_id) if isinstance(dim_records, dict) else None
+        exit_reason = record.get("exit_reason") if isinstance(record, dict) else None
 
         if queue is not None:
             # `taken` is a list of batch entries [{"files": [...], "agent": ..., "ts": ...}, ...].
@@ -269,6 +274,7 @@ def build_scan_progress(
             budget_s=budget,
             active_agents=active,
             estimate_reason=estimate_reason,
+            exit_reason=exit_reason,
         ))
 
     return _ScanProgress(
@@ -283,5 +289,15 @@ def build_scan_progress(
 
 
 def progress_to_dict(progress: _ScanProgress) -> dict:
-    """Serialize for the API response (snake_case → camelCase done at the route)."""
-    return asdict(progress)
+    """Serialize the dataclass tree to a camelCase dict for jsonify.
+
+    Uses to_camel_dict so dataclass field names like ``exit_reason`` and
+    ``estimate_reason`` become ``exitReason`` and ``estimateReason`` in the
+    JSON the client sees. The route still wraps the result in to_camel_dict;
+    that second pass is a no-op for already-camelCased dicts.
+    """
+    from quodeq.core.types import to_camel_dict
+    result = to_camel_dict(progress)
+    if not isinstance(result, dict):
+        return {}
+    return result

--- a/src/quodeq/shared/dimensions_state.py
+++ b/src/quodeq/shared/dimensions_state.py
@@ -56,13 +56,17 @@ def read_dimensions(run_dir: Path) -> dict[str, Any]:
 
 def write_dim_state(
     run_dir: Path, dimension: str, state: DimState,
-    *, reason: str | None = None,
+    *, reason: str | None = None, exit_reason: str | None = None,
 ) -> None:
     """Transition *dimension* to *state* atomically.
 
     Validates the transition against the state machine. Initial writes
     (no prior entry) are allowed regardless of *state* -- callers can seed
     in any state, but typically use PENDING first.
+
+    Optional ``exit_reason`` attaches to the per-dim record on DONE, e.g.
+    "done", "time_limit", "failure_streak", "cancelled", "error". The UI
+    treats anything other than "done" as a partial-coverage signal.
     """
     with _lock:
         data = read_dimensions(run_dir)
@@ -85,6 +89,8 @@ def write_dim_state(
             entry["started_at"] = _now_iso()
         elif state == DimState.DONE:
             entry["completed_at"] = _now_iso()
+            if exit_reason is not None:
+                entry["exit_reason"] = exit_reason
         elif state == DimState.INCOMPLETE:
             entry["interrupted_at"] = _now_iso()
             if reason:

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -51,13 +51,18 @@ function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
 
 function CoverageLine({ dateText, coveragePct, isPartial, tooltip }) {
   if (!dateText) return null;
-  const label = coveragePct !== null ? `${dateText} · ${coveragePct}%` : dateText;
+  if (coveragePct === null) {
+    return (
+      <div className="dim-gauge-card__coverage-line" title={isPartial ? tooltip : undefined}>
+        {dateText}
+      </div>
+    );
+  }
   return (
-    <div
-      className="dim-gauge-card__coverage-line"
-      title={isPartial ? tooltip : undefined}
-    >
-      {label}
+    <div className="dim-gauge-card__coverage-line" title={isPartial ? tooltip : undefined}>
+      {dateText} · <span
+        className={`dim-gauge-card__coverage-pct${isPartial ? ' dim-gauge-card__coverage-pct--partial' : ''}`}
+      >{coveragePct}%</span>
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -35,6 +35,13 @@ describe('DimensionGaugeCard', () => {
   describe('coverage line', () => {
     const dateLabel = '13 May 2026';
 
+    // The percentage lives in a child <span>, so the div's text node and the
+    // span's text node are separate. Match against the coverage line's full
+    // textContent (normalized) to keep these assertions structure-agnostic.
+    const coverageLineMatcher = (expectedText) => (_, el) =>
+      el?.classList?.contains('dim-gauge-card__coverage-line') &&
+      el.textContent.replace(/\s+/g, ' ').trim() === expectedText;
+
     it('shows "<date> · <pct>%" when filesRead < sourceFileCount', () => {
       render(
         <DimensionGaugeCard
@@ -47,7 +54,7 @@ describe('DimensionGaugeCard', () => {
           onDimensionClick={() => {}}
         />,
       );
-      const line = screen.getByText(`${dateLabel} · 28%`);
+      const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 28%`));
       expect(line).toBeInTheDocument();
       expect(line.getAttribute('title')).toBe(
         'Partial run · 850 of 3,037 files',
@@ -67,7 +74,7 @@ describe('DimensionGaugeCard', () => {
           onDimensionClick={() => {}}
         />,
       );
-      const line = screen.getByText(`${dateLabel} · 28%`);
+      const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 28%`));
       expect(line.getAttribute('title')).toBe(
         'Partial run · 850 of 3,037 files · stopped: deadline',
       );
@@ -86,7 +93,7 @@ describe('DimensionGaugeCard', () => {
           onDimensionClick={() => {}}
         />,
       );
-      const line = screen.getByText(`${dateLabel} · 100%`);
+      const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`));
       expect(line.getAttribute('title')).toBe(
         'Partial run · 100 of 100 files · stopped: deadline',
       );
@@ -105,7 +112,7 @@ describe('DimensionGaugeCard', () => {
           onDimensionClick={() => {}}
         />,
       );
-      const line = screen.getByText(`${dateLabel} · 100%`);
+      const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 100%`));
       expect(line.getAttribute('title')).toBeNull();
     });
 
@@ -135,5 +142,30 @@ describe('DimensionGaugeCard', () => {
       );
     });
 
+  });
+
+  describe('partial coverage colouring', () => {
+    it('applies the partial CSS class to the coverage % span when exitReason != "done"', () => {
+      const item = {
+        ...baseItem,
+        dateLabel: '23 May 2026',
+        filesRead: 8, sourceFileCount: 100,
+        exitReason: 'time_limit',
+      };
+      const { container } = render(<DimensionGaugeCard item={item} onDimensionClick={() => {}} />);
+      const pctEl = container.querySelector('.dim-gauge-card__coverage-pct--partial');
+      expect(pctEl).not.toBeNull();
+    });
+
+    it('does not apply the partial CSS class when exitReason is "done"', () => {
+      const item = {
+        ...baseItem,
+        dateLabel: '23 May 2026',
+        filesRead: 100, sourceFileCount: 100,
+        exitReason: 'done',
+      };
+      const { container } = render(<DimensionGaugeCard item={item} onDimensionClick={() => {}} />);
+      expect(container.querySelector('.dim-gauge-card__coverage-pct--partial')).toBeNull();
+    });
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -76,11 +76,22 @@ function DimRow({ dim }) {
       ? <span className="scan-progress__dim-meta-projected">0 / {total}{reasonBadge}</span>
       : <span className="scan-progress__dim-meta-projected">estimating…</span>;
   } else if (isDone) {
+    const coveragePct = total > 0 ? Math.round((taken / total) * 100) : null;
+    const isPartial = typeof dim.exitReason === 'string' && dim.exitReason !== 'done';
+    const partialTooltip = isPartial
+      ? `stopped: ${dim.exitReason} · ${taken} of ${total} files`
+      : undefined;
     meta = (
       <>
         {total > 0 ? `${taken} files` : ''}
         {dim.violations > 0 && <> · <span className="scan-progress__v">{dim.violations}v</span></>}
         {dim.compliance > 0 && <> · <span className="scan-progress__c">{dim.compliance}c</span></>}
+        {coveragePct !== null && (
+          <> · <span
+            className={`scan-progress__coverage${isPartial ? ' scan-progress__coverage--partial' : ''}`}
+            title={partialTooltip}
+          >{coveragePct}%</span></>
+        )}
         {dim.elapsedS != null && <> · {formatClock(dim.elapsedS)}</>}
       </>
     );

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom/vitest';
 import { EvalLogContext } from '../eval-log/EvalLogContext.js';
 import ScanProgress from './ScanProgress.jsx';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { getEvaluationProgress } from '../../../api/index.js';
 
 vi.mock('../../../api/index.js', () => ({
   getEvaluationProgress: vi.fn(() => Promise.resolve({ dimensions: [], totalElapsedS: 0 })),
@@ -65,5 +66,46 @@ describe('ScanProgress terminal button', () => {
       activeJobId: 'job-1', status: 'streaming', openLog: vi.fn(), closeLog: vi.fn(), updateJobStatus: vi.fn(),
     });
     expect(document.querySelector('.console-shell')).toBeNull();
+  });
+});
+
+describe('ScanProgress partial coverage signal', () => {
+  function payload(dim) {
+    return {
+      runId: 'r1', phase: 'analyzing', currentDimension: null,
+      totalElapsedS: 60, projectFiles: 100, state: 'running',
+      dimensions: [dim],
+    };
+  }
+
+  const ctx = { openLog: vi.fn(), closeLog: vi.fn(), updateJobStatus: vi.fn() };
+
+  it('renders coverage % in amber when dim.exitReason is a non-done value', async () => {
+    getEvaluationProgress.mockResolvedValueOnce(payload({
+      id: 'maintainability', state: 'done',
+      files: { taken: 8, total: 100 },
+      violations: 74, compliance: 9,
+      elapsedS: 754, exitReason: 'time_limit',
+    }));
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    // Wait for react-query to settle, then open the per-dim detail panel.
+    fireEvent.click(await screen.findByTitle('Show per-dimension detail'));
+    await screen.findByText('maintainability');
+    const pctEl = container.querySelector('.scan-progress__coverage--partial');
+    expect(pctEl).not.toBeNull();
+    expect(pctEl.textContent).toMatch(/8\s*%/);
+  });
+
+  it('renders coverage % in default colour when exitReason is "done"', async () => {
+    getEvaluationProgress.mockResolvedValueOnce(payload({
+      id: 'maintainability', state: 'done',
+      files: { taken: 100, total: 100 },
+      violations: 0, compliance: 5,
+      elapsedS: 60, exitReason: 'done',
+    }));
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    fireEvent.click(await screen.findByTitle('Show per-dimension detail'));
+    await screen.findByText('maintainability');
+    expect(container.querySelector('.scan-progress__coverage--partial')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/models/dimension.js
+++ b/src/quodeq/ui/src/models/dimension.js
@@ -30,7 +30,9 @@
  * @property {string|null}   fromDateISO
  * @property {number|null}   [filesRead]         - files analyzed in this dim (Phase 1+)
  * @property {number|null}   [sourceFileCount]   - total project source-file count (Phase 1+)
- * @property {string|null}   [exitReason]        - run-level exit_reason (e.g. "deadline"); null/undefined => complete
+ * @property {string|null}   [exitReason]        - per-dim or run-level exit signal.
+ *   Values: "done" (success), "time_limit", "failure_streak", "cancelled",
+ *   "error", or null/missing (legacy, treated as "done" by the UI).
  *
  * @typedef {Object} DimensionEval
  * @property {string}           dimension

--- a/src/quodeq/ui/src/styles/dim-gauge-card.css
+++ b/src/quodeq/ui/src/styles/dim-gauge-card.css
@@ -122,6 +122,12 @@
   color: var(--color-text-muted);
   text-align: center;
 }
+.dim-gauge-card__coverage-pct {
+  color: inherit;
+}
+.dim-gauge-card__coverage-pct--partial {
+  color: #f0b95f;
+}
 
 .dim-gauge-card__gauge--insuf .dim-gauge-card__score {
   fill: var(--color-text-subtle);

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2907,6 +2907,13 @@ button.eval-provider-badge--clickable:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.scan-progress__coverage {
+  color: inherit;
+}
+.scan-progress__coverage--partial {
+  color: #f0b95f;
+  cursor: help;
+}
 .scan-progress__dim-meta-pending {
   color: var(--color-text-dim, var(--color-text-muted));
   font-style: italic;

--- a/tests/analysis/subagents/test_consolidated_exit_reason.py
+++ b/tests/analysis/subagents/test_consolidated_exit_reason.py
@@ -1,0 +1,86 @@
+"""Consolidated mode threads pool.exit_reason into per-dim Evidence."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from quodeq.analysis.subagents._consolidated import (
+    _ConsolidatedPaths,
+    _ConsolidatedRunContext,
+    _collect_consolidated_results,
+)
+
+
+def test_collect_consolidated_results_threads_exit_reason_into_context(tmp_path):
+    """The EvidenceContext built for consolidated parsing carries pool.exit_reason."""
+    config = MagicMock()
+    config.language = "python"
+    config.src = tmp_path
+    config.source_file_count = 100
+    config.target = None
+    config.evaluators_dir = None
+
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    # Touch the merged JSONL so deduplicate_jsonl is happy with the path.
+    (evidence_dir / "consolidated_evidence.jsonl").write_text("", encoding="utf-8")
+
+    ctx_obj = MagicMock()
+    ctx_obj.date_str = "2026-05-23"
+
+    run_ctx = _ConsolidatedRunContext(
+        dimensions=["security"],
+        ctx=ctx_obj,
+        results=[],
+        files=[],
+        exit_reason="time_limit",
+    )
+    paths = _ConsolidatedPaths(evidence_dir=evidence_dir, compiled_dir=None)
+
+    with patch(
+        "quodeq.analysis.subagents._consolidated.SubagentPool.deduplicate_jsonl"
+    ), patch(
+        "quodeq.analysis.subagents._consolidated.parse_jsonl_to_evidence_by_dimension",
+        return_value={},
+    ) as mock_parse:
+        _collect_consolidated_results(config, run_ctx, paths)
+
+    # The EvidenceContext passed into the parser must carry the exit_reason.
+    assert mock_parse.called, "parse_jsonl_to_evidence_by_dimension was not called"
+    ev_ctx_arg = mock_parse.call_args.args[1]
+    assert ev_ctx_arg.exit_reason == "time_limit"
+
+
+def test_collect_consolidated_results_exit_reason_defaults_to_none(tmp_path):
+    """When no exit_reason is supplied, EvidenceContext.exit_reason stays None."""
+    config = MagicMock()
+    config.language = "python"
+    config.src = tmp_path
+    config.source_file_count = 100
+    config.target = None
+    config.evaluators_dir = None
+
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "consolidated_evidence.jsonl").write_text("", encoding="utf-8")
+
+    ctx_obj = MagicMock()
+    ctx_obj.date_str = "2026-05-23"
+
+    run_ctx = _ConsolidatedRunContext(
+        dimensions=["security"],
+        ctx=ctx_obj,
+        results=[],
+        files=[],
+    )
+    paths = _ConsolidatedPaths(evidence_dir=evidence_dir, compiled_dir=None)
+
+    with patch(
+        "quodeq.analysis.subagents._consolidated.SubagentPool.deduplicate_jsonl"
+    ), patch(
+        "quodeq.analysis.subagents._consolidated.parse_jsonl_to_evidence_by_dimension",
+        return_value={},
+    ) as mock_parse:
+        _collect_consolidated_results(config, run_ctx, paths)
+
+    ev_ctx_arg = mock_parse.call_args.args[1]
+    assert ev_ctx_arg.exit_reason is None

--- a/tests/analysis/test_dim_state_transitions.py
+++ b/tests/analysis/test_dim_state_transitions.py
@@ -49,6 +49,7 @@ class TestPerDimensionLoopTransitions:
         config = _mk_config(tmp_path)
         ctx = MagicMock(total=1)
         ev = MagicMock()
+        ev.exit_reason = None  # DONE-write path forwards this into dimensions.json
 
         run_per_dimension_loop(config, ["security"], ctx, runner=_runner_returning(ev))
 
@@ -97,6 +98,7 @@ class TestPerDimensionLoopTransitions:
         config = _mk_config(tmp_path)
         ctx = MagicMock(total=2)
         ev = MagicMock()
+        ev.exit_reason = None
 
         def proc(_cfg, dim, _idx, _ctx, *, emit_log=True):
             if dim == "security":
@@ -119,6 +121,7 @@ class TestIncrementalLoopTransitions:
         config = _mk_config(tmp_path)
         ctx = MagicMock(total=1)
         ev = MagicMock()
+        ev.exit_reason = None
         # Patch the success-log call so the test doesn't depend on its side
         # effects (markers, log_success). The loop calls _log_dimension_result
         # directly after a successful incremental dim.
@@ -144,6 +147,7 @@ class TestIncrementalLoopTransitions:
         config = RunConfig(src=tmp_path, language="python", work_dir=tmp_path, options=options)
         ctx = MagicMock(total=1)
         ev = MagicMock()
+        ev.exit_reason = None
         monkeypatch.setattr("quodeq.analysis._loops._log_dimension_result", MagicMock())
         # First call (incremental) fails with RuntimeError → loop triggers
         # the fallback call, which succeeds and returns ev.
@@ -246,6 +250,7 @@ class TestRunDirResolution:
 
             # Now drive the loop -- transition to DONE.
             ev = MagicMock()
+            ev.exit_reason = None
             ctx = MagicMock(total=1)
             run_per_dimension_loop(
                 config, ["security"], ctx,

--- a/tests/analysis/test_evidence_collector_exit_reason.py
+++ b/tests/analysis/test_evidence_collector_exit_reason.py
@@ -1,0 +1,32 @@
+"""End-to-end: pool.exit_reason flows into the Evidence built by _collect_evidence."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from quodeq.analysis.subagents._evidence_collector import _CollectionContext, _collect_evidence
+
+
+def test_collect_evidence_passes_exit_reason_into_evidence(tmp_path):
+    config = MagicMock()
+    config.standards_dir = None
+    config.evaluators_dir = None
+    config.language = "python"
+    config.src = tmp_path
+    config.source_file_count = 100
+    config.target = None
+
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "security_evidence.jsonl").write_text("", encoding="utf-8")
+
+    ctx_obj = MagicMock()
+    ctx_obj.date_str = "2026-05-23"
+
+    collection = _CollectionContext(results=[], ctx=ctx_obj, files=[], exit_reason="time_limit")
+
+    with patch("quodeq.analysis.subagents._evidence_collector.SubagentPool.deduplicate_jsonl"), \
+         patch("quodeq.analysis.subagents._evidence_collector._collect_all_evidence", return_value=5):
+        ev = _collect_evidence(config, "security", evidence_dir, collection)
+
+    assert ev.exit_reason == "time_limit"

--- a/tests/analysis/test_loops_safety.py
+++ b/tests/analysis/test_loops_safety.py
@@ -59,6 +59,9 @@ class _FakeEvidence:
     # check_zero_findings (called after the loop) iterates principles —
     # an empty dict satisfies it without any findings logic.
     principles: dict = None  # type: ignore[assignment]
+    # The DONE write site forwards Evidence.exit_reason into dimensions.json;
+    # default None matches the real Evidence model so safe-write skips the field.
+    exit_reason: str | None = None
 
     def __post_init__(self) -> None:
         if self.principles is None:

--- a/tests/analysis/test_pool_exit_reason.py
+++ b/tests/analysis/test_pool_exit_reason.py
@@ -1,0 +1,57 @@
+"""Verify SubagentPool.exit_reason reflects the actual exit path."""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+from pathlib import Path
+
+from quodeq.analysis.subagents.pool import SubagentPool
+from quodeq.analysis.subagents._pool_models import PoolOptions, PoolPaths
+from quodeq.analysis.subprocess import AnalysisConfig
+
+
+def _build_pool(tmp_path: Path, time_limit: int = 0) -> SubagentPool:
+    work = tmp_path / "work"
+    work.mkdir()
+    evidence = tmp_path / "evidence"
+    evidence.mkdir()
+    queue = tmp_path / "queue.json"
+    queue.write_text('{"files": []}', encoding="utf-8")
+    return SubagentPool(
+        paths=PoolPaths(work_dir=work, evidence_dir=evidence, queue_path=queue),
+        options=PoolOptions(n_agents=1, prompt="p", dimension="security", scout_first=False),
+        config=AnalysisConfig(time_limit=time_limit),
+    )
+
+
+def test_pool_exit_reason_defaults_to_done_on_natural_drain(tmp_path):
+    pool = _build_pool(tmp_path)
+    # Patch both loops to be no-ops so the with-block exits immediately.
+    with patch("quodeq.analysis.subagents.pool.scout_loop"), \
+         patch("quodeq.analysis.subagents.pool.immediate_loop"):
+        pool.run()
+    assert pool.exit_reason == "done"
+
+
+def test_pool_exit_reason_time_limit_when_elapsed_exceeds_budget(tmp_path):
+    pool = _build_pool(tmp_path, time_limit=1)  # 1-second budget
+    # Make the loop sleep past the budget before returning.
+    def _slow_loop(ctx):
+        time.sleep(1.1)
+    with patch("quodeq.analysis.subagents.pool.scout_loop", side_effect=_slow_loop), \
+         patch("quodeq.analysis.subagents.pool.immediate_loop", side_effect=_slow_loop):
+        pool.run()
+    assert pool.exit_reason == "time_limit"
+
+
+def test_pool_exit_reason_error_when_loop_raises(tmp_path):
+    pool = _build_pool(tmp_path)
+    def _raise(ctx):
+        raise RuntimeError("boom")
+    with patch("quodeq.analysis.subagents.pool.scout_loop", side_effect=_raise), \
+         patch("quodeq.analysis.subagents.pool.immediate_loop", side_effect=_raise):
+        try:
+            pool.run()
+        except RuntimeError:
+            pass
+    assert pool.exit_reason == "error"

--- a/tests/analysis/test_report_assembly_exit_reason.py
+++ b/tests/analysis/test_report_assembly_exit_reason.py
@@ -1,0 +1,37 @@
+"""_assemble_report_dict surfaces evidence.exit_reason as exitReason in the dict."""
+from __future__ import annotations
+
+from quodeq.analysis._report_assembly import _ReportData, _assemble_report_dict
+
+
+def _evidence_dict(exit_reason: str | None) -> dict:
+    return {
+        "repository": "r", "discipline": "Python", "date": "2026-05-23",
+        "source_file_count": 100, "files_read": 8, "coverage_pct": 8.0,
+        "meta": {},
+        "exit_reason": exit_reason,
+    }
+
+
+def test_report_dict_includes_exit_reason_when_set():
+    data = _ReportData(
+        dimension="security", evidence=_evidence_dict("time_limit"),
+        top_score="5.7/10", top_grade="Poor",
+        principle_rows=[], flat_violations=[], flat_compliance=[],
+        sev_tally={"critical": 0, "major": 0, "minor": 0},
+    )
+    report = _assemble_report_dict(data)
+    assert report["exitReason"] == "time_limit"
+
+
+def test_report_dict_exit_reason_none_when_evidence_missing_field():
+    data = _ReportData(
+        dimension="security", evidence={**_evidence_dict(None)},
+        top_score=None, top_grade=None,
+        principle_rows=[], flat_violations=[], flat_compliance=[],
+        sev_tally={"critical": 0, "major": 0, "minor": 0},
+    )
+    # Drop the key entirely
+    data.evidence.pop("exit_reason")
+    report = _assemble_report_dict(data)
+    assert report.get("exitReason") is None

--- a/tests/data/fs/report_parser/test_report_parsing_exit_reason.py
+++ b/tests/data/fs/report_parser/test_report_parsing_exit_reason.py
@@ -1,0 +1,54 @@
+"""parse_report_json preserves exitReason from the per-dim JSON."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.data.fs.report_parser._report_parsing import parse_report_json
+
+
+def test_parse_report_json_includes_exit_reason(tmp_path: Path):
+    json_path = tmp_path / "security.json"
+    json_path.write_text(json.dumps({
+        "schema_version": 1,
+        "dimension": "security",
+        "project": "r",
+        "discipline": "Python",
+        "date": "2026-05-23",
+        "sourceFileCount": 100,
+        "filesRead": 8,
+        "coveragePct": 8.0,
+        "exitReason": "time_limit",
+        "meta": {},
+        "overallScore": "5.7/10",
+        "overallGrade": "Poor",
+        "principles": [],
+        "violations": [],
+        "compliance": [],
+        "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
+    }), encoding="utf-8")
+    result = parse_report_json(json_path)
+    assert result["exitReason"] == "time_limit"
+
+
+def test_parse_report_json_exit_reason_none_when_absent(tmp_path: Path):
+    json_path = tmp_path / "security.json"
+    json_path.write_text(json.dumps({
+        "schema_version": 1,
+        "dimension": "security",
+        "project": "r",
+        "discipline": "Python",
+        "date": "2026-05-23",
+        "sourceFileCount": 100,
+        "filesRead": 8,
+        "coveragePct": 8.0,
+        "meta": {},
+        "overallScore": "5.7/10",
+        "overallGrade": "Poor",
+        "principles": [],
+        "violations": [],
+        "compliance": [],
+        "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
+    }), encoding="utf-8")
+    result = parse_report_json(json_path)
+    assert result.get("exitReason") is None

--- a/tests/data/sqlite/test_schema.py
+++ b/tests/data/sqlite/test_schema.py
@@ -26,8 +26,8 @@ def test_evaluation_ddl_includes_confidence_column():
     assert "confidence" in _schema.EVALUATION_DDL
 
 
-def test_schema_version_is_4() -> None:
-    assert SCHEMA_VERSION == 4
+def test_schema_version_is_5() -> None:
+    assert SCHEMA_VERSION == 5
 
 
 def test_principle_grades_table_exists(tmp_path: Path) -> None:

--- a/tests/data/sqlite/test_schema_exit_reason.py
+++ b/tests/data/sqlite/test_schema_exit_reason.py
@@ -1,0 +1,61 @@
+"""dimension_scores has an exit_reason column on fresh and upgraded DBs."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from quodeq.data.sqlite._migrations import apply_evaluation_schema
+from quodeq.data.sqlite._schema import SCHEMA_VERSION
+
+
+def test_fresh_db_dimension_scores_has_exit_reason_column(tmp_path: Path):
+    db_path = tmp_path / "fresh.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        apply_evaluation_schema(conn)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(dimension_scores)").fetchall()]
+        assert "exit_reason" in cols
+        # Verify it is nullable by inserting a row without that column.
+        conn.execute(
+            "INSERT INTO dimension_scores (dimension, coverage_pct) VALUES (?, ?)",
+            ("security", 50.0),
+        )
+        row = conn.execute(
+            "SELECT exit_reason FROM dimension_scores WHERE dimension = ?",
+            ("security",),
+        ).fetchone()
+        assert row[0] is None
+    finally:
+        conn.close()
+
+
+def test_schema_version_bumped_to_5():
+    assert SCHEMA_VERSION == 5
+
+
+def test_upgrade_from_v4_adds_exit_reason(tmp_path: Path):
+    """Existing v4 DB gets the new column via _upgrade_v4_to_v5."""
+    db_path = tmp_path / "v4.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        # Simulate a v4 DB: write the existing schema without exit_reason.
+        conn.executescript("""
+            CREATE TABLE dimension_scores (
+                dimension       TEXT PRIMARY KEY,
+                score           REAL,
+                grade           TEXT,
+                confidence      TEXT,
+                files_read      INTEGER NOT NULL DEFAULT 0,
+                source_count    INTEGER NOT NULL DEFAULT 0,
+                coverage_pct    REAL NOT NULL DEFAULT 0.0,
+                completed_at    TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            PRAGMA user_version = 4;
+        """)
+        apply_evaluation_schema(conn)
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(dimension_scores)").fetchall()]
+        assert "exit_reason" in cols
+        # Confirm user_version was bumped.
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 5
+    finally:
+        conn.close()

--- a/tests/data/sqlite/test_v3_to_v4_rebuilds.py
+++ b/tests/data/sqlite/test_v3_to_v4_rebuilds.py
@@ -77,10 +77,16 @@ def test_v3_to_v4_migration_clears_projection_checkpoint(tmp_path: Path) -> None
 
     from quodeq.data.sqlite.connection import open_evaluation_db
 
-    # First open triggers the migration.
+    # First open triggers the migration. The chain runs through to the
+    # current SCHEMA_VERSION (the v3->v4 step is what this test cares about
+    # — the projection checkpoint clear happens during that step).
     with open_evaluation_db(tmp_path) as conn:
+        from quodeq.data.sqlite._schema import SCHEMA_VERSION
+
         version = conn.execute("PRAGMA user_version").fetchone()[0]
-        assert version == 4, f"Expected v4 after migration, got v{version}"
+        assert version == SCHEMA_VERSION, (
+            f"Expected current schema version after migration, got v{version}"
+        )
 
         # Existing findings stay; the rebuild path clears them when triggered
         # by the next ensure_projected. What matters for this migration is

--- a/tests/engine/test_evidence.py
+++ b/tests/engine/test_evidence.py
@@ -133,3 +133,46 @@ def test_evidence_to_scoring_dict_omits_exit_reason_when_none():
     )
     d = evidence_to_scoring_dict(ev)
     assert "exit_reason" not in d or d["exit_reason"] is None
+
+
+def test_merge_evidence_preserves_first_non_none_exit_reason():
+    from quodeq.core.evidence.merge import merge_evidence
+    ev_a = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=10, coverage_pct=100.0,
+        exit_reason=None,
+    )
+    ev_b = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=2, coverage_pct=20.0,
+        exit_reason="time_limit",
+    )
+    merged = merge_evidence([ev_a, ev_b], source_file_count=10, src="r", language="python")
+    assert merged.exit_reason == "time_limit"
+
+
+def test_merge_evidence_exit_reason_none_when_all_inputs_none():
+    from quodeq.core.evidence.merge import merge_evidence
+    ev = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=10, coverage_pct=100.0,
+    )
+    merged = merge_evidence([ev], source_file_count=10, src="r", language="python")
+    assert merged.exit_reason is None
+
+
+def test_merge_evidence_done_outranked_by_incomplete():
+    """A 'done' input should not mask a 'time_limit' input in the merged result."""
+    from quodeq.core.evidence.merge import merge_evidence
+    ev_a = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=10, coverage_pct=100.0,
+        exit_reason="done",
+    )
+    ev_b = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=2, coverage_pct=20.0,
+        exit_reason="time_limit",
+    )
+    merged = merge_evidence([ev_a, ev_b], source_file_count=10, src="r", language="python")
+    assert merged.exit_reason == "time_limit"

--- a/tests/engine/test_evidence.py
+++ b/tests/engine/test_evidence.py
@@ -104,3 +104,32 @@ def test_evidence_to_v1_dict():
     assert d["principles"]["ts-001"]["violations"][0]["severity"] == "high"
     assert d["source_file_count"] == 100
     assert d["files_read"] == 50
+
+
+def test_evidence_exit_reason_defaults_to_none():
+    ev = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=5, coverage_pct=50.0,
+    )
+    assert ev.exit_reason is None
+
+
+def test_evidence_to_scoring_dict_includes_exit_reason():
+    from quodeq.core.evidence.model import evidence_to_scoring_dict
+    ev = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=5, coverage_pct=50.0,
+        exit_reason="time_limit",
+    )
+    d = evidence_to_scoring_dict(ev)
+    assert d["exit_reason"] == "time_limit"
+
+
+def test_evidence_to_scoring_dict_omits_exit_reason_when_none():
+    from quodeq.core.evidence.model import evidence_to_scoring_dict
+    ev = Evidence(
+        repository="r", language="python", date="2026-05-23",
+        source_file_count=10, files_read=5, coverage_pct=50.0,
+    )
+    d = evidence_to_scoring_dict(ev)
+    assert "exit_reason" not in d or d["exit_reason"] is None

--- a/tests/engine/test_evidence_parser.py
+++ b/tests/engine/test_evidence_parser.py
@@ -267,3 +267,24 @@ class TestParseJsonlToEvidence:
         assert "violations" in d["principles"]["ts-001"]
         assert "compliance" in d["principles"]["ts-001"]
         assert "metrics" in d["principles"]["ts-001"]
+
+
+def test_build_evidence_propagates_exit_reason(tmp_path):
+    """EvidenceContext.exit_reason flows into the built Evidence."""
+    from quodeq.core.evidence.parser import EvidenceContext, _build_evidence
+    ctx = EvidenceContext(
+        language="python", repository="r", date_str="2026-05-23",
+        source_file_count=100, files_read=8, exit_reason="time_limit",
+    )
+    ev = _build_evidence(ctx, principles={})
+    assert ev.exit_reason == "time_limit"
+
+
+def test_build_evidence_defaults_exit_reason_to_none(tmp_path):
+    from quodeq.core.evidence.parser import EvidenceContext, _build_evidence
+    ctx = EvidenceContext(
+        language="python", repository="r", date_str="2026-05-23",
+        source_file_count=100, files_read=8,
+    )
+    ev = _build_evidence(ctx, principles={})
+    assert ev.exit_reason is None

--- a/tests/services/test_dashboard_exit_reason.py
+++ b/tests/services/test_dashboard_exit_reason.py
@@ -1,0 +1,22 @@
+"""Dashboard attaches per-dim exit_reason when available, falls back to run-level."""
+from __future__ import annotations
+
+from quodeq.services.dashboard import _attach_exit_reason_to_dim
+
+
+def test_per_dim_exit_reason_wins_over_run_level():
+    dim = {"dimension": "security", "exit_reason": "time_limit"}
+    out = _attach_exit_reason_to_dim(dim, run_exit_reason="deadline")
+    assert out["exitReason"] == "time_limit"
+
+
+def test_falls_back_to_run_level_when_dim_missing():
+    dim = {"dimension": "security"}
+    out = _attach_exit_reason_to_dim(dim, run_exit_reason="deadline")
+    assert out["exitReason"] == "deadline"
+
+
+def test_no_exit_reason_when_both_absent():
+    dim = {"dimension": "security"}
+    out = _attach_exit_reason_to_dim(dim, run_exit_reason=None)
+    assert "exitReason" not in out

--- a/tests/services/test_scan_progress_exit_reason.py
+++ b/tests/services/test_scan_progress_exit_reason.py
@@ -1,0 +1,52 @@
+"""scan_progress includes per-dim exit_reason when present in dimensions.json."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
+
+
+def _make_run(tmp_path: Path) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "scan.json").write_text(json.dumps({"total_files": 100}), encoding="utf-8")
+    run = project / "run"
+    run.mkdir()
+    return run
+
+
+def test_scan_progress_includes_exit_reason(tmp_path):
+    run = _make_run(tmp_path)
+    (run / "status.json").write_text(json.dumps({
+        "phase": "analyzing", "current_dimension": None,
+        "started_at": "2026-05-23T08:00:00+00:00",
+        "dimensions": ["security"],
+    }), encoding="utf-8")
+    (run / "dimensions.json").write_text(json.dumps({
+        "dimensions": {"security": {"state": "done", "exit_reason": "time_limit"}},
+    }), encoding="utf-8")
+    (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
+
+    progress = build_scan_progress("job-1", run, time_limit_s=None)
+    d = progress_to_dict(progress)
+    security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
+    assert security_dim["exitReason"] == "time_limit"
+
+
+def test_scan_progress_omits_exit_reason_when_absent(tmp_path):
+    run = _make_run(tmp_path)
+    (run / "status.json").write_text(json.dumps({
+        "phase": "analyzing", "current_dimension": None,
+        "started_at": "2026-05-23T08:00:00+00:00",
+        "dimensions": ["security"],
+    }), encoding="utf-8")
+    (run / "dimensions.json").write_text(json.dumps({
+        "dimensions": {"security": {"state": "done"}},
+    }), encoding="utf-8")
+    (run / "security_evidence.jsonl").write_text("", encoding="utf-8")
+
+    progress = build_scan_progress("job-1", run, time_limit_s=None)
+    d = progress_to_dict(progress)
+    security_dim = next(x for x in d["dimensions"] if x["id"] == "security")
+    assert security_dim.get("exitReason") is None

--- a/tests/shared/test_dimensions_state_exit_reason.py
+++ b/tests/shared/test_dimensions_state_exit_reason.py
@@ -1,0 +1,41 @@
+"""dimensions.json carries an optional per-dim exit_reason on DONE."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.shared.dimensions_state import DimState, read_dimensions, write_dim_state
+
+
+def test_write_dim_state_persists_exit_reason_on_done(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_dim_state(run_dir, "security", DimState.DONE, exit_reason="time_limit")
+    raw = json.loads((run_dir / "dimensions.json").read_text(encoding="utf-8"))
+    assert raw["dimensions"]["security"]["exit_reason"] == "time_limit"
+    assert raw["dimensions"]["security"]["state"] == "done"
+
+
+def test_read_dimensions_returns_exit_reason(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_dim_state(run_dir, "security", DimState.DONE, exit_reason="time_limit")
+    state = read_dimensions(run_dir)
+    assert state["dimensions"]["security"]["exit_reason"] == "time_limit"
+
+
+def test_write_dim_state_omits_exit_reason_when_none(tmp_path: Path):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_dim_state(run_dir, "security", DimState.DONE)
+    raw = json.loads((run_dir / "dimensions.json").read_text(encoding="utf-8"))
+    assert "exit_reason" not in raw["dimensions"]["security"]
+
+
+def test_exit_reason_ignored_for_non_done_states(tmp_path: Path):
+    """exit_reason only attaches to DONE; RUNNING/INCOMPLETE use different fields."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    write_dim_state(run_dir, "security", DimState.RUNNING, exit_reason="ignored")
+    raw = json.loads((run_dir / "dimensions.json").read_text(encoding="utf-8"))
+    assert "exit_reason" not in raw["dimensions"]["security"]


### PR DESCRIPTION
## Summary

Plumbs a per-dimension `exit_reason` from `SubagentPool` through Evidence, `dimensions.json`, the progress endpoint, the per-dim report dict, and the dashboard, then renders the dim's coverage % in **amber** on both the in-progress page and the report card when the pool exited for any reason other than `"done"`.

Closes the "8% coverage shows as a green ✓ POOR card" visual gap that surfaced on Victor's 7290-file local-model run, where each dim's subagent pool was force-stopped at the auto-scaled 2h cap but the UI rendered the partial results as if they were a clean drain.

**Spec:** `docs/superpowers/specs/2026-05-23-per-dim-exit-reason-design.md`
**Plan:** `docs/superpowers/plans/2026-05-23-per-dim-exit-reason.md`

### Data flow

```
SubagentPool.exit_reason (done | time_limit | error)
  → _CollectionContext.exit_reason
  → EvidenceContext.exit_reason
  → Evidence.exit_reason
  → dimensions.json (per-dim sidecar)        ──►  /api/evaluations/<jobId>/progress  ──► ScanProgress amber %
  → evaluation/<dim>.json (per-dim report)   ──►  DimensionResult.exit_reason         ──► DimensionGaugeCard amber %
```

### What's in this PR

- New optional `Evidence.exit_reason` field, threaded through `EvidenceContext`, `_build_evidence`, and `merge_evidence` (incomplete-dominates rule).
- `SubagentPool.run()` tracks its own exit cause across three paths: natural drain, time-limit hit, exception.
- Per-dim `exit_reason` persisted to `dimensions.json` and surfaced in the live progress payload.
- Per-dim `exitReason` written to `evaluation/<dim>.json` and round-tripped via `DimensionResult` + `parse_dimension_result` + `parse_report_json`.
- `_attach_exit_reason_to_dim` now prefers per-dim value; falls back to run-level for legacy runs.
- SQLite schema bumped v4 → v5, adds nullable `exit_reason TEXT` column to `dimension_scores` (reserved for a future consumer; dashboard reads from JSON in this PR).
- `ScanProgress.jsx` and `DimensionGaugeCard.jsx` colour the coverage % amber (`#f0b95f`) when `exitReason !== 'done'`, with a hover tooltip naming the cause.
- Side-fix: `progress_to_dict` now calls `to_camel_dict` directly instead of `asdict`, so the route correctly emits camelCase keys. This was a pre-existing latent bug that would have made `dim.exitReason` silently undefined; also fixes `estimateReason`, `activeAgents`, `elapsedS`, and `budgetS` rendering on the in-progress page.

### Backwards compatibility

Fully additive:
- Legacy Evidence files without `exit_reason` → field is `None` → UI treats as `"done"` → no amber. Unchanged rendering.
- Existing `evaluation.db` upgrades v4 → v5 idempotently via `_upgrade_v4_to_v5`. Nullable column, no backfill required.
- Run-level `Job.exit_reason` path is untouched and still serves as fallback for legacy runs.

Runs started before this PR ships won't have per-dim `exit_reason` even after the upgrade — only new runs will surface amber. Documented in the spec under "Retroactivity caveat."

## Test Plan

- [x] Start a fresh evaluation against a large project (7000+ files) on Ollama; force at least one dim to hit the 2h `_MAX_AUTO_POOL_BUDGET` cap.
- [x] On the in-progress page, watch the dim transition to `done` — coverage % token should render amber the moment the state flips, with tooltip `stopped: time_limit · X of Y files`.
- [x] When the run completes, open the report; confirm the matching gauge card's `· X%` footer is amber.
- [x] Run a small project that drains all dims naturally; confirm coverage % renders in the default colour (no amber, no tooltip cause).
- [x] Open a historical run (started before this PR); confirm it renders unchanged — no amber, no console errors.
- [x] Verify the `evaluation.db` migration runs cleanly on first read of an existing project (`PRAGMA user_version` should be `5` after the read).