### PR TITLE
feat(ci): PR reviews comment only on touched code (omit out-of-diff findings)

### DIFF
--- a/src/quodeq/ci/reporter.py
+++ b/src/quodeq/ci/reporter.py
@@ -172,9 +172,11 @@ def build_review_payload(
 
     if changed_lines is None:
         comments = all_comments
-        out_of_diff_count = 0
     else:
-        comments, out_of_diff_count = filter_comments_to_diff(all_comments, changed_lines)
+        # Out-of-diff comments are dropped: a PR review speaks only to the
+        # touched code. The dropped findings are not surfaced in the summary
+        # either — they remain in the full evaluation artifact.
+        comments, _ = filter_comments_to_diff(all_comments, changed_lines)
 
     summary = build_review_summary(
         reports,
@@ -183,7 +185,6 @@ def build_review_payload(
         duration_seconds=duration_seconds,
         baseline_available=baseline_available,
         artifact_url=artifact_url,
-        out_of_diff_count=out_of_diff_count,
     )
     verdict = determine_verdict(new_violations)
 

--- a/src/quodeq/ci/review_builder.py
+++ b/src/quodeq/ci/review_builder.py
@@ -76,13 +76,13 @@ def build_review_summary(
     duration_seconds: int | None = None,
     baseline_available: bool = True,
     artifact_url: str | None = None,
-    out_of_diff_count: int = 0,
 ) -> str:
     """Build the review body summarizing all dimension results.
 
-    out_of_diff_count: number of violations that were found but fell outside
-    the PR's changed lines. They can't be posted as line-anchored comments
-    (GitHub would 422); this count is surfaced in the body so reviewers know.
+    Violations outside the PR's changed lines are omitted entirely — they are
+    never posted as comments (GitHub would 422) and are not surfaced in the
+    body either. A PR review speaks only to the touched code; out-of-diff
+    findings remain available in the full evaluation artifact.
     """
     # Diff mode is signaled by reports with unscored ("N/A") dimensions —
     # PR diff runs skip scoring, so the per-dimension score table and the
@@ -135,13 +135,6 @@ def build_review_summary(
         minutes = duration_seconds // 60
         seconds = duration_seconds % 60
         lines.append(f"_Evaluation completed in {minutes}m {seconds}s_")
-
-    if out_of_diff_count > 0:
-        lines.append("")
-        lines.append(
-            f"_{out_of_diff_count} additional violation(s) found outside the PR diff — "
-            "see the full evaluation artifact._"
-        )
 
     if artifact_url is not None:
         lines.append("")

--- a/tests/ci/test_pr_diff_filter.py
+++ b/tests/ci/test_pr_diff_filter.py
@@ -191,7 +191,13 @@ def test_build_review_payload_filters_when_changed_lines_provided() -> None:
     assert payload["comments"][0]["path"] == "src/a.py"
 
 
-def test_build_review_payload_summary_mentions_out_of_diff_count() -> None:
+def test_build_review_payload_summary_omits_out_of_diff_violations() -> None:
+    """Out-of-diff violations are omitted from the PR review entirely.
+
+    They are never posted as comments (GitHub would 422), and the summary body
+    no longer surfaces a count of them either — a PR review speaks only to the
+    code that was touched. The findings still live in the evaluation artifact.
+    """
     reports = [{
         "dimension": "security",
         "overallScore": "7/10",
@@ -203,8 +209,10 @@ def test_build_review_payload_summary_mentions_out_of_diff_count() -> None:
     }]
     payload = build_review_payload(reports, changed_lines={})  # empty diff → all dropped
     assert payload["comments"] == []
-    # Summary body should mention the dropped count so users aren't misled.
-    assert "outside the pr diff" in payload["body"].lower()
+    # Summary must say nothing about findings outside the touched code.
+    body = payload["body"].lower()
+    assert "outside the pr diff" not in body
+    assert "additional violation" not in body
 
 
 def test_build_review_payload_no_filter_when_changed_lines_is_none() -> None:


### PR DESCRIPTION
## What

PR reviews should speak only to the code that was changed. Vulnerabilities elsewhere in a touched file (outside the diff) are now omitted from the PR review entirely.

## Before

Inline comments were already filtered to the PR's changed hunks (`filter_comments_to_diff`), but the summary still appended a line:

> _N additional violation(s) found outside the PR diff — see the full evaluation artifact._

So the review still referenced findings on untouched code.

## After

That summary line is gone. A PR review now contains only:
- inline comments on lines inside the diff (unchanged — whole-hunk scope, including the few context lines GitHub shows around edits)
- the per-diff violation summary for those touched-code findings

Out-of-diff findings are still computed and remain in the uploaded evaluation artifact; they're just not surfaced in the PR conversation.

## Changes

- `review_builder.build_review_summary`: drop the out-of-diff rendering block and the now-unused `out_of_diff_count` parameter.
- `reporter.build_review_payload`: stop computing/passing the dropped-count.
- Test flipped: `test_build_review_payload_summary_omits_out_of_diff_violations` asserts the body says nothing about out-of-diff findings.

## Verification

`uv run pytest tests/ci/` → **88 passed**. Red-then-green confirmed on the flipped test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)