### PR TITLE
fix(analysis): surface Ollama failures and stop cancel orphans

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import re
+import time
 from dataclasses import dataclass
 from enum import Enum as _Enum
 from pathlib import Path
@@ -212,18 +213,38 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         timeout=timeout,
     ) as oa_client:
         client = instructor.from_openai(oa_client, mode=mode)
+        start = time.monotonic()
         try:
             result = client.chat.completions.create(**create_kwargs)
-            _log.debug("Instructor returned %d findings", len(result.findings))
+            _log.debug("Instructor returned %d findings in %.0fs", len(result.findings), time.monotonic() - start)
             return [f.model_dump() for f in result.findings], False
         except Exception as exc:
+            elapsed = time.monotonic() - start
+            # Timeouts are unrecoverable -- no JSON to salvage, and the
+            # message wouldn't tell the user what's wrong. Call them out
+            # explicitly so the failure mode is visible in default INFO logs.
+            if isinstance(exc, (httpx.ReadTimeout, httpx.TimeoutException)):
+                _log.warning(
+                    "Ollama call timed out after %.0fs (model=%s). "
+                    "Likely causes: --n-subagents > 1 with OLLAMA_NUM_PARALLEL=1 "
+                    "(requests queue and second-in-line exceeds the timeout), "
+                    "or context too large (try QUODEQ_CONTEXT_SIZE).",
+                    elapsed, config.model,
+                )
+                return [], True
             # Try to salvage valid findings from the malformed response
             raw = str(exc)
             salvaged = _salvage_partial_findings(raw)
             if salvaged:
-                _log.debug("Instructor validation failed — salvaged %d findings from malformed response", len(salvaged))
+                _log.warning(
+                    "Model %s returned malformed JSON after %.0fs -- salvaged %d findings from the response",
+                    config.model, elapsed, len(salvaged),
+                )
                 return salvaged, True
-            _log.debug("Instructor validation failed — no findings salvaged: %s", str(exc)[:200])
+            _log.warning(
+                "Model %s call failed after %.0fs, no findings recovered: %s",
+                config.model, elapsed, str(exc)[:300],
+            )
             return [], True
 
 

--- a/src/quodeq/analysis/_pipeline.py
+++ b/src/quodeq/analysis/_pipeline.py
@@ -12,12 +12,43 @@ from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.dimension_runner import DimensionRunner, _log_dimension_result
 from quodeq.analysis.errors import EvaluationError as EvaluationError  # re-export
 from quodeq.analysis.subagents.runner import process_consolidated_dimensions
+from quodeq.analysis._provider_cache import get_provider_configs
 from quodeq.analysis.subprocess import _get_provider_type
 from quodeq.core.evidence.model import Evidence
 from quodeq.core.evidence.merge import merge_evidence
 from quodeq.engine._runner_markers import emit_marker
 from quodeq.shared.logging import log_info, log_warning
 from quodeq.shared.utils import get_ai_cmd
+
+_LOCAL_API_HOSTS = ("localhost", "127.0.0.1", "::1")
+
+
+def _warn_if_local_api_oversubscribed(config: RunConfig) -> None:
+    """Warn when subagents will queue behind one local-API inference slot.
+
+    Local model servers (Ollama, llama.cpp, omlx) default to serving one
+    request per loaded model. With ``--n-subagents > 1`` the second agent
+    queues behind the first and typically exceeds the read timeout, surfacing
+    as silent timeouts. The fix is either ``--n-subagents 1`` or raising the
+    server's parallelism (e.g. ``OLLAMA_NUM_PARALLEL``). Cloud API providers
+    don't have this constraint, so we narrow the warning to loopback bases.
+    """
+    if config.options.max_subagents <= 1:
+        return
+    ai_cmd = get_ai_cmd()
+    if _get_provider_type(ai_cmd) != "api":
+        return
+    api_base = get_provider_configs().get(ai_cmd, {}).get("api_base", "")
+    if not any(host in api_base for host in _LOCAL_API_HOSTS):
+        return
+    log_warning(
+        f"--n-subagents={config.options.max_subagents} with local provider "
+        f"'{ai_cmd}' will likely time out: local model servers serve one "
+        f"request per model by default, so subagents queue and the second "
+        f"exceeds the read timeout. Use --n-subagents 1 or raise the "
+        f"server's parallelism (e.g. OLLAMA_NUM_PARALLEL="
+        f"{config.options.max_subagents})."
+    )
 
 
 def load_analysis_context(config: RunConfig) -> tuple[list[str], _AnalysisContext]:
@@ -80,6 +111,8 @@ def _run_dimensions(
     """Run AI analysis for each dimension and return per-dimension Evidence."""
     if config.options.dry_run:
         return _run_dry_run(config, on_dimension_done=on_dimension_done)
+
+    _warn_if_local_api_oversubscribed(config)
 
     dimensions, ctx = load_analysis_context(config)
     # Activate the per-run classify stash so ``_persist_dim_estimates``

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -17,7 +17,7 @@ import subprocess
 
 from quodeq.core.types import JobSnapshot
 
-from quodeq.analysis._process import _kill_tree
+from quodeq.analysis._process import _kill_tree, _terminate_process
 from quodeq.shared.run_log import RunLogWriter
 from quodeq.services._job_model import (
     Job,
@@ -155,7 +155,15 @@ class JobManager:
         return self._cancel_internal(job_id)
 
     def _cancel_internal(self, job_id: str) -> bool:
-        """Kill an internal tracked subprocess."""
+        """Kill an internal tracked subprocess, escalating SIGTERM -> SIGKILL.
+
+        Bare SIGTERM doesn't reliably interrupt a child blocked in a long
+        httpx socket read (e.g. waiting on an Ollama inference that takes
+        minutes) -- the signal queues behind the syscall and the process
+        keeps holding the upstream connection. ``_terminate_process`` runs
+        SIGTERM with a grace window then escalates to SIGKILL, matching the
+        external-cancel path in ``_external_jobs.cancel_external_run``.
+        """
         with self._lock:
             job = self._store.get(job_id)
             process = self._processes.get(job_id)
@@ -165,7 +173,7 @@ class JobManager:
             job.ended_at = datetime.now(timezone.utc).isoformat()
             self._store.put(job)
         if process:
-            _kill_tree(process.pid)
+            _terminate_process(process)
         return True
 
     def _cancel_external(self, job_id: str, reports_root: Path) -> bool:

--- a/tests/services/test_job_manager.py
+++ b/tests/services/test_job_manager.py
@@ -93,8 +93,8 @@ class TestCancelJob:
         mgr = JobManager(job_store=store)
         assert mgr.cancel_job("j1") is False
 
-    @patch("quodeq.services.jobs._kill_tree")
-    def test_cancel_running_job(self, mock_kill):
+    @patch("quodeq.services.jobs._terminate_process")
+    def test_cancel_running_job(self, mock_terminate):
         store = InMemoryJobStore()
         store.put(Job("j1", STATUS_RUNNING, [], "now", None, None))
         mgr = JobManager(job_store=store)
@@ -104,7 +104,10 @@ class TestCancelJob:
         mgr._processes["j1"] = fake_proc
         assert mgr.cancel_job("j1") is True
         assert store.get("j1").status == STATUS_CANCELLED
-        mock_kill.assert_called_once_with(999)
+        # Internal cancel must go through _terminate_process (TERM → grace →
+        # SIGKILL); bare _kill_tree leaves orphans when the child is blocked
+        # in a long socket read.
+        mock_terminate.assert_called_once_with(fake_proc)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three compounding bugs made local Ollama evaluations look "stuck" with no visible errors. Diagnosed by reproducing during a stalled run that showed 33/38 chat/completions returning 500 after exactly 8m20s (the client read timeout) with no failures surfaced to the user.

- **Failures now visible**: Instructor timeouts and malformed-JSON salvage paths were logged at DEBUG, invisible at default INFO. Now log at WARNING with elapsed seconds + model name. Timeouts are distinguished from validation errors so the right remedy is obvious from the message.
- **Cancellation actually kills the subprocess**: `_cancel_internal` sent bare SIGTERM with no escalation, which never reaches a child blocked in a long httpx socket read (waiting on an Ollama call that takes minutes). Switched to the existing `_terminate_process` helper (TERM, 10s grace, then SIGKILL), matching what `cancel_external_run` already did for external jobs.
- **Startup guardrail for local-API oversubscription**: `--n-subagents > 1` against Ollama with default `OLLAMA_NUM_PARALLEL=1` guarantees the second-queued request exceeds the read timeout. New `_warn_if_local_api_oversubscribed` fires once per run for loopback `api_base` providers, with a hint to either lower subagents or raise the server's parallelism.

Per-call latency itself (1 to 8 min on M4 Max with gemma4:26b at 64k context) is hardware reality and out of scope for this PR.

## Test plan

- [x] `pytest tests/` passes (3086 tests)
- [x] `tests/services/test_job_manager.py::test_cancel_running_job` updated to verify `_terminate_process` is called with the process object (not bare `_kill_tree`)
- [x] Smoke-tested `_warn_if_local_api_oversubscribed` across three cases: ollama+2 (warns), openai+2 (silent), ollama+1 (silent)
- [ ] Manual: run an evaluation with `--n-subagents 2 AI_PROVIDER=ollama` and confirm the WARN appears at startup
- [ ] Manual: trigger a long Ollama call, cancel via UI, verify the python subprocess actually dies within ~10 seconds (previously: orphan held open)
- [ ] Manual: cause an Instructor failure (e.g. tiny context size that truncates the response) and confirm the WARNING line shows elapsed time + model