### PR TITLE
feat(eval-strip): live ELAPSED ticker + reading-speed/ETA subtext

### DIFF
--- a/docs/superpowers/plans/2026-06-08-eval-elapsed-eta.md
+++ b/docs/superpowers/plans/2026-06-08-eval-elapsed-eta.md
@@ -1,0 +1,488 @@
+# Live ELAPSED ticker + reading-speed/ETA subtext — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the running-evaluation ELAPSED card tick every second and add a `~1.2 files/s · ~5h left` subtext driven by a sliding-window throughput estimate.
+
+**Architecture:** All estimate math lives as pure, framework-free helpers in `buildJobStatCells.js` (computeRate / formatRate / formatEta / buildEtaHint). `JobStatStrip.jsx` owns the React wiring: a 1-second tick that recomputes wall-clock elapsed, and a windowed sample buffer (one sample per progress poll) fed into the pure helpers. No backend changes.
+
+**Tech Stack:** React (hooks), @tanstack/react-query (existing 2s progress poll), `node:test` for pure-helper unit tests, `vitest` + @testing-library/react for the component test.
+
+Spec: `docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md`
+
+All commands run from the UI package root:
+`cd /Users/victor/GitHub/quodeq/src/quodeq/ui`
+
+---
+
+## File Structure
+
+- **Modify** `src/features/evaluation/components/buildJobStatCells.js` — add `RATE_WINDOW_MS`, `computeRate`, `formatRate`, `formatEta`, `buildEtaHint`; thread an `etaHint` input into the running branch's ELAPSED cell.
+- **Modify** `src/features/evaluation/components/buildJobStatCells.test.js` — `node:test` units for the new helpers (existing tests untouched).
+- **Modify** `src/features/evaluation/components/JobStatStrip.jsx` — 1s ticker, windowed sample buffer, wall-clock elapsed, wire `rate`/`etaHint`.
+- **Modify** `src/features/evaluation/components/JobStatStrip.test.jsx` — `vitest` tests for the subtext + ticking (existing tests untouched).
+
+---
+
+## Task 1: `computeRate` sliding-window throughput
+
+**Files:**
+- Modify: `src/features/evaluation/components/buildJobStatCells.js`
+- Test: `src/features/evaluation/components/buildJobStatCells.test.js`
+
+- [ ] **Step 1: Write the failing test** — append to `buildJobStatCells.test.js`:
+
+```js
+import { computeRate, RATE_WINDOW_MS } from './buildJobStatCells.js';
+
+test('computeRate: files/sec from oldest→newest over the window', () => {
+  // 30 files over 30s = 1.0 files/s
+  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_030_000, taken: 40 }];
+  assert.equal(computeRate(s), 1);
+});
+
+test('computeRate: null when fewer than 2 samples', () => {
+  assert.equal(computeRate([]), null);
+  assert.equal(computeRate([{ t: 1, taken: 5 }]), null);
+  assert.equal(computeRate(null), null);
+});
+
+test('computeRate: null when window span is below the minimum (~15s)', () => {
+  // 10s span -> not enough to be honest yet
+  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_010_000, taken: 30 }];
+  assert.equal(computeRate(s), null);
+});
+
+test('computeRate: null when files have not advanced (stalled)', () => {
+  const s = [{ t: 1_000_000, taken: 50 }, { t: 1_040_000, taken: 50 }];
+  assert.equal(computeRate(s), null);
+});
+
+test('RATE_WINDOW_MS is exported for the buffer to window against', () => {
+  assert.equal(typeof RATE_WINDOW_MS, 'number');
+  assert.ok(RATE_WINDOW_MS > 0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: FAIL — `computeRate is not a function` / `RATE_WINDOW_MS` undefined.
+
+- [ ] **Step 3: Write minimal implementation** — add near the top of `buildJobStatCells.js` (after the file header comment):
+
+```js
+// Throughput estimate tuning. The rate is measured over a sliding window so it
+// reflects *current* speed (cache-hit bursts vs slow LLM misses, and the
+// per-dimension speed shifts) rather than a startup-biased lifetime average.
+export const RATE_WINDOW_MS = 60000;   // sliding window the buffer is trimmed to
+const RATE_MIN_SPAN_MS = 15000;        // refuse to estimate from < this much data
+
+/**
+ * Files/sec from a buffer of {t, taken} samples (t = epoch ms, ascending).
+ * Returns null — meaning "no honest estimate yet" — when there are fewer than
+ * two samples, the window spans less than RATE_MIN_SPAN_MS, or files have not
+ * advanced across the window (a stall).
+ * @param {Array<{t:number, taken:number}>} samples
+ * @returns {number|null}
+ */
+export function computeRate(samples) {
+  if (!Array.isArray(samples) || samples.length < 2) return null;
+  const oldest = samples[0];
+  const newest = samples[samples.length - 1];
+  const spanMs = newest.t - oldest.t;
+  if (spanMs < RATE_MIN_SPAN_MS) return null;
+  const dFiles = newest.taken - oldest.taken;
+  if (dFiles <= 0) return null;
+  return dFiles / (spanMs / 1000);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: PASS (all tests in the file, old + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/evaluation/components/buildJobStatCells.js src/features/evaluation/components/buildJobStatCells.test.js
+git commit -m "feat(eval-strip): add computeRate sliding-window throughput helper"
+```
+
+---
+
+## Task 2: `formatRate` + `formatEta` formatters
+
+**Files:**
+- Modify: `src/features/evaluation/components/buildJobStatCells.js`
+- Test: `src/features/evaluation/components/buildJobStatCells.test.js`
+
+- [ ] **Step 1: Write the failing test** — append to `buildJobStatCells.test.js`:
+
+```js
+import { formatRate, formatEta } from './buildJobStatCells.js';
+
+test('formatRate: one decimal below 10/s, integer at/above 10/s', () => {
+  assert.equal(formatRate(1.234), '~1.2 files/s');
+  assert.equal(formatRate(9.96), '~10.0 files/s'); // toFixed rounds; still < 10 path
+  assert.equal(formatRate(12.7), '~13 files/s');
+});
+
+test('formatRate: null for non-positive / non-finite / null', () => {
+  assert.equal(formatRate(0), null);
+  assert.equal(formatRate(-1), null);
+  assert.equal(formatRate(Infinity), null);
+  assert.equal(formatRate(null), null);
+});
+
+test('formatEta: "finishing" when essentially done', () => {
+  assert.equal(formatEta(0, 1), 'finishing');     // nothing left
+  assert.equal(formatEta(40, 1), 'finishing');    // 40s <= 45s
+});
+
+test('formatEta: minute buckets (nearest 1 under 10m, nearest 5 over)', () => {
+  assert.equal(formatEta(120, 1), '~2 min left');   // 120s
+  assert.equal(formatEta(1000, 1), '~15 min left'); // 1000s ≈ 16.7m -> nearest 5 = 15
+  assert.equal(formatEta(50, 1), '~1 min left');    // 50s -> 1m (just over the 45s floor)
+});
+
+test('formatEta: hour buckets, minutes to nearest 5, carry at 60', () => {
+  assert.equal(formatEta(18000, 1), '~5h left');        // 5h exactly
+  assert.equal(formatEta(19800, 1), '~5h 30m left');    // 5h30m
+  assert.equal(formatEta(7080, 1), '~2h left');         // 1h58m -> minutes round to 60 -> carry
+});
+
+test('formatEta: estimating when rate is unusable', () => {
+  assert.equal(formatEta(100, 0), 'estimating…');
+  assert.equal(formatEta(100, null), 'estimating…');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: FAIL — `formatRate` / `formatEta` not a function.
+
+- [ ] **Step 3: Write minimal implementation** — add to `buildJobStatCells.js` (below `computeRate`):
+
+```js
+/** "~1.2 files/s" (1 decimal below 10/s, integer above). null when unusable. */
+export function formatRate(rate) {
+  if (rate == null || !Number.isFinite(rate) || rate <= 0) return null;
+  const shown = rate < 10 ? rate.toFixed(1) : String(Math.round(rate));
+  return `~${shown} files/s`;
+}
+
+/**
+ * Coarse, human-readable time remaining from files-left + files/sec rate.
+ * "finishing" near the end; "~N min left"; "~Hh left" / "~Hh Mm left".
+ * Returns "estimating…" if rate is unusable (caller normally gates first).
+ */
+export function formatEta(remainingFiles, rate) {
+  if (!(rate > 0) || !Number.isFinite(rate)) return 'estimating…';
+  if (remainingFiles <= 0) return 'finishing';
+  const etaSec = remainingFiles / rate;
+  if (etaSec <= 45) return 'finishing';
+  if (etaSec < 3600) {
+    const rawMin = etaSec / 60;
+    let min = rawMin < 10 ? Math.max(1, Math.round(rawMin)) : Math.round(rawMin / 5) * 5;
+    if (min >= 60) return '~1h left';
+    return `~${min} min left`;
+  }
+  let hours = Math.floor(etaSec / 3600);
+  let min = Math.round(((etaSec % 3600) / 60) / 5) * 5;
+  if (min === 60) { hours += 1; min = 0; }
+  return min === 0 ? `~${hours}h left` : `~${hours}h ${min}m left`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/evaluation/components/buildJobStatCells.js src/features/evaluation/components/buildJobStatCells.test.js
+git commit -m "feat(eval-strip): add formatRate + formatEta human-readable formatters"
+```
+
+---
+
+## Task 3: `buildEtaHint` combiner + wire into `buildJobStatCells`
+
+**Files:**
+- Modify: `src/features/evaluation/components/buildJobStatCells.js`
+- Test: `src/features/evaluation/components/buildJobStatCells.test.js`
+
+- [ ] **Step 1: Write the failing test** — append to `buildJobStatCells.test.js`:
+
+```js
+import { buildEtaHint } from './buildJobStatCells.js';
+
+test('buildEtaHint: null when total is unknown (preparing…)', () => {
+  assert.equal(buildEtaHint({ rate: 1, takenFiles: 0, totalFiles: 0 }), null);
+});
+
+test('buildEtaHint: "estimating…" when rate is unusable but total is known', () => {
+  assert.equal(buildEtaHint({ rate: null, takenFiles: 5, totalFiles: 100 }), 'estimating…');
+});
+
+test('buildEtaHint: "~rate files/s · ~eta" when estimate is available', () => {
+  // 90 files left at 1 file/s = 90s -> "~2 min left"
+  assert.equal(
+    buildEtaHint({ rate: 1, takenFiles: 10, totalFiles: 100 }),
+    '~1.0 files/s · ~2 min left',
+  );
+});
+
+test('buildJobStatCells: running ELAPSED cell carries the etaHint as its subtext', () => {
+  const cells = buildJobStatCells('running', { ...baseInputs, etaHint: '~1.2 files/s · ~5h left' });
+  assert.equal(cells[3].label, 'ELAPSED');
+  assert.equal(cells[3].hint, '~1.2 files/s · ~5h left');
+});
+
+test('buildJobStatCells: done DURATION cell ignores etaHint', () => {
+  const cells = buildJobStatCells('done', { ...baseInputs, takenFiles: 220, etaHint: 'should-not-appear' });
+  assert.equal(cells[3].label, 'DURATION');
+  assert.equal(cells[3].hint, 'total');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: FAIL — `buildEtaHint` undefined; running ELAPSED `hint` is `null` not the etaHint.
+
+- [ ] **Step 3: Write minimal implementation**
+
+3a. Add to `buildJobStatCells.js` (below `formatEta`):
+
+```js
+/**
+ * ELAPSED subtext for a running job: "~1.2 files/s · ~5h left".
+ *  - null  when totalFiles is unknown (the PROGRESS card shows "preparing…").
+ *  - "estimating…" when total is known but the rate isn't trustworthy yet.
+ * @param {{rate:number|null, takenFiles:number, totalFiles:number}} args
+ */
+export function buildEtaHint({ rate, takenFiles, totalFiles }) {
+  if (!(totalFiles > 0)) return null;
+  const rateStr = formatRate(rate);
+  if (rateStr == null) return 'estimating…';
+  return `${rateStr} · ${formatEta(totalFiles - takenFiles, rate)}`;
+}
+```
+
+3b. In `buildJobStatCells.js`, change the running branch's ELAPSED cell to pass the hint. Find:
+
+```js
+    foundCell(inputs.liveCount),
+    elapsedCell(inputs.elapsedS),
+  ];
+```
+
+Replace with:
+
+```js
+    foundCell(inputs.liveCount),
+    elapsedCell(inputs.elapsedS, 'ELAPSED', inputs.etaHint ?? null),
+  ];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test src/features/evaluation/components/buildJobStatCells.test.js`
+Expected: PASS (old + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/evaluation/components/buildJobStatCells.js src/features/evaluation/components/buildJobStatCells.test.js
+git commit -m "feat(eval-strip): combine rate+eta into ELAPSED subtext hint"
+```
+
+---
+
+## Task 4: Wire `JobStatStrip` — 1s ticker, sample buffer, wall-clock elapsed
+
+**Files:**
+- Modify: `src/features/evaluation/components/JobStatStrip.jsx`
+- Test: `src/features/evaluation/components/JobStatStrip.test.jsx`
+
+- [ ] **Step 1: Write the failing tests** — append inside the `describe('JobStatStrip', …)` block in `JobStatStrip.test.jsx`:
+
+```js
+  it('shows "estimating…" subtext for a fresh running job (one sample)', async () => {
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+    });
+    const job = { jobId: 'job-3', status: 'running', startedAt: new Date(Date.now() - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('estimating…')).toBeInTheDocument();
+  });
+
+  it('ELAPSED reflects wall-clock from startedAt (not backend elapsed)', async () => {
+    const now = new Date('2026-06-08T10:00:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+      totalElapsedS: 9999, // would show 166:39 if backend value were used
+    });
+    const job = { jobId: 'job-4', status: 'running', startedAt: new Date(now - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('0:05')).toBeInTheDocument();
+    nowSpy.mockRestore();
+  });
+
+  it('ELAPSED ticks forward each second', async () => {
+    vi.useFakeTimers();
+    try {
+      const t0 = new Date('2026-06-08T10:00:00Z').getTime();
+      vi.setSystemTime(t0);
+      getEvaluationProgress.mockResolvedValue({
+        dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+      });
+      const job = { jobId: 'job-5', status: 'running', startedAt: new Date(t0 - 5000).toISOString() };
+      renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+      await vi.advanceTimersByTimeAsync(0);     // flush the initial fetch
+      expect(screen.getByText('0:05')).toBeInTheDocument();
+      await vi.advanceTimersByTimeAsync(2000);  // two 1s ticks
+      expect(screen.getByText('0:07')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/features/evaluation/components/JobStatStrip.test.jsx`
+Expected: FAIL — no `estimating…` text; ELAPSED shows backend-derived value, not `0:05`/`0:07`.
+
+- [ ] **Step 3: Write the implementation** — replace the entire contents of `JobStatStrip.jsx` with:
+
+```jsx
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getEvaluationProgress } from '../../../api/index.js';
+import { evaluationKeys } from '../../../api/queryKeys.js';
+import { StatStrip, Stat } from '../../../components/terminal/index.js';
+import { computeOverallProgress } from './scanProgressTotals.js';
+import { buildJobStatCells, computeRate, buildEtaHint, RATE_WINDOW_MS } from './buildJobStatCells.js';
+
+const POLL_INTERVAL_MS = 2000;
+const TICK_INTERVAL_MS = 1000;
+const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
+
+function sumLiveViolations(liveViolations) {
+  if (!liveViolations) return 0;
+  return Object.values(liveViolations).reduce((n, vs) => n + (vs?.length || 0), 0);
+}
+
+// Live elapsed from wall-clock so the cell ticks every second between the 2s
+// progress polls. Falls back to the backend-reported elapsed only when the job
+// carries no usable startedAt.
+function deriveElapsedS(startedAt, endedAt, isTerminal, fallbackElapsed) {
+  if (startedAt) {
+    const start = Date.parse(startedAt);
+    if (!Number.isNaN(start)) {
+      const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
+      if (!Number.isNaN(end)) return Math.max(0, (end - start) / 1000);
+    }
+  }
+  if (fallbackElapsed != null && Number.isFinite(fallbackElapsed)) return fallbackElapsed;
+  return null;
+}
+
+export default function JobStatStrip({ job, liveViolations }) {
+  const jobId = job?.jobId;
+  const isTerminal = TERMINAL_STATES.has(job?.status);
+
+  const { data: progress, dataUpdatedAt } = useQuery({
+    queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
+    queryFn: () => getEvaluationProgress(jobId),
+    enabled: !!jobId,
+    refetchInterval: isTerminal ? false : POLL_INTERVAL_MS,
+    staleTime: 0,
+    retry: false,
+  });
+
+  // Per-second re-render so wall-clock elapsed advances between the 2s polls.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (isTerminal || !jobId) return undefined;
+    const id = setInterval(() => setTick((t) => t + 1), TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [isTerminal, jobId]);
+
+  // Throughput samples: one per completed poll (keyed on dataUpdatedAt, which
+  // advances every poll even when the data is identical — so a stall registers
+  // as flat samples). Trimmed to RATE_WINDOW_MS. Kept in a ref so pushes don't
+  // trigger renders; the 1s tick picks the new sample up within a second.
+  const samplesRef = useRef([]);
+  useEffect(() => { samplesRef.current = []; }, [jobId]);
+  useEffect(() => {
+    if (!progress || isTerminal) return;
+    const { takenFiles, totalFiles } = computeOverallProgress(progress);
+    if (!(totalFiles > 0)) return;
+    const now = Date.now();
+    const buf = samplesRef.current;
+    buf.push({ t: now, taken: takenFiles });
+    while (buf.length > 1 && now - buf[0].t > RATE_WINDOW_MS) buf.shift();
+  }, [dataUpdatedAt, isTerminal, progress]);
+
+  const cells = useMemo(() => {
+    if (!jobId) return [];
+    const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
+    const elapsedS = deriveElapsedS(job?.startedAt, job?.endedAt, isTerminal, progress?.totalElapsedS);
+    const liveCount = sumLiveViolations(liveViolations);
+    const rate = isTerminal ? null : computeRate(samplesRef.current);
+    const etaHint = isTerminal ? null : buildEtaHint({ rate, takenFiles, totalFiles });
+    return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint });
+    // `tick` drives the per-second recompute; samplesRef is read (not a dep).
+  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, tick]);
+
+  if (!jobId) return null;
+
+  return (
+    <div className="eval-job-stat-strip">
+      <StatStrip cards>
+        {cells.map((c) => (
+          <Stat key={c.label} label={c.label} value={c.value} hint={c.hint} tone={c.tone} />
+        ))}
+      </StatStrip>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/evaluation/components/JobStatStrip.test.jsx`
+Expected: PASS — including the 4 pre-existing tests (they pass no `startedAt`, so elapsed falls back to `totalElapsedS` and still reads `2:14` / `4:32`).
+
+Note: if the fake-timer test (`ticks forward each second`) is flaky against react-query's internal timers, keep the `estimating…` and Date.now-spy tests (they cover the new behavior) and assert the tick via the same `Date.now` spy incremented between `vi.advanceTimersByTime` calls. Do not weaken the other two tests.
+
+- [ ] **Step 5: Run the full UI suite to confirm nothing regressed**
+
+Run: `npm run test && npm run test:ui`
+Expected: PASS for both runners.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/evaluation/components/JobStatStrip.jsx src/features/evaluation/components/JobStatStrip.test.jsx
+git commit -m "feat(eval-strip): tick ELAPSED every second + show files/s and ETA"
+```
+
+---
+
+## Definition of Done
+
+- Pure helpers `computeRate`/`formatRate`/`formatEta`/`buildEtaHint` exist and are unit-tested (`node --test`).
+- Running ELAPSED card ticks every second from wall-clock; subtext shows `~<rate> files/s · <eta>`, `estimating…` before enough data, and nothing while `preparing…`.
+- Terminal states are unchanged (DURATION/total, no ETA, no ticker).
+- `npm run test` and `npm run test:ui` both pass.
+- Manual check: `quodeq dashboard`, start a scan, confirm ELAPSED ticks 1s and the subtext appears and updates.

--- a/docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md
+++ b/docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md
@@ -1,0 +1,121 @@
+# Live ELAPSED ticker + reading-speed/ETA subtext
+
+Date: 2026-06-08
+Status: Approved design, pending implementation plan
+Area: Web dashboard, evaluation stat strip (`src/quodeq/ui/src/features/evaluation/`)
+
+## Problem
+
+On the running-evaluation panel (`JobStatStrip`), the ELAPSED card only updates
+when the progress poll fires (`POLL_INTERVAL_MS = 2000`), so the clock visibly
+jumps every ~2 seconds. There is also no estimate of how much longer the run
+will take. For a 6-dimension run over thousands of files (which can take hours),
+the operator has no sense of remaining time or current throughput.
+
+## Goals
+
+1. ELAPSED advances smoothly, **once per second**.
+2. A subtext under ELAPSED shows the **current reading speed and a rough,
+   human-readable time remaining**, e.g. `~1.2 files/s · ~5h left`.
+3. The estimate is **honest**: it shows the *current* throughput (not a
+   lifetime average), and it refuses to print a number when it does not yet
+   have enough data (shows `estimating…`).
+
+## Non-goals
+
+- No backend changes. All inputs (`takenFiles`, `totalFiles`, `startedAt`) are
+  already available client-side.
+- No precision guarantee. The estimate is explicitly rough and coarse-bucketed.
+- No ETA on terminal states (done/failed/cancelled/lost keep DURATION/total).
+
+## Design
+
+### Part 1 — second-by-second ELAPSED
+
+`JobStatStrip` adds a 1-second `setInterval` tick (a `useState` counter) that is
+active only while the job is non-terminal. Each tick re-renders the strip.
+`elapsedS` for the display is derived from wall-clock
+(`(Date.now() - Date.parse(job.startedAt)) / 1000`) so it advances between the
+2s polls. On a terminal state the interval is cleared and elapsed freezes to
+`(endedAt - startedAt)`. This replaces reliance on `progress.totalElapsedS` for
+the *live* display; the backend value is no longer needed for ticking (the
+wall-clock delta is accurate to within the poll skew and updates every second).
+
+### Part 2 — `~1.2 files/s · ~5h left` subtext
+
+**Rate: sliding window.** `JobStatStrip` keeps a `useRef` buffer of samples
+`{ t, taken }`. A sample is pushed **once per completed poll** — the push effect
+is keyed on the query's `dataUpdatedAt` (which advances every poll even when the
+data is identical), NOT on the 1s tick and NOT on `takenFiles` changing. Pushing
+on every poll regardless of change is deliberate: a stall then shows up as a run
+of flat samples (`Δfiles == 0` across the window), which the guard below detects.
+Samples older than `WINDOW_MS` (~60s) are dropped. The rate is:
+
+```
+rate = (newest.taken - oldest.taken) / ((newest.t - oldest.t) / 1000)   // files/sec
+```
+
+This reflects current throughput and sheds the slow agent/model warmup at t=0.
+
+**ETA.** `etaSec = (totalFiles - takenFiles) / rate`.
+
+**Formatting (pure helpers in `buildJobStatCells.js`):**
+
+- `formatRate(rate)` → `~1.2 files/s` (1 decimal below 10/s, integer above).
+- `formatEta(remainingFiles, rate)` → coarse human bucket:
+  - `remainingFiles <= 0` or `etaSec <= 45` → `finishing`
+  - `etaSec < 3600` → `~M min left`, where M = round(etaSec/60), rounded to the
+    nearest 1 minute below 10, nearest 5 minutes from 10–59.
+  - `etaSec >= 3600` → `~Hh left` or `~Hh Mm left`, with minutes rounded to the
+    nearest 5 (carry to the hour at 60; drop the minutes term when 0).
+- Combined subtext: `${formatRate(rate)} · ${formatEta(...)}`.
+
+**Accountability guard — when to show `estimating…` instead of a number.**
+`computeRate(samples)` returns `null` (→ subtext = `estimating…`) when any of:
+
+- fewer than 2 samples, or
+- window span `< MIN_WINDOW_S` (~15s) — too little data to be honest, or
+- `Δfiles <= 0` across the window — files have stalled, so a 0/near-0 rate
+  would yield a meaningless or infinite ETA.
+
+When `totalFiles` is unknown (0, the `preparing…` window), the subtext is
+omitted entirely (`hint = null`), consistent with the PROGRESS card showing
+`preparing…`.
+
+### Code placement and boundaries
+
+- **`buildJobStatCells.js`** (pure, no React/DOM — existing contract): new
+  helpers `computeRate(samples, nowMs)`, `formatRate(rate)`,
+  `formatEta(remainingFiles, rate)`. The running branch's `elapsedCell` receives
+  the computed subtext as its `hint`.
+- **`JobStatStrip.jsx`**: owns the 1s ticker (`useEffect` + `setInterval`), the
+  sample-buffer `useRef`, and the per-poll push effect. It derives wall-clock
+  `elapsedS` and calls the pure helpers. No business logic lives in the
+  component beyond wiring.
+
+## Edge cases
+
+- Job not started / no `startedAt` → elapsed `—`, no subtext.
+- Terminal state → DURATION/total, no ticker, no ETA.
+- `takenFiles` stalls mid-run → `estimating…` (guard), recovers when it advances.
+- `totalFiles` revised upward as dims reveal queues → ETA recomputes naturally;
+  the sliding window keeps it current.
+- Very fast finish → `finishing`.
+
+## Testing
+
+- Unit (`buildJobStatCells.test.js` style):
+  - `computeRate`: normal window, `<2` samples → null, span `< MIN_WINDOW_S` →
+    null, stalled (`Δfiles <= 0`) → null, old-sample eviction.
+  - `formatRate`: sub-10 decimal vs integer.
+  - `formatEta`: `finishing` (≤45s and remaining≤0), minute buckets (rounding
+    below 10 vs nearest-5), hour buckets (with/without minutes, carry at 60).
+- Component (`JobStatStrip.test.jsx` style): elapsed advances on a faked 1s
+  interval; subtext renders `~rate files/s · …`; `estimating…` before enough
+  data; no subtext on terminal/`preparing…`.
+
+## Out of scope / future
+
+- Per-dimension ETA breakdown.
+- Persisting throughput history across reconnects (the in-memory window resets
+  on remount; acceptable — it refills within `WINDOW_MS`).

--- a/docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md
+++ b/docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md
@@ -16,7 +16,7 @@ the operator has no sense of remaining time or current throughput.
 
 1. ELAPSED advances smoothly, **once per second**.
 2. A subtext under ELAPSED shows the **current reading speed and a rough,
-   human-readable time remaining**, e.g. `~1.2 files/s · ~5h left`.
+   human-readable time remaining**, e.g. `~5 files/min · ~5h left`.
 3. The estimate is **honest**: it shows the *current* throughput (not a
    lifetime average), and it refuses to print a number when it does not yet
    have enough data (shows `estimating…`).
@@ -41,7 +41,7 @@ active only while the job is non-terminal. Each tick re-renders the strip.
 the *live* display; the backend value is no longer needed for ticking (the
 wall-clock delta is accurate to within the poll skew and updates every second).
 
-### Part 2 — `~1.2 files/s · ~5h left` subtext
+### Part 2 — `~5 files/min · ~5h left` subtext
 
 **Rate: sliding window.** `JobStatStrip` keeps a `useRef` buffer of samples
 `{ t, taken }`. A sample is pushed **once per completed poll** — the push effect
@@ -49,7 +49,10 @@ is keyed on the query's `dataUpdatedAt` (which advances every poll even when the
 data is identical), NOT on the 1s tick and NOT on `takenFiles` changing. Pushing
 on every poll regardless of change is deliberate: a stall then shows up as a run
 of flat samples (`Δfiles == 0` across the window), which the guard below detects.
-Samples older than `WINDOW_MS` (~60s) are dropped. The rate is:
+Samples older than `RATE_WINDOW_MS` (~120s / 2 min) are dropped. The eval runs
+only a few files per minute, so a wide window is required: at ~3-10 files/min a
+short (60s) window sees too few file completions to give a steady number. The
+rate is:
 
 ```
 rate = (newest.taken - oldest.taken) / ((newest.t - oldest.t) / 1000)   // files/sec
@@ -61,7 +64,9 @@ This reflects current throughput and sheds the slow agent/model warmup at t=0.
 
 **Formatting (pure helpers in `buildJobStatCells.js`):**
 
-- `formatRate(rate)` → `~1.2 files/s` (1 decimal below 10/s, integer above).
+- `formatRate(rate)` converts the files/sec rate to **files/min** for display →
+  `~5 files/min` (integer at/above 1/min, one decimal below). Per-second would
+  read ~0.08 for this workload, which is illegible.
 - `formatEta(remainingFiles, rate)` → coarse human bucket:
   - `remainingFiles <= 0` or `etaSec <= 45` → `finishing`
   - `etaSec < 3600` → `~M min left`, where M = round(etaSec/60), rounded to the
@@ -74,7 +79,7 @@ This reflects current throughput and sheds the slow agent/model warmup at t=0.
 `computeRate(samples)` returns `null` (→ subtext = `estimating…`) when any of:
 
 - fewer than 2 samples, or
-- window span `< MIN_WINDOW_S` (~15s) — too little data to be honest, or
+- window span `< RATE_MIN_SPAN_MS` (~30s) — too little data to be honest, or
 - `Δfiles <= 0` across the window — files have stalled, so a 0/near-0 rate
   would yield a meaningless or infinite ETA.
 
@@ -111,7 +116,7 @@ omitted entirely (`hint = null`), consistent with the PROGRESS card showing
   - `formatEta`: `finishing` (≤45s and remaining≤0), minute buckets (rounding
     below 10 vs nearest-5), hour buckets (with/without minutes, carry at 60).
 - Component (`JobStatStrip.test.jsx` style): elapsed advances on a faked 1s
-  interval; subtext renders `~rate files/s · …`; `estimating…` before enough
+  interval; subtext renders `~rate files/min · …`; `estimating…` before enough
   data; no subtext on terminal/`preparing…`.
 
 ## Out of scope / future

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -1,12 +1,13 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getEvaluationProgress } from '../../../api/index.js';
 import { evaluationKeys } from '../../../api/queryKeys.js';
 import { StatStrip, Stat } from '../../../components/terminal/index.js';
 import { computeOverallProgress } from './scanProgressTotals.js';
-import { buildJobStatCells } from './buildJobStatCells.js';
+import { buildJobStatCells, computeRate, buildEtaHint, RATE_WINDOW_MS } from './buildJobStatCells.js';
 
 const POLL_INTERVAL_MS = 2000;
+const TICK_INTERVAL_MS = 1000;
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
 function sumLiveViolations(liveViolations) {
@@ -14,26 +15,26 @@ function sumLiveViolations(liveViolations) {
   return Object.values(liveViolations).reduce((n, vs) => n + (vs?.length || 0), 0);
 }
 
-// Backend-reported elapsed (`progress.totalElapsedS`) lands on a few ticks
-// inside a poll, leaving the cell blank for the first second or two of a
-// run and silent for runs whose progress payload omits the field. Fall
-// back to the wall-clock delta from `job.startedAt` so the strip always
-// shows something live as soon as the job has started.
-function deriveElapsedS(progressElapsed, startedAt, endedAt, isTerminal) {
-  if (progressElapsed != null && Number.isFinite(progressElapsed)) return progressElapsed;
-  if (!startedAt) return null;
-  const start = Date.parse(startedAt);
-  if (Number.isNaN(start)) return null;
-  const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
-  if (Number.isNaN(end)) return null;
-  return Math.max(0, (end - start) / 1000);
+// Live elapsed from wall-clock so the cell ticks every second between the 2s
+// progress polls. Falls back to the backend-reported elapsed only when the job
+// carries no usable startedAt.
+function deriveElapsedS(startedAt, endedAt, isTerminal, fallbackElapsed) {
+  if (startedAt) {
+    const start = Date.parse(startedAt);
+    if (!Number.isNaN(start)) {
+      const end = isTerminal && endedAt ? Date.parse(endedAt) : Date.now();
+      if (!Number.isNaN(end)) return Math.max(0, (end - start) / 1000);
+    }
+  }
+  if (fallbackElapsed != null && Number.isFinite(fallbackElapsed)) return fallbackElapsed;
+  return null;
 }
 
 export default function JobStatStrip({ job, liveViolations }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
 
-  const { data: progress } = useQuery({
+  const { data: progress, dataUpdatedAt } = useQuery({
     queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
     queryFn: () => getEvaluationProgress(jobId),
     enabled: !!jobId,
@@ -42,13 +43,40 @@ export default function JobStatStrip({ job, liveViolations }) {
     retry: false,
   });
 
+  // Per-second re-render so wall-clock elapsed advances between the 2s polls.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (isTerminal || !jobId) return undefined;
+    const id = setInterval(() => setTick((t) => t + 1), TICK_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [isTerminal, jobId]);
+
+  // Throughput samples: one per completed poll (keyed on dataUpdatedAt, which
+  // advances every poll even when the data is identical — so a stall registers
+  // as flat samples). Trimmed to RATE_WINDOW_MS. Kept in a ref so pushes don't
+  // trigger renders; the 1s tick picks the new sample up within a second.
+  const samplesRef = useRef([]);
+  useEffect(() => { samplesRef.current = []; }, [jobId]);
+  useEffect(() => {
+    if (!progress || isTerminal) return;
+    const { takenFiles, totalFiles } = computeOverallProgress(progress);
+    if (!(totalFiles > 0)) return;
+    const now = Date.now();
+    const buf = samplesRef.current;
+    buf.push({ t: now, taken: takenFiles });
+    while (buf.length > 1 && now - buf[0].t > RATE_WINDOW_MS) buf.shift();
+  }, [dataUpdatedAt, isTerminal, progress]);
+
   const cells = useMemo(() => {
     if (!jobId) return [];
     const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
-    const elapsedS = deriveElapsedS(progress?.totalElapsedS, job?.startedAt, job?.endedAt, isTerminal);
+    const elapsedS = deriveElapsedS(job?.startedAt, job?.endedAt, isTerminal, progress?.totalElapsedS);
     const liveCount = sumLiveViolations(liveViolations);
-    return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount });
-  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations]);
+    const rate = isTerminal ? null : computeRate(samplesRef.current);
+    const etaHint = isTerminal ? null : buildEtaHint({ rate, takenFiles, totalFiles });
+    return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint });
+    // `tick` drives the per-second recompute; samplesRef is read (not a dep).
+  }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, tick]);
 
   if (!jobId) return null;
 

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -61,4 +61,49 @@ describe('JobStatStrip', () => {
     const { container } = renderWithClient(<JobStatStrip job={null} liveViolations={{}} />);
     expect(container.firstChild).toBeNull();
   });
+
+  it('shows "estimating…" subtext for a fresh running job (one sample)', async () => {
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+    });
+    const job = { jobId: 'job-3', status: 'running', startedAt: new Date(Date.now() - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('estimating…')).toBeInTheDocument();
+  });
+
+  it('ELAPSED reflects wall-clock from startedAt (not backend elapsed)', async () => {
+    const now = new Date('2026-06-08T10:00:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+      totalElapsedS: 9999, // would show 166:39 if backend value were used
+    });
+    const job = { jobId: 'job-4', status: 'running', startedAt: new Date(now - 5000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    // Wait for the poll to resolve (PROGRESS shows 1%) so we assert the
+    // post-resolution value: with the old code this would flip to backend
+    // 9999s (166:39); the new code keeps wall-clock 0:05.
+    expect(await screen.findByText('1%')).toBeInTheDocument();
+    expect(screen.getByText('0:05')).toBeInTheDocument();
+    nowSpy.mockRestore();
+  });
+
+  it('ELAPSED ticks forward each second', async () => {
+    vi.useFakeTimers();
+    try {
+      const t0 = new Date('2026-06-08T10:00:00Z').getTime();
+      vi.setSystemTime(t0);
+      getEvaluationProgress.mockResolvedValue({
+        dimensions: [{ state: 'running', files: { taken: 10, total: 1000 } }],
+      });
+      const job = { jobId: 'job-5', status: 'running', startedAt: new Date(t0 - 5000).toISOString() };
+      renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+      await vi.advanceTimersByTimeAsync(0);     // flush the initial fetch
+      expect(screen.getByText('0:05')).toBeInTheDocument();
+      await vi.advanceTimersByTimeAsync(2000);  // two 1s ticks
+      expect(screen.getByText('0:07')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -57,6 +57,19 @@ export function formatEta(remainingFiles, rate) {
   return min === 0 ? `~${hours}h left` : `~${hours}h ${min}m left`;
 }
 
+/**
+ * ELAPSED subtext for a running job: "~1.2 files/s · ~5h left".
+ *  - null  when totalFiles is unknown (the PROGRESS card shows "preparing…").
+ *  - "estimating…" when total is known but the rate isn't trustworthy yet.
+ * @param {{rate:number|null, takenFiles:number, totalFiles:number}} args
+ */
+export function buildEtaHint({ rate, takenFiles, totalFiles }) {
+  if (!(totalFiles > 0)) return null;
+  const rateStr = formatRate(rate);
+  if (rateStr == null) return 'estimating…';
+  return `${rateStr} · ${formatEta(totalFiles - takenFiles, rate)}`;
+}
+
 export function formatClock(s) {
   if (s == null || !Number.isFinite(s)) return '—';
   const total = Math.max(0, Math.floor(s));
@@ -131,7 +144,7 @@ export function buildJobStatCells(status, inputs) {
     statusCell,
     progressCell(inputs),
     foundCell(inputs.liveCount),
-    elapsedCell(inputs.elapsedS),
+    elapsedCell(inputs.elapsedS, 'ELAPSED', inputs.etaHint ?? null),
   ];
 }
 

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -3,6 +3,31 @@
  * No React, no network, no DOM — drop-in testable.
  */
 
+// Throughput estimate tuning. The rate is measured over a sliding window so it
+// reflects *current* speed (cache-hit bursts vs slow LLM misses, and the
+// per-dimension speed shifts) rather than a startup-biased lifetime average.
+export const RATE_WINDOW_MS = 60000;   // sliding window the buffer is trimmed to
+const RATE_MIN_SPAN_MS = 15000;        // refuse to estimate from < this much data
+
+/**
+ * Files/sec from a buffer of {t, taken} samples (t = epoch ms, ascending).
+ * Returns null — meaning "no honest estimate yet" — when there are fewer than
+ * two samples, the window spans less than RATE_MIN_SPAN_MS, or files have not
+ * advanced across the window (a stall).
+ * @param {Array<{t:number, taken:number}>} samples
+ * @returns {number|null}
+ */
+export function computeRate(samples) {
+  if (!Array.isArray(samples) || samples.length < 2) return null;
+  const oldest = samples[0];
+  const newest = samples[samples.length - 1];
+  const spanMs = newest.t - oldest.t;
+  if (spanMs < RATE_MIN_SPAN_MS) return null;
+  const dFiles = newest.taken - oldest.taken;
+  if (dFiles <= 0) return null;
+  return dFiles / (spanMs / 1000);
+}
+
 export function formatClock(s) {
   if (s == null || !Number.isFinite(s)) return '—';
   const total = Math.max(0, Math.floor(s));

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -28,6 +28,35 @@ export function computeRate(samples) {
   return dFiles / (spanMs / 1000);
 }
 
+/** "~1.2 files/s" (1 decimal below 10/s, integer above). null when unusable. */
+export function formatRate(rate) {
+  if (rate == null || !Number.isFinite(rate) || rate <= 0) return null;
+  const shown = rate < 10 ? rate.toFixed(1) : String(Math.round(rate));
+  return `~${shown} files/s`;
+}
+
+/**
+ * Coarse, human-readable time remaining from files-left + files/sec rate.
+ * "finishing" near the end; "~N min left"; "~Hh left" / "~Hh Mm left".
+ * Returns "estimating…" if rate is unusable (caller normally gates first).
+ */
+export function formatEta(remainingFiles, rate) {
+  if (!(rate > 0) || !Number.isFinite(rate)) return 'estimating…';
+  if (remainingFiles <= 0) return 'finishing';
+  const etaSec = remainingFiles / rate;
+  if (etaSec <= 45) return 'finishing';
+  if (etaSec < 3600) {
+    const rawMin = etaSec / 60;
+    let min = rawMin < 10 ? Math.max(1, Math.round(rawMin)) : Math.round(rawMin / 5) * 5;
+    if (min >= 60) return '~1h left';
+    return `~${min} min left`;
+  }
+  let hours = Math.floor(etaSec / 3600);
+  let min = Math.round(((etaSec % 3600) / 60) / 5) * 5;
+  if (min === 60) { hours += 1; min = 0; }
+  return min === 0 ? `~${hours}h left` : `~${hours}h ${min}m left`;
+}
+
 export function formatClock(s) {
   if (s == null || !Number.isFinite(s)) return '—';
   const total = Math.max(0, Math.floor(s));

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -3,11 +3,14 @@
  * No React, no network, no DOM — drop-in testable.
  */
 
-// Throughput estimate tuning. The rate is measured over a sliding window so it
-// reflects *current* speed (cache-hit bursts vs slow LLM misses, and the
-// per-dimension speed shifts) rather than a startup-biased lifetime average.
-export const RATE_WINDOW_MS = 60000;   // sliding window the buffer is trimmed to
-const RATE_MIN_SPAN_MS = 15000;        // refuse to estimate from < this much data
+// Throughput estimate tuning. The eval completes only a few files per MINUTE
+// (one slow LLM call per file), so the rate is shown per minute and measured
+// over a wide window: at ~3-10 files/min a short window sees too few files to
+// be stable and would flicker to "estimating…". The window also reflects
+// *current* speed (cache-hit bursts vs slow misses, per-dimension shifts)
+// rather than a startup-biased lifetime average.
+export const RATE_WINDOW_MS = 120000;  // 2-min sliding window the buffer is trimmed to
+const RATE_MIN_SPAN_MS = 30000;        // refuse to estimate from < this much data
 
 /**
  * Files/sec from a buffer of {t, taken} samples (t = epoch ms, ascending).
@@ -28,11 +31,16 @@ export function computeRate(samples) {
   return dFiles / (spanMs / 1000);
 }
 
-/** "~1.2 files/s" (1 decimal below 10/s, integer above). null when unusable. */
+/**
+ * "~5 files/min" from a files/SECOND rate. The eval runs only a few files per
+ * minute, so per-second would read ~0.08; per-minute is legible. Integer
+ * at/above 1/min, one decimal below. null when unusable.
+ */
 export function formatRate(rate) {
   if (rate == null || !Number.isFinite(rate) || rate <= 0) return null;
-  const shown = rate < 10 ? rate.toFixed(1) : String(Math.round(rate));
-  return `~${shown} files/s`;
+  const perMin = rate * 60;
+  const shown = perMin >= 1 ? String(Math.round(perMin)) : perMin.toFixed(1);
+  return `~${shown} files/min`;
 }
 
 /**
@@ -58,7 +66,7 @@ export function formatEta(remainingFiles, rate) {
 }
 
 /**
- * ELAPSED subtext for a running job: "~1.2 files/s · ~5h left".
+ * ELAPSED subtext for a running job: "~5 files/min · ~5h left".
  *  - null  when totalFiles is unknown (the PROGRESS card shows "preparing…").
  *  - "estimating…" when total is known but the rate isn't trustworthy yet.
  * @param {{rate:number|null, takenFiles:number, totalFiles:number}} args

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS } from './buildJobStatCells.js';
+import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS, formatRate, formatEta } from './buildJobStatCells.js';
 
 const baseInputs = {
   overallPct: 62,
@@ -125,4 +125,43 @@ test('computeRate: null when files have not advanced (stalled)', () => {
 test('RATE_WINDOW_MS is exported for the buffer to window against', () => {
   assert.equal(typeof RATE_WINDOW_MS, 'number');
   assert.ok(RATE_WINDOW_MS > 0);
+});
+
+// ---------------------------------------------------------------------------
+// formatRate / formatEta
+// ---------------------------------------------------------------------------
+
+test('formatRate: one decimal below 10/s, integer at/above 10/s', () => {
+  assert.equal(formatRate(1.234), '~1.2 files/s');
+  assert.equal(formatRate(9.96), '~10.0 files/s'); // toFixed rounds; still < 10 path
+  assert.equal(formatRate(12.7), '~13 files/s');
+});
+
+test('formatRate: null for non-positive / non-finite / null', () => {
+  assert.equal(formatRate(0), null);
+  assert.equal(formatRate(-1), null);
+  assert.equal(formatRate(Infinity), null);
+  assert.equal(formatRate(null), null);
+});
+
+test('formatEta: "finishing" when essentially done', () => {
+  assert.equal(formatEta(0, 1), 'finishing');     // nothing left
+  assert.equal(formatEta(40, 1), 'finishing');    // 40s <= 45s
+});
+
+test('formatEta: minute buckets (nearest 1 under 10m, nearest 5 over)', () => {
+  assert.equal(formatEta(120, 1), '~2 min left');   // 120s
+  assert.equal(formatEta(1000, 1), '~15 min left'); // 1000s ≈ 16.7m -> nearest 5 = 15
+  assert.equal(formatEta(50, 1), '~1 min left');    // 50s -> 1m (just over the 45s floor)
+});
+
+test('formatEta: hour buckets, minutes to nearest 5, carry at 60', () => {
+  assert.equal(formatEta(18000, 1), '~5h left');        // 5h exactly
+  assert.equal(formatEta(19800, 1), '~5h 30m left');    // 5h30m
+  assert.equal(formatEta(7080, 1), '~2h left');         // 1h58m -> minutes round to 60 -> carry
+});
+
+test('formatEta: estimating when rate is unusable', () => {
+  assert.equal(formatEta(100, 0), 'estimating…');
+  assert.equal(formatEta(100, null), 'estimating…');
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -100,9 +100,9 @@ test('buildJobStatCells: failed/cancelled show PROGRESS + FOUND-so-far + ELAPSED
 // ---------------------------------------------------------------------------
 
 test('computeRate: files/sec from oldest→newest over the window', () => {
-  // 30 files over 30s = 1.0 files/s
-  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_030_000, taken: 40 }];
-  assert.equal(computeRate(s), 1);
+  // 30 files over 60s = 0.5 files/s (returned in files/sec; displayed per-min)
+  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_060_000, taken: 40 }];
+  assert.equal(computeRate(s), 0.5);
 });
 
 test('computeRate: null when fewer than 2 samples', () => {
@@ -111,7 +111,7 @@ test('computeRate: null when fewer than 2 samples', () => {
   assert.equal(computeRate(null), null);
 });
 
-test('computeRate: null when window span is below the minimum (~15s)', () => {
+test('computeRate: null when window span is below the minimum (~30s)', () => {
   // 10s span -> not enough to be honest yet
   const s = [{ t: 1_000_000, taken: 10 }, { t: 1_010_000, taken: 30 }];
   assert.equal(computeRate(s), null);
@@ -131,10 +131,11 @@ test('RATE_WINDOW_MS is exported for the buffer to window against', () => {
 // formatRate / formatEta
 // ---------------------------------------------------------------------------
 
-test('formatRate: one decimal below 10/s, integer at/above 10/s', () => {
-  assert.equal(formatRate(1.234), '~1.2 files/s');
-  assert.equal(formatRate(9.96), '~10.0 files/s'); // toFixed rounds; still < 10 path
-  assert.equal(formatRate(12.7), '~13 files/s');
+test('formatRate: per-minute display (integer at/above 1/min, 1 decimal below)', () => {
+  assert.equal(formatRate(0.05), '~3 files/min');      // 0.05/s = 3/min
+  assert.equal(formatRate(0.1), '~6 files/min');       // 6/min
+  assert.equal(formatRate(0.25), '~15 files/min');     // 15/min
+  assert.equal(formatRate(1 / 600), '~0.1 files/min'); // 0.1/min keeps a decimal
 });
 
 test('formatRate: null for non-positive / non-finite / null', () => {
@@ -178,18 +179,18 @@ test('buildEtaHint: "estimating…" when rate is unusable but total is known', (
   assert.equal(buildEtaHint({ rate: null, takenFiles: 5, totalFiles: 100 }), 'estimating…');
 });
 
-test('buildEtaHint: "~rate files/s · ~eta" when estimate is available', () => {
-  // 90 files left at 1 file/s = 90s -> "~2 min left"
+test('buildEtaHint: "~rate files/min · ~eta" when estimate is available', () => {
+  // 90 files left at 0.1 file/s (6/min) = 900s -> "~15 min left"
   assert.equal(
-    buildEtaHint({ rate: 1, takenFiles: 10, totalFiles: 100 }),
-    '~1.0 files/s · ~2 min left',
+    buildEtaHint({ rate: 0.1, takenFiles: 10, totalFiles: 100 }),
+    '~6 files/min · ~15 min left',
   );
 });
 
 test('buildJobStatCells: running ELAPSED cell carries the etaHint as its subtext', () => {
-  const cells = buildJobStatCells('running', { ...baseInputs, etaHint: '~1.2 files/s · ~5h left' });
+  const cells = buildJobStatCells('running', { ...baseInputs, etaHint: '~6 files/min · ~5h left' });
   assert.equal(cells[3].label, 'ELAPSED');
-  assert.equal(cells[3].hint, '~1.2 files/s · ~5h left');
+  assert.equal(cells[3].hint, '~6 files/min · ~5h left');
 });
 
 test('buildJobStatCells: done DURATION cell ignores etaHint', () => {

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildJobStatCells, formatClock } from './buildJobStatCells.js';
+import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS } from './buildJobStatCells.js';
 
 const baseInputs = {
   overallPct: 62,
@@ -93,4 +93,36 @@ test('buildJobStatCells: failed/cancelled show PROGRESS + FOUND-so-far + ELAPSED
   assert.equal(failed[1].label, 'PROGRESS');
   assert.equal(failed[2].label, 'FOUND');
   assert.equal(failed[3].label, 'ELAPSED');
+});
+
+// ---------------------------------------------------------------------------
+// computeRate (sliding-window throughput)
+// ---------------------------------------------------------------------------
+
+test('computeRate: files/sec from oldest→newest over the window', () => {
+  // 30 files over 30s = 1.0 files/s
+  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_030_000, taken: 40 }];
+  assert.equal(computeRate(s), 1);
+});
+
+test('computeRate: null when fewer than 2 samples', () => {
+  assert.equal(computeRate([]), null);
+  assert.equal(computeRate([{ t: 1, taken: 5 }]), null);
+  assert.equal(computeRate(null), null);
+});
+
+test('computeRate: null when window span is below the minimum (~15s)', () => {
+  // 10s span -> not enough to be honest yet
+  const s = [{ t: 1_000_000, taken: 10 }, { t: 1_010_000, taken: 30 }];
+  assert.equal(computeRate(s), null);
+});
+
+test('computeRate: null when files have not advanced (stalled)', () => {
+  const s = [{ t: 1_000_000, taken: 50 }, { t: 1_040_000, taken: 50 }];
+  assert.equal(computeRate(s), null);
+});
+
+test('RATE_WINDOW_MS is exported for the buffer to window against', () => {
+  assert.equal(typeof RATE_WINDOW_MS, 'number');
+  assert.ok(RATE_WINDOW_MS > 0);
 });

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS, formatRate, formatEta } from './buildJobStatCells.js';
+import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS, formatRate, formatEta, buildEtaHint } from './buildJobStatCells.js';
 
 const baseInputs = {
   overallPct: 62,
@@ -164,4 +164,36 @@ test('formatEta: hour buckets, minutes to nearest 5, carry at 60', () => {
 test('formatEta: estimating when rate is unusable', () => {
   assert.equal(formatEta(100, 0), 'estimating…');
   assert.equal(formatEta(100, null), 'estimating…');
+});
+
+// ---------------------------------------------------------------------------
+// buildEtaHint + ELAPSED cell wiring
+// ---------------------------------------------------------------------------
+
+test('buildEtaHint: null when total is unknown (preparing…)', () => {
+  assert.equal(buildEtaHint({ rate: 1, takenFiles: 0, totalFiles: 0 }), null);
+});
+
+test('buildEtaHint: "estimating…" when rate is unusable but total is known', () => {
+  assert.equal(buildEtaHint({ rate: null, takenFiles: 5, totalFiles: 100 }), 'estimating…');
+});
+
+test('buildEtaHint: "~rate files/s · ~eta" when estimate is available', () => {
+  // 90 files left at 1 file/s = 90s -> "~2 min left"
+  assert.equal(
+    buildEtaHint({ rate: 1, takenFiles: 10, totalFiles: 100 }),
+    '~1.0 files/s · ~2 min left',
+  );
+});
+
+test('buildJobStatCells: running ELAPSED cell carries the etaHint as its subtext', () => {
+  const cells = buildJobStatCells('running', { ...baseInputs, etaHint: '~1.2 files/s · ~5h left' });
+  assert.equal(cells[3].label, 'ELAPSED');
+  assert.equal(cells[3].hint, '~1.2 files/s · ~5h left');
+});
+
+test('buildJobStatCells: done DURATION cell ignores etaHint', () => {
+  const cells = buildJobStatCells('done', { ...baseInputs, takenFiles: 220, etaHint: 'should-not-appear' });
+  assert.equal(cells[3].label, 'DURATION');
+  assert.equal(cells[3].hint, 'total');
 });


### PR DESCRIPTION
## Summary

On the running-evaluation stat strip (`JobStatStrip`), the ELAPSED card jumped every ~2s (it only updated on the progress poll) and gave no sense of how much longer a run would take. This adds:

- **Second-by-second ELAPSED** — a 1s ticker recomputes elapsed from wall-clock (`Date.now() - startedAt`) between the 2s polls. Freezes on terminal states.
- **`~5 files/min · ~5h left` subtext** under ELAPSED — current reading speed plus a rough, human-readable time remaining.

The estimate is honest about its basis:
- **Per-minute rate.** The eval completes only a few files per minute (one slow LLM call per file), so throughput is shown as files/min (per-second would read ~0.08, illegible).
- **Sliding window (~2 min).** Reflects *current* throughput and sheds the slow agent/model warmup at t=0, rather than a startup-biased lifetime average. The window is wide because at ~3-10 files/min a short window sees too few completions to be steady. Speed genuinely varies across a run (cache-hit bursts vs slow misses, and the 6 dimensions differ).
- **`estimating…`** until the window spans enough time (~30s), or if files stall (rate ≈ 0) — never invents a number from too little data.
- Coarse ETA buckets so it doesn't flicker: `finishing` / `~N min left` / `~Nh Mm left`.
- No subtext while `preparing…` (total unknown). Terminal states are unchanged (DURATION/total, no ETA).

No backend changes — all inputs (`takenFiles`, `totalFiles`, `startedAt`) already flow client-side. All estimate math lives as pure, framework-free helpers in `buildJobStatCells.js`; `JobStatStrip` owns the React wiring (ticker + windowed sample buffer).

Design spec: `docs/superpowers/specs/2026-06-08-eval-elapsed-eta-design.md`

## Test plan

Automated (TDD, red→green per commit):
- [x] `computeRate` window math + guards (`<2` samples, span `<30s`, stalled) — `node:test`
- [x] `formatRate` (per-minute display) / `formatEta` buckets incl. minute/hour rounding and the 60-min carry — `node:test`
- [x] `buildEtaHint` (`preparing…`→null, `estimating…`, combined string) + ELAPSED cell wiring — `node:test`
- [x] `JobStatStrip`: `estimating…` subtext, wall-clock elapsed (backend value ignored), per-second tick — `vitest`
- [x] Full UI suite green: 196 node:test + 369 vitest; production build compiles.

Manual:
- [x] `quodeq dashboard`, start a scan: ELAPSED ticks every second; subtext shows `~N files/min · ~time left`, updates as the run proceeds, and reads `finishing` near the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)