### PR TITLE
fix(ci): nightly eval runs all 6 dimensions, not just security

### DIFF
--- a/.github/workflows/quodeq-nightly.yml
+++ b/.github/workflows/quodeq-nightly.yml
@@ -22,9 +22,9 @@ on:
       dimensions:
         description: "Dimensions (empty = all)"
         default: ""
-      pool_budget:
-        description: "Pool budget in seconds"
-        default: "600"
+      time_limit:
+        description: "Run time limit in seconds (0 = unlimited). Default 11h truncates gracefully before the 12h job timeout."
+        default: "39600"
 
 jobs:
   nightly:
@@ -100,12 +100,18 @@ jobs:
           # Precedence: workflow_dispatch input > NIGHTLY_DIMENSIONS from quodeq.env > all
           DIMS="${{ github.event.inputs.dimensions }}"
           DIMS="${DIMS:-$NIGHTLY_DIMENSIONS}"
-          BUDGET="${{ github.event.inputs.pool_budget }}"
-          BUDGET="${BUDGET:-600}"
+          # Run-level time limit (seconds). 0 = unlimited. The default 39600 (11h)
+          # gives the whole 6-dimension loop room to run: each dimension's pool is
+          # still auto-capped at 2h, so all dims get a fair slice instead of the
+          # first one (security) consuming the entire budget. An 11h ceiling also
+          # truncates gracefully (scoring completed dims) about 1h before GitHub's
+          # 12h job timeout would hard-kill the process tree.
+          LIMIT="${{ github.event.inputs.time_limit }}"
+          LIMIT="${LIMIT:-39600}"
           # Use an array so flag values are passed as proper argv entries
           # (avoids SC2086 word-splitting issues with unquoted $ARGS).
           ARGS=(evaluate .
-                --pool-budget "$BUDGET"
+                --time-limit "$LIMIT"
                 --max-duration 300
                 --n-subagents "${N_SUBAGENTS:-3}"
                 --output "$EVAL_DIR")


### PR DESCRIPTION
## Problem

The scheduled **Quodeq Nightly** has been silently evaluating only `security` every night, skipping the other 5 dimensions (`rel, mnt, perf, flex, ux`). Runs show **green** because partial completion is graceful, so it looked fine.

Every nightly for the last several days ends:
```
[loop] incremental: 6 dim(s) to process: security, reliability, maintainability, performance, usability, flexibility
[loop] completed iteration 1/6 for security
[loop] deadline reached -- skipping reliability and remaining dims
[loop] incremental finished: processed 1 of 6 dim(s) (security)
```

## Root cause

The workflow passed `--pool-budget 600`. That value sets a **fixed 10-minute run-level deadline** (`deadline_at = now + 600s`, [`_pipeline.py`](https://github.com/quodeq/quodeq/blob/develop/src/quodeq/analysis/_pipeline.py)). The per-dimension limit auto-scales with file count (security scaled to ~91 min), but the run-level deadline does **not** — so 10 minutes in, while security is still draining its queue, the deadline fires. Security finishes and scores, then the loop checks the deadline before dimension 2 and skips reliability + the remaining four. Since dimension order is fixed (security first), the same 1/6 runs every night.

This directly contradicts `timeout-minutes: 720` (12h) and the workflow comment that designs for ~10h full runs.

## Fix

- Raise the nightly run budget from `600` (10 min) to **`39600` (11h)** so the full 6-dimension loop has room.
- Each dimension's pool stays auto-capped at 2h, so every dim gets a fair slice instead of security consuming the whole budget.
- The 11h ceiling truncates **gracefully** (scoring completed dims, green + Partial badge) about 1h before GitHub's 12h job timeout would hard-kill the process tree.
- Switch the deprecated `--pool-budget` alias to `--time-limit` (drops the per-run deprecation warning). Same dest, verified in `cli_parser.py`.

`workflow_dispatch` input renamed `pool_budget` -> `time_limit` (default `39600`, `0` = unlimited) for manual runs.

## Validation

- `actionlint` passes on the workflow.
- Embedded bash `bash -n` clean.
- Traced budget semantics through `_pipeline.py`, `_pool_launcher.py`, `_pool_scaling.py`, `_loops.py` to confirm: no run-level deadline starvation, per-dim 2h cap preserved, graceful truncation under the job timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)