### PR TITLE
fix(sqlite): self-heal interrupted schema migrations + widen evaluation.db read seams

### DIFF
--- a/src/quodeq/data/fs/report_parser/_evidence.py
+++ b/src/quodeq/data/fs/report_parser/_evidence.py
@@ -43,16 +43,17 @@ def load_evidence_map(evidence_dir: Path) -> dict[str, dict[str, Any]]:
     """
     run_dir = evidence_dir.parent
     if not sqlite_disabled() and has_evaluation_db(run_dir):
-        from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
+        import sqlite3  # noqa: PLC0415
         try:
             return load_evidence_map_from_db(run_dir)
-        except SchemaVersionError:
-            # evaluation.db was written by a newer Quodeq than this binary
-            # understands. Don't crash the run read; fall back to the
+        except sqlite3.DatabaseError:
+            # evaluation.db is unreadable by this binary: written by a newer
+            # Quodeq (SchemaVersionError, a DatabaseError subclass) or otherwise
+            # corrupt/half-written. Don't crash the run read; fall back to the
             # per-dimension _evidence.json files below.
             _logger.warning(
-                "evaluation.db at %s has a newer schema than this binary; "
-                "falling back to _evidence.json files", run_dir,
+                "evaluation.db at %s is unreadable; falling back to "
+                "_evidence.json files", run_dir,
             )
 
     evidence_map = _load_evidence_from_dir(evidence_dir)

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -23,14 +23,31 @@ def _current_version(conn: sqlite3.Connection) -> int:
 # Incremental upgrades from version N to N+1. Each function takes a connection
 # already at version N; the caller bumps PRAGMA user_version to N+1 afterwards.
 def _upgrade_v1_to_v2(conn: sqlite3.Connection) -> None:
-    """Add per-finding confidence column (default 100 = full confidence)."""
-    conn.execute("ALTER TABLE findings ADD COLUMN confidence INTEGER NOT NULL DEFAULT 100")
+    """Add per-finding confidence column (default 100 = full confidence).
+
+    Idempotency: the ALTER and the PRAGMA user_version bump commit separately,
+    so a crash between them leaves the column added but the version still 1.
+    Skip if it already exists, otherwise the re-run raises "duplicate column
+    name: confidence" and bricks the run (see _upgrade_v4_to_v5 for the same
+    guard on exit_reason).
+    """
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(findings)")}
+    if "confidence" not in columns:
+        conn.execute("ALTER TABLE findings ADD COLUMN confidence INTEGER NOT NULL DEFAULT 100")
 
 
 def _upgrade_v2_to_v3(conn: sqlite3.Connection) -> None:
-    """Add principle_grades table for per-principle scoring."""
+    """Add principle_grades table for per-principle scoring.
+
+    Idempotency: executescript commits the DDL immediately, independent of the
+    later PRAGMA user_version bump in apply_evaluation_schema. A crash between
+    them leaves the table created but the version still 2, so re-running a bare
+    CREATE would raise "table principle_grades already exists" -- a plain
+    OperationalError the scoring/dashboard read seams don't catch, permanently
+    bricking the run. IF NOT EXISTS makes the re-run a no-op and self-heal.
+    """
     conn.executescript("""
-        CREATE TABLE principle_grades (
+        CREATE TABLE IF NOT EXISTS principle_grades (
             dimension        TEXT NOT NULL,
             principle_id     TEXT NOT NULL,
             score            REAL,
@@ -41,7 +58,7 @@ def _upgrade_v2_to_v3(conn: sqlite3.Connection) -> None:
             PRIMARY KEY (dimension, principle_id)
         );
 
-        CREATE INDEX idx_principle_grades_dimension ON principle_grades(dimension);
+        CREATE INDEX IF NOT EXISTS idx_principle_grades_dimension ON principle_grades(dimension);
     """)
 
 
@@ -209,7 +226,15 @@ def _upgrade_v4_to_v5(conn: sqlite3.Connection) -> None:
         "SELECT 1 FROM sqlite_master WHERE type='table' AND name='dimension_scores'"
     ).fetchone() is not None
     if has_dim_scores:
-        conn.execute("ALTER TABLE dimension_scores ADD COLUMN exit_reason TEXT")
+        # Idempotency: the ALTER and the PRAGMA user_version bump in
+        # apply_evaluation_schema commit separately (autocommit), so a crash
+        # in between leaves the column added but the version still 4. Re-running
+        # the bare ALTER would then raise "duplicate column name: exit_reason"
+        # -- a plain OperationalError the scoring/dashboard read seams don't
+        # catch, permanently bricking the run. Skip if the column already exists.
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(dimension_scores)")}
+        if "exit_reason" not in columns:
+            conn.execute("ALTER TABLE dimension_scores ADD COLUMN exit_reason TEXT")
 
 
 _UPGRADES = {

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -431,7 +431,8 @@ def _apply_sql_grade_override(
     Falls back to the FS-based grades when grade tables are empty or the
     run directory does not exist.
     """
-    from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
+    import sqlite3  # noqa: PLC0415
+
     from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
     from quodeq.data.sqlite.state_store import SQLiteStateStore  # noqa: PLC0415
 
@@ -444,12 +445,14 @@ def _apply_sql_grade_override(
         repo = SqliteFindingsRepository(run_dir)
         repo._ensure_fresh()  # noqa: SLF001
         dim_rows = store.read_dimension_scores()
-    except SchemaVersionError:
-        # evaluation.db was written by a newer Quodeq than this binary; keep the
-        # FS-based grades already in the payload rather than crashing the build.
+    except sqlite3.DatabaseError:
+        # evaluation.db is unreadable by this binary: written by a newer Quodeq
+        # (SchemaVersionError, a DatabaseError subclass) or otherwise corrupt /
+        # half-written. Keep the FS-based grades already in the payload rather
+        # than crashing the build.
         _logger.warning(
-            "evaluation.db for %s/%s has a newer schema than this binary; "
-            "keeping FS-based grades in the dashboard.", project, run_id,
+            "evaluation.db for %s/%s is unreadable; keeping FS-based grades "
+            "in the dashboard.", project, run_id,
         )
         return payload
     if not dim_rows:

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -288,21 +288,23 @@ def get_scores_raw(
     # without one, skip straight to the JSON-file fallback so we don't have
     # to wait on a no-op projection that will leave the grade tables empty.
     if (run_dir / "events.jsonl").is_file():
-        from quodeq.data.sqlite._migrations import SchemaVersionError  # noqa: PLC0415
+        import sqlite3  # noqa: PLC0415
         try:
             repo = SqliteFindingsRepository(run_dir)
             repo._ensure_fresh()  # noqa: SLF001
             store = SQLiteStateStore(run_dir)
             if store.read_dimension_scores():
                 return _build_response_from_grade_tables(run_dir)
-        except SchemaVersionError:
-            # evaluation.db was written by a newer Quodeq than this binary
-            # understands. Don't crash the score read; fall back to the JSON
-            # eval files (schema-independent) so a downgraded install still works.
+        except sqlite3.DatabaseError:
+            # evaluation.db is unreadable by this binary: it was written by a
+            # newer Quodeq (SchemaVersionError, a DatabaseError subclass) or is
+            # otherwise corrupt/half-written. Don't crash the score read; fall
+            # back to the JSON eval files (schema-independent) so a downgraded
+            # or upgrading install still works.
             _logger.warning(
-                "Run %s/%s has an evaluation.db from a newer Quodeq version; "
-                "serving scores from the JSON eval files. Upgrade to read the "
-                "SQL grade tables.", project, run_id,
+                "Run %s/%s has an unreadable evaluation.db; serving scores "
+                "from the JSON eval files instead of the SQL grade tables.",
+                project, run_id,
             )
 
     return _build_response_from_eval_files(reports_root, project, run_id)

--- a/tests/api/test_scores_routes.py
+++ b/tests/api/test_scores_routes.py
@@ -106,6 +106,22 @@ def test_get_scores_raw_falls_back_when_db_schema_too_new(tmp_path: Path) -> Non
     assert "summary" in result
 
 
+def test_get_scores_raw_falls_back_when_db_is_corrupt(tmp_path: Path) -> None:
+    """A corrupt or half-written evaluation.db raises a generic
+    sqlite3.DatabaseError (e.g. 'file is not a database'), not the narrower
+    SchemaVersionError. The score read must still degrade to the JSON-eval-file
+    path instead of crashing. SchemaVersionError already subclasses
+    DatabaseError, so widening the seam to DatabaseError covers both."""
+    _seed_run(tmp_path, "myproject", "r1", violations=_scorable_violations())
+    db = tmp_path / "myproject" / "r1" / "evaluation.db"
+    db.write_bytes(b"this is not a sqlite database at all")
+
+    result = get_scores_raw(tmp_path, "myproject", "r1")  # must not raise
+
+    assert "dimensions" in result
+    assert "summary" in result
+
+
 def test_get_scores_raw_uses_sql_when_grades_present(tmp_path: Path, monkeypatch) -> None:
     """When grade tables have rows, get_scores_raw reads them, not the legacy rescore."""
     _seed_run(tmp_path, "myproject", "r1", violations=[_DEFAULT_VIOLATION])

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -5,7 +5,7 @@ from quodeq.data.sqlite._migrations import (
     SchemaVersionError,
     _upgrade_v3_to_v4,
 )
-from quodeq.data.sqlite._schema import SCHEMA_VERSION
+from quodeq.data.sqlite._schema import EVALUATION_DDL, SCHEMA_VERSION
 
 
 # Column list shared by the v3 `findings` table and its renamed `findings_old_v3`.
@@ -172,6 +172,95 @@ def test_upgrade_v3_to_v4_recovers_when_partial_new_table_present():
     assert "findings_old_v3" not in tables
     rows = conn.execute("SELECT practice_id, file FROM findings").fetchall()
     assert rows == [("P1", "a.py")]  # original rows recovered, not the empty copy
+
+
+def test_upgrade_v4_to_v5_idempotent_when_exit_reason_already_present():
+    """An interrupted v4->v5 migration can leave dimension_scores.exit_reason
+    already added but user_version still 4 (the ALTER committed in autocommit,
+    the separate PRAGMA bump never did). Re-running must self-heal to v5, not
+    raise 'duplicate column name: exit_reason' -- a bare OperationalError the
+    scoring/dashboard read seams don't catch, which permanently bricks the
+    run's scores and dashboard with no recovery."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(EVALUATION_DDL)        # full v5 schema: exit_reason present
+    conn.execute("PRAGMA user_version = 4")   # pretend the version bump never landed
+
+    apply_evaluation_schema(conn)             # must not raise
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+
+def test_upgrade_v1_to_v2_idempotent_when_confidence_already_present():
+    """An interrupted v1->v2 migration can leave findings.confidence added but
+    user_version still 1 (the ALTER committed, the separate PRAGMA bump didn't).
+    Re-running must self-heal to v5, not raise 'duplicate column name:
+    confidence' -- the same brick-the-run failure class as the other steps."""
+    conn = _build_v1_db()
+    conn.execute("ALTER TABLE findings ADD COLUMN confidence INTEGER NOT NULL DEFAULT 100")
+    # user_version is still 1 (set by _build_v1_db); the bump never landed.
+
+    apply_evaluation_schema(conn)  # must not raise
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+
+def test_upgrade_v2_to_v3_idempotent_when_principle_grades_already_present():
+    """An interrupted v2->v3 migration can leave principle_grades created but
+    user_version still 2 (executescript committed the CREATE, the separate
+    PRAGMA bump never landed). Re-running must self-heal all the way to v5 and
+    preserve rows, not raise 'table principle_grades already exists' -- a bare
+    OperationalError the read seams don't catch, which permanently bricks the
+    run."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        PRAGMA user_version = 2;
+        CREATE TABLE findings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            schema_version INTEGER NOT NULL DEFAULT 1,
+            practice_id TEXT NOT NULL,
+            dimension TEXT NOT NULL DEFAULT '',
+            requirement TEXT,
+            verdict TEXT NOT NULL CHECK (verdict IN ('violation','compliance','dismissed')),
+            severity TEXT NOT NULL CHECK (severity IN ('critical','high','medium','low','minor')),
+            file TEXT NOT NULL DEFAULT '',
+            line INTEGER NOT NULL DEFAULT 0,
+            end_line INTEGER NOT NULL DEFAULT 0,
+            title TEXT NOT NULL DEFAULT '',
+            reason TEXT NOT NULL DEFAULT '',
+            snippet TEXT NOT NULL DEFAULT '',
+            violation_type TEXT NOT NULL DEFAULT '',
+            context TEXT NOT NULL DEFAULT '',
+            scope TEXT NOT NULL DEFAULT '',
+            req_refs_json TEXT,
+            dedup_key TEXT NOT NULL UNIQUE,
+            confidence INTEGER NOT NULL DEFAULT 100,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE dimension_scores (
+            dimension TEXT PRIMARY KEY, score REAL, grade TEXT, confidence TEXT,
+            files_read INTEGER NOT NULL DEFAULT 0, source_count INTEGER NOT NULL DEFAULT 0,
+            coverage_pct REAL NOT NULL DEFAULT 0.0,
+            completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE run_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        -- an interrupted v2->v3 attempt already created these:
+        CREATE TABLE principle_grades (
+            dimension TEXT NOT NULL, principle_id TEXT NOT NULL, score REAL, grade TEXT,
+            finding_count INTEGER NOT NULL DEFAULT 0, dismissed_count INTEGER NOT NULL DEFAULT 0,
+            completed_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (dimension, principle_id)
+        );
+        CREATE INDEX idx_principle_grades_dimension ON principle_grades(dimension);
+        INSERT INTO findings (practice_id, verdict, severity, dedup_key)
+            VALUES ('P-2', 'violation', 'high', 'k2');
+    """)
+
+    apply_evaluation_schema(conn)  # must not raise
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    # the row survives the full v2->v5 walk (including the v3->v4 table rebuild)
+    row = conn.execute("SELECT confidence FROM findings WHERE practice_id='P-2'").fetchone()
+    assert row[0] == 100
 
 
 def test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path():

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -169,6 +169,41 @@ class TestBuildDashboard:
         assert dim["overallGrade"] == "B"
         assert dim["overallScore"] == "7.0"
 
+    def test_build_dashboard_survives_corrupt_db(self, tmp_path):
+        """If the per-run evaluation.db is corrupt or half-written it raises a
+        generic sqlite3.DatabaseError, not SchemaVersionError. The SQL grade
+        override must keep the FS-based grades instead of crashing the dashboard
+        build. Widening the seam to DatabaseError (which SchemaVersionError
+        subclasses) covers both the too-new and the corrupt case."""
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+
+        run_dir = tmp_path / "proj" / "r1"
+        run_dir.mkdir(parents=True)
+        log = run_dir / "events.jsonl"
+        EventLogWriter(log).emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="P1", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1",
+        )))
+        # A truncated / non-SQLite evaluation.db: opening it raises
+        # "file is not a database" when the override path tries to project.
+        (run_dir / "evaluation.db").write_bytes(b"this is not a sqlite database")
+
+        run = _make_run("r1", "2024-01-01")
+        dims = [_dim("security", "B", "7.0")]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=[run]),
+            patch("quodeq.services.dashboard.read_run_data", return_value=dims),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj", "latest")  # must not raise
+
+        assert len(result["dimensions"]) == 1
+        dim = result["dimensions"][0]
+        assert dim["overallGrade"] == "B"
+        assert dim["overallScore"] == "7.0"
+
     def test_latest_skips_cancelled_runs(self, tmp_path):
         # ``"latest"`` defaults to the most recent fully-completed run so the
         # per-dim cards reflect a coherent run that agrees with the headline.


### PR DESCRIPTION
## Why

Found during the **1.2.0 release-readiness audit**. A 1.1.2 user's per-run `evaluation.db` is at SQLite schema **v2**. On first open after upgrading, each old run's DB walks `v2 -> v3 -> v4 -> v5`. The `CREATE`/`ALTER` DDL in `v1->v2`, `v2->v3`, and `v4->v5` commits **separately** from the `PRAGMA user_version` bump (autocommit; no transaction wraps the loop in `apply_evaluation_schema`). A hard kill / OOM / force-quit in that window leaves the DDL applied but the version unchanged. Re-opening then re-runs the bare DDL and raises a plain `sqlite3.OperationalError` (`duplicate column name` / `table already exists`) that is **not** a `SchemaVersionError`, so the scoring/dashboard read seams don't catch it and the run is **permanently bricked** (scores + dashboard crash on every subsequent load, no self-heal).

This is the **exact failure class #576 fixed for `v3->v4`**, left unguarded in the three sibling steps. Verified with a deterministic repro and confirmed reachable (`open_evaluation_db` does not wrap schema application atomically; old v2 DBs migrate lazily on dashboard/scoring/precedent reads).

## What

**1. Idempotent migrations (`_migrations.py`)** so an interrupted upgrade self-heals on the next open instead of bricking:
- `v1->v2`: `table_info` check before the `confidence` ALTER
- `v2->v3`: `CREATE TABLE/INDEX IF NOT EXISTS` for `principle_grades`
- `v4->v5`: `table_info` check before the `exit_reason` ALTER (mirrors the existing table-existence guard)

**2. Widen the read seams** from `except SchemaVersionError` to `except sqlite3.DatabaseError` (which `SchemaVersionError` already subclasses) as defense-in-depth, so a corrupt or half-written DB degrades to the schema-independent JSON eval files / FS grades rather than crashing:
- `services/scoring/__init__.py` (`get_scores_raw`)
- `data/fs/report_parser/_evidence.py` (`load_evidence_map`) — required for the scoring fallback to complete (same multi-seam pattern as #577)
- `services/dashboard.py` (`_apply_sql_grade_override`)

## Tests (TDD, red-green)

5 new tests, each confirmed to fail pre-fix:
- `test_upgrade_v1_to_v2_idempotent_when_confidence_already_present`
- `test_upgrade_v2_to_v3_idempotent_when_principle_grades_already_present`
- `test_upgrade_v4_to_v5_idempotent_when_exit_reason_already_present`
- `test_get_scores_raw_falls_back_when_db_is_corrupt`
- `test_build_dashboard_survives_corrupt_db`

Full suite: **3180 passed, 0 failures**.

## Verification

Put through a 3-lens adversarial review (interruption-window self-heal, seam-widening over-catch + completeness sweep, guard correctness + test non-vacuousness). All three returned **fix holds, zero real defects**. Reviewers reproduced a real mid-`executescript` SIGKILL leaving durable partial DDL and proved `apply_evaluation_schema` converges to v5 with data intact from every reachable half-migrated state (including multi-step interruptions), and confirmed no reachable user-facing read seam is left unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)