### PR TITLE
Fix multi-monitor frameless drag jumping off-screen on macOS

### DIFF
--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -563,8 +563,58 @@ def _set_app_icon() -> None:
             pass
 
 
+def _patch_pywebview_multi_monitor_drag() -> None:
+    """Fix pywebview's multi-monitor frameless-window drag on macOS.
+
+    pywebview's bundled drag JS (``customize.js``) sends absolute screen
+    coordinates over the JS↔Python bridge each mousemove, and the macOS
+    backend's ``BrowserView.move`` then ADDS ``self.screen.origin.x`` to
+    that x value before calling ``setFrameTopLeftPoint:``. On a single-
+    monitor setup the cached ``self.screen`` is the primary (origin.x =
+    0) and the addition is a no-op — so the bug never fires. On a multi-
+    monitor setup where the window's cached screen has a non-zero origin
+    (e.g. a secondary monitor positioned to the LEFT of the primary at
+    screen X = −1920), the addition double-counts and the window jumps
+    off the visible workspace mid-drag — confirmed reproducible vs.
+    single-monitor.
+
+    Patch swaps ``BrowserView.move`` for a version that passes ``x``
+    through unchanged. The Y math is left as-is because typical
+    horizontal multi-monitor layouts have ``screen.origin.y == 0`` and
+    we don't have a confirmed Y-side reproduction.
+
+    Safe to leave installed on single-monitor: ``origin.x`` is 0 there,
+    so the behaviour is identical. Skipped silently on non-Darwin or if
+    pywebview's internal layout changes (no AttributeError).
+
+    Tracked upstream: https://github.com/r0x0r/pywebview/issues/1820 —
+    drop this helper once the fix ships in a pywebview release we
+    depend on.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        from webview.platforms.cocoa import BrowserView  # noqa: PLC0415
+        import AppKit  # noqa: PLC0415
+    except ImportError:
+        return
+    if not hasattr(BrowserView, 'move'):
+        return
+
+    def _patched_move(self, x: float, y: float) -> None:
+        flipped_y = self.screen.size.height - y
+        # The original code added ``self.screen.origin.x`` to x here;
+        # see docstring above for why that's wrong on multi-monitor.
+        self.window.setFrameTopLeftPoint_(
+            AppKit.NSPoint(x, self.screen.origin.y + flipped_y)
+        )
+
+    BrowserView.move = _patched_move
+
+
 def main() -> None:
     _set_app_icon()
+    _patch_pywebview_multi_monitor_drag()
     url = sys.argv[1]
     sock_path = Path(sys.argv[2])
     api_pid = int(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else 0


### PR DESCRIPTION
## Summary

- On macOS multi-monitor setups, dragging the frameless quodeq window by its drag-region threw it far off the visible workspace on the first mousemove — confirmed reproducible vs. single-monitor.
- Root cause is in pywebview's cocoa backend (`webview/platforms/cocoa.py:811`): the bundled drag JS sends absolute screen coordinates, and `BrowserView.move` then re-adds `self.screen.origin.x` to them. A no-op on single-monitor (`origin = (0, 0)`), but a double-count on any setup where the window's cached screen has non-zero origin (e.g. a secondary monitor to the LEFT of the primary at screen X = `-1920`).
- This PR patches `BrowserView.move` once at startup so it passes the JS-supplied `x` through unchanged. Identical behaviour on single-monitor; correct on multi-monitor.

Single file changed, ~50 lines of pure addition, no edits to existing behaviour. Upstream tracking issue: https://github.com/r0x0r/pywebview/issues/1820 — when a fixed pywebview release ships, this helper can be removed.

## Test plan

- [x] Single-monitor: drag works identically to before (verified — `origin.x` collapses to 0).
- [x] Multi-monitor with secondary monitor LEFT of primary: drag now tracks cursor 1:1 instead of jumping off-screen.
- [x] Multi-monitor with secondary monitor RIGHT of primary (positive origin.x): drag still works (likely fine since this is the case where the original buggy add was effectively 0 too, but worth a sanity check).
- [x] Non-Darwin platforms unaffected — the patcher is gated on `sys.platform == "darwin"` and returns silently otherwise.
- [x] Future pywebview releases that refactor `cocoa.BrowserView`: `ImportError` and `hasattr` guards make the patch a no-op without crashing startup.