### PR TITLE
fix(migration): fold legacy dismissed.json so upgrades don't lose dismissals

### DIFF
--- a/src/quodeq/data/migrations/dismissed_json_to_actions_log.py
+++ b/src/quodeq/data/migrations/dismissed_json_to_actions_log.py
@@ -1,57 +1,92 @@
 """One-shot migration: fold project_dir/dismissed.json into actions.jsonl.
 
-Runs lazily on first projection of a project. Idempotent -- skips when
-actions.jsonl already exists. Leaves dismissed.json in place as a read-only
+Runs lazily the first time a project's dismissed state is read or written
+(see quodeq.services.dismissed) and on first projection. Idempotency is keyed
+off a sentinel marker file, NOT off actions.jsonl: a user can dismiss a
+finding (creating actions.jsonl) before this migration ever runs, and the
+legacy dismissed.json must STILL be folded in. Appending the legacy
+FindingDismissed events is safe even when actions.jsonl already has entries --
+the dismissed set is computed by replaying the log, so a key dismissed twice
+is still just dismissed. dismissed.json is left in place as a read-only
 fallback for one release.
 """
 from __future__ import annotations
 
 import json
 import logging
+import threading
+from collections import defaultdict
 from pathlib import Path
 
 from quodeq.core.events.models import FindingDismissed, FindingDismissedEvent
-from quodeq.data.actions_log import ACTIONS_LOG_FILENAME, ActionLogWriter
+from quodeq.data.actions_log import ActionLogWriter
 
 _logger = logging.getLogger(__name__)
 
+#: Sentinel written next to dismissed.json once the fold has run. Its presence
+#: (not actions.jsonl's) is what makes the migration idempotent.
+MIGRATION_MARKER = ".dismissed_migrated"
+
+# One lock per project so a concurrent first read + first write can't double-fold.
+_migration_locks: dict[Path, threading.Lock] = defaultdict(threading.Lock)
+
 
 def migrate_if_needed(project_dir: Path) -> int:
-    """Fold dismissed.json into actions.jsonl. Returns count of entries migrated."""
-    actions_log = project_dir / ACTIONS_LOG_FILENAME
-    if actions_log.exists():
+    """Fold dismissed.json into actions.jsonl exactly once. Returns count migrated."""
+    marker = project_dir / MIGRATION_MARKER
+    if marker.exists():
         return 0
 
     dismissed_json = project_dir / "dismissed.json"
     if not dismissed_json.is_file():
+        # Fresh install (no legacy data). Nothing to fold and nothing to mark;
+        # the two cheap exists() checks above keep this path negligible.
         return 0
 
-    try:
-        entries = json.loads(dismissed_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        _logger.warning("Could not read %s during migration; skipping", dismissed_json)
-        return 0
-    if not isinstance(entries, list):
-        return 0
+    with _migration_locks[project_dir]:
+        if marker.exists():  # another thread won the race
+            return 0
 
-    writer = ActionLogWriter(project_dir)
-    count = 0
-    for entry in entries:
         try:
-            payload = FindingDismissed(
-                req=str(entry.get("req", "")),
-                file=str(entry.get("file", "")),
-                line=int(entry.get("line", 0)),
-                reason=None,
-            )
-            writer.emit(FindingDismissedEvent(payload=payload))
-            count += 1
-        except Exception:
-            _logger.exception("Failed to migrate dismissed entry: %s", entry)
-            continue
-    _logger.info(
-        "Migrated %d entries from dismissed.json to actions.jsonl in %s",
-        count,
-        project_dir,
-    )
-    return count
+            entries = json.loads(dismissed_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            _logger.warning("Could not read %s during migration; skipping", dismissed_json)
+            return 0
+        if not isinstance(entries, list):
+            # Malformed legacy file: nothing to fold, but mark so we never retry.
+            _write_marker(marker)
+            return 0
+
+        writer = ActionLogWriter(project_dir)
+        count = 0
+        for entry in entries:
+            try:
+                payload = FindingDismissed(
+                    req=str(entry.get("req", "")),
+                    file=str(entry.get("file", "")),
+                    line=int(entry.get("line", 0)),
+                    reason=None,
+                )
+                writer.emit(FindingDismissedEvent(payload=payload))
+                count += 1
+            except Exception:
+                _logger.exception("Failed to migrate dismissed entry: %s", entry)
+                continue
+
+        # Mark last: a crash mid-fold leaves the marker absent so the next call
+        # re-folds. Re-folding only appends duplicate FindingDismissed events,
+        # which are idempotent for the replayed dismissed set.
+        _write_marker(marker)
+        _logger.info(
+            "Migrated %d entries from dismissed.json to actions.jsonl in %s",
+            count,
+            project_dir,
+        )
+        return count
+
+
+def _write_marker(marker: Path) -> None:
+    try:
+        marker.write_text("", encoding="utf-8")
+    except OSError:
+        _logger.warning("Could not write migration marker %s", marker)

--- a/src/quodeq/services/dismissed.py
+++ b/src/quodeq/services/dismissed.py
@@ -20,11 +20,16 @@ from quodeq.core.events.models import (
 )
 from quodeq.core.types.finding import Finding, SeverityTally, Totals
 from quodeq.data.actions_log import ActionLogWriter, read_action_events
+from quodeq.data.migrations.dismissed_json_to_actions_log import migrate_if_needed
 from quodeq.data.sqlite.connection import open_evaluation_db
 
 
 def dismiss_finding(project_dir: Path, finding: dict) -> None:
     """Append a FindingDismissed event to project_dir/actions.jsonl."""
+    # Fold any legacy dismissed.json in FIRST, so the new event lands after the
+    # migrated history rather than the migration appending stale dismissals on
+    # top of this action later (see migrate_if_needed).
+    migrate_if_needed(project_dir)
     payload = FindingDismissed(
         req=str(finding.get("req", "")),
         file=str(finding.get("file", "")),
@@ -36,6 +41,9 @@ def dismiss_finding(project_dir: Path, finding: dict) -> None:
 
 def restore_finding(project_dir: Path, finding: dict) -> None:
     """Append a FindingUndismissed event to project_dir/actions.jsonl."""
+    # Fold legacy dismissals in before recording the restore, otherwise the
+    # migration would re-dismiss this finding after the fact (ordering bug).
+    migrate_if_needed(project_dir)
     payload = FindingUndismissed(
         req=str(finding.get("req", "")),
         file=str(finding.get("file", "")),
@@ -61,6 +69,12 @@ def dismissed_keys(project_dir: Path) -> set[tuple]:
     """
     if not project_dir.is_dir():
         return set()
+
+    # Pure-legacy projects (dismissed.json, no actions.jsonl, no events.jsonl)
+    # have nothing in the action log until this fold runs. Trigger it at the
+    # read seam so the very first score/list after upgrade reflects the user's
+    # existing dismissals instead of an empty set.
+    migrate_if_needed(project_dir)
 
     keys: set[tuple] = set()
     for event in read_action_events(project_dir):

--- a/tests/data/migrations/test_dismissed_json_to_actions_log.py
+++ b/tests/data/migrations/test_dismissed_json_to_actions_log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from quodeq.core.events.models import FindingDismissed, FindingDismissedEvent
 from quodeq.data.actions_log import ActionLogWriter, read_action_events
 from quodeq.data.migrations.dismissed_json_to_actions_log import migrate_if_needed
 
@@ -28,15 +29,41 @@ def test_migration_creates_actions_log_from_dismissed_json(tmp_path: Path) -> No
     assert events[1].payload.req == "R2"
 
 
-def test_migration_idempotent_when_actions_log_exists(tmp_path: Path) -> None:
+def test_folds_legacy_even_when_actions_log_already_exists(tmp_path: Path) -> None:
+    """A user who dismisses a finding before the migration ever runs creates
+    actions.jsonl first. The legacy dismissed.json must STILL be folded in,
+    not skipped, otherwise every pre-1.2.0 dismissal is silently orphaned."""
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    _write_dismissed_json(project_dir, [{"req": "R1", "file": "a.py", "line": 10}])
-    (project_dir / "actions.jsonl").write_text("")  # exists, even if empty
+    _write_dismissed_json(project_dir, [
+        {"req": "R1", "file": "a.py", "line": 10},
+        {"req": "R2", "file": "b.py", "line": 20},
+    ])
+    # Simulate the user dismissing a NEW finding first, which creates actions.jsonl.
+    ActionLogWriter(project_dir).emit(FindingDismissedEvent(
+        payload=FindingDismissed(req="R3", file="c.py", line=30, reason=None)
+    ))
 
     migrated = migrate_if_needed(project_dir)
 
-    assert migrated == 0
+    assert migrated == 2
+    reqs = {e.payload.req for e in read_action_events(project_dir)}
+    assert reqs == {"R1", "R2", "R3"}
+
+
+def test_idempotent_after_first_migration(tmp_path: Path) -> None:
+    """Once folded, a second call is a no-op and does not duplicate events,
+    even though dismissed.json is intentionally left on disk."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_dismissed_json(project_dir, [{"req": "R1", "file": "a.py", "line": 10}])
+
+    first = migrate_if_needed(project_dir)
+    second = migrate_if_needed(project_dir)
+
+    assert first == 1
+    assert second == 0
+    assert len(list(read_action_events(project_dir))) == 1
 
 
 def test_migration_no_op_when_no_dismissed_json(tmp_path: Path) -> None:

--- a/tests/services/test_dismissed.py
+++ b/tests/services/test_dismissed.py
@@ -1,6 +1,7 @@
 """Tests for the dismissed findings storage service."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
@@ -24,6 +25,52 @@ def _seed_run(project_dir: Path, run_id: str, *, req: str, file: str, line: int)
     # Project events.jsonl into evaluation.db so SQL reads work.
     Projector().project(log, run_dir)
     return run_dir
+
+
+def _write_legacy_dismissed(project_dir: Path, entries: list[dict]) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "dismissed.json").write_text(json.dumps(entries), encoding="utf-8")
+
+
+def test_dismissed_keys_folds_legacy_dismissed_json(tmp_path: Path) -> None:
+    """Pure-legacy project upgraded to 1.2.0: dismissed.json present, no
+    actions.jsonl, no events.jsonl anywhere. Reading the dismissed set must
+    surface the legacy dismissals instead of an empty set (which would make
+    every previously-hidden finding reappear on first launch)."""
+    project_dir = tmp_path / "project"
+    _write_legacy_dismissed(project_dir, [
+        {"req": "R1", "file": "a.py", "line": 10},
+        {"req": "R2", "file": "b.py", "line": 20},
+    ])
+
+    assert dismissed_keys(project_dir) == {("R1", "a.py", 10), ("R2", "b.py", 20)}
+
+
+def test_dismiss_after_upgrade_preserves_legacy_dismissals(tmp_path: Path) -> None:
+    """Dismissing a new finding right after upgrade must not orphan the legacy
+    dismissed.json entries. This is the 'first dismiss creates actions.jsonl and
+    locks the migration out forever' regression."""
+    project_dir = tmp_path / "project"
+    _write_legacy_dismissed(project_dir, [{"req": "R1", "file": "a.py", "line": 10}])
+
+    dismiss_finding(project_dir, {"req": "R2", "file": "b.py", "line": 20})
+
+    assert dismissed_keys(project_dir) == {("R1", "a.py", 10), ("R2", "b.py", 20)}
+
+
+def test_restore_after_upgrade_nets_to_undismissed(tmp_path: Path) -> None:
+    """Restoring a legacy-dismissed finding right after upgrade must leave it
+    undismissed. The fold has to be ordered BEFORE the restore event, otherwise
+    a later read re-folds the dismissal on top of the restore and it reappears."""
+    project_dir = tmp_path / "project"
+    _write_legacy_dismissed(project_dir, [
+        {"req": "R1", "file": "a.py", "line": 10},
+        {"req": "R2", "file": "b.py", "line": 20},
+    ])
+
+    restore_finding(project_dir, {"req": "R1", "file": "a.py", "line": 10})
+
+    assert dismissed_keys(project_dir) == {("R2", "b.py", 20)}
 
 
 def test_dismiss_finding_appends_to_actions_log(tmp_path: Path) -> None:


### PR DESCRIPTION
## The bug (1.2.0 release blocker)

The `dismissed.json -> actions.jsonl` fold was gated on `actions.jsonl` **not** existing, and only ran from `Projector.ensure_projected`, which itself requires `events.jsonl`. But `events.jsonl` did not exist before 1.2.0 (`EventLogWriter` is new this release), so for **every** upgrading project the migration never ran:

- `dismissed_keys()` / `load_dismissed()` read only `actions.jsonl` and returned nothing, so the **Dismissed tab went empty** and previously-hidden findings **reappeared in scores**.
- Worse, the first dismiss/restore wrote `actions.jsonl` directly, **permanently locking the migration out** so the legacy data became unreachable.

This was confirmed and reproduced live by an adversarial review of the 1.2.0 diff (three independent agents reproduced it from the real code path).

## The fix

- Key the migration's idempotency off a sentinel marker file (`.dismissed_migrated`) instead of `actions.jsonl` existence, so a user dismissing first can no longer skip the fold.
- Trigger the fold eagerly at the dismissed-state **read seam** (`dismissed_keys`) and **before both write emits** (`dismiss_finding`, `restore_finding`). Folding before the emit keeps legacy history ordered ahead of new actions, so restoring a legacy-dismissed finding nets to *undismissed* instead of reappearing.
- `dismissed.json` is left on disk (read-only fallback for one release).

## Tests (TDD, red first)

- `test_folds_legacy_even_when_actions_log_already_exists` — replaces the old test that **encoded the bug** (asserted the fold returns 0 when `actions.jsonl` exists).
- `test_idempotent_after_first_migration` — marker prevents re-fold / duplicate events.
- `test_dismissed_keys_folds_legacy_dismissed_json` — pure-legacy project surfaces its dismissals.
- `test_dismiss_after_upgrade_preserves_legacy_dismissals` — first dismiss no longer orphans legacy entries.
- `test_restore_after_upgrade_nets_to_undismissed` — restore ordering nets correctly.

**Full suite: 3159 passed.** Verified end-to-end through the real `load_dismissed` / `dismiss_finding` API (Dismissed tab shows the legacy entries, legacy preserved after first dismiss, idempotent across reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)