### PR TITLE
test(windows): headless API smoke + nightly Windows integration lane

### DIFF
--- a/.github/workflows/windows-integration.yml
+++ b/.github/workflows/windows-integration.yml
@@ -1,0 +1,33 @@
+name: Windows integration (non-blocking)
+
+# Exercises the @pytest.mark.integration suite (real subprocesses, server boot,
+# signal handling) on Windows. These are timing-sensitive and some paths are
+# POSIX-only, so this lane is intentionally NOT a required PR check: it runs on
+# a schedule (and on demand) to surface Windows-specific regressions for triage.
+
+on:
+  schedule:
+    - cron: "0 4 * * *"   # nightly 04:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  windows-integration:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run integration tests
+        run: uv run pytest tests/ -v -ra --tb=short -m integration

--- a/tests/ci/test_cli_signals.py
+++ b/tests/ci/test_cli_signals.py
@@ -71,8 +71,19 @@ def _write_wrapper(tmp_path: Path, pause: float = 1.0) -> Path:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows TerminateProcess (what send_signal(SIGTERM) maps to) is not "
+    "catchable, so the SIGTERM handler that writes the cancelled status never "
+    "runs. Windows cancellation uses CTRL_BREAK_EVENT, which the CLI lifecycle "
+    "does not yet handle; a Windows-specific cancellation test is a separate "
+    "follow-up.",
+)
 def test_sigterm_writes_cancelled_status(tmp_path: Path) -> None:
-    """Spawn CLI subprocess, send SIGTERM mid-run, assert status.json=cancelled."""
+    """Spawn CLI subprocess, send SIGTERM mid-run, assert status.json=cancelled.
+
+    POSIX-only: see the skipif above for why this cannot run on Windows.
+    """
     src = tmp_path / "src"
     src.mkdir()
     (src / "hello.py").write_text("def f(): return 1\n")

--- a/tests/ci/test_server_health_smoke.py
+++ b/tests/ci/test_server_health_smoke.py
@@ -1,0 +1,85 @@
+"""Boot the Flask API as a real subprocess and assert /api/health serves 200.
+
+Exercises the real socket bind + subprocess spawn cross-platform (the parts a
+Flask ``test_client`` cannot cover). This is the headless backend smoke that
+gives confidence the server starts on Windows without a desktop session.
+
+Marked ``integration``: it spawns a real process and is timing-sensitive, so it
+runs in the dedicated lanes (nightly + windows-integration.yml), not the fast,
+deterministic PR gate.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_READY_TIMEOUT_S = 30
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@pytest.mark.integration
+def test_api_health_subprocess(tmp_path: Path) -> None:
+    """The API process starts, binds, and serves GET /api/health -> 200."""
+    port = _free_port()
+    state = tmp_path / "state"
+    env = {
+        **os.environ,
+        # Isolate the server's real state dir. api.app startup runs
+        # sweep_orphaned_clones(), which reads the vars below (falling back to
+        # the real ~/.quodeq/*). QUODEQ_HOME is read by nothing, so it does NOT
+        # isolate state on its own; point the real keys at tmp_path.
+        "QUODEQ_DIR": str(state),
+        "QUODEQ_INDEX_DB_PATH": str(state / "index.db"),
+        "QUODEQ_EVALUATIONS_DIR": str(state / "evaluations"),
+        "QUODEQ_CLONES_DIR": str(state / "clones"),
+        "QUODEQ_ACTION_API_HOST": "127.0.0.1",
+        "QUODEQ_ACTION_API_PORT": str(port),
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "quodeq.api.app"],
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    try:
+        url = f"http://127.0.0.1:{port}/api/health"
+        deadline = time.monotonic() + _READY_TIMEOUT_S
+        last_err: Exception | None = None
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                _out, err = proc.communicate()
+                pytest.fail(
+                    f"API process exited early (rc={proc.returncode}):\n"
+                    f"{err.decode('utf-8', 'replace')}"
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=2) as resp:  # noqa: S310
+                    body = resp.read().decode("utf-8")
+                    assert resp.status == 200, f"status={resp.status} body={body}"
+                    assert '"ok"' in body, f"unexpected /api/health body: {body}"
+                    return
+            except urllib.error.URLError as exc:  # not bound yet -> retry
+                last_err = exc
+                time.sleep(0.5)
+        pytest.fail(
+            f"/api/health never returned 200 within {_READY_TIMEOUT_S}s "
+            f"(last error: {last_err!r})"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()


### PR DESCRIPTION
## Summary
Exercise the risky runtime paths on Windows that the (now blocking) unit gate does not cover:
- **Headless API smoke** (`tests/ci/test_server_health_smoke.py`): spawns `python -m quodeq.api.app` on an ephemeral port and asserts `GET /api/health` returns 200, then tears the process down. Proves the server boots + binds + serves without a desktop session. Isolates state via `QUODEQ_INDEX_DB_PATH`/`QUODEQ_EVALUATIONS_DIR`/`QUODEQ_CLONES_DIR` (the keys the server actually reads).
- **Windows-correct signals** (`tests/ci/test_cli_signals.py`): skip `test_sigterm_writes_cancelled_status` on Windows, where `send_signal(SIGTERM)` maps to the uncatchable `TerminateProcess` so the cancel handler never runs. The signal-free completion test still runs on Windows.
- **Nightly Windows integration lane** (`.github/workflows/windows-integration.yml`): runs `pytest -m integration` on `windows-latest` on a schedule + `workflow_dispatch`. Intentionally **non-blocking** (timing-sensitive, some integration paths are POSIX-only); its job is to surface Windows regressions for triage.

## Notes
- The lane also collects `test_index_e2e.py` and `test_terminal_stream_e2e.py`. Per plan, their first Windows runs may surface failures to triage as follow-ups; this PR does not promise every integration test is green on Windows.
- Follow-ups (separate): a Windows `CTRL_BREAK_EVENT` cancellation test once the CLI lifecycle handles it, and stdout/stderr console encoding.

## Test Plan
- [x] `test_server_health_smoke.py` + touched `test_cli_signals.py` pass locally on macOS
- [x] `actionlint` passes on the new workflow
- [ ] Lane runs green-or-triaged via `workflow_dispatch` after merge

Part of the Windows compatibility initiative (follows #560, #561).

🤖 Generated with [Claude Code](https://claude.com/claude-code)