### PR TITLE
fix(ui): bump react to 19.2.7 to match react-dom (restore lockstep)

### DIFF
--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-virtual": "^3.13.24",
         "d3-hierarchy": "^3.1.2",
-        "react": "19.2.6",
+        "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
@@ -3244,9 +3244,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-virtual": "^3.13.24",
     "d3-hierarchy": "^3.1.2",
-    "react": "19.2.6",
+    "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.1",


### PR DESCRIPTION
## Problem

`quodeq dashboard` (and the wheel build) fail at `npm ci` with `ERESOLVE`:

```
npm error While resolving: react-dom@19.2.7
npm error Conflicting peer dependency: react@19.2.7
npm error   peer react@"^19.2.7" from react-dom@19.2.7
```

`dashboard/_build_npm.py` runs `npm ci`, which installs strictly from the lockfile and refuses to resolve an unsatisfiable peer tree, so the dashboard never starts.

## Root cause

PR #596 (`3e22f45f`) bumped **react-dom** `19.2.6 -> 19.2.7` but left **react** at `19.2.6`. `react-dom@19.2.7` peer-requires `react@^19.2.7`, which `19.2.6` does not satisfy. React and react-dom are released in lockstep at identical versions, so they must be bumped together. The react-dom dependabot PR's **Wheel smoke** check went red for exactly this reason, but the PR merged anyway (non-blocking check), leaving `develop` broken for source/dev builds.

## Fix

Bump `react` `19.2.6 -> 19.2.7` to match react-dom. One-line `package.json` change plus the regenerated `package-lock.json` (react-only, no other dependency drift).

## Verification (local)

- `npm ci` -> exit 0 (`added 259 packages, found 0 vulnerabilities`) — the exact command that was failing.
- `npm run build` -> succeeds (`1152 modules transformed`, vite build OK).
- Lockfile diff touches only `node_modules/react`.

## Follow-up (not in this PR)

Dependabot opens separate PRs for `react` and `react-dom`, so this lockstep break can recur. Worth adding a dependabot `groups` entry to bump them together. Happy to do that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)