### PR TITLE
fix(api-runner): salvage from Instructor's failed_attempts.completion

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -170,6 +170,59 @@ def _extract_finding_dicts(node: object, sink: list[dict]) -> None:
             _extract_finding_dicts(item, sink)
 
 
+def _completion_text(completion: object) -> str | None:
+    """Extract ``choices[0].message.content`` from an LLM completion.
+
+    Tolerates both pydantic-model and dict shapes so the helper survives
+    openai/instructor version drift. Returns None when the structure
+    isn't recognisable -- callers must treat that as "no salvage data
+    available here" and continue.
+    """
+    try:
+        choices = getattr(completion, "choices", None)
+        if choices is None and isinstance(completion, dict):
+            choices = completion.get("choices")
+        if not choices:
+            return None
+        first = choices[0]
+        message = getattr(first, "message", None)
+        if message is None and isinstance(first, dict):
+            message = first.get("message")
+        if message is None:
+            return None
+        content = getattr(message, "content", None)
+        if content is None and isinstance(message, dict):
+            content = message.get("content")
+        return content if isinstance(content, str) else None
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return None
+
+
+def _salvage_from_failed_attempts(exc: BaseException) -> list[dict]:
+    """Recover findings from Instructor's per-attempt completion data.
+
+    When Pydantic rejects ``list[_Finding]`` because one element is
+    missing a required field, the ValidationError message only quotes
+    the offending element -- every structurally-valid sibling is lost
+    if we salvage from ``str(exc)`` alone. Instructor stashes the raw
+    LLM completion on each ``FailedAttempt``, which contains everything
+    the model emitted, so walking those gives us a complete view.
+
+    Duck-typed so an Instructor version bump that renames the
+    attribute or moves the class still works.
+    """
+    findings: list[dict] = []
+    attempts = getattr(exc, "failed_attempts", None) or []
+    for attempt in attempts:
+        completion = getattr(attempt, "completion", None)
+        if completion is None:
+            continue
+        text = _completion_text(completion)
+        if text:
+            findings.extend(_salvage_partial_findings(text))
+    return findings
+
+
 def _salvage_partial_findings(raw_json: str) -> list[dict]:
     """Try to extract valid findings from malformed JSON.
 
@@ -304,9 +357,17 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
                     elapsed, config.model,
                 )
                 return [], True
-            # Try to salvage valid findings from the malformed response
-            raw = str(exc)
-            salvaged = _salvage_partial_findings(raw)
+            # Try Instructor's stashed completions first: when the model
+            # emits a valid {"findings":[...]} array but ONE element fails
+            # validation (e.g. missing ``reason``), Pydantic's error message
+            # only quotes the offending element. The good siblings are
+            # invisible in ``str(exc)`` but they are in
+            # ``failed_attempts[*].completion.choices[0].message.content``.
+            salvaged = _salvage_from_failed_attempts(exc)
+            # Fall back to exception-string salvage for older Instructor
+            # versions or non-retry exceptions where completion is absent.
+            if not salvaged:
+                salvaged = _salvage_partial_findings(str(exc))
             if salvaged:
                 _log.warning(
                     "Model %s returned malformed JSON after %.0fs -- salvaged %d findings from the response",

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -16,11 +16,13 @@ from quodeq.analysis._api_runner import (
     _LOCAL_TIMEOUT,
     _build_router_context,
     _call_api,
+    _completion_text,
     _Finding,
     _Findings,
     _FindingType,
     _is_timeout_error,
     _resolve_file_paths,
+    _salvage_from_failed_attempts,
     _salvage_partial_findings,
     _Severity,
     run_api_analysis,
@@ -117,6 +119,107 @@ class TestSalvagePartialFindings:
         result = _salvage_partial_findings(raw)
         assert len(result) == 1
         assert result[0]["req"] == "R-MAT-5"
+
+
+# ---------------------------------------------------------------------------
+# _completion_text + _salvage_from_failed_attempts
+# ---------------------------------------------------------------------------
+
+class TestCompletionText:
+    """Extract response text from an OpenAI ChatCompletion-shaped object.
+
+    The helper has to tolerate both pydantic-model and dict shapes so it
+    survives openai/instructor version drift.
+    """
+
+    def test_pydantic_model_shape(self):
+        msg = MagicMock(content="hello")
+        choice = MagicMock(message=msg)
+        completion = MagicMock(choices=[choice])
+        assert _completion_text(completion) == "hello"
+
+    def test_dict_shape(self):
+        completion = {"choices": [{"message": {"content": "hi"}}]}
+        assert _completion_text(completion) == "hi"
+
+    def test_mixed_pydantic_outer_dict_inner(self):
+        choice = MagicMock(message={"content": "mixed"})
+        completion = MagicMock(choices=[choice])
+        assert _completion_text(completion) == "mixed"
+
+    def test_returns_none_when_no_choices(self):
+        assert _completion_text(MagicMock(choices=[])) is None
+        assert _completion_text({"choices": []}) is None
+
+    def test_returns_none_when_completion_is_none(self):
+        assert _completion_text(None) is None
+
+    def test_returns_none_when_content_missing(self):
+        choice = {"message": {}}
+        assert _completion_text({"choices": [choice]}) is None
+
+    def test_returns_none_when_content_is_not_string(self):
+        """Some providers return content as a list of parts; we only know
+        what to do with a plain string."""
+        completion = {"choices": [{"message": {"content": [{"text": "x"}]}}]}
+        assert _completion_text(completion) is None
+
+
+class TestSalvageFromFailedAttempts:
+    """When Instructor exhausts retries it stashes the raw LLM completion
+    on each FailedAttempt. The Pydantic ValidationError that fires when
+    one finding in a {"findings":[...]} array is missing a required field
+    only quotes the bad finding -- the good siblings are lost unless we
+    pull them from completion.choices[0].message.content.
+    """
+
+    def _make_attempt(self, content):
+        return MagicMock(exception=Exception("boom"),
+                         completion={"choices": [{"message": {"content": content}}]})
+
+    def test_recovers_good_finding_from_completion_when_sibling_bad(self):
+        """The motivating case: model returned a wrapped array where one
+        finding is missing ``reason``. The exception string only mentions
+        the bad one; we should still recover the good one."""
+        content = (
+            '{"findings":['
+            '{"req":"A-1","t":"violation","file":"a.py","line":1,'
+            '"severity":"minor","w":"ok","snippet":"x = 1","reason":"valid"},'
+            '{"req":"B-2","t":"compliance","file":"b.py","line":2,'
+            '"severity":"minor","w":"bad","snippet":"y = 2"}'   # missing reason
+            ']}'
+        )
+        exc = RuntimeError("InstructorRetryException")
+        exc.failed_attempts = [self._make_attempt(content)]
+        result = _salvage_from_failed_attempts(exc)
+        assert len(result) == 1
+        assert result[0]["req"] == "A-1"
+
+    def test_returns_empty_when_no_failed_attempts(self):
+        assert _salvage_from_failed_attempts(ValueError("plain")) == []
+
+    def test_returns_empty_when_completion_is_none(self):
+        exc = RuntimeError("retry")
+        exc.failed_attempts = [MagicMock(exception=Exception(), completion=None)]
+        assert _salvage_from_failed_attempts(exc) == []
+
+    def test_aggregates_findings_across_attempts(self):
+        """Multiple failed attempts each contribute their salvageable findings."""
+        attempt1_content = (
+            '{"req":"A-1","t":"violation","file":"a.py","line":1,'
+            '"severity":"minor","w":"first","snippet":"x","reason":"r"}'
+        )
+        attempt2_content = (
+            '{"req":"B-2","t":"compliance","file":"b.py","line":2,'
+            '"severity":"minor","w":"second","snippet":"y","reason":"r"}'
+        )
+        exc = RuntimeError("retry")
+        exc.failed_attempts = [
+            self._make_attempt(attempt1_content),
+            self._make_attempt(attempt2_content),
+        ]
+        result = _salvage_from_failed_attempts(exc)
+        assert {r["req"] for r in result} == {"A-1", "B-2"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #548. The salvage path runs on ``str(exc)``, which works fine when the model returns malformed JSON (the exception message contains the bytes). But when Pydantic rejects ``list[_Finding]`` because one element in a valid array is missing a required field, the ValidationError only quotes the offending element -- every structurally-valid sibling is invisible to the salvage path.

Observed live on the quodeq codebase after #548 merged:
```
1 validation error for _Findings
findings.1.reason
 Field required [type=missing, input_value={'req': 'R-FT-5', ...}, input_type=dict]
```

``findings.0`` was a valid finding the user never saw. The whole 3-file batch was lost.

## Fix

The raw LLM response actually lives on Instructor's ``InstructorRetryException.failed_attempts[*].completion``. New helpers:

- ``_completion_text(completion)`` -- extracts ``choices[0].message.content`` from an LLM completion, tolerating both pydantic-model and dict shapes for openai/instructor version drift
- ``_salvage_from_failed_attempts(exc)`` -- walks ``exc.failed_attempts``, pulls each completion's text, runs the existing salvage walker on it (which already handles wrapped arrays, bare objects, nested fields)

The except handler in ``_call_api`` now tries ``_salvage_from_failed_attempts(exc)`` first, then falls back to ``str(exc)`` salvage for older Instructor or non-retry exceptions.

## Test plan

- [x] 11 new tests: ``_completion_text`` shape variants (pydantic, dict, mixed, None, no choices, missing content, non-string content) + ``_salvage_from_failed_attempts`` (motivating case, empty attempts, missing completion, aggregation across attempts)
- [x] All 12 pre-existing ``_call_api`` and salvage tests still pass
- [x] ``pytest tests/ --ignore=tests/ui`` passes (3109 tests)
- [x] Manual: after merge + eval restart, the same ``findings.N.reason Field required`` failure should produce a WARN reading "salvaged N findings from malformed response" and the run should keep moving instead of dropping the batch

## Note on the broader question

This is the third salvage-related patch in two days (#548, this, and the upcoming "per-finding parsing vs strict array validation" rethink). The pattern says we should reconsider whether ``_Findings = list[_Finding]`` is the right shape -- strict array validation means one malformed finding nukes its siblings. Per-finding parsing (validate each independently) would eliminate the whole salvage path. Out of scope for this PR; will be its own discussion.