### PR TITLE
fix(eval-strip): even ELAPSED ticking + persist throughput window on re-entry

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -1,13 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getEvaluationProgress } from '../../../api/index.js';
 import { evaluationKeys } from '../../../api/queryKeys.js';
 import { StatStrip, Stat } from '../../../components/terminal/index.js';
 import { computeOverallProgress } from './scanProgressTotals.js';
-import { buildJobStatCells, computeRate, buildEtaHint, RATE_WINDOW_MS } from './buildJobStatCells.js';
+import { buildJobStatCells, computeRate, buildEtaHint, msUntilNextSecond } from './buildJobStatCells.js';
+import { recordRateSample, getRateSamples } from './rateSampleStore.js';
 
 const POLL_INTERVAL_MS = 2000;
-const TICK_INTERVAL_MS = 1000;
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
 function sumLiveViolations(liveViolations) {
@@ -43,39 +43,50 @@ export default function JobStatStrip({ job, liveViolations }) {
     retry: false,
   });
 
-  // Per-second re-render so wall-clock elapsed advances between the 2s polls.
+  // Re-render aligned to each whole-second boundary of wall-clock elapsed, so
+  // ELAPSED ticks *evenly*. A fixed setInterval(1000) has its phase fixed at
+  // mount and beats against the second boundary as timer jitter drifts it,
+  // producing visible double/skip ticks. A self-correcting timeout recomputes
+  // the delay from absolute `now` each tick — it re-aligns to the boundary and
+  // never accumulates drift. Inactive on terminal states / without a startedAt
+  // (the elapsed value is then poll-derived and can't tick per-second anyway).
   const [tick, setTick] = useState(0);
+  const startMs = job?.startedAt ? Date.parse(job.startedAt) : NaN;
   useEffect(() => {
-    if (isTerminal || !jobId) return undefined;
-    const id = setInterval(() => setTick((t) => t + 1), TICK_INTERVAL_MS);
-    return () => clearInterval(id);
-  }, [isTerminal, jobId]);
+    if (isTerminal || !jobId || Number.isNaN(startMs)) return undefined;
+    let id;
+    const schedule = () => {
+      id = setTimeout(() => { setTick((t) => t + 1); schedule(); }, msUntilNextSecond(Date.now() - startMs));
+    };
+    schedule();
+    return () => clearTimeout(id);
+  }, [isTerminal, jobId, startMs]);
 
-  // Throughput samples: one per completed poll (keyed on dataUpdatedAt, which
-  // advances every poll even when the data is identical — so a stall registers
-  // as flat samples). Trimmed to RATE_WINDOW_MS. Kept in a ref so pushes don't
-  // trigger renders; the 1s tick picks the new sample up within a second.
-  const samplesRef = useRef([]);
-  useEffect(() => { samplesRef.current = []; }, [jobId]);
+  // Throughput samples live in a module-level store (rateSampleStore.js) keyed
+  // by jobId, so the sliding-window rate SURVIVES navigating out of and back
+  // into a running job — re-entry shows the current rate immediately instead of
+  // re-measuring from "estimating…". One sample per completed poll (keyed on
+  // dataUpdatedAt, which advances every poll even when the data is identical, so
+  // a stall registers as flat samples and reads as "estimating…").
   useEffect(() => {
     if (!progress || isTerminal) return;
     const { takenFiles, totalFiles } = computeOverallProgress(progress);
     if (!(totalFiles > 0)) return;
-    const now = Date.now();
-    const buf = samplesRef.current;
-    buf.push({ t: now, taken: takenFiles });
-    while (buf.length > 1 && now - buf[0].t > RATE_WINDOW_MS) buf.shift();
-  }, [dataUpdatedAt, isTerminal, progress]);
+    recordRateSample(jobId, Date.now(), takenFiles);
+  }, [dataUpdatedAt, isTerminal, progress, jobId]);
 
   const cells = useMemo(() => {
     if (!jobId) return [];
     const { takenFiles, totalFiles, overallPct } = computeOverallProgress(progress);
     const elapsedS = deriveElapsedS(job?.startedAt, job?.endedAt, isTerminal, progress?.totalElapsedS);
     const liveCount = sumLiveViolations(liveViolations);
-    const rate = isTerminal ? null : computeRate(samplesRef.current);
+    // Current throughput from the persisted sliding window (null → "estimating…"
+    // until ~30s of samples accumulate). No whole-run average: it over-reads
+    // because the parallel start burst-completes cached files cheaply.
+    const rate = isTerminal ? null : computeRate(getRateSamples(jobId));
     const etaHint = isTerminal ? null : buildEtaHint({ rate, takenFiles, totalFiles });
     return buildJobStatCells(job.status, { overallPct, takenFiles, totalFiles, elapsedS, liveCount, etaHint });
-    // `tick` drives the per-second recompute; samplesRef is read (not a dep).
+    // `tick` drives the per-second recompute; the sample store is read (not a dep).
   }, [jobId, job?.status, job?.startedAt, job?.endedAt, isTerminal, progress, liveViolations, tick]);
 
   if (!jobId) return null;

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -7,6 +7,7 @@ vi.mock('../../../api/index.js', () => ({
   getEvaluationProgress: vi.fn(),
 }));
 import { getEvaluationProgress } from '../../../api/index.js';
+import { recordRateSample, _resetRateSamples } from './rateSampleStore.js';
 
 function renderWithClient(ui) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -17,7 +18,7 @@ const runningJob = { jobId: 'job-1', status: 'running' };
 const doneJob    = { jobId: 'job-2', status: 'done' };
 
 describe('JobStatStrip', () => {
-  beforeEach(() => { getEvaluationProgress.mockReset(); });
+  beforeEach(() => { getEvaluationProgress.mockReset(); _resetRateSamples(); });
 
   it('renders 4 stat cells for a running job', async () => {
     getEvaluationProgress.mockResolvedValue({
@@ -69,6 +70,39 @@ describe('JobStatStrip', () => {
     const job = { jobId: 'job-3', status: 'running', startedAt: new Date(Date.now() - 5000).toISOString() };
     renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
     expect(await screen.findByText('estimating…')).toBeInTheDocument();
+  });
+
+  it('cold entry into a deep-in-progress run stays "estimating…" (no biased whole-run average)', async () => {
+    // Even at 500/3000 files and 20 min in, with no persisted samples we have
+    // not measured *current* throughput yet — show "estimating…", not a number
+    // skewed high by the cache-hit burst at the start of the run.
+    const now = new Date('2026-06-08T10:20:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 500, total: 3000 } }],
+    });
+    const job = { jobId: 'job-6', status: 'running', startedAt: new Date(now - 20 * 60 * 1000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText('estimating…')).toBeInTheDocument();
+    expect(screen.queryByText(/files\/min/)).not.toBeInTheDocument();
+    nowSpy.mockRestore();
+  });
+
+  it('re-entry uses throughput samples persisted from a previous mount (no re-measuring)', async () => {
+    // Simulate the window built up before navigating away: 30 files over 60s =
+    // 0.5 files/s = 30 files/min. On re-entry the rate is shown immediately.
+    const now = new Date('2026-06-08T10:20:00Z').getTime();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    recordRateSample('job-7', now - 60_000, 470);
+    recordRateSample('job-7', now, 500);
+    getEvaluationProgress.mockResolvedValue({
+      dimensions: [{ state: 'running', files: { taken: 500, total: 3000 } }],
+    });
+    const job = { jobId: 'job-7', status: 'running', startedAt: new Date(now - 20 * 60 * 1000).toISOString() };
+    renderWithClient(<JobStatStrip job={job} liveViolations={{}} />);
+    expect(await screen.findByText(/^~30 files\/min/)).toBeInTheDocument();
+    expect(screen.queryByText('estimating…')).not.toBeInTheDocument();
+    nowSpy.mockRestore();
   });
 
   it('ELAPSED reflects wall-clock from startedAt (not backend elapsed)', async () => {

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.js
@@ -78,6 +78,20 @@ export function buildEtaHint({ rate, takenFiles, totalFiles }) {
   return `${rateStr} · ${formatEta(totalFiles - takenFiles, rate)}`;
 }
 
+/**
+ * Milliseconds from an elapsed-ms value to the next whole-second boundary.
+ * The ELAPSED display shows `floor(elapsedMs / 1000)`, so it flips exactly on
+ * these boundaries; scheduling the next re-render for this delay (instead of a
+ * fixed 1s interval whose phase is fixed at mount and drifts against the
+ * boundary) keeps the clock ticking evenly and never accumulates drift. Always
+ * in (0, 1000]; defaults to 1000 for a non-finite input.
+ */
+export function msUntilNextSecond(elapsedMs) {
+  if (!Number.isFinite(elapsedMs)) return 1000;
+  const rem = ((elapsedMs % 1000) + 1000) % 1000;  // normalize negatives
+  return 1000 - rem;
+}
+
 export function formatClock(s) {
   if (s == null || !Number.isFinite(s)) return '—';
   const total = Math.max(0, Math.floor(s));

--- a/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/buildJobStatCells.test.js
@@ -1,6 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildJobStatCells, formatClock, computeRate, RATE_WINDOW_MS, formatRate, formatEta, buildEtaHint } from './buildJobStatCells.js';
+import {
+  buildJobStatCells,
+  formatClock,
+  computeRate,
+  RATE_WINDOW_MS,
+  formatRate,
+  formatEta,
+  buildEtaHint,
+  msUntilNextSecond,
+} from './buildJobStatCells.js';
 
 const baseInputs = {
   overallPct: 62,
@@ -197,4 +206,22 @@ test('buildJobStatCells: done DURATION cell ignores etaHint', () => {
   const cells = buildJobStatCells('done', { ...baseInputs, takenFiles: 220, etaHint: 'should-not-appear' });
   assert.equal(cells[3].label, 'DURATION');
   assert.equal(cells[3].hint, 'total');
+});
+
+// ---------------------------------------------------------------------------
+// msUntilNextSecond (boundary-aligned re-render delay for the ELAPSED ticker)
+// ---------------------------------------------------------------------------
+
+test('msUntilNextSecond: delay to the next whole-second boundary, in (0, 1000]', () => {
+  assert.equal(msUntilNextSecond(0), 1000);      // on a boundary → a full second to the next
+  assert.equal(msUntilNextSecond(5000), 1000);   // whole second elapsed
+  assert.equal(msUntilNextSecond(5300), 700);    // 300ms into the second
+  assert.equal(msUntilNextSecond(999), 1);       // just before the boundary
+  assert.equal(msUntilNextSecond(1500), 500);
+});
+
+test('msUntilNextSecond: normalizes negatives and defaults non-finite to 1000', () => {
+  assert.equal(msUntilNextSecond(-300), 300);
+  assert.equal(msUntilNextSecond(NaN), 1000);
+  assert.equal(msUntilNextSecond(Infinity), 1000);
 });

--- a/src/quodeq/ui/src/features/evaluation/components/rateSampleStore.js
+++ b/src/quodeq/ui/src/features/evaluation/components/rateSampleStore.js
@@ -1,0 +1,40 @@
+/**
+ * Module-level throughput-sample store for the live evaluation stat strip.
+ *
+ * Samples (`{ t: epoch ms, taken: files done }`) are kept here, keyed by jobId,
+ * rather than in component state — so the sliding-window rate SURVIVES a
+ * `JobStatStrip` unmount/remount. Navigating out of and back into a running
+ * evaluation must not restart the window from empty; doing so blanked the rate
+ * to "estimating…" for ~30s on every entry (and tempted a biased whole-run
+ * average as a stopgap). The buffer persists for the life of the page; a full
+ * reload starts fresh, which is acceptable.
+ *
+ * No React, no DOM — drop-in testable.
+ */
+
+import { RATE_WINDOW_MS } from './buildJobStatCells.js';
+
+const byJob = new Map();
+
+/**
+ * Append a sample for a job and trim anything older than RATE_WINDOW_MS.
+ * Always keeps at least the newest sample (so a long stall still has a point).
+ * @returns {Array<{t:number, taken:number}>} the job's (trimmed) buffer
+ */
+export function recordRateSample(jobId, t, taken) {
+  let buf = byJob.get(jobId);
+  if (!buf) { buf = []; byJob.set(jobId, buf); }
+  buf.push({ t, taken });
+  while (buf.length > 1 && t - buf[0].t > RATE_WINDOW_MS) buf.shift();
+  return buf;
+}
+
+/** The job's current sample buffer (empty array if none recorded yet). */
+export function getRateSamples(jobId) {
+  return byJob.get(jobId) || [];
+}
+
+/** Test hygiene: the store is module-level and would otherwise leak across tests. */
+export function _resetRateSamples() {
+  byJob.clear();
+}

--- a/src/quodeq/ui/src/features/evaluation/components/rateSampleStore.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/rateSampleStore.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { recordRateSample, getRateSamples, _resetRateSamples } from './rateSampleStore.js';
+import { RATE_WINDOW_MS } from './buildJobStatCells.js';
+
+test('rateSampleStore: records and returns samples for a job', () => {
+  _resetRateSamples();
+  recordRateSample('j1', 1000, 10);
+  recordRateSample('j1', 2000, 12);
+  assert.deepEqual(getRateSamples('j1'), [{ t: 1000, taken: 10 }, { t: 2000, taken: 12 }]);
+});
+
+test('rateSampleStore: survives reads — a remount keeps appending, not resetting', () => {
+  _resetRateSamples();
+  recordRateSample('j1', 1000, 10);
+  getRateSamples('j1');               // "first mount" reads the buffer
+  recordRateSample('j1', 2000, 12);   // "second mount" keeps appending to the same buffer
+  assert.equal(getRateSamples('j1').length, 2);
+});
+
+test('rateSampleStore: trims samples older than RATE_WINDOW_MS', () => {
+  _resetRateSamples();
+  const t0 = 1_000_000;
+  recordRateSample('j1', t0, 10);
+  recordRateSample('j1', t0 + RATE_WINDOW_MS + 1, 40);  // pushes the first out of the window
+  const buf = getRateSamples('j1');
+  assert.equal(buf.length, 1);
+  assert.equal(buf[0].taken, 40);
+});
+
+test('rateSampleStore: never empties — keeps the newest even if older than the window', () => {
+  _resetRateSamples();
+  recordRateSample('j1', 0, 5);
+  assert.equal(getRateSamples('j1').length, 1);
+});
+
+test('rateSampleStore: isolates samples per job', () => {
+  _resetRateSamples();
+  recordRateSample('j1', 1000, 10);
+  recordRateSample('j2', 1000, 99);
+  assert.equal(getRateSamples('j1').length, 1);
+  assert.equal(getRateSamples('j2')[0].taken, 99);
+});
+
+test('rateSampleStore: returns an empty array for an unknown job', () => {
+  _resetRateSamples();
+  assert.deepEqual(getRateSamples('nope'), []);
+});


### PR DESCRIPTION
## Summary

Two fixes to the live evaluation stat strip (`JobStatStrip`), both follow-ups to the just-merged #607 (live ELAPSED ticker + ETA subtext).

### 1. ELAPSED now ticks evenly
The display is `floor((now - startedAt) / 1000)`, but the re-render was driven by a fixed `setInterval(1000)` whose phase is fixed at mount. Two unsynchronized ~1 Hz clocks **beat**: timer jitter (the 2 s poll, GC, renders) and background-tab throttling drift the interval against the second boundary, producing a double-render in one second (clock appears to freeze ~2 s) or a skipped second.

Replaced with a self-correcting `setTimeout` aligned to the next whole-second boundary (`msUntilNextSecond`) — the delay is recomputed from absolute `now` each tick, so it re-aligns to the boundary and never accumulates drift.

### 2. Re-entering a running job no longer re-measures throughput
The sliding-window samples lived in a `useRef` wiped on every mount, so navigating out of and back into a running evaluation restarted the rate from empty — showing `estimating…` for ~30 s on every entry. (A short-lived lifetime-average bootstrap made this worse: it over-read ~18 files/min then decayed to the real ~4, because the parallel start burst-completes cached files cheaply.)

Samples now live in a module-level store keyed by jobId (`rateSampleStore.js`) that **survives unmount/remount**, so re-entry shows the current rate immediately. The biased lifetime average is dropped entirely; a genuine cold start shows `estimating…` until the window fills, which is honest.

## Test plan

- `node:test`: **204 pass** — new coverage for `msUntilNextSecond` (boundary math) and `rateSampleStore` (persistence across reads, windowing, per-job isolation).
- `vitest`: **371 pass** — component tests for cold entry → `estimating…`, re-entry with persisted samples → immediate rate, and the existing per-second ticker test (now against the aligned timer).

## Live verification

Against a real run (`gemma4:26b-mlx`, 108 files):

| Behavior | Evidence | Result |
|---|---|---|
| Even ticking | ELAPSED change gaps: 977, 978, 1040, 976, 989 ms | ~1 s, no freeze/skip |
| Cold start | `estimating…` → stable `~3 files/min` | no inflated number |
| Re-entry (the bug) | left to settings (unmounted) → returned: rate at **25 ms**, no `estimating…` flicker | fixed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
