### PR TITLE
feat(cache): permissive content-addressed eval cache (file-change-only key)

### DIFF
--- a/src/quodeq/analysis/cache/__init__.py
+++ b/src/quodeq/analysis/cache/__init__.py
@@ -1,12 +1,19 @@
 """Content-addressed cache for analysis results.
 
-A successful (file, dimension) analysis is keyed by the SHA-256 of its
-inputs (file content, standards, prompts, model, ...) and stored as one
-atomic JSON entry. The next run computes the same key and either serves
-the recorded result or dispatches the work and writes the new entry.
+A successful (file, dimension) analysis is keyed by the SHA-256 of its real
+per-unit inputs (file content, path, dimension, language) and stored as one
+atomic, self-describing JSON entry. The next run computes the same key and
+either serves the recorded result or dispatches the work and writes the new
+entry.
 
-This is the canonical incremental layer. Half-computed work never gets
-a key, so there is no partial state to recover from.
+The key is permissive (cost-first): volatile inputs (model, prompts,
+standards, sampling) are NOT keyed — switching them reuses prior work. Each
+entry records those in its ``provenance`` block, so reuse across a model /
+prompts / standards boundary is surfaced, not silent; the user refreshes on
+demand with ``--clean-scan``.
+
+This is the canonical incremental layer. Half-computed work never gets a
+key, so there is no partial state to recover from.
 """
 from __future__ import annotations
 
@@ -15,9 +22,14 @@ from quodeq.analysis.cache.dimension_helpers import (
     ClassifyResult,
     build_cache_key_for_file,
     classify_files_via_cache,
+    format_provenance_drift,
     persist_dispatch_results,
 )
 from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.gc import (
+    collect_legacy_entries,
+    maybe_collect_legacy_entries,
+)
 from quodeq.analysis.cache.key import CacheKey, compute_key
 from quodeq.analysis.cache.local import LocalFileBackend, default_cache_root
 from quodeq.analysis.cache.runner import (
@@ -44,7 +56,10 @@ __all__ = [
     "analyze_unit",
     "build_cache_key_for_file",
     "classify_files_via_cache",
+    "collect_legacy_entries",
     "compute_key",
     "default_cache_root",
+    "format_provenance_drift",
+    "maybe_collect_legacy_entries",
     "persist_dispatch_results",
 ]

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -26,7 +26,7 @@ from quodeq.analysis.cache.dimension_helpers import (
     _SCHEMA_VERSION,
     _hash_prompts_combined,
 )
-from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.entry import CacheEntry, build_provenance, quodeq_version
 from quodeq.analysis.cache.key import CacheKey, compute_key
 from quodeq.analysis.cache.local import LocalFileBackend
 from quodeq.analysis.fingerprint import _hash_file, _hash_standards
@@ -67,10 +67,14 @@ def build_cache_writer(
     write already succeeded, so the run continues.
     """
     cache = LocalFileBackend(root=cache_root)
+    # Provenance context, captured once at construction (run-constant). These
+    # left the cache key in schema 3 but are recorded on each entry so reuse
+    # across a model/prompts/standards boundary is surfaceable, not silent.
     standards_hash = (
         (_hash_standards(standards_dir, dimension) if standards_dir else "") or ""
     )
     prompts_hash = _hash_prompts_combined()
+    version = quodeq_version()
 
     def write(file_path: str, findings: list[dict]) -> None:
         content_hash = _hash_file(src_root / file_path) or ""
@@ -79,10 +83,6 @@ def build_cache_writer(
             file_content_hash=content_hash,
             file_path=file_path,
             dimension=dimension,
-            standards_hash=standards_hash,
-            prompts_hash=prompts_hash,
-            evaluator_hash="",  # not yet versioned; matches build_cache_key_for_file
-            model_id=model_id,
             language=language,
         )
         key = compute_key(key_struct)
@@ -94,6 +94,12 @@ def build_cache_writer(
             file_path=file_path,
             dimension=dimension,
             model_id=model_id,
+            file_content_hash=content_hash,
+            language=language,
+            provenance=build_provenance(
+                model_id=model_id, prompts_hash=prompts_hash,
+                standards_hash=standards_hash, version=version,
+            ),
         )
         cache.put(key, entry)
 

--- a/src/quodeq/analysis/cache/dimension_helpers.py
+++ b/src/quodeq/analysis/cache/dimension_helpers.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.cache.backend import CacheBackend
-from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.entry import CacheEntry, build_provenance, quodeq_version
 from quodeq.analysis.cache.key import CacheKey, compute_key
 from quodeq.analysis.fingerprint import _hash_file, _hash_prompts_map, _hash_standards
 
@@ -42,7 +42,14 @@ _logger = logging.getLogger(__name__)
 # v1 -> v2: file_done marker contract; entries written without marker
 # filtering are no longer trusted, so old entries naturally invalidate
 # on the next input change.
-_SCHEMA_VERSION = 2
+# v2 -> v3: permissive key — model/prompts/standards/sampling left the key
+# (now provenance on the entry). The formula change re-keys every entry, so
+# schema-2 entries land in a different namespace that schema-3 lookups never
+# reach; the one-time GC (cache/gc.py) then reclaims them. This is the LAST
+# key change that costs a re-eval: entries are now self-describing
+# (file_content_hash stored), so any future key change is losslessly
+# migratable.
+_SCHEMA_VERSION = 3
 
 
 @dataclass(frozen=True)
@@ -54,6 +61,73 @@ class ClassifyResult:
     # Per-file cache key for the missed files, so the caller can write
     # entries after dispatch without recomputing the key.
     miss_keys: dict[str, str] = field(default_factory=dict)
+    # Per-field drift among cache hits: field -> {"count", "from", "to"}.
+    # Only fields that actually drifted appear. Lets the caller surface how
+    # many reused findings predate the current model / standards / prompts,
+    # so reuse across those boundaries is never silent.
+    provenance_drift: dict = field(default_factory=dict)
+
+
+# Provenance fields compared at classify time, in display order.
+_PROV_FIELDS = ("model_id", "standards_hash", "prompts_hash", "quodeq_version")
+# Fields whose values are human-readable enough to show in a summary; hashes
+# are not (an opaque SHA helps no one).
+_PROV_HUMAN_VALUE = frozenset({"model_id", "quodeq_version"})
+_PROV_LABELS = {
+    "model_id": "model",
+    "standards_hash": "standards",
+    "prompts_hash": "prompts",
+    "quodeq_version": "quodeq version",
+}
+
+
+def _current_provenance(config: RunConfig, dimension: str) -> dict:
+    """The provenance the current run would stamp on a fresh entry."""
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension)
+        if config.standards_dir else ""
+    ) or ""
+    return {
+        "model_id": _model_id_from(config),
+        "standards_hash": standards_hash,
+        "prompts_hash": _hash_prompts_combined(),
+        "quodeq_version": quodeq_version(),
+    }
+
+
+def _accumulate_drift(drift: dict, entry_provenance: dict, current: dict) -> None:
+    """Count, per provenance field, hits whose recorded value differs from the
+    current run. Unknown (blank/missing) entry values are skipped — we only
+    claim drift we can prove, so legacy/empty-provenance entries are quiet."""
+    for fname in _PROV_FIELDS:
+        old = entry_provenance.get(fname)
+        if not old:
+            continue
+        new = current.get(fname, "")
+        if old != new:
+            record = drift.setdefault(fname, {"count": 0, "from": old, "to": new})
+            record["count"] += 1
+
+
+def format_provenance_drift(drift: dict, *, reused: int) -> str:
+    """One-line summary of how many reused findings predate the current
+    model / standards / prompts. Empty string when nothing drifted."""
+    if not drift or reused <= 0:
+        return ""
+    parts: list[str] = []
+    for fname in _PROV_FIELDS:
+        record = drift.get(fname)
+        if not record:
+            continue
+        label = _PROV_LABELS[fname]
+        if fname in _PROV_HUMAN_VALUE:
+            parts.append(
+                f"{record['count']} across {label} change "
+                f"({record['from']} -> {record['to']})"
+            )
+        else:
+            parts.append(f"{record['count']} across {label} change")
+    return ", ".join(parts)
 
 
 def _hash_prompts_combined() -> str:
@@ -82,22 +156,22 @@ def _model_id_from(config: RunConfig) -> str:
 def build_cache_key_for_file(config: RunConfig, file_path: str, dimension: str) -> str:
     """Compute the cache key for a (file, dimension) pair under ``config``.
 
-    Returns a 64-char hex SHA-256. Same inputs always produce the same key.
+    Returns a 64-char hex SHA-256. The key is permissive: it depends only on
+    the real per-unit inputs (file content, path, dimension, language), so a
+    model switch or a quodeq/standards update reuses the cached result. The
+    volatile context is recorded on the entry's provenance at write time.
+
+    MUST stay byte-for-byte identical to the key built in
+    ``cache_writer.build_cache_writer`` and ``cache.runner._key_for`` —
+    ``CacheKey`` is the single source of truth and all three populate exactly
+    its fields.
     """
     content_hash = _hash_file(config.src / file_path) or ""
-    standards_hash = (
-        _hash_standards(config.standards_dir, dimension)
-        if config.standards_dir else ""
-    ) or ""
     key = CacheKey(
         schema_version=_SCHEMA_VERSION,
         file_content_hash=content_hash,
         file_path=file_path,
         dimension=dimension,
-        standards_hash=standards_hash,
-        prompts_hash=_hash_prompts_combined(),
-        evaluator_hash="",  # not yet versioned; revisit when evaluators are.
-        model_id=_model_id_from(config),
         language=config.language or "",
     )
     return compute_key(key)
@@ -133,6 +207,8 @@ def classify_files_via_cache(
     cached_findings: list[dict] = []
     misses: list[str] = []
     miss_keys: dict[str, str] = {}
+    provenance_drift: dict = {}
+    current_prov: dict | None = None  # computed lazily, only if there are hits
     for f in files:
         key = build_cache_key_for_file(config, f, dimension)
         hit = None if bypass_reads else cache.get(key)
@@ -141,10 +217,14 @@ def classify_files_via_cache(
             miss_keys[f] = key
         else:
             cached_findings.extend(hit.findings)
+            if current_prov is None:
+                current_prov = _current_provenance(config, dimension)
+            _accumulate_drift(provenance_drift, hit.provenance or {}, current_prov)
     result = ClassifyResult(
         cached_findings=cached_findings,
         misses=misses,
         miss_keys=miss_keys,
+        provenance_drift=provenance_drift,
     )
     if not bypass_reads and run_cache is not None:
         run_cache[dimension] = (files_tuple, result)
@@ -202,6 +282,14 @@ def persist_dispatch_results(
         return
     grouped, ok_files = _group_findings_by_file(jsonl_path)
     model_id = _model_id_from(config)
+    # Provenance context — run-constant, computed once. These left the cache
+    # key in schema 3; recording them keeps each entry self-describing.
+    standards_hash = (
+        _hash_standards(config.standards_dir, dimension)
+        if config.standards_dir else ""
+    ) or ""
+    prompts_hash = _hash_prompts_combined()
+    version = quodeq_version()
     for f in miss_files:
         if f not in ok_files:
             continue
@@ -217,5 +305,11 @@ def persist_dispatch_results(
             file_path=f,
             dimension=dimension,
             model_id=model_id,
+            file_content_hash=_hash_file(config.src / f) or "",
+            language=config.language or "",
+            provenance=build_provenance(
+                model_id=model_id, prompts_hash=prompts_hash,
+                standards_hash=standards_hash, version=version,
+            ),
         )
         cache.put(key, entry)

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -48,8 +48,10 @@ from quodeq.analysis.cache.dimension_helpers import (
     _group_findings_by_file,
     build_cache_key_for_file,
     classify_files_via_cache,
+    format_provenance_drift,
     persist_dispatch_results,
 )
+from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
 from quodeq.analysis.cache.local import LocalFileBackend
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.analysis.subagents.runner import (
@@ -215,6 +217,10 @@ def process_dimension_with_cache(
     """
     if cache is None:
         cache = LocalFileBackend()
+        # First cache open of a real run (tests inject their own cache and
+        # skip this branch). Reclaim entries orphaned by the schema bump,
+        # once per process. Best-effort: never blocks the run.
+        maybe_collect_legacy_entries(cache.root)
 
     files, _ext = _list_source_files(config, dim_id)
     if not files:
@@ -248,10 +254,15 @@ def process_dimension_with_cache(
         config, dim_id, files, cache, bypass_reads=bypass_reads,
     )
     n_hits = len(files) - len(classify.misses)
+    # Surface provenance drift on the classify log so reuse across a
+    # model/standards/prompts boundary is never silent (run.log -> side-pane
+    # log viewer + CLI). The user decides when to --clean-scan to refresh.
+    drift_note = format_provenance_drift(classify.provenance_drift, reused=n_hits)
     _logger.info(
-        "[%s] cache: %d hits / %d misses (%d total)%s",
+        "[%s] cache: %d hits / %d misses (%d total)%s%s",
         dim_id, n_hits, len(classify.misses), len(files),
         " - clean-scan invalidated" if bypass_reads else "",
+        f" - reused {drift_note}" if drift_note else "",
     )
     # Structured marker for the dashboard / SSE stream - one event per
     # dim summarising hit/miss split. Per-file events would be too noisy

--- a/src/quodeq/analysis/cache/entry.py
+++ b/src/quodeq/analysis/cache/entry.py
@@ -7,16 +7,49 @@ just a stream of finding dicts and migration is mechanical.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 
 # Bumped whenever the entry format itself changes shape. Independent of
 # CacheKey.schema_version, which gates input-side invalidation.
-ENTRY_FORMAT_VERSION = 1
+# v1 -> v2: entry became self-describing — it now stores the
+# ``file_content_hash`` it was keyed under plus a ``provenance`` block, so
+# any future key change can be migrated losslessly by recomputing the key
+# from stored fields instead of re-evaluating.
+ENTRY_FORMAT_VERSION = 2
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def quodeq_version() -> str:
+    """Best-effort current quodeq version string for provenance.
+
+    Lazily imported so this module stays import-cheap and never raises if the
+    package metadata is unavailable (e.g. running from an uninstalled tree)."""
+    try:
+        from quodeq import __version__  # noqa: PLC0415
+        return __version__ or ""
+    except Exception:  # noqa: BLE001 — provenance must never break a cache write
+        return ""
+
+
+def build_provenance(
+    *, model_id: str | None, prompts_hash: str | None, standards_hash: str | None,
+    version: str | None = None,
+) -> dict:
+    """Assemble the provenance block recorded on a cache entry.
+
+    Single source of truth for the provenance shape, so the three cache-write
+    sites (cache_writer, persist_dispatch_results, runner.analyze_unit) stay
+    identical. ``version`` defaults to the current quodeq version."""
+    return {
+        "model_id": model_id or "",
+        "prompts_hash": prompts_hash or "",
+        "standards_hash": standards_hash or "",
+        "quodeq_version": version if version is not None else quodeq_version(),
+    }
 
 
 @dataclass
@@ -30,6 +63,17 @@ class CacheEntry:
     file_path: str
     dimension: str
     model_id: str
+    # Self-describing fields (format v2). ``file_content_hash`` and
+    # ``language`` are the key fields not otherwise stored (``file_path`` and
+    # ``dimension`` already are); together with them, an entry records EVERY
+    # input its key was computed from, so any future cache-key change is
+    # losslessly migratable (recompute from stored fields, no re-eval).
+    # ``provenance`` records the volatile context the findings were produced
+    # under (model, prompts, standards, quodeq version) so reuse across those
+    # boundaries is never silent. All defaulted so format-1 entries still load.
+    file_content_hash: str = ""
+    language: str = ""
+    provenance: dict = field(default_factory=dict)
     created_at: str = field(default_factory=_utc_now)
     cache_format_version: int = ENTRY_FORMAT_VERSION
 
@@ -39,4 +83,10 @@ class CacheEntry:
     @classmethod
     def from_json(cls, text: str) -> CacheEntry:
         data = json.loads(text)
-        return cls(**data)
+        # Tolerate format drift in BOTH directions so a version mismatch never
+        # throws (a throw would make LocalFileBackend treat the entry as
+        # corrupt and DELETE it, destroying cached work):
+        #  - older entry, missing new keys -> defaulted fields fill in;
+        #  - newer entry, extra unknown keys -> ignore them.
+        valid = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in valid})

--- a/src/quodeq/analysis/cache/gc.py
+++ b/src/quodeq/analysis/cache/gc.py
@@ -1,0 +1,91 @@
+"""One-time garbage collection of cache entries from an older schema.
+
+Changing the cache-key formula (the schema 2 -> 3 permissive-key change)
+re-keys every entry: old entries land at paths current-schema lookups never
+reach, so they can only waste disk. This module reclaims them once, lazily,
+on the first cache open under a new schema.
+
+Best-effort and idempotent: an entry that fails to read is skipped and
+logged, never fatal; a second pass finds nothing left to remove. A per-root
+marker file plus an in-process memo ensure the walk runs at most once per
+schema per process.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+# Mirrors local._ENTRY_FILENAME. Duplicated rather than imported so this
+# module stays a leaf with no intra-package imports at load time (the GC is
+# triggered from dimension_runner, not local).
+_ENTRY_FILENAME = "entry.json"
+
+# (root, schema) pairs already collected in this process.
+_collected: set[tuple[str, int]] = set()
+
+
+def _current_schema() -> int:
+    # Lazy import: dimension_helpers is a heavier module (pulls RunConfig,
+    # fingerprint, etc.) and imports this package's other cache modules.
+    # Deferring keeps gc import-cheap and the dependency one-directional.
+    from quodeq.analysis.cache.dimension_helpers import _SCHEMA_VERSION  # noqa: PLC0415
+    return _SCHEMA_VERSION
+
+
+def collect_legacy_entries(root: Path, *, min_schema: int) -> int:
+    """Delete every cached entry whose ``schema_version`` is below *min_schema*.
+
+    Returns the number of entries removed. Never raises: an entry that cannot
+    be read is skipped and logged (we can't prove it's legacy, so we leave
+    it). Safe to call repeatedly — a second pass removes nothing.
+    """
+    if not root.exists():
+        return 0
+    removed = 0
+    for entry_path in root.rglob(_ENTRY_FILENAME):
+        try:
+            data = json.loads(entry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            _logger.debug("cache GC: skipping unreadable entry %s: %s", entry_path, exc)
+            continue
+        schema = data.get("schema_version")
+        if isinstance(schema, int) and schema < min_schema:
+            try:
+                shutil.rmtree(entry_path.parent)
+                removed += 1
+            except OSError as exc:
+                _logger.debug("cache GC: failed to remove %s: %s", entry_path.parent, exc)
+    return removed
+
+
+def maybe_collect_legacy_entries(root: Path) -> None:
+    """Run the legacy-entry GC at most once per (root, schema) per process.
+
+    Guarded by an in-process memo and an on-disk marker so the cache is
+    walked at most once after an upgrade. A non-existent root is a cheap
+    no-op — a brand-new cache has no legacy entries to reclaim.
+    """
+    schema = _current_schema()
+    memo_key = (str(root), schema)
+    if memo_key in _collected:
+        return
+    _collected.add(memo_key)
+    if not root.exists():
+        return
+    marker = root / f".gc_schema_{schema}"
+    try:
+        if marker.exists():
+            return
+        removed = collect_legacy_entries(root, min_schema=schema)
+        marker.write_text("", encoding="utf-8")
+        if removed:
+            _logger.info(
+                "cache GC: reclaimed %d entr%s older than schema %d",
+                removed, "y" if removed == 1 else "ies", schema,
+            )
+    except OSError as exc:  # marker write / unexpected IO — never fatal
+        _logger.debug("cache GC: best-effort pass failed for %s: %s", root, exc)

--- a/src/quodeq/analysis/cache/key.py
+++ b/src/quodeq/analysis/cache/key.py
@@ -1,16 +1,28 @@
 """Cache key — content-addressed identity for a (file, dimension) work unit.
 
-The key is the SHA-256 of a canonical JSON serialization of every input
-that affects the analysis output. Two runs with identical inputs compute
-the same key and share the cached result; any diverging input produces
-a different key and forces a fresh dispatch.
+The key is the SHA-256 of a canonical JSON serialization of the inputs that
+define *"this exact code, evaluated for this dimension."* Two runs with
+identical inputs compute the same key and share the cached result.
 
-What is intentionally NOT in the key:
-- timestamps, run_id, machine, user, git_commit, branch — those are
-  metadata about the run, not inputs to the analysis itself.
+The key is **permissive** (cost-first): it invalidates ONLY on a real
+per-unit change. Evaluations are expensive, the user already owns the
+explicit refresh path (``--clean-scan``), so cached findings stay resilient
+to everything except an actual file change.
 
-What might be added later:
-- evaluator code hash, when evaluators start shaping output deterministically.
+What is intentionally NOT in the key (recorded in ``CacheEntry.provenance``
+instead, so reuse across these boundaries is surfaced rather than silently
+re-evaluated):
+- ``model_id`` — switching models reuses prior work; the user refreshes if
+  they want the new model to re-run.
+- ``prompts_hash`` / ``standards_hash`` — a quodeq update or a standards edit
+  reuses prior work; ``--clean-scan`` refreshes on demand.
+- ``evaluator_hash`` and sampling params (``temperature``, ``max_tokens``).
+- timestamps, run_id, machine, user, git_commit, branch — run metadata, never
+  inputs to the analysis itself.
+
+``language`` stays in the key: it is a stable project property (not a quodeq
+update) and changing it genuinely changes which files exist and how they are
+analyzed.
 """
 from __future__ import annotations
 
@@ -21,21 +33,19 @@ from dataclasses import asdict, dataclass
 
 @dataclass(frozen=True)
 class CacheKey:
-    """Inputs that uniquely determine the analysis output for one work unit."""
+    """The real per-unit inputs that determine the analysis output.
+
+    Only these fields. Volatile inputs (model, prompts, standards, sampling)
+    are deliberately excluded — they live in ``CacheEntry.provenance``. Adding
+    a field here is a cache-wide invalidation, so do it only for a genuine
+    per-unit input.
+    """
 
     schema_version: int
     file_content_hash: str
     file_path: str
     dimension: str
-    standards_hash: str
-    prompts_hash: str
-    evaluator_hash: str
-    model_id: str
     language: str
-    # Sampling params: optional today, but baked into the key so any future
-    # variation invalidates correctly without a schema bump.
-    temperature: float | None = None
-    max_tokens: int | None = None
 
 
 def compute_key(key: CacheKey) -> str:

--- a/src/quodeq/analysis/cache/runner.py
+++ b/src/quodeq/analysis/cache/runner.py
@@ -24,7 +24,8 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from quodeq.analysis.cache.backend import CacheBackend
-from quodeq.analysis.cache.entry import CacheEntry
+from quodeq.analysis.cache.dimension_helpers import _SCHEMA_VERSION
+from quodeq.analysis.cache.entry import CacheEntry, build_provenance
 from quodeq.analysis.cache.key import CacheKey, compute_key
 
 
@@ -76,18 +77,15 @@ class UnitResult:
 
 
 def _key_for(unit: WorkUnit, schema_version: int) -> str:
+    # Permissive key: only the real per-unit inputs. The unit's volatile
+    # fields (standards/prompts/evaluator/model/sampling) are carried for
+    # provenance, not keying.
     return compute_key(CacheKey(
         schema_version=schema_version,
         file_content_hash=unit.file_content_hash,
         file_path=unit.file_path,
         dimension=unit.dimension,
-        standards_hash=unit.standards_hash,
-        prompts_hash=unit.prompts_hash,
-        evaluator_hash=unit.evaluator_hash,
-        model_id=unit.model_id,
         language=unit.language,
-        temperature=unit.temperature,
-        max_tokens=unit.max_tokens,
     ))
 
 
@@ -96,7 +94,7 @@ def analyze_unit(
     *,
     cache: CacheBackend,
     dispatcher: Dispatcher,
-    schema_version: int = 1,
+    schema_version: int = _SCHEMA_VERSION,
 ) -> UnitResult:
     """Cache-or-dispatch one work unit.
 
@@ -120,6 +118,12 @@ def analyze_unit(
         file_path=unit.file_path,
         dimension=unit.dimension,
         model_id=unit.model_id,
+        file_content_hash=unit.file_content_hash,
+        language=unit.language,
+        provenance=build_provenance(
+            model_id=unit.model_id, prompts_hash=unit.prompts_hash,
+            standards_hash=unit.standards_hash,
+        ),
     )
     cache.put(key, entry)
     return UnitResult(entry=entry, cache_hit=False)

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -84,6 +84,86 @@ def test_cache_writer_writes_empty_findings_entry(tmp_path):
     assert len(entries) == 1
 
 
+def test_cache_writer_records_provenance_and_content_hash(tmp_path):
+    """The written entry is self-describing: it stores the file_content_hash
+    it was keyed under and a provenance block (model / prompts / standards /
+    quodeq version) recording the volatile context it was produced under."""
+    import quodeq
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+    from quodeq.analysis.cache.dimension_helpers import (
+        _hash_prompts_combined,
+        build_cache_key_for_file,
+    )
+    from quodeq.analysis.cache.local import LocalFileBackend
+    from quodeq.analysis.fingerprint import _hash_file
+
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "Foo.kt").write_text("class Foo")
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root,
+        src_root=src_root,
+        standards_dir=None,
+        dimension="flexibility",
+        model_id="sonnet",
+        language="kotlin",
+    )
+    write("Foo.kt", [])
+
+    config = _make_config(src_root, model="sonnet", language="kotlin")
+    key = build_cache_key_for_file(config, "Foo.kt", "flexibility")
+    entry = LocalFileBackend(root=cache_root).get(key)
+    assert entry is not None
+    assert entry.file_content_hash == _hash_file(src_root / "Foo.kt")
+    prov = entry.provenance
+    assert prov["model_id"] == "sonnet"
+    assert prov["standards_hash"] == ""  # standards_dir=None
+    assert prov["prompts_hash"] == _hash_prompts_combined()
+    assert prov["quodeq_version"] == (quodeq.__version__ or "")
+
+
+def test_entry_is_self_describing_for_future_key_migration(tmp_path):
+    """The schema-3 self-describing guarantee: an entry stores EVERY field its
+    key was computed from (content hash, path, dimension, language), so a
+    future key change can be recomputed losslessly from the entry alone — no
+    re-evaluation. This is what makes the 2->3 change the last one that costs
+    a re-eval. Regressing it (e.g. dropping language from the entry) silently
+    breaks future migratability, so pin it."""
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+    from quodeq.analysis.cache.dimension_helpers import build_cache_key_for_file
+    from quodeq.analysis.cache.key import CacheKey, compute_key
+    from quodeq.analysis.cache.local import LocalFileBackend
+
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "Foo.kt").write_text("class Foo")
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root, src_root=src_root, standards_dir=None,
+        dimension="flexibility", model_id="sonnet", language="kotlin",
+    )
+    write("Foo.kt", [])
+
+    config = _make_config(src_root, model="sonnet", language="kotlin")
+    key = build_cache_key_for_file(config, "Foo.kt", "flexibility")
+    entry = LocalFileBackend(root=cache_root).get(key)
+    assert entry is not None
+
+    # Recompute the key PURELY from stored entry fields (the migration
+    # primitive — a real migration does this with schema_version + 1).
+    recomputed = compute_key(CacheKey(
+        schema_version=entry.schema_version,
+        file_content_hash=entry.file_content_hash,
+        file_path=entry.file_path,
+        dimension=entry.dimension,
+        language=entry.language,
+    ))
+    assert recomputed == key
+
+
 def test_cache_writer_key_matches_classify_files_via_cache(tmp_path):
     """LOAD-BEARING TEST: the key the closure computes MUST equal
     build_cache_key_for_file(config, file, dim). Otherwise the parent's

--- a/tests/analysis/cache/test_dimension_helpers.py
+++ b/tests/analysis/cache/test_dimension_helpers.py
@@ -25,6 +25,7 @@ from quodeq.analysis.cache.dimension_helpers import (
     ClassifyResult,
     build_cache_key_for_file,
     classify_files_via_cache,
+    format_provenance_drift,
     persist_dispatch_results,
 )
 
@@ -91,13 +92,15 @@ class TestKeyComposition:
             != build_cache_key_for_file(config, "a.py", "documentation")
         )
 
-    def test_model_change_invalidates(self, tmp_path: Path):
+    def test_model_change_does_not_invalidate(self, tmp_path: Path):
+        # Permissive key: switching model reuses the cache (model lives in
+        # provenance, not the key). This is the cost-first behavior.
         _write_files(tmp_path / "src", {"a.py": "x"})
         c1 = _make_config(tmp_path / "src", model="claude-opus-4-7")
         c2 = _make_config(tmp_path / "src", model="claude-sonnet-4-6")
         assert (
             build_cache_key_for_file(c1, "a.py", "security")
-            != build_cache_key_for_file(c2, "a.py", "security")
+            == build_cache_key_for_file(c2, "a.py", "security")
         )
 
     def test_language_change_invalidates(self, tmp_path: Path):
@@ -109,7 +112,10 @@ class TestKeyComposition:
             != build_cache_key_for_file(c2, "a.py", "security")
         )
 
-    def test_standards_change_invalidates(self, tmp_path: Path):
+    def test_standards_change_does_not_invalidate(self, tmp_path: Path):
+        # Permissive key: editing a standard reuses the cache. Standards drift
+        # is surfaced via provenance, and the user refreshes with --clean-scan
+        # when they want to re-evaluate against new standards.
         _write_files(tmp_path / "src", {"a.py": "x"})
         std_dir = tmp_path / "standards"
         _write_compiled_standards(std_dir, "security", '{"v": 1}')
@@ -117,22 +123,12 @@ class TestKeyComposition:
         k1 = build_cache_key_for_file(c1, "a.py", "security")
 
         _write_compiled_standards(std_dir, "security", '{"v": 2}')
-        # The in-process standards hash is memoized via _hash_file_by_stat,
-        # keyed on (path, size, mtime_ns). Both writes here produce 8-byte
-        # JSON, and on Windows file timestamps are quantized to ~16ms by
-        # the OS — so two rewrites in the same millisecond can share both
-        # size and mtime_ns, falsely hitting the cache. Explicitly bump
-        # mtime past the quantum so the cache invariant we're asserting
-        # ("standards rewrite invalidates the cache key") is testable on
-        # every platform. In real ``quodeq evaluate`` runs the standards
-        # file is not rewritten mid-process; this only matters for tests
-        # that simulate mid-run mutation.
         import os
         compiled = std_dir / "compiled" / "security.json"
         st = compiled.stat()
         os.utime(compiled, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
         k2 = build_cache_key_for_file(c1, "a.py", "security")
-        assert k1 != k2
+        assert k1 == k2
 
     def test_path_change_invalidates(self, tmp_path: Path):
         _write_files(tmp_path / "src", {"a.py": "x", "sub/a.py": "x"})
@@ -220,6 +216,107 @@ class TestClassify:
 
 
 # ============================================================
+# provenance drift (reuse across model/standards/prompts boundary)
+# ============================================================
+
+class TestProvenanceDrift:
+    def _seed(self, cache, config, files, *, provenance):
+        for f in files:
+            key = build_cache_key_for_file(config, f, "security")
+            cache.put(key, CacheEntry(
+                key=key, schema_version=3, findings=[{"file": f}],
+                files_read=1, file_path=f, dimension="security",
+                model_id=provenance.get("model_id", ""), provenance=provenance,
+            ))
+
+    def test_reports_model_drift_across_hits(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x", "b.py": "y"})
+        config = _make_config(tmp_path / "src", model="new-model")
+        # Seed entries produced under a different model. Other provenance
+        # fields are blank, so only the model field is a known difference.
+        self._seed(cache, config, files, provenance={
+            "model_id": "old-model", "standards_hash": "",
+            "prompts_hash": "", "quodeq_version": "",
+        })
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.misses == []
+        drift = result.provenance_drift
+        assert drift["model_id"]["count"] == 2
+        assert drift["model_id"]["from"] == "old-model"
+        assert drift["model_id"]["to"] == "new-model"
+        # Blank (unknown) fields are never reported as drift.
+        assert "standards_hash" not in drift
+        assert "prompts_hash" not in drift
+
+    def test_ignores_unknown_provenance(self, tmp_path: Path, cache: LocalFileBackend):
+        # A legacy / empty-provenance entry must not be claimed as drift —
+        # we can't know what it was produced under.
+        files = _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src", model="new-model")
+        self._seed(cache, config, files, provenance={})
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.misses == []
+        assert result.provenance_drift == {}
+
+    def test_no_drift_when_provenance_matches(self, tmp_path: Path, cache: LocalFileBackend):
+        files = _write_files(tmp_path / "src", {"a.py": "x"})
+        config = _make_config(tmp_path / "src", model="same-model")
+        self._seed(cache, config, files, provenance={
+            "model_id": "same-model", "standards_hash": "",
+            "prompts_hash": "", "quodeq_version": "",
+        })
+        result = classify_files_via_cache(config, "security", files, cache)
+        assert result.provenance_drift == {}
+
+
+class TestFormatProvenanceDrift:
+    def test_names_model_and_standards_with_counts(self):
+        drift = {
+            "model_id": {"count": 240, "from": "claude-sonnet-4", "to": "claude-opus-4"},
+            "standards_hash": {"count": 240, "from": "s3", "to": "s4"},
+        }
+        msg = format_provenance_drift(drift, reused=240)
+        assert "240" in msg
+        assert "model" in msg
+        assert "claude-sonnet-4" in msg and "claude-opus-4" in msg
+        assert "standards" in msg
+        # Opaque standards hashes are not dumped into user-facing text.
+        assert "s3" not in msg
+        # No em-dash in user-facing strings (repo convention).
+        assert "—" not in msg
+
+    def test_empty_when_no_drift(self):
+        assert format_provenance_drift({}, reused=100) == ""
+
+    def test_shows_version_transition_suppresses_all_hashes_in_order(self):
+        # Covers the other two field branches: quodeq_version (human-value,
+        # shows from->to) and prompts_hash (opaque, value suppressed). Pins
+        # that NEITHER the 'from' nor 'to' of an opaque hash leaks, and that
+        # fields render in _PROV_FIELDS order.
+        drift = {
+            "model_id": {"count": 3, "from": "sonnet", "to": "opus"},
+            "standards_hash": {"count": 3, "from": "s3", "to": "s4"},
+            "prompts_hash": {"count": 3, "from": "p3", "to": "p4"},
+            "quodeq_version": {"count": 3, "from": "1.0.0", "to": "1.1.2"},
+        }
+        msg = format_provenance_drift(drift, reused=3)
+        # Human-value fields show the transition.
+        assert "1.0.0" in msg and "1.1.2" in msg
+        assert "quodeq version" in msg
+        assert "prompts" in msg
+        # Opaque hashes never leak — neither 'from' nor 'to'.
+        for opaque in ("s3", "s4", "p3", "p4"):
+            assert opaque not in msg
+        # Rendered in _PROV_FIELDS order: model, standards, prompts, version.
+        assert (
+            msg.index("model")
+            < msg.index("standards")
+            < msg.index("prompts")
+            < msg.index("quodeq version")
+        )
+
+
+# ============================================================
 # persist_dispatch_results
 # ============================================================
 
@@ -300,6 +397,33 @@ class TestPersist:
         # Only a.py's key is in the cache; carried.py was never dispatched here.
         assert cache.get(miss_keys["a.py"]) is not None
         # No entry for carried.py — its key isn't even in miss_keys.
+
+    def test_persisted_entry_is_self_describing(self, tmp_path: Path, cache: LocalFileBackend):
+        # persist_dispatch_results writes entries that record the content
+        # hash they were keyed under and the provenance they were produced
+        # under, so reuse across a model/standards boundary is surfaceable.
+        files = _write_files(tmp_path / "src", {"a.py": "hello"})
+        config = _make_config(tmp_path / "src", work_dir=tmp_path / "work", model="model-1")
+        miss_keys = {f: build_cache_key_for_file(config, f, "security") for f in files}
+
+        jsonl = tmp_path / "work" / "security_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        jsonl.write_text(
+            json.dumps({"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n"
+        )
+
+        persist_dispatch_results(
+            config, "security", miss_files=files,
+            jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
+        )
+
+        entry = cache.get(miss_keys["a.py"])
+        assert entry is not None
+        assert entry.file_content_hash == hashlib.sha256(b"hello").hexdigest()
+        assert entry.provenance["model_id"] == "model-1"
+        assert "prompts_hash" in entry.provenance
+        assert "standards_hash" in entry.provenance
+        assert "quodeq_version" in entry.provenance
 
     def test_handles_missing_jsonl(self, tmp_path: Path, cache: LocalFileBackend):
         files = _write_files(tmp_path / "src", {"a.py": "x"})

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -21,6 +21,7 @@ state and the dispatcher call recorder.
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
@@ -207,6 +208,160 @@ class TestAllHits:
         jsonl = (tmp_path / "work" / "security_evidence.jsonl").read_text()
         lines = [json.loads(l) for l in jsonl.splitlines() if l.strip()]
         assert {l["w"] for l in lines} == {"a-cached", "b-cached"}
+
+
+class _ListHandler(logging.Handler):
+    """Capture log messages off a specific logger. The ``quodeq`` logger sets
+    propagate=False, so pytest's caplog (root) can't see these records — we
+    attach directly to the module logger instead."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+class TestProvenanceSurfacing:
+    def test_classify_log_names_model_drift_on_all_hits(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Reuse across a model change must never be silent: the per-dim
+        # classify log line surfaces that reused findings predate the
+        # current model.
+        config, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+        for f in ["a.py", "b.py"]:
+            key = build_cache_key_for_file(config, f, "security")
+            cache.put(key, CacheEntry(
+                key=key, schema_version=3,
+                findings=[{"file": f, "line": 1, "t": "violation", "w": f"{f}-cached"}],
+                files_read=1, file_path=f, dimension="security",
+                model_id="old-model",
+                provenance={
+                    "model_id": "old-model", "standards_hash": "",
+                    "prompts_hash": "", "quodeq_version": "",
+                },
+            ))
+
+        handler = _ListHandler()
+        logger = logging.getLogger("quodeq.analysis.cache.dimension_runner")
+        logger.addHandler(handler)
+        dispatcher = FakeDispatcher(src)
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=dispatcher,
+            ):
+                process_dimension_with_cache(
+                    config, "security", idx=1, ctx=_make_ctx(),
+                    callbacks=_make_callbacks(), cache=cache,
+                )
+        finally:
+            logger.removeHandler(handler)
+
+        assert dispatcher.calls == []
+        text = "\n".join(handler.messages)
+        assert "model" in text.lower()
+        assert "old-model" in text  # the model the reused findings predate
+
+
+class TestModelSwitchReuse:
+    def test_second_run_with_new_model_is_all_hits(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # The headline cost-first behavior: run a dimension on model A, then
+        # the SAME code on model B. The second run reuses every cached
+        # finding with zero re-dispatch, and the entries still record model A
+        # as their provenance so the drift is surfaceable.
+        config_a, src = _setup(tmp_path, {"a.py": "x", "b.py": "y"})
+        # config_a model is "test-model" (the _make_config default).
+
+        d1 = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=d1,
+        ):
+            process_dimension_with_cache(
+                config_a, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+        assert len(d1.calls) == 1  # cold cache -> dispatched the misses
+
+        # Same project, different model.
+        config_b = replace(
+            config_a,
+            options=replace(config_a.options, subagent_model="other-model"),
+        )
+        d2 = FakeDispatcher(src)
+        handler = _ListHandler()
+        logger = logging.getLogger("quodeq.analysis.cache.dimension_runner")
+        logger.addHandler(handler)
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=d2,
+            ):
+                ev = process_dimension_with_cache(
+                    config_b, "security", idx=1, ctx=_make_ctx(),
+                    callbacks=_make_callbacks(), cache=cache,
+                )
+        finally:
+            logger.removeHandler(handler)
+
+        # All hits despite the model change: no re-dispatch.
+        assert d2.calls == []
+        assert ev is not None
+
+        # The cache key is identical across the model switch, and the entry
+        # still remembers the model that produced it.
+        key = build_cache_key_for_file(config_b, "a.py", "security")
+        assert key == build_cache_key_for_file(config_a, "a.py", "security")
+        entry = cache.get(key)
+        assert entry is not None
+        assert entry.provenance["model_id"] == "test-model"
+
+        # End-to-end: the provenance written by run 1's persist is read back
+        # by run 2's classify and surfaced on the log, naming the model the
+        # reused findings predate. This pins the persist -> classify ->
+        # format_provenance_drift seam that the unit tests stub.
+        text = "\n".join(handler.messages)
+        assert "model" in text.lower()
+        assert "test-model" in text
+
+
+class TestGcWiring:
+    def test_default_backend_open_collects_legacy_entries(
+        self, tmp_path: Path, monkeypatch,
+    ):
+        # When no cache is injected (the production path), opening the default
+        # backend runs the one-time GC, reclaiming schema<3 entries. Sandbox
+        # the cache root via env so we never touch the real ~/.quodeq cache.
+        from quodeq.analysis.cache.local import default_cache_root
+
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path / "qroot"))
+        results_root = default_cache_root()
+        legacy_dir = results_root / "aa" / ("0" * 62)
+        legacy_dir.mkdir(parents=True, exist_ok=True)
+        (legacy_dir / "entry.json").write_text(json.dumps({
+            "key": "aa" + "0" * 62, "schema_version": 2, "findings": [],
+            "files_read": 1, "file_path": "old.py", "dimension": "security",
+            "model_id": "m",
+        }))
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            # cache=None -> production default-backend path -> GC fires.
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=None,
+            )
+
+        assert not (legacy_dir / "entry.json").exists()
 
 
 class TestAllMisses:

--- a/tests/analysis/cache/test_entry.py
+++ b/tests/analysis/cache/test_entry.py
@@ -1,6 +1,8 @@
 """Cache entry — JSON round-trip and shape."""
 from __future__ import annotations
 
+import json
+
 from quodeq.analysis.cache.entry import CacheEntry, ENTRY_FORMAT_VERSION
 
 
@@ -42,3 +44,78 @@ def test_created_at_is_iso_utc():
 def test_empty_findings_round_trip():
     entry = _make(findings=[])
     assert CacheEntry.from_json(entry.to_json()).findings == []
+
+
+def test_format_version_bumped_to_2():
+    # The new self-describing entry (file_content_hash + provenance) is
+    # format 2; the bump marks the shape change for any future migration.
+    assert ENTRY_FORMAT_VERSION == 2
+
+
+def test_file_content_hash_defaults_empty():
+    # Self-describing: an entry records the content hash it was keyed under,
+    # but the field is defaulted so legacy/partial construction still works.
+    assert _make().file_content_hash == ""
+
+
+def test_provenance_defaults_empty():
+    assert _make().provenance == {}
+
+
+def test_file_content_hash_round_trips():
+    entry = _make(file_content_hash="deadbeef")
+    assert CacheEntry.from_json(entry.to_json()).file_content_hash == "deadbeef"
+
+
+def test_provenance_round_trips():
+    prov = {
+        "model_id": "claude-opus-4-7",
+        "prompts_hash": "p123",
+        "standards_hash": "s456",
+        "quodeq_version": "1.1.2",
+    }
+    entry = _make(provenance=prov)
+    assert CacheEntry.from_json(entry.to_json()).provenance == prov
+
+
+def test_from_json_tolerates_legacy_format1_entry():
+    # A format-1 entry on disk has no file_content_hash / provenance keys.
+    # The read path must still load it, applying defaults, so an upgrade
+    # never throws on an old entry.
+    legacy = json.dumps({
+        "key": "abc123",
+        "schema_version": 2,
+        "findings": [],
+        "files_read": 1,
+        "file_path": "a.py",
+        "dimension": "security",
+        "model_id": "claude-opus-4-7",
+        "created_at": "2026-05-01T00:00:00+00:00",
+        "cache_format_version": 1,
+    })
+    restored = CacheEntry.from_json(legacy)
+    assert restored.file_content_hash == ""
+    assert restored.language == ""
+    assert restored.provenance == {}
+    assert restored.cache_format_version == 1
+    assert restored.model_id == "claude-opus-4-7"
+
+
+def test_from_json_ignores_unknown_future_keys():
+    # A newer quodeq may add entry fields. An older reader must IGNORE the
+    # extra keys, not raise — a TypeError here makes LocalFileBackend.get
+    # treat the entry as corrupt and DELETE it, destroying cached work that a
+    # concurrent newer process may still be using (a destructive downgrade).
+    future = json.dumps({
+        "key": "abc123",
+        "schema_version": 3,
+        "findings": [],
+        "files_read": 1,
+        "file_path": "a.py",
+        "dimension": "security",
+        "model_id": "m",
+        "a_field_a_future_quodeq_added": {"nested": 1},
+    })
+    restored = CacheEntry.from_json(future)
+    assert restored.key == "abc123"
+    assert restored.model_id == "m"

--- a/tests/analysis/cache/test_gc.py
+++ b/tests/analysis/cache/test_gc.py
@@ -1,0 +1,86 @@
+"""One-time GC of cache entries from an older schema.
+
+The permissive-key change (schema 2 -> 3) re-keys every entry, orphaning the
+old ones at paths current lookups never reach. The GC reclaims that dead disk
+once, lazily, on first cache open under the new schema. It must be
+best-effort and idempotent: never fatal on a bad entry, a no-op on a second
+pass, and it must never touch current-schema entries.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.analysis.cache.gc import (
+    collect_legacy_entries,
+    maybe_collect_legacy_entries,
+)
+
+
+def _write_entry(root: Path, key: str, *, schema: int) -> Path:
+    """Write a raw entry.json at the sharded path for *key*. Returns its dir."""
+    entry_dir = root / key[:2] / key[2:]
+    entry_dir.mkdir(parents=True, exist_ok=True)
+    (entry_dir / "entry.json").write_text(json.dumps({
+        "key": key, "schema_version": schema, "findings": [],
+        "files_read": 1, "file_path": "a.py", "dimension": "security",
+        "model_id": "m",
+    }))
+    return entry_dir
+
+
+def test_collect_deletes_entries_below_min_schema(tmp_path: Path):
+    root = tmp_path / "cache"
+    old = _write_entry(root, "aa" + "0" * 62, schema=2)
+    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+
+    removed = collect_legacy_entries(root, min_schema=3)
+
+    assert removed == 1
+    assert not (old / "entry.json").exists()
+    assert (new / "entry.json").exists()
+
+
+def test_collect_is_idempotent(tmp_path: Path):
+    root = tmp_path / "cache"
+    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+    _write_entry(root, "aa" + "0" * 62, schema=2)
+
+    assert collect_legacy_entries(root, min_schema=3) == 1
+    # Second pass finds nothing left to remove.
+    assert collect_legacy_entries(root, min_schema=3) == 0
+    assert (new / "entry.json").exists()
+
+
+def test_collect_skips_unreadable_entry(tmp_path: Path):
+    root = tmp_path / "cache"
+    corrupt_dir = root / "cc" / ("2" * 62)
+    corrupt_dir.mkdir(parents=True)
+    (corrupt_dir / "entry.json").write_text("{ not valid json")
+    new = _write_entry(root, "bb" + "1" * 62, schema=3)
+
+    # Must not raise; the corrupt entry is left in place (we can't read its
+    # schema to know it's legacy), and current entries are untouched.
+    removed = collect_legacy_entries(root, min_schema=3)
+
+    assert removed == 0
+    assert (corrupt_dir / "entry.json").exists()
+    assert (new / "entry.json").exists()
+
+
+def test_collect_handles_missing_root(tmp_path: Path):
+    assert collect_legacy_entries(tmp_path / "does-not-exist", min_schema=3) == 0
+
+
+def test_maybe_collect_runs_once_per_process(tmp_path: Path):
+    root = tmp_path / "cache"
+    _write_entry(root, "aa" + "0" * 62, schema=2)
+
+    maybe_collect_legacy_entries(root)
+    assert not (root / "aa" / ("0" * 62) / "entry.json").exists()  # collected
+    assert (root / ".gc_schema_3").exists()  # marker written
+
+    # A legacy entry seeded after the one-time pass is NOT collected again.
+    _write_entry(root, "dd" + "3" * 62, schema=2)
+    maybe_collect_legacy_entries(root)
+    assert (root / "dd" / ("3" * 62) / "entry.json").exists()

--- a/tests/analysis/cache/test_key.py
+++ b/tests/analysis/cache/test_key.py
@@ -1,25 +1,43 @@
-"""Cache key — stability and sensitivity properties."""
+"""Cache key — stability, sensitivity, and the permissive field set.
+
+The V2 cache key is permissive (cost-first): it invalidates ONLY on real
+per-unit changes — file content, file path, dimension, language. Volatile
+inputs (model, prompts, standards, sampling params) are deliberately NOT in
+the key; they are recorded in ``CacheEntry.provenance`` so reuse across those
+boundaries is surfaced, not silently re-evaluated.
+"""
 from __future__ import annotations
+
+import dataclasses
 
 from quodeq.analysis.cache.key import CacheKey, compute_key
 
 
 def _base_key(**overrides) -> CacheKey:
     defaults = dict(
-        schema_version=1,
+        schema_version=3,
         file_content_hash="aa" * 32,
         file_path="src/auth.py",
         dimension="security",
-        standards_hash="bb" * 32,
-        prompts_hash="cc" * 32,
-        evaluator_hash="dd" * 32,
-        model_id="claude-opus-4-7",
         language="python",
-        temperature=None,
-        max_tokens=None,
     )
     defaults.update(overrides)
     return CacheKey(**defaults)
+
+
+class TestPermissiveFieldSet:
+    def test_key_holds_only_file_change_fields(self):
+        # Structural guard: this is the contract. If a volatile field
+        # (model_id, prompts_hash, standards_hash, temperature, ...) is ever
+        # re-added to the key, this fails loudly — that is a cache-wide
+        # re-eval the user did not ask for.
+        assert {f.name for f in dataclasses.fields(CacheKey)} == {
+            "schema_version",
+            "file_content_hash",
+            "file_path",
+            "dimension",
+            "language",
+        }
 
 
 class TestStability:
@@ -29,11 +47,13 @@ class TestStability:
     def test_field_declaration_order_does_not_affect_key(self):
         # CacheKey is frozen and the canonicalization sorts keys, so a key
         # built piecewise in any order produces the same hash.
-        k1 = _base_key(model_id="claude-sonnet-4-6")
+        k1 = _base_key()
         k2 = CacheKey(
-            schema_version=1, file_content_hash="aa" * 32, file_path="src/auth.py",
-            dimension="security", standards_hash="bb" * 32, prompts_hash="cc" * 32,
-            evaluator_hash="dd" * 32, language="python", model_id="claude-sonnet-4-6",
+            file_content_hash="aa" * 32,
+            file_path="src/auth.py",
+            dimension="security",
+            language="python",
+            schema_version=3,
         )
         assert compute_key(k1) == compute_key(k2)
 
@@ -49,26 +69,16 @@ class TestSensitivity:
         b = compute_key(_base_key(dimension="documentation"))
         assert a != b
 
-    def test_standards_change_invalidates(self):
-        assert compute_key(_base_key(standards_hash="11" * 32)) != compute_key(_base_key(standards_hash="22" * 32))
-
-    def test_prompts_change_invalidates(self):
-        assert compute_key(_base_key(prompts_hash="11" * 32)) != compute_key(_base_key(prompts_hash="22" * 32))
-
-    def test_evaluator_change_invalidates(self):
-        assert compute_key(_base_key(evaluator_hash="11" * 32)) != compute_key(_base_key(evaluator_hash="22" * 32))
-
-    def test_model_change_invalidates(self):
-        assert compute_key(_base_key(model_id="claude-opus-4-7")) != compute_key(_base_key(model_id="claude-sonnet-4-6"))
+    def test_language_change_invalidates(self):
+        # Language stays in the key: it is a stable project property, and
+        # changing it genuinely changes which files exist and how they are
+        # analyzed.
+        a = compute_key(_base_key(language="python"))
+        b = compute_key(_base_key(language="kotlin"))
+        assert a != b
 
     def test_schema_version_change_invalidates(self):
-        assert compute_key(_base_key(schema_version=1)) != compute_key(_base_key(schema_version=2))
-
-    def test_temperature_change_invalidates(self):
-        assert compute_key(_base_key(temperature=None)) != compute_key(_base_key(temperature=0.7))
-
-    def test_max_tokens_change_invalidates(self):
-        assert compute_key(_base_key(max_tokens=None)) != compute_key(_base_key(max_tokens=4096))
+        assert compute_key(_base_key(schema_version=2)) != compute_key(_base_key(schema_version=3))
 
     def test_path_change_invalidates(self):
         # Path-sensitive rules (e.g. src/ vs tests/) must produce distinct keys.

--- a/tests/analysis/cache/test_runner.py
+++ b/tests/analysis/cache/test_runner.py
@@ -123,27 +123,38 @@ class TestDispatcherFailure:
         assert result.cache_hit is True
 
 
-# ---------- key sensitivity (every CacheKey field invalidates) ----------
+# ---------- key sensitivity (only real per-unit changes invalidate) ----------
 
 class TestInvalidation:
     @pytest.mark.parametrize("override", [
         {"file_content_hash": "00" * 32},
         {"file_path": "src/other.py"},
         {"dimension": "documentation"},
-        {"standards_hash": "11" * 32},
-        {"prompts_hash": "22" * 32},
-        {"evaluator_hash": "33" * 32},
-        {"model_id": "claude-sonnet-4-6"},
         {"language": "typescript"},
-        {"temperature": 0.7},
-        {"max_tokens": 4096},
     ])
-    def test_each_input_change_misses(self, cache: LocalFileBackend, override: dict):
+    def test_each_real_change_misses(self, cache: LocalFileBackend, override: dict):
         dispatcher = _RecordingDispatcher()
         analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
         result = analyze_unit(_unit(**override), cache=cache, dispatcher=dispatcher)
         assert result.cache_hit is False
         assert len(dispatcher.calls) == 2
+
+    @pytest.mark.parametrize("override", [
+        {"standards_hash": "11" * 32},
+        {"prompts_hash": "22" * 32},
+        {"evaluator_hash": "33" * 32},
+        {"model_id": "claude-sonnet-4-6"},
+        {"temperature": 0.7},
+        {"max_tokens": 4096},
+    ])
+    def test_volatile_change_reuses(self, cache: LocalFileBackend, override: dict):
+        # Permissive key: changing model / prompts / standards / sampling
+        # params reuses the cached result rather than re-dispatching.
+        dispatcher = _RecordingDispatcher()
+        analyze_unit(_unit(), cache=cache, dispatcher=dispatcher)
+        result = analyze_unit(_unit(**override), cache=cache, dispatcher=dispatcher)
+        assert result.cache_hit is True
+        assert len(dispatcher.calls) == 1
 
     def test_schema_version_bump_invalidates_everything(self, cache: LocalFileBackend):
         dispatcher = _RecordingDispatcher()
@@ -174,6 +185,42 @@ class TestRunnerOwnsKey:
         assert result.entry.file_path == "src/special.py"
         assert result.entry.dimension == "performance"
         assert result.entry.model_id == "claude-haiku-4"
+
+
+# ---------- schema default stays aligned with the live cache ----------
+
+class TestSchemaDefault:
+    def test_default_schema_matches_current_version(self, cache: LocalFileBackend):
+        # analyze_unit's default schema_version must equal the live cache
+        # schema, so it can never silently key into a stale namespace (whose
+        # writes the one-time GC would then reclaim). Keeps the runner
+        # byte-identical to the two live key sites by default.
+        from quodeq.analysis.cache.dimension_helpers import _SCHEMA_VERSION
+        result = analyze_unit(_unit(), cache=cache, dispatcher=_RecordingDispatcher())
+        assert result.entry.schema_version == _SCHEMA_VERSION
+
+
+# ---------- self-describing entry (file_content_hash + provenance) ----------
+
+class TestProvenance:
+    def test_entry_records_content_hash_and_provenance(self, cache: LocalFileBackend):
+        # The entry remembers exactly what it was keyed under (content hash)
+        # and the volatile context it was produced under (provenance), so the
+        # cache is self-describing and reuse across a model/standards boundary
+        # is never silent.
+        unit = _unit(
+            file_content_hash="ab" * 32,
+            model_id="model-a",
+            prompts_hash="prompts-1",
+            standards_hash="standards-1",
+        )
+        result = analyze_unit(unit, cache=cache, dispatcher=_RecordingDispatcher())
+        assert result.entry.file_content_hash == "ab" * 32
+        prov = result.entry.provenance
+        assert prov["model_id"] == "model-a"
+        assert prov["prompts_hash"] == "prompts-1"
+        assert prov["standards_hash"] == "standards-1"
+        assert "quodeq_version" in prov
 
 
 # ---------- concurrency (atomic writes from the backend) ----------

--- a/tests/analysis/cache/test_standards_drift_degradation.py
+++ b/tests/analysis/cache/test_standards_drift_degradation.py
@@ -1,0 +1,62 @@
+"""Standards-drift safety net for the permissive cache.
+
+The permissive cache reuses findings after a standards edit (standards is no
+longer in the cache key — see docs design 2026-06-01). A reused finding can
+therefore reference a requirement/standard ID that no longer exists in the
+current standards. This is the one real risk called out in the design, so we
+pin the guarantee: scoring/grouping must degrade GRACEFULLY on an absent
+requirement ID — no crash, no KeyError — at worst the finding becomes an
+orphan principle. (Reconciling orphan IDs back to current standards is the
+separately-tracked "remap findings to correct req IDs" follow-up.)
+"""
+from __future__ import annotations
+
+from quodeq.core.evidence._req_mapping import _group_judgments
+from quodeq.core.evidence.model import Evidence, PrincipleEvidence
+from quodeq.core.events.models import Judgment
+from quodeq.core.scoring.engine import score_evidence
+
+
+def _ghost_judgment() -> Judgment:
+    # practice_id that exists in no current standard (the reused-finding case).
+    return Judgment(
+        practice_id="GHOST-1",
+        verdict="violation",
+        dimension="security",
+        file="src/ghost.py",
+        line=42,
+        reason="references a requirement that no longer exists",
+        severity="high",
+    )
+
+
+def test_grouping_does_not_crash_on_absent_requirement_id():
+    # With no current mappings, an unknown practice_id falls back to itself
+    # (orphan principle) instead of raising.
+    grouped = _group_judgments([_ghost_judgment()], dimension="security", evaluators_dir=None)
+    assert "GHOST-1" in grouped.violations
+    assert len(grouped.violations["GHOST-1"]) == 1
+
+
+def test_scoring_does_not_crash_on_orphan_principle():
+    orphan = PrincipleEvidence(
+        practice_id="GHOST-1",
+        display_name="GHOST-1",
+        dimension="security",
+        severity="high",
+        violations=[{"file": "src/ghost.py", "line": 42, "reason": "absent req"}],
+        compliance=[],
+        metrics={
+            "total_instances": 1, "compliant": 0, "violating": 1,
+            "compliance_percentage": 0.0, "confidence_level": "low",
+            "is_balanced": False,
+        },
+    )
+    evidence = Evidence(
+        repository="test", language="python", date="2026-06-01",
+        source_file_count=10, files_read=5, coverage_pct=50.0,
+        principles={"GHOST-1": orphan},
+    )
+    # The assertion that matters: this returns instead of raising.
+    result = score_evidence(evidence, mode="numerical")
+    assert "GHOST-1" in result.principles

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,13 @@ def _isolate_quodeq_home(tmp_path_factory: pytest.TempPathFactory,
       * ``QUODEQ_INDEX_DB_PATH``    — ``services/filesystem._open_index``
       * ``QUODEQ_EVALUATIONS_DIR``  — ``services/filesystem.list_evaluations`` etc.
       * ``QUODEQ_DIR``              — ``dashboard/_build_npm._quodeq_dir``
+      * ``QUODEQ_CACHE_ROOT``       — ``analysis/cache/local.default_cache_root``
+        (and the online cache). Without this, the content-addressed result
+        cache falls through to the real ``~/.quodeq/cache``; the one-time
+        legacy-entry GC would then walk and delete from the developer's real
+        cache whenever a test reaches the ``cache is None`` production path.
+        Sandbox it so the suite is safe by construction, not by per-test
+        discipline.
     ``QUODEQ_HOME`` is kept for any out-of-tree consumer that may rely on it.
     """
     home = tmp_path_factory.mktemp("quodeq-home")
@@ -27,6 +34,7 @@ def _isolate_quodeq_home(tmp_path_factory: pytest.TempPathFactory,
     monkeypatch.setenv("QUODEQ_DIR", str(home))
     monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(home / "index.db"))
     monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(home / "evaluations"))
+    monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(home / "cache"))
 
 
 class DummyProcess:


### PR DESCRIPTION
## Summary

Flip the V2 result cache from correctness-first to cost-first: the cache key now invalidates **only** on a real per-unit change (file content, path, dimension, language). Switching model, updating quodeq (prompts/standards), and running single dimensions reuse cached findings with **zero re-dispatch**; the user refreshes on demand with `--clean-scan` (unchanged).

- **Trim the key** (`key.py`): `CacheKey` keeps `{schema_version, file_content_hash, file_path, dimension, language}`; model/prompts/standards/sampling leave the key. `_SCHEMA_VERSION` 2 → 3. All three key-construction sites (`dimension_helpers`, `cache_writer`, `runner`) trimmed in lockstep.
- **Self-describing entry** (`entry.py`, format v2): store every key field (`file_content_hash` + `language`) plus a `provenance` block `{model_id, prompts_hash, standards_hash, quodeq_version}`, so any future key change is **losslessly migratable**. `from_json` tolerates format drift in both directions (missing *and* unknown keys) so a version mismatch never deletes cached work.
- **Never silent**: `classify` aggregates per-field provenance drift across hits; `dimension_runner` surfaces it on the classify log line, which reaches `run.log` (side-pane log viewer + CLI). Reuse across a model/standards/prompts boundary is reported, not hidden.
- **One-time GC** (`gc.py`): best-effort, idempotent reclaim of `schema<current` entries orphaned by the key change, on first cache open of a real run.

## Deviations from the design doc (intentional)
- `runner.py` was an undocumented **third** key site (no production caller) — trimmed in lockstep; its `analyze_unit` schema default aligned to `_SCHEMA_VERSION`.
- Added `language` to the entry (the key includes it; required for the self-describing guarantee).
- Provenance is surfaced via the classify **log line** (Option 1), not `evaluation_mixin.py` (which does not build the run summary). A dashboard badge is a tracked follow-up.

## Test plan
- [x] Full non-integration suite: `uv run pytest tests/ -q -m "not integration"` → **3138 passed**
- [x] Cache-module coverage **91%** (gate 80%)
- [x] Key stability/sensitivity; provenance + format-1/forward-compat read; drift aggregation/formatting; GC idempotency + skip-unreadable; model-switch all-hits + drift surfacing; future-migratability; standards graceful degradation
- [x] `conftest` sandboxes `QUODEQ_CACHE_ROOT` so the GC never touches the real `~/.quodeq` cache during the suite
- [x] Adversarial multi-agent review (7 findings confirmed and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)