### PR TITLE
fix(ci): fail loudly when the model is unreachable (no more silent-green no-ops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Quodeq needs an LLM to do the evaluation. You have two options:
 **Local, free, private** — [Ollama](https://ollama.com/download) with Gemma 4:
 ```bash
 # install ollama from https://ollama.com/download, then:
-ollama pull gemma4:26b-mlx
+ollama pull gemma4:26b
 ollama serve    # runs in the background
 ```
 

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -396,8 +396,12 @@ def run_api_analysis(
         them all. Individual malformed findings may have been dropped during
         per-finding parsing (and were logged with a count), but that does not
         invalidate the file: it was analysed, so it should not re-dispatch.
-        Only a genuine call failure (network/timeout, ``was_lossy`` True)
-        suppresses the markers, so those files re-dispatch on the next run.
+        On a genuine call failure (network/timeout/unreachable, ``was_lossy``
+        True), every file gets an ``error`` marker instead. ``error`` markers
+        are excluded from the cache's ``ok_files`` set, so those files still
+        re-dispatch on the next run -- but, unlike emitting no marker at all,
+        they let the failure-streak breaker trip and the post-run
+        reachability guard fail the run loudly when the model is unreachable.
 
     *source_file_paths* should be the full per-dim file list. When omitted,
     no markers are emitted (preserves caller flexibility but the run will
@@ -423,9 +427,10 @@ def run_api_analysis(
     ctx = _build_router_context(compiled_dir, dimension, work_dir, project_dir)
 
     _log.debug(
-        "API runner: %d findings, lossy=%s, marking %d files",
+        "API runner: %d findings, lossy=%s, marking %d file(s) as %s",
         len(findings), was_lossy,
-        len(source_file_paths) if source_file_paths and not was_lossy else 0,
+        len(source_file_paths) if source_file_paths else 0,
+        "error" if was_lossy else "ok",
     )
 
     events_log = jsonl_file.parent.parent / "events.jsonl"
@@ -457,6 +462,13 @@ def run_api_analysis(
         )
         for f in findings:
             router.receive(f)
-        if not was_lossy and source_file_paths:
+        if source_file_paths:
+            # Clean end-to-end call -> 'ok'; lossy call (model unreachable /
+            # network / timeout) -> 'error'. The 'error' status is excluded
+            # from the cache's ok_files set (files still re-dispatch next run),
+            # but lets the failure-streak breaker and the post-run
+            # reachability guard see the failure and fail the run loudly.
+            status = "error" if was_lossy else "ok"
+            reason = "model call failed (unreachable or errored)" if was_lossy else None
             for path in source_file_paths:
-                router.mark_file_done(file=path, status="ok")
+                router.mark_file_done(file=path, status=status, reason=reason)

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -118,17 +118,25 @@ def check_zero_findings(
     """
     if not result or source_file_count <= 0 or incremental_filter_active:
         return
-    total_findings = sum(
-        sum(len(pe.violations) + len(pe.compliance) for pe in ev.principles.values())
-        for ev in result.values()
-    )
-    if total_findings == 0:
+    if _count_findings(result) == 0:
         skip_msg = f" ({skipped_count} skipped)" if skipped_count else ""
         raise EvaluationError(
             f"Evaluation produced 0 findings across {len(result)} dimensions{skip_msg}. "
             f"This usually means the AI CLI could not read files or report findings "
             "- check tool permissions and MCP configuration."
         )
+
+
+def _count_findings(result: dict[str, Evidence]) -> int:
+    """Total violations + compliance findings across all dimension Evidence.
+
+    Counts findings carried forward from cache as well as freshly produced
+    ones -- both land in ``Evidence.principles`` for the dims in ``result``.
+    """
+    return sum(
+        sum(len(pe.violations) + len(pe.compliance) for pe in ev.principles.values())
+        for ev in result.values()
+    )
 
 
 def _tally_markers(jsonl_path: Path) -> tuple[int, int]:
@@ -140,7 +148,10 @@ def _tally_markers(jsonl_path: Path) -> tuple[int, int]:
     """
     last_status: dict[str, str] = {}
     try:
-        with jsonl_path.open("r", encoding="utf-8") as fh:
+        # errors="replace" so a corrupt (non-UTF8) evidence file degrades to
+        # unparseable lines (dropped by the json.loads guard) instead of
+        # raising UnicodeDecodeError out of an otherwise-successful run.
+        with jsonl_path.open("r", encoding="utf-8", errors="replace") as fh:
             for raw in fh:
                 raw = raw.strip()
                 if not raw:
@@ -162,18 +173,35 @@ def _tally_markers(jsonl_path: Path) -> tuple[int, int]:
     return ok, err
 
 
-def check_model_reachable(run_dir: Path | None) -> None:
-    """Raise EvaluationError if files were dispatched but none were analysed.
+def check_model_reachable(run_dir: Path | None, result: dict) -> None:
+    """Raise EvaluationError if the run attempted analysis but produced nothing.
 
-    Distinguishes a misconfigured/unreachable model (files dispatched, every
-    call failed -> only ``error`` markers, zero ``ok`` markers) from a
-    legitimately empty scan (no applicable files dispatched -> no markers at
-    all). Runs in every mode, including diff (review) and incremental (nightly)
-    where ``check_zero_findings`` is deliberately bypassed -- those are exactly
-    the modes where an unreachable model used to exit 0 (green) while producing
-    nothing.
+    Fires only when ALL of the following hold, so it flags a genuinely worthless
+    run (an unreachable/misconfigured model) without false-positiving on healthy
+    or partial runs:
+
+    - the run produced zero findings (fresh OR carried forward from cache). Any
+      finding means real output exists, so a mostly-cached run is not failed just
+      because the model blipped on the uncached remainder. (A lossy call now
+      writes ``error`` markers, so the dim yields an *empty* Evidence rather than
+      being skipped -- hence we gate on findings, not on ``result`` emptiness.)
+    - zero files were successfully analysed (no ``ok`` file_done markers); and
+    - at least one file was dispatched and failed (an ``error`` marker exists).
+
+    Runs in every mode, including diff (review) and incremental (nightly) where
+    ``check_zero_findings`` is deliberately bypassed -- those are exactly the
+    modes where an unreachable model used to exit 0 (green) while producing
+    nothing. A legitimately empty scan (no applicable files dispatched -> no
+    markers) does not raise.
+
+    Coverage note: the guard keys off file_done ``error`` markers. The Ollama /
+    API provider path writes those on a lossy call (``run_api_analysis``), so the
+    Ollama-backed CI flows are covered. A CLI provider (claude/gemini/codex) that
+    is itself unreachable never connects to the MCP server and writes no markers
+    at all, so this guard cannot see that failure in diff/incremental mode --
+    that remains a known gap, out of scope for the Ollama incident this targets.
     """
-    if run_dir is None:
+    if run_dir is None or _count_findings(result) > 0:
         return
     evidence_dir = run_dir / "evidence"
     if not evidence_dir.is_dir():
@@ -184,12 +212,12 @@ def check_model_reachable(run_dir: Path | None) -> None:
         ok, err = _tally_markers(jsonl)
         ok_total += ok
         err_total += err
-    if err_total > 0 and ok_total == 0:
+    if ok_total == 0 and err_total > 0:
         raise EvaluationError(
             f"Model produced no analysis: all {err_total} dispatched file(s) failed "
-            f"and 0 were analysed. The AI model is unreachable or misconfigured -- "
-            f"check the provider/model name and that the server is running "
-            f"(e.g. `ollama list`)."
+            f"and 0 were analysed. The model is likely unreachable or misconfigured "
+            f"(check the provider/model name and that the server is running, "
+            f"e.g. `ollama list`), or every dispatched file errored during analysis."
         )
 
 
@@ -312,7 +340,7 @@ def run_incremental_loop(
         incremental_filter_active=config.options.incremental_file_filter is not None
             or config.options.skip_scoring,
     )
-    check_model_reachable(_run_dir_for(config))
+    check_model_reachable(_run_dir_for(config), result)
     return result
 
 
@@ -418,5 +446,5 @@ def run_per_dimension_loop(
         incremental_filter_active=config.options.incremental_file_filter is not None
             or config.options.skip_scoring,
     )
-    check_model_reachable(_run_dir_for(config))
+    check_model_reachable(_run_dir_for(config), result)
     return result

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -131,6 +131,68 @@ def check_zero_findings(
         )
 
 
+def _tally_markers(jsonl_path: Path) -> tuple[int, int]:
+    """Return ``(ok_count, error_count)`` from a dim's evidence JSONL.
+
+    Counts each file once by its *latest* ``file_done`` marker status, matching
+    the cache's ok_files semantics (a file that errored then re-succeeded counts
+    as ok). Unreadable/missing files contribute nothing.
+    """
+    last_status: dict[str, str] = {}
+    try:
+        with jsonl_path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    entry = json.loads(raw)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    continue
+                if entry.get("_marker") != "file_done":
+                    continue
+                file = entry.get("file")
+                status = entry.get("status")
+                if isinstance(file, str) and status in ("ok", "error"):
+                    last_status[file] = status
+    except (FileNotFoundError, OSError):
+        return 0, 0
+    ok = sum(1 for s in last_status.values() if s == "ok")
+    err = sum(1 for s in last_status.values() if s == "error")
+    return ok, err
+
+
+def check_model_reachable(run_dir: Path | None) -> None:
+    """Raise EvaluationError if files were dispatched but none were analysed.
+
+    Distinguishes a misconfigured/unreachable model (files dispatched, every
+    call failed -> only ``error`` markers, zero ``ok`` markers) from a
+    legitimately empty scan (no applicable files dispatched -> no markers at
+    all). Runs in every mode, including diff (review) and incremental (nightly)
+    where ``check_zero_findings`` is deliberately bypassed -- those are exactly
+    the modes where an unreachable model used to exit 0 (green) while producing
+    nothing.
+    """
+    if run_dir is None:
+        return
+    evidence_dir = run_dir / "evidence"
+    if not evidence_dir.is_dir():
+        return
+    ok_total = 0
+    err_total = 0
+    for jsonl in evidence_dir.glob("*_evidence.jsonl"):
+        ok, err = _tally_markers(jsonl)
+        ok_total += ok
+        err_total += err
+    if err_total > 0 and ok_total == 0:
+        raise EvaluationError(
+            f"Model produced no analysis: all {err_total} dispatched file(s) failed "
+            f"and 0 were analysed. The AI model is unreachable or misconfigured -- "
+            f"check the provider/model name and that the server is running "
+            f"(e.g. `ollama list`)."
+        )
+
+
 def run_incremental_loop(
     config: RunConfig, dimensions: list[str], ctx: _AnalysisContext,
     *, runner: DimensionRunner,
@@ -250,6 +312,7 @@ def run_incremental_loop(
         incremental_filter_active=config.options.incremental_file_filter is not None
             or config.options.skip_scoring,
     )
+    check_model_reachable(_run_dir_for(config))
     return result
 
 
@@ -355,4 +418,5 @@ def run_per_dimension_loop(
         incremental_filter_active=config.options.incremental_file_filter is not None
             or config.options.skip_scoring,
     )
+    check_model_reachable(_run_dir_for(config))
     return result

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -186,10 +186,15 @@ class TestMarkerContract:
         assert markers[0]["file"] == "src/clean.py"
         assert markers[0]["status"] == "ok"
 
-    def test_network_error_does_not_emit_markers(self, tmp_path, api_config):
-        """When the model call fails with a network error (was_lossy=True),
-        we cannot prove which files were analysed. Don't emit markers so the
-        next run re-runs all files."""
+    def test_network_error_emits_error_markers(self, tmp_path, api_config):
+        """When the model call fails (was_lossy=True), emit an 'error' marker
+        for every file in the batch.
+
+        This makes the failure visible to the failure-streak circuit breaker
+        and the post-run model-reachability guard, so an unreachable/broken
+        model fails the run loudly instead of silently producing zero findings.
+        'error' markers are excluded from the cache's ok_files set, so the
+        files still re-dispatch on the next run (retry semantics preserved)."""
         jsonl_file = tmp_path / "evidence.jsonl"
         raw_client = MagicMock()
         raw_client.chat.completions.create.side_effect = httpx.ReadTimeout("timeout")
@@ -201,10 +206,12 @@ class TestMarkerContract:
                 source_file_paths=["src/a.py", "src/b.py"],
             )
 
-        # File may not exist at all if nothing was written
-        if jsonl_file.exists() and jsonl_file.read_text().strip():
-            lines = self._read_jsonl(jsonl_file)
-            assert self._markers(lines) == []
+        lines = self._read_jsonl(jsonl_file)
+        markers = self._markers(lines)
+        assert {m["file"] for m in markers} == {"src/a.py", "src/b.py"}
+        assert all(m["status"] == "error" for m in markers)
+        # A failed call produces no findings.
+        assert self._findings_only(lines) == []
 
     def test_no_source_files_no_markers(self, tmp_path, api_config):
         """Backward-compat: callers that don't pass source_file_paths get

--- a/tests/analysis/test_loops_reachability.py
+++ b/tests/analysis/test_loops_reachability.py
@@ -1,0 +1,87 @@
+"""Tests for the post-run model-reachability guard.
+
+Motivating incident: the CI Ollama model name in quodeq.env pointed at a model
+that no longer existed on the runner. Every analysis call returned HTTP 404, so
+``_call_api`` flagged each call lossy and ``run_api_analysis`` wrote no markers.
+The failure-streak breaker (which only counts ``file_done`` error markers) never
+saw the failures, ``check_zero_findings`` is bypassed in diff/incremental mode,
+and the run exited 0 — green CI that did zero work for weeks.
+
+The guard pinned down here raises ``EvaluationError`` (mapped to exit 1 by the
+CLI) when files were dispatched to the model but *none* were successfully
+analysed: every file ended on an ``error`` marker and not one on ``ok``. That is
+the signature of an unreachable/misconfigured model. A legitimately empty diff
+scan (no applicable files dispatched -> no markers at all) does NOT raise.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._loops import check_model_reachable
+from quodeq.analysis.errors import EvaluationError
+
+
+def _write_evidence(run_dir: Path, dim: str, markers: list[tuple[str, str]]) -> None:
+    """Write a ``<dim>_evidence.jsonl`` with the given (file, status) markers."""
+    evidence_dir = run_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    path = evidence_dir / f"{dim}_evidence.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for file, status in markers:
+            fh.write(json.dumps({
+                "_marker": "file_done", "file": file, "status": status,
+            }) + "\n")
+
+
+def test_all_error_markers_raises(tmp_path):
+    """Files dispatched, every one failed (0 ok) -> model unreachable -> raise."""
+    _write_evidence(tmp_path, "security", [("a.py", "error"), ("b.py", "error")])
+    with pytest.raises(EvaluationError) as exc:
+        check_model_reachable(tmp_path)
+    # Message should point at the model / provider so the cause is obvious.
+    assert "2" in str(exc.value)
+    assert "model" in str(exc.value).lower()
+
+
+def test_all_error_across_multiple_dims_raises(tmp_path):
+    _write_evidence(tmp_path, "security", [("a.py", "error")])
+    _write_evidence(tmp_path, "reliability", [("b.py", "error"), ("c.py", "error")])
+    with pytest.raises(EvaluationError):
+        check_model_reachable(tmp_path)
+
+
+def test_any_ok_marker_does_not_raise(tmp_path):
+    """At least one successful analysis means the model is reachable; a partial
+    failure is handled by the existing graceful-cancellation path, not here."""
+    _write_evidence(tmp_path, "security", [("a.py", "ok"), ("b.py", "error")])
+    check_model_reachable(tmp_path)  # must not raise
+
+
+def test_only_ok_markers_does_not_raise(tmp_path):
+    _write_evidence(tmp_path, "security", [("a.py", "ok"), ("b.py", "ok")])
+    check_model_reachable(tmp_path)
+
+
+def test_latest_marker_per_file_wins(tmp_path):
+    """A file that errored then later succeeded (re-dispatch) counts as ok."""
+    _write_evidence(tmp_path, "security", [("a.py", "error"), ("a.py", "ok")])
+    check_model_reachable(tmp_path)  # latest is ok -> reachable -> no raise
+
+
+def test_no_markers_does_not_raise(tmp_path):
+    """Legitimately empty scan: a diff that touches none of the dimension's
+    language dispatches nothing, so there are no markers at all. Not a failure."""
+    (tmp_path / "evidence").mkdir()
+    (tmp_path / "evidence" / "security_evidence.jsonl").write_text("", encoding="utf-8")
+    check_model_reachable(tmp_path)
+
+
+def test_no_evidence_dir_does_not_raise(tmp_path):
+    check_model_reachable(tmp_path)  # nothing written yet
+
+
+def test_run_dir_none_does_not_raise():
+    check_model_reachable(None)

--- a/tests/analysis/test_loops_reachability.py
+++ b/tests/analysis/test_loops_reachability.py
@@ -37,10 +37,11 @@ def _write_evidence(run_dir: Path, dim: str, markers: list[tuple[str, str]]) -> 
 
 
 def test_all_error_markers_raises(tmp_path):
-    """Files dispatched, every one failed (0 ok) -> model unreachable -> raise."""
+    """Files dispatched, every one failed (0 ok), no Evidence produced
+    -> model unreachable -> raise."""
     _write_evidence(tmp_path, "security", [("a.py", "error"), ("b.py", "error")])
     with pytest.raises(EvaluationError) as exc:
-        check_model_reachable(tmp_path)
+        check_model_reachable(tmp_path, {})
     # Message should point at the model / provider so the cause is obvious.
     assert "2" in str(exc.value)
     assert "model" in str(exc.value).lower()
@@ -50,25 +51,65 @@ def test_all_error_across_multiple_dims_raises(tmp_path):
     _write_evidence(tmp_path, "security", [("a.py", "error")])
     _write_evidence(tmp_path, "reliability", [("b.py", "error"), ("c.py", "error")])
     with pytest.raises(EvaluationError):
-        check_model_reachable(tmp_path)
+        check_model_reachable(tmp_path, {})
+
+
+class _FakePrinciple:
+    def __init__(self, n_violations: int):
+        self.violations = [{"i": i} for i in range(n_violations)]
+        self.compliance = []
+
+
+class _FakeEvidence:
+    def __init__(self, n_violations: int):
+        self.principles = {"p": _FakePrinciple(n_violations)}
+
+
+def test_cached_findings_present_does_not_raise(tmp_path):
+    """A run that produced findings (e.g. dims served from cache, which write
+    findings but no 'ok' markers) must NOT fail just because the model went
+    unreachable for the uncached remainder. Real output means the run isn't a
+    total outage, so the guard stays silent even with error markers on disk."""
+    # Uncached dim's files all errored, but another dim carried cached findings.
+    _write_evidence(tmp_path, "reliability", [("b.py", "error"), ("c.py", "error")])
+    result = {"security": _FakeEvidence(n_violations=3)}
+    check_model_reachable(tmp_path, result)  # findings exist -> must not raise
+
+
+def test_empty_evidence_with_errors_still_raises(tmp_path):
+    """The incident shape: error markers now make the dim yield an *empty*
+    Evidence (zero findings) rather than being skipped, so result is non-empty
+    but carries no findings. The guard must still fire."""
+    _write_evidence(tmp_path, "security", [("a.py", "error"), ("b.py", "error")])
+    result = {"security": _FakeEvidence(n_violations=0)}
+    with pytest.raises(EvaluationError):
+        check_model_reachable(tmp_path, result)
+
+
+def test_corrupt_evidence_file_does_not_crash(tmp_path):
+    """A non-UTF8 / corrupt evidence file must be tolerated, not crash the run."""
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    (evidence_dir / "security_evidence.jsonl").write_bytes(b'\xff\xfe not valid utf8\n')
+    check_model_reachable(tmp_path, {})  # must not raise (no valid markers found)
 
 
 def test_any_ok_marker_does_not_raise(tmp_path):
     """At least one successful analysis means the model is reachable; a partial
     failure is handled by the existing graceful-cancellation path, not here."""
     _write_evidence(tmp_path, "security", [("a.py", "ok"), ("b.py", "error")])
-    check_model_reachable(tmp_path)  # must not raise
+    check_model_reachable(tmp_path, {})  # must not raise
 
 
 def test_only_ok_markers_does_not_raise(tmp_path):
     _write_evidence(tmp_path, "security", [("a.py", "ok"), ("b.py", "ok")])
-    check_model_reachable(tmp_path)
+    check_model_reachable(tmp_path, {})
 
 
 def test_latest_marker_per_file_wins(tmp_path):
     """A file that errored then later succeeded (re-dispatch) counts as ok."""
     _write_evidence(tmp_path, "security", [("a.py", "error"), ("a.py", "ok")])
-    check_model_reachable(tmp_path)  # latest is ok -> reachable -> no raise
+    check_model_reachable(tmp_path, {})  # latest is ok -> reachable -> no raise
 
 
 def test_no_markers_does_not_raise(tmp_path):
@@ -76,12 +117,12 @@ def test_no_markers_does_not_raise(tmp_path):
     language dispatches nothing, so there are no markers at all. Not a failure."""
     (tmp_path / "evidence").mkdir()
     (tmp_path / "evidence" / "security_evidence.jsonl").write_text("", encoding="utf-8")
-    check_model_reachable(tmp_path)
+    check_model_reachable(tmp_path, {})
 
 
 def test_no_evidence_dir_does_not_raise(tmp_path):
-    check_model_reachable(tmp_path)  # nothing written yet
+    check_model_reachable(tmp_path, {})  # nothing written yet
 
 
 def test_run_dir_none_does_not_raise():
-    check_model_reachable(None)
+    check_model_reachable(None, {})


### PR DESCRIPTION
## Why

This is the deeper root cause behind the recent CI outage. When the Ollama model in `quodeq.env` didn't exist, **every** model call returned HTTP 404 — yet both the nightly and PR-review workflows exited **0 (green)** while producing zero findings. The breakage hid for weeks because nothing failed.

### The silent-green chain (all confirmed in source)
1. A failed call (`_call_api`) returns `([], was_lossy=True)`.
2. `run_api_analysis` wrote **no marker** for lossy calls (`if not was_lossy and source_file_paths:`).
3. The `FailureStreakWatcher` only counts `file_done` markers with `status:"error"` — it never saw the failures, so it never tripped.
4. `check_zero_findings` is deliberately bypassed in diff (review, `skip_scoring`) and incremental (nightly, `incremental_file_filter`) modes.
5. → run completes with zero evidence → exit 0.

## Fix (two parts)

**1. Persist lossy as `error` markers** (`_api_runner.py`). A lossy call now writes a `file_done` `status:"error"` marker per file instead of nothing. This is safe:
- `ok_files = {f for f,s in last_status if s=="ok"}` (dimension_helpers) excludes `error`, so files **still re-dispatch** next run — retry semantics preserved.
- `_compute_files_read` excludes `error`, so coverage stays accurate (0 on all-lossy).
- The breaker counts *consecutive* errors **reset by any `ok`**, and calls batch ≤3 files into a shared dim JSONL — so a transient single-batch blip in a healthy run is reset by neighbouring successes; only a *sustained* outage (5+ consecutive) trips it. That's the intended fail-fast for the 10h nightly.

**2. Mode-independent reachability guard** (`_loops.py`, `check_model_reachable`). Runs after both loops in every mode. Raises `EvaluationError` (→ exit 1 via the CLI's `except (AnalysisError, EvaluationError): return 1`) when files were dispatched but **none** succeeded (all `error`, zero `ok`). A legitimately empty diff (no applicable files → no markers) does **not** raise.

**3. README cleanup.** Getting-started now pulls `gemma4:26b` (matches the desktop-app default in `ai_providers.json` and the recommendation table at line ~161); CI keeps `gemma4:26b-mlx` for runner speed.

## Verification

- **Red→green TDD.** `test_network_error_emits_error_markers` + new `tests/analysis/test_loops_reachability.py` (8 cases: all-error raises, any-ok/latest-ok/no-markers/None don't).
- **Real end-to-end repro on this machine:**
  - Bogus model, diff mode → **exit 1** with `Model produced no analysis: all N dispatched file(s) failed and 0 were analysed...`
  - Real `gemma4:26b-mlx`, diff mode → **exit 0**, 2 `ok` / 0 `error` markers, evidence produced (no false-positive).
- **Full suite: 3152 passed**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)