### PR TITLE
fix(ci-review): surface out-of-diff findings in the PR summary instead of silently dropping them

### DIFF
--- a/src/quodeq/ci/reporter.py
+++ b/src/quodeq/ci/reporter.py
@@ -103,6 +103,20 @@ def fetch_pr_changed_lines(
     return result
 
 
+def _violation_anchorable(violation: dict, changed_lines: dict[str, set[int]]) -> bool:
+    """True when a violation's file+line falls on a PR changed line.
+
+    Mirrors ``filter_comments_to_diff``'s keep condition (a comment's path is
+    its violation's ``file`` and its line is the violation's ``line``), so a
+    violation is anchorable exactly when its inline comment would survive the
+    filter. Used to identify the NEW violations GitHub cannot anchor, which are
+    then listed in the summary instead of silently dropped.
+    """
+    path = violation.get("file")
+    line = violation.get("line")
+    return bool(path) and line is not None and line in changed_lines.get(path, set())
+
+
 def filter_comments_to_diff(
     comments: list[dict],
     changed_lines: dict[str, set[int]],
@@ -157,7 +171,9 @@ def build_review_payload(
     changed_lines: when provided, review comments are filtered to only those
     whose path+line fall within the PR's changed hunks. GitHub rejects
     comments outside the diff with HTTP 422, so the CLI must fetch the PR's
-    files and pass this mapping. Dropped comments are counted in the summary.
+    files and pass this mapping. NEW violations that fall outside the changed
+    lines can't be inline-anchored, so they're surfaced in the summary body
+    (file:line + description) instead of silently dropped.
     """
     all_violations: list[dict] = []
     for report in reports:
@@ -172,11 +188,16 @@ def build_review_payload(
 
     if changed_lines is None:
         comments = all_comments
+        outside_diff_new: list[dict] = []
     else:
-        # Out-of-diff comments are dropped: a PR review speaks only to the
-        # touched code. The dropped findings are not surfaced in the summary
-        # either — they remain in the full evaluation artifact.
+        # Out-of-diff comments can't be posted inline (GitHub 422), so they're
+        # dropped from `comments`. But rather than silently lose them, the NEW
+        # violations among them are surfaced in the summary body with file:line
+        # so the headline count and the visible findings agree.
         comments, _ = filter_comments_to_diff(all_comments, changed_lines)
+        outside_diff_new = [
+            v for v in new_violations if not _violation_anchorable(v, changed_lines)
+        ]
 
     summary = build_review_summary(
         reports,
@@ -185,6 +206,7 @@ def build_review_payload(
         duration_seconds=duration_seconds,
         baseline_available=baseline_available,
         artifact_url=artifact_url,
+        outside_diff_violations=outside_diff_new,
     )
     verdict = determine_verdict(new_violations)
 

--- a/src/quodeq/ci/review_builder.py
+++ b/src/quodeq/ci/review_builder.py
@@ -76,14 +76,22 @@ def build_review_summary(
     duration_seconds: int | None = None,
     baseline_available: bool = True,
     artifact_url: str | None = None,
+    outside_diff_violations: list[dict] | None = None,
 ) -> str:
     """Build the review body summarizing all dimension results.
 
-    Violations outside the PR's changed lines are omitted entirely — they are
-    never posted as comments (GitHub would 422) and are not surfaced in the
-    body either. A PR review speaks only to the touched code; out-of-diff
-    findings remain available in the full evaluation artifact.
+    outside_diff_violations: NEW violations whose file:line falls outside the
+    PR's changed hunks. GitHub can't anchor an inline comment there, so they're
+    listed in a dedicated section with file:line + description instead of being
+    silently dropped. The headline count and severity breakdown then reflect
+    only the in-diff (inline-anchorable) violations, so the number shown agrees
+    with the inline comments actually posted.
     """
+    outside = outside_diff_violations or []
+    _outside_ids = {id(v) for v in outside}
+    # Count and break down only the violations shown as inline comments; the
+    # out-of-diff ones get their own listed section below.
+    new_violations = [v for v in new_violations if id(v) not in _outside_ids]
     # Diff mode is signaled by reports with unscored ("N/A") dimensions —
     # PR diff runs skip scoring, so the per-dimension score table and the
     # "no baseline" note (which frames absence-of-baseline as a scoring
@@ -129,6 +137,24 @@ def build_review_summary(
         parts = [f"{n} {sev}" for sev, n in new_severity_counts.items() if n > 0]
         if parts:
             lines.append(f"New violations by severity: {', '.join(parts)}")
+        lines.append("")
+
+    if outside:
+        n = len(outside)
+        noun = "finding" if n == 1 else "findings"
+        lines.append(
+            f"**{n} {noun} outside the changed lines** "
+            "(GitHub can't anchor an inline comment to unchanged lines, so "
+            "they're listed here):"
+        )
+        lines.append("")
+        for v in outside:
+            file = v.get("file", "?")
+            line = v.get("line")
+            loc = f"{file}:{line}" if line is not None else file
+            severity = str(v.get("severity", "minor")).upper()
+            title = v.get("title") or "Violation"
+            lines.append(f"- `{loc}` — **{severity}** {title}")
         lines.append("")
 
     if duration_seconds is not None:

--- a/tests/ci/test_pr_diff_filter.py
+++ b/tests/ci/test_pr_diff_filter.py
@@ -191,28 +191,30 @@ def test_build_review_payload_filters_when_changed_lines_provided() -> None:
     assert payload["comments"][0]["path"] == "src/a.py"
 
 
-def test_build_review_payload_summary_omits_out_of_diff_violations() -> None:
-    """Out-of-diff violations are omitted from the PR review entirely.
+def test_build_review_payload_summary_surfaces_out_of_diff_violations() -> None:
+    """Out-of-diff findings cannot be inline comments (GitHub rejects anchors
+    outside the diff hunks with HTTP 422), but they ARE surfaced in the summary
+    body with file:line + description so they aren't silently lost.
 
-    They are never posted as comments (GitHub would 422), and the summary body
-    no longer surfaces a count of them either — a PR review speaks only to the
-    code that was touched. The findings still live in the evaluation artifact.
+    This reverses the earlier "omit entirely" behavior: a finding that the eval
+    flags on an unchanged line of a changed file (e.g. a pre-existing helper)
+    was previously counted but never shown, leaving "N found" with zero visible
+    findings. Now it is listed in an "outside the changed lines" section.
     """
     reports = [{
         "dimension": "security",
         "overallScore": "7/10",
         "overallGrade": "B",
         "violations": [
-            {"file": "src/z.py", "line": 99, "title": "out of diff", "reason": "", "severity": "major"},
+            {"file": "src/z.py", "line": 99, "title": "unsafe eval", "reason": "", "severity": "major"},
         ],
         "totals": {"violationCount": 1, "severity": {"major": 1}},
     }]
-    payload = build_review_payload(reports, changed_lines={})  # empty diff → all dropped
-    assert payload["comments"] == []
-    # Summary must say nothing about findings outside the touched code.
-    body = payload["body"].lower()
-    assert "outside the pr diff" not in body
-    assert "additional violation" not in body
+    payload = build_review_payload(reports, changed_lines={})  # empty diff → no inline anchors
+    assert payload["comments"] == []                # still not posted as an inline comment
+    body = payload["body"]
+    assert "src/z.py:99" in body                    # surfaced with file:line
+    assert "unsafe eval" in body                    # and its description
 
 
 def test_build_review_payload_no_filter_when_changed_lines_is_none() -> None:

--- a/tests/ci/test_review_builder.py
+++ b/tests/ci/test_review_builder.py
@@ -239,6 +239,44 @@ def test_diff_mode_uses_diff_phrasing_for_violation_count():
     assert "introduced by this PR" not in summary
 
 
+def test_summary_lists_outside_diff_findings_and_counts_only_in_diff():
+    """Out-of-diff NEW findings are listed in their own section with file:line,
+    and the headline count + severity breakdown reflect only the in-diff
+    (inline-anchorable) violations, so the number shown matches the inline
+    comments posted."""
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "pr-diff", "violations": [],
+                "overallScore": "N/A", "overallGrade": "N/A"}]
+    in_diff = {"file": "src/a.py", "line": 10, "severity": "high", "title": "in-diff issue"}
+    outside = {"file": "tests/t.py", "line": 37, "severity": "minor", "title": "f-string DDL"}
+    summary = build_review_summary(
+        reports, [in_diff, outside], [], baseline_available=False,
+        outside_diff_violations=[outside],
+    )
+    # Headline + severity reflect the in-diff finding only.
+    assert "1 violation(s) found in PR diff" in summary
+    assert "1 high" in summary
+    assert "1 minor" not in summary  # the outside minor is not in the by-severity line
+    # The outside finding is surfaced with file:line, severity, and title.
+    assert "outside the changed lines" in summary
+    assert "tests/t.py:37" in summary
+    assert "f-string DDL" in summary
+
+
+def test_summary_no_outside_section_when_all_in_diff():
+    """Backward compat: with no out-of-diff findings, no extra section appears
+    and the count is unchanged."""
+    from quodeq.ci.review_builder import build_review_summary
+
+    reports = [{"dimension": "pr-diff", "violations": [],
+                "overallScore": "N/A", "overallGrade": "N/A"}]
+    new = [{"file": "src/a.py", "line": 10, "severity": "high", "title": "x"}]
+    summary = build_review_summary(reports, new, [], baseline_available=False)
+    assert "1 violation(s) found in PR diff" in summary
+    assert "outside the changed lines" not in summary
+
+
 def test_scored_mode_preserves_existing_summary_shape():
     """Regression guard: scored reports still get the old framing."""
     from quodeq.ci.review_builder import build_review_summary


### PR DESCRIPTION
## Why (observed on #582)

The PR review action reported **"1 minor violation found in PR diff"** but posted **zero** inline comments and gave no reason. Root cause:

- The eval runs in `--diff-from` mode and flagged `tests/data/sqlite/test_migrations.py:37` (the `_make_findings_table` helper, a minor false-positive "SQL injection via identifier interpolation").
- **That line was introduced by #576, not by the PR** — it's an unchanged line in a changed file. GitHub only accepts inline review comments anchored to lines inside the PR's diff hunks, so the comment is un-anchorable (would 422) and `filter_comments_to_diff` correctly drops it.
- But the **summary counts every eval finding** while inline comments are independently filtered, so the two disagreed: `1 new, 0 pre-existing (0 inline comment(s) in diff scope)`. The drop was silent.

## What

- The headline count and severity breakdown now reflect **only the in-diff (inline-anchorable) violations**, so the number shown matches the inline comments posted.
- **NEW findings outside the changed lines are surfaced** in a dedicated summary section with `file:line` + severity + title, instead of being silently dropped:

```
🔍 **0 violation(s) found in PR diff**

**1 finding outside the changed lines** (GitHub can't anchor an inline comment to unchanged lines, so they're listed here):

- `tests/data/sqlite/test_migrations.py:37` — **MINOR** SQL injection via identifier interpolation
```

This reverses #573's "omit out-of-diff findings entirely" decision (per product call): out-of-diff findings are now visible, just not as inline anchors (which GitHub disallows).

## Tests (TDD, red-green)

- Rewrote `test_build_review_payload_summary_omits_out_of_diff_violations` → `..._surfaces_...`: asserts the out-of-diff finding appears in the body with `file:line` and is **not** an inline comment.
- Added `test_summary_lists_outside_diff_findings_and_counts_only_in_diff` (headline counts in-diff only; section renders) and `test_summary_no_outside_section_when_all_in_diff` (backward-compat).
- ci suite: 90 passed. Full suite: **3182 passed**.

Note: this does not change the eval's own tendency to flag unchanged lines of changed files (a separate diff-scoping concern); it makes the review output honest and complete about what was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)