### PR TITLE
Fix #556: in-progress eval card shows the running job's provider/model

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -21,14 +21,13 @@ from quodeq.analysis.runner import AnalysisOptions, EvaluationError, RunConfig, 
 from quodeq.engine.scoring_pipeline import run_full
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.shared.logging import log_error, log_info, log_warning
-from quodeq.shared.utils import get_ai_model, is_repo_url, project_name_from_repo, write_text
+from quodeq.shared.utils import get_ai_model, get_ai_provider, is_repo_url, project_name_from_repo, write_text
 from quodeq.shared.repo_handler import cleanup_cloned_repo
 from quodeq.engine._runner_markers import emit_marker
 from quodeq.shared.prereqs import check_evaluate_prereqs
 from quodeq.analysis._dimension_aliases import expand_dimension_aliases
 from quodeq.analysis._diff_resolver import DiffResolveError, resolve_diff_files
 from quodeq.shared.run_lifecycle import RunLifecycleContext
-from quodeq.shared._env import get_ai_provider, get_ai_model
 
 # Re-export resolution helpers — keep the public API stable
 from quodeq._cli_resolution import (  # noqa: F401

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -28,6 +28,7 @@ from quodeq.shared.prereqs import check_evaluate_prereqs
 from quodeq.analysis._dimension_aliases import expand_dimension_aliases
 from quodeq.analysis._diff_resolver import DiffResolveError, resolve_diff_files
 from quodeq.shared.run_lifecycle import RunLifecycleContext
+from quodeq.shared._env import get_ai_provider, get_ai_model
 
 # Re-export resolution helpers — keep the public API stable
 from quodeq._cli_resolution import (  # noqa: F401
@@ -300,10 +301,14 @@ def _run_pipeline_with_cleanup(
         # Lifecycle context: pending → running on enter, done on clean exit,
         # failed on exception, cancelled on SIGINT/SIGTERM/SIGHUP or atexit.
         try:
+            ai_provider = get_ai_provider()
+            ai_model = get_ai_model()
             with RunLifecycleContext(
                 run_dir=run_dir,
                 job_id=f"ext-{run_id}",
                 dimensions=dimensions_list,
+                ai_provider=ai_provider,
+                ai_model=ai_model,
             ) as lifecycle:
                 try:
                     # Mark the pipeline as actively analyzing so dashboard

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -21,7 +21,7 @@ from quodeq.analysis.runner import AnalysisOptions, EvaluationError, RunConfig, 
 from quodeq.engine.scoring_pipeline import run_full
 from quodeq.shared.project_resolver import ProjectIdentity, resolve_project_uuid
 from quodeq.shared.logging import log_error, log_info, log_warning
-from quodeq.shared.utils import get_ai_model, get_ai_provider, is_repo_url, project_name_from_repo, write_text
+from quodeq.shared.utils import get_ai_cmd, get_ai_model, is_repo_url, project_name_from_repo, write_text
 from quodeq.shared.repo_handler import cleanup_cloned_repo
 from quodeq.engine._runner_markers import emit_marker
 from quodeq.shared.prereqs import check_evaluate_prereqs
@@ -300,7 +300,7 @@ def _run_pipeline_with_cleanup(
         # Lifecycle context: pending → running on enter, done on clean exit,
         # failed on exception, cancelled on SIGINT/SIGTERM/SIGHUP or atexit.
         try:
-            ai_provider = get_ai_provider()
+            ai_provider = get_ai_cmd()
             ai_model = get_ai_model()
             with RunLifecycleContext(
                 run_dir=run_dir,

--- a/src/quodeq/core/types/job.py
+++ b/src/quodeq/core/types/job.py
@@ -21,3 +21,5 @@ class JobSnapshot:
     error: str | None = None
     source: str = "internal"  # "internal" | "external"
     exit_reason: str | None = None
+    ai_provider: str | None = None
+    ai_model: str | None = None

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -307,6 +307,8 @@ class EvaluationsIndex:
         logs: list[str] = []
         dimensions: list[str] | None = None
         deadline_at: str | None = None
+        ai_provider: str | None = None
+        ai_model: str | None = None
         if row.run_dir:
             run_dir_path = Path(row.run_dir)
             try:
@@ -321,6 +323,10 @@ class EvaluationsIndex:
                 deadline_at = _read_deadline_from_status(run_dir_path)
             except (OSError, ValueError):
                 deadline_at = None
+            try:
+                ai_provider, ai_model = _read_provider_model_from_status(run_dir_path)
+            except (OSError, ValueError):
+                ai_provider, ai_model = None, None
         return JobSnapshot(
             job_id=row.job_id,
             status=row.state,
@@ -338,6 +344,8 @@ class EvaluationsIndex:
             error=row.exit_reason,
             source="external" if row.job_id.startswith("ext-") else "internal",
             exit_reason=row.exit_reason,
+            ai_provider=ai_provider,
+            ai_model=ai_model,
         )
 
 
@@ -386,3 +394,27 @@ def _read_deadline_from_status(run_dir: Path) -> str | None:
         return None
     val = data.get("deadline_at")
     return val if isinstance(val, str) else None
+
+
+def _read_provider_model_from_status(run_dir: Path) -> tuple[str | None, str | None]:
+    """Read (ai_provider, ai_model) from status.json, or (None, None).
+
+    External (CLI) runs aren't tracked by JobManager, so they don't carry
+    provider/model on an in-memory Job. Reading directly from status.json
+    keeps the dashboard's in-progress card self-describing for ext- runs.
+    """
+    status_path = run_dir / "status.json"
+    if not status_path.is_file():
+        return (None, None)
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return (None, None)
+    if not isinstance(data, dict):
+        return (None, None)
+    provider = data.get("ai_provider")
+    model = data.get("ai_model")
+    return (
+        provider if isinstance(provider, str) else None,
+        model if isinstance(model, str) else None,
+    )

--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -255,6 +255,9 @@ def force_promote_to_cancelled_stale(
                 current_dimension=current_dimension,
                 pid=pid if isinstance(pid, int) else None,
                 exit_reason="stale_detected",
+                deadline_at=existing.get("deadline_at"),
+                ai_provider=existing.get("ai_provider"),
+                ai_model=existing.get("ai_model"),
             )
             _upsert_from_status(
                 db, run_dir, project_uuid=project_uuid, run_id=run_id,

--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -318,6 +318,9 @@ def _check_stale_and_promote(
             # Preserve deadline_at across the stale → cancelled rewrite so
             # downstream readers (filesystem snapshot builder) still see it.
             deadline_at=status.get("deadline_at"),
+            # Preserve provider/model so the dashboard card stays self-describing.
+            ai_provider=status.get("ai_provider"),
+            ai_model=status.get("ai_model"),
         )
         with db:
             _upsert_from_status(db, run_dir, project_uuid=project_uuid, run_id=run_id)

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -85,6 +85,8 @@ class Job:
             deadline_at=self.deadline_at,
             current_dimension=self.current_dimension,
             dimensions=self.dimensions,
+            ai_provider=self.ai_provider,
+            ai_model=self.ai_model,
         )
 
 

--- a/src/quodeq/services/_job_model.py
+++ b/src/quodeq/services/_job_model.py
@@ -43,6 +43,8 @@ class Job:
     deadline_at: str | None = None
     current_dimension: str | None = None
     dimensions: list[str] | None = None
+    ai_provider: str | None = None
+    ai_model: str | None = None
 
     def complete(self, exit_code: int, ended_at: str) -> None:
         """Transition job to a terminal state based on exit code."""
@@ -173,6 +175,8 @@ def _job_to_json(job: Job) -> dict:
         "deadline_at": job.deadline_at,
         "current_dimension": job.current_dimension,
         "dimensions": job.dimensions,
+        "ai_provider": job.ai_provider,
+        "ai_model": job.ai_model,
     }
 
 
@@ -193,6 +197,8 @@ def _job_from_json(data: dict) -> Job:
         deadline_at=data.get("deadline_at"),
         current_dimension=data.get("current_dimension"),
         dimensions=data.get("dimensions"),
+        ai_provider=data.get("ai_provider"),
+        ai_model=data.get("ai_model"),
     )
 
 

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -44,6 +44,8 @@ class EvaluationDispatcher(Protocol):
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        ai_provider: str | None = None,
+        ai_model: str | None = None,
     ) -> JobSnapshot:
         """Submit an evaluation command and return the initial job state."""
         ...
@@ -61,8 +63,13 @@ class SubprocessDispatcher:
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,
+        ai_provider: str | None = None,
+        ai_model: str | None = None,
     ) -> JobSnapshot:
-        return self._jobs.start_job(cmd, cwd=cwd, env=env)
+        return self._jobs.start_job(
+            cmd, cwd=cwd, env=env,
+            ai_provider=ai_provider, ai_model=ai_model,
+        )
 
 
 def _build_evaluate_cmd(
@@ -300,7 +307,11 @@ class FsEvaluationMixin:
                 candidate = candidate.parent
         else:
             cwd = str(resolved)
-        return self.dispatcher.dispatch(cmd, cwd=cwd, env=env)
+        return self.dispatcher.dispatch(
+            cmd, cwd=cwd, env=env,
+            ai_provider=options.ai_cmd,
+            ai_model=options.ai_model,
+        )
 
     def get_evaluation_status(self, job_id: str, reports_dir: str | None = None) -> JobSnapshot | None:
         """Return the current status of an evaluation job.

--- a/src/quodeq/services/jobs.py
+++ b/src/quodeq/services/jobs.py
@@ -102,7 +102,7 @@ class JobManager:
         """
         self._reports_root = path
 
-    def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None) -> JobSnapshot:
+    def start_job(self, cmd: list[str], *, cwd: str | None = None, env: dict[str, str] | None = None, ai_provider: str | None = None, ai_model: str | None = None) -> JobSnapshot:
         """Spawn a subprocess and return its initial job state."""
         job_id = str(uuid.uuid4())
         job = Job(
@@ -112,6 +112,8 @@ class JobManager:
             started_at=datetime.now(timezone.utc).isoformat(),
             ended_at=None,
             exit_code=None,
+            ai_provider=ai_provider,
+            ai_model=ai_model,
         )
 
         try:

--- a/src/quodeq/shared/run_lifecycle.py
+++ b/src/quodeq/shared/run_lifecycle.py
@@ -57,6 +57,8 @@ class RunLifecycleContext:
         dimensions: list[str],
         *,
         heartbeat_interval: float = 5.0,
+        ai_provider: str | None = None,
+        ai_model: str | None = None,
     ) -> None:
         self._run_dir = run_dir
         self._job_id = job_id
@@ -66,6 +68,8 @@ class RunLifecycleContext:
         self._phase: str | None = None
         self._current_dimension: str | None = None
         self._deadline_at: str | None = None
+        self._ai_provider = ai_provider
+        self._ai_model = ai_model
         self._heartbeat = HeartbeatThread(run_dir, interval=heartbeat_interval)
         self._resources = ResourceSampler()
         self._previous_handlers: dict[int, Any] = {}
@@ -174,6 +178,8 @@ class RunLifecycleContext:
             current_dimension=self._current_dimension,
             exit_reason=exit_reason,
             deadline_at=self._deadline_at,
+            ai_provider=self._ai_provider,
+            ai_model=self._ai_model,
         )
 
     def _seed_dimension_states(self) -> None:
@@ -222,6 +228,8 @@ class RunLifecycleContext:
                 current_dimension=self._current_dimension,
                 exit_reason=f"signal_{name}",
                 deadline_at=self._deadline_at,
+                ai_provider=self._ai_provider,
+                ai_model=self._ai_model,
             )
             self._current_state = RunState.CANCELLED
             raise SystemExit(128 + signum)
@@ -262,6 +270,8 @@ class RunLifecycleContext:
             current_dimension=self._current_dimension,
             exit_reason="atexit_unfinalized",
             deadline_at=self._deadline_at,
+            ai_provider=self._ai_provider,
+            ai_model=self._ai_model,
         )
 
     def _deregister_atexit(self) -> None:

--- a/src/quodeq/shared/run_status.py
+++ b/src/quodeq/shared/run_status.py
@@ -82,6 +82,8 @@ def write_status(
     exit_reason: str | None = None,
     finalized_at: str | None = None,
     deadline_at: str | None = None,
+    ai_provider: str | None = None,
+    ai_model: str | None = None,
 ) -> None:
     """Atomically write status.json with *state* and metadata.
 
@@ -107,6 +109,10 @@ def write_status(
         "exit_reason": exit_reason,
         "deadline_at": deadline_at,
     }
+    if ai_provider is not None:
+        payload["ai_provider"] = ai_provider
+    if ai_model is not None:
+        payload["ai_model"] = ai_model
     body = json.dumps(payload, indent=2)
     tmp_path = run_dir / (STATUS_FILENAME + ".tmp")
     final_path = run_dir / STATUS_FILENAME

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -46,7 +46,9 @@ function JobIdLine({ jobId, aiProvider, aiModel }) {
       <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(jobId)} />
       {aiProvider && aiModel && (
         <span data-testid="job-runtime-chip">
-          {aiProvider} · {aiModel}
+          {aiProvider}
+          <span className="eval-provider-sep" aria-hidden="true"> · </span>
+          {aiModel}
         </span>
       )}
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -38,12 +38,17 @@ function JobHeader({ job, projectLabel, onDismiss, onCancel }) {
   );
 }
 
-function JobIdLine({ jobId }) {
+function JobIdLine({ jobId, aiProvider, aiModel }) {
   return (
     <div className="evaluate-job-id-line">
       <span className="evaluate-job-id-line__label">job</span>
       <code>{jobId}</code>
       <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(jobId)} />
+      {aiProvider && aiModel && (
+        <span data-testid="job-runtime-chip">
+          {aiProvider} · {aiModel}
+        </span>
+      )}
     </div>
   );
 }
@@ -56,7 +61,7 @@ export default function EvaluationStatus({ job, project, projectInfo, liveViolat
     <div className="panel evaluate-panel--terminal">
       <JobHeader job={job} projectLabel={projectLabel} onDismiss={onDismiss} onCancel={onCancel} />
       <JobStatStrip job={job} liveViolations={liveViolations} />
-      <JobIdLine jobId={job.jobId} />
+      <JobIdLine jobId={job.jobId} aiProvider={job.aiProvider} aiModel={job.aiModel} />
       <ScanProgress job={job} hasEvaluations={hasEvaluations} />
       <LiveViolationsFeed liveViolations={liveViolations} />
     </div>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -26,4 +26,20 @@ describe('JobIdLine', () => {
     expect(screen.getByText('job-123')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /copy job id/i })).toBeInTheDocument();
   });
+
+  it('renders job-runtime-chip when both aiProvider and aiModel are present', () => {
+    renderWithClient(
+      <EvaluationStatus
+        job={{ ...baseJob, aiProvider: 'llamacpp', aiModel: 'qwen3.6-27b' }}
+      />
+    );
+    expect(screen.getByTestId('job-runtime-chip')).toHaveTextContent('llamacpp · qwen3.6-27b');
+  });
+
+  it('does not render job-runtime-chip when aiModel is absent', () => {
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, aiProvider: 'llamacpp' }} />
+    );
+    expect(screen.queryByTestId('job-runtime-chip')).toBeNull();
+  });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -42,4 +42,11 @@ describe('JobIdLine', () => {
     );
     expect(screen.queryByTestId('job-runtime-chip')).toBeNull();
   });
+
+  it('does not render job-runtime-chip when aiProvider is absent', () => {
+    renderWithClient(
+      <EvaluationStatus job={{ ...baseJob, aiModel: 'qwen3.6-27b' }} />
+    );
+    expect(screen.queryByTestId('job-runtime-chip')).toBeNull();
+  });
 });

--- a/src/quodeq/ui/src/models/job.js
+++ b/src/quodeq/ui/src/models/job.js
@@ -17,6 +17,8 @@
  * @property {number|null}   exitCode
  * @property {string|null}   error
  * @property {'internal'|'external'} source  - 'internal' = launched from dashboard; 'external' = CLI/CI
+ * @property {string|null}   aiProvider     - Provider this job is actually using (e.g. 'ollama', 'llamacpp')
+ * @property {string|null}   aiModel        - Model this job is actually using
  */
 
 /**
@@ -43,5 +45,7 @@ export function createJob(raw) {
     exitCode:         raw.exitCode ?? null,
     error:            raw.error ?? null,
     source:           raw.source ?? 'internal',
+    aiProvider:       raw.aiProvider ?? null,
+    aiModel:          raw.aiModel ?? null,
   };
 }

--- a/src/quodeq/ui/src/models/job.test.js
+++ b/src/quodeq/ui/src/models/job.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createJob } from './job.js';
+
+test('createJob maps aiProvider and aiModel from API response', () => {
+  const raw = { jobId: 'ext-1', aiProvider: 'llamacpp', aiModel: 'qwen3.6-27b' };
+  const job = createJob(raw);
+  assert.equal(job.aiProvider, 'llamacpp');
+  assert.equal(job.aiModel, 'qwen3.6-27b');
+});
+
+test('createJob leaves aiProvider/aiModel null when API omits them', () => {
+  const job = createJob({ jobId: 'ext-1' });
+  assert.equal(job.aiProvider, null);
+  assert.equal(job.aiModel, null);
+});

--- a/tests/api/test_power_selector_backend.py
+++ b/tests/api/test_power_selector_backend.py
@@ -64,7 +64,7 @@ class TestEvaluationMixinSubagentModel:
         from quodeq.services.filesystem import FilesystemActionProvider
 
         class StubJobs:
-            def start_job(self, cmd, cwd, env):
+            def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
                 captured["cmd"] = cmd
                 captured["env"] = env
                 return {"jobId": "test"}

--- a/tests/api/test_power_selector_e2e.py
+++ b/tests/api/test_power_selector_e2e.py
@@ -193,7 +193,7 @@ class _StubJobManager:
     def __init__(self):
         self.captured_env: dict = {}
 
-    def start_job(self, cmd, cwd, env):
+    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
         self.captured_env = env
         return {"jobId": "test"}
 

--- a/tests/ci/test_cli_lifecycle_integration.py
+++ b/tests/ci/test_cli_lifecycle_integration.py
@@ -332,3 +332,38 @@ def test_pipeline_records_provider_and_model_from_env(tmp_path: Path, monkeypatc
     assert status is not None, "status.json must be written"
     assert status["ai_provider"] == "test-provider"
     assert status["ai_model"] == "test-model"
+
+
+def test_pipeline_records_ai_cmd_as_provider(tmp_path: Path, monkeypatch) -> None:
+    """status.json records AI_CMD as ai_provider when AI_CMD is set (not AI_PROVIDER).
+
+    Locks in get_ai_cmd() semantics: the pipeline selects its provider via
+    AI_CMD → AI_PROVIDER → default; the external path must record the same
+    value as the internal path's options.ai_cmd.
+    """
+    import quodeq._cli_evaluation as cli
+
+    monkeypatch.setenv("AI_CMD", "llamacpp")
+    monkeypatch.setenv("AI_MODEL", "qwen3.6-27b")
+    monkeypatch.delenv("AI_PROVIDER", raising=False)
+
+    evidence_dir = tmp_path / "proj" / "run" / "evidence"
+    evaluation_dir = tmp_path / "proj" / "run" / "evaluation"
+    evidence_dir.mkdir(parents=True)
+    evaluation_dir.mkdir(parents=True)
+
+    with patch.object(cli, "_execute_pipeline", return_value=0), \
+         patch.object(cli, "_save_manifest"), \
+         patch.object(cli, "_build_run_config"), \
+         patch.object(cli, "is_repo_url", return_value=False), \
+         patch.object(cli, "emit_marker"):
+        import argparse
+        args = argparse.Namespace(repo="local")
+        inputs = type("I", (), {"src": tmp_path, "language": "python", "manifest": None, "dims_data": None})()
+        cli._run_pipeline_with_cleanup(args, inputs, (tmp_path, evidence_dir, evaluation_dir))
+
+    run_dir = evaluation_dir.parent
+    status = read_status(run_dir)
+    assert status is not None, "status.json must be written"
+    assert status["ai_provider"] == "llamacpp"
+    assert status["ai_model"] == "qwen3.6-27b"

--- a/tests/ci/test_cli_lifecycle_integration.py
+++ b/tests/ci/test_cli_lifecycle_integration.py
@@ -299,3 +299,36 @@ def test_c88be50e_partial_state_invariants_agree(tmp_path: Path) -> None:
         f"source_file_count ({source_file_count}) — otherwise the dashboard "
         "computes coverage_pct=100 and renders a partial run as complete"
     )
+
+
+# ---------------------------------------------------------------------------
+# Provider/model wiring (Task 5)
+# ---------------------------------------------------------------------------
+
+def test_pipeline_records_provider_and_model_from_env(tmp_path: Path, monkeypatch) -> None:
+    """status.json records the AI_PROVIDER/AI_MODEL the CLI ran with."""
+    import quodeq._cli_evaluation as cli
+
+    monkeypatch.setenv("AI_PROVIDER", "test-provider")
+    monkeypatch.setenv("AI_MODEL", "test-model")
+
+    evidence_dir = tmp_path / "proj" / "run" / "evidence"
+    evaluation_dir = tmp_path / "proj" / "run" / "evaluation"
+    evidence_dir.mkdir(parents=True)
+    evaluation_dir.mkdir(parents=True)
+
+    with patch.object(cli, "_execute_pipeline", return_value=0), \
+         patch.object(cli, "_save_manifest"), \
+         patch.object(cli, "_build_run_config"), \
+         patch.object(cli, "is_repo_url", return_value=False), \
+         patch.object(cli, "emit_marker"):
+        import argparse
+        args = argparse.Namespace(repo="local")
+        inputs = type("I", (), {"src": tmp_path, "language": "python", "manifest": None, "dims_data": None})()
+        cli._run_pipeline_with_cleanup(args, inputs, (tmp_path, evidence_dir, evaluation_dir))
+
+    run_dir = evaluation_dir.parent
+    status = read_status(run_dir)
+    assert status is not None
+    assert status["ai_provider"] == "test-provider"
+    assert status["ai_model"] == "test-model"

--- a/tests/ci/test_cli_lifecycle_integration.py
+++ b/tests/ci/test_cli_lifecycle_integration.py
@@ -329,6 +329,6 @@ def test_pipeline_records_provider_and_model_from_env(tmp_path: Path, monkeypatc
 
     run_dir = evaluation_dir.parent
     status = read_status(run_dir)
-    assert status is not None
+    assert status is not None, "status.json must be written"
     assert status["ai_provider"] == "test-provider"
     assert status["ai_model"] == "test-model"

--- a/tests/core/types/test_job_snapshot.py
+++ b/tests/core/types/test_job_snapshot.py
@@ -1,0 +1,24 @@
+"""Tests for JobSnapshot serialisation, focusing on provider/model fields."""
+from __future__ import annotations
+
+from quodeq.core.types.job import JobSnapshot
+from quodeq.core.types._serialization import to_camel_dict
+
+
+def test_job_snapshot_serialises_provider_and_model():
+    snap = JobSnapshot(
+        job_id="ext-abc",
+        status="running",
+        ai_provider="llamacpp",
+        ai_model="qwen3.6-27b",
+    )
+    payload = to_camel_dict(snap)
+    assert payload["aiProvider"] == "llamacpp"
+    assert payload["aiModel"] == "qwen3.6-27b"
+
+
+def test_job_snapshot_omits_provider_and_model_when_none():
+    snap = JobSnapshot(job_id="ext-abc", status="running")
+    payload = to_camel_dict(snap)
+    assert "aiProvider" not in payload
+    assert "aiModel" not in payload

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -18,7 +18,7 @@ class StubJobs:
     def __init__(self):
         self.captured: dict = {}
 
-    def start_job(self, cmd, cwd, env):
+    def start_job(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
         self.captured["cmd"] = cmd
         self.captured["cwd"] = cwd
         self.captured["env"] = env

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -22,6 +22,8 @@ class StubJobs:
         self.captured["cmd"] = cmd
         self.captured["cwd"] = cwd
         self.captured["env"] = env
+        self.captured["ai_provider"] = ai_provider
+        self.captured["ai_model"] = ai_model
         return {"jobId": "test"}
 
 

--- a/tests/services/test_action_provider_jobs.py
+++ b/tests/services/test_action_provider_jobs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -117,7 +118,7 @@ def test_job_manager_handles_failure() -> None:
     assert any("boom" in line for line in result.logs)
 
 
-def test_start_evaluation_forwards_provider_and_model(tmp_path: pytest.fixture) -> None:
+def test_start_evaluation_forwards_provider_and_model(tmp_path: Path) -> None:
     """start_evaluation must pass ai_provider/ai_model through the dispatcher."""
     from unittest.mock import patch
     from quodeq.services.base import EvaluationOptions

--- a/tests/services/test_action_provider_jobs.py
+++ b/tests/services/test_action_provider_jobs.py
@@ -115,3 +115,29 @@ def test_job_manager_handles_failure() -> None:
     assert result.status == "failed"
     assert result.exit_code == 2
     assert any("boom" in line for line in result.logs)
+
+
+def test_start_evaluation_forwards_provider_and_model(tmp_path: pytest.fixture) -> None:
+    """start_evaluation must pass ai_provider/ai_model through the dispatcher."""
+    from unittest.mock import patch
+    from quodeq.services.base import EvaluationOptions
+    from quodeq.services.evaluation_mixin import FsEvaluationMixin
+
+    captured: dict = {}
+
+    class _SpyDispatcher:
+        def dispatch(self, cmd, *, cwd=None, env=None, ai_provider=None, ai_model=None):
+            captured["ai_provider"] = ai_provider
+            captured["ai_model"] = ai_model
+            return JobSnapshot(job_id="job-1", status="running")
+
+    mixin = FsEvaluationMixin()
+    mixin._jobs = None  # not used — spy bypasses JobManager entirely
+    mixin._dispatcher = _SpyDispatcher()
+
+    opts = EvaluationOptions(ai_cmd="ollama", ai_model="gemma4:26b-mlx")
+    with patch("quodeq.services.evaluation_mixin._register_project"):
+        mixin.start_evaluation(str(tmp_path), str(tmp_path / "reports"), opts)
+
+    assert captured["ai_provider"] == "ollama"
+    assert captured["ai_model"] == "gemma4:26b-mlx"

--- a/tests/services/test_evaluation_mixin.py
+++ b/tests/services/test_evaluation_mixin.py
@@ -192,7 +192,9 @@ class TestSubprocessDispatcher:
         dispatcher = SubprocessDispatcher(mock_mgr)
         result = dispatcher.dispatch(["cmd"], cwd="/tmp", env={"A": "1"})
         assert result == expected
-        mock_mgr.start_job.assert_called_once_with(["cmd"], cwd="/tmp", env={"A": "1"})
+        mock_mgr.start_job.assert_called_once_with(
+            ["cmd"], cwd="/tmp", env={"A": "1"}, ai_provider=None, ai_model=None,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_evaluations_index_dedup.py
+++ b/tests/services/test_evaluations_index_dedup.py
@@ -82,6 +82,64 @@ def test_list_returns_one_entry_for_dashboard_spawned_run(tmp_path: Path) -> Non
     )
 
 
+def test_external_snapshot_carries_provider_and_model(tmp_path: Path) -> None:
+    """An ext- run's status.json provider/model reach the JobSnapshot."""
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid-pm"
+    run_id = "run-uuid-pm"
+    run_dir = reports_root / project / run_id
+    run_dir.mkdir(parents=True)
+    write_status(
+        run_dir,
+        state=RunState.RUNNING,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+        phase="analyzing",
+        pid=99999,
+        ai_provider="llamacpp",
+        ai_model="qwen3.6-27b",
+    )
+
+    store = InMemoryJobStore()  # no internal job for this run
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=tmp_path / "index.db",
+        reports_root=reports_root,
+    )
+    entries = index.list(reports_dir=reports_root)
+    match = [e for e in entries if e.output_run_id == run_id]
+    assert len(match) == 1, f"expected one external entry, got {match}"
+    snap = match[0]
+    assert snap.source == "external"
+    assert snap.ai_provider == "llamacpp"
+    assert snap.ai_model == "qwen3.6-27b"
+
+
+def test_external_snapshot_provider_model_absent_when_not_in_status(tmp_path: Path) -> None:
+    """When status.json has no provider/model, the snapshot fields are None."""
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid-pm2"
+    run_id = "run-uuid-pm2"
+    _seed_status(reports_root, project, run_id)  # no ai_provider/ai_model
+
+    store = InMemoryJobStore()  # no internal job for this run
+    jobs = JobManager(job_store=store, reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=tmp_path / "index.db",
+        reports_root=reports_root,
+    )
+    entries = index.list(reports_dir=reports_root)
+    match = [e for e in entries if e.output_run_id == run_id]
+    assert len(match) == 1, f"expected one external entry, got {match}"
+    snap = match[0]
+    assert snap.source == "external"
+    assert snap.ai_provider is None
+    assert snap.ai_model is None
+
+
 def test_list_prefers_internal_over_indexed_external(tmp_path: Path) -> None:
     """When both an internal and external entry exist for the same run, keep the internal one.
 

--- a/tests/services/test_index_sync.py
+++ b/tests/services/test_index_sync.py
@@ -18,6 +18,7 @@ from quodeq.services._index_sync import (
     _sync_legacy_run,
     _upsert_from_status,
     _check_stale_and_promote,
+    force_promote_to_cancelled_stale,
 )
 
 
@@ -319,5 +320,38 @@ def test_stale_promotion_terminal_state_untouched(tmp_path: Path) -> None:
         assert promoted is False
         row = db.execute("SELECT state FROM runs WHERE job_id = ?", ("ext-r9",)).fetchone()
         assert row[0] == "done"
+    finally:
+        db.close()
+
+
+def test_force_promote_preserves_provider_model_deadline(tmp_path: Path) -> None:
+    """force_promote_to_cancelled_stale must carry ai_provider/ai_model/deadline_at
+    into the rewritten status.json, consistent with _check_stale_and_promote."""
+    db = open_index(tmp_path / "idx.db")
+    try:
+        run = _make_run_dir(tmp_path, "p", "r11")
+        write_status(
+            run,
+            state=RunState.RUNNING,
+            job_id="ext-r11",
+            started_at="2026-04-20T00:00:00+00:00",
+            dimensions=[],
+            pid=999999999,
+            ai_provider="llamacpp",
+            ai_model="qwen3.6-27b",
+            deadline_at="2026-01-01T00:00:00+00:00",
+        )
+        _upsert_from_status(db, run, project_uuid="p", run_id="r11")
+
+        promoted = force_promote_to_cancelled_stale(db, "ext-r11", run_dir=run)
+        assert promoted is True
+
+        from quodeq.shared.run_status import read_status
+        disk = read_status(run)
+        assert disk is not None
+        assert disk["state"] == "cancelled"
+        assert disk["ai_provider"] == "llamacpp"
+        assert disk["ai_model"] == "qwen3.6-27b"
+        assert disk["deadline_at"] == "2026-01-01T00:00:00+00:00"
     finally:
         db.close()

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -244,6 +244,16 @@ class TestSerialization:
         assert restored.ai_provider is None
         assert restored.ai_model is None
 
+    def test_to_dict_carries_provider_and_model(self):
+        job = Job(
+            job_id="job-1", status="running", command=["x"],
+            started_at="2026-01-01T00:00:00Z", ended_at=None, exit_code=None,
+            ai_provider="ollama", ai_model="gemma4:26b-mlx",
+        )
+        snap = job.to_dict()
+        assert snap.ai_provider == "ollama"
+        assert snap.ai_model == "gemma4:26b-mlx"
+
 
 # ---------------------------------------------------------------------------
 # FileJobStore

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -210,6 +210,40 @@ class TestSerialization:
         }
         assert set(data.keys()) == expected_keys
 
+    def test_job_round_trips_provider_and_model(self):
+        job = Job(
+            job_id="job-1",
+            status="running",
+            command=["x"],
+            started_at="2026-01-01T00:00:00Z",
+            ended_at=None,
+            exit_code=None,
+            ai_provider="ollama",
+            ai_model="gemma4:26b-mlx",
+        )
+        blob = _job_to_json(job)
+        assert blob["ai_provider"] == "ollama"
+        assert blob["ai_model"] == "gemma4:26b-mlx"
+        restored = _job_from_json(blob)
+        assert restored.ai_provider == "ollama"
+        assert restored.ai_model == "gemma4:26b-mlx"
+
+    def test_job_defaults_provider_and_model_to_none(self):
+        job = Job(
+            job_id="job-1",
+            status="running",
+            command=["x"],
+            started_at="2026-01-01T00:00:00Z",
+            ended_at=None,
+            exit_code=None,
+        )
+        blob = _job_to_json(job)
+        blob.pop("ai_provider", None)
+        blob.pop("ai_model", None)
+        restored = _job_from_json(blob)
+        assert restored.ai_provider is None
+        assert restored.ai_model is None
+
 
 # ---------------------------------------------------------------------------
 # FileJobStore
@@ -378,44 +412,3 @@ class TestReportPathRegex:
 
     def test_no_match_on_garbage(self):
         assert REPORT_PATH_RE.search("no report here") is None
-
-
-# ---------------------------------------------------------------------------
-# ai_provider / ai_model fields
-# ---------------------------------------------------------------------------
-
-
-def test_job_round_trips_provider_and_model():
-    from quodeq.services._job_model import Job, _job_to_json, _job_from_json
-    job = Job(
-        job_id="job-1",
-        status="running",
-        command=["x"],
-        started_at="2026-01-01T00:00:00Z",
-        ended_at=None,
-        exit_code=None,
-        ai_provider="ollama",
-        ai_model="gemma4:26b-mlx",
-    )
-    blob = _job_to_json(job)
-    assert blob["ai_provider"] == "ollama"
-    assert blob["ai_model"] == "gemma4:26b-mlx"
-    restored = _job_from_json(blob)
-    assert restored.ai_provider == "ollama"
-    assert restored.ai_model == "gemma4:26b-mlx"
-
-
-def test_job_defaults_provider_and_model_to_none():
-    from quodeq.services._job_model import Job, _job_to_json, _job_from_json
-    job = Job(
-        job_id="job-1",
-        status="running",
-        command=["x"],
-        started_at="2026-01-01T00:00:00Z",
-        ended_at=None,
-        exit_code=None,
-    )
-    blob = _job_to_json(job)
-    restored = _job_from_json(blob)
-    assert restored.ai_provider is None
-    assert restored.ai_model is None

--- a/tests/services/test_job_model.py
+++ b/tests/services/test_job_model.py
@@ -206,6 +206,7 @@ class TestSerialization:
             "job_id", "status", "command", "started_at", "ended_at",
             "exit_code", "logs", "output_project", "output_run_id",
             "phase", "deadline_at", "current_dimension", "dimensions",
+            "ai_provider", "ai_model",
         }
         assert set(data.keys()) == expected_keys
 
@@ -377,3 +378,44 @@ class TestReportPathRegex:
 
     def test_no_match_on_garbage(self):
         assert REPORT_PATH_RE.search("no report here") is None
+
+
+# ---------------------------------------------------------------------------
+# ai_provider / ai_model fields
+# ---------------------------------------------------------------------------
+
+
+def test_job_round_trips_provider_and_model():
+    from quodeq.services._job_model import Job, _job_to_json, _job_from_json
+    job = Job(
+        job_id="job-1",
+        status="running",
+        command=["x"],
+        started_at="2026-01-01T00:00:00Z",
+        ended_at=None,
+        exit_code=None,
+        ai_provider="ollama",
+        ai_model="gemma4:26b-mlx",
+    )
+    blob = _job_to_json(job)
+    assert blob["ai_provider"] == "ollama"
+    assert blob["ai_model"] == "gemma4:26b-mlx"
+    restored = _job_from_json(blob)
+    assert restored.ai_provider == "ollama"
+    assert restored.ai_model == "gemma4:26b-mlx"
+
+
+def test_job_defaults_provider_and_model_to_none():
+    from quodeq.services._job_model import Job, _job_to_json, _job_from_json
+    job = Job(
+        job_id="job-1",
+        status="running",
+        command=["x"],
+        started_at="2026-01-01T00:00:00Z",
+        ended_at=None,
+        exit_code=None,
+    )
+    blob = _job_to_json(job)
+    restored = _job_from_json(blob)
+    assert restored.ai_provider is None
+    assert restored.ai_model is None

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -197,3 +197,20 @@ def test_breaker_exit_writes_failed_with_reason(tmp_path: Path) -> None:
     assert status is not None
     assert status["state"] == "failed"
     assert status["exit_reason"] == "failure_streak"
+
+
+def test_lifecycle_context_threads_provider_to_status(tmp_path: Path) -> None:
+    """ai_provider and ai_model passed to RunLifecycleContext must land in status.json."""
+    import json
+
+    with RunLifecycleContext(
+        run_dir=tmp_path,
+        job_id="ext-1",
+        dimensions=["maintainability"],
+        ai_provider="ollama",
+        ai_model="gemma4:26b-mlx",
+    ):
+        pass
+    data = json.loads((tmp_path / "status.json").read_text())
+    assert data.get("ai_provider") == "ollama"
+    assert data.get("ai_model") == "gemma4:26b-mlx"

--- a/tests/shared/test_run_lifecycle.py
+++ b/tests/shared/test_run_lifecycle.py
@@ -201,8 +201,6 @@ def test_breaker_exit_writes_failed_with_reason(tmp_path: Path) -> None:
 
 def test_lifecycle_context_threads_provider_to_status(tmp_path: Path) -> None:
     """ai_provider and ai_model passed to RunLifecycleContext must land in status.json."""
-    import json
-
     with RunLifecycleContext(
         run_dir=tmp_path,
         job_id="ext-1",
@@ -211,6 +209,6 @@ def test_lifecycle_context_threads_provider_to_status(tmp_path: Path) -> None:
         ai_model="gemma4:26b-mlx",
     ):
         pass
-    data = json.loads((tmp_path / "status.json").read_text())
-    assert data.get("ai_provider") == "ollama"
-    assert data.get("ai_model") == "gemma4:26b-mlx"
+    data = read_status(tmp_path)
+    assert data["ai_provider"] == "ollama"
+    assert data["ai_model"] == "gemma4:26b-mlx"

--- a/tests/shared/test_run_status.py
+++ b/tests/shared/test_run_status.py
@@ -87,9 +87,7 @@ def test_read_unsupported_schema_raises(tmp_path: Path) -> None:
         read_status(tmp_path)
 
 
-def test_write_status_persists_provider_and_model(tmp_path):
-    from quodeq.shared.run_status import write_status, RunState
-    import json
+def test_write_status_persists_provider_and_model(tmp_path: Path) -> None:
     write_status(
         tmp_path,
         state=RunState.RUNNING,
@@ -104,9 +102,7 @@ def test_write_status_persists_provider_and_model(tmp_path):
     assert data["ai_model"] == "qwen3.6-27b"
 
 
-def test_write_status_omits_provider_and_model_when_unset(tmp_path):
-    from quodeq.shared.run_status import write_status, RunState
-    import json
+def test_write_status_omits_provider_and_model_when_unset(tmp_path: Path) -> None:
     write_status(
         tmp_path,
         state=RunState.RUNNING,

--- a/tests/shared/test_run_status.py
+++ b/tests/shared/test_run_status.py
@@ -87,6 +87,38 @@ def test_read_unsupported_schema_raises(tmp_path: Path) -> None:
         read_status(tmp_path)
 
 
+def test_write_status_persists_provider_and_model(tmp_path):
+    from quodeq.shared.run_status import write_status, RunState
+    import json
+    write_status(
+        tmp_path,
+        state=RunState.RUNNING,
+        job_id="ext-abc",
+        started_at="2026-01-01T00:00:00Z",
+        dimensions=["maintainability"],
+        ai_provider="llamacpp",
+        ai_model="qwen3.6-27b",
+    )
+    data = json.loads((tmp_path / "status.json").read_text())
+    assert data["ai_provider"] == "llamacpp"
+    assert data["ai_model"] == "qwen3.6-27b"
+
+
+def test_write_status_omits_provider_and_model_when_unset(tmp_path):
+    from quodeq.shared.run_status import write_status, RunState
+    import json
+    write_status(
+        tmp_path,
+        state=RunState.RUNNING,
+        job_id="ext-abc",
+        started_at="2026-01-01T00:00:00Z",
+        dimensions=[],
+    )
+    data = json.loads((tmp_path / "status.json").read_text())
+    assert "ai_provider" not in data
+    assert "ai_model" not in data
+
+
 def test_concurrent_writes_no_partial_file(tmp_path: Path) -> None:
     """Two threads writing concurrently: each read sees a valid JSON document."""
     barrier = threading.Barrier(2)


### PR DESCRIPTION
## Summary

The dashboard's in-progress evaluation card showed the UI's globally-selected provider/model (from localStorage) instead of what the running job is actually using. For external (`ext-`) jobs launched by `quodeq evaluate` with different env vars than the UI's last selection, the card was misleading, exactly when you need it accurate for A/B model comparisons.

This plumbs `ai_provider` / `ai_model` end-to-end through the existing `JobSnapshot` shape so the in-progress card is self-describing, for both job paths:

- **Internal (dashboard-spawned):** `start_evaluation` maps `options.ai_cmd`/`ai_model` into `dispatch` to `JobManager.start_job`, onto the `Job`, and `Job.to_dict()` copies them into the `JobSnapshot`.
- **External (CLI `ext-` runs):** the CLI records `get_ai_cmd()`/`get_ai_model()` into `RunLifecycleContext`, which writes them into `status.json` on every lifecycle transition (incl. signal handler and atexit). The dashboard reads them back in `EvaluationsIndex._run_row_to_snapshot` via a new `_read_provider_model_from_status` helper (mirroring the existing `deadline_at` pattern), and both stale-promotion paths preserve them across the terminal-state rewrite.

The API needs no route changes (fields ride `to_camel_dict` as `aiProvider`/`aiModel`). The frontend `Job` model maps them and the card renders a small chip `{aiProvider} · {aiModel}` only when both are present, so legacy/unknown runs render no chip rather than guessing. The header chip (top-right) is intentionally unchanged: it represents what would be used on the next `+ Evaluate`.

Scope is provider/model only. The related project-mismatch case noted in the issue is a separate follow-up.

Design + plan: `docs/superpowers/specs/2026-05-27-issue-556-inprogress-card-job-provider-model-design.md`.

## Notable findings during implementation

The original plan covered writing the fields but missed two read/projection sites that actually populate the served `JobSnapshot`. Both were added after tracing the data flow:
- `EvaluationsIndex._run_row_to_snapshot` (the external-job population site, core path of the issue).
- `_index_sync` stale-promotion rewrites (`_check_stale_and_promote` and `force_promote_to_cancelled_stale`) were dropping the fields when rewriting `status.json` on stale/cancel; now preserved.

## Test plan

- [x] Full backend suite: 3127 passed, 0 failed
- [x] UI unit (node:test): 180 passed
- [x] UI component (vitest): 364 passed
- [x] New coverage at every hop: JobSnapshot↔camelCase round-trip, Job↔JSON + backward-compat (absent keys), `write_status` persistence, `RunLifecycleContext` threading (all 3 write sites), CLI env→status.json (AI_PROVIDER and AI_CMD paths), dispatcher→start_job→Job→to_dict forwarding, external `index.list()`→snapshot (present + absent), stale-promote preservation, frontend model mapping, and chip render (present / absent / symmetric-absent)
- [x] Manual dashboard smoke (live provider): not run in this environment; recommend a quick check in dev, launch an `ext-` eval with `AI_PROVIDER`/`AI_MODEL` differing from the UI selection and confirm the in-progress card chip matches the running job while the header chip stays on the UI selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)