### PR TITLE
fix(progress): recover dim list from sidecars when status.json has none (restores evaluation ETA)

### DIFF
--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -217,6 +217,19 @@ def build_scan_progress(
     dim_estimates = _read_dim_estimates(run_dir)
     dim_records = read_dimensions(run_dir).get("dimensions") or {}
     dim_ids = list(status.get("dimensions") or [])
+    if not dim_ids:
+        # "All dimensions" runs (no --dimensions filter) record an empty list in
+        # status.json: the raw, unresolved filter is None and gets coerced to []
+        # before the lifecycle writes it. Reading the dim list from status alone
+        # would then zero out the whole progress header — and the ETA the UI
+        # derives from it — for the entire run. The per-dim sidecars still hold
+        # the resolved dims, so recover the list from them (order-preserving,
+        # deduped) when status carries none.
+        recovered: dict[str, None] = {}
+        record_keys = dim_records.keys() if isinstance(dim_records, dict) else ()
+        for key in (*record_keys, *dim_estimates.keys()):
+            recovered.setdefault(key, None)
+        dim_ids = list(recovered)
     evidence_dir = run_dir / "evidence"
 
     dim_results: list[_DimProgress] = []

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -133,3 +133,96 @@ class TestPendingDimTotals:
         assert progress is not None
         # Corrupt estimates → empty dict → pending dim reports 0 (preparing…).
         assert progress.dimensions[0].files["total"] == 0
+
+
+def _write_dimensions_json(run_dir: Path, states: dict[str, str]) -> None:
+    payload = {
+        "schema_version": 1,
+        "dimensions": {d: {"state": s} for d, s in states.items()},
+    }
+    (run_dir / "dimensions.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestEmptyStatusDimensionsRecovery:
+    """Runs launched with *all* dimensions (no --dimensions filter) record an
+    empty ``dimensions: []`` in status.json: the raw, unresolved filter is None
+    and gets coerced to [] before the lifecycle writes it. The reader must
+    recover the dim list from the per-dim sidecars (dimensions.json,
+    dim_estimates.json), otherwise the progress header total — and the ETA the
+    UI derives from it — collapse to zero for the entire run (PROGRESS stuck on
+    "preparing…", no ETA ever shown).
+    """
+
+    def test_recovers_dims_from_sidecars_when_status_empty(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])  # the bug condition
+        _write_dimensions_json(run_dir, {"security": "pending", "reliability": "pending"})
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({
+                "security": {"count": 5, "reason": "first-run"},
+                "reliability": {"count": 7, "reason": "first-run"},
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        totals = {d.id: d.files["total"] for d in progress.dimensions}
+        # Non-zero header total → the ETA can compute instead of preparing…
+        assert totals == {"security": 5, "reliability": 7}
+
+    def test_recovers_from_estimates_alone(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 5, "reason": "first-run"}}),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["security"]
+        assert progress.dimensions[0].files["total"] == 5
+
+    def test_recovers_running_dim_from_dimensions_json_alone(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+        _write_dimensions_json(run_dir, {"security": "running"})
+        (run_dir / "evidence" / "security_queue.json").write_text(
+            json.dumps({
+                "taken": [{"files": ["a.py", "b.py"], "agent": "a1", "ts": 1}],
+                "pending": ["c.py"],
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["security"]
+        assert progress.dimensions[0].files == {"taken": 2, "total": 3}
+
+    def test_explicit_status_dims_take_precedence_over_fallback(self, tmp_path: Path) -> None:
+        # When status.json *does* carry a list, the fallback must not fire or
+        # add dims from the sidecars — the explicit (possibly filtered) list wins.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["reliability"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({
+                "security": {"count": 5, "reason": "first-run"},
+                "reliability": {"count": 7, "reason": "first-run"},
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["reliability"]
+
+    def test_empty_status_and_no_sidecars_stays_empty(self, tmp_path: Path) -> None:
+        # Nothing to recover from → empty list, no crash.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.dimensions == []


### PR DESCRIPTION
## Problem

The evaluation **ETA never appears on screen** (and PROGRESS stays on `preparing…`) for any run launched with **all dimensions** (the default, i.e. no `--dimensions` filter).

Root cause, traced end to end:

1. No filter → `dimensions_filter = None` ([`_cli_evaluation.py:201`](https://github.com/quodeq/quodeq/blob/develop/src/quodeq/_cli_evaluation.py#L201)); the log even prints `Dimensions: all`.
2. `None` is not a list → coerced to `[]` ([`_cli_evaluation.py:296-297`](https://github.com/quodeq/quodeq/blob/develop/src/quodeq/_cli_evaluation.py#L296)), then written to `status.json` on **every** lifecycle transition, so it's empty the whole run.
3. `build_scan_progress` read the dim list from `status.json` alone ([`scan_progress.py:219`](https://github.com/quodeq/quodeq/blob/develop/src/quodeq/services/scan_progress.py#L219)) → **0 dimensions**, even though `dimensions.json` and `dim_estimates.json` held the full resolved set.
4. UI `computeOverallProgress` sees zero dims → `totalFiles: 0` → `buildEtaHint` returns `null` → no ETA renders.

Verified by replaying a real on-disk run through the production code: it returned `num dimensions: 0` despite `dim_estimates.json` listing all 8 dims. This has been latent since the lifecycle status work in April (#254), affecting every all-dimensions external run.

## Fix

Consumer-side, self-contained: when `status.json` carries no dimension list, recover it from the per-dim sidecars that `build_scan_progress` **already loads two lines up** (`dimensions.json` keys unioned with `dim_estimates.json` keys, order-preserving and deduped). Running/pending dims then report their real queue/estimate totals, so the header total is non-zero and the ETA computes. Explicit (filtered) lists still win; empty status + no sidecars stays empty without crashing.

After the fix, the same real run recovers all 8 dimensions.

## Tests

Added `TestEmptyStatusDimensionsRecovery` (5 cases): recover from both sidecars, from estimates alone, from `dimensions.json` alone (running dim → real queue counts), explicit-list precedence, and empty-everything graceful. Full file: 13 passed. `ruff` clean.

## Follow-up (not in this PR)

The producer also writes the unresolved filter into `status.json` — worth recording the **resolved** dim list there so other consumers (e.g. `_index_sync.py:316`) are correct too. The consumer fallback here makes that non-urgent and is the right defensive layer regardless.