### PR TITLE
perf(api-prompt): lead with constant prefix, trail variable file block (#551)

### DIFF
--- a/src/quodeq/data/prompts/api_prompt.md
+++ b/src/quodeq/data/prompts/api_prompt.md
@@ -11,16 +11,16 @@ You MUST evaluate EVERY principle group — not just the first ones.
 
 {{PROJECT_SHAPE}}
 
-## Source Files
-
-{{FILES_BLOCK}}
-
 ## Your Task
 
-Evaluate the source files against EACH principle group in the checklist above. Clean code returns `{"findings": []}`.
+Evaluate the source files below against EACH principle group in the checklist above. Clean code returns `{"findings": []}`.
 
 {{EVALUATION_RULES}}
 
 {{FINDING_SCHEMA}}
+
+## Source Files
+
+{{FILES_BLOCK}}
 
 Respond with ONLY this JSON.

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -66,6 +66,31 @@ class TestAssembleApiPrompt:
         assert '"severity"' in prompt
         assert '"violation"' in prompt
 
+    def test_constant_instructions_precede_variable_file_content(self, src_dir, standards_text):
+        """Constant task instructions and the finding schema must come BEFORE the
+        variable file content.
+
+        The API runner makes one call per file (or small file batch) in a
+        dimension run, and everything except the file block is identical across
+        those calls. Putting the constant instructions/schema first and the
+        per-call file content last maximises the shared prompt prefix so
+        Ollama/llama.cpp prompt-prefix caching can reuse it. The finding schema
+        is the last constant block before the file content, so asserting it
+        precedes the file content transitively guards the rules block too.
+        """
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        task_idx = prompt.index("## Your Task")
+        schema_idx = prompt.index("Each finding must be a JSON object")
+        file_content_idx = prompt.index("def hello():")
+
+        assert task_idx < file_content_idx, "task instructions must precede file content"
+        assert schema_idx < file_content_idx, "finding schema must precede file content"
+
     def test_handles_unreadable_file_gracefully(self, src_dir, standards_text):
         missing = src_dir / "gone.py"
         prompt = assemble_api_prompt(


### PR DESCRIPTION
## Summary

Reorders the API runner's evaluation prompt so the constant instructional segments lead and the variable per-file content trails. This is the prompt-prefix-caching item (issue #551 "what to consider" option 4) that was explicitly deferred from #559.

## Background

The direct-API path (`assemble_api_prompt` -> `api_prompt.md`) makes one model call per file (or small batch) in a dimension run. Within that run every prompt segment is identical across calls **except** the Source Files block:

| Segment | Varies per call? |
|---|---|
| Dimension, repo name, standards checklist, project shape | No (constant within a dimension run) |
| Task instructions, evaluation rules, finding schema | No (constant always) |
| **Source Files block** | **Yes** |

Previously the Source Files block sat in the middle of the template, so ~1k tokens of constant evaluation rules + finding schema trailed it. Ollama/llama.cpp prompt-prefix caching reuses the KV cache only up to the first token that differs, so everything after the file block was re-prefilled on every per-file call.

## Change

Template-only reorder of `src/quodeq/data/prompts/api_prompt.md`: move `## Source Files` + `{{FILES_BLOCK}}` to the end, after `## Your Task`, `{{EVALUATION_RULES}}`, and `{{FINDING_SCHEMA}}`. The task sentence gains the word "below" so its spatial reference stays accurate. No instruction text is added or removed.

New order: dimension / repo / standards / project shape -> task / rules / schema -> **source files** -> "Respond with ONLY this JSON."

## Why it helps

The divergence point moves from the middle of the prompt to the very end, so the shared prefix across per-file calls now includes the ~1k tokens of rules + schema. On a verified sample render the variable content is the last ~70 of ~4470 chars, section order is monotonic top-to-bottom, and no placeholders are left unrendered. Every call after the first in a dimension run now skips re-prefilling the rules + schema block.

## Not changed (by design)

- No semantic change to the instructions (pure reorder plus one positional word).
- System message (`_SYSTEM_PROMPT` in `_call_api`) unchanged and still constant.
- No Python logic touched; the per-finding parsing from #559 is untouched.
- Cross-dimension reordering (e.g. hoisting global constants above the dimension line) intentionally skipped: the dominant win is within a dimension run, and the issue scoped this to "task instructions + schema before file content."

## Testing

- New `test_constant_instructions_precede_variable_file_content` asserts the task header and finding schema precede the file content (schema is the last constant block, so it transitively guards the rules too). Written test-first: confirmed it failed on the old template (`## Your Task` at offset 458 came after `def hello():` at 417), passes after the reorder.
- Full `tests/analysis/` suite green (618 passed).

Refs #551. Builds on #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)