### PR TITLE
fix(dependabot): re-register npm at src/quodeq/ui to stop weekly /package.json failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,13 @@ updates:
       semver-patch-days: 2
 
   - package-ecosystem: "npm"
-    # package.json lives under src/quodeq/ui, not the repo root.
-    directory: "/src/quodeq/ui"
+    # package.json lives under src/quodeq/ui, not the repo root. Use the
+    # `directories` (list) form: an earlier `directory:` value change (2026-05-25)
+    # did not dislodge Dependabot's stale root-scoped npm version-update job,
+    # which keeps failing weekly with "/package.json not found". Changing the
+    # config shape forces Dependabot to re-register the ecosystem at the new path.
+    directories:
+      - "/src/quodeq/ui"
     schedule:
       interval: "weekly"
     target-branch: "develop"


### PR DESCRIPTION
## Problem

The **npm version-update** Dependabot job has failed **every week since ~April**, aborting with:

```
ERROR: Error during file fetching; aborting: /package.json not found
```

It runs scoped to the repo **root** (`/.`), but there is no root `package.json` (the UI manifest is at `src/quodeq/ui/package.json`).

The directory was already corrected from `/` to `/src/quodeq/ui` on 2026-05-25, **but that value change did not dislodge Dependabot's stale root-scoped registration** — the npm job kept running at `/.` and failing (05-28, 06-04).

## Fix

Switch the npm entry to the modern `directories:` (list) form. A config **shape** change is more likely to force Dependabot to re-register the ecosystem at the new path than the same-key value change was.

```diff
-    directory: "/src/quodeq/ui"
+    directories:
+      - "/src/quodeq/ui"
```

Validated: YAML parses; npm resolves to `['/src/quodeq/ui']`; pip + github-actions unchanged.

## Impact / scope

- Low severity, **not release-related**. No build break.
- npm **security** updates already work (the postcss security PR succeeded at the correct path); only routine **version-bump** PRs for the UI were blocked.

## ⚠️ Pair with a manual re-trigger

Because the prior config edit didn't reconcile the stale job, after merge it's worth forcing reconciliation in the UI: **Insights -> Dependency graph -> Dependabot -> npm -> "Check for updates"**. The config change + the manual re-trigger together are the most reliable way to drop the stuck root job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)