### PR TITLE
fix(ci): repoint CI Ollama model to gemma4:26b-mlx (was missing gemma4-26b-32k)

### DIFF
--- a/.github/workflows/quodeq-nightly.yml
+++ b/.github/workflows/quodeq-nightly.yml
@@ -54,7 +54,7 @@ jobs:
           else
             {
               echo "AI_PROVIDER=ollama"
-              echo "AI_MODEL=gemma4-26b-32k:latest"
+              echo "AI_MODEL=gemma4:26b-mlx"
               echo "EVAL_DIR=$HOME/.quodeq/evaluations"
             } >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/quodeq-review.yml
+++ b/.github/workflows/quodeq-review.yml
@@ -59,7 +59,7 @@ jobs:
           else
             {
               echo "AI_PROVIDER=ollama"
-              echo "AI_MODEL=gemma4-26b-32k:latest"
+              echo "AI_MODEL=gemma4:26b-mlx"
               echo "EVAL_DIR=$HOME/.quodeq/evaluations"
             } >> "$GITHUB_ENV"
           fi

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Quodeq needs an LLM to do the evaluation. You have two options:
 **Local, free, private** — [Ollama](https://ollama.com/download) with Gemma 4:
 ```bash
 # install ollama from https://ollama.com/download, then:
-ollama pull gemma4-26b-32k
+ollama pull gemma4:26b-mlx
 ollama serve    # runs in the background
 ```
 

--- a/quodeq.env
+++ b/quodeq.env
@@ -6,7 +6,7 @@
 # Format: KEY=VALUE per line. No spaces around '='. No shell expansions.
 
 AI_PROVIDER=ollama
-AI_MODEL=gemma4-26b-32k:latest
+AI_MODEL=gemma4:26b-mlx
 N_SUBAGENTS=8
 # Where the runner writes evaluation output. `~` expands to the runner user's home.
 # Default `~/.quodeq/evaluations` unifies CI runs with the local dashboard on


### PR DESCRIPTION
## What was broken

The **Nightly** and **PR Review** workflows have been running green but doing **zero actual work** for a while.

Both load `AI_MODEL` from `quodeq.env`, which pinned `gemma4-26b-32k:latest`. That custom model no longer exists on the self-hosted runner's Ollama (current models are `gemma4:26b`, `gemma4:26b-mlx`, `gemma4:31b`, `qwen3.6:*`, ...). So every model call returned:

```
Error code: 404 - model 'gemma4-26b-32k:latest' not found
```

Result: nightly burned through 1227 files with all-misses and finished in ~3 min (vs. the ~hours a real run takes); PR review queued the diff, got "no valid evidence", and posted an empty review in ~25s. Green check, nothing evaluated. That is why it looked like the flows "weren't triggering" — they trigger fine (runner online, schedule fires on `develop`, PRs trigger on open), they just had no working model.

## Fix

Repoint `AI_MODEL` to `gemma4:26b-mlx`, an existing 26B Gemma build (MLX-optimized, faster on the M4 Max runner). Quodeq sets `num_ctx` itself (`_api_runner.py`), so dropping the cosmetic `-32k` from the name does not change the context window.

Changed in lockstep so the fallback path can't reintroduce the dead name:
- `quodeq.env` (the value CI actually loads)
- `.github/workflows/quodeq-nightly.yml` fallback default
- `.github/workflows/quodeq-review.yml` fallback default
- `README.md` ollama pull instruction

## Verification

Reproduced the PR-review flow locally against the new model:

```
quodeq evaluate . --diff-from origin/develop --dimensions sec ...
```

- No `404 / model not found` warnings (previously every call 404'd)
- `completed iteration 1/1 for security (ev=set)` — evidence produced
- `security_evidence.jsonl` contains a real finding record, vs. "0 unique findings" on the last broken run

🤖 Generated with [Claude Code](https://claude.com/claude-code)