### PR TITLE
ci(windows): boot-smoke the packaged exe on /api/health

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -96,6 +96,37 @@ jobs:
         shell: pwsh
         run: .\packaging\windows\build-exe.ps1
 
+      - name: Smoke test exe (headless API)
+        shell: pwsh
+        # Boot the built bundle in headless API mode (Quodeq.exe --_api routes to
+        # quodeq.api.app:main via dashboard_entry.py) and assert it serves
+        # /api/health. Proves the PyInstaller bundle + bundled static UI start on
+        # a clean Windows runner. Non-blocking (continue-on-error) until it has
+        # been seen green on a real release, so an unverified assumption can't
+        # break a release; then drop continue-on-error to gate the release,
+        # mirroring how the windows-latest test job was promoted to blocking.
+        continue-on-error: true
+        run: |
+          $exe = "dist\dashboard-build\dist\Quodeq\Quodeq.exe"
+          if (-not (Test-Path $exe)) { throw "Quodeq.exe not found at $exe" }
+          $env:QUODEQ_ACTION_API_HOST = "127.0.0.1"
+          $env:QUODEQ_ACTION_API_PORT = "7863"
+          $p = Start-Process -FilePath $exe -ArgumentList "--_api" -PassThru
+          try {
+            $ok = $false
+            for ($i = 0; $i -lt 30; $i++) {
+              if ($p.HasExited) { throw "exe exited early (code $($p.ExitCode))" }
+              try {
+                $r = Invoke-WebRequest -UseBasicParsing "http://127.0.0.1:7863/api/health" -TimeoutSec 2
+                if ($r.StatusCode -eq 200) { $ok = $true; break }
+              } catch { Start-Sleep -Seconds 1 }
+            }
+            if (-not $ok) { throw "exe did not serve /api/health within 30s" }
+            Write-Host "Packaged exe served /api/health OK"
+          } finally {
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+          }
+
       - name: Upload zip to release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
Adds a boot-smoke step to the `build-windows-exe` job: after building, it launches the produced `Quodeq.exe --_api` (headless API mode, routed to `quodeq.api.app:main` via `packaging/macos/dashboard_entry.py`), polls `GET /api/health` until 200, then tears the process down. This proves the PyInstaller bundle + bundled static UI actually start on a clean Windows runner, instead of only asserting the zip exists.

## Non-blocking on purpose
The step is `continue-on-error: true` for now, mirroring how the `windows-latest` test job was introduced (#561): an unverified assumption about the packaged runtime must not break a release. Once it has been seen green on a real release, drop `continue-on-error` to make it gate the release.

## Verification limits (please read)
I can't run a Windows PyInstaller build here, so I verified what I could statically:
- `--_api` routing exists: `dashboard_entry.py:28-31` (`from quodeq.api.app import main as api_main`), and the Windows spec uses that entry (`packaging/windows/quodeq_dashboard.spec:35`).
- Built exe path: `build-exe.ps1` -> `dist\dashboard-build\dist\Quodeq\Quodeq.exe` (the COLLECT output, present before zipping).
- `actionlint` passes.

The step itself first executes on the next `release: published` run (this workflow has no `pull_request` trigger, so it does not run on this PR). Watch that release's `build-windows-exe` logs for "Packaged exe served /api/health OK"; if it misbehaves it will warn (not fail) thanks to `continue-on-error`.

## Test Plan
- [x] `actionlint` passes on `build-dmg.yml`
- [x] Next release: `build-windows-exe` shows the smoke step green, then a follow-up drops `continue-on-error`

Part of the Windows compatibility initiative (follows #560, #561, #562, #564).

🤖 Generated with [Claude Code](https://claude.com/claude-code)