### PR TITLE
fix(dependabot): drop unsupported semver cooldown keys from github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,6 @@ updates:
     target-branch: "develop"
     open-pull-requests-limit: 5
     cooldown:
+      # github-actions does not version with semver, so Dependabot rejects the
+      # semver-*-days keys for this ecosystem. Only default-days is supported.
       default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 3
-      semver-patch-days: 2


### PR DESCRIPTION
## Problem

Dependabot reported a config schema error:

```
The property '#/updates/2/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/2/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

`#/updates/2` is the **github-actions** entry. GitHub Actions versions are not semver, so Dependabot only supports `default-days` in the cooldown block for that ecosystem (the `semver-*-days` keys are valid for pip/npm but not github-actions).

## Fix

Remove the three `semver-*-days` keys from the **github-actions** cooldown only, keeping `default-days: 3` (the yank-protection window). pip and npm are unchanged.

```diff
   cooldown:
     default-days: 3
-    semver-major-days: 7
-    semver-minor-days: 3
-    semver-patch-days: 2
```

A config schema error makes Dependabot ignore parts of the file, so clearing this also helps the npm `directories` fix (#588) actually take effect. After merge, it's still worth hitting **Insights -> Dependency graph -> Dependabot -> "Check for updates"** to force a clean re-read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)