### PR TITLE
fix(windows): pin UTF-8 on all text I/O + regression guard

### DIFF
--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -277,7 +277,7 @@ def _run_pipeline_with_cleanup(
     # Write a .pid file so the dashboard can detect and cancel this external run
     pid_file = run_dir / ".pid"
     try:
-        pid_file.write_text(str(os.getpid()))
+        pid_file.write_text(str(os.getpid()), encoding="utf-8")
     except OSError:
         pass  # non-fatal; cancel-by-filesystem just won't work for this run
 

--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -23,7 +23,7 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
     seen = set(result)
     for _p in evaluators_dir.glob("*.json"):
         try:
-            _eid = _json.loads(_p.read_text()).get("id")
+            _eid = _json.loads(_p.read_text(encoding="utf-8")).get("id")
             if _eid and _eid not in seen:
                 result.append(_eid)
                 seen.add(_eid)

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -451,7 +451,7 @@ def run_api_analysis(
             language=run_config.language or "",
         )
 
-    with open(jsonl_file, "a") as fh:
+    with open(jsonl_file, "a", encoding="utf-8") as fh:
         router = FindingsRouter(
             fh, context=ctx, event_log=event_log, on_file_done=cache_writer,
         )

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -97,7 +97,7 @@ def _silence_broken_stdout() -> None:
     does. Swapping the streams to /dev/null lets remaining dimensions run.
     """
     try:
-        devnull = open(os.devnull, "w")  # noqa: SIM115 - long-lived
+        devnull = open(os.devnull, "w", encoding="utf-8")  # noqa: SIM115 - long-lived
         sys.stdout = devnull
         sys.stderr = devnull
     except OSError:

--- a/src/quodeq/analysis/_process.py
+++ b/src/quodeq/analysis/_process.py
@@ -93,7 +93,7 @@ def _check_process_result(process: subprocess.Popen, stream_err: Path) -> None:
         stderr_text = ""
         if stream_err.exists():
             try:
-                stderr_text = _sanitize_stderr(stream_err.read_text().strip())
+                stderr_text = _sanitize_stderr(stream_err.read_text(encoding="utf-8").strip())
             except (OSError, UnicodeDecodeError):
                 stderr_text = "(stderr unreadable)"
         raise AnalysisError(
@@ -107,7 +107,7 @@ def _spawn_and_monitor(
     paths: _SpawnPaths, cfg: AnalysisConfig,
 ) -> tuple[subprocess.Popen, bool]:
     """Spawn the AI CLI process, monitor with heartbeat, return (process, timed_out)."""
-    with open(paths.stream_file, "w") as out, open(paths.stream_err, "w") as err:
+    with open(paths.stream_file, "w", encoding="utf-8") as out, open(paths.stream_err, "w", encoding="utf-8") as err:
         # start_new_session creates a new process group so we can kill the
         # entire tree (including child processes) when the agent is cancelled.
         process = subprocess.Popen(

--- a/src/quodeq/analysis/_provider_cache.py
+++ b/src/quodeq/analysis/_provider_cache.py
@@ -55,7 +55,7 @@ class _ProviderConfigCache:
             with self._lock:
                 if self._configs is None:
                     try:
-                        self._configs = json.loads(_AI_PROVIDERS_PATH.read_text())
+                        self._configs = json.loads(_AI_PROVIDERS_PATH.read_text(encoding="utf-8"))
                     except (OSError, json.JSONDecodeError):
                         self._configs = _PROVIDER_CONFIGS_FALLBACK
         return self._configs

--- a/src/quodeq/analysis/_report_io.py
+++ b/src/quodeq/analysis/_report_io.py
@@ -15,7 +15,7 @@ def _persist_json(data: dict, path: Path) -> None:
     """Write a report dict as formatted JSON to *path* (I/O adapter)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
-        path.write_text(json.dumps(data, indent=2))
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except OSError as exc:
         raise OSError(f"Failed to write report to {path}: {exc}") from exc
 

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -36,7 +36,7 @@ Each finding must be a JSON object with these fields:
 def _read_file_safe(path: Path) -> str | None:
     """Read a file, returning None on failure."""
     try:
-        return path.read_text()
+        return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         _log.warning("Could not read file: %s", path)
         return None

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -196,7 +196,7 @@ def _write_findings(
 ) -> None:
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
-    with jsonl.open(mode) as out:
+    with jsonl.open(mode, encoding="utf-8") as out:
         for finding in findings:
             out.write(json.dumps(finding) + "\n")
     if emit_events:

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -121,7 +121,7 @@ def _apply_precedent_downweight(
 
 
 def _default_read_file(path: Path) -> str:
-    return path.read_text()
+    return path.read_text(encoding="utf-8")
 
 
 class FindingEnricher:

--- a/src/quodeq/analysis/mcp/findings_server.py
+++ b/src/quodeq/analysis/mcp/findings_server.py
@@ -70,7 +70,7 @@ def main() -> None:
         queue = FileQueue(Path(sa.queue_path))
 
     try:
-        with open(sa.findings_file, "a") as findings_fh:
+        with open(sa.findings_file, "a", encoding="utf-8") as findings_fh:
             router = _build_router(findings_fh, Path(sa.findings_file), ctx, sa)
             while True:
                 msg = read_message()

--- a/src/quodeq/analysis/prompts/_standards_io.py
+++ b/src/quodeq/analysis/prompts/_standards_io.py
@@ -16,7 +16,7 @@ def write_standards_file(work_dir: Path, dimension: str, content: str) -> Path:
     """
     standards_path = work_dir / f"{_STANDARDS_FILE_PREFIX}{dimension}.md"
     try:
-        standards_path.write_text(content)
+        standards_path.write_text(content, encoding="utf-8")
     except OSError as exc:
         raise OSError(f"Failed to write standards file {standards_path}: {exc}") from exc
     return standards_path

--- a/src/quodeq/analysis/prompts/_template.py
+++ b/src/quodeq/analysis/prompts/_template.py
@@ -27,14 +27,14 @@ def load_template(
     """
     if template_path:
         try:
-            return template_path.read_text()
+            return template_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:
             raise FileNotFoundError(f"Cannot read template {template_path}: {exc}") from exc
     if prompts_dir is None:
         prompts_dir = default_paths().prompts_dir
     path = prompts_dir / template_name
     try:
-        return path.read_text()
+        return path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         raise FileNotFoundError(f"Cannot read template {path}: {exc}") from exc
 

--- a/src/quodeq/analysis/subagents/_queue_state.py
+++ b/src/quodeq/analysis/subagents/_queue_state.py
@@ -94,7 +94,7 @@ def locked(lock_path: Path):
 def read_state(path: Path) -> dict:
     """Read and validate the queue JSON file."""
     try:
-        raw = path.read_text()
+        raw = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise FileQueueError(f"Cannot read queue file: {exc}") from exc
     try:

--- a/src/quodeq/analysis/subagents/priority_config.py
+++ b/src/quodeq/analysis/subagents/priority_config.py
@@ -26,7 +26,7 @@ def load_priority_config() -> dict:
     """Load file priority config. Cached after first call."""
     config_path = default_paths().root / "config" / "file_priority.json"
     try:
-        return json.loads(config_path.read_text())
+        return json.loads(config_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, PermissionError, json.JSONDecodeError):
         return {}
 

--- a/src/quodeq/analysis/subagents/priority_fan_in.py
+++ b/src/quodeq/analysis/subagents/priority_fan_in.py
@@ -26,7 +26,7 @@ def compute_fan_in(
         if not path.exists():
             return None
         try:
-            return path.read_text(errors="ignore")
+            return path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             return None
 

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -107,7 +107,7 @@ def _load_skip_dirs() -> frozenset[str]:
     """Load skip_dirs from detection.json (shared with manifest builder)."""
     try:
         det_path = Path(__file__).resolve().parent.parent / "data" / "config" / "detection.json"
-        data = _json.loads(det_path.read_text())
+        data = _json.loads(det_path.read_text(encoding="utf-8"))
         return frozenset(data.get("skip_dirs", []))
     except (OSError, _json.JSONDecodeError):
         return frozenset({"node_modules", ".git", "__pycache__", "venv", ".venv", "dist", "build"})
@@ -184,7 +184,7 @@ def _load_standards_text(compiled_dir: Path | None, dimension: str | None) -> st
     json_path = compiled_dir / f"{dimension}.json"
     if json_path.exists():
         try:
-            data = _json.loads(json_path.read_text())
+            data = _json.loads(json_path.read_text(encoding="utf-8"))
             text = _render_standards_grouped(data)
             if text:
                 if len(text) > _MAX_STANDARDS_CHARS:
@@ -197,7 +197,7 @@ def _load_standards_text(compiled_dir: Path | None, dimension: str | None) -> st
     md_path = compiled_dir / f"{dimension}.md"
     if md_path.exists():
         try:
-            text = md_path.read_text()
+            text = md_path.read_text(encoding="utf-8")
             if len(text) > _MAX_STANDARDS_CHARS:
                 text = text[:_MAX_STANDARDS_CHARS] + "\n\n[... standards truncated for context limits ...]"
             return text
@@ -276,7 +276,7 @@ def _gather_api_source_files(
             # Don't touch jsonl_file — it's the SHARED `{dim}_evidence.jsonl`
             # that every agent in the pool appends to via MCP. Truncating it
             # here wipes findings from every other agent in the pool.
-            stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
+            stream_file.write_text('{"type":"api_runner","status":"complete"}\n', encoding="utf-8")
             return None
         return source_files
     return _gather_source_files(work_dir)
@@ -336,7 +336,7 @@ def _run_api_analysis_bridge(
         dim_id=cfg.dimension,
     )
 
-    stream_file.write_text('{"type":"api_runner","status":"complete"}\n')
+    stream_file.write_text('{"type":"api_runner","status":"complete"}\n', encoding="utf-8")
     _log.debug("API analysis complete, evidence written to %s", jsonl_file)
 
 

--- a/src/quodeq/api/_log_stream_routes.py
+++ b/src/quodeq/api/_log_stream_routes.py
@@ -179,7 +179,7 @@ def register_log_stream_routes(app: Flask) -> None:
             if status_path.exists():
                 try:
                     import json
-                    data = json.loads(status_path.read_text())
+                    data = json.loads(status_path.read_text(encoding="utf-8"))
                     state = data.get("state")
                     if isinstance(state, str):
                         return state

--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -106,7 +106,7 @@ def _read_status(run_dir: Path) -> tuple[dict[str, Any], float]:
     except OSError:
         return {"state": "pending"}, _STATUS_MTIME_MISSING
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             return {"state": "pending"}, mtime
         return data, mtime
@@ -137,7 +137,7 @@ def _read_dim_eval(run_dir: Path, dimension: str) -> dict[str, Any] | None:
     """
     path = run_dir / "evaluation" / f"{dimension}{_DIM_FILENAME_SUFFIX}"
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         return data if isinstance(data, dict) else None
     except (OSError, ValueError) as exc:
         _logger.warning("dimension eval read failed at %s: %s", path, exc)

--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -250,7 +250,7 @@ def _find_identity_collision(reports_root: Path, identity: ProjectIdentity, *, i
         if not info_file.exists():
             continue
         try:
-            data = json.loads(info_file.read_text())
+            data = json.loads(info_file.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         if data.get("name") != identity.project_name:
@@ -279,12 +279,12 @@ def _rewrite_repository_info(project_dir: Path, new_uuid: str) -> None:
     """Update the imported project's repository_info.json with its new UUID."""
     info_path = project_dir / _REPO_INFO_FILENAME
     try:
-        data = json.loads(info_path.read_text())
+        data = json.loads(info_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return
     data["uuid"] = new_uuid
     try:
-        info_path.write_text(json.dumps(data, indent=2))
+        info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except OSError as exc:
         _logger.warning("import: could not rewrite repository_info.json: %s", exc)
 

--- a/src/quodeq/api/routes_project_list.py
+++ b/src/quodeq/api/routes_project_list.py
@@ -47,7 +47,7 @@ def _find_existing_project(reports_root: str, repo: str, scope_path: str | None)
         if not info_file.exists():
             continue
         try:
-            data = json.loads(info_file.read_text())
+            data = json.loads(info_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
         if data.get("name") != expected_name:
@@ -185,7 +185,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
         scan_path = project_dir / "scan.json"
         if scan_path.exists():
             try:
-                data = json.loads(scan_path.read_text())
+                data = json.loads(scan_path.read_text(encoding="utf-8"))
                 return jsonify(data)
             except (json.JSONDecodeError, OSError):
                 pass
@@ -197,7 +197,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
             return jsonify(body), status
 
         try:
-            info = json.loads(info_path.read_text())
+            info = json.loads(info_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             body, status = error_response("Could not read project info", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL")
             return jsonify(body), status
@@ -341,7 +341,7 @@ def register_project_list_routes(app: Flask, provider: ActionProvider) -> None:
         # scan.json is now always present after _register_project succeeds.
         scan_path = Path(reports_root) / project_uuid / "scan.json"
         try:
-            scan_data = json.loads(scan_path.read_text())
+            scan_data = json.loads(scan_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError, FileNotFoundError):
             scan_data = {
                 "total_files": 0,

--- a/src/quodeq/api/zip.py
+++ b/src/quodeq/api/zip.py
@@ -47,7 +47,7 @@ def _build_manifest(project_path: Path) -> dict[str, object]:
     info_path = project_path / "repository_info.json"
     if info_path.exists():
         try:
-            info = json.loads(info_path.read_text())
+            info = json.loads(info_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             info = {}
     return {

--- a/src/quodeq/ci/reporter.py
+++ b/src/quodeq/ci/reporter.py
@@ -133,7 +133,7 @@ def load_evaluation_reports(evaluation_dir: Path) -> list[dict]:
     for path in sorted(evaluation_dir.glob("*.json")):
         if path.stem.endswith("_full"):
             continue
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             reports.append(json.load(f))
     return reports
 

--- a/src/quodeq/config/_env_loader.py
+++ b/src/quodeq/config/_env_loader.py
@@ -24,7 +24,7 @@ def load_env_file(paths: ConfigPaths, target: dict[str, str] | None = None) -> N
     if not paths.env_file.exists():
         return
     try:
-        lines = paths.env_file.read_text().splitlines()
+        lines = paths.env_file.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
         _logger.warning("Failed to read env file %s: %s", paths.env_file, exc)
         return

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -41,7 +41,7 @@ def get_current_provider(
     if provider is not None:
         return provider
     if paths.env_file.exists():
-        for line in paths.env_file.read_text().splitlines():
+        for line in paths.env_file.read_text(encoding="utf-8").splitlines():
             if line.strip().startswith(_AI_PROVIDER_EXPORT_PREFIX):
                 return line.split("=", 1)[1].strip()
     if default_provider is not None:
@@ -100,10 +100,10 @@ def _write_env(paths: ConfigPaths, provider: str, api_key_var: str, api_key_valu
 def _ensure_gitignore(paths: ConfigPaths) -> None:
     if not paths.gitignore_file.exists():
         return
-    content = paths.gitignore_file.read_text().splitlines()
+    content = paths.gitignore_file.read_text(encoding="utf-8").splitlines()
     if ".quodeq.env" not in content:
         content.append(".quodeq.env")
-        paths.gitignore_file.write_text("\n".join(content) + "\n")
+        paths.gitignore_file.write_text("\n".join(content) + "\n", encoding="utf-8")
         log_info("Added .quodeq.env to .gitignore")
 
 

--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -34,7 +34,7 @@ def _build_req_to_principle_map(dimension: str, evaluators_dir: Path | None = No
     if not path.is_file():
         return {}
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         mapping: dict[str, str] = {}
         for principle in data.get("principles", []):
             pname = principle.get("name", "")

--- a/src/quodeq/dashboard/_api_spawn.py
+++ b/src/quodeq/dashboard/_api_spawn.py
@@ -59,7 +59,7 @@ def spawn_action_api(
         **_popen_platform_kwargs(),
     )
     try:
-        pid_file_path.write_text(str(proc.pid))
+        pid_file_path.write_text(str(proc.pid), encoding="utf-8")
     except (OSError, AttributeError) as exc:
         log_warning(f"Could not write PID file: {exc}")
     return proc

--- a/src/quodeq/dashboard/_build.py
+++ b/src/quodeq/dashboard/_build.py
@@ -80,7 +80,7 @@ def maybe_build_ui(no_build: bool, reinstall: bool, dev: bool = False) -> Path:
         log_info("Building web UI (source changed)...")
         static_dir.mkdir(parents=True, exist_ok=True)
         run_npm_build(source_dir, static_dir)
-        (static_dir / _HASH_FILE).write_text(compute_source_hash(source_dir))
+        (static_dir / _HASH_FILE).write_text(compute_source_hash(source_dir), encoding="utf-8")
         return static_dir
 
     # Production: the wheel ships a pre-built UI. Never invoke npm here.

--- a/src/quodeq/dashboard/_build_hash.py
+++ b/src/quodeq/dashboard/_build_hash.py
@@ -47,6 +47,6 @@ def needs_rebuild(source_dir: Path, static_dir: Path, reinstall: bool) -> bool:
     hash_file = static_dir / _HASH_FILE
     if not hash_file.exists():
         return True
-    stored_hash = hash_file.read_text().strip()
+    stored_hash = hash_file.read_text(encoding="utf-8").strip()
     current_hash = compute_source_hash(source_dir)
     return stored_hash != current_hash

--- a/src/quodeq/dashboard/_instance.py
+++ b/src/quodeq/dashboard/_instance.py
@@ -114,7 +114,7 @@ class InstanceController:
         """Windows: use TCP localhost with port stored in a file."""
         if self._port_file.exists():
             try:
-                port = int(self._port_file.read_text().strip())
+                port = int(self._port_file.read_text(encoding="utf-8").strip())
                 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
                     probe.settimeout(_SOCK_TIMEOUT)
                     probe.connect((_TCP_LOCALHOST, port))
@@ -129,7 +129,7 @@ class InstanceController:
         self._tcp_port = self._server_sock.getsockname()[1]
         self._server_sock.listen(_LISTEN_BACKLOG)
         self._server_sock.settimeout(_SOCK_TIMEOUT)
-        self._port_file.write_text(str(self._tcp_port))
+        self._port_file.write_text(str(self._tcp_port), encoding="utf-8")
         return True
 
     def start_listening(self, on_reload: Callable[[str], None]) -> None:

--- a/src/quodeq/dashboard/_process.py
+++ b/src/quodeq/dashboard/_process.py
@@ -41,7 +41,7 @@ def _kill_stale_action_api(host: str, port: int) -> None:
     pid_file = _get_pid_file()
     if pid_file.exists():
         try:
-            pid = int(pid_file.read_text().strip())
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
             _terminate_pid(pid)
         except (ValueError, OSError) as exc:
             log_debug(f"Could not kill stale action API (pid file): {exc}")

--- a/src/quodeq/data/fs/_index_io.py
+++ b/src/quodeq/data/fs/_index_io.py
@@ -27,7 +27,7 @@ def _load_index(reports_dir: Path) -> dict[str, str]:
     if cached is not None and cached[0] == mtime:
         return dict(cached[1])  # return a copy so callers can mutate safely
     try:
-        data = json.loads(index_path.read_text())
+        data = json.loads(index_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
     index_cache.set(index_path, (mtime, dict(data)))

--- a/src/quodeq/data/fs/_json_loader.py
+++ b/src/quodeq/data/fs/_json_loader.py
@@ -41,7 +41,7 @@ def load_json_file(path: Path, label: str) -> dict:
     if not path.exists():
         raise NotFoundError(f"{label}")
     try:
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
         raise NotFoundError(
             f"Invalid JSON in {label} — check the file for syntax errors or validate with a JSON linter"

--- a/src/quodeq/data/fs/_resolution.py
+++ b/src/quodeq/data/fs/_resolution.py
@@ -70,7 +70,7 @@ def _find_existing_project(
         if not info_file.exists():
             continue
         try:
-            info = json.loads(info_file.read_text())
+            info = json.loads(info_file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
         if info.get("name") != identity.project_name:
@@ -119,7 +119,7 @@ def _create_project(
     if parent_uuid:
         info["parent"] = parent_uuid
     try:
-        (project_dir / _REPO_INFO_FILENAME).write_text(json.dumps(info, indent=2))
+        (project_dir / _REPO_INFO_FILENAME).write_text(json.dumps(info, indent=2), encoding="utf-8")
     except OSError as exc:
         logging.getLogger(__name__).warning("Could not write repository_info.json: %s", exc)
     index = load_fn(reports_dir)

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -40,7 +40,7 @@ def _read_source_file_count(run_dir: Path) -> int:
         if path.suffix != ".json":
             continue
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         count = data.get("sourceFileCount")

--- a/src/quodeq/llm_bridge/_models.py
+++ b/src/quodeq/llm_bridge/_models.py
@@ -26,7 +26,7 @@ def get_known_models(*, _cache: dict | None = None) -> dict[str, list[dict]]:
     if _KNOWN_MODELS is not None:
         return _KNOWN_MODELS
     try:
-        _KNOWN_MODELS = json.loads(_models_path().read_text())
+        _KNOWN_MODELS = json.loads(_models_path().read_text(encoding="utf-8"))
         return _KNOWN_MODELS
     except (OSError, json.JSONDecodeError) as exc:
         _log.warning("Could not load known_models.json: %s", exc)

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -32,7 +32,7 @@ def _read_omlx_api_key() -> str:
     if env_key:
         return env_key
     try:
-        cfg = json.loads((Path.home() / ".omlx" / "settings.json").read_text())
+        cfg = json.loads((Path.home() / ".omlx" / "settings.json").read_text(encoding="utf-8"))
         return cfg.get("auth", {}).get("api_key", "")
     except (OSError, json.JSONDecodeError):
         return ""

--- a/src/quodeq/services/_ephemeral_cleanup.py
+++ b/src/quodeq/services/_ephemeral_cleanup.py
@@ -50,7 +50,7 @@ def maybe_cleanup_after_job(
     """
     info_path = Path(reports_root) / project_uuid / "repository_info.json"
     try:
-        raw = info_path.read_text()
+        raw = info_path.read_text(encoding="utf-8")
     except (OSError, ValueError):
         return
     try:

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -26,7 +26,7 @@ def _status_json_terminal(run_dir: Path) -> bool:
     if not status_path.exists():
         return False
     try:
-        data = json.loads(status_path.read_text())
+        data = json.loads(status_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return False
     state = data.get("state")

--- a/src/quodeq/services/_external_jobs.py
+++ b/src/quodeq/services/_external_jobs.py
@@ -46,7 +46,7 @@ def resolve_external_pid(project_uuid: str, run_id: str, reports_root: Path) -> 
     if not pid_file.exists():
         return None
     try:
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
     except (OSError, ValueError):
         return None
     # Use the shared liveness probe -- os.kill(pid, 0) is unsafe on

--- a/src/quodeq/services/_filesystem_helpers.py
+++ b/src/quodeq/services/_filesystem_helpers.py
@@ -18,7 +18,7 @@ def _read_dimensions_from_file(dims_file: str) -> tuple[str, ...]:
     try:
         p = Path(dims_file)
         if p.exists():
-            data = json.loads(p.read_text())
+            data = json.loads(p.read_text(encoding="utf-8"))
             return tuple(d["id"] for d in data.get("applies", []))
         return ()
     except (OSError, json.JSONDecodeError, KeyError, TypeError):

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -15,7 +15,7 @@ def _read_scan_summary(reports_root: Path, entry_name: str) -> dict[str, Any]:
     if not scan_path.exists():
         return {}
     try:
-        data = json.loads(scan_path.read_text())
+        data = json.loads(scan_path.read_text(encoding="utf-8"))
         return {
             "scanDate": data.get("scanned_at"),
             "totalFiles": data.get("total_files"),
@@ -50,7 +50,7 @@ def _read_repo_info(reports_root: Path, entry_name: str) -> dict[str, Any]:
     if not info_path.exists():
         return {}
     try:
-        return json.loads(info_path.read_text())
+        return json.loads(info_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return {}
 
@@ -83,7 +83,7 @@ def _read_language_stats(reports_root: Path, entry_name: str, runs: list[RunInfo
     for run in runs:
         manifest_path = reports_root / entry_name / run.run_id / "evidence" / "manifest.json"
         try:
-            data = json.loads(manifest_path.read_text())
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
             stats = data.get("language_stats") or {}
             if stats:
                 return {k.lstrip("."): v for k, v in stats.items()}
@@ -95,7 +95,7 @@ def _read_language_stats(reports_root: Path, entry_name: str, runs: list[RunInfo
 def _read_discipline_from_eval(eval_path: Path) -> str | None:
     """Try to read a discipline string from a single evidence JSON file."""
     try:
-        return json.loads(eval_path.read_text()).get("discipline") or None
+        return json.loads(eval_path.read_text(encoding="utf-8")).get("discipline") or None
     except (OSError, json.JSONDecodeError):
         return None
 

--- a/src/quodeq/services/_fs_project_helpers.py
+++ b/src/quodeq/services/_fs_project_helpers.py
@@ -31,14 +31,14 @@ def _backfill_onboarding_field(project_dir: Path) -> dict | None:
     if not info_path.exists():
         return None
     try:
-        data = json.loads(info_path.read_text())
+        data = json.loads(info_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
     if "onboardingCompletedAt" in data:
         return data
     data["onboardingCompletedAt"] = data.get("createdAt") or datetime.now(timezone.utc).isoformat()
     try:
-        info_path.write_text(json.dumps(data, indent=2))
+        info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
     except OSError:
         pass
     return data

--- a/src/quodeq/services/_fs_projects.py
+++ b/src/quodeq/services/_fs_projects.py
@@ -59,7 +59,7 @@ def find_children(reports_root: Path, parent_id: str) -> list[str]:
         if not info_path.exists():
             continue
         try:
-            info = json.loads(info_path.read_text())
+            info = json.loads(info_path.read_text(encoding="utf-8"))
             if info.get("parent") == parent_id:
                 children.append(entry.name)
         except (json.JSONDecodeError, OSError):
@@ -76,7 +76,7 @@ def _build_parent_child_sets(reports_root: Path, dir_names: list[str]) -> tuple[
         if not info_path.exists():
             continue
         try:
-            info = json.loads(info_path.read_text())
+            info = json.loads(info_path.read_text(encoding="utf-8"))
             parent = info.get("parent")
             if parent:
                 parent_ids.add(parent)
@@ -150,10 +150,10 @@ def update_project_path(reports_dir: str, project: str, new_path: str) -> bool:
         location = "local"
 
     try:
-        info = json.loads(info_path.read_text())
+        info = json.loads(info_path.read_text(encoding="utf-8"))
         info["path"] = resolved_path
         info["location"] = location
-        info_path.write_text(json.dumps(info, indent=2))
+        info_path.write_text(json.dumps(info, indent=2), encoding="utf-8")
         return True
     except (json.JSONDecodeError, OSError):
         return False
@@ -190,7 +190,7 @@ def get_project_info(reports_dir: str, project: str) -> dict[str, Any] | None:
     if not info_path.exists():
         return None
     try:
-        info = json.loads(info_path.read_text())
+        info = json.loads(info_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 

--- a/src/quodeq/services/_fs_reports.py
+++ b/src/quodeq/services/_fs_reports.py
@@ -21,7 +21,7 @@ def _enrich_with_coverage(reports_dir: str, project: str, payload: dict[str, Any
     if not scan_path.exists():
         return payload
     try:
-        scan = json.loads(scan_path.read_text())
+        scan = json.loads(scan_path.read_text(encoding="utf-8"))
         total = scan.get("total_files", 0)
         payload["totalFiles"] = total
         # Compute analyzed_files from the files_count already tracked in run data.

--- a/src/quodeq/services/_fs_scan.py
+++ b/src/quodeq/services/_fs_scan.py
@@ -123,4 +123,4 @@ def _write_scan_json(scan: ScanData, output_dir: Path) -> None:
     """Persist scan data as JSON."""
     output_dir.mkdir(parents=True, exist_ok=True)
     payload = dataclasses.asdict(scan)
-    (output_dir / "scan.json").write_text(json.dumps(payload, indent=2))
+    (output_dir / "scan.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/quodeq/services/_index_sync.py
+++ b/src/quodeq/services/_index_sync.py
@@ -161,7 +161,7 @@ def _sync_legacy_run(
         state, exit_reason = "done", None
     elif pid_path.exists():
         try:
-            pid = int(pid_path.read_text().strip())
+            pid = int(pid_path.read_text(encoding="utf-8").strip())
             alive = _is_pid_alive(pid)
         except (OSError, ValueError):
             alive = False

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -26,12 +26,12 @@ def _require_id(data: dict, source: str) -> str:
 
 def default_read_json(path: Path) -> dict:
     """Read and parse a JSON file from disk."""
-    return json.loads(path.read_text())
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def default_write_json(path: Path, data: dict) -> None:
     """Serialize *data* as pretty-printed JSON and write it to *path*."""
-    path.write_text(json.dumps(data, indent=2))
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
 def count_principles_and_requirements(data: dict) -> tuple[int, int]:

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -87,7 +87,7 @@ def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None)
     if not path.is_file():
         return {}
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         mapping: dict[str, str] = {}
         for p in data.get("principles", []):
             pname = p.get("name", "")

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -129,7 +129,7 @@ def _enrich_from_json_eval(run_dir: Path, keys: set[tuple], out: dict[tuple, dic
         if path.suffix != ".json":
             continue
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
         dimension = path.stem

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -107,7 +107,7 @@ def _scan_parent_project(project_dir: Path, reports_path: Path, repo_path: Path)
     """Scan the parent project directory if it lacks a scan.json."""
     info_path = project_dir / "repository_info.json"
     try:
-        parent_uuid = json.loads(info_path.read_text()).get("parent")
+        parent_uuid = json.loads(info_path.read_text(encoding="utf-8")).get("parent")
         if parent_uuid:
             parent_dir = reports_path / parent_uuid
             if not (parent_dir / "scan.json").exists():
@@ -175,11 +175,11 @@ def _register_project(
 
     # Persist the resolved path + ephemeral flag in repository_info.json.
     info_path = project_dir / "repository_info.json"
-    info = json.loads(info_path.read_text()) if info_path.exists() else {}
+    info = json.loads(info_path.read_text(encoding="utf-8")) if info_path.exists() else {}
     info["path"] = str(target_path.resolve())
     info["location"] = _LOCATION_LOCAL
     info["ephemeral"] = bool(ephemeral)
-    info_path.write_text(json.dumps(info, indent=2))
+    info_path.write_text(json.dumps(info, indent=2), encoding="utf-8")
 
     # Scan now that files are guaranteed on disk.
     scan_project(target_path, output_dir=project_dir)
@@ -200,13 +200,13 @@ def _ensure_onboarding_field(project_dir: Path) -> None:
     if not info_path.exists():
         return
     try:
-        data = json.loads(info_path.read_text())
+        data = json.loads(info_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return
     if "onboardingCompletedAt" in data:
         return
     data["onboardingCompletedAt"] = None
-    info_path.write_text(json.dumps(data, indent=2))
+    info_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
 class FsEvaluationMixin:

--- a/src/quodeq/services/standards_library.py
+++ b/src/quodeq/services/standards_library.py
@@ -65,7 +65,7 @@ class StandardsLibraryClient:
             raise ValueError(f"Invalid standard ID from library: {data['id']}")
         # Check for collision with existing standard
         if dest.is_file():
-            existing = json.loads(dest.read_text())
+            existing = json.loads(dest.read_text(encoding="utf-8"))
             if existing.get("origin") == file_path:
                 # Same origin — update in place
                 pass
@@ -79,5 +79,5 @@ class StandardsLibraryClient:
         data["managed"] = True
         data["origin"] = file_path
         data["origin_hash"] = content_hash
-        dest.write_text(json.dumps(data, indent=2))
+        dest.write_text(json.dumps(data, indent=2), encoding="utf-8")
         return dest

--- a/src/quodeq/shared/_diff.py
+++ b/src/quodeq/shared/_diff.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 def show_diff(path: Path, new_content: str) -> None:
     """Print a unified diff between *path*'s current content and *new_content*."""
-    old_lines = path.read_text().splitlines(keepends=True) if path.exists() else []
+    old_lines = path.read_text(encoding="utf-8").splitlines(keepends=True) if path.exists() else []
     new_lines = new_content.splitlines(keepends=True)
     diff = list(difflib.unified_diff(old_lines, new_lines, fromfile=str(path), tofile="<new>"))
     if diff:

--- a/tests/test_no_bare_text_io.py
+++ b/tests/test_no_bare_text_io.py
@@ -1,0 +1,52 @@
+# tests/test_no_bare_text_io.py
+"""Guard: text-mode file I/O must pin encoding (UTF-8) for Windows safety.
+
+On Windows, Path.read_text()/write_text() and builtin open() default to the
+locale code page (e.g. cp1252), not UTF-8. Non-ASCII content then mis-decodes
+or raises UnicodeDecodeError at runtime, a bug class ASCII-only unit fixtures
+never catch. Pass encoding= explicitly on every text-mode call.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src" / "quodeq"
+
+_READ_WRITE = re.compile(r"\.(read_text|write_text)\(")
+_OPEN = re.compile(r"(?<![\w.])open\(")
+_HAS_ENCODING = re.compile(r"encoding\s*=")
+_BINARY_MODE = re.compile(r"""['"][rwax]{1,2}b\+?['"]""")
+
+# Sites that legitimately cannot pin encoding (document the reason).
+# Format: "src-relative/path.py:LINE"
+_ALLOWLIST: set[str] = {
+    # write_text() opener on its own line; encoding="utf-8" is passed on the
+    # following continuation line. The call IS UTF-8-safe; the line-based
+    # scanner just can't see a kwarg that lives on a different physical line.
+    "analysis/_dim_estimates.py:70",
+}
+
+
+def _offenders() -> list[str]:
+    bad: list[str] = []
+    for py in sorted(SRC.rglob("*.py")):
+        rel = py.relative_to(SRC).as_posix()
+        for i, line in enumerate(py.read_text(encoding="utf-8").splitlines(), 1):
+            if f"{rel}:{i}" in _ALLOWLIST:
+                continue
+            if _HAS_ENCODING.search(line) or _BINARY_MODE.search(line):
+                continue
+            if _READ_WRITE.search(line) or _OPEN.search(line):
+                bad.append(f"{rel}:{i}: {line.strip()}")
+    return bad
+
+
+def test_no_bare_text_io() -> None:
+    offenders = _offenders()
+    assert not offenders, (
+        f"{len(offenders)} text-I/O call(s) without explicit encoding "
+        "(breaks on Windows cp1252). Pass encoding='utf-8':\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/test_no_bare_text_io.py
+++ b/tests/test_no_bare_text_io.py
@@ -5,6 +5,12 @@ On Windows, Path.read_text()/write_text() and builtin open() default to the
 locale code page (e.g. cp1252), not UTF-8. Non-ASCII content then mis-decodes
 or raises UnicodeDecodeError at runtime, a bug class ASCII-only unit fixtures
 never catch. Pass encoding= explicitly on every text-mode call.
+
+This is a line-based scan. It also covers text-mode ``<receiver>.open(...)``
+calls (e.g. ``Path.open("w")``), which share the same cp1252 default. Receivers
+whose ``.open()`` is not a text-file open (fd-level ``os.open``, ``webbrowser``,
+or binary/archive openers like ``gzip``/``tarfile``/``zipfile``) are excluded
+via ``_NON_TEXT_OPEN``; binary-mode opens are exempted by ``_BINARY_MODE``.
 """
 from __future__ import annotations
 
@@ -16,8 +22,20 @@ SRC = REPO_ROOT / "src" / "quodeq"
 
 _READ_WRITE = re.compile(r"\.(read_text|write_text)\(")
 _OPEN = re.compile(r"(?<![\w.])open\(")
+_DOT_OPEN = re.compile(r"\.open\(")
 _HAS_ENCODING = re.compile(r"encoding\s*=")
 _BINARY_MODE = re.compile(r"""['"][rwax]{1,2}b\+?['"]""")
+
+# .open() receivers that are NOT text-file opens (fd-level, URLs, or binary/archive).
+_NON_TEXT_OPEN = (
+    "os.open(",
+    "webbrowser.open(",
+    "gzip.open(",
+    "tarfile.open(",
+    "zipfile.",
+    # zipfile.ZipFile.open() returns a binary stream (no encoding= concept).
+    "zf.open(",
+)
 
 # Sites that legitimately cannot pin encoding (document the reason).
 # Format: "src-relative/path.py:LINE"
@@ -38,7 +56,10 @@ def _offenders() -> list[str]:
                 continue
             if _HAS_ENCODING.search(line) or _BINARY_MODE.search(line):
                 continue
-            if _READ_WRITE.search(line) or _OPEN.search(line):
+            dot_open = _DOT_OPEN.search(line) and not any(
+                token in line for token in _NON_TEXT_OPEN
+            )
+            if _READ_WRITE.search(line) or _OPEN.search(line) or dot_open:
                 bad.append(f"{rel}:{i}: {line.strip()}")
     return bad
 


### PR DESCRIPTION
## Summary
- Pins `encoding="utf-8"` on all text-mode file I/O in `src/quodeq` (83 sites across 52 files: `read_text`/`write_text`/builtin `open()` plus a missed `Path.open()` JSONL writer). On Windows these default to the locale code page (cp1252), so any non-ASCII content (code snippets, accented paths, non-English findings) raised `UnicodeDecodeError` or corrupted silently. ASCII-only unit fixtures never caught it.
- Adds `tests/test_no_bare_text_io.py`, a regression guard that fails if any new unencoded text I/O (`read_text`/`write_text`/`open`/`.open`) lands, with documented exclusions for binary, file-descriptor, and URL openers.
- Behavior-preserving: purely additive `encoding="utf-8"`, no routing through helpers, no exception-semantics changes.

## Test Plan
- [x] `uv run pytest tests/test_no_bare_text_io.py` passes (guard green)
- [x] `uv run pytest tests/ -m "not integration"` gives 3108 passed, 5 deselected
- [x] No new mypy errors (verified against baseline)
- [x] Windows CI (windows-latest) stays green on this PR

Part of the Windows compatibility initiative. Separate follow-up: stdout/stderr console encoding for non-ASCII printing on a cp1252 Windows console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)