### PR TITLE
ci(windows): make windows-latest a blocking test gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,24 +9,14 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    # Windows is non-blocking for now — first time the suite runs there,
-    # expect platform-specific failures. Drop continue-on-error once the
-    # job is consistently green.
-    continue-on-error: ${{ matrix.experimental }}
-    # Cap the whole job so a hanging Windows test (no platform-safe
-    # timeout in the suite yet) fails fast instead of burning 6 h of
-    # runner minutes. Ubuntu + macOS finish in ~1 min; 15 min is plenty.
+    # Cap the whole job so a hanging test fails fast instead of burning
+    # runner minutes. Ubuntu + macOS finish in ~1 min, Windows in ~2-3 min.
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.13"]
-        experimental: [false]
-        include:
-          - os: windows-latest
-            python-version: "3.13"
-            experimental: true
 
     steps:
       - uses: actions/checkout@v6
@@ -51,6 +41,6 @@ jobs:
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         # Verbose + -ra so per-test names and the FAILED summary survive
-        # GitHub's log truncation. Until Windows is fully green we need
-        # the test names visible to fix individual failures.
+        # GitHub's log truncation, making any Windows-specific failure easy
+        # to pinpoint now that Windows is a blocking gate.
         run: uv run pytest tests/ -v -ra --tb=short -m "not integration"


### PR DESCRIPTION
## Summary
- Folds `windows-latest` into the main test matrix and removes the `experimental` dimension + `continue-on-error`, so a Windows test failure now **blocks** PRs instead of being silently masked.
- Windows is confirmed green: PR #560's run was `3074 passed, 34 skipped, 5 deselected` on `windows-latest` (the 34 skips are platform-specific POSIX tests). This closes the silent-regression hole the old `continue-on-error` left open.

## Branch protection (action required after merge)
Dropping the `experimental` matrix value **renames the status checks**:
- `test (ubuntu-latest, 3.13, false)` -> `test (ubuntu-latest, 3.13)`
- `test (macos-latest, 3.13, false)` -> `test (macos-latest, 3.13)`
- `test (windows-latest, 3.13, true)` -> `test (windows-latest, 3.13)`

Update the required status checks on `develop` and `main` branch protection to the new names (and add `test (windows-latest, 3.13)` as required). Otherwise the old required-check names stop reporting and can block future PRs.

## Test Plan
- [x] This PR's own `test (windows-latest, 3.13)` job passes (and is now required to merge)
- [x] `actionlint` passes on the edited workflow

Part of the Windows compatibility initiative (follows #560).

🤖 Generated with [Claude Code](https://claude.com/claude-code)