### PR TITLE
chore(security): harden npm install pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,7 @@
 version: 2
+# Cooldown defers PRs until a release has settled, defending against
+# compromised versions that get yanked within hours of publication.
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
 updates:
   - package-ecosystem: "pip"
     directory: "/"
@@ -6,13 +9,24 @@ updates:
       interval: "weekly"
     target-branch: "develop"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
 
   - package-ecosystem: "npm"
-    directory: "/"
+    # package.json lives under src/quodeq/ui, not the repo root.
+    directory: "/src/quodeq/ui"
     schedule:
       interval: "weekly"
     target-branch: "develop"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,3 +34,8 @@ updates:
       interval: "weekly"
     target-branch: "develop"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,11 +46,21 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install UI dependencies
+        working-directory: src/quodeq/ui
+        run: npm ci
+
+      - name: Verify package signatures
+        working-directory: src/quodeq/ui
+        run: npm audit signatures
+
+      - name: Audit for high-severity vulnerabilities
+        working-directory: src/quodeq/ui
+        run: npm audit --audit-level=high
+
       - name: Build web UI
-        run: |
-          cd src/quodeq/ui
-          npm ci
-          npm run build
+        working-directory: src/quodeq/ui
+        run: npm run build
 
       - name: Build package
         run: uv build

--- a/src/quodeq/dashboard/_build_npm.py
+++ b/src/quodeq/dashboard/_build_npm.py
@@ -68,7 +68,11 @@ def run_npm_build(workdir: Path, static_dir: Path) -> None:
         )
 
     log_info("Installing npm dependencies...")
-    subprocess.run([npm, "install"], cwd=str(workdir), check=True, timeout=_NPM_INSTALL_TIMEOUT_S)
+    # Use `npm ci` to enforce lockfile-pinned installs (refuses to mutate
+    # package-lock.json, errors if it's out of sync). `_SYNC_ITEMS` in
+    # `_build_hash.py` copies package-lock.json into the workdir before this
+    # runs, so a lockfile is always present.
+    subprocess.run([npm, "ci"], cwd=str(workdir), check=True, timeout=_NPM_INSTALL_TIMEOUT_S)
 
     log_info("Building web UI...")
     env = {**os.environ, "QUODEQ_BUILD_OUTDIR": str(static_dir)}

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -92,12 +92,12 @@ def _check_tool_version(cmd: list[str], tool_name: str, min_major: int, install_
         )
 
 
-def check_node(min_major: int = 18) -> None:
+def check_node(min_major: int = 20) -> None:
     """Raise RuntimeError if Node.js is missing or below minimum version."""
     _check_tool_version(["node", "--version"], "Node.js", min_major, _INSTALL_HINT_NODE)
 
 
-def check_npm(min_major: int = 9) -> None:
+def check_npm(min_major: int = 10) -> None:
     """Raise RuntimeError if npm is missing or below minimum version."""
     _check_tool_version(["npm", "--version"], "npm", min_major, _INSTALL_HINT_NODE)
 
@@ -178,10 +178,10 @@ def check_dashboard_prereqs() -> None:
     packages) gets the full story in one message, with one install command.
     """
     issues: list[str] = []
-    node_issue = _collect_tool_issue(["node", "--version"], "Node.js", 18)
+    node_issue = _collect_tool_issue(["node", "--version"], "Node.js", 20)
     if node_issue is not None:
         issues.append(node_issue)
-    npm_issue = _collect_tool_issue(["npm", "--version"], "npm", 9)
+    npm_issue = _collect_tool_issue(["npm", "--version"], "npm", 10)
     if npm_issue is not None:
         issues.append(npm_issue)
     if not issues:

--- a/src/quodeq/ui/.npmrc
+++ b/src/quodeq/ui/.npmrc
@@ -1,1 +1,8 @@
 registry=https://registry.npmjs.org/
+
+# Security hardening — see docs/superpowers/plans/2026-05-25-npm-security-hardening.md
+ignore-scripts=true
+audit-level=high
+fund=false
+engine-strict=true
+save-exact=true

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -2,6 +2,10 @@
   "name": "quodeq-ui-web",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -18,7 +18,7 @@ class TestCheckNode:
     def test_old_node_raises(self):
         result = subprocess.CompletedProcess([], 0, stdout="16.20.0\n")
         with patch("subprocess.run", return_value=result):
-            with pytest.raises(RuntimeError, match="18"):
+            with pytest.raises(RuntimeError, match="20"):
                 check_node()
 
     def test_valid_node_passes(self):
@@ -36,7 +36,7 @@ class TestCheckNpm:
     def test_old_npm_raises(self):
         result = subprocess.CompletedProcess([], 0, stdout="8.19.0\n")
         with patch("subprocess.run", return_value=result):
-            with pytest.raises(RuntimeError, match="9"):
+            with pytest.raises(RuntimeError, match="10"):
                 check_npm()
 
     def test_valid_npm_passes(self):

--- a/tools/build-dist.sh
+++ b/tools/build-dist.sh
@@ -5,7 +5,7 @@
 #   ./scripts/build-dist.sh
 #
 # Prerequisites:
-#   - Node.js 18+ and npm 8+
+#   - Node.js 20+ and npm 10+
 #   - uv (https://docs.astral.sh/uv/)
 set -euo pipefail
 
@@ -16,7 +16,7 @@ WEB_DIR="${QUODEQ_WEB_DIR:-$REPO_ROOT/ui/web}"
 
 echo "==> Building web UI..."
 cd "$WEB_DIR"
-npm install
+npm ci
 npm run build
 cd "$REPO_ROOT"
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -9,7 +9,7 @@ UI_WEB="${QUODEQ_UI_WEB:-$ROOT/ui/web}"
 STATIC_DEST="${QUODEQ_STATIC_DEST:-$ROOT/src/quodeq/static}"
 
 echo "==> Building frontend..."
-(cd "$UI_WEB" && npm install && npm run build)
+(cd "$UI_WEB" && npm ci && npm run build)
 
 echo "==> Bundling frontend into package..."
 rm -rf "$STATIC_DEST"


### PR DESCRIPTION
## Summary

Closes the npm vs pnpm security gap without switching package managers. Defense in depth across install, audit, version pinning, and the dependency-update workflow.

- **Block lifecycle scripts** (`ignore-scripts=true`) — the top npm supply-chain attack vector. Pre-flight verified no installed dep uses pre/install/postinstall, so this does not break the build.
- **Lockfile-pinned installs everywhere** — `npm ci` instead of `npm install` in all four build paths, including the runtime build inside `_build_npm.py` that runs on end-user machines.
- **CI gates**: `npm audit signatures` (Sigstore verification, 259/259 packages pass) and `npm audit --audit-level=high` (0 findings) run before every wheel publish.
- **Engine pinning**: `engines` field in `package.json` + `engine-strict=true` in `.npmrc`, plus matching `prereqs.py` checks (Node 18->20, npm 9->10).
- **Save-exact**: new installs pin exact versions, no `^`/`~` drift.
- **Dependabot cooldown**: 2-7 day delay before update PRs open, depending on semver scope. Defends against compromised versions yanked within hours of publication (the pnpm `minimumReleaseAge` equivalent).
- **Bonus fix**: dependabot npm config pointed at `/` but `package.json` lives at `/src/quodeq/ui`. Dependabot has been silently not seeing the npm package. Now corrected.

## Why this isn't pnpm

Closes ~90% of the security gap. The one remaining gap (pnpm's strict module resolution vs npm's hoisting) is solvable later with `eslint-plugin-import`'s `no-extraneous-dependencies` rule if needed.

## Test plan

- [x] `npm ci` clean install with hardened config succeeds (259 packages, 0 vulns)
- [x] `npm run build` produces working static bundle
- [x] `npm run test:all` passes (361/361)
- [x] `npm audit signatures` exits 0 (259 signed, 51 with provenance attestations)
- [x] `npm audit --audit-level=high` exits 0
- [x] `uv run pytest -m "not integration"` passes (3104/3104)
- [x] `uv build` produces wheel + sdist
- [x] Runtime build path (`_build_npm.run_npm_build`) end-to-end smoke test passes
- [x] CI green on this PR