### PR TITLE
ci: integration lane on Linux + Windows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,22 +1,26 @@
-name: Windows integration (non-blocking)
+name: Integration (non-blocking)
 
 # Exercises the @pytest.mark.integration suite (real subprocesses, server boot,
-# signal handling) on Windows. These are timing-sensitive and some paths are
-# POSIX-only, so this lane is intentionally NOT a required PR check: it runs on
-# a schedule (and on demand) to surface Windows-specific regressions for triage.
+# signal handling) on Linux AND Windows. Timing-sensitive and some paths are
+# platform-specific, so this lane is intentionally NOT a required PR check: it
+# runs on a schedule (and on demand) to surface OS-specific regressions for triage.
 
 on:
   schedule:
-    - cron: "0 4 * * *"   # nightly 04:00 UTC
+    - cron: "0 4 * * *"
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
 jobs:
-  windows-integration:
-    runs-on: windows-latest
+  integration:
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Generalizes the Windows-only `windows-integration.yml` into `integration.yml` with a `matrix.os: [ubuntu-latest, windows-latest]`, running `pytest -m integration` on both. Closes the gap that Linux e2e coverage currently lags Windows: the subprocess / server-boot / eval-pipeline / signal paths now run on Linux too.

On Linux the SIGTERM-cancellation test (`test_sigterm_writes_cancelled_status`, skipped only on win32) actually runs, adding real coverage of the cancellation path.

Non-blocking by design (scheduled nightly + `workflow_dispatch`), same as before.

## Test Plan
- [x] `actionlint` passes
- [x] `integration (ubuntu-latest)` job green via `workflow_dispatch` (triggered on this branch)

Part of the Linux compatibility initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)