### PR TITLE
fix(api-runner): salvage path handles nested and concatenated findings

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 import time
 from dataclasses import dataclass
 from enum import Enum as _Enum
@@ -148,25 +147,73 @@ def _is_timeout_error(exc: BaseException) -> bool:
     return False
 
 
+def _extract_finding_dicts(node: object, sink: list[dict]) -> None:
+    """Walk a decoded JSON value, appending any dict that parses as a `_Finding`.
+
+    Used by ``_salvage_partial_findings`` so we recover findings whether
+    the model emitted them as a bare object, a list, a wrapped
+    ``{"findings": [...]}``, or nested somewhere unexpected. Recursion
+    stops at a successful ``_Finding`` validation (so we don't dive into
+    a finding's own fields looking for sub-findings).
+    """
+    if isinstance(node, dict):
+        try:
+            f = _Finding.model_validate(node)
+            sink.append(f.model_dump())
+            return
+        except (ValueError, KeyError, TypeError):
+            pass
+        for value in node.values():
+            _extract_finding_dicts(value, sink)
+    elif isinstance(node, list):
+        for item in node:
+            _extract_finding_dicts(item, sink)
+
+
 def _salvage_partial_findings(raw_json: str) -> list[dict]:
     """Try to extract valid findings from malformed JSON.
 
-    Local models sometimes drop a brace in long arrays, producing invalid
-    JSON. We try to parse each object individually.
+    Local models produce several distinct failure shapes:
+    - Bare finding objects concatenated without an array wrapper
+      (``{...}{...}``), which trips the JSON parser at "trailing
+      characters" after the first object.
+    - A complete ``{"findings": [...]}`` wrapper that Instructor still
+      rejected for a non-structural reason (extra hedging text, etc).
+    - Findings with nested fields like ``req_refs: [{...}]``.
 
-    Note: the regex ``r'\\{[^{}]*\\}'`` is intentionally shallow — it matches
-    single-level (non-nested) JSON objects only.  This is sufficient for
-    salvaging malformed local-model output where each finding is a flat
-    object, and avoids the complexity of nested-brace matching.
+    Strategy: walk the input with ``json.JSONDecoder().raw_decode()`` to
+    find every complete top-level JSON value (object or array) regardless
+    of nested braces, then recurse into each decoded value harvesting
+    anything that validates as a ``_Finding``. ``raw_decode`` is
+    bracket-aware so nested structures pass through; the previous regex
+    approach (shallow ``{[^{}]*}``) silently dropped any finding with a
+    nested field.
     """
-    objects = re.findall(r'\{[^{}]*\}', raw_json)
-    findings = []
-    for obj_str in objects:
+    decoder = json.JSONDecoder()
+    findings: list[dict] = []
+    i = 0
+    n = len(raw_json)
+    while i < n:
+        # Advance to the next plausible JSON start. Skipping non-`{`/`[`
+        # chars handles the wrapper text Instructor/Pydantic prepends to
+        # the model's raw output ("Invalid JSON: ...", error preambles).
+        brace = raw_json.find("{", i)
+        bracket = raw_json.find("[", i)
+        candidates = [c for c in (brace, bracket) if c >= 0]
+        if not candidates:
+            break
+        start = min(candidates)
         try:
-            f = _Finding.model_validate_json(obj_str)
-            findings.append(f.model_dump())
-        except (ValueError, KeyError, TypeError):
+            node, end = decoder.raw_decode(raw_json, start)
+        except json.JSONDecodeError:
+            # Not a real JSON value at this offset -- advance one char
+            # and keep scanning. The decoder is the source of truth for
+            # "is this position a complete value"; the brace/bracket
+            # scan above is just a cheap pre-filter.
+            i = start + 1
             continue
+        _extract_finding_dicts(node, findings)
+        i = end
     return findings
 
 

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -60,6 +60,64 @@ class TestSalvagePartialFindings:
         result = _salvage_partial_findings(raw)
         assert len(result) == 2
 
+    def test_handles_finding_with_nested_req_refs(self):
+        """The shallow-regex predecessor silently dropped any finding with a
+        nested object; this was the exact failure pattern reported in a real
+        run where the model emitted ``req_refs: [{"label": "CWE-..."}]``."""
+        raw = (
+            '{"req":"R-MAT-5","t":"violation","file":"a.py","line":1,'
+            '"severity":"minor","w":"nested","snippet":"x = 1","reason":"r",'
+            '"req_refs":[{"label":"CWE-79","url":"https://example.com"}]}'
+        )
+        result = _salvage_partial_findings(raw)
+        assert len(result) == 1
+        assert result[0]["req"] == "R-MAT-5"
+
+    def test_handles_bare_findings_concatenated(self):
+        """Reproduces the production failure where the model emitted two
+        bare finding objects back-to-back (no array wrapper, no separator).
+        The JSON parser stops at "trailing characters" after the first."""
+        raw = (
+            '{"req":"R-MAT-5","t":"violation","file":"a.py","line":10,'
+            '"severity":"minor","w":"first","snippet":"foo","reason":"one"}\n'
+            '{"req":"R-FT-1","t":"violation","file":"b.py","line":11,'
+            '"severity":"minor","w":"second","snippet":"bar","reason":"two"}'
+        )
+        result = _salvage_partial_findings(raw)
+        assert len(result) == 2
+        assert {r["req"] for r in result} == {"R-MAT-5", "R-FT-1"}
+
+    def test_handles_wrapped_findings_array(self):
+        """If the model returned the canonical {"findings":[...]} but
+        Instructor still rejected it for some non-structural reason, the
+        salvage path should still recover everything."""
+        raw = (
+            '{"findings":['
+            '{"req":"A-1","t":"violation","file":"a.py","line":1,'
+            '"severity":"minor","w":"one","snippet":"x","reason":"r"},'
+            '{"req":"B-2","t":"compliance","file":"b.py","line":2,'
+            '"severity":"minor","w":"two","snippet":"y","reason":"r"}'
+            ']}'
+        )
+        result = _salvage_partial_findings(raw)
+        assert len(result) == 2
+
+    def test_handles_findings_buried_in_error_preamble(self):
+        """Mirrors what Pydantic's ValidationError stringification looks like:
+        a chunk of error message followed by the bad input. The salvage walker
+        must skip the preamble and find the JSON object inside."""
+        raw = (
+            "1 validation error for _Findings\n"
+            "Invalid JSON: trailing characters at line 10 column 4\n"
+            "input_value='"
+            '{"req":"R-MAT-5","t":"violation","file":"a.py","line":3,'
+            '"severity":"minor","w":"ok","snippet":"x","reason":"r"}'
+            "', input_type=str"
+        )
+        result = _salvage_partial_findings(raw)
+        assert len(result) == 1
+        assert result[0]["req"] == "R-MAT-5"
+
 
 # ---------------------------------------------------------------------------
 # _is_timeout_error


### PR DESCRIPTION
## Summary

Follow-up to #546 / #547. The salvage path's regex (`{[^{}]*}`) matched only flat single-level JSON objects and silently dropped anything with a nested field (e.g. `req_refs: [{"label": "CWE-79", "url": "..."}]`).

Observed in a live run on growstuff:
```
Model gemma4:26b-mlx call failed after 285s, no findings recovered: <failed_attempts>
 <generation number="1">
 <exception>
  1 validation error for _Findings
  Invalid JSON: trailing characters at line 10 column 4
  input_value='{ "req": "R-MAT-5", ... "reason": "...re processing it." }'
```

The model had emitted two valid bare finding objects concatenated without an array wrapper. Pydantic stops parsing at "trailing characters after the first object," Instructor raises ValidationError, and the salvage regex couldn't reach the second object because its nested `req_refs` array tripped the shallow-brace match.

## Fix

Replaced the regex with `json.JSONDecoder().raw_decode()` walking forward through the input, plus a recursive `_extract_finding_dicts(node, sink)` that harvests any dict validating as `_Finding` from a decoded value tree. Same path now handles:

- Bare finding objects concatenated (the production failure)
- Findings with nested `req_refs` arrays
- The canonical `{"findings": [...]}` wrapper (in case Instructor rejected it for some non-structural reason)
- Findings embedded inside a Pydantic ValidationError preamble

`import re` removed (was the regex's only caller).

## Test plan

- [x] 4 new tests cover each of the four shapes above
- [x] 4 pre-existing salvage tests still pass unchanged
- [x] `pytest tests/ --ignore=tests/ui` passes (3098 tests)
- [x] Manual: trigger the failure mode again in a live run; the same input that produced "no findings recovered" should now produce salvaged findings with the WARN message reading "salvaged N findings from malformed response"