### PR TITLE
feat(analysis): emit 'vt' taxonomy codes from producers

### DIFF
--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -88,6 +88,15 @@ class _Finding(BaseModel):
         ),
     )
     severity: _Severity = Field(default=_Severity.minor)
+    vt: str | None = Field(
+        default=None,
+        description=(
+            "Violation type taxonomy code: a short, stable, kebab-case class "
+            "of the violation (e.g. 'code-injection', 'hardcoded-secret', "
+            "'missing-error-handling'). Reuse the exact same code for every "
+            "finding of the same kind so near-duplicates group together."
+        ),
+    )
     w: str = Field(description="Short title of the finding")
     snippet: str = Field(
         description=(

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -30,6 +30,7 @@ Each finding must be a JSON object with these fields:
   Optional:
     "end_line": integer - last line if multi-line
     "scope": string - "file", "class", or "module"
+    "vt": string - violation type taxonomy code: a short, stable, kebab-case class of the violation (e.g. "code-injection", "hardcoded-secret", "missing-error-handling"); reuse the exact same code for every finding of the same kind
 """
 
 

--- a/src/quodeq/analysis/mcp/schemas.py
+++ b/src/quodeq/analysis/mcp/schemas.py
@@ -20,6 +20,7 @@ REPORT_FINDING_SCHEMA = {
         "end_line": {"type": "integer", "description": "Last line of the violation pattern (omit if single line)"},
         "scope": {"type": "string", "enum": ["file", "class", "module"], "description": "Set when the finding affects an entire file/class/module rather than specific lines"},
         "severity": {"type": "string", "enum": ["critical", "major", "minor"], "description": "Severity level"},
+        "vt": {"type": "string", "description": "Violation type taxonomy code: a short, stable, kebab-case class of the violation (e.g. 'code-injection', 'hardcoded-secret', 'missing-error-handling'). Reuse the exact same code for every finding of the same kind."},
         "w": {"type": "string", "description": "Short description of the finding"},
         "reason": {"type": "string", "description": "Why this is a violation or compliance"},
         "p": {"type": "string", "description": "Sub-characteristic name — auto-filled from req if omitted"},

--- a/src/quodeq/data/prompts/cli_consolidated_prompt.md
+++ b/src/quodeq/data/prompts/cli_consolidated_prompt.md
@@ -26,7 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 
 **Required:** `req` (the **exact requirement ID from the checklist below**, e.g. `M-MOD-1`, `S-CON-3` — you MUST use the IDs exactly as listed, do NOT invent new ones), `t` (`violation` or `compliance`), `file`, `line`, `severity` (`critical`/`major`/`minor`), `w` (short description), `reason` (why this is a violation or compliance)
 
-**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope)
+**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope), `vt` (violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`; reuse the exact same code for every finding of the same kind so near-duplicates group together)
 
 ## Rules
 

--- a/src/quodeq/data/prompts/cli_subagent_prompt.md
+++ b/src/quodeq/data/prompts/cli_subagent_prompt.md
@@ -26,7 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 **Required:** `req` (the **exact requirement ID from the checklist below**, e.g. `M-MOD-1`, `S-CON-3` — you MUST use the IDs exactly as listed, do NOT invent new ones), `t` (`violation` or `compliance`), `file`, `line`, `severity` (`critical`/`major`/`minor`), `w` (short description), `reason` (why this is a violation or compliance)
 
-**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope)
+**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope), `vt` (violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`; reuse the exact same code for every finding of the same kind so near-duplicates group together)
 
 ## Rules
 

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -26,6 +26,7 @@ For EVERY finding (violation or compliance), call `report_finding` with:
 - `severity` — `critical`, `major`, or `minor`
 - `w` — short description
 - `reason` — why this is a violation or compliance
+- `vt` — OPTIONAL violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`. Reuse the exact same code for every finding of the same kind so near-duplicates group together.
 
 ## Search Strategy
 

--- a/tests/analysis/mcp/test_schemas.py
+++ b/tests/analysis/mcp/test_schemas.py
@@ -4,7 +4,19 @@ from quodeq.analysis.mcp.schemas import (
     MARK_FILE_DONE_NAME,
     MARK_FILE_DONE_DESC,
     MARK_FILE_DONE_SCHEMA,
+    REPORT_FINDING_SCHEMA,
 )
+
+
+class TestReportFindingSchema:
+    def test_vt_is_optional_taxonomy_string(self):
+        vt = REPORT_FINDING_SCHEMA["properties"]["vt"]
+        assert vt["type"] == "string"
+        assert "vt" not in REPORT_FINDING_SCHEMA["required"]
+
+    def test_vt_description_mentions_taxonomy(self):
+        desc = REPORT_FINDING_SCHEMA["properties"]["vt"]["description"].lower()
+        assert "taxonomy" in desc
 
 
 class TestMarkFileDoneSchema:

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -66,6 +66,16 @@ class TestAssembleApiPrompt:
         assert '"severity"' in prompt
         assert '"violation"' in prompt
 
+    def test_schema_offers_vt_taxonomy_field(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert '"vt"' in prompt
+        assert "code-injection" in prompt  # concrete example anchors the format
+
     def test_constant_instructions_precede_variable_file_content(self, src_dir, standards_text):
         """Constant task instructions and the finding schema must come BEFORE the
         variable file content.

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -176,6 +176,26 @@ class TestParserDropAccounting:
         assert dropped == 0
 
 
+class TestFindingVtTaxonomy:
+    """The optional 'vt' taxonomy code must survive _Finding validation, or
+    every fresh API run scores with taxonomy_used=False (free-text reason
+    grouping counts near-duplicates as distinct types and depresses scores)."""
+
+    _BASE = {
+        "req": "S-CON-3", "t": "violation", "file": "src/a.py", "line": 3,
+        "severity": "critical", "w": "eval usage",
+        "snippet": "eval(x)", "reason": "Direct code injection via eval.",
+    }
+
+    def test_vt_survives_validate_and_dump(self):
+        dumped = _Finding.model_validate({**self._BASE, "vt": "code-injection"}).model_dump()
+        assert dumped["vt"] == "code-injection"
+
+    def test_vt_defaults_to_none_when_absent(self):
+        dumped = _Finding.model_validate(self._BASE).model_dump()
+        assert dumped["vt"] is None
+
+
 class TestTruncationDetection:
     """A length-truncated response is incomplete: mark the call lossy so the
     file re-dispatches instead of being cached as a clean analysis."""

--- a/tests/analysis/test_prompt_vt_taxonomy.py
+++ b/tests/analysis/test_prompt_vt_taxonomy.py
@@ -1,0 +1,46 @@
+"""The CLI prompts must offer the optional 'vt' taxonomy parameter.
+
+Without the prompt instruction no MCP-path producer ever emits a taxonomy,
+so fresh runs score with taxonomy_used=False (free-text reason grouping).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SUBAGENT = Path("src/quodeq/data/prompts/cli_subagent_prompt.md").read_text()
+CONSOLIDATED = Path("src/quodeq/data/prompts/cli_consolidated_prompt.md").read_text()
+COMPASS = Path("src/quodeq/data/prompts/compass.md").read_text()
+
+
+def _optional_params_line(prompt: str) -> str:
+    return next(line for line in prompt.splitlines() if line.startswith("**Optional:**"))
+
+
+def _vt_field_line(prompt: str) -> str:
+    return next(line for line in prompt.splitlines() if line.startswith("- `vt`"))
+
+
+def test_subagent_prompt_offers_vt_param():
+    assert "`vt`" in _optional_params_line(SUBAGENT)
+
+
+def test_consolidated_prompt_offers_vt_param():
+    assert "`vt`" in _optional_params_line(CONSOLIDATED)
+
+
+def test_compass_prompt_offers_vt_param():
+    # compass.md is the default per-dimension analysis template, the
+    # most-exercised MCP/CLI producer path. Its report_finding field list
+    # must offer 'vt' too, or the default path never emits a taxonomy.
+    line = _vt_field_line(COMPASS)
+    assert "`vt`" in line
+
+
+def test_prompts_explain_stable_taxonomy_codes():
+    for prompt in (SUBAGENT, CONSOLIDATED):
+        line = _optional_params_line(prompt)
+        assert "taxonomy" in line.lower()
+        assert "code-injection" in line  # concrete example anchors the format
+    compass_line = _vt_field_line(COMPASS)
+    assert "taxonomy" in compass_line.lower()
+    assert "code-injection" in compass_line

--- a/tests/engine/test_taxonomy_e2e.py
+++ b/tests/engine/test_taxonomy_e2e.py
@@ -7,6 +7,10 @@ production path; this test drives the actual parser.
 """
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.core.scoring.engine import score_evidence
 
@@ -23,6 +27,96 @@ def test_taxonomy_used_on_parse_then_score(tmp_path):
         _evidence_line(p="ts-001", t="violation", vt="code-injection",
                        severity="critical", file="src/c.ts", line=3),
     ]) + "\n")
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True
+
+
+def test_taxonomy_from_mcp_producer_to_score(tmp_path):
+    """A fresh MCP/CLI-path run whose report_finding calls carry 'vt' must
+    score with taxonomy_used=True.
+
+    Drives the genuine MCP producer seam: the agent's report_finding
+    arguments are forwarded verbatim by handle_tools_call to
+    FindingsRouter.receive, which delegates to FindingEnricher.enrich (the
+    enricher copies every non-None arg key, including 'vt', into the JSONL
+    line) before the real parse -> score. Before the schema documented 'vt',
+    the default per-dimension template never instructed the model to emit it,
+    so fresh runs fell back to free-text reason grouping.
+    """
+    from quodeq.analysis.mcp.router import FindingsRouter
+
+    # Exactly the shape handle_tools_call forwards (params['arguments']) for a
+    # report_finding MCP tool call: three near-duplicate findings sharing 'vt'.
+    report_finding_args = [
+        {"p": "ts-001", "t": "violation", "file": f"src/{name}.ts", "line": i,
+         "severity": "critical", "w": "eval usage", "snippet": "eval(userInput)",
+         "reason": reason, "vt": "code-injection"}
+        for i, (name, reason) in enumerate([
+            ("a", "eval of user input enables code injection."),
+            ("b", "Dynamic eval executes attacker-controlled strings."),
+            ("c", "Unsanitised input reaches eval."),
+        ], start=1)
+    ]
+
+    jsonl = tmp_path / "evidence.jsonl"
+    with open(jsonl, "w") as fh:
+        router = FindingsRouter(fh)
+        for args in report_finding_args:
+            _message, is_dup = router.receive(args)
+            assert is_dup is False
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True
+
+
+def test_taxonomy_from_api_producer_to_score(tmp_path):
+    """A fresh API-runner run whose model output carries 'vt' must score with
+    taxonomy_used=True.
+
+    Drives the actual producer seam the writer-side tests above cannot reach:
+    raw model output -> _parse_findings (_Finding validation) -> FindingsRouter
+    -> JSONL -> parse -> score. Before _Finding carried 'vt', validation
+    silently stripped the taxonomy and every fresh run fell back to free-text
+    reason grouping.
+    """
+    pytest.importorskip("openai", reason="requires the openai SDK")
+    from quodeq.analysis._api_runner import _parse_findings
+    from quodeq.analysis.mcp.router import FindingsRouter
+
+    raw = json.dumps({"findings": [
+        {"req": "ts-001", "t": "violation", "file": f"src/{name}.ts", "line": i,
+         "severity": "critical", "w": "eval usage", "snippet": "eval(userInput)",
+         "reason": reason, "vt": "code-injection"}
+        for i, (name, reason) in enumerate([
+            ("a", "eval of user input enables code injection."),
+            ("b", "Dynamic eval executes attacker-controlled strings."),
+            ("c", "Unsanitised input reaches eval."),
+        ], start=1)
+    ]})
+    findings, dropped = _parse_findings(raw)
+    assert dropped == 0
+    assert len(findings) == 3
+
+    jsonl = tmp_path / "evidence.jsonl"
+    with open(jsonl, "w") as fh:
+        router = FindingsRouter(fh)
+        for f in findings:
+            router.receive(f)
 
     evidence = parse_jsonl_to_evidence(
         jsonl,


### PR DESCRIPTION
## Summary

Closes the producer half of the taxonomy-grouping fix. The consumer side (PR #623 and the merged #622) understands the `vt` violation-type taxonomy end to end, but no producer emitted it, so every **fresh** run still scored with `taxonomy_used=False` and fell back to free-text reason grouping, which counts near-duplicate findings as distinct types and depresses scores.

**Stacked on #623** (`fix/audit-phase1-remediation`): the e2e verification needs `judgment_to_dict` to emit `vt`, which only exists on that branch. Merge #623 first; GitHub will retarget this PR to `develop` when the base branch is deleted.

## Changes

One change per producer path:

- **MCP/CLI path** ([schemas.py](src/quodeq/analysis/mcp/schemas.py)): optional `vt` string property on `REPORT_FINDING_SCHEMA`. The MCP handler forwards args verbatim and `FindingEnricher` already copies every non-None key into the JSONL line, so the schema entry plus prompt instruction is all the plumbing the CLI path needs.
- **API path** ([_api_runner.py](src/quodeq/analysis/_api_runner.py)): optional `vt` field on `_Finding`. Pydantic drops unknown keys on `model_validate`, so a model-emitted `vt` was silently stripped before reaching the router.
- **Prompts**: `cli_subagent_prompt.md`, `cli_consolidated_prompt.md`, and the API `_FINDING_SCHEMA` block in [api_prompt_assembly.py](src/quodeq/analysis/api_prompt_assembly.py) now document `vt` as a short, stable, kebab-case violation class (e.g. `code-injection`, `hardcoded-secret`), reused for every finding of the same kind.

No canonical closed taxonomy list exists in the repo; `_tallies.py` groups by distinct `vt` value, so within-run stability of the code is what matters, and the prompts say exactly that.

## Tests (written first, watched fail)

- `test_taxonomy_e2e.py::test_taxonomy_from_api_producer_to_score`: drives the real producer seam (raw model output -> `_parse_findings` -> `FindingsRouter` -> JSONL -> `parse_jsonl_to_evidence` -> `score_evidence`) and asserts `taxonomy_used=True`. Failed with `taxonomy_used=False` before the `_Finding` change.
- `TestFindingVtTaxonomy`: `vt` survives `_Finding` validate/dump; defaults to None.
- `TestReportFindingSchema`: `vt` present, optional, described as taxonomy.
- `test_prompt_vt_taxonomy.py` + `test_api_prompt.py`: all three prompt surfaces offer `vt` with the concrete example.

Full suite: 3277 passed.