### PR TITLE
fix(windows): force UTF-8 stdout/stderr at CLI and API entry

### DIFF
--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -124,6 +124,8 @@ def create_app(
 
 def main(env: dict[str, str] | None = None) -> None:
     """Start the Flask development server using environment configuration."""
+    from quodeq.shared._io import configure_stdio_utf8
+    configure_stdio_utf8()
     _env = env if env is not None else os.environ
     # SECURITY: API key read from environment. For hardened deployments,
     # consider a secrets manager or platform keychain instead.

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -82,6 +82,8 @@ def _install_broken_pipe_guard() -> None:
 
 def main(argv: list[str] | None = None) -> int:
     """Parse arguments and dispatch to the appropriate subcommand handler."""
+    from quodeq.shared._io import configure_stdio_utf8
+    configure_stdio_utf8()
     _install_broken_pipe_guard()
     load_env_file(default_paths())
     parser = build_parser()

--- a/src/quodeq/shared/_io.py
+++ b/src/quodeq/shared/_io.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any, IO
 
@@ -30,3 +32,24 @@ def read_json(path: Path) -> dict[str, Any]:
         return json.loads(path.read_text(encoding=TEXT_ENCODING))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
+
+
+def configure_stdio_utf8() -> None:
+    """Ensure this process (and spawned Python children) use UTF-8 for console I/O.
+
+    On Windows the console defaults to the active code page (e.g. cp1252), and a
+    bare ``LANG=C`` locale does the same on POSIX; printing non-ASCII text (file
+    paths, finding messages) then raises ``UnicodeEncodeError``. This reconfigures
+    stdout/stderr to UTF-8 for the current process and defaults ``PYTHONUTF8=1`` so
+    spawned Python children start in UTF-8 mode too. Call once at process entry; it
+    is safe and idempotent, and no-ops on streams that cannot be reconfigured.
+    """
+    os.environ.setdefault("PYTHONUTF8", "1")
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (ValueError, OSError):
+            pass

--- a/tests/shared/test_stdio_utf8.py
+++ b/tests/shared/test_stdio_utf8.py
@@ -1,0 +1,42 @@
+"""configure_stdio_utf8() lets a process print non-ASCII under a non-UTF-8 console.
+
+Simulates the Windows cp1252 console (and POSIX ``LANG=C``) by forcing a child
+interpreter to start with an ASCII stdout, then verifies that calling
+configure_stdio_utf8() makes non-ASCII output succeed instead of raising
+UnicodeEncodeError.
+"""
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+
+from quodeq.shared._io import configure_stdio_utf8
+
+
+def test_non_ascii_print_survives_ascii_console(tmp_path) -> None:
+    script = tmp_path / "print_unicode.py"
+    script.write_text(
+        "from quodeq.shared._io import configure_stdio_utf8\n"
+        "configure_stdio_utf8()\n"
+        "print('caf\\u00e9 \\u2713 \\U0001f600')\n",
+        encoding="utf-8",
+    )
+    # Force the child to start with an ASCII stdout (no UTF-8 mode), the way a
+    # legacy Windows console / LANG=C terminal behaves.
+    env = {**os.environ, "PYTHONIOENCODING": "ascii", "PYTHONUTF8": "0"}
+    result = subprocess.run(
+        [sys.executable, str(script)], env=env, capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+    assert "café".encode("utf-8") in result.stdout
+
+
+def test_configure_stdio_utf8_is_safe_and_sets_pythonutf8(monkeypatch) -> None:
+    # Streams without a reconfigure() method (e.g. StringIO) must not crash.
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+    configure_stdio_utf8()
+    assert os.environ.get("PYTHONUTF8") == "1"


### PR DESCRIPTION
## Summary
Closes the deferred console-encoding gap from the Windows initiative. On Windows the console defaults to the active code page (e.g. cp1252), so printing non-ASCII output (file paths with accents, finding messages, non-English text) raises `UnicodeEncodeError`. A bare `LANG=C` locale does the same on POSIX.

- New helper `quodeq.shared._io.configure_stdio_utf8()`: reconfigures `stdout`/`stderr` to UTF-8 for the current process (guarded + idempotent; no-ops on streams without `reconfigure`), and defaults `PYTHONUTF8=1` so spawned Python children start in UTF-8 mode too.
- Wired into the two output-producing entry points: `cli.py:main` (the CLI / `evaluate` output, and the dashboard launcher it dispatches to) and `api/app.py:main` (the server process). The `PYTHONUTF8=1` default then propagates UTF-8 mode to the API/webview children these spawn; frozen sub-dispatches (`--_api`, `--_evaluate`) route through these same `main()`s.

## Test Plan
- [x] New `tests/shared/test_stdio_utf8.py`: a child interpreter forced to ASCII stdout (`PYTHONIOENCODING=ascii`, simulating a cp1252 console) prints non-ASCII successfully **after** `configure_stdio_utf8()` (would `UnicodeEncodeError` without it); plus an idempotency/safety check. Runs on all platforms incl. `windows-latest`.
- [x] `uv run pytest tests/ -m "not integration"` -> 3112 passed
- [x] Entry-point integration tests still boot: `test_server_health_smoke` (api.app.main) and `test_normal_completion_writes_done` (cli.main) pass

Completes the Windows compatibility initiative (follows #560, #561, #562, #564, #565).

🤖 Generated with [Claude Code](https://claude.com/claude-code)