### PR TITLE
1.2.0 hardening: fix-after-release issues #576-#580 (adversarially reviewed)

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -1,7 +1,8 @@
 name: Wheel smoke test
 
 # Builds the wheel, asserts it's under the size budget, and verifies the
-# production maybe_build_ui codepath works without npm on PATH. Catches
+# production maybe_build_ui codepath works without npm on PATH. Also builds the
+# sdist and asserts it excludes node_modules and stays small. Catches
 # regressions in the "ship pre-built UI in wheel" architecture before
 # they reach PyPI.
 #
@@ -73,6 +74,31 @@ jobs:
             exit 1
           fi
           echo "OK: index.html present in wheel"
+
+      - name: Build sdist
+        run: uv build --sdist
+
+      # node_modules (~28 MB / 11k files, reproducible from package-lock.json)
+      # must never reach the source tarball. source-exclude in pyproject keeps
+      # it out; this asserts it stays out and the sdist stays small. npm ci ran
+      # above, so node_modules is present and a missing exclude would be caught.
+      - name: Assert sdist excludes node_modules and is under 5 MB
+        run: |
+          sdist=$(ls dist/quodeq-*.tar.gz)
+          echo "sdist: $sdist"
+          if tar tzf "$sdist" | grep -q "node_modules"; then
+            echo "::error::sdist bundles node_modules. Check source-exclude in pyproject.toml."
+            tar tzf "$sdist" | grep "node_modules" | head
+            exit 1
+          fi
+          size=$(stat -c%s "$sdist")
+          max=5242880
+          echo "Size: $size bytes (budget: $max bytes / 5 MB)"
+          if [ "$size" -gt "$max" ]; then
+            echo "::error::sdist exceeds 5 MB budget. Did a large directory get included?"
+            exit 1
+          fi
+          echo "OK: sdist clean and under budget"
 
       - name: Install wheel in clean venv
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,6 @@ build-backend = "uv_build"
 # pre-built UI. End users no longer need Node/npm at runtime. Build it
 # with `tools/build-dist.sh` (runs npm ci + vite build before uv build).
 wheel-exclude = ["src/quodeq/ui/node_modules"]
+# Keep the installed JS dependency tree (~28MB / 11k files, reproducible from
+# package-lock.json) out of the published source tarball too.
+source-exclude = ["src/quodeq/ui/node_modules"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,9 @@ build-backend = "uv_build"
 # with `tools/build-dist.sh` (runs npm ci + vite build before uv build).
 wheel-exclude = ["src/quodeq/ui/node_modules"]
 # Keep the installed JS dependency tree (~28MB / 11k files, reproducible from
-# package-lock.json) out of the published source tarball too.
-source-exclude = ["src/quodeq/ui/node_modules"]
+# package-lock.json) and local build cruft out of the published source tarball.
+source-exclude = [
+    "src/quodeq/ui/node_modules",
+    "src/quodeq/ui/.mypy_cache",
+    "**/.DS_Store",
+]

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -131,9 +131,13 @@ class ApiRunnerConfig:
 # `req` identifier is a *dropped finding* attempt: counted once for observability,
 # then we stop (its own fields are not separate findings, mirroring the valid path).
 # A dict that LOOKS like a finding (shares >=2 fields with the schema) but is missing
-# `req` is also a dropped attempt -- counting it makes that silent loss visible.
-# A pure container/wrapper (e.g. {"findings": [...]}) shares no finding fields, so we
-# recurse into it to recover findings nested inside.
+# `req` is also a dropped attempt -- BUT only when it is a leaf (no nested dict/list
+# values). A dict that shares field names yet nests dicts/lists is treated as a
+# wrapper and recursed into, so real findings inside it (e.g. {"findings": [...]}) are
+# recovered rather than swallowed. The trade-off: a malformed, req-less finding that
+# itself nests a container is recursed instead of counted, so it is not tallied in the
+# (observability-only) dropped count -- acceptable, since a req-bearing attempt is
+# still always counted regardless of nesting.
 _DROPPED_FINDING_KEY = "req"
 _FINDING_FIELDS = frozenset(_Finding.model_fields)
 

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -162,7 +162,16 @@ def _extract_finding_dicts(node: object, sink: list[dict], dropped: list[dict]) 
             sink.append(f.model_dump())
             return
         except (ValueError, KeyError, TypeError):
-            if _DROPPED_FINDING_KEY in node or _looks_like_finding(node):
+            if _DROPPED_FINDING_KEY in node:
+                dropped.append(node)
+                return
+            # A finding-shaped LEAF (shares finding fields, no nested containers)
+            # that failed validation is a malformed finding attempt -> count it.
+            # A dict that merely shares field names while NESTING dicts/lists is a
+            # wrapper: fall through and recurse so its real findings are recovered
+            # rather than swallowed (counting + stopping here would lose them).
+            has_nested = any(isinstance(v, (dict, list)) for v in node.values())
+            if _looks_like_finding(node) and not has_nested:
                 dropped.append(node)
                 return
         for value in node.values():

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -130,10 +130,20 @@ class ApiRunnerConfig:
 # A dict that fails `_Finding` validation but carries the required, domain-specific
 # `req` identifier is a *dropped finding* attempt: counted once for observability,
 # then we stop (its own fields are not separate findings, mirroring the valid path).
-# A dict without `req` is a container/wrapper (e.g. {"findings": [...]}) we recurse
-# into to recover findings nested inside it. `req` alone avoids false positives from
-# generic short keys like "t"/"w".
+# A dict that LOOKS like a finding (shares >=2 fields with the schema) but is missing
+# `req` is also a dropped attempt -- counting it makes that silent loss visible.
+# A pure container/wrapper (e.g. {"findings": [...]}) shares no finding fields, so we
+# recurse into it to recover findings nested inside.
 _DROPPED_FINDING_KEY = "req"
+_FINDING_FIELDS = frozenset(_Finding.model_fields)
+
+
+def _looks_like_finding(node: dict) -> bool:
+    """True if *node* shares enough keys with the finding schema to be a finding
+    attempt rather than a generic container. Two-field floor avoids false
+    positives from generic short keys like ``t``/``w`` appearing alone.
+    """
+    return len(_FINDING_FIELDS.intersection(node)) >= 2
 
 
 def _extract_finding_dicts(node: object, sink: list[dict], dropped: list[dict]) -> None:
@@ -142,9 +152,9 @@ def _extract_finding_dicts(node: object, sink: list[dict], dropped: list[dict]) 
     Recovers findings whether the model emitted them as a bare object, a list,
     a wrapped ``{"findings": [...]}``, or nested somewhere unexpected. Recursion
     stops at a successful ``_Finding`` validation. A dict that fails validation
-    but carries the ``req`` key is treated as a dropped finding attempt: counted
-    once for observability, then recursion stops (mirroring the valid path).
-    Pure containers (no ``req`` key) are recursed to recover nested findings.
+    but is a finding attempt (carries ``req`` or otherwise looks like a finding)
+    is counted as dropped, then recursion stops (mirroring the valid path). Pure
+    containers (no finding-like keys) are recursed to recover nested findings.
     """
     if isinstance(node, dict):
         try:
@@ -152,7 +162,7 @@ def _extract_finding_dicts(node: object, sink: list[dict], dropped: list[dict]) 
             sink.append(f.model_dump())
             return
         except (ValueError, KeyError, TypeError):
-            if _DROPPED_FINDING_KEY in node:
+            if _DROPPED_FINDING_KEY in node or _looks_like_finding(node):
                 dropped.append(node)
                 return
         for value in node.values():
@@ -202,8 +212,10 @@ def _parse_findings(raw_json: str) -> tuple[list[dict], int]:
 def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     """Call the LLM raw, validate each finding independently, return ``(findings, was_lossy)``.
 
-    ``was_lossy`` is True only when we failed to REACH the model (network /
-    timeout). A response where some findings were malformed returns
+    ``was_lossy`` is True when the analysis is unreliable: we failed to REACH
+    the model (network / timeout), OR the response was truncated by the output
+    budget (``finish_reason == "length"``) so findings past the cut are lost. A
+    response where only some individual findings were malformed returns
     ``(good_findings, False)`` -- the call succeeded end-to-end, so
     ``run_api_analysis`` may mark files done. Dropped malformed findings are
     logged (count) but do not set ``was_lossy``. See ``run_api_analysis`` for
@@ -279,9 +291,24 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
                 )
             return [], True
 
-    text = (response.choices[0].message.content or "") if response.choices else ""
+    choice = response.choices[0] if response.choices else None
+    finish_reason = getattr(choice, "finish_reason", None)
+    text = (choice.message.content or "") if choice else ""
     findings, dropped = _parse_findings(text)
     elapsed = time.monotonic() - start
+
+    # A length-truncated response is an incomplete analysis: the model ran out of
+    # output budget mid-stream, so findings after the cut are simply gone. Treat
+    # it as lossy so run_api_analysis writes an 'error' marker and the file(s)
+    # re-dispatch next run, rather than caching a partial result as 'ok'.
+    truncated = finish_reason == "length"
+    if truncated:
+        _log.warning(
+            "Model %s response was truncated (finish_reason=length) after %.0fs; "
+            "kept %d finding(s) but the analysis is incomplete and will re-dispatch. "
+            "Reduce input size or raise the model context window.",
+            config.model, elapsed, len(findings),
+        )
     if dropped:
         _log.warning(
             "Model %s: dropped %d malformed finding(s) of %d parsed in %.0fs "
@@ -292,7 +319,7 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
         "Model %s returned %d valid findings in %.0fs (raw bytes: %d)",
         config.model, len(findings), elapsed, len(text),
     )
-    return findings, False
+    return findings, truncated
 
 
 # ---------------------------------------------------------------------------
@@ -396,8 +423,9 @@ def run_api_analysis(
         them all. Individual malformed findings may have been dropped during
         per-finding parsing (and were logged with a count), but that does not
         invalidate the file: it was analysed, so it should not re-dispatch.
-        On a genuine call failure (network/timeout/unreachable, ``was_lossy``
-        True), every file gets an ``error`` marker instead. ``error`` markers
+        On a lossy call (network/timeout/unreachable, or a length-truncated
+        response, ``was_lossy`` True), every file gets an ``error`` marker
+        instead. ``error`` markers
         are excluded from the cache's ``ok_files`` set, so those files still
         re-dispatch on the next run -- but, unlike emitting no marker at all,
         they let the failure-streak breaker trip and the post-run

--- a/src/quodeq/data/fs/report_parser/_evidence.py
+++ b/src/quodeq/data/fs/report_parser/_evidence.py
@@ -43,7 +43,17 @@ def load_evidence_map(evidence_dir: Path) -> dict[str, dict[str, Any]]:
     """
     run_dir = evidence_dir.parent
     if not sqlite_disabled() and has_evaluation_db(run_dir):
-        return load_evidence_map_from_db(run_dir)
+        from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
+        try:
+            return load_evidence_map_from_db(run_dir)
+        except SchemaVersionError:
+            # evaluation.db was written by a newer Quodeq than this binary
+            # understands. Don't crash the run read; fall back to the
+            # per-dimension _evidence.json files below.
+            _logger.warning(
+                "evaluation.db at %s has a newer schema than this binary; "
+                "falling back to _evidence.json files", run_dir,
+            )
 
     evidence_map = _load_evidence_from_dir(evidence_dir)
     for entry in safe_read_dir(evidence_dir):

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -6,8 +6,14 @@ import sqlite3
 from quodeq.data.sqlite._schema import EVALUATION_DDL, SCHEMA_VERSION
 
 
-class SchemaVersionError(RuntimeError):
-    """Raised when the on-disk DB has a newer schema than this binary supports."""
+class SchemaVersionError(sqlite3.DatabaseError):
+    """Raised when the on-disk DB has a newer schema than this binary supports.
+
+    Subclasses ``sqlite3.DatabaseError`` (not bare ``RuntimeError``) so the
+    existing ``except sqlite3.DatabaseError`` guards around evaluation.db reads
+    degrade gracefully when an older binary opens a newer-schema DB, instead of
+    letting the error escape and crash the read.
+    """
 
 
 def _current_version(conn: sqlite3.Connection) -> int:

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -61,7 +61,31 @@ def _upgrade_v3_to_v4(conn: sqlite3.Connection) -> None:
 
     Note: ``user_version`` is bumped by ``apply_evaluation_schema`` after
     this function returns.
+
+    Recovery: this rebuild renames ``findings`` -> ``findings_old_v3`` before
+    recreating it. If a previous attempt was interrupted partway, the DB is
+    left in a half-migrated state that would brick every subsequent open:
+    either ``findings`` is already gone (the rename below would raise "no such
+    table: findings") or a stale ``findings_old_v3`` lingers (the rename would
+    raise "table findings_old_v3 already exists"). Normalise both states first
+    so the migration is idempotent across interruptions and self-heals on the
+    next open instead of failing permanently.
     """
+    tables = {
+        r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+    }
+    if "findings_old_v3" in tables:
+        if "findings" not in tables:
+            # Interrupted after the rename, before the rebuild: restore the
+            # original name and continue.
+            conn.execute("ALTER TABLE findings_old_v3 RENAME TO findings")
+        else:
+            # Interrupted after the new table was built, before the old one was
+            # dropped: `findings` is authoritative; discard the stale copy.
+            conn.execute("DROP TABLE findings_old_v3")
+
     conn.executescript("""
         -- Drop triggers and FTS index that reference the old table by name.
         DROP TRIGGER IF EXISTS findings_ai;

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -77,14 +77,17 @@ def _upgrade_v3_to_v4(conn: sqlite3.Connection) -> None:
         )
     }
     if "findings_old_v3" in tables:
-        if "findings" not in tables:
-            # Interrupted after the rename, before the rebuild: restore the
-            # original name and continue.
-            conn.execute("ALTER TABLE findings_old_v3 RENAME TO findings")
-        else:
-            # Interrupted after the new table was built, before the old one was
-            # dropped: `findings` is authoritative; discard the stale copy.
-            conn.execute("DROP TABLE findings_old_v3")
+        if "findings" in tables:
+            # Both present: a previous attempt recreated `findings` (possibly
+            # empty or partial, if interrupted before/within the copy) without
+            # dropping the original. findings_old_v3 holds the complete original
+            # rows, so discard the partial copy and restore the original; the
+            # rebuild below redoes the copy cleanly. Dropping the original here
+            # instead would lose every finding when the new table was empty.
+            conn.execute("DROP TABLE findings")
+        # Interrupted after the rename, before the rebuild finished: restore the
+        # original name so the rebuild runs against the complete data.
+        conn.execute("ALTER TABLE findings_old_v3 RENAME TO findings")
 
     conn.executescript("""
         -- Drop triggers and FTS index that reference the old table by name.

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -84,13 +84,28 @@ class SQLiteStateStore:
             conn.commit()
 
     def update_verdict(self, *, req: str, file: str, line: int, verdict: str) -> int:
-        """Update a finding's verdict by (requirement, file, line). Returns row count."""
+        """Update a finding's verdict by (requirement, file, line). Returns row count.
+
+        A finding with no requirement id is stored with ``requirement`` NULL, but
+        the dismiss/restore event carries an empty string. ``requirement = ''``
+        never matches NULL in SQL, so an empty ``req`` is matched on (file, line)
+        against rows whose requirement is NULL or empty, scoped so it cannot
+        sweep a different, req-bearing finding at the same location.
+        """
         with open_evaluation_db(self._run_dir) as conn:
-            cur = conn.execute(
-                "UPDATE findings SET verdict = ? "
-                "WHERE requirement = ? AND file = ? AND line = ?",
-                (verdict, req, file, line),
-            )
+            if req:
+                cur = conn.execute(
+                    "UPDATE findings SET verdict = ? "
+                    "WHERE requirement = ? AND file = ? AND line = ?",
+                    (verdict, req, file, line),
+                )
+            else:
+                cur = conn.execute(
+                    "UPDATE findings SET verdict = ? "
+                    "WHERE (requirement IS NULL OR requirement = '') "
+                    "AND file = ? AND line = ?",
+                    (verdict, file, line),
+                )
             conn.commit()
             return cur.rowcount
 

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -1,6 +1,7 @@
 """Dashboard and accumulated-view logic, split from action_provider_fs."""
 from __future__ import annotations
 
+import logging
 import os
 import threading
 from collections import OrderedDict
@@ -21,6 +22,8 @@ from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services.dim_resolution import is_eligible_for_default_view
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -428,6 +431,7 @@ def _apply_sql_grade_override(
     Falls back to the FS-based grades when grade tables are empty or the
     run directory does not exist.
     """
+    from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
     from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
     from quodeq.data.sqlite.state_store import SQLiteStateStore  # noqa: PLC0415
 
@@ -435,11 +439,19 @@ def _apply_sql_grade_override(
     if not run_dir.is_dir():
         return payload
 
-    repo = SqliteFindingsRepository(run_dir)
-    repo._ensure_fresh()  # noqa: SLF001
-
     store = SQLiteStateStore(run_dir)
-    dim_rows = store.read_dimension_scores()
+    try:
+        repo = SqliteFindingsRepository(run_dir)
+        repo._ensure_fresh()  # noqa: SLF001
+        dim_rows = store.read_dimension_scores()
+    except SchemaVersionError:
+        # evaluation.db was written by a newer Quodeq than this binary; keep the
+        # FS-based grades already in the payload rather than crashing the build.
+        _logger.warning(
+            "evaluation.db for %s/%s has a newer schema than this binary; "
+            "keeping FS-based grades in the dashboard.", project, run_id,
+        )
+        return payload
     if not dim_rows:
         return payload
 

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -288,11 +288,22 @@ def get_scores_raw(
     # without one, skip straight to the JSON-file fallback so we don't have
     # to wait on a no-op projection that will leave the grade tables empty.
     if (run_dir / "events.jsonl").is_file():
-        repo = SqliteFindingsRepository(run_dir)
-        repo._ensure_fresh()  # noqa: SLF001
-        store = SQLiteStateStore(run_dir)
-        if store.read_dimension_scores():
-            return _build_response_from_grade_tables(run_dir)
+        from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
+        try:
+            repo = SqliteFindingsRepository(run_dir)
+            repo._ensure_fresh()  # noqa: SLF001
+            store = SQLiteStateStore(run_dir)
+            if store.read_dimension_scores():
+                return _build_response_from_grade_tables(run_dir)
+        except SchemaVersionError:
+            # evaluation.db was written by a newer Quodeq than this binary
+            # understands. Don't crash the score read; fall back to the JSON
+            # eval files (schema-independent) so a downgraded install still works.
+            _logger.warning(
+                "Run %s/%s has an evaluation.db from a newer Quodeq version; "
+                "serving scores from the JSON eval files. Upgrade to read the "
+                "SQL grade tables.", project, run_id,
+            )
 
     return _build_response_from_eval_files(reports_root, project, run_id)
 

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -163,6 +163,18 @@ class TestParserDropAccounting:
         assert len(findings) == 1
         assert dropped == 0
 
+    def test_recovers_real_findings_nested_in_finding_shaped_wrapper(self):
+        # A wrapper that happens to share >=2 finding field names (severity,
+        # reason) but NESTS a real finding must not have that finding swallowed.
+        # Counting the wrapper as a drop AND stopping recursion would lose it.
+        valid = {"req": "R1", "t": "violation", "file": "a.py", "line": 5,
+                 "severity": "minor", "w": "x", "snippet": "code", "reason": "bad"}
+        raw = json.dumps({"severity": "major", "reason": "run summary", "items": [valid]})
+        findings, dropped = _parse_findings(raw)
+        assert len(findings) == 1
+        assert findings[0]["req"] == "R1"
+        assert dropped == 0
+
 
 class TestTruncationDetection:
     """A length-truncated response is incomplete: mark the call lossy so the
@@ -274,6 +286,28 @@ class TestMarkerContract:
         assert all(m["status"] == "error" for m in markers)
         # A failed call produces no findings.
         assert self._findings_only(lines) == []
+
+    def test_truncated_response_emits_error_markers(self, tmp_path, api_config):
+        """A length-truncated response is lossy: emit 'error' markers so the
+        files re-dispatch and the breaker/reachability guard see the failure,
+        while still surfacing the partial findings recovered before the cut."""
+        jsonl_file = tmp_path / "evidence.jsonl"
+        content = _make_findings_json(("X-1", "violation", "a.py", 1, "minor", "x"))
+        raw_client = _mock_raw_client_finish(content, "length")
+
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = raw_client
+            run_api_analysis(
+                prompt="t", jsonl_file=jsonl_file, config=api_config,
+                source_file_paths=["src/a.py"],
+            )
+
+        lines = self._read_jsonl(jsonl_file)
+        markers = self._markers(lines)
+        assert {m["file"] for m in markers} == {"src/a.py"}
+        assert all(m["status"] == "error" for m in markers)
+        # Partial findings recovered before the cut are still surfaced.
+        assert len(self._findings_only(lines)) == 1
 
     def test_no_source_files_no_markers(self, tmp_path, api_config):
         """Backward-compat: callers that don't pass source_file_paths get

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -12,8 +12,18 @@ pytest.importorskip("openai", reason="requires the openai SDK")
 
 from quodeq.analysis._api_runner import (
     run_api_analysis, ApiRunnerConfig,
-    _call_api, _Finding, _FindingType, _Severity, _LOCAL_TIMEOUT,
+    _call_api, _parse_findings, _Finding, _FindingType, _Severity, _LOCAL_TIMEOUT,
 )
+
+
+def _mock_raw_client_finish(content: str, finish_reason: str) -> MagicMock:
+    """Mock client whose single choice carries an explicit finish_reason."""
+    msg = MagicMock(content=content)
+    choice = MagicMock(message=msg, finish_reason=finish_reason)
+    response = MagicMock(choices=[choice])
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    return client
 
 
 def _make_findings_json(*findings_data) -> str:
@@ -126,6 +136,58 @@ class TestRunApiAnalysis:
             mock_oa.return_value.__enter__.return_value = client
             _call_api("prompt", api_config)
         assert mock_oa.call_args.kwargs["max_retries"] == 0
+
+
+class TestParserDropAccounting:
+    """Every finding-shaped object the model emits but we can't keep must be
+    counted, so a systemic loss is visible in the logs instead of silent."""
+
+    def test_counts_finding_missing_req_as_dropped(self):
+        # A finding-shaped object missing the required `req`. Today it is
+        # silently recursed away and NOT counted; it must count as dropped.
+        raw = json.dumps({"findings": [
+            {"t": "violation", "file": "a.py", "line": 5, "w": "x",
+             "snippet": "code", "reason": "bad"},  # no req
+        ]})
+        findings, dropped = _parse_findings(raw)
+        assert findings == []
+        assert dropped == 1
+
+    def test_does_not_count_non_finding_noise(self):
+        # A stray container/noise object that does not look like a finding
+        # must NOT inflate the dropped count.
+        valid = {"req": "R1", "t": "violation", "file": "a.py", "line": 5,
+                 "severity": "minor", "w": "x", "snippet": "code", "reason": "bad"}
+        raw = '{"note": "analysis complete"}' + json.dumps({"findings": [valid]})
+        findings, dropped = _parse_findings(raw)
+        assert len(findings) == 1
+        assert dropped == 0
+
+
+class TestTruncationDetection:
+    """A length-truncated response is incomplete: mark the call lossy so the
+    file re-dispatches instead of being cached as a clean analysis."""
+
+    def test_truncated_response_is_lossy(self, api_config):
+        content = _make_findings_json(
+            ("R1", "violation", "a.py", 5, "minor", "x"),
+        )
+        client = _mock_raw_client_finish(content, "length")
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            _findings, was_lossy = _call_api("prompt", api_config)
+        assert was_lossy is True
+
+    def test_complete_response_is_not_lossy(self, api_config):
+        content = _make_findings_json(
+            ("R1", "violation", "a.py", 5, "minor", "x"),
+        )
+        client = _mock_raw_client_finish(content, "stop")
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            findings, was_lossy = _call_api("prompt", api_config)
+        assert was_lossy is False
+        assert len(findings) == 1
 
 
 class TestMarkerContract:

--- a/tests/api/test_scores_routes.py
+++ b/tests/api/test_scores_routes.py
@@ -85,6 +85,27 @@ def test_get_scores_raw_reads_from_sql_after_projection(tmp_path: Path) -> None:
     assert security_dim["overallScore"] is not None
 
 
+def test_get_scores_raw_falls_back_when_db_schema_too_new(tmp_path: Path) -> None:
+    """A run whose evaluation.db was written by a NEWER Quodeq (higher schema
+    version) must not crash the score read on an older binary; get_scores_raw
+    degrades to the JSON-eval-file path instead of raising SchemaVersionError."""
+    import sqlite3  # noqa: PLC0415
+
+    from quodeq.data.sqlite._schema import SCHEMA_VERSION  # noqa: PLC0415
+
+    _seed_run(tmp_path, "myproject", "r1", violations=_scorable_violations())
+    db = tmp_path / "myproject" / "r1" / "evaluation.db"
+    conn = sqlite3.connect(db)
+    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 5}")
+    conn.commit()
+    conn.close()
+
+    result = get_scores_raw(tmp_path, "myproject", "r1")  # must not raise
+
+    assert "dimensions" in result
+    assert "summary" in result
+
+
 def test_get_scores_raw_uses_sql_when_grades_present(tmp_path: Path, monkeypatch) -> None:
     """When grade tables have rows, get_scores_raw reads them, not the legacy rescore."""
     _seed_run(tmp_path, "myproject", "r1", violations=[_DEFAULT_VIOLATION])

--- a/tests/data/projection/test_handlers_actions.py
+++ b/tests/data/projection/test_handlers_actions.py
@@ -51,6 +51,65 @@ def test_handle_finding_undismissed_restores_violation(tmp_path: Path) -> None:
     assert _verdict_for(tmp_path, "R1", "a.py", 10) == "violation"
 
 
+def _verdict_at(tmp_path: Path, file: str, line: int) -> str | None:
+    """Verdict of the finding stored with a NULL requirement at (file, line)."""
+    with open_evaluation_db(tmp_path) as conn:
+        row = conn.execute(
+            "SELECT verdict FROM findings "
+            "WHERE requirement IS NULL AND file=? AND line=?",
+            (file, line),
+        ).fetchone()
+    return row[0] if row else None
+
+
+def test_handle_dismissed_flips_verdict_for_finding_without_req(tmp_path: Path) -> None:
+    """A finding with no requirement id is stored with requirement NULL. The
+    dismiss event carries an empty req, so matching on `requirement = ''` never
+    hits it and the score never moves. The verdict must still flip, matched on
+    (file, line)."""
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req=None,
+    ))
+
+    handle(FindingDismissedEvent(payload=FindingDismissed(req="", file="a.py", line=10)), store)
+
+    assert _verdict_at(tmp_path, "a.py", 10) == "dismissed"
+
+
+def test_handle_undismissed_restores_finding_without_req(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req=None,
+    ))
+    handle(FindingDismissedEvent(payload=FindingDismissed(req="", file="a.py", line=10)), store)
+
+    handle(FindingUndismissedEvent(payload=FindingUndismissed(req="", file="a.py", line=10)), store)
+
+    assert _verdict_at(tmp_path, "a.py", 10) == "violation"
+
+
+def test_dismiss_empty_req_does_not_touch_req_bearing_finding_at_same_location(tmp_path: Path) -> None:
+    """Dismissing the null-req finding must not sweep a different finding that
+    carries a req at the same (file, line)."""
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req=None,
+    ))
+    store.record_finding(Judgment(
+        practice_id="P2", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",
+    ))
+
+    handle(FindingDismissedEvent(payload=FindingDismissed(req="", file="a.py", line=10)), store)
+
+    assert _verdict_at(tmp_path, "a.py", 10) == "dismissed"      # null-req one
+    assert _verdict_for(tmp_path, "R1", "a.py", 10) == "violation"  # req one untouched
+
+
 def test_handle_dismissed_no_op_when_finding_absent(tmp_path: Path) -> None:
     # Project A's actions log may contain dismissals for findings that this
     # run never produced. The handler should silently no-op.

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -154,13 +154,14 @@ def test_upgrade_v3_to_v4_recovers_when_findings_already_renamed():
     assert rows == [("P1", "a.py")]  # data carried in the renamed table survived
 
 
-def test_upgrade_v3_to_v4_recovers_when_stale_old_table_present():
-    """An attempt interrupted before dropping `findings_old_v3` leaves BOTH
-    tables. The rebuild's RENAME would fail with 'table findings_old_v3 already
-    exists'; the upgrade must drop the stale leftover and finish."""
+def test_upgrade_v3_to_v4_recovers_when_partial_new_table_present():
+    """An attempt interrupted after `findings` was recreated but before the
+    copy finished leaves BOTH tables: an empty/partial new `findings` and the
+    original `findings_old_v3`. The ORIGINAL data must win, otherwise dropping
+    findings_old_v3 (and keeping the empty new table) loses every finding."""
     conn = sqlite3.connect(":memory:")
-    _make_findings_table(conn, "findings", dedup="P1|a.py|10|violation")
-    _make_findings_table(conn, "findings_old_v3", dedup="stale")
+    conn.execute(f"CREATE TABLE findings ({_V3_FINDINGS_COLUMNS})")  # empty new table
+    _make_findings_table(conn, "findings_old_v3", dedup="P1|a.py|10|violation")  # original
 
     _upgrade_v3_to_v4(conn)  # must not raise
 
@@ -170,7 +171,7 @@ def test_upgrade_v3_to_v4_recovers_when_stale_old_table_present():
     assert "findings" in tables
     assert "findings_old_v3" not in tables
     rows = conn.execute("SELECT practice_id, file FROM findings").fetchall()
-    assert rows == [("P1", "a.py")]  # authoritative `findings` data kept
+    assert rows == [("P1", "a.py")]  # original rows recovered, not the empty copy
 
 
 def test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path():

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -42,6 +42,18 @@ def test_apply_evaluation_schema_rejects_newer_version():
         apply_evaluation_schema(conn)
 
 
+def test_newer_version_error_is_a_database_error():
+    """SchemaVersionError must be a sqlite3.DatabaseError so the existing
+    `except sqlite3.DatabaseError` guards (e.g. dismissed-list enrichment)
+    degrade gracefully instead of crashing when an older binary opens a
+    newer-schema evaluation.db."""
+    assert issubclass(SchemaVersionError, sqlite3.DatabaseError)
+    conn = sqlite3.connect(":memory:")
+    conn.execute("PRAGMA user_version = 99")
+    with pytest.raises(sqlite3.DatabaseError):
+        apply_evaluation_schema(conn)
+
+
 def _build_v1_db() -> sqlite3.Connection:
     """Recreate the schema as it existed at SCHEMA_VERSION=1, before the
     confidence column was added. Used to verify the v1 → v2 upgrade path."""

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -3,8 +3,44 @@ import pytest
 from quodeq.data.sqlite._migrations import (
     apply_evaluation_schema,
     SchemaVersionError,
+    _upgrade_v3_to_v4,
 )
 from quodeq.data.sqlite._schema import SCHEMA_VERSION
+
+
+# Column list shared by the v3 `findings` table and its renamed `findings_old_v3`.
+_V3_FINDINGS_COLUMNS = """
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    practice_id TEXT NOT NULL,
+    dimension TEXT NOT NULL DEFAULT '',
+    requirement TEXT,
+    verdict TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    file TEXT NOT NULL DEFAULT '',
+    line INTEGER NOT NULL DEFAULT 0,
+    end_line INTEGER NOT NULL DEFAULT 0,
+    title TEXT NOT NULL DEFAULT '',
+    reason TEXT NOT NULL DEFAULT '',
+    snippet TEXT NOT NULL DEFAULT '',
+    violation_type TEXT NOT NULL DEFAULT '',
+    context TEXT NOT NULL DEFAULT '',
+    scope TEXT NOT NULL DEFAULT '',
+    req_refs_json TEXT,
+    dedup_key TEXT NOT NULL UNIQUE,
+    confidence INTEGER NOT NULL DEFAULT 100,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+"""
+
+
+def _make_findings_table(conn: sqlite3.Connection, name: str, *, dedup: str) -> None:
+    conn.execute(f"CREATE TABLE {name} ({_V3_FINDINGS_COLUMNS})")
+    conn.execute(
+        f"INSERT INTO {name} (practice_id, verdict, severity, file, line, dedup_key) "
+        "VALUES ('P1', 'violation', 'critical', 'a.py', 10, ?)",
+        (dedup,),
+    )
+    conn.commit()
 
 
 def test_apply_evaluation_schema_on_fresh_db_sets_version():
@@ -97,6 +133,44 @@ def test_apply_evaluation_schema_upgrades_v1_to_current():
     assert cur.fetchone()[0] == SCHEMA_VERSION
     cur = conn.execute("SELECT confidence FROM findings WHERE practice_id='P-1'")
     assert cur.fetchone()[0] == 100
+
+
+def test_upgrade_v3_to_v4_recovers_when_findings_already_renamed():
+    """An interrupted v3->v4 migration leaves `findings` renamed to
+    `findings_old_v3` with no `findings` table. Re-running the upgrade must
+    recover and finish, not raise 'no such table: findings' forever (which
+    permanently bricked the run's DB)."""
+    conn = sqlite3.connect(":memory:")
+    _make_findings_table(conn, "findings_old_v3", dedup="P1|a.py|10|violation")
+
+    _upgrade_v3_to_v4(conn)  # must not raise
+
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "findings" in tables
+    assert "findings_old_v3" not in tables
+    rows = conn.execute("SELECT practice_id, file FROM findings").fetchall()
+    assert rows == [("P1", "a.py")]  # data carried in the renamed table survived
+
+
+def test_upgrade_v3_to_v4_recovers_when_stale_old_table_present():
+    """An attempt interrupted before dropping `findings_old_v3` leaves BOTH
+    tables. The rebuild's RENAME would fail with 'table findings_old_v3 already
+    exists'; the upgrade must drop the stale leftover and finish."""
+    conn = sqlite3.connect(":memory:")
+    _make_findings_table(conn, "findings", dedup="P1|a.py|10|violation")
+    _make_findings_table(conn, "findings_old_v3", dedup="stale")
+
+    _upgrade_v3_to_v4(conn)  # must not raise
+
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "findings" in tables
+    assert "findings_old_v3" not in tables
+    rows = conn.execute("SELECT practice_id, file FROM findings").fetchall()
+    assert rows == [("P1", "a.py")]  # authoritative `findings` data kept
 
 
 def test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path():

--- a/tests/data/test_state_store.py
+++ b/tests/data/test_state_store.py
@@ -133,6 +133,39 @@ def test_update_verdict_returns_zero_when_no_match(tmp_path: Path) -> None:
     assert rows == 0
 
 
+def test_update_verdict_empty_req_returns_zero_when_no_match(tmp_path: Path) -> None:
+    """The empty-req branch must report no match cleanly when there is no
+    null/empty-requirement finding at that location."""
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="R1",  # has a req, NULL branch won't hit it
+    ))
+
+    rows = store.update_verdict(req="", file="a.py", line=10, verdict="dismissed")
+
+    assert rows == 0
+
+
+def test_update_verdict_empty_req_matches_empty_string_requirement(tmp_path: Path) -> None:
+    """A finding physically stored with requirement='' (not NULL) is also
+    matched by the empty-req branch."""
+    store = SQLiteStateStore(tmp_path)
+    store.record_finding(Judgment(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="a.py", line=10, reason="r", req="",  # stored as empty string
+    ))
+
+    rows = store.update_verdict(req="", file="a.py", line=10, verdict="dismissed")
+
+    assert rows == 1
+    with open_evaluation_db(tmp_path) as conn:
+        row = conn.execute(
+            "SELECT verdict FROM findings WHERE file=? AND line=?", ("a.py", 10),
+        ).fetchone()
+        assert row[0] == "dismissed"
+
+
 def test_actions_projected_size_round_trips(tmp_path: Path) -> None:
     store = SQLiteStateStore(tmp_path)
     assert store.get_actions_projected_size() is None

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -128,6 +128,42 @@ class TestBuildDashboard:
         assert len(result["dimensions"]) == 1
         assert "trend" in result
 
+    def test_build_dashboard_survives_too_new_db(self, tmp_path):
+        """The SQL grade override reads the per-run evaluation.db. If that DB was
+        written by a newer Quodeq, build_dashboard must keep the FS-based grades
+        instead of crashing on SchemaVersionError."""
+        import sqlite3
+
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+        from quodeq.data.projection.projector import Projector
+        from quodeq.data.sqlite._schema import SCHEMA_VERSION
+
+        run_dir = tmp_path / "proj" / "r1"
+        run_dir.mkdir(parents=True)
+        log = run_dir / "events.jsonl"
+        EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="P1", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1",
+        )))
+        Projector().ensure_projected(log, run_dir, project_dir=tmp_path / "proj")
+        conn = sqlite3.connect(run_dir / "evaluation.db")
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 5}")
+        conn.commit()
+        conn.close()
+
+        run = _make_run("r1", "2024-01-01")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[run]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")  # must not raise
+
+        assert len(result["dimensions"]) == 1
+
     def test_latest_skips_cancelled_runs(self, tmp_path):
         # ``"latest"`` defaults to the most recent fully-completed run so the
         # per-dim cards reflect a coherent run that agrees with the headline.

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -162,7 +162,12 @@ class TestBuildDashboard:
         ):
             result = build_dashboard(str(tmp_path), "proj", "latest")  # must not raise
 
+        # The FS-based grades survive: the SQL override is skipped, not silently
+        # blanked, so the dimension keeps the grade/score from read_run_data.
         assert len(result["dimensions"]) == 1
+        dim = result["dimensions"][0]
+        assert dim["overallGrade"] == "B"
+        assert dim["overallScore"] == "7.0"
 
     def test_latest_skips_cancelled_runs(self, tmp_path):
         # ``"latest"`` defaults to the most recent fully-completed run so the


### PR DESCRIPTION
Closes the five fix-after-release issues surfaced by the 1.2.0 release analysis, so they ship *in* 1.2.0. Each fix is TDD (red→green) and was put through an adversarial review pass, which caught three real defects in the first cut (all fixed here and re-verified).

## Fixes

- **#578 (parser silent finding loss)** — count finding-shaped drops missing `req`; treat a `finish_reason==length` truncation as lossy so the file re-dispatches instead of caching a partial as `ok`.
- **#577 (SchemaVersionError crash on downgrade)** — `SchemaVersionError` now subclasses `sqlite3.DatabaseError`; `get_scores_raw`, `load_evidence_map`, and `_apply_sql_grade_override` fall back to the schema-independent JSON files so an older binary degrades instead of crashing.
- **#579 (null-req dismiss no-op)** — `update_verdict` matches an empty `req` on `(file, line)` against NULL/empty-requirement rows, scoped so it can't sweep a req-bearing finding at the same location.
- **#580 (sdist ships node_modules)** — `source-exclude` drops `node_modules` (and `.mypy_cache`/`.DS_Store`); sdist goes **29 MB → 1.6 MB**. wheel-smoke asserts it stays out and small.
- **#576 (interrupted v3→v4 migration bricks the DB)** — the migration self-heals from both half-migrated states (rename the original back / drop a partial new table and restore the original) instead of raising forever.

## Adversarial review caught (and this PR fixes)

1. **#578 regression** — the new drop-counter swallowed *real* findings nested in finding-shaped wrappers. Now counts finding-shaped **leaves** only; wrappers are recursed.
2. **#577 gap** — `_apply_sql_grade_override` (called unconditionally by `build_dashboard`) was still unguarded and crashed the dashboard. Now guarded.
3. **#576 data loss** — the both-present recovery could drop the original rows if the new `findings` table was empty. Now always restores from `findings_old_v3` (the complete original).

## Verification

- TDD on every fix; the re-verification confirmed all three regressions are genuinely closed (red→green proven) with no new functional issues.
- Full suite: **3171 passed**. (A SIGTERM-timing test in `tests/ci/test_cli_signals.py` is known-flaky under full-suite parallel load and passes in isolation; unrelated to this diff.)

Independent of #575 (legacy dismissed migration); both land on `develop` before the 1.2.0 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)