### PR TITLE
fix(ci): derive Homebrew version from the release commit, not develop

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -14,7 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: develop
+          # Check out the exact commit the release was published from -- the tag
+          # commit that triggered "Publish to PyPI" -- NOT `develop`. publish.yml
+          # only runs on `release: published`, so workflow_run.head_sha is always
+          # the release commit. develop is stale at release time (the sync PR
+          # main->develop has not merged yet), which previously pinned the tap to
+          # the OLD version. Reading head_sha ties the formula to the published
+          # release and makes re-runs version-correct regardless of develop.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Extract version from pyproject.toml
         id: version


### PR DESCRIPTION
## Problem (hit during the v1.2.0 release)

`update-homebrew.yml` did `checkout ref: develop` and read the version from develop's `pyproject.toml`. The workflow runs right after **Publish to PyPI** (`workflow_run`), which fires at release time. But at that moment **develop is still on the OLD version** because the sync PR (main -> develop) hasn't merged yet. So the tap formula got pinned to **1.1.2** during the **1.2.0** release, and had to be corrected by hand.

## Fix

`publish.yml` triggers **only** on `release: published`, so `github.event.workflow_run.head_sha` is always the exact commit the release was published from (the tag commit). Check that out instead of `develop`:

```diff
-          ref: develop
+          ref: ${{ github.event.workflow_run.head_sha }}
```

The "Extract version from pyproject.toml" step is unchanged -- it now just reads the right commit.

## Why this is the robust fix

- **No ordering dependency**: the tap always matches the tag being published, regardless of whether the develop sync PR has merged.
- **Re-runs are correct**: `gh run rerun` preserves the `workflow_run` context, so head_sha (and thus the version) stays the published one -- re-running no longer reverts the tap.
- **Future releases just work**: the manual merge-order dance and hand-patching go away.

Validated: YAML parses, checkout `ref` resolves to `head_sha`, no `ref: develop` remains, trigger unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)