### PR TITLE
fix(scoring): stop dropping untagged violations under partial taxonomy coverage

### DIFF
--- a/src/quodeq/core/scoring/_principle.py
+++ b/src/quodeq/core/scoring/_principle.py
@@ -17,10 +17,7 @@ from quodeq.core.scoring.internals import (
     evidence_has_taxonomy,
     score_to_grade_label,
     severity_grade_floor,
-    tally_compliance_types_by_reason,
-    tally_compliance_types_by_taxonomy,
-    tally_types_by_reason,
-    tally_types_by_taxonomy,
+    tally_types,
     violation_base,
     violation_ceiling,
 )
@@ -46,10 +43,18 @@ class _PrincipleContext:
 def compute_tallies(
     violations: list, compliance: list,
 ) -> tuple[dict[str, int], dict[str, int], bool]:
-    """Tally violation and compliance type counts, selecting taxonomy or reason mode."""
+    """Tally distinct violation and compliance types per severity.
+
+    A ``vt`` taxonomy code is a per-finding grouping key, not a per-principle
+    mode switch: each finding is grouped by its ``vt`` when present and by its
+    ``reason`` otherwise, so a partly tagged principle still counts all of its
+    findings (including untagged criticals). ``using_taxonomy`` is reported
+    (any finding carries a ``vt``) for display only; it no longer changes which
+    findings are counted.
+    """
     using_taxonomy = evidence_has_taxonomy(violations)
-    vt_counts = tally_types_by_taxonomy(violations) if using_taxonomy else tally_types_by_reason(violations)
-    ct_counts = tally_compliance_types_by_taxonomy(compliance) if using_taxonomy else tally_compliance_types_by_reason(compliance)
+    vt_counts = tally_types(violations)
+    ct_counts = tally_types(compliance)
     return vt_counts, ct_counts, using_taxonomy
 
 

--- a/src/quodeq/core/scoring/_tallies.py
+++ b/src/quodeq/core/scoring/_tallies.py
@@ -6,49 +6,37 @@ from typing import Mapping
 from quodeq.core.scoring._constants import _SEVERITY_WEIGHT
 
 
-def _tally_types(
-    items: list[dict], key_field: str, skip_empty: bool = False,
-) -> dict[str, int]:
-    """Count distinct types per severity bucket.
-
-    *key_field* selects which dict key to group by (e.g. ``"vt"`` or ``"reason"``).
-    When *skip_empty* is ``True``, items whose *key_field* is falsy are ignored.
-    """
-    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
-    for item in items:
-        value = item.get(key_field)
-        if skip_empty and not value:
-            continue
-        if value is None:
-            value = "unknown"
-        sev = item.get("severity", "minor")
-        buckets.setdefault(sev, set()).add(value)
-    return {sev: len(seen) for sev, seen in buckets.items()}
-
-
 def evidence_has_taxonomy(violations: list[dict]) -> bool:
     """Return True if at least one violation carries a 'vt' field."""
     return any(item.get("vt") for item in violations)
 
 
-def tally_types_by_taxonomy(violations: list[dict]) -> dict[str, int]:
-    """Count distinct violation types per severity using the 'vt' taxonomy field."""
-    return _tally_types(violations, "vt", skip_empty=True)
+def _tally_types_fallback(items: list[dict], key_fields: tuple[str, ...]) -> dict[str, int]:
+    """Count distinct types per severity, grouping each item by the first
+    present key in *key_fields*.
+
+    Unlike taxonomy-only tallying, an item is never dropped: when its preferred
+    key (``vt``) is absent it falls back to the next key (``reason``). A single
+    tagged finding can therefore no longer flip a principle into a mode that
+    discards its untagged findings.
+    """
+    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
+    for item in items:
+        value = next((item[k] for k in key_fields if item.get(k)), "unknown")
+        sev = item.get("severity", "minor")
+        buckets.setdefault(sev, set()).add(value)
+    return {sev: len(seen) for sev, seen in buckets.items()}
 
 
-def tally_types_by_reason(violations: list[dict]) -> dict[str, int]:
-    """Count distinct violation types per severity using (severity, reason) pairs."""
-    return _tally_types(violations, "reason")
+def tally_types(items: list[dict]) -> dict[str, int]:
+    """Count distinct violation/compliance types per severity.
 
-
-def tally_compliance_types_by_taxonomy(compliance: list[dict]) -> dict[str, int]:
-    """Count distinct compliance types per severity using the 'vt' field."""
-    return _tally_types(compliance, "vt", skip_empty=True)
-
-
-def tally_compliance_types_by_reason(compliance: list[dict]) -> dict[str, int]:
-    """Count distinct compliance types per severity using (severity, reason) pairs."""
-    return _tally_types(compliance, "reason")
+    Prefers the stable ``vt`` taxonomy code and falls back to the free-text
+    ``reason`` when a finding carries no ``vt``. Because nothing is dropped, the
+    result is continuous in taxonomy coverage: 0 tags and 1 tag tally the same,
+    and full coverage only sharpens the grouping.
+    """
+    return _tally_types_fallback(items, ("vt", "reason"))
 
 
 def _weighted_sum(

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -15,13 +15,9 @@ from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
     scale_multiplier,
 )
 from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
-    _tally_types,
     _weighted_sum,
     evidence_has_taxonomy,
-    tally_compliance_types_by_reason,
-    tally_compliance_types_by_taxonomy,
-    tally_types_by_reason,
-    tally_types_by_taxonomy,
+    tally_types,
 )
 from quodeq.core.scoring.confidence import confidence_interval_for  # noqa: F401 — re-export
 from quodeq.core.scoring.numerical import (  # noqa: F401 — re-export

--- a/tests/core/test_partial_taxonomy_coverage.py
+++ b/tests/core/test_partial_taxonomy_coverage.py
@@ -1,0 +1,77 @@
+"""Regression: partial taxonomy coverage must not drop untagged violations.
+
+A real quodeq self-scan scored the Modularity principle 9.7/Exemplary while it
+held 2 critical and 22 major violations. Root cause: the scoring tally enters
+"taxonomy mode" as soon as *any* one violation carries a ``vt`` tag
+(``evidence_has_taxonomy``), and ``tally_types_by_taxonomy`` then drops every
+violation lacking a ``vt`` (``_tally_types(..., skip_empty=True)``). With only 1
+of 80 violations tagged, 79 of them -- including both criticals -- vanished from
+the score.
+
+The intended behaviour: a ``vt`` tag is a per-finding grouping key, not a
+per-principle mode switch. A tagged finding groups by its ``vt``; an untagged
+finding falls back to grouping by ``reason``. Nothing is ever dropped, so the
+score is continuous across tag coverage (0 tags and 1 tag score the same; full
+coverage just groups more precisely).
+"""
+from __future__ import annotations
+
+from quodeq.core.scoring._principle import compute_tallies
+from quodeq.core.types.finding import Finding
+from quodeq.services.scoring.projector_scoring import compute_principle_grade
+
+
+def _v(severity: str, reason: str, vt: str | None = None) -> dict:
+    item = {"severity": severity, "reason": reason}
+    if vt:
+        item["vt"] = vt
+    return item
+
+
+def test_partial_taxonomy_keeps_untagged_violations_in_tally():
+    """One tagged minor must not erase two untagged criticals from the tally."""
+    violations = [
+        _v("minor", "function has too many parameters", vt="excessive-parameters"),
+        _v("critical", "incorrect function call signature"),
+        _v("critical", "syntax error in jsx closing tag"),
+        _v("major", "circular dependency between modules"),
+    ]
+
+    vt_counts, _compliance_counts, _used_taxonomy = compute_tallies(violations, [])
+
+    # The bug produced {'critical': 0, 'major': 0, 'minor': 1}: the lone tag
+    # flipped the principle into taxonomy mode and skip_empty dropped the rest.
+    assert vt_counts["critical"] == 2  # two distinct untagged criticals (by reason)
+    assert vt_counts["major"] == 1
+    assert vt_counts["minor"] == 1     # the one tagged minor (by vt)
+
+
+def _f(severity: str, reason: str, vt: str | None = None) -> Finding:
+    return Finding(
+        practice_id="Modularity", verdict="violation", file="a.py", line=1,
+        end_line=1, title="t", reason=reason, snippet="s", severity=severity,
+        cwe=None, req="R1", req_refs=[], context="", dimension="maintainability",
+        violation_type=vt, scope="", confidence=100,
+    )
+
+
+def test_partial_taxonomy_does_not_inflate_principle_grade():
+    """Reproduces the self-scan: 1 tagged minor + 2 critical + 22 major + 55 minor.
+
+    Before the fix this scored 9.7/Exemplary because the untagged criticals and
+    majors were dropped; with them counted it must be a low, non-Exemplary grade.
+    """
+    findings = (
+        [_f("minor", "too many parameters", vt="excessive-parameters")]
+        + [_f("critical", f"critical defect {i}") for i in range(2)]
+        + [_f("major", f"major defect {i}") for i in range(22)]
+        + [_f("minor", f"minor defect {i}") for i in range(55)]
+    )
+
+    result = compute_principle_grade(
+        principle_id="Modularity", findings=findings, compliance=[],
+    )
+
+    assert result["finding_count"] == 80
+    assert result["grade"] != "Exemplary"
+    assert result["score"] < 7.0

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -129,12 +129,14 @@ def test_numerical_high_confidence_with_violations():
     )
     scores = score_evidence(ev, mode="numerical")
     ts001 = scores.principles["ts-001"]
-    # New model: base = 10/(1+0.12*5.5) ≈ 6.0 (1 crit @ 4.0 + 1 major @ 1.5)
-    # Compliance has no vt → 0 types via taxonomy → lift = 0
-    # Score = base, capped by ceiling
+    # base = 10/(1+0.12*5.5) ≈ 6.0 (1 crit @ 4.0 + 1 major @ 1.5)
+    # Compliance carries no vt, but it is no longer dropped: it falls back to
+    # grouping by `reason`, so the passing evidence yields a small positive lift
+    # above the violation base. (Before the taxonomy-fallback fix this asserted
+    # lift == 0.0 / final == 6.0, because untagged compliance was discarded.)
     assert ts001.base_score == 6.0
-    assert ts001.dampening_multiplier == 0.0  # lift factor (no compliance types)
-    assert ts001.final_score == 6.0
+    assert ts001.dampening_multiplier > 0.0  # untagged compliance now counts (reason fallback)
+    assert ts001.final_score == 6.2
 
 
 def test_graded_high_confidence_no_violations():


### PR DESCRIPTION
## The bug

A quodeq self-scan scored the **Modularity** principle **9.7 / Exemplary** while it held **2 critical + 22 major** violations. The score and the violation badge were reading the same findings through two different code paths.

The scoring tally counts *distinct violation types per severity*. `evidence_has_taxonomy()` flipped a principle into "taxonomy mode" the moment **any one** violation carried a `vt` tag, and `tally_types_by_taxonomy()` then used `_tally_types(..., skip_empty=True)`, which **silently dropped every untagged violation**. With near-zero tagging coverage (1 of 80 modularity violations tagged), 79 findings, including both criticals, vanished from the score: weighted violations ≈ 0.25 → base `10/(1+0.12·0.25)` ≈ 9.71 → **9.7**.

The badge counts raw instances (`build_totals`), so the card showed `2 CRIT` and `EXEMPLARY 9.7` at the same time. Across the run, every principle with ≥1 tag scored 9.7; every 0-tag principle scored realistically.

## The fix

Make `vt` a **per-finding grouping key, not a per-principle mode switch**. New `tally_types()` groups each finding by its `vt` when present and falls back to `reason` when absent, never dropping. `compute_tallies` uses it for both violations and compliance. `using_taxonomy` is kept purely as a display flag. The now-dead `tally_types_by_taxonomy/reason`, `tally_compliance_types_by_*`, and `_tally_types`/`skip_empty` are removed.

**Continuity property:** a 0-tag principle still groups by `reason` and a fully-tagged one still groups by `vt`, both bit-identical to before. Only **partially-tagged** principles (the broken ones) change. Adding or removing one tag no longer swings the score.

## Validation

Real run, same saved grade-formula params, only the code differs:

| principle | tags | before | after |
|---|:---:|:---:|:---:|
| Modularity | 1 | 9.7 | **1.3** |
| Learnability | 1 | 9.7 | **5.0** |
| Recoverability | 1 | 9.7 | **5.3** |
| Integrity | 1 | 9.7 | **7.6** |
| 6 zero-tag principles | 0 | — | **0 drift** |

- New regression test: `tests/core/test_partial_taxonomy_coverage.py` (tally unit + principle-grade symptom).
- `tests/engine/test_scoring.py::test_numerical_high_confidence_with_violations` updated: it had asserted the symmetric bug ("untagged compliance → lift 0"); untagged compliance now correctly contributes a small lift (6.0 → 6.2).
- Full suite: **2441 passed**.

## Note on root cause / follow-ups (not in this PR)

This scan ran *after* the producer-side `vt` emission (#624) merged, but the permissive cache (`analysis/cache/key.py` excludes `prompts_hash` by design) reused pre-`vt` cached findings, so coverage stayed near zero. This PR fixes the scoring layer so partial coverage is no longer corrupting. Possible follow-ups: decide whether output-shape prompt changes should bump a cache namespace, and surface a tagging-coverage metric in the report.