### PR TITLE
fix(ci): gate Homebrew update on PyPI JSON API instead of legacy URL

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -29,33 +29,42 @@ jobs:
           VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for PyPI availability
+      - name: Wait for PyPI sdist and get URL + SHA256
+        id: sdist
+        # Poll the JSON API, not the legacy /packages/source/ redirect: the
+        # redirect lags far behind upload (v1.3.0 still 404'd there hours
+        # after the sdist was listed in the JSON API, timing out this gate
+        # and leaving the tap pointing at a dead URL until a manual fix).
+        # The API carries the canonical hashed download URL plus the
+        # authoritative sha256 digest, so the formula gets a URL that
+        # resolves immediately and we never hash an error-page body.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          for i in $(seq 1 30); do
-            if curl -sf "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz" -o /dev/null; then
-              echo "Package available on PyPI"
+          for i in $(seq 1 40); do
+            SDIST="$(curl -sf "https://pypi.org/pypi/quodeq/${VERSION}/json" \
+              | jq -c '[.urls[] | select(.packagetype == "sdist")][0] // empty' || true)"
+            if [ -n "$SDIST" ]; then
+              URL="$(echo "$SDIST" | jq -r '.url')"
+              SHA="$(echo "$SDIST" | jq -r '.digests.sha256')"
+              echo "sdist available on PyPI: ${URL} (sha256: ${SHA})"
+              echo "url=$URL" >> "$GITHUB_OUTPUT"
+              echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Waiting for PyPI... ($i/30)"
-            sleep 10
+            echo "Waiting for PyPI sdist... ($i/40)"
+            sleep 30
           done
-          echo "Timed out waiting for PyPI"
+          echo "Timed out after 20 minutes waiting for sdist quodeq-${VERSION}.tar.gz on PyPI."
+          echo "Check that the publish workflow actually uploaded an sdist for ${VERSION}."
           exit 1
-
-      - name: Get SHA256 of tarball
-        id: sha
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA=$(curl -sL "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz" | shasum -a 256 | cut -d' ' -f1)
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Update homebrew-tap repo
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          SHA="${{ steps.sha.outputs.sha256 }}"
+          URL="${{ steps.sdist.outputs.url }}"
+          SHA="${{ steps.sdist.outputs.sha256 }}"
 
           # Get current file SHA from the tap repo
           FILE_SHA=$(gh api repos/quodeq/homebrew-tap/contents/quodeq.rb --jq '.sha')
@@ -67,7 +76,7 @@ jobs:
 
             desc "AI-powered source code quality evaluation platform"
             homepage "https://github.com/quodeq/quodeq"
-            url "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz"
+            url "${URL}"
             sha256 "${SHA}"
             license "MIT"
 


### PR DESCRIPTION
## Problem

During the v1.3.0 release the "Wait for PyPI availability" step timed out and the tap needed a manual formula fix, the second release in a row this misfired. The step polled the legacy `files.pythonhosted.org/packages/source/...` redirect 30 times at 10s (5 minutes total). The sdist was already listed in the PyPI JSON API, but the legacy redirect lagged behind and still returned 404 when the window expired.

It is worse than a lag: the legacy URL for 1.3.0 **still returns 404 hours after release** (1.2.0's resolves fine), which is why the manual tap fix had to switch to the hashed URL. So the legacy URL was not safe inside the formula either, contrary to what we assumed.

## Fix

- Poll `https://pypi.org/pypi/quodeq/<version>/json` for an sdist entry, 40 tries at 30s (20 minutes), failing loudly if no sdist ever appears.
- Take the canonical hashed download URL and the authoritative `sha256` digest from the same JSON response. The formula now gets a URL that resolves immediately, and the digest comes from PyPI metadata instead of downloading and hashing.
- This also removes a latent silent-corruption bug: the old SHA step used `curl -sL` without `-f`, so a lagging redirect would have hashed an error body into the formula.

## Verification

Ran the new step logic locally under `bash -e` (the Actions default shell):
- Version 1.3.0: extracts `https://files.pythonhosted.org/packages/44/81/.../quodeq-1.3.0.tar.gz` with sha256 `28a787...c86d4e`, byte-identical to what the manual tap fix used.
- Missing version 9.9.9: stays in the wait loop, not killed by `-e`.
- YAML validated with pyyaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)