### PR TITLE
fix(dependabot): group react packages so peer-locked bumps land together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,18 @@ updates:
       semver-major-days: 7
       semver-minor-days: 3
       semver-patch-days: 2
+    # react-dom's peer dependency pins an exactly-matching react version
+    # (react-dom@19.2.7 needs react@^19.2.7). Bumping one without the other in
+    # separate PRs breaks `npm ci` with ERESOLVE (happened in #596/#599). Group
+    # the react packages so they are always bumped together in a single PR.
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@testing-library/react"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Problem

Dependabot opens separate PRs for `react` and `react-dom` under `src/quodeq/ui/`. Because `react-dom`'s peer dependency requires an exactly-matching `react` version (e.g. `react-dom@19.2.7` needs `react@^19.2.7`), merging one bump without the other breaks `npm ci` with **ERESOLVE**.

This already happened: [#596](https://github.com/quodeq/quodeq/pull/596) bumped `react-dom` to 19.2.7 while `react` stayed 19.2.6, breaking `quodeq dashboard` and the wheel-smoke build (fixed reactively in [#599](https://github.com/quodeq/quodeq/pull/599)).

## Fix

Add a Dependabot `groups` config under the npm / `src/quodeq/ui` ecosystem entry so the react packages are always bumped together in a single PR:

```yaml
groups:
  react:
    patterns:
      - "react"
      - "react-dom"
      - "@types/react"
      - "@types/react-dom"
      - "@testing-library/react"
```

`react` + `react-dom` are the hard peer-locked pair. `@types/react*` are harmless future-proofing (the UI is currently plain JS, so they match nothing today). `@testing-library/react` declares react/react-dom peer deps, so grouping it reduces churn and avoids a similar mismatch.

## Verification

- YAML parses cleanly; the `groups` key is correctly nested under the npm ecosystem entry (which uses the `directories: ["/src/quodeq/ui"]` list form).
- Exact (non-wildcard) patterns match only the named packages, so `react-markdown` is **not** swept in by the `react` pattern.
