### PR TITLE
fix(breaker): final scan on stop so failure-streak trips deterministically

### DIFF
--- a/src/quodeq/analysis/cache/_failure_streak.py
+++ b/src/quodeq/analysis/cache/_failure_streak.py
@@ -86,18 +86,43 @@ class FailureStreakWatcher:
         recent: list[FileError] = []
         while not self._stop.is_set():
             offset, streak, recent = self._scan_once(offset, streak, recent)
-            if streak >= self._threshold and self.trip_event is None:
-                if not cancellation.is_cancelled():
-                    event = TripEvent(streak=streak, recent=list(recent[-self._threshold:]))
-                    self.trip_event = event
-                    _logger.error(
-                        "failure-streak breaker tripped: %d consecutive errors; recent=%s",
-                        streak, [(e.file, e.reason) for e in event.recent],
-                    )
-                    cancellation.request_cancel()
-                self._tripped.set()
+            if self._maybe_trip(streak, recent):
                 return  # one trip, then we're done
             self._stop.wait(timeout=_POLL_INTERVAL_S)
+        # Stop was signaled (dispatch finished or raised). Do one last scan so
+        # a streak written since the previous poll still trips. Without it, a
+        # dispatch that fails fast and returns within a single poll interval
+        # (a dead endpoint erroring every file, or a time-compressed test) can
+        # finish *between* polls -- the loop then exits at the top check having
+        # never scanned the errors, and the breaker misses a trip it should
+        # have caught. This mirrors the periodic-persist watcher's
+        # final-persist-on-stop guarantee and makes the trip independent of
+        # poll timing (the slow-runner flake).
+        offset, streak, recent = self._scan_once(offset, streak, recent)
+        self._maybe_trip(streak, recent)
+
+    def _maybe_trip(self, streak: int, recent: list[FileError]) -> bool:
+        """Record a trip when the consecutive-error streak hits the threshold.
+
+        Idempotent and safe to call after stop: only the first trip sets
+        ``trip_event`` and requests cancellation. Returns True once a trip is
+        registered so the poll loop knows to stop. If the run is already
+        cancelling for another reason, set ``_tripped`` but leave
+        ``trip_event`` None -- the breaker must not claim a cancellation it
+        didn't cause (preserves the prior behavior).
+        """
+        if streak < self._threshold or self.trip_event is not None:
+            return False
+        if not cancellation.is_cancelled():
+            event = TripEvent(streak=streak, recent=list(recent[-self._threshold:]))
+            self.trip_event = event
+            _logger.error(
+                "failure-streak breaker tripped: %d consecutive errors; recent=%s",
+                streak, [(e.file, e.reason) for e in event.recent],
+            )
+            cancellation.request_cancel()
+        self._tripped.set()
+        return True
 
     def _scan_once(
         self, offset: int, streak: int, recent: list[FileError],

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -444,9 +444,9 @@ class TestCircuitBreakerWiring:
                     "_marker": "file_done", "file": "b.py",
                     "status": "error", "reason": "token_limit",
                 }) + "\n")
-            # Give the watcher's poll loop time to read both errors and trip.
-            import time as _time
-            _time.sleep(1.0)
+            # No sleep: the breaker does a final scan on stop (see
+            # FailureStreakWatcher._run), so the trip is detected once dispatch
+            # returns rather than depending on a poll landing mid-dispatch.
             return _make_dummy_evidence(files_read=2)
 
         try:

--- a/tests/analysis/cache/test_failure_streak_breaker.py
+++ b/tests/analysis/cache/test_failure_streak_breaker.py
@@ -1,6 +1,7 @@
 """Consecutive-failure circuit breaker for the dim runner."""
 from __future__ import annotations
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,34 @@ class TestFailureStreakBreaker:
         watcher.stop_and_join(timeout=5.0)
         # The watcher sees cancellation already set and does not record a trip event.
         assert watcher.trip_event is None
+
+    def test_trips_on_final_scan_when_dispatch_ends_between_polls(self, tmp_path: Path):
+        """Regression (slow-runner flake): a streak written while the watcher
+        is parked in its poll wait, with stop signaled before the next poll,
+        must still trip via the final scan on stop.
+
+        On a fast machine a poll usually lands in time; on a slow/loaded
+        runner the dispatch can finish *between* polls, and without a
+        final-scan-on-stop guarantee the breaker exits its loop having never
+        scanned the errors -- the "DID NOT RAISE CircuitBreakerError" flake.
+        """
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.write_text("")  # empty: first scan sees nothing, watcher parks
+        watcher = FailureStreakWatcher(jsonl, threshold=2)
+        watcher.start()
+        # Let the watcher do its first (empty) scan and park in _stop.wait().
+        # This reproduces the exact slow-runner state: parked mid-interval.
+        time.sleep(0.05)
+        # Dispatch writes a 2-error streak, then finishes immediately -- stop
+        # is signaled well within one poll interval, before the next scan.
+        _append(jsonl, {"_marker": "file_done", "file": "a.py",
+                        "status": "error", "reason": "token_limit"})
+        _append(jsonl, {"_marker": "file_done", "file": "b.py",
+                        "status": "error", "reason": "token_limit"})
+        watcher.stop_and_join(timeout=5.0)
+        assert isinstance(watcher.trip_event, TripEvent)
+        assert watcher.trip_event.streak == 2
+        assert cancellation.is_cancelled()
 
 
 class TestCircuitBreakerError:

--- a/tests/integration/test_cancel_resume.py
+++ b/tests/integration/test_cancel_resume.py
@@ -145,9 +145,11 @@ class _ScriptedDispatcher:
         with jsonl.open("a") as out:
             for entry in self._script(files):
                 out.write(json.dumps(entry) + "\n")
-        # Give the breaker watcher a moment to read errors that may trip it.
-        import time as _t
-        _t.sleep(0.6)
+        # No sleep: the breaker does a final scan when the runner signals stop
+        # (see FailureStreakWatcher._run), so a trip is detected deterministically
+        # once dispatch returns -- it no longer depends on a poll landing during
+        # dispatch. The old fixed sleep was a slow-runner flake ("DID NOT RAISE
+        # CircuitBreakerError" on macos-latest).
         return _make_dummy_evidence(files_read=len(files))
 
     def _script(self, files: list[str]):


### PR DESCRIPTION
## Problem

`tests/integration/test_cancel_resume.py::TestBreakerTrip::test_breaker_raises_at_threshold` is flaky on CI. On 2026-05-30 it failed on `macos-latest` (`DID NOT RAISE CircuitBreakerError`) while passing on `ubuntu-latest`/`windows-latest` and on a sibling macOS job minutes later. It is **not** marked `@pytest.mark.integration`, so it runs in the fast PR gate (`-m "not integration"`) where `macos-latest` is a blocking gate, so the flake can intermittently block unrelated PRs.

## Root cause (a genuine breaker gap, surfaced as a test flake)

`FailureStreakWatcher._run` polls the evidence JSONL every `0.5s` and checks `while not self._stop.is_set()` at the **top** of the loop. The runner runs the dispatcher, then in `finally` calls `breaker.stop_and_join()` (sets `_stop`) and only afterward checks `breaker.trip_event`.

So if a dispatch writes a failure streak and finishes **within one poll interval**, the loop exits at the top check having **never scanned those errors**, `trip_event` stays `None`, and no `CircuitBreakerError` is raised.

- **Production gap:** a fast-failing dispatch (dead model endpoint erroring every file in well under 0.5s) could finish without being flagged as `exit_reason=failure_streak`.
- **The flake:** the test's `time.sleep(0.6)` only bought a 0.1s margin over the 0.5s poll. On a slow/contended `macos-latest` runner, scheduler jitter eats that margin, the post-write poll never fires before `_stop` is set, and the breaker misses the trip.

Proven deterministically with a repro against the real watcher (parked mid-poll, stop before next poll): **0/8 trips before the fix, 8/8 after.**

## Fix

Add a guaranteed **final scan after the stop loop**, with the trip logic extracted into an idempotent `_maybe_trip` helper. This mirrors the periodic-persist watcher's existing final-persist-on-stop guarantee and makes the trip **independent of poll timing**. Behavior for long-running dispatches is unchanged; only the between-polls edge case is now caught.

## Tests

- **New deterministic unit regression test** reproducing the slow-runner state (watcher parked mid-poll, stop before next poll). Fails without the fix (`trip_event = None`), passes with it. This is the real guard.
- **Removed the fragile sleeps** (`0.6s` and `1.0s`) from the two integration-style breaker tests; they now pass via the deterministic final scan, not timing.

## Verification

| Check | Result |
|---|---|
| Repro (real watcher) | 0/8 → 8/8 trips |
| New regression test, with fix / without fix | passes / fails (confirmed via stash) |
| Target test | 10/10, 0.71s → 0.10s |
| 3 breaker tests x 15 under full 16-core saturation | 15/15 |
| Affected suites (breaker + dim_runner + cancel_resume + lifecycle) | 48 passed |
| Full `tests/analysis/cache/` | 136 passed |
| mypy --strict on changed source | clean |
| Source-inspection guards (`breaker.stop_and_join(timeout=5.0)`, `watcher.join()`) | still pass (fix lives in `_failure_streak.py`, not the runner) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)