### PR TITLE
fix(api-runner): detect timeouts wrapped by Instructor's retry layer

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -127,6 +127,27 @@ class ApiRunnerConfig:
     context_size: int = 0
 
 
+def _is_timeout_error(exc: BaseException) -> bool:
+    """Detect httpx timeouts even when Instructor's retry layer wrapped them.
+
+    Instructor raises ``InstructorRetryException`` when ``max_retries`` is
+    exhausted, stashing each underlying error in a ``failed_attempts`` list.
+    A bare ``isinstance(exc, httpx.ReadTimeout)`` misses these wrapped cases,
+    so timeouts surface as "no findings recovered" instead of the
+    timeout-specific WARN that tells the user how to fix it. We duck-type
+    ``failed_attempts`` so an Instructor version bump that renames or moves
+    the exception class still works.
+    """
+    if isinstance(exc, (httpx.ReadTimeout, httpx.TimeoutException)):
+        return True
+    attempts = getattr(exc, "failed_attempts", None) or []
+    for attempt in attempts:
+        inner = getattr(attempt, "exception", None)
+        if isinstance(inner, (httpx.ReadTimeout, httpx.TimeoutException)):
+            return True
+    return False
+
+
 def _salvage_partial_findings(raw_json: str) -> list[dict]:
     """Try to extract valid findings from malformed JSON.
 
@@ -223,7 +244,11 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
             # Timeouts are unrecoverable -- no JSON to salvage, and the
             # message wouldn't tell the user what's wrong. Call them out
             # explicitly so the failure mode is visible in default INFO logs.
-            if isinstance(exc, (httpx.ReadTimeout, httpx.TimeoutException)):
+            # Note: when Instructor exhausts retries it wraps the underlying
+            # ReadTimeout in InstructorRetryException; ``_is_timeout_error``
+            # walks ``failed_attempts`` so wrapped timeouts still surface
+            # with the actionable hint rather than as generic failures.
+            if _is_timeout_error(exc):
                 _log.warning(
                     "Ollama call timed out after %.0fs (model=%s). "
                     "Likely causes: --n-subagents > 1 with OLLAMA_NUM_PARALLEL=1 "

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -1,4 +1,4 @@
-"""Extended tests for _api_runner.py — salvage, enrichment, path resolution."""
+"""Extended tests for _api_runner.py: salvage, enrichment, path resolution."""
 from __future__ import annotations
 
 import json
@@ -9,6 +9,8 @@ import pytest
 
 instructor = pytest.importorskip("instructor", reason="requires quodeq[api] extra")
 
+import httpx
+
 from quodeq.analysis._api_runner import (
     ApiRunnerConfig,
     _LOCAL_TIMEOUT,
@@ -17,6 +19,7 @@ from quodeq.analysis._api_runner import (
     _Finding,
     _Findings,
     _FindingType,
+    _is_timeout_error,
     _resolve_file_paths,
     _salvage_partial_findings,
     _Severity,
@@ -56,6 +59,63 @@ class TestSalvagePartialFindings:
         )
         result = _salvage_partial_findings(raw)
         assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _is_timeout_error
+# ---------------------------------------------------------------------------
+
+class TestIsTimeoutError:
+    """Timeout detection must see through Instructor's retry wrapper.
+
+    When Instructor exhausts retries it raises ``InstructorRetryException``
+    with the original ``ReadTimeout`` buried in ``failed_attempts``. A bare
+    ``isinstance(exc, httpx.ReadTimeout)`` misses these wrapped cases and the
+    user sees a generic "no findings recovered" instead of the actionable
+    timeout WARN.
+    """
+
+    def test_bare_read_timeout(self):
+        assert _is_timeout_error(httpx.ReadTimeout("read timeout")) is True
+
+    def test_bare_timeout_exception(self):
+        assert _is_timeout_error(httpx.TimeoutException("timeout")) is True
+
+    def test_unrelated_exception(self):
+        assert _is_timeout_error(ValueError("not a timeout")) is False
+
+    def test_no_failed_attempts_attribute(self):
+        """Plain exceptions without failed_attempts return False cleanly."""
+        assert _is_timeout_error(RuntimeError("boom")) is False
+
+    def test_wrapped_read_timeout_in_failed_attempts(self):
+        """Instructor's retry wrapper stashes the original exception per attempt."""
+        wrapper = RuntimeError("InstructorRetryException")
+        # Duck-typed failed_attempts: any object with .exception attribute
+        attempt = MagicMock(exception=httpx.ReadTimeout("upstream timed out"))
+        wrapper.failed_attempts = [attempt]
+        assert _is_timeout_error(wrapper) is True
+
+    def test_failed_attempts_with_non_timeout(self):
+        """Validation errors in failed_attempts must not be misread as timeouts."""
+        wrapper = RuntimeError("InstructorRetryException")
+        attempt = MagicMock(exception=ValueError("schema mismatch"))
+        wrapper.failed_attempts = [attempt]
+        assert _is_timeout_error(wrapper) is False
+
+    def test_failed_attempts_mixed_one_timeout_wins(self):
+        """At least one wrapped timeout means we should categorise the whole call as a timeout."""
+        wrapper = RuntimeError("InstructorRetryException")
+        wrapper.failed_attempts = [
+            MagicMock(exception=ValueError("first attempt bad json")),
+            MagicMock(exception=httpx.ReadTimeout("second attempt timed out")),
+        ]
+        assert _is_timeout_error(wrapper) is True
+
+    def test_empty_failed_attempts(self):
+        wrapper = RuntimeError("InstructorRetryException")
+        wrapper.failed_attempts = []
+        assert _is_timeout_error(wrapper) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #546. Patch A's `isinstance(exc, httpx.ReadTimeout)` missed the common case: when Instructor exhausts `max_retries`, it wraps the underlying `ReadTimeout` inside `InstructorRetryException` with the real exception stashed in `failed_attempts`. The wrapper is not an httpx exception, so the timeout-specific WARN branch never fired and the call surfaced as generic "no findings recovered" instead of the actionable timeout message.

**Observed in a real growstuff run after #546 landed**: 6 Ollama-side 500 timeouts (all exact 8m20s = client read timeout) produced 0 "timed out after" WARNs and only 2 "no findings recovered" WARNs.

## Fix

Added `_is_timeout_error(exc)` that walks `failed_attempts` (duck-typed so an Instructor version bump that renames or moves the exception class still works) and treats any wrapped httpx timeout as a timeout. Used in place of the bare isinstance check in the except handler.

## Notes on the commit history

This change was originally pushed directly to develop as `b198d775` by mistake. To restore the feature-branch-then-PR workflow, that commit was reverted on develop (`f7573fa3`) and the same change re-applied on this branch via cherry-pick (`e7395857`). Net effect: the same diff, but now reviewable.

## Test plan

- [x] 8 new tests for `_is_timeout_error` cover: bare ReadTimeout, bare TimeoutException, plain non-timeout exception, no failed_attempts attribute, wrapped ReadTimeout in failed_attempts, validation error in failed_attempts (not misread), mixed attempts (one timeout wins), empty failed_attempts
- [x] `pytest tests/analysis/test_api_runner.py tests/analysis/test_api_runner_coverage.py tests/services/` passes (815 tests)
- [ ] Manual: run an evaluation that hits the 500s read timeout and verify the WARN now reads "Ollama call timed out after..." instead of "no findings recovered"