### PR TITLE
test: cover principle-level SQL grade overlay (closes #612)

### DIFF
--- a/tests/services/test_scoring_sql_overlay.py
+++ b/tests/services/test_scoring_sql_overlay.py
@@ -21,6 +21,7 @@ import pytest
 
 from quodeq.core.events.models import Judgment
 from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.data.fs.report_parser.runs import read_run_data
 from quodeq.data.projection.grade_projector import recompute_grades
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 from quodeq.services import grade_formula
@@ -48,13 +49,19 @@ def _clear_cache():
     clear_shared_dimension_cache()
 
 
-def _build_event_log_run(project_dir: Path, run_id: str) -> Path:
+def _build_event_log_run(
+    project_dir: Path, run_id: str, *, principles: list[dict] | None = None,
+) -> Path:
     """Create one complete event-log run: findings, SQL grades, eval JSON, manifest.
 
     Mirrors the ``_make_run`` fixture style from tests/services/test_grade_formula.py
     but adds the minimum scaffolding ``list_runs`` / ``read_run_data`` need:
     an ``evidence/manifest.json`` (so the run is listed) and an eval JSON per
     dimension (so read_run_data parses a dimension to overlay onto).
+
+    *principles* entries (``{"name":..., "score":..., "grade":...}``) are written
+    verbatim into every dimension's eval JSON — the eval-time principle grades
+    the SQL overlay matches against by name.
     """
     run_dir = project_dir / run_id
     run_dir.mkdir(parents=True)
@@ -95,7 +102,7 @@ def _build_event_log_run(project_dir: Path, run_id: str) -> Path:
             "sourceFileCount": 100,
             "overallScore": f"{row['score']}/10",
             "overallGrade": row["grade"],
-            "principles": [],
+            "principles": principles or [],
             "violations": [],
             "compliance": [],
             "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
@@ -173,3 +180,77 @@ def test_get_project_scores_serves_default_grades_before_apply(
     sec = {d["dimension"]: d for d in result["accumulated"]["dimensions"]}["security"]
     assert sec["overallScore"] == f"{default_rows['security']['score']}/10"
     assert sec["overallGrade"] == default_rows["security"]["grade"]
+
+
+def test_read_run_data_overlays_sql_principle_grades_after_apply(
+    tmp_path, formula_path,
+):
+    """Principle-level overlay: eval-time principle grades whose name matches a
+    SQL ``principle_id`` are replaced by the re-baked SQL values after Apply.
+
+    The eval JSON carries deliberately wrong sentinel values so the assertion
+    can only pass if the overlay actually substituted the SQL row.
+    """
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid"
+    run_dir = _build_event_log_run(
+        reports_root / project, "run1",
+        # "p1" matches the practice_id of every finding baked into SQL.
+        principles=[{"name": "p1", "score": "9.9/10", "grade": "A+"}],
+    )
+
+    default_p1 = next(
+        r for r in SQLiteStateStore(run_dir).read_principle_grades()
+        if r["dimension"] == "security" and r["principle_id"] == "p1"
+    )
+
+    grade_formula.save_params(_STRICT)
+    assert grade_formula.apply_to_all_runs(reports_root) == 1
+
+    custom_p1 = next(
+        r for r in SQLiteStateStore(run_dir).read_principle_grades()
+        if r["dimension"] == "security" and r["principle_id"] == "p1"
+    )
+    # Sanity: the custom formula actually changed the baked principle grade.
+    assert (custom_p1["score"], custom_p1["grade"]) != (
+        default_p1["score"], default_p1["grade"]
+    )
+
+    dims = read_run_data(reports_root, project, "run1")
+    security = next(d for d in dims if d.dimension == "security")
+    p1 = next(p for p in security.principles if p.principle == "p1")
+    assert p1.score == f"{custom_p1['score']}/10"
+    assert p1.grade == custom_p1["grade"]
+
+
+def test_read_run_data_keeps_eval_time_principle_on_name_mismatch(
+    tmp_path, formula_path,
+):
+    """A JSON principle whose name matches no SQL ``principle_id`` falls back
+    gracefully: no crash, eval-time values kept, dimension overlay still applied.
+    """
+    reports_root = tmp_path / "reports"
+    project = "proj-uuid"
+    run_dir = _build_event_log_run(
+        reports_root / project, "run1",
+        # SQL only knows principle_id "p1"; this name matches nothing.
+        principles=[{"name": "Renamed Principle", "score": "3.3/10", "grade": "D"}],
+    )
+
+    grade_formula.save_params(_STRICT)
+    assert grade_formula.apply_to_all_runs(reports_root) == 1
+    custom_rows = {r["dimension"]: r for r in SQLiteStateStore(run_dir).read_dimension_scores()}
+
+    dims = read_run_data(reports_root, project, "run1")
+    security = next(d for d in dims if d.dimension == "security")
+
+    # The dimension-level overlay fired (proves we went through the SQL path,
+    # not a no-op early return)...
+    assert security.overall_score == f"{custom_rows['security']['score']}/10"
+    assert security.overall_grade == custom_rows["security"]["grade"]
+    # ...but the unmatched principle kept its eval-time values.
+    mismatched = next(
+        p for p in security.principles if p.principle == "Renamed Principle"
+    )
+    assert mismatched.score == "3.3/10"
+    assert mismatched.grade == "D"


### PR DESCRIPTION
> *This was generated by AI during triage.*

Closes #612.

Stacked on #611 (the overlay under test lands there); GitHub will retarget this to `develop` automatically when #611 merges.

## Summary

- Adds two regression tests for the principle-level portion of the SQL grade overlay in `read_run_data`, which previously had zero direct coverage (fixtures used empty principle lists):
  - **Match path**: eval-time principle grades carrying deliberately wrong sentinel values (`9.9/10` / `A+`) are replaced by the SQL-baked values after a custom-params Apply, so the assertion can only pass if the overlay actually substituted the SQL row.
  - **Mismatch fallback**: a principle name that matches no SQL `principle_id` keeps its eval-time values without crashing, while the dimension-level overlay on the same dimension still fires (proving the SQL path ran, not an early return).
- Extends the existing `_build_event_log_run` fixture with an optional `principles` parameter rather than duplicating scaffolding.

## Test Plan

- [x] Both new tests fail when the `_overlay_principles` call is removed from the overlay (mutation-checked)
- [x] `tests/services/test_scoring_sql_overlay.py`: 4 passed
- [x] `tests/services/`: 788 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)