### PR TITLE
ci(wheel-smoke): assert the wheel bundles data/ and static/assets/ (#619)

### DIFF
--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -65,15 +65,36 @@ jobs:
             exit 1
           fi
 
-      - name: Confirm wheel contains pre-built UI static
+      # The size assert above only catches the wheel getting too BIG. This
+      # catches it getting too SMALL: if the uv_build include rules regress,
+      # the wheel can ship without its runtime payload and every PyPI install
+      # is broken at runtime while CI stays green. Assert the payload is there:
+      #   quodeq/data/**          - evaluators, standards, prompts, config
+      #   quodeq/static/index.html + quodeq/static/assets/** - pre-built dashboard
+      # (index.html alone is not enough; a broken UI build leaves assets/ empty.)
+      - name: Confirm wheel bundles the runtime payload
         run: |
           wheel=$(ls dist/quodeq-*.whl)
-          if ! unzip -l "$wheel" | grep -q "quodeq/static/index.html"; then
-            echo "::error::Wheel is missing quodeq/static/index.html"
-            unzip -l "$wheel" | head -40
+          echo "Wheel: $wheel"
+          fail=0
+          require() {  # require <grep -E pattern> <human description>
+            n=$(unzip -l "$wheel" | grep -cE "$1" || true)
+            if [ "$n" -eq 0 ]; then
+              echo "::error::Wheel is missing $2"
+              fail=1
+            else
+              echo "OK: $2 ($n entries)"
+            fi
+          }
+          require 'quodeq/data/.+[^/]$'          'runtime data under quodeq/data/'
+          require 'quodeq/static/index\.html$'   'quodeq/static/index.html'
+          require 'quodeq/static/assets/.+[^/]$' 'dashboard assets under quodeq/static/assets/'
+          if [ "$fail" -ne 0 ]; then
+            echo "---- wheel contents (first 60) ----"
+            unzip -l "$wheel" | head -60
             exit 1
           fi
-          echo "OK: index.html present in wheel"
+          echo "OK: wheel bundles the full runtime payload"
 
       - name: Build sdist
         run: uv build --sdist


### PR DESCRIPTION
Fixes #619.

## Problem
The `wheel-smoke` job asserts the wheel stays **under** the size budget, that the npm-free `maybe_build_ui` path works, and that the sdist excludes `node_modules`. It never asserts the wheel actually **contains** its runtime payload. The size assert only catches the wheel getting too **big** — not too small/empty. If the `uv_build` include rules regress, the wheel can ship without:

- `quodeq/data/**` — evaluators, standards, prompts, config (the runtime data bundle)
- `quodeq/static/assets/**` — the pre-built dashboard JS/CSS bundle

…and every PyPI install breaks at runtime while CI stays green. The pre-existing check only looked for `quodeq/static/index.html`, which a broken UI build can leave behind even when `assets/` is empty.

## Change
Replace the `index.html`-only step with a **runtime-payload** check that requires at least one entry under each of:

- `quodeq/data/**`
- `quodeq/static/index.html`
- `quodeq/static/assets/**`

Loud `::error::` annotation + a wheel-contents dump on failure.

## Verification (local)
Built the wheel with `uv build --wheel` and ran the exact step logic under GitHub's shell mode (`bash -eo pipefail`):

- **Good wheel** → pass: `quodeq/data/` (105 entries), `index.html` (1), `quodeq/static/assets/` (50).
- **Stripped wheel** (`zip -d` removing `data/*` and `static/assets/*`) → fails loud on both missing paths, exit 1.

The `[^/]$` patterns match files only, so a bare directory entry can't satisfy the check. YAML validated with `yaml.safe_load`.

Non-blocking; CI-hardening only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)