### PR TITLE
Fix nested <button> in clickable Stat (overview VIOLATIONS card)

### DIFF
--- a/src/quodeq/ui/src/components/terminal/StatStrip.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.jsx
@@ -31,22 +31,35 @@ export function StatStrip({ children, cards = false }) {
  */
 export function Stat({ label, value, hint, trailing, tone = 'default', onClick, ariaLabel }) {
   const className = `term-stat term-stat--${tone}${onClick ? ' term-stat--clickable' : ''}`;
-  const content = (
+  const labelValue = (
     <>
       <div className="term-stat__label">{label}</div>
       <div className="term-stat__value-row">
         <span className="term-stat__value">{value}</span>
         {trailing != null && <span className="term-stat__trailing">{trailing}</span>}
       </div>
-      {hint != null && <div className="term-stat__hint">{hint}</div>}
     </>
   );
+  const hintEl = hint != null ? <div className="term-stat__hint">{hint}</div> : null;
   if (onClick) {
+    // The card itself stays a plain <div> so the hint — which may hold its own
+    // interactive elements (e.g. clickable SevBadges) — sits beside the button
+    // rather than inside it. Nesting a <button> in a <button> is invalid HTML,
+    // breaks hydration, and is an accessibility trap. The label+value act as the
+    // primary click target; severity badges remain independent siblings.
     return (
-      <button type="button" className={className} onClick={onClick} aria-label={ariaLabel || label}>
-        {content}
-      </button>
+      <div className={className}>
+        <button type="button" className="term-stat__hitbox" onClick={onClick} aria-label={ariaLabel || label}>
+          {labelValue}
+        </button>
+        {hintEl}
+      </div>
     );
   }
-  return <div className={className}>{content}</div>;
+  return (
+    <div className={className}>
+      {labelValue}
+      {hintEl}
+    </div>
+  );
 }

--- a/src/quodeq/ui/src/components/terminal/StatStrip.test.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { StatStrip, Stat, SevBadge } from './index.js';
+
+// Returns every <button> that contains another <button> — invalid HTML and a
+// hydration/accessibility bug. The overview's VIOLATIONS card is the canonical
+// offender: a clickable Stat whose hint holds clickable SevBadges.
+function nestedButtons(container) {
+  return [...container.querySelectorAll('button')].filter((b) => b.querySelector('button'));
+}
+
+function renderViolationsCard({ onStat, onBadge } = {}) {
+  return render(
+    <StatStrip cards>
+      <Stat
+        label="VIOLATIONS"
+        value={228}
+        onClick={onStat}
+        ariaLabel="Show all violations"
+        hint={<SevBadge level="critical" count={1} format="count-abbr" onClick={onBadge} />}
+      />
+    </StatStrip>,
+  );
+}
+
+describe('Stat with interactive hint', () => {
+  it('does not nest a <button> inside a <button>', () => {
+    const { container } = renderViolationsCard({ onStat: vi.fn(), onBadge: vi.fn() });
+    expect(nestedButtons(container)).toHaveLength(0);
+  });
+
+  it('keeps the stat clickable as its own button', () => {
+    const onStat = vi.fn();
+    const onBadge = vi.fn();
+    renderViolationsCard({ onStat, onBadge });
+    fireEvent.click(screen.getByRole('button', { name: 'Show all violations' }));
+    expect(onStat).toHaveBeenCalledTimes(1);
+    expect(onBadge).not.toHaveBeenCalled();
+  });
+
+  it('keeps the severity badge independently clickable', () => {
+    const onStat = vi.fn();
+    const onBadge = vi.fn();
+    renderViolationsCard({ onStat, onBadge });
+    fireEvent.click(screen.getByRole('button', { name: 'critical severity' }));
+    expect(onBadge).toHaveBeenCalledTimes(1);
+    expect(onStat).not.toHaveBeenCalled();
+  });
+
+  it('renders a plain (non-button) card when not clickable', () => {
+    const { container } = render(
+      <StatStrip cards>
+        <Stat label="SCORE" value="9.0" hint="grade B" />
+      </StatStrip>,
+    );
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+    expect(screen.getByText('9.0')).toBeInTheDocument();
+    expect(screen.getByText('grade B')).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -136,22 +136,38 @@
 .term-stat--warning .term-stat__value { color: var(--color-warning); }
 .term-stat--critical .term-stat__value { color: var(--color-sev-critical-text); }
 
-/* Clickable variant — used when a Stat doubles as a navigation affordance. */
-button.term-stat--clickable {
+/* Clickable variant — a Stat doubles as a navigation affordance. The card stays
+   a <div>; an inner `.term-stat__hitbox` button is the actual click target so
+   the hint (which may hold its own interactive badges) is a sibling of the
+   button, never nested inside it. Nesting <button> in <button> is invalid HTML. */
+.term-stat--clickable {
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.term-stat__hitbox {
   appearance: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: none;
   font: inherit;
   color: inherit;
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease;
+  display: flex;
+  flex-direction: column;
+  gap: var(--term-space-1);
+  width: 100%;
 }
-button.term-stat--clickable:hover {
-  border-color: var(--color-accent);
-  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
-}
-button.term-stat--clickable:focus-visible {
+.term-stat__hitbox:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
+  border-radius: var(--term-radius);
+}
+/* Whole-card hover highlight, driven by the inner hitbox — not the sibling
+   severity badges, which are their own independent click targets. */
+.term-stat--clickable:has(.term-stat__hitbox:hover) {
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 6%, var(--color-surface));
 }
 
 /* ------------------------------------------------------------


### PR DESCRIPTION
## Problem

The overview / DashboardPage logged repeated React console errors:

> `In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.`
> `<button> cannot contain a nested <button>.`

Component stack: `DashboardPage → DashboardContent → AccumulatedOverviewPanel → AccumulatedHeroSection → StatStrip → Stat → SeverityBadgeRow → SevBadge`.

A clickable `Stat` rendered the **entire card** (label + value + `hint`) as a `<button>`. The VIOLATIONS card passes a `SeverityBadgeRow` as its `hint`, and each `SevBadge` is itself a `<button>` — so an interactive button was nested inside another interactive button. Invalid HTML, a hydration mismatch, and an accessibility trap.

## Fix

Restructure `Stat` (option c — don't nest, make siblings):

- A clickable `Stat` is now a `<div className="term-stat…">` container holding an inner `<button className="term-stat__hitbox">` that wraps **only** the label + value (the navigation target).
- The `hint` renders as a **sibling** of that button, so its interactive badges are never descendants of a button.
- CSS: replaced `button.term-stat--clickable` rules with `.term-stat__hitbox` (button reset + focus ring). Whole-card hover affordance is preserved via `.term-stat--clickable:has(.term-stat__hitbox:hover)` — driven by the hitbox, not the sibling badges.
- Non-clickable `Stat` behavior is unchanged.

## Verification

- **New regression test** `StatStrip.test.jsx`: failed first (RED) and reproduced the exact React error; passes after the fix. Asserts zero nested buttons, that the Stat and SevBadge clicks fire independently, and that non-clickable Stats render no button.
- **Full UI suite**: 65 files / 376 tests pass.
- **Live dev server** (overview for a project with an accumulated eval): clickable Stat is now a `DIV` with an inner hitbox button; the 3 severity badges render as sibling buttons; `document.querySelectorAll('button button')` returns 0; console clean of the nesting/hydration error; card layout visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)