### PR TITLE
fix(core): accept both 'vt' and 'violation_type' in wire dict readers

### DIFF
--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -42,7 +42,9 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         end_line=d.get("end_line"),
         snippet=d.get("snippet"),
         severity=d.get("severity") or "medium",
-        violation_type=d.get("violation_type"),
+        # The taxonomy travels as 'vt' on the JSONL wire (see evidence/_jsonl.py);
+        # accept the long key too so both spellings survive this seam.
+        violation_type=d.get("vt") or d.get("violation_type"),
         reason=d.get("reason") or "",
         title=d.get("w"),
         context=d.get("context"),

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -53,7 +53,9 @@ def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
         "title": finding.get("w", "") or "",
         "reason": finding.get("reason", "") or "",
         "snippet": finding.get("snippet", "") or "",
-        "violation_type": finding.get("violation_type", "") or "",
+        # The taxonomy travels as 'vt' on the JSONL wire (see evidence/_jsonl.py);
+        # accept the long key too so both spellings survive this seam.
+        "violation_type": finding.get("vt") or finding.get("violation_type") or "",
         "context": finding.get("context", "") or "",
         "scope": finding.get("scope", "") or "",
         "req_refs_json": json.dumps(refs) if refs is not None else None,

--- a/tests/core/test_finding_mappings.py
+++ b/tests/core/test_finding_mappings.py
@@ -60,6 +60,23 @@ class TestWireDictToJudgment:
         )
         assert j.confidence == 50
 
+    def test_violation_type_read_from_short_vt_key(self):
+        """Regression: the JSONL wire format carries the taxonomy as 'vt'
+        (see core/evidence/_jsonl.py); this reader must not silently drop it
+        on the event-log/SQLite path when only the short key is present."""
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "vt": "code-injection"}
+        )
+        assert j.violation_type == "code-injection"
+
+    def test_violation_type_read_from_long_key(self):
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "violation_type": "code-injection"}
+        )
+        assert j.violation_type == "code-injection"
+
     def test_round_trip_via_judgment_dump(self):
         """wire_dict → Judgment → dump preserves the long-name fields."""
         d = {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -46,6 +46,22 @@ def test_finding_dict_to_row_handles_missing_optionals():
     assert row["dedup_key"] == "P1||0|compliance"
 
 
+def test_finding_dict_to_row_reads_violation_type_from_short_vt_key():
+    """Regression: the JSONL wire format carries the taxonomy as 'vt'
+    (see core/evidence/_jsonl.py); the row mapper must accept both keys."""
+    finding = {"p": "P1", "t": "violation", "severity": "medium",
+               "vt": "missed_deadline"}
+    row = finding_dict_to_row(finding)
+    assert row["violation_type"] == "missed_deadline"
+
+
+def test_finding_dict_to_row_reads_violation_type_from_long_key():
+    finding = {"p": "P1", "t": "violation", "severity": "medium",
+               "violation_type": "missed_deadline"}
+    row = finding_dict_to_row(finding)
+    assert row["violation_type"] == "missed_deadline"
+
+
 def test_row_to_finding_roundtrip():
     finding = {
         "p": "P1", "d": "dim", "req": "R1", "t": "violation", "severity": "medium",


### PR DESCRIPTION
## Summary

Closes the reader half of the violation-taxonomy key inconsistency on the FindingsRouter wire format (the writer half was fixed in 1fe70918, which made `judgment_to_dict` emit both keys).

The JSONL wire format carries the taxonomy as the short key `vt`:
- `parse_jsonl_line` (`core/evidence/_jsonl.py`) reads `obj.get("vt")`
- `services/violations_parsing.py` reads `obj.get("vt")`

But two readers of the same wire dict shape only read the long key:
- `wire_dict_to_judgment` (`core/finding_mappings.py`) read `d.get("violation_type")`
- `finding_dict_to_row` (`data/sqlite/_row_mappers.py`) read `finding.get("violation_type", "")`

This is latent today (current producers define no violation-type field), but if a producer reintroduces the taxonomy as `vt`, the event-log/SQLite path (`wire_dict_to_judgment` -> `JudgmentCreatedEvent` -> SQLite `violation_type` column) would silently drop it while the JSONL parse path keeps it, and event-sourced rescoring (`services/rescore.py`, `services/scoring/projector_scoring.py`) would lose taxonomy scoring.

## Changes

- `wire_dict_to_judgment`: `violation_type=d.get("vt") or d.get("violation_type")`
- `finding_dict_to_row`: `"violation_type": finding.get("vt") or finding.get("violation_type") or ""`
- Regression tests for both spellings in both readers (TDD: watched the short-key tests fail first)

## Test plan

- [x] New tests fail before the fix, pass after
- [x] `tests/core tests/data tests/services`: 1065 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)