### PR TITLE
feat(dashboard): ship pre-built UI in wheel, drop runtime npm dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,15 @@ uv sync
 uv run pytest
 ```
 
+## Building the Web Dashboard
+
+The web dashboard is a Vite + React app at `src/quodeq/ui/`. End users get a pre-built copy inside the wheel and do not need Node.js or npm. Contributors need them in two situations:
+
+1. **Local wheel builds.** `uv build` on its own produces a wheel without the UI. Use `tools/build-dist.sh` instead. It runs `npm ci && npm run build` and then `uv build`, so the wheel ships with `src/quodeq/static/` populated.
+2. **Iterating on the UI source.** `quodeq dashboard --dev` rebuilds the UI from `src/quodeq/ui/` on the fly. This is the only runtime codepath that still invokes npm.
+
+Minimum dev versions: Python 3.12+, Node.js 20+, npm 10+.
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -60,17 +60,17 @@ Each finding includes a reason, the offending code, and a fix plan. Results are 
 
 | OS | Command |
 |---|---|
-| **macOS** | `brew install python node pipx` |
-| **Windows** _(experimental)_ | `winget install Python.Python.3.13 OpenJS.NodeJS` then `python -m pip install --user pipx && python -m pipx ensurepath` |
-| **Debian / Ubuntu** | `sudo apt install -y python3.12 python3-pip pipx nodejs npm` |
-| **Fedora / RHEL** | `sudo dnf install -y python3.12 python3-pip pipx nodejs npm` |
-| **Arch** | `sudo pacman -S python python-pipx nodejs npm` |
+| **macOS** | `brew install python pipx` |
+| **Windows** _(experimental)_ | `winget install Python.Python.3.13` then `python -m pip install --user pipx && python -m pipx ensurepath` |
+| **Debian / Ubuntu** | `sudo apt install -y python3.12 python3-pip pipx` |
+| **Fedora / RHEL** | `sudo dnf install -y python3.12 python3-pip pipx` |
+| **Arch** | `sudo pacman -S python python-pipx` |
 
-> **Debian/Ubuntu heads-up:** `nodejs` and `npm` are separate packages. `apt install nodejs` alone is not enough. If you also use the native desktop window (not `--browser`), you'll need `sudo apt install -y python3-gi gir1.2-webkit2-4.1` too — otherwise quodeq will auto-fall-back to opening the dashboard in your default browser.
+> **Debian/Ubuntu heads-up:** If you use the native desktop window (not `--browser`), you'll need `sudo apt install -y python3-gi gir1.2-webkit2-4.1` too. Otherwise quodeq will auto-fall-back to opening the dashboard in your default browser.
 
-> **Windows heads-up:** Windows is supported on a best-effort basis. The full test suite runs green on `windows-latest` in CI, but we don't have a Windows machine to smoke-test the dashboard or end-to-end runs against — so please [open an issue](https://github.com/quodeq/quodeq/issues) if anything misbehaves.
+> **Windows heads-up:** Windows is supported on a best-effort basis. The full test suite runs green on `windows-latest` in CI, but we don't have a Windows machine to smoke-test the dashboard or end-to-end runs against, so please [open an issue](https://github.com/quodeq/quodeq/issues) if anything misbehaves.
 
-Minimum versions: Python 3.12+, Node.js 18+, npm 9+.
+Minimum versions: Python 3.12+. (The dashboard UI ships pre-built inside the wheel, so end users no longer need Node.js or npm. Contributors who want to iterate on the UI source need Node 20+ and npm 10+, see [CONTRIBUTING.md](CONTRIBUTING.md).)
 
 ### 2. Install quodeq
 
@@ -208,7 +208,7 @@ uv run quodeq             # launch the dashboard
 uv run pytest             # run the test suite
 ```
 
-Same OS prerequisites apply as for the pipx install — Node.js 18+ + npm for the dashboard UI, and a configured LLM provider (Ollama or Claude Code / Codex CLI / Gemini CLI) before you can actually scan anything.
+Same OS prerequisites as the pipx install (Python 3.12+), plus Node 20+ and npm 10+ because a source checkout builds the dashboard UI from the working copy. You also need a configured LLM provider (Ollama or Claude Code / Codex CLI / Gemini CLI) before you can actually scan anything.
 
 If the dashboard window doesn't appear on Linux, run `uv run quodeq --browser` (the native window needs `python3-gi` + `gir1.2-webkit2-4.1`, which aren't pulled in by the pip wheel).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,7 @@ requires = ["uv_build>=0.10.6,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]
-wheel-exclude = ["src/quodeq/static", "src/quodeq/ui/node_modules"]
+# Note: src/quodeq/static is intentionally INCLUDED so the wheel ships a
+# pre-built UI. End users no longer need Node/npm at runtime. Build it
+# with `tools/build-dist.sh` (runs npm ci + vite build before uv build).
+wheel-exclude = ["src/quodeq/ui/node_modules"]

--- a/src/quodeq/dashboard/_build.py
+++ b/src/quodeq/dashboard/_build.py
@@ -1,7 +1,13 @@
-"""UI build helpers — copy source to cache, hash-based rebuild detection, npm build.
+"""UI build helpers — production reads bundled static, dev rebuilds from source.
+
+Production installs ship a pre-built UI inside the wheel (see
+``pyproject.toml``'s ``wheel-exclude``). End users never invoke npm at
+runtime. The ``--dev`` codepath keeps the source-aware rebuild loop for
+contributors working out of the repo.
 
 This module is the public entry point; implementation is split across
-``_build_hash`` (hashing / rebuild detection) and ``_build_npm`` (npm execution).
+``_build_hash`` (hashing / rebuild detection) and ``_build_npm`` (npm
+execution, dev-only).
 """
 from __future__ import annotations
 
@@ -28,41 +34,64 @@ from quodeq.dashboard._build_npm import (  # noqa: F401
 )
 
 
-def maybe_build_ui(no_build: bool, reinstall: bool, dev: bool = False) -> Path:
-    """Build the UI if needed and return the path to the static dist directory.
+def _static_dir_bundled() -> Path:
+    """Path to the wheel-bundled static dist directory.
 
-    Raises FileNotFoundError if --no-build is set and no cached build exists.
+    In an installed wheel this is ``<site-packages>/quodeq/static/``.
+    When running from a source checkout it resolves to
+    ``src/quodeq/static/`` (populated by ``tools/build-dist.sh`` or
+    ``npm run build``).
+    """
+    return Path(__file__).resolve().parent.parent / "static"
+
+
+def maybe_build_ui(no_build: bool, reinstall: bool, dev: bool = False) -> Path:
+    """Return the static dist directory, building if necessary (dev mode only).
+
+    Production mode (``dev=False``) reads the wheel-bundled static dir and
+    never invokes npm. Missing static raises ``FileNotFoundError`` with
+    installation guidance instead of falling back to a silent rebuild.
+
+    Dev mode (``dev=True``) keeps the legacy behavior: resolve the repo
+    source, rebuild via ``run_npm_build`` when ``needs_rebuild`` says so,
+    or honor ``--no-build`` if the user wants to reuse the cached build.
+
+    Raises ``FileNotFoundError`` when:
+      - production: bundled ``static/index.html`` is absent
+      - dev + ``no_build=True``: no cached ``static-dev/index.html`` exists
     """
     if dev:
         source_dir = resolve_dev_source()
         static_dir = _dev_static_dir()
         log_info(f"Dev mode: building from {source_dir}")
-    else:
-        source_dir = _get_ui_source_dir()
-        static_dir = _static_dir()
 
-    if no_build:
-        if not (static_dir / "index.html").exists():
-            raise FileNotFoundError(
-                f"No cached dashboard build found at {static_dir}.\n"
-                "Run `quodeq dashboard` without --no-build first."
-            )
+        if no_build:
+            if not (static_dir / "index.html").exists():
+                raise FileNotFoundError(
+                    f"No cached dashboard build found at {static_dir}.\n"
+                    "Run `quodeq dashboard --dev` without --no-build first."
+                )
+            return static_dir
+
+        if not needs_rebuild(source_dir, static_dir, reinstall):
+            log_info("Web UI is up to date, skipping build.")
+            return static_dir
+
+        log_info("Building web UI (source changed)...")
+        static_dir.mkdir(parents=True, exist_ok=True)
+        run_npm_build(source_dir, static_dir)
+        (static_dir / _HASH_FILE).write_text(compute_source_hash(source_dir))
         return static_dir
 
-    if not dev and not needs_rebuild(source_dir, static_dir, reinstall):
-        log_info("Web UI is up to date, skipping build.")
-        return static_dir
-
-    log_info("Building web UI (source changed)...")
-    if dev:
-        workdir = source_dir
-    else:
-        workdir = _build_workdir()
-        sync_source_to_workdir(source_dir, workdir)
-    static_dir.mkdir(parents=True, exist_ok=True)
-    run_npm_build(workdir, static_dir)
-
-    current_hash = compute_source_hash(source_dir)
-    (static_dir / _HASH_FILE).write_text(current_hash)
-
+    # Production: the wheel ships a pre-built UI. Never invoke npm here.
+    static_dir = _static_dir_bundled()
+    if not (static_dir / "index.html").exists():
+        raise FileNotFoundError(
+            "UI static assets are missing from the installed quodeq package.\n"
+            "This usually means the wheel was built without running the UI build first.\n"
+            "  If you installed via pipx/pip: try `pipx reinstall quodeq` "
+            "(or `pip install --force-reinstall quodeq`).\n"
+            "  If you built locally from source: run `tools/build-dist.sh` "
+            "(which builds the UI before packaging) instead of `uv build` directly."
+        )
     return static_dir

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -23,7 +23,7 @@ from quodeq.dashboard._server import (
 from quodeq.shared.config_loader import get_default_host as _get_default_host
 from quodeq.shared.logging import log_info, log_warning
 from quodeq.shared.paths import resolve_path
-from quodeq.shared.prereqs import check_dashboard_prereqs
+from quodeq.shared.prereqs import check_dashboard_dev_prereqs
 
 __all__ = [
     "BuildConfig",
@@ -58,19 +58,15 @@ def _resolve_paths_and_build(config: DashboardConfig) -> DashboardConfig:
         log_warning(f"Port {config.server.port} is in use. Using {chosen_port} instead.")
 
     if config.build.dev:
-        check_dashboard_prereqs()
+        check_dashboard_dev_prereqs()
         static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall, dev=True)
     elif not config.static_dist_defaulted:
         user_provided_dist = resolve_path(str(config.static_dist))
         if (user_provided_dist / "index.html").exists():
             static_dist = user_provided_dist
         else:
-            if not config.build.no_build:
-                check_dashboard_prereqs()
             static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall)
     else:
-        if not config.build.no_build:
-            check_dashboard_prereqs()
         static_dist = maybe_build_ui(config.build.no_build, config.build.reinstall)
 
     return DashboardConfig(

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -169,13 +169,18 @@ def _collect_tool_issue(cmd: list[str], tool_name: str, min_major: int) -> str |
     return None
 
 
-def check_dashboard_prereqs() -> None:
-    """Check all prerequisites for the dashboard command in one pass.
+def check_dashboard_dev_prereqs() -> None:
+    """Check Node.js and npm prerequisites for `quodeq dashboard --dev`.
+
+    Production dashboards ship a pre-built UI inside the wheel and do not
+    require Node or npm at runtime. This check is only relevant when
+    running with `--dev`, which rebuilds the UI from source on the user's
+    machine.
 
     Runs every tool check, collects any issues, and raises a single
-    RuntimeError that lists them all — so a user missing both Node.js and
-    npm (common on fresh Debian/Ubuntu systems where they're separate
-    packages) gets the full story in one message, with one install command.
+    RuntimeError listing them all, so a contributor missing both Node and
+    npm (common on fresh Debian/Ubuntu systems where they ship as separate
+    packages) gets the full story in one message with one install command.
     """
     issues: list[str] = []
     node_issue = _collect_tool_issue(["node", "--version"], "Node.js", 20)

--- a/tests/dashboard/test_build_coverage.py
+++ b/tests/dashboard/test_build_coverage.py
@@ -8,53 +8,89 @@ import pytest
 
 
 class TestMaybeBuildUi:
-    def test_no_build_with_cache(self, tmp_path):
-        from quodeq.dashboard._build import maybe_build_ui
-        with patch("quodeq.dashboard._build._static_dir", return_value=tmp_path):
-            (tmp_path / "index.html").write_text("<html></html>")
-            result = maybe_build_ui(no_build=True, reinstall=False)
-            assert result == tmp_path
+    # --- Production: wheel-bundled static is authoritative, never invokes npm. ---
 
-    def test_no_build_without_cache(self, tmp_path):
+    def test_production_returns_bundled_static_when_present(self, tmp_path):
+        """Production returns the wheel-bundled static dir without invoking npm."""
         from quodeq.dashboard._build import maybe_build_ui
-        with patch("quodeq.dashboard._build._static_dir", return_value=tmp_path):
+        bundled = tmp_path / "static"
+        bundled.mkdir()
+        (bundled / "index.html").write_text("<html></html>")
+        with patch("quodeq.dashboard._build._static_dir_bundled", return_value=bundled), \
+             patch("quodeq.dashboard._build.run_npm_build") as mock_build:
+            result = maybe_build_ui(no_build=False, reinstall=False)
+            assert result == bundled
+            mock_build.assert_not_called()
+
+    def test_production_raises_when_bundled_static_missing(self, tmp_path):
+        """Production never falls back to npm. Missing static must fail loud."""
+        from quodeq.dashboard._build import maybe_build_ui
+        empty = tmp_path / "static"
+        empty.mkdir()
+        with patch("quodeq.dashboard._build._static_dir_bundled", return_value=empty):
+            with pytest.raises(FileNotFoundError, match="UI static assets are missing"):
+                maybe_build_ui(no_build=False, reinstall=False)
+
+    def test_production_ignores_no_build_flag(self, tmp_path):
+        """no_build is irrelevant in production since npm is never invoked."""
+        from quodeq.dashboard._build import maybe_build_ui
+        bundled = tmp_path / "static"
+        bundled.mkdir()
+        (bundled / "index.html").write_text("<html></html>")
+        with patch("quodeq.dashboard._build._static_dir_bundled", return_value=bundled):
+            assert maybe_build_ui(no_build=True, reinstall=False) == bundled
+            assert maybe_build_ui(no_build=False, reinstall=False) == bundled
+
+    # --- Dev mode: source-aware rebuild loop, contributor workflow. ---
+
+    def test_dev_no_build_with_cache(self, tmp_path):
+        from quodeq.dashboard._build import maybe_build_ui
+        dev_source = tmp_path / "dev_source"
+        dev_source.mkdir()
+        dev_static = tmp_path / "dev_static"
+        dev_static.mkdir()
+        (dev_static / "index.html").write_text("<html></html>")
+        with patch("quodeq.dashboard._build.resolve_dev_source", return_value=dev_source), \
+             patch("quodeq.dashboard._build._dev_static_dir", return_value=dev_static):
+            result = maybe_build_ui(no_build=True, reinstall=False, dev=True)
+            assert result == dev_static
+
+    def test_dev_no_build_without_cache(self, tmp_path):
+        from quodeq.dashboard._build import maybe_build_ui
+        dev_source = tmp_path / "dev_source"
+        dev_source.mkdir()
+        dev_static = tmp_path / "dev_static"
+        with patch("quodeq.dashboard._build.resolve_dev_source", return_value=dev_source), \
+             patch("quodeq.dashboard._build._dev_static_dir", return_value=dev_static):
             with pytest.raises(FileNotFoundError, match="No cached"):
-                maybe_build_ui(no_build=True, reinstall=False)
+                maybe_build_ui(no_build=True, reinstall=False, dev=True)
 
-    def test_skip_when_up_to_date(self, tmp_path):
-        from quodeq.dashboard._build import maybe_build_ui
-        with patch("quodeq.dashboard._build._get_ui_source_dir", return_value=tmp_path), \
-             patch("quodeq.dashboard._build._static_dir", return_value=tmp_path), \
-             patch("quodeq.dashboard._build.needs_rebuild", return_value=False):
-            result = maybe_build_ui(no_build=False, reinstall=False)
-            assert result == tmp_path
-
-    def test_rebuilds_when_needed(self, tmp_path):
-        from quodeq.dashboard._build import maybe_build_ui
-        source = tmp_path / "source"
-        source.mkdir()
-        static = tmp_path / "static"
-        with patch("quodeq.dashboard._build._get_ui_source_dir", return_value=source), \
-             patch("quodeq.dashboard._build._static_dir", return_value=static), \
-             patch("quodeq.dashboard._build.needs_rebuild", return_value=True), \
-             patch("quodeq.dashboard._build._build_workdir", return_value=tmp_path / "work"), \
-             patch("quodeq.dashboard._build.sync_source_to_workdir"), \
-             patch("quodeq.dashboard._build.run_npm_build"), \
-             patch("quodeq.dashboard._build.compute_source_hash", return_value="abc123"):
-            result = maybe_build_ui(no_build=False, reinstall=False)
-            assert result == static
-
-    def test_dev_mode(self, tmp_path):
+    def test_dev_skip_when_up_to_date(self, tmp_path):
         from quodeq.dashboard._build import maybe_build_ui
         dev_source = tmp_path / "dev_source"
         dev_source.mkdir()
         dev_static = tmp_path / "dev_static"
         with patch("quodeq.dashboard._build.resolve_dev_source", return_value=dev_source), \
              patch("quodeq.dashboard._build._dev_static_dir", return_value=dev_static), \
-             patch("quodeq.dashboard._build.run_npm_build"), \
-             patch("quodeq.dashboard._build.compute_source_hash", return_value="def456"):
+             patch("quodeq.dashboard._build.needs_rebuild", return_value=False), \
+             patch("quodeq.dashboard._build.run_npm_build") as mock_build:
             result = maybe_build_ui(no_build=False, reinstall=False, dev=True)
             assert result == dev_static
+            mock_build.assert_not_called()
+
+    def test_dev_rebuilds_when_needed(self, tmp_path):
+        from quodeq.dashboard._build import maybe_build_ui
+        dev_source = tmp_path / "dev_source"
+        dev_source.mkdir()
+        dev_static = tmp_path / "dev_static"
+        with patch("quodeq.dashboard._build.resolve_dev_source", return_value=dev_source), \
+             patch("quodeq.dashboard._build._dev_static_dir", return_value=dev_static), \
+             patch("quodeq.dashboard._build.needs_rebuild", return_value=True), \
+             patch("quodeq.dashboard._build.run_npm_build") as mock_build, \
+             patch("quodeq.dashboard._build.compute_source_hash", return_value="abc123"):
+            result = maybe_build_ui(no_build=False, reinstall=False, dev=True)
+            assert result == dev_static
+            mock_build.assert_called_once()
 
 
 class TestBuildNpmHelpers:

--- a/tests/dashboard/test_dashboard_action_api.py
+++ b/tests/dashboard/test_dashboard_action_api.py
@@ -57,7 +57,7 @@ def test_force_action_api_host_port(monkeypatch):
 
     monkeypatch.setattr(runner, "_ensure_action_api_forced", fake_ensure)
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *_args, **_kwargs: Path("ui/web/dist"))
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
     monkeypatch.setattr(runner, "validate_paths", lambda *_args, **_kwargs: None)
 
     config = runner.DashboardConfig(

--- a/tests/dashboard/test_dashboard_build.py
+++ b/tests/dashboard/test_dashboard_build.py
@@ -158,7 +158,7 @@ class TestStaticDistDefaulted:
 
         config = self._make_config(tmp_path, static_dist_defaulted=True, no_build=False)
         monkeypatch.setattr(runner, "maybe_build_ui", fake_build)
-        monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+        monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
         monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *a, **k: None)
         monkeypatch.setattr(
             runner, "_ensure_action_api",
@@ -182,7 +182,7 @@ class TestStaticDistDefaulted:
 
         config = self._make_config(tmp_path, static_dist_defaulted=False)
         monkeypatch.setattr(runner, "maybe_build_ui", fake_build)
-        monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+        monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
         monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *a, **k: None)
         monkeypatch.setattr(
             runner, "_ensure_action_api",

--- a/tests/dashboard/test_dashboard_runner.py
+++ b/tests/dashboard/test_dashboard_runner.py
@@ -47,7 +47,7 @@ def test_run_dashboard_spawns_action_api_with_static_dist(tmp_path: Path, monkey
     monkeypatch.setattr(runner, "_kill_stale_action_api", lambda *_a, **_k: None)
     monkeypatch.setattr(runner, "_ensure_action_api", fake_ensure)
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     config = _make_config(tmp_path, static_dist=static_dist)
 
@@ -66,7 +66,7 @@ def test_run_dashboard_creates_default_reports(tmp_path: Path, monkeypatch):
         lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
     )
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     reports_dir = tmp_path / "reports"
     config = _make_config(tmp_path, reports_dir=reports_dir, static_dist=static_dist, reports_defaulted=True)
@@ -94,7 +94,7 @@ def test_run_dashboard_auto_picks_ui_port(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(_networking, "_is_port_open", lambda host, port: port == _TEST_PORT)
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     config = _make_config(tmp_path, static_dist=static_dist, reports_defaulted=True)
 
@@ -145,7 +145,7 @@ def test_run_dashboard_native_window(tmp_path: Path, monkeypatch):
         lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
     )
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     from quodeq.dashboard import _server
 
@@ -179,7 +179,7 @@ def test_run_dashboard_browser_fallback(tmp_path: Path, monkeypatch):
         lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
     )
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     def fake_serve(url, proc, config):
         browser_calls.append(config.build.use_native)
@@ -208,7 +208,7 @@ def test_run_dashboard_verbose_sets_env(tmp_path: Path, monkeypatch):
         lambda *_args, **_kwargs: (f"http://127.0.0.1:{_TEST_PORT}", DummyProcess()),
     )
     monkeypatch.setattr(runner, "maybe_build_ui", lambda *a, **k: static_dist)
-    monkeypatch.setattr(runner, "check_dashboard_prereqs", lambda: None)
+    monkeypatch.setattr(runner, "check_dashboard_dev_prereqs", lambda: None)
 
     test_env: dict[str, str] = {}
     config = _make_config(

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from quodeq.shared.prereqs import (
-    check_node, check_npm, check_dashboard_prereqs, check_evaluate_prereqs,
+    check_node, check_npm, check_dashboard_dev_prereqs, check_evaluate_prereqs,
     _check_cli_provider, _check_api_provider, _is_provider_explicitly_configured,
 )
 
@@ -97,13 +97,13 @@ class TestCompositeChecks:
         node_result = subprocess.CompletedProcess([], 0, stdout="v20.11.0\n")
         npm_result = subprocess.CompletedProcess([], 0, stdout="10.2.0\n")
         with patch("subprocess.run", side_effect=[node_result, npm_result]):
-            check_dashboard_prereqs()
+            check_dashboard_dev_prereqs()
 
     def test_dashboard_prereqs_reports_both_missing_in_one_error(self):
         """Both node and npm missing — user should see both in a single message."""
         with patch("subprocess.run", side_effect=FileNotFoundError):
             with pytest.raises(RuntimeError) as excinfo:
-                check_dashboard_prereqs()
+                check_dashboard_dev_prereqs()
         msg = str(excinfo.value)
         assert "Node.js" in msg
         assert "npm" in msg
@@ -115,7 +115,7 @@ class TestCompositeChecks:
         node_result = subprocess.CompletedProcess([], 0, stdout="v20.11.0\n")
         with patch("subprocess.run", side_effect=[node_result, FileNotFoundError()]):
             with pytest.raises(RuntimeError) as excinfo:
-                check_dashboard_prereqs()
+                check_dashboard_dev_prereqs()
         msg = str(excinfo.value)
         assert "npm" in msg
         assert "Node.js 18+ not found" not in msg  # don't falsely claim node is missing

--- a/tools/build-dist.sh
+++ b/tools/build-dist.sh
@@ -2,7 +2,7 @@
 # Build the distribution package (sdist + wheel) with pre-built web UI.
 #
 # Usage:
-#   ./scripts/build-dist.sh
+#   ./tools/build-dist.sh
 #
 # Prerequisites:
 #   - Node.js 20+ and npm 10+
@@ -10,19 +10,15 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# Standard project layout paths; override via environment if needed.
-STATIC_DIR="${QUODEQ_STATIC_DIR:-$REPO_ROOT/src/quodeq/static}"
-WEB_DIR="${QUODEQ_WEB_DIR:-$REPO_ROOT/ui/web}"
+UI_DIR="${QUODEQ_UI_DIR:-$REPO_ROOT/src/quodeq/ui}"
 
 echo "==> Building web UI..."
-cd "$WEB_DIR"
+cd "$UI_DIR"
 npm ci
+# vite.config.js writes to ../static (i.e. src/quodeq/static) by default,
+# which is exactly where the wheel picks the bundled UI up from.
 npm run build
 cd "$REPO_ROOT"
-
-echo "==> Copying dist to bundled static directory..."
-rm -rf "$STATIC_DIR"
-cp -r "$WEB_DIR/dist" "$STATIC_DIR"
 
 echo "==> Building Python package..."
 uv build

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -4,16 +4,12 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-# Standard project layout paths; override via environment if needed.
-UI_WEB="${QUODEQ_UI_WEB:-$ROOT/ui/web}"
-STATIC_DEST="${QUODEQ_STATIC_DEST:-$ROOT/src/quodeq/static}"
+UI_DIR="${QUODEQ_UI_DIR:-$ROOT/src/quodeq/ui}"
 
 echo "==> Building frontend..."
-(cd "$UI_WEB" && npm ci && npm run build)
-
-echo "==> Bundling frontend into package..."
-rm -rf "$STATIC_DEST"
-cp -r "$UI_WEB/dist" "$STATIC_DEST"
+# vite.config.js writes to ../static (i.e. src/quodeq/static) by default,
+# which is exactly where the wheel picks the bundled UI up from.
+(cd "$UI_DIR" && npm ci && npm run build)
 
 echo "==> Syncing engine_version in plugin files..."
 VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('$ROOT/pyproject.toml','rb'))['project']['version'])")


### PR DESCRIPTION
## Summary

Production installs no longer need Node.js or npm. The wheel ships a pre-built UI under `quodeq/static/`, and the dashboard reads that bundled path directly. The `--dev` codepath is unchanged for contributors iterating on the UI source.

This is the natural follow-up to #552 (npm security hardening). That PR closed the supply-chain attack surface around the runtime npm invocation. This PR removes the runtime npm invocation entirely.

## What changes for end users

| Before | After |
|---|---|
| `pipx install quodeq` then dashboard launch shells out to `npm ci && vite build` | Dashboard launch reads `<site-packages>/quodeq/static/index.html` directly |
| First launch slow (~30-60s npm install + build) | First launch instant |
| ~250 MB in `~/.quodeq/ui_build/node_modules/` | Zero footprint |
| Needs Node 20+ / npm 10+ on the user's machine | Needs Python 3.12+ only |
| Needs network to npmjs.org on first launch | Fully offline-capable |

## What stays the same

- `--dev` mode for contributors (still rebuilds from `src/quodeq/ui/` source)
- DMG and Homebrew installs (already pre-built)
- The npm security hardening from #552 (still applies to `--dev` and to the packaging-time build)

## Implementation notes

- New helper `_static_dir_bundled()` returns `<package>/static/`. The old `_static_dir()` (which pointed at `~/.quodeq/static/`) is now unused by production paths but kept available for backward-compat callers.
- `maybe_build_ui` in production never invokes npm. Missing static raises a `FileNotFoundError` with installation guidance instead of falling back to a silent rebuild.
- `check_dashboard_prereqs` renamed to `check_dashboard_dev_prereqs` and dropped from both production branches of `_resolve_paths_and_build` in `runner.py`. Only the `--dev` branch still calls it.
- `tools/build-dist.sh` and `tools/build.sh` had a stale path (`$ROOT/ui/web`, which doesn't exist) plus a redundant `cp -r dist static/` step. Both fixed. Vite's `outDir: '../static'` default writes to `src/quodeq/static/` directly.

## Test plan

- [x] `uv run pytest -m "not integration"` passes (3108/3108)
- [x] New TDD red-green for production static-only contract
- [x] `tools/build-dist.sh` produces a wheel containing `quodeq/static/index.html`
- [x] Wheel size: 1.5 MB -> 2.0 MB (acceptable)
- [x] Smoke test in a fresh venv with `env -i PATH=` lacking npm: `maybe_build_ui` returns the bundled path; the trapped `run_npm_build` is never called
- [x] No stale `check_dashboard_prereqs` references remain
- [x] CI green on this PR