### PR TITLE
Fix #556 follow-up: in-progress eval card shows the running job's own project

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -71,12 +71,18 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onG
   const { connected, setConnected } = serverHealth;
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
+  // The in-progress card describes the running job's own project, which can
+  // differ from the UI's global selection. Resolve it the same way so the
+  // card label follows the job rather than the selection.
+  const jobProjectInfo = job?.outputProject
+    ? (projects?.find(p => (p.id || p.name) === job.outputProject) || null)
+    : null;
   return (
     <>
       {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
-        context={{ selectedProject, projectInfo }}
+        context={{ selectedProject, projectInfo, jobProjectInfo }}
         actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects, onGoToSettings }}
       />
     </>

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -113,7 +113,7 @@ function NoProjectSelected({ onGoToProjects }) {
 
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
-  const { selectedProject, projectInfo } = context;
+  const { selectedProject, projectInfo, jobProjectInfo } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects, onGoToSettings } = actions;
   const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
@@ -145,6 +145,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
           job={job}
           project={selectedProject}
           projectInfo={projectInfo}
+          jobProjectInfo={jobProjectInfo}
           liveViolations={liveViolations}
           onDismiss={onDismiss}
           onCancel={onCancel}

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -55,9 +55,14 @@ function JobIdLine({ jobId, aiProvider, aiModel }) {
   );
 }
 
-export default function EvaluationStatus({ job, project, projectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
+export default function EvaluationStatus({ job, project, projectInfo, jobProjectInfo, liveViolations = {}, onDismiss, onCancel, hasEvaluations }) {
   if (!job) return null;
-  const projectLabel = projectInfo?.displayName || projectInfo?.name || project || null;
+  // Prefer the running job's own project so the card stays accurate when the
+  // UI's global selection points at a different project than the job is
+  // actually scanning. Fall back to the selected project when the job's
+  // project can't be resolved (e.g. before the report-path marker fires).
+  const jobProjectLabel = jobProjectInfo?.displayName || jobProjectInfo?.name || null;
+  const projectLabel = jobProjectLabel || projectInfo?.displayName || projectInfo?.name || project || null;
 
   return (
     <div className="panel evaluate-panel--terminal">

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -50,3 +50,33 @@ describe('JobIdLine', () => {
     expect(screen.queryByTestId('job-runtime-chip')).toBeNull();
   });
 });
+
+describe('project label', () => {
+  const selectedInfo = { id: 'uuid-b', name: 'project-b', displayName: 'Project B' };
+  const jobInfo = { id: 'uuid-a', name: 'project-a', displayName: 'Project A' };
+
+  it("shows the running job's own project, not the globally-selected one", () => {
+    renderWithClient(
+      <EvaluationStatus
+        job={{ ...baseJob, status: 'running', outputProject: 'uuid-a' }}
+        project="uuid-b"
+        projectInfo={selectedInfo}
+        jobProjectInfo={jobInfo}
+      />
+    );
+    expect(screen.getByText('Project A')).toBeInTheDocument();
+    expect(screen.queryByText('Project B')).toBeNull();
+  });
+
+  it("falls back to the selected project when the job's project is not resolvable", () => {
+    renderWithClient(
+      <EvaluationStatus
+        job={{ ...baseJob, status: 'running' }}
+        project="uuid-b"
+        projectInfo={selectedInfo}
+        jobProjectInfo={null}
+      />
+    );
+    expect(screen.getByText('Project B')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to [#556](https://github.com/quodeq/quodeq/issues/556) / [#557](https://github.com/quodeq/quodeq/pull/557). PR #557 fixed the provider/model half of the issue. This addresses the issue's **"Same pattern: project change"** section, which was explicitly left as a follow-up.

**The bug:** when the user changed the selected project in the UI while a job ran on a *different* project, the in-progress card's project label followed the UI's global selection instead of the project the running job was actually scanning. The two labels silently disagreed, exactly when you need the card accurate (e.g. monitoring a CLI-launched eval on project A while browsing project B).

## Approach

Mirrors #557: source the label from the job's own state rather than the UI's globals. The backend data is already present, so this is a **frontend-only** change.

`JobSnapshot` already carries `output_project` (the job's project UUID) for both job paths:
- Internal jobs: `Job.to_dict()` sets it (from the `report_path` marker).
- External (`ext-`) jobs: `EvaluationsIndex._run_row_to_snapshot` sets `output_project=row.project_uuid`.

The frontend `Job` model already maps `outputProject`. So:

- **`App.jsx` (`EvaluateCase`)** resolves the job's project from the `projects` list using the exact same `projects.find(p => (p.id || p.name) === ...)` pattern it already uses for the selected project's `projectInfo`.
- **`EvaluateScreen.jsx`** threads `jobProjectInfo` through `context`.
- **`EvaluationStatus.jsx`** prefers the job's own project label, falling back to the selected project when the job's project can't be resolved (e.g. before the `report_path` marker fires, or an unknown/legacy UUID). So early and legacy states render exactly as before.

The header chip (top-right) is intentionally unchanged: it represents "what would be used on the next + Evaluate", per the issue.

Scope is the project-label mismatch only.

## Test plan

- [x] New deterministic coverage in `EvaluationStatus.test.jsx` reproducing the exact issue scenario: job on project A + UI selection on project B renders "Project A", not "Project B"; plus a fallback case (no resolvable job project renders the selected project).
- [x] Full UI suite green: vitest 366 passed (64 files; +2 new), node:test unit suite passed.
- [x] Production build compiles (`vite build` to a temp outdir; `EvaluateScreen` + `App` chunks build clean).
- [x] Manual dashboard smoke (live job): not run in this environment. Recommend a quick check in dev: launch an eval on one project, switch the UI selection to another project, and confirm the in-progress card keeps the running job's project while the header chip stays on the UI selection. (Same live-smoke caveat as #557 for this card.)

Closes #556.