### PR TITLE
fix(index): rebuild downgraded index.db instead of crashing (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+- **Index downgrade no longer crashes the dashboard**: when `~/.quodeq/index.db` was migrated forward by a newer quodeq and you then run an older one, the cross-run index is discarded and rebuilt from the run files on disk instead of raising an unhandled schema error on first access. The index is a derived projection, so nothing is lost (#621).
+
 ## [1.3.0] - 2026-06-11
 
 ### Features

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -29,10 +29,6 @@ _logger = logging.getLogger(__name__)
 SCHEMA_VERSION = 1
 
 
-class UnsupportedIndexSchemaError(RuntimeError):
-    """Raised when index.db has schema_version > SCHEMA_VERSION."""
-
-
 @dataclass(frozen=True)
 class RunRow:
     """One row of the runs table, as a plain dataclass."""
@@ -97,8 +93,14 @@ def _read_schema_version(db: sqlite3.Connection) -> int | None:
 def open_index(db_path: Path) -> sqlite3.Connection:
     """Open (or create) the index DB at *db_path*, migrate to current schema.
 
-    Raises UnsupportedIndexSchemaError if the existing DB has a newer schema.
-    Recovers from a corrupt file by deleting and recreating.
+    The index is derived state — rebuildable from the run files on disk — so a
+    DB this binary can't use is discarded and recreated rather than fatal:
+
+    * a corrupt/unreadable file, or
+    * a downgraded index whose ``schema_version`` is newer than we support
+      (the user ran a newer quodeq, then installed an older one).
+
+    Either way the next ``sync_index`` repopulates it from disk.
     """
     db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,10 +129,24 @@ def open_index(db_path: Path) -> sqlite3.Connection:
         _apply_schema_v1(db)
         return db
     if version > SCHEMA_VERSION:
-        db.close()
-        raise UnsupportedIndexSchemaError(
-            f"index schema_version={version} newer than supported ({SCHEMA_VERSION})"
+        # Downgrade: a newer quodeq migrated the index forward. It's a derived
+        # projection, so discard and rebuild rather than crash — mirrors the
+        # corrupt-file recovery above. The next sync_index repopulates it.
+        _logger.warning(
+            "index DB at %s has schema_version=%s newer than supported (%s) — "
+            "rebuilding from run files", db_path, version, SCHEMA_VERSION,
         )
+        # Close before unlink — Windows holds the file handle open otherwise.
+        try:
+            db.close()
+        except sqlite3.Error:
+            pass
+        db_path.unlink(missing_ok=True)
+        db = sqlite3.connect(str(db_path))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=3000")
+        _apply_schema_v1(db)
+        return db
     return db
 
 

--- a/tests/services/test_evaluations_index_downgrade.py
+++ b/tests/services/test_evaluations_index_downgrade.py
@@ -1,0 +1,66 @@
+"""Regression test for issue #621: a downgraded index.db must not crash.
+
+When a newer quodeq migrates ``~/.quodeq/index.db`` to a ``schema_version``
+this (older) binary doesn't support, the first index access previously raised
+an uncaught ``UnsupportedIndexSchemaError`` — crashing the dashboard's
+evaluations list wherever the index was first opened.
+
+The index is a derived projection of the on-disk run files, so it is now
+discarded and rebuilt at the open boundary instead of being fatal.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from quodeq.services._evaluations_index import EvaluationsIndex
+from quodeq.services._job_model import InMemoryJobStore
+from quodeq.services.jobs import JobManager
+from quodeq.shared.run_status import RunState, write_status
+
+
+def _seed_run(reports_root: Path, project: str, run_id: str) -> None:
+    """Create a finished run dir matching what a CLI/subprocess writes."""
+    run_dir = reports_root / project / run_id
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    write_status(
+        run_dir,
+        state=RunState.DONE,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+    )
+
+
+def _write_downgraded_index(db_path: Path) -> None:
+    """Write an index.db whose schema_version is newer than this binary supports."""
+    raw = sqlite3.connect(db_path)
+    raw.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    raw.execute("INSERT INTO schema_version VALUES (99)")
+    raw.commit()
+    raw.close()
+
+
+def test_list_rebuilds_downgraded_index_instead_of_crashing(tmp_path: Path) -> None:
+    reports_root = tmp_path / "reports"
+    _seed_run(reports_root, "proj-uuid", "run-uuid")
+
+    index_db_path = tmp_path / "index.db"
+    _write_downgraded_index(index_db_path)
+
+    jobs = JobManager(job_store=InMemoryJobStore(), reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=index_db_path,
+        reports_root=reports_root,
+    )
+
+    # Previously raised UnsupportedIndexSchemaError on the first access; must now
+    # degrade by discarding the stale DB and rebuilding from the run files.
+    entries = index.list(reports_dir=reports_root)
+
+    match = [e for e in entries if e.output_run_id == "run-uuid"]
+    assert len(match) == 1, f"expected the run to survive the rebuild, got {match}"
+    assert match[0].source == "external"
+    assert match[0].status == "done"

--- a/tests/services/test_run_index.py
+++ b/tests/services/test_run_index.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 from quodeq.services.run_index import (
     RunRow,
     SCHEMA_VERSION,
-    UnsupportedIndexSchemaError,
     open_index,
 )
 
@@ -44,15 +41,56 @@ def test_open_is_idempotent_on_existing_v1(tmp_path: Path) -> None:
         db.close()
 
 
-def test_open_raises_on_newer_schema(tmp_path: Path) -> None:
+def test_open_preserves_rows_on_current_schema(tmp_path: Path) -> None:
+    """Reopening a current-schema index must NOT wipe it.
+
+    Guards the load-bearing counterpart to the downgrade recovery: open_index
+    discards-and-rebuilds ONLY when version > SCHEMA_VERSION. If that condition
+    ever loosened to fire on the equal-version path, every reopen would destroy
+    the user's index — this row survives reopen, so that regression fails loudly.
+    """
+    db_path = tmp_path / "index.db"
+    db = open_index(db_path)
+    db.execute(
+        "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+        "started_at, updated_at, status_mtime) "
+        "VALUES ('ext-keep', 'p', 'keep', '/p/keep', 'done', '0', '0', 0)"
+    )
+    db.commit()
+    db.close()
+
+    db = open_index(db_path)
+    try:
+        kept = db.execute("SELECT state FROM runs WHERE job_id = 'ext-keep'").fetchone()
+        assert kept is not None and kept[0] == "done"
+    finally:
+        db.close()
+
+
+def test_open_recovers_from_newer_schema(tmp_path: Path) -> None:
+    """A downgraded index.db (schema newer than this binary) is rebuilt, not fatal.
+
+    Scenario from issue #621: a newer quodeq migrated index.db forward, then the
+    user installed an older one. The index is derived state, so open_index
+    discards the unusable DB and recreates an empty current-schema one (the next
+    sync repopulates it) instead of crashing with a raw schema error.
+    """
     db_path = tmp_path / "index.db"
     raw = sqlite3.connect(db_path)
     raw.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
     raw.execute("INSERT INTO schema_version VALUES (99)")
     raw.commit()
     raw.close()
-    with pytest.raises(UnsupportedIndexSchemaError):
-        open_index(db_path)
+
+    db = open_index(db_path)
+    try:
+        v = db.execute("SELECT version FROM schema_version").fetchone()[0]
+        assert v == SCHEMA_VERSION == 1
+        # Full current schema recreated, not just the version table.
+        cols = {row[1] for row in db.execute("PRAGMA table_info(runs)").fetchall()}
+        assert "job_id" in cols
+    finally:
+        db.close()
 
 
 def test_open_recovers_from_corrupt_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #621.

## Problem
`run_index.open_index()` raised `UnsupportedIndexSchemaError` when `~/.quodeq/index.db` carried a `schema_version` newer than the running code supports — the **downgrade** case: a newer quodeq migrates the index forward, then an older quodeq is installed. No caller caught it, so the first index access (dashboard `list` / `get_status` / `delete` / `rebuild`) crashed with a raw traceback.

## Fix
The index is **derived state** — a projection rebuildable from the per-run files on disk. So a DB this binary can't use is now **discarded and recreated** at the single open boundary (`open_index`), exactly mirroring the corrupt-file recovery already living in that function. The next `sync_index` repopulates it. A warning is logged with the path and offending version.

This deliberately differs from the per-run `evaluation.db` handling in `638a1eb5` (which *degrades to JSON read-through* rather than deleting): that DB has durable data alongside it, whereas `index.db` has nothing to preserve. The "rebuild" policy matches how the rest of the storage layer treats SQLite as a disposable projection.

### Changes
- `open_index()`: recover (delete + recreate + reapply schema) on `version > SCHEMA_VERSION` instead of raising.
- Removed the now-unused `UnsupportedIndexSchemaError` class (only referenced by run_index and its tests).
- `CHANGELOG.md`: `Unreleased → Fixes` entry.

### Tests
- Replaced the unit `test_open_raises_on_newer_schema` with `test_open_recovers_from_newer_schema` (asserts the full schema is rebuilt).
- New `tests/services/test_evaluations_index_downgrade.py`: end-to-end regression — `EvaluationsIndex.list()` rebuilds a downgraded index and returns the run instead of crashing.
- New `test_open_preserves_rows_on_current_schema` guard: an equal-version index is **never** wiped on reopen (verified to fail if `>` is ever loosened to `>=`).

**Verification:** full `tests/services/` suite — **790 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)