### PR TITLE
fix(api-runner): cap OpenAI SDK retry compounding (orphan commit from #547)

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -126,8 +126,15 @@ class ApiRunnerConfig:
     context_size: int = 0
 
 
+_TIMEOUT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    httpx.ReadTimeout,
+    httpx.TimeoutException,
+    openai.APITimeoutError,
+)
+
+
 def _is_timeout_error(exc: BaseException) -> bool:
-    """Detect httpx timeouts even when Instructor's retry layer wrapped them.
+    """Detect timeouts even when Instructor's retry layer wrapped them.
 
     Instructor raises ``InstructorRetryException`` when ``max_retries`` is
     exhausted, stashing each underlying error in a ``failed_attempts`` list.
@@ -136,13 +143,18 @@ def _is_timeout_error(exc: BaseException) -> bool:
     timeout-specific WARN that tells the user how to fix it. We duck-type
     ``failed_attempts`` so an Instructor version bump that renames or moves
     the exception class still works.
+
+    ``openai.APITimeoutError`` is included alongside the httpx classes
+    because the OpenAI SDK wraps ``httpx.ReadTimeout`` into its own
+    ``APITimeoutError`` after exhausting its internal retries -- the
+    wrapped form never satisfies an httpx isinstance check.
     """
-    if isinstance(exc, (httpx.ReadTimeout, httpx.TimeoutException)):
+    if isinstance(exc, _TIMEOUT_EXCEPTIONS):
         return True
     attempts = getattr(exc, "failed_attempts", None) or []
     for attempt in attempts:
         inner = getattr(attempt, "exception", None)
-        if isinstance(inner, (httpx.ReadTimeout, httpx.TimeoutException)):
+        if isinstance(inner, _TIMEOUT_EXCEPTIONS):
             return True
     return False
 
@@ -332,6 +344,13 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         base_url=config.api_base,
         api_key=config.api_key or _OLLAMA_DEFAULT_API_KEY,
         timeout=timeout,
+        # OpenAI SDK retries httpx timeouts internally (default max_retries=2,
+        # so 1 initial + 2 retries = 3 attempts). Each attempt waits the full
+        # read timeout, compounding a single 500s timeout into ~1500s of dead
+        # wall time before APITimeoutError finally surfaces. Disable that
+        # layer so a timeout fails fast at the configured read budget;
+        # Instructor still owns logical retries above us.
+        max_retries=0,
     ) as oa_client:
         client = instructor.from_openai(oa_client, mode=mode)
         start = time.monotonic()

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -81,6 +81,7 @@ class TestRunApiAnalysis:
                 base_url="http://localhost:8000/v1",
                 api_key="test-key",
                 timeout=_LOCAL_TIMEOUT,
+                max_retries=0,
             )
 
     def test_handles_empty_findings(self, tmp_path, api_config):

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -10,6 +10,7 @@ import pytest
 instructor = pytest.importorskip("instructor", reason="requires quodeq[api] extra")
 
 import httpx
+import openai
 
 from quodeq.analysis._api_runner import (
     ApiRunnerConfig,
@@ -242,6 +243,21 @@ class TestIsTimeoutError:
     def test_bare_timeout_exception(self):
         assert _is_timeout_error(httpx.TimeoutException("timeout")) is True
 
+    def test_bare_openai_api_timeout(self):
+        """The OpenAI SDK collapses an httpx.ReadTimeout into its own
+        APITimeoutError after exhausting internal retries; treat that as
+        a timeout so the surfaced WARN stays accurate."""
+        request = httpx.Request("POST", "http://localhost/v1/chat/completions")
+        assert _is_timeout_error(openai.APITimeoutError(request=request)) is True
+
+    def test_wrapped_openai_api_timeout_in_failed_attempts(self):
+        """Instructor may wrap an openai.APITimeoutError directly (when the
+        SDK already collapsed the underlying httpx error)."""
+        request = httpx.Request("POST", "http://localhost/v1/chat/completions")
+        wrapper = RuntimeError("InstructorRetryException")
+        wrapper.failed_attempts = [MagicMock(exception=openai.APITimeoutError(request=request))]
+        assert _is_timeout_error(wrapper) is True
+
     def test_unrelated_exception(self):
         assert _is_timeout_error(ValueError("not a timeout")) is False
 
@@ -365,10 +381,14 @@ class TestCallApi:
             mock_inst.Mode.JSON = "json"
             _call_api("test", config)
 
+        # max_retries=0 disables the OpenAI SDK's internal retry-on-timeout
+        # so a single 500s read timeout fails fast instead of compounding
+        # into the SDK's default 3-attempt 1500s wall time.
         mock_openai.OpenAI.assert_called_once_with(
             base_url="http://localhost:11434/v1",
             api_key="ollama",
             timeout=_LOCAL_TIMEOUT,
+            max_retries=0,
         )
 
     def test_returns_clean_flag_on_success(self):


### PR DESCRIPTION
## Summary

Restores a commit that was orphaned during the PR #547 merge cycle. The original commit is [`f1019703`](https://github.com/quodeq/quodeq/commit/f1019703) (cherry-picked here as `7d0fd2dc`).

### Timeline of the orphan

1. PR #547 opened with one commit: \`e7395857\` (wrap detection in \`_is_timeout_error\`)
2. PR #547 was merged
3. \`f1019703\` was pushed to the same feature branch shortly after, intending to extend PR #547 with two extra fixes
4. The push succeeded but PR #547 was already closed, so the new commit never reached \`develop\`
5. Re-spun here as a fresh PR off latest \`develop\`

### What's in this commit

Two related fixes that share the same diagnosis (timeouts compounding inside the OpenAI SDK):

1. **\`max_retries=0\` on \`openai.OpenAI()\`** — the SDK's default \`max_retries=2\` (1 initial + 2 retries) wraps every \`httpx.ReadTimeout\` in its own internal retry loop. With our 500s read budget, a single dead request balloons into ~1500s of wall time before \`APITimeoutError\` surfaces. Observed live as "call failed after 1501s." This disables the SDK layer so one read timeout fails fast at the configured budget; Instructor still owns logical retries above us.

2. **Recognise \`openai.APITimeoutError\` in \`_is_timeout_error\`** — when the SDK collapses the underlying \`httpx.ReadTimeout\` into its own \`APITimeoutError\` after exhausting internal retries, the wrapped form never satisfies an httpx isinstance check. Treat it as a timeout alongside the httpx classes so the actionable WARN ("lower subagents or raise OLLAMA_NUM_PARALLEL") still surfaces. Both the bare exception and the Instructor-wrapped form (via \`failed_attempts\`) are covered.

### Test plan

- [x] 2 new tests for \`_is_timeout_error\` cover bare and wrapped \`openai.APITimeoutError\`
- [x] Existing assertion on \`openai.OpenAI(...)\` kwargs updated to expect \`max_retries=0\`
- [x] \`pytest tests/ --ignore=tests/ui\` passes (3111 tests)
- [x] Manual: trigger a timeout in a live run; verify the WARN reads "timed out after Ns" instead of generic "no findings recovered," and that the elapsed time is bounded by the httpx 500s rather than 1500s