### PR TITLE
Audit Phase 1: fix taxonomy scoring bug, enforce coverage and import-rule gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         # send signals, which are inherently timing-sensitive on shared CI
         # runners. They run elsewhere (e.g. nightly) where flakes are
         # tolerable. PR CI should be fast and deterministic.
-        run: uv run pytest tests/ -q --tb=short -m "not integration"
+        run: uv run pytest tests/ -q --tb=short -m "not integration" --cov=quodeq --cov-report=term-missing
 
       - name: Run tests (Windows)
         if: runner.os == 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 __pycache__/
 *.pyc
 .venv/
+.coverage*
+htmlcov/
 evaluations/
 
 docs/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,6 +28,11 @@ shared/        -> stdlib only
 config/        -> stdlib, shared/
 ```
 
+These rules are enforced in CI by `tools/check_imports.py` via `tests/tools/test_import_layers.py`.
+Pre-existing violations are grandfathered in `tools/import_baseline.txt` (a burn-down list: fix
+imports rather than add entries). Regenerate the baseline only with justification:
+`python tools/check_imports.py --update-baseline`.
+
 ## File Size Guidelines (soft limits)
 
 | Metric | Limit | Rationale |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Open an issue using the **Feature Request** template. Describe the problem you a
 1. Fork the repo and create a branch from `develop`
 2. Make your changes
 3. Run the tests: `uv run pytest`
+   CI enforces a coverage floor (80%, see `fail_under` in `pyproject.toml`); reproduce locally with
+   `uv run pytest tests/ -q -m "not integration" --cov=quodeq`.
 4. Open a pull request targeting `develop`
 
 Keep pull requests focused on a single change. If you are fixing a bug and also want to refactor something, open two PRs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,11 @@ timeout_method = "thread"
 
 [tool.coverage.run]
 source = ["quodeq"]
+branch = true
 
 [tool.coverage.report]
+# Enforced gate (activated by --cov in CI). Ratchet this up as coverage
+# improves; never lower it without justification.
 fail_under = 80
 
 [build-system]

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -66,8 +66,14 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
 def judgment_to_dict(j: Judgment) -> dict:
     """Convert a Judgment to the dict format used in PrincipleEvidence lists."""
     d: dict = {"file": j.file}
+    # Emit BOTH the long key (UI/report read 'violation_type', see
+    # ui/src/models/violation.js and core/finding_mappings.py) AND the short
+    # key the scoring tally groups by ('vt', see core/scoring/_tallies.py).
+    # They carry the same value; keeping both fixes taxonomy scoring without
+    # breaking any consumer.
     _optional = {"line": j.line, "end_line": j.end_line, "snippet": j.snippet,
                  "severity": j.severity, "violation_type": j.violation_type,
+                 "vt": j.violation_type,
                  "context": j.context, "scope": j.scope}
     d.update({k: v for k, v in _optional.items() if v})
     if j.req:

--- a/tests/core/test_judgment_to_dict_taxonomy.py
+++ b/tests/core/test_judgment_to_dict_taxonomy.py
@@ -1,0 +1,37 @@
+"""Regression: judgment_to_dict must emit the 'vt' key the scorer groups by.
+
+The scoring tally (core/scoring/_tallies.py) detects the violation taxonomy
+via item.get("vt"). If judgment_to_dict only emits "violation_type", taxonomy
+grouping silently disables on the production parse->score path.
+"""
+from __future__ import annotations
+
+from quodeq.core.events.models import Judgment
+from quodeq.core.evidence._jsonl import judgment_to_dict
+from quodeq.core.scoring._tallies import evidence_has_taxonomy
+
+
+def _violation(vt: str | None) -> Judgment:
+    return Judgment(
+        practice_id="ts-001", verdict="violation", dimension="security",
+        file="src/app.ts", line=10, reason="eval is dangerous",
+        severity="critical", violation_type=vt,
+    )
+
+
+def test_judgment_to_dict_emits_vt_key():
+    d = judgment_to_dict(_violation("code-injection"))
+    assert d["vt"] == "code-injection"
+    # Keep the long key too: the UI/report read 'violation_type'.
+    assert d["violation_type"] == "code-injection"
+
+
+def test_scorer_detects_taxonomy_from_judgment_to_dict_output():
+    dicts = [judgment_to_dict(_violation("code-injection"))]
+    assert evidence_has_taxonomy(dicts) is True
+
+
+def test_no_vt_key_when_violation_type_absent():
+    d = judgment_to_dict(_violation(None))
+    assert "vt" not in d
+    assert "violation_type" not in d

--- a/tests/engine/test_taxonomy_e2e.py
+++ b/tests/engine/test_taxonomy_e2e.py
@@ -1,0 +1,35 @@
+"""End-to-end regression: a 'vt' taxonomy survives parse -> score.
+
+Guards the seam between judgment_to_dict (writer) and the scoring tally
+(reader). The unit tests in test_scoring.py hand-build violation dicts with
+the 'vt' key, so they cannot catch a writer/reader key drift on the real
+production path; this test drives the actual parser.
+"""
+from __future__ import annotations
+
+from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
+from quodeq.core.scoring.engine import score_evidence
+
+from tests.engine.conftest import _evidence_line
+
+
+def test_taxonomy_used_on_parse_then_score(tmp_path):
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text("\n".join([
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/a.ts", line=1),
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/b.ts", line=2),
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/c.ts", line=3),
+    ]) + "\n")
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True

--- a/tests/tools/test_import_layers.py
+++ b/tests/tools/test_import_layers.py
@@ -1,0 +1,30 @@
+"""Layer-import gate: fail the build on NEW violations beyond the baseline."""
+from __future__ import annotations
+
+import check_imports
+
+
+def test_no_new_import_violations():
+    baseline = check_imports.load_baseline()
+    new = [
+        v for v in check_imports.collect_violations()
+        if check_imports.violation_key(v) not in baseline
+    ]
+    assert new == [], (
+        "New layer-import violation(s) introduced. Fix the import, or only "
+        "with justification run `python tools/check_imports.py --update-baseline`:\n"
+        + "\n".join(check_imports.violation_key(v) for v in new)
+        + "\nIf test_baseline_has_no_stale_entries also fails for the same "
+        "file and target, you only shifted lines above a grandfathered "
+        "import; regenerating the baseline is the correct fix."
+    )
+
+
+def test_baseline_has_no_stale_entries():
+    """Fixing a violation must shrink the baseline, keeping it honest."""
+    current = {check_imports.violation_key(v) for v in check_imports.collect_violations()}
+    stale = sorted(check_imports.load_baseline() - current)
+    assert stale == [], (
+        "Baseline lists violations that no longer exist; regenerate with "
+        "`python tools/check_imports.py --update-baseline`:\n" + "\n".join(stale)
+    )

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Lint script that validates layer import rules for src/quodeq/."""
+"""Lint script that validates layer import rules for src/quodeq/.
+
+Existing violations are grandfathered via tools/import_baseline.txt so the
+gate runs green in CI today while preventing NEW violations. Regenerate the
+baseline (only with justification) via:
+    python tools/check_imports.py --update-baseline
+"""
 import re
 import sys
 from pathlib import Path
@@ -18,6 +24,7 @@ IMPORT_RE = re.compile(
     r"^\s*(?:from\s+quodeq\.(\w+)|import\s+quodeq\.(\w+))"
 )
 SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "quodeq"
+BASELINE_PATH = Path(__file__).resolve().parent / "import_baseline.txt"
 
 
 def source_layer(path: Path) -> str | None:
@@ -45,7 +52,8 @@ def check_file(path: Path, layer: str) -> list[tuple[int, str, str]]:
     return violations
 
 
-def main() -> int:
+def collect_violations() -> list[tuple[str, int, str, str]]:
+    """Return all (relpath, lineno, target, line) layer-rule violations."""
     all_violations: list[tuple[str, int, str, str]] = []
     for py in sorted(SRC_ROOT.rglob("*.py")):
         layer = source_layer(py)
@@ -53,12 +61,60 @@ def main() -> int:
             continue
         for lineno, target, line in check_file(py, layer):
             rel = py.relative_to(SRC_ROOT.parent.parent)
-            all_violations.append((str(rel), lineno, target, line))
-    if not all_violations:
-        print("OK: no violations")
+            all_violations.append((rel.as_posix(), lineno, target, line))
+    return all_violations
+
+
+def violation_key(v: tuple[str, int, str, str]) -> str:
+    """Identity for a violation, independent of the source line text."""
+    filepath, lineno, target, _line = v
+    return f"{filepath}:{lineno}:{target}"
+
+
+def load_baseline(path: Path = BASELINE_PATH) -> set[str]:
+    """Return the set of grandfathered violation keys (empty if no baseline)."""
+    if not path.exists():
+        return set()
+    return {
+        stripped
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    }
+
+
+def write_baseline(path: Path = BASELINE_PATH) -> int:
+    """Write current violations to the baseline file; return the count."""
+    keys = sorted(violation_key(v) for v in collect_violations())
+    header = (
+        "# Grandfathered layer-import violations. Do NOT add entries without\n"
+        "# justification -- the goal is to burn this list down, not grow it.\n"
+        "# Regenerate intentionally: python tools/check_imports.py --update-baseline\n"
+    )
+    path.write_text(header + "\n".join(keys) + ("\n" if keys else ""), encoding="utf-8")
+    return len(keys)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    unknown = [a for a in args if a != "--update-baseline"]
+    if unknown:
+        print(f"Unknown argument(s): {' '.join(unknown)}. Usage: check_imports.py [--update-baseline]")
+        return 2
+    if "--update-baseline" in args:
+        n = write_baseline()
+        print(f"Wrote {n} violation(s) to {BASELINE_PATH}")
         return 0
-    print(f"Found {len(all_violations)} import violation(s):\n")
-    for filepath, lineno, target, line in all_violations:
+
+    baseline = load_baseline()
+    all_violations = collect_violations()
+    new = [v for v in all_violations if violation_key(v) not in baseline]
+    grandfathered = len(all_violations) - len(new)
+
+    if not new:
+        print(f"OK: no new import violations ({grandfathered} grandfathered).")
+        return 0
+    print(f"Found {len(new)} NEW import violation(s) ({grandfathered} grandfathered):\n")
+    for filepath, lineno, target, line in new:
         print(f"  {filepath}:{lineno}  forbidden import of '{target}'")
         print(f"    {line}\n")
     return 1

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -1,0 +1,35 @@
+# Grandfathered layer-import violations. Do NOT add entries without
+# justification -- the goal is to burn this list down, not grow it.
+# Regenerate intentionally: python tools/check_imports.py --update-baseline
+src/quodeq/analysis/_api_runner.py:36:context
+src/quodeq/analysis/_api_runner.py:37:context
+src/quodeq/analysis/api_prompt_assembly.py:14:context
+src/quodeq/analysis/api_prompt_assembly.py:15:context
+src/quodeq/analysis/mcp/enricher.py:15:context
+src/quodeq/analysis/mcp/enricher.py:16:context
+src/quodeq/analysis/mcp/enricher.py:17:context
+src/quodeq/analysis/mcp/findings_server.py:20:context
+src/quodeq/analysis/mcp/findings_server.py:21:context
+src/quodeq/analysis/subprocess.py:244:llm_bridge
+src/quodeq/api/_evaluation_routes.py:19:analysis
+src/quodeq/api/import_project.py:30:data
+src/quodeq/api/import_project.py:31:data
+src/quodeq/api/import_project.py:32:data
+src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
+src/quodeq/api/routes_findings.py:85:data
+src/quodeq/data/fs/project_resolver.py:17:services
+src/quodeq/data/fs/repo_clone.py:19:context
+src/quodeq/data/fs/report_parser/runs.py:109:services
+src/quodeq/data/projection/grade_projector.py:130:services
+src/quodeq/data/projection/grade_projector.py:20:services
+src/quodeq/data/sqlite/state_store.py:198:services
+src/quodeq/engine/scoring_pipeline.py:10:services
+src/quodeq/services/_external_jobs.py:22:analysis
+src/quodeq/services/_violations_jsonl.py:11:analysis
+src/quodeq/services/_violations_stream.py:10:analysis
+src/quodeq/services/_violations_stream.py:11:analysis
+src/quodeq/services/evaluation_mixin.py:19:analysis
+src/quodeq/services/evaluation_mixin.py:445:analysis
+src/quodeq/services/jobs.py:20:analysis
+src/quodeq/services/scan_progress.py:23:analysis
+src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
## Summary

Phase 1 of the 2026-06-12 codebase audit remediation. The audit's dominant theme was **enforcement drift**: guarantees that exist as documentation or dormant config but are enforced by nothing. This PR fixes the one production correctness bug the audit confirmed and installs the two enforcement ratchets, so the stated invariants are checked by CI instead of trusted.

### 1. fix(scoring): taxonomy grouping was dead in production
`judgment_to_dict` wrote the taxonomy under `violation_type` while the scoring tally reads `vt`, so every real CLI/MCP `parse_jsonl_to_evidence -> score_evidence` run silently fell back to free-text reason grouping, inflating `weighted_violations` and depressing scores. The fix emits both keys (the UI and report read `violation_type`; the scorer reads `vt`). Complements #622, which added the same tolerance on the wire-dict reader side.

- New seam unit test (`tests/core/test_judgment_to_dict_taxonomy.py`) and end-to-end parse->score regression test (`tests/engine/test_taxonomy_e2e.py`), both verified to fail without the fix.

### 2. ci(test): the 80% coverage gate is now enforced
`fail_under = 80` was declared but no pipeline ever ran with `--cov`. The Linux/macOS test job now collects coverage (branch coverage enabled), so the existing floor actually gates merges. Current coverage: 82.45%. Windows job intentionally left without coverage (one canonical measurement, per-OS variance verified to be a non-issue). `.coverage*`/`htmlcov/` gitignored.

### 3. ci(arch): layer import rules are now a contract
`tools/check_imports.py` reported 32 real violations and exited 1, but ran in no CI/test/build. It now grandfathers the existing 32 into `tools/import_baseline.txt` and a pytest gate (`tests/tools/test_import_layers.py`) fails on any NEW violation; a stale-entry test forces the baseline to shrink as violations get fixed. Paths are stored POSIX-style so the gate behaves identically on Windows. Burn-down of the 32 is Phase 3 of the remediation plan.

### 4. docs
`ARCHITECTURE.md` and `CONTRIBUTING.md` now point contributors at both gates.

## Test plan
- [x] Full non-integration suite with the exact CI command: 3262 passed (rebased on #622), `Required test coverage of 80.0% reached. Total coverage: 82.45%`
- [x] Pre-fix failure verified for both new taxonomy tests (stash sanity check)
- [x] Import gate proven to catch a planted violation and a planted stale baseline entry, and `--update-baseline` regeneration is idempotent
- [x] Coverage gate proven to fail when the floor is not met
- [x] Every commit passed an independent spec-compliance review and a code-quality review; whole-branch final review caught and fixed the Windows path-separator issue
