### PR TITLE
fix(eval-strip): refetch progress on terminal transition (fixes stuck-at-97%)

### DIFF
--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getEvaluationProgress } from '../../../api/index.js';
-import { evaluationKeys } from '../../../api/queryKeys.js';
 import { StatStrip, Stat } from '../../../components/terminal/index.js';
 import { computeOverallProgress } from './scanProgressTotals.js';
 import { buildJobStatCells, computeRate, buildEtaHint, msUntilNextSecond } from './buildJobStatCells.js';
 import { recordRateSample, getRateSamples } from './rateSampleStore.js';
+import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
 
-const POLL_INTERVAL_MS = 2000;
 const TERMINAL_STATES = new Set(['done', 'completed', 'failed', 'cancelled', 'lost']);
 
 function sumLiveViolations(liveViolations) {
@@ -34,14 +31,7 @@ export default function JobStatStrip({ job, liveViolations }) {
   const jobId = job?.jobId;
   const isTerminal = TERMINAL_STATES.has(job?.status);
 
-  const { data: progress, dataUpdatedAt } = useQuery({
-    queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
-    queryFn: () => getEvaluationProgress(jobId),
-    enabled: !!jobId,
-    refetchInterval: isTerminal ? false : POLL_INTERVAL_MS,
-    staleTime: 0,
-    retry: false,
-  });
+  const { data: progress, dataUpdatedAt } = useEvaluationProgress(jobId, isTerminal);
 
   // Re-render aligned to each whole-second boundary of wall-clock elapsed, so
   // ELAPSED ticks *evenly*. A fixed setInterval(1000) has its phase fixed at

--- a/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/JobStatStrip.test.jsx
@@ -88,6 +88,24 @@ describe('JobStatStrip', () => {
     nowSpy.mockRestore();
   });
 
+  it('refetches progress on the terminal transition so a fast run reaches 100% (no 97% freeze)', async () => {
+    // Reproduces the incremental/cached freeze: the last running poll catches
+    // 34/35 (97%); the final files complete as the job goes terminal, but the
+    // poll has stopped — so without a terminal refetch the bar stays at 97%.
+    getEvaluationProgress
+      .mockResolvedValueOnce({ dimensions: [{ state: 'running', files: { taken: 34, total: 35 } }] })
+      .mockResolvedValue({ dimensions: [{ state: 'running', files: { taken: 35, total: 35 } }] });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const startedAt = new Date(Date.now() - 5000).toISOString();
+    const wrap = (j) => <QueryClientProvider client={client}><JobStatStrip job={j} liveViolations={{}} /></QueryClientProvider>;
+    const { rerender } = render(wrap({ jobId: 'jt', status: 'running', startedAt }));
+    expect(await screen.findByText('97%')).toBeInTheDocument();
+    const before = getEvaluationProgress.mock.calls.length;
+    rerender(wrap({ jobId: 'jt', status: 'cancelled', startedAt }));   // running -> terminal
+    expect(await screen.findByText('100%')).toBeInTheDocument();
+    expect(getEvaluationProgress.mock.calls.length).toBeGreaterThan(before);
+  });
+
   it('re-entry uses throughput samples persisted from a previous mount (no re-measuring)', async () => {
     // Simulate the window built up before navigating away: 30 files over 60s =
     // 0.5 files/s = 30 files/min. On re-entry the rate is shown immediately.

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -1,13 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { getEvaluationProgress } from '../../../api/index.js';
-import { evaluationKeys } from '../../../api/queryKeys.js';
 import { useEvalLog } from '../eval-log/EvalLogContext.js';
 import { pct, computeOverallProgress } from './scanProgressTotals.js';
 import ConsoleButton from '../../../components/ConsoleButton.jsx';
 import { SectionLabel } from '../../../components/terminal/index.js';
+import { useEvaluationProgress } from '../hooks/useEvaluationProgress.js';
 
-const POLL_INTERVAL_MS = 2000;
 const TERMINAL_STATES = new Set(['done', 'failed', 'cancelled']);
 const STATUS_MARKERS = { arrow: '\u2192', check: '\u2713', error: 'Error:', failed: 'failed' };
 
@@ -150,14 +147,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   const consoleOpen = evalLog.activeJobId === jobId;
   const isTerminal = TERMINAL_STATES.has(status);
 
-  const progressQuery = useQuery({
-    queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
-    queryFn: () => getEvaluationProgress(jobId),
-    enabled: !!jobId,
-    refetchInterval: isTerminal ? false : POLL_INTERVAL_MS,
-    staleTime: 0,
-    retry: false,
-  });
+  const progressQuery = useEvaluationProgress(jobId, isTerminal);
   // Best-effort: surface the last successful payload, ignore errors silently
   // (progress is purely informational and should never block the UI).
   const progress = progressQuery.data ?? null;

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluationProgress.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluationProgress.js
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getEvaluationProgress } from '../../../api/index.js';
+import { evaluationKeys } from '../../../api/queryKeys.js';
+
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Shared live-progress query for a run, used by both the stat strip
+ * (`JobStatStrip`) and the progress bar (`ScanProgress`). They share the same
+ * queryKey, so React Query collapses them into one cache entry — keeping this
+ * in one hook removes the duplicated query and the duplicated terminal-refetch.
+ *
+ * Polls every POLL_INTERVAL_MS while the job is non-terminal. When the job
+ * reaches a terminal state the poll stops — but the final flush of taken-file
+ * counts often lands *between* the last running poll and the terminal
+ * transition (in fast incremental/cached runs the last 2s window completes the
+ * remaining files), so the cached value would freeze below 100% (the classic
+ * "stuck at 97%"). To avoid that, fetch once more on the running→terminal edge
+ * so the UI reflects the final counts.
+ *
+ * @param {string|undefined} jobId
+ * @param {boolean} isTerminal  caller-derived (the two consumers use slightly
+ *   different terminal-state sets, so the decision stays with them)
+ */
+export function useEvaluationProgress(jobId, isTerminal) {
+  const query = useQuery({
+    queryKey: jobId ? [...evaluationKeys.evaluation(jobId), 'progress'] : ['evaluation', '_none_', 'progress'],
+    queryFn: () => getEvaluationProgress(jobId),
+    enabled: !!jobId,
+    refetchInterval: isTerminal ? false : POLL_INTERVAL_MS,
+    staleTime: 0,
+    retry: false,
+  });
+
+  const { refetch } = query;
+  const settledRef = useRef(false);
+  useEffect(() => {
+    if (!jobId) return;
+    if (isTerminal && !settledRef.current) {
+      settledRef.current = true;
+      refetch();
+    } else if (!isTerminal) {
+      // Reset for the next run/transition (e.g. a re-used component instance).
+      settledRef.current = false;
+    }
+  }, [jobId, isTerminal, refetch]);
+
+  return query;
+}


### PR DESCRIPTION
## Summary

Fixes the progress bar / PROGRESS card freezing **below 100% (e.g. "stuck at 97%")** on fast runs — most visible on incremental/cached evaluations that finish in seconds.

### Root cause (not a backend miscount)
The backend's final counts are correct. Pulled live from a completed incremental run:

```
all 6 dimensions: { taken: 35, total: 35 }, state: "done"  →  210/210 = 100%
```

But both progress consumers — `JobStatStrip` (the PROGRESS card) and `ScanProgress` (the `X / Y checks · Z%` bar) — share one query that **stops polling the instant the job goes terminal** (`refetchInterval: isTerminal ? false : 2000`). In a fast incremental run (1205 cache hits / 35 misses, ~48s) the last ~6 files complete *and* the job flips to `done` inside the final 2-second poll window. React Query clearing the interval does **not** trigger a final fetch, so the UI keeps the last running-poll value (~204/210 = 97%) forever. A fresh page load shows 100% (it re-fetches on mount), which is why it only bites the session that watched the run finish.

### Fix
Extract the duplicated progress query into a shared `useEvaluationProgress(jobId, isTerminal)` hook that fetches once more on the running→terminal edge, so the UI lands on the real final counts. This also removes the copy-pasted query from both components. Each component keeps deriving its own `isTerminal` (the two use slightly different terminal-state sets).

## Test plan

- `node:test`: **204 pass**
- `vitest`: **372 pass** — added a regression test that reproduces the freeze (running at 34/35 → 97%, then a terminal transition) and asserts a refetch lands the final 100%. Verified RED (stays 97%) → GREEN.
- Production build compiles.

## Verification

Confirmed against your live backend: the completed incremental run reported 100% (35/35 × 6) via the API while the UI had frozen at 97%. The refactored hook renders with no new console errors.

Follow-up to #608 (which only touched the rate/ticker display). Kept as a separate PR per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
