### PR TITLE
feat(analysis): per-run aggregate drop-ratio metric for the API runner

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -28,6 +28,7 @@ import httpx
 import openai
 from pydantic import BaseModel, Field
 
+from quodeq.analysis._drop_stats import record as _record_drop_stats
 from quodeq.analysis.mcp.router import CompiledContext, FindingsRouter
 
 if TYPE_CHECKING:
@@ -309,6 +310,10 @@ def _call_api(prompt: str, config: ApiRunnerConfig) -> tuple[list[dict], bool]:
     text = (choice.message.content or "") if choice else ""
     findings, dropped = _parse_findings(text)
     elapsed = time.monotonic() - start
+
+    # Feed the per-run aggregate so the dimension loops can report ONE
+    # drop-ratio signal at end of run instead of N scattered per-call lines.
+    _record_drop_stats(dropped=dropped, kept=len(findings))
 
     # A length-truncated response is an incomplete analysis: the model ran out of
     # output budget mid-stream, so findings after the cut are simply gone. Treat

--- a/src/quodeq/analysis/_drop_stats.py
+++ b/src/quodeq/analysis/_drop_stats.py
@@ -1,0 +1,106 @@
+"""Per-run aggregate of API-runner parse drops (issue #606).
+
+``_api_runner._parse_findings`` counts finding-shaped objects the model
+emitted but validation rejected. Each call already logs that count as a
+WARNING, but a systemic output-shape problem (a prompt or model change that
+malformes findings across many files) drowns in thousands of per-call lines.
+
+This module accumulates the per-call (dropped, kept) counts process-wide —
+the whole run (all dimensions, all pool worker threads) executes in one
+process, so a lock-guarded module counter is the aggregation seam. The
+dimension loops call :func:`report_run_drop_stats` once at end of run to
+log the aggregate, elevate a single warning when the drop ratio crosses
+:data:`DROP_RATIO_WARN_THRESHOLD`, and emit a structured ``drop_stats``
+marker for the dashboard stream (mirroring the per-dim ``cache_stats``
+marker).
+
+Deliberately stdlib-only: ``_loops`` imports this module, and must not pull
+in ``_api_runner`` (which requires the ``quodeq[api]`` extra).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+
+_logger = logging.getLogger(__name__)
+
+# Elevate one run-level warning when MORE than this fraction of parsed
+# findings was dropped. Strict inequality: 'crosses', not 'reaches'.
+DROP_RATIO_WARN_THRESHOLD = 0.05
+
+
+@dataclass(frozen=True)
+class DropStats:
+    """Run totals: findings the model emitted vs findings we kept."""
+
+    dropped: int = 0
+    kept: int = 0
+
+    @property
+    def parsed(self) -> int:
+        """Total finding-shaped objects the model emitted this run."""
+        return self.dropped + self.kept
+
+    @property
+    def ratio(self) -> float:
+        """Fraction of parsed findings that was dropped (0.0 when none parsed)."""
+        return self.dropped / self.parsed if self.parsed else 0.0
+
+
+_lock = threading.Lock()
+_dropped = 0
+_kept = 0
+
+
+def record(*, dropped: int, kept: int) -> None:
+    """Accumulate one API call's parse counts. Thread-safe."""
+    global _dropped, _kept
+    with _lock:
+        _dropped += dropped
+        _kept += kept
+
+
+def consume() -> DropStats:
+    """Return the accumulated totals and reset the accumulator.
+
+    Consume-and-reset keeps sequential runs in one process independent.
+    """
+    global _dropped, _kept
+    with _lock:
+        stats = DropStats(dropped=_dropped, kept=_kept)
+        _dropped = 0
+        _kept = 0
+    return stats
+
+
+def report_run_drop_stats() -> DropStats:
+    """Log the run's aggregate drop ratio and emit the ``drop_stats`` marker.
+
+    Silent no-op when no API calls were recorded (CLI-provider runs, or a
+    run where the model emitted no finding-shaped objects at all) — there
+    is no ratio to report and the marker would be noise.
+    """
+    stats = consume()
+    if stats.parsed == 0:
+        return stats
+    _logger.info(
+        "API runner parse summary: kept %d, dropped %d of %d parsed finding(s) "
+        "(%.1f%% drop ratio)",
+        stats.kept, stats.dropped, stats.parsed, stats.ratio * 100,
+    )
+    if stats.ratio > DROP_RATIO_WARN_THRESHOLD:
+        _logger.warning(
+            "API runner dropped %.1f%% of parsed findings this run (%d of %d) -- "
+            "above the %.0f%% threshold. This points at a systemic output-shape "
+            "problem (prompt or model change?); see the per-call drop warnings "
+            "in the run log for samples.",
+            stats.ratio * 100, stats.dropped, stats.parsed,
+            DROP_RATIO_WARN_THRESHOLD * 100,
+        )
+    from quodeq.engine._runner_markers import emit_marker  # noqa: PLC0415
+    emit_marker(
+        "drop_stats",
+        dropped=stats.dropped, kept=stats.kept, ratio=round(stats.ratio, 4),
+    )
+    return stats

--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 from collections.abc import Callable
 from pathlib import Path
 
+from quodeq.analysis._drop_stats import report_run_drop_stats
 from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.dimension_runner import DimensionRunner, _log_dimension_result
 from quodeq.analysis.errors import EvaluationError
@@ -335,6 +336,9 @@ def run_incremental_loop(
         f"[loop] incremental finished: processed {len(result)} of {len(dimensions)} dim(s) "
         f"({', '.join(result) if result else 'none'})",
     )
+    # Before the guards: the drop-ratio summary must land even when a
+    # guard raises (a high drop ratio and a worthless run often co-occur).
+    report_run_drop_stats()
     check_zero_findings(
         result, config.source_file_count,
         incremental_filter_active=config.options.incremental_file_filter is not None
@@ -441,6 +445,9 @@ def run_per_dimension_loop(
         f"[loop] per-dimension finished: processed {len(result)} of {len(dimensions)} dim(s) "
         f"({', '.join(result) if result else 'none'}, {skipped_count} skipped)",
     )
+    # Before the guards: the drop-ratio summary must land even when a
+    # guard raises (a high drop ratio and a worthless run often co-occur).
+    report_run_drop_stats()
     check_zero_findings(
         result, config.source_file_count, skipped_count,
         incremental_filter_active=config.options.incremental_file_filter is not None

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -391,6 +391,46 @@ class TestSyncCacheWrite:
         )
 
 
+class TestDropStatsRecording:
+    """_call_api feeds the per-run drop-ratio accumulator (issue #606).
+
+    The per-call WARNING already counts dropped findings; recording the same
+    (dropped, kept) pair into ``_drop_stats`` lets the run loop surface ONE
+    aggregate signal instead of N scattered lines.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_accumulator(self):
+        from quodeq.analysis import _drop_stats
+        _drop_stats.consume()
+        yield
+        _drop_stats.consume()
+
+    def test_call_with_malformed_finding_records_drop_and_kept(self, api_config):
+        from quodeq.analysis import _drop_stats
+        valid = {"req": "R1", "t": "violation", "file": "a.py", "line": 5,
+                 "severity": "minor", "w": "x", "snippet": "code", "reason": "bad"}
+        malformed = {"t": "violation", "file": "b.py", "line": 1, "w": "y",
+                     "snippet": "code", "reason": "bad"}  # no req -> dropped
+        content = json.dumps({"findings": [valid, malformed]})
+        client = _mock_raw_client(content)
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            _call_api("prompt", api_config)
+        stats = _drop_stats.consume()
+        assert stats.dropped == 1
+        assert stats.kept == 1
+
+    def test_failed_call_records_nothing(self, api_config):
+        from quodeq.analysis import _drop_stats
+        client = MagicMock()
+        client.chat.completions.create.side_effect = httpx.ReadTimeout("timeout")
+        with patch("quodeq.analysis._api_runner.openai.OpenAI") as mock_oa:
+            mock_oa.return_value.__enter__.return_value = client
+            _call_api("prompt", api_config)
+        assert _drop_stats.consume().parsed == 0
+
+
 class TestApiRunnerConfig:
     """ApiRunnerConfig dataclass."""
 

--- a/tests/analysis/test_drop_stats.py
+++ b/tests/analysis/test_drop_stats.py
@@ -1,0 +1,110 @@
+"""Per-run aggregate drop-ratio metric for the API runner (issue #606).
+
+Dropped-finding counts are surfaced per call as WARNING lines in
+``_api_runner``; a systemic parsing problem (a prompt or model change that
+makes the model emit a malformed finding shape across many files) is
+invisible without eyeballing thousands of per-call lines. The
+``_drop_stats`` accumulator aggregates per-call (dropped, kept) counts
+across the run; the dimension loops report the aggregate once at end of
+run, elevate a single warning when the drop ratio crosses the threshold,
+and emit a structured ``drop_stats`` marker for the dashboard stream.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from quodeq.analysis import _drop_stats
+
+
+@pytest.fixture(autouse=True)
+def _reset_accumulator():
+    _drop_stats.consume()
+    yield
+    _drop_stats.consume()
+
+
+@pytest.fixture(autouse=True)
+def _propagate_quodeq_logs():
+    # The quodeq logger has propagate=False (StderrHandler only); flip it so
+    # pytest's caplog handler (on the root logger) receives the records.
+    qlog = logging.getLogger("quodeq")
+    orig = qlog.propagate
+    qlog.propagate = True
+    yield
+    qlog.propagate = orig
+
+
+class TestAccumulator:
+    def test_record_accumulates_and_consume_resets(self):
+        _drop_stats.record(dropped=2, kept=8)
+        _drop_stats.record(dropped=1, kept=9)
+        stats = _drop_stats.consume()
+        assert stats.dropped == 3
+        assert stats.kept == 17
+        assert stats.parsed == 20
+        assert stats.ratio == pytest.approx(0.15)
+        # consume() resets: the next consume sees a fresh accumulator.
+        assert _drop_stats.consume().parsed == 0
+
+    def test_ratio_is_zero_when_nothing_parsed(self):
+        assert _drop_stats.DropStats().ratio == 0.0
+
+
+class TestReport:
+    def test_silent_when_no_api_calls_recorded(self, caplog, capsys):
+        """CLI-provider runs (no API calls) must not gain a noise line or a
+        spurious marker."""
+        with caplog.at_level(logging.INFO):
+            stats = _drop_stats.report_run_drop_stats()
+        assert stats.parsed == 0
+        assert caplog.records == []
+        assert capsys.readouterr().out == ""
+
+    def test_logs_summary_below_threshold_without_warning(self, caplog):
+        _drop_stats.record(dropped=1, kept=99)  # 1% < 5% threshold
+        with caplog.at_level(logging.INFO):
+            _drop_stats.report_run_drop_stats()
+        infos = [r for r in caplog.records if r.levelno == logging.INFO]
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(infos) == 1
+        assert "dropped 1 of 100" in infos[0].getMessage()
+        assert warnings == []
+
+    def test_elevates_single_warning_above_threshold(self, caplog):
+        _drop_stats.record(dropped=2, kept=8)  # 20% > 5% threshold
+        with caplog.at_level(logging.INFO):
+            _drop_stats.report_run_drop_stats()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1
+        assert "20.0%" in warnings[0].getMessage()
+
+    def test_no_warning_at_exactly_the_threshold(self, caplog):
+        """The threshold is strict: 'crosses', not 'reaches'."""
+        _drop_stats.record(dropped=1, kept=19)  # exactly 5%
+        with caplog.at_level(logging.INFO):
+            _drop_stats.report_run_drop_stats()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings == []
+
+    def test_emits_drop_stats_marker(self, capsys):
+        """Structured marker for the dashboard / SSE stream, mirroring the
+        per-dim ``cache_stats`` marker pattern."""
+        _drop_stats.record(dropped=2, kept=8)
+        _drop_stats.report_run_drop_stats()
+        out = capsys.readouterr().out
+        markers = [json.loads(ln) for ln in out.splitlines() if ln.strip()]
+        drop_markers = [m for m in markers if m.get("_cc") == "drop_stats"]
+        assert len(drop_markers) == 1
+        assert drop_markers[0]["dropped"] == 2
+        assert drop_markers[0]["kept"] == 8
+        assert drop_markers[0]["ratio"] == pytest.approx(0.2)
+
+    def test_report_consumes_the_accumulator(self):
+        """One report per run: a second report (or next run in the same
+        process) starts from zero."""
+        _drop_stats.record(dropped=1, kept=1)
+        _drop_stats.report_run_drop_stats()
+        assert _drop_stats.consume().parsed == 0

--- a/tests/analysis/test_loops_drop_stats.py
+++ b/tests/analysis/test_loops_drop_stats.py
@@ -1,0 +1,62 @@
+"""The dimension loops report the per-run drop-ratio aggregate (issue #606).
+
+Both loop orchestrators end with the post-run guards (zero-findings,
+model-reachability). The drop-stats report must run there too — once per
+run, before the guards so the summary lands even when a guard raises.
+
+The loops are exercised with an empty dimension list: the loop body never
+runs, but the end-of-loop reporting and guards do, which is exactly the
+seam under test.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.analysis import _drop_stats
+from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
+
+
+@pytest.fixture(autouse=True)
+def _reset_accumulator():
+    _drop_stats.consume()
+    yield
+    _drop_stats.consume()
+
+
+@pytest.fixture(autouse=True)
+def _propagate_quodeq_logs():
+    # The quodeq logger has propagate=False (StderrHandler only); flip it so
+    # pytest's caplog handler (on the root logger) receives the records.
+    qlog = logging.getLogger("quodeq")
+    orig = qlog.propagate
+    qlog.propagate = True
+    yield
+    qlog.propagate = orig
+
+
+def _loop_config() -> MagicMock:
+    config = MagicMock()
+    config.options.deadline_at = None
+    config.options.incremental_file_filter = None
+    config.options.skip_scoring = False
+    return config
+
+
+def test_per_dimension_loop_reports_drop_stats_at_end(caplog):
+    _drop_stats.record(dropped=1, kept=9)
+    with caplog.at_level(logging.INFO):
+        run_per_dimension_loop(_loop_config(), [], MagicMock(), runner=MagicMock())
+    assert "dropped 1 of 10" in caplog.text
+    # The loop's report consumed the accumulator.
+    assert _drop_stats.consume().parsed == 0
+
+
+def test_incremental_loop_reports_drop_stats_at_end(caplog):
+    _drop_stats.record(dropped=1, kept=9)
+    with caplog.at_level(logging.INFO):
+        run_incremental_loop(_loop_config(), [], MagicMock(), runner=MagicMock())
+    assert "dropped 1 of 10" in caplog.text
+    assert _drop_stats.consume().parsed == 0


### PR DESCRIPTION
Closes #606.

## What

Dropped-finding counts were surfaced only as per-call `WARNING` lines in `src/quodeq/analysis/_api_runner.py`, so a systemic parsing problem (a prompt or model change that makes the model emit a malformed finding shape across many files) could only be spotted by eyeballing thousands of per-call lines. This adds the per-run aggregate the issue asked for.

## How

- **New `analysis/_drop_stats.py`**: a lock-guarded, process-wide accumulator (`record` / `consume`). The whole run (all dimensions, all pool worker threads) executes in one process, so this is the aggregation seam. Deliberately stdlib-only so `_loops` can import it without pulling in `_api_runner` (which needs the `quodeq[api]` extra).
- **`_call_api` records `(dropped, kept)` per call**, right where `_parse_findings` already produces the drop count. Failed/unreachable calls record nothing (no parse happened).
- **Both dimension loops call `report_run_drop_stats()` once at end of run**, before the zero-findings / model-reachability guards so the summary lands even when a guard raises (a high drop ratio and a worthless run often co-occur). The report:
  - logs one INFO summary line: `API runner parse summary: kept N, dropped D of P parsed finding(s) (X% drop ratio)`
  - elevates a single WARNING when the ratio crosses 5% (strict), pointing at a systemic output-shape problem
  - emits a structured `drop_stats` marker for the dashboard/SSE stream, mirroring the per-dim `cache_stats` marker
  - stays silent for CLI-provider runs and runs that parsed no finding-shaped objects at all (no noise line, no spurious marker)

## Notes

- A durable JSONL-marker approach (like `file_done`) was considered and rejected: `deduplicate_jsonl` keys on `(p, file, line, t)`, so identical-keyed `parse_stats` lines would collapse to one and lose counts.
- `consume()` resets the accumulator, keeping sequential runs in one process independent.

## Tests

- `tests/analysis/test_drop_stats.py`: accumulator semantics, report thresholds (below / exactly-at / above), marker emission, silence with no API calls.
- `tests/analysis/test_loops_drop_stats.py`: both loops report at end of run.
- `tests/analysis/test_api_runner.py`: `_call_api` records drops; failed calls record nothing.

Full suite: 3258 passed.