### PR TITLE
fix: resolve 6 critical findings from self-analysis (fa56db32)

### DIFF
--- a/src/quodeq/analysis/cache/local.py
+++ b/src/quodeq/analysis/cache/local.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -30,6 +31,10 @@ _ROOT_ENV = "QUODEQ_CACHE_ROOT"
 _RESULTS_SUBDIR = "results"
 _ENTRY_FILENAME = "entry.json"
 _TMP_PREFIX = ".tmp."
+# Content-addressed keys are SHA-256 hex in production; restrict to a
+# path-safe charset so a key can never contain '/', '\\', or '..' and
+# escape the cache root in _dir_for.
+_SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def default_cache_root() -> Path:
@@ -56,6 +61,8 @@ class LocalFileBackend:
     def _dir_for(self, key: str) -> Path:
         if len(key) < 3:
             raise ValueError(f"cache key too short: {key!r}")
+        if not _SAFE_KEY_RE.fullmatch(key):
+            raise ValueError(f"invalid cache key: {key!r}")
         return self._root / key[:2] / key[2:]
 
     def _entry_path(self, key: str) -> Path:

--- a/src/quodeq/api/_rate_limit_config.py
+++ b/src/quodeq/api/_rate_limit_config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 _DEFAULT_RATE_LIMIT_WINDOW = 60
 # 60/min was too tight for the dashboard's bulk-dismiss UX — burst-dismissing
@@ -29,3 +30,12 @@ def _rate_limit_max(env: dict[str, str] | None = None) -> int:
         return int((env or os.environ).get("QUODEQ_RATE_LIMIT_MAX", str(_DEFAULT_RATE_LIMIT_MAX)))
     except (ValueError, TypeError):
         return _DEFAULT_RATE_LIMIT_MAX
+
+
+def default_rate_limit_path() -> Path:
+    """Default rate-limit file under the per-user ~/.quodeq directory.
+
+    A per-user, non-world-writable location removes the shared-temp-dir
+    symlink-attack precondition that a bare tempfile.gettempdir() path had.
+    """
+    return Path.home() / ".quodeq" / "quodeq_rate_limits.json"

--- a/src/quodeq/api/_rate_limit_factory.py
+++ b/src/quodeq/api/_rate_limit_factory.py
@@ -3,25 +3,22 @@ from __future__ import annotations
 
 import logging
 import os
-import tempfile
 from pathlib import Path
 
+from quodeq.api._rate_limit_config import default_rate_limit_path
 from quodeq.api._rate_limit_store import InMemoryRateLimitStore, RateLimitStore
 
 _logger = logging.getLogger(__name__)
 
 _KNOWN_BACKENDS = {"memory", "file"}
-# Use the platform's temp dir (e.g. C:\Users\<user>\AppData\Local\Temp on
-# Windows) instead of a hardcoded /tmp path that doesn't exist there.
-_DEFAULT_RATE_LIMIT_FILE = str(Path(tempfile.gettempdir()) / "quodeq_rate_limits.json")
+_DEFAULT_RATE_LIMIT_FILE = str(default_rate_limit_path())
 
 
 def _validated_rate_limit_path(raw: str) -> str:
     """Reject obviously-unsafe rate-limit file paths from the env.
 
-    Falls back to the default if *raw* is empty, relative, or resolves to a
-    location with parent-traversal components. Symlink resolution is
-    deliberately not strict (the file may not exist yet on first run).
+    Falls back to the default if *raw* is empty, relative, resolves to a
+    location with parent-traversal components, or is a symlink.
     """
     if not raw:
         return _DEFAULT_RATE_LIMIT_FILE
@@ -32,6 +29,11 @@ def _validated_rate_limit_path(raw: str) -> str:
         resolved = candidate.resolve(strict=False)
         if ".." in resolved.parts:
             raise ValueError("path contains parent-directory traversal")
+        # Defense in depth: FileRateLimitStore._save writes via os.replace,
+        # which already defeats a symlink planted later. This rejects an
+        # obviously-symlinked configured path early.
+        if candidate.is_symlink():
+            raise ValueError("path is a symlink")
     except (OSError, ValueError) as exc:
         _logger.warning(
             "Ignoring unsafe QUODEQ_RATE_LIMIT_FILE=%r (%s); using default %s",
@@ -48,7 +50,7 @@ def create_rate_limit_store(env: dict[str, str] | None = None) -> RateLimitStore
 
     - ``memory`` (default): process-local, no external dependencies.
     - ``file``: JSON file in ``QUODEQ_RATE_LIMIT_FILE`` (default:
-      ``quodeq_rate_limits.json`` in the platform temp dir).  Suitable for
+      ``~/.quodeq/quodeq_rate_limits.json``).  Suitable for
       single-machine multi-worker setups but not recommended for
       high-throughput.
 

--- a/src/quodeq/api/_rate_limit_file_store.py
+++ b/src/quodeq/api/_rate_limit_file_store.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import tempfile
 import threading
 from pathlib import Path
 
-from quodeq.api._rate_limit_config import _rate_limit_max, _rate_limit_window
+from quodeq.api._rate_limit_config import _rate_limit_max, _rate_limit_window, default_rate_limit_path
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULT_PATH = str(Path(tempfile.gettempdir()) / "quodeq_rate_limits.json")
+_DEFAULT_PATH = str(default_rate_limit_path())
 
 
 class FileRateLimitStore:
@@ -40,10 +41,28 @@ class FileRateLimitStore:
             return {}
 
     def _save(self, data: dict[str, list[float]]) -> None:
+        parent = self._path.parent
         try:
-            self._path.write_text(json.dumps(data), encoding="utf-8")
+            parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            _logger.warning("Failed to create rate-limit dir %s", parent)
+            return
+        # Write a fresh temp file then os.replace() onto the target. If an
+        # attacker planted a symlink at self._path, the rename replaces the
+        # link itself with our regular file and never truncates its target.
+        payload = json.dumps(data).encode("utf-8")
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=parent, prefix=".rl-", suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "wb") as fh:
+                fh.write(payload)
+            os.chmod(tmp_name, 0o600)
+            os.replace(tmp_name, self._path)
         except OSError:
             _logger.warning("Failed to write rate-limit file %s", self._path)
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
 
     def record(self, ip: str, now: float) -> None:
         """Record a request from *ip* at time *now*."""

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import urllib.error
 import urllib.request
@@ -43,23 +44,28 @@ _SETTINGS_HINT = (
 _VERSION_CMD_TIMEOUT_S = 30
 _API_CHECK_TIMEOUT_S = 5
 
+# Provider/command tokens are restricted to a charset with no shell
+# metacharacters, so even on the Windows shell=True path (needed for npm
+# .cmd shim resolution) a value like "x & calc.exe" can never reach cmd.exe.
+_SAFE_CMD_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
+
 
 def _run_version_cmd(cmd: list[str]) -> str:
-    """Run a command and return its stdout, or raise FileNotFoundError.
+    """Run a version command and return its stdout, or raise.
 
-    ``shell=True`` is required on Windows so that ``where`` and other
-    shell built-ins resolve correctly and executables installed via npm
-    (which are .cmd shims) can be found on PATH.  The *cmd* parameter
-    is always a ``list[str]`` hard-coded by callers in this module
-    (never user-influenced), so the shell injection risk does not apply.
-
-    SECURITY: Do not pass user-controlled strings into *cmd*.
-    All callers in this module construct *cmd* from string literals
-    (e.g. ``["node", "--version"]``).  If this function is ever
-    exposed to external input, ``shell=True`` MUST be removed.
+    On Windows ``shell=True`` is required so npm-installed ``.cmd`` shims
+    resolve on PATH. To keep that shell safe, every token in *cmd* is
+    validated against a strict ``[A-Za-z0-9._-]`` charset, so no shell
+    metacharacter (space, ``&``, ``|``, ``>`` ...) can reach ``cmd.exe``.
+    Callers that accept external input (e.g. a provider name from the
+    ``AI_CMD`` env var) must still validate at their own layer; this is
+    defense in depth.
     """
     if not isinstance(cmd, list):
         raise TypeError("cmd must be a list of strings, not a raw string")
+    for token in cmd:
+        if not isinstance(token, str) or not _SAFE_CMD_TOKEN_RE.fullmatch(token):
+            raise ValueError(f"unsafe command token: {token!r}")
     result = subprocess.run(
         cmd, capture_output=True, text=True, check=True, shell=_IS_WIN32,
         timeout=_VERSION_CMD_TIMEOUT_S,
@@ -109,6 +115,13 @@ def _is_provider_explicitly_configured() -> bool:
 
 def _check_cli_provider(provider: str) -> None:
     """Check that a CLI provider binary is available on PATH."""
+    if not _SAFE_CMD_TOKEN_RE.fullmatch(provider):
+        raise RuntimeError(
+            f"'{provider}' is not a valid AI provider name.\n\n"
+            f"Provider names may only contain letters, digits, '.', '_', and '-'.\n\n"
+            f"Choose a provider in the dashboard Settings:\n"
+            f"  quodeq"
+        )
     try:
         _run_version_cmd([provider, "--version"])
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -21,7 +21,7 @@ import { projectKeys } from "../../../api/queryKeys.js";
  * not via SSE. ``refreshDashboard`` is what the dismiss handlers call to
  * trigger a refetch of the accumulated (cross-run) dashboard payload.
  */
-export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = true }) {
+export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = true } = {}) {
   const { getDashboard } = useApi();
   const queryClient = useQueryClient();
 

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -42,7 +42,7 @@ export function labelFor(entry) {
  * segments are clickable to pop the nav stack; the current segment is
  * accent-colored and non-interactive.
  */
-export default function NavBreadcrumb({ stack, onGoTo, projectName }) {
+export default function NavBreadcrumb({ stack = [], onGoTo, projectName }) {
   const crumbs = [];
   if (projectName) crumbs.push({ label: projectName, index: -1 });
   stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));

--- a/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
@@ -13,7 +13,7 @@ const MIN_GAP = 0.5;
  * (descending). Dragging divider i moves the ascending boundary i.
  * onChange receives a full new thresholds array (descending, labels preserved).
  */
-export default function GradeBoundaryBar({ thresholds, onChange }) {
+export default function GradeBoundaryBar({ thresholds = [], onChange }) {
   const barRef = useRef(null);
   // ascending boundary values, e.g. [3,5,7,9]
   const asc = [...thresholds].map(([t]) => t).reverse();

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -21,7 +21,7 @@ import { projectKeys } from "../api/queryKeys.js";
  *
  * keepPlaceholder (default true): see useDashboard for rationale.
  */
-export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true }) {
+export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true } = {}) {
   const queryClient = useQueryClient();
 
   const latestQuery = useQuery({

--- a/tests/analysis/cache/test_local_backend.py
+++ b/tests/analysis/cache/test_local_backend.py
@@ -55,6 +55,11 @@ class TestSharding:
         with pytest.raises(ValueError):
             backend.has("ab")
 
+    def test_traversal_key_rejected(self, backend: LocalFileBackend):
+        for bad in ["../../etc/passwd", "ab/cd", "abc.def", "/abcdef"]:
+            with pytest.raises(ValueError):
+                backend.has(bad)
+
 
 class TestAtomicity:
     def test_put_overwrites_atomically(self, backend: LocalFileBackend):

--- a/tests/analysis/cache/test_persist_dispatch_results_markers.py
+++ b/tests/analysis/cache/test_persist_dispatch_results_markers.py
@@ -40,14 +40,14 @@ class TestPersistFiltersByOkMarker:
             # c.py: explicit error
             {"_marker": "file_done", "file": "c.py", "status": "error", "reason": "token_limit"},
         ])
-        miss_keys = {f: f"key-{f}" for f in ("a.py", "b.py", "c.py")}
+        miss_keys = {f: f"key-{f}".replace(".", "-") for f in ("a.py", "b.py", "c.py")}
         persist_dispatch_results(
             config, "security", miss_files=["a.py", "b.py", "c.py"],
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
         )
-        assert cache.get("key-a.py") is not None
-        assert cache.get("key-b.py") is None
-        assert cache.get("key-c.py") is None
+        assert cache.get("key-a-py") is not None
+        assert cache.get("key-b-py") is None
+        assert cache.get("key-c-py") is None
 
     def test_clean_file_with_ok_marker_is_cached_empty(
         self, tmp_path: Path, cache: LocalFileBackend,

--- a/tests/api/test_rate_limit_hardening.py
+++ b/tests/api/test_rate_limit_hardening.py
@@ -1,0 +1,50 @@
+"""Hardening regression tests for the file rate-limit store (crit #94)."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from quodeq.api._rate_limit_file_store import FileRateLimitStore
+from quodeq.api._rate_limit_factory import _validated_rate_limit_path, _DEFAULT_RATE_LIMIT_FILE
+
+_skip_no_symlink = pytest.mark.skipif(
+    sys.platform == "win32", reason="symlink/POSIX-mode semantics differ on Windows"
+)
+
+
+@_skip_no_symlink
+def test_save_does_not_follow_symlink(tmp_path: Path):
+    sentinel = tmp_path / "victim.txt"
+    sentinel.write_text("DO NOT TRUNCATE", encoding="utf-8")
+    target = tmp_path / "quodeq_rate_limits.json"
+    os.symlink(sentinel, target)  # attacker plants a symlink at the predictable name
+
+    store = FileRateLimitStore(path=target)
+    store.record("1.2.3.4", 1000.0)
+
+    # The victim file the symlink pointed at is untouched ...
+    assert sentinel.read_text(encoding="utf-8") == "DO NOT TRUNCATE"
+    # ... and the target is now a real file holding our JSON, not a link.
+    assert not target.is_symlink()
+    assert "1.2.3.4" in json.loads(target.read_text(encoding="utf-8"))
+
+
+@_skip_no_symlink
+def test_save_writes_0600_permissions(tmp_path: Path):
+    target = tmp_path / "rl.json"
+    FileRateLimitStore(path=target).record("1.2.3.4", 1000.0)
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+
+@_skip_no_symlink
+def test_validated_path_rejects_symlink(tmp_path: Path):
+    real = tmp_path / "real.json"
+    real.write_text("{}", encoding="utf-8")
+    link = tmp_path / "link.json"
+    os.symlink(real, link)
+    assert _validated_rate_limit_path(str(link)) == _DEFAULT_RATE_LIMIT_FILE

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -6,6 +6,7 @@ import pytest
 from quodeq.shared.prereqs import (
     check_node, check_npm, check_dashboard_dev_prereqs, check_evaluate_prereqs,
     _check_cli_provider, _check_api_provider, _is_provider_explicitly_configured,
+    _run_version_cmd,
 )
 
 
@@ -134,3 +135,20 @@ class TestCompositeChecks:
                     return_value={"claude": {"type": "cli", "cmd": "claude"}},
                 ):
                     check_evaluate_prereqs()
+
+
+class TestProviderInjection:
+    def test_run_version_cmd_rejects_shell_metacharacters(self):
+        with pytest.raises(ValueError, match="unsafe command token"):
+            _run_version_cmd(["x & echo PWNED", "--version"])
+
+    def test_check_cli_provider_rejects_injection(self):
+        with patch("subprocess.run") as mock_run:
+            with pytest.raises(RuntimeError):
+                _check_cli_provider("x & echo PWNED")
+            mock_run.assert_not_called()
+
+    def test_check_cli_provider_accepts_valid_name(self):
+        result = subprocess.CompletedProcess([], 0, stdout="1.0.0\n")
+        with patch("subprocess.run", return_value=result):
+            _check_cli_provider("claude")  # must not raise


### PR DESCRIPTION
Resolves the 6 critical findings from quodeq self-analysis run `fa56db32`. Each critical was adversarially re-verified against current source: **2 are real bugs, 4 are false positives** (the analyzer flagged defensive-coding patterns without modeling the call graph).

## Real bugs (fixed + regression tests)

- **#29 command injection** (`shared/prereqs.py`): `AI_CMD`/`AI_PROVIDER` flowed into `subprocess.run(..., shell=_IS_WIN32)`, so on Windows a value like `AI_PROVIDER="x & calc.exe"` (e.g. from a malicious `.quodeq.env` in a cloned repo) could execute. Now provider/command tokens are validated against `[A-Za-z0-9._-]+` (fullmatch) in both `_check_cli_provider` (the reachable sink, before any subprocess) and `_run_version_cmd` (defense in depth). `shell=_IS_WIN32` is intentionally kept (needed for npm `.cmd` shim resolution).
- **#94 symlink/predictable temp path** (`api/_rate_limit_file_store.py`, `_rate_limit_factory.py`, `_rate_limit_config.py`): the file rate-limit backend wrote with `Path.write_text` to a world-writable temp path, so a planted symlink would be followed and its target truncated. Now writes are atomic and no-follow (`mkstemp` + `0o600` + `os.replace`, which replaces a symlink rather than following it); the default moves to per-user `~/.quodeq/` (created `mode=0o700`); the duplicated default constant is deduped; and `_validated_rate_limit_path` rejects a symlinked configured path. Local-only, opt-in (`QUODEQ_RATE_LIMIT_BACKEND=file`) vector.

## False positives (one-line contract guards + dismissed in quodeq)

- #45 cache key: path-safe charset guard in `LocalFileBackend._dir_for` (`[A-Za-z0-9_-]`)
- #282 hook args: `= {}` default (`useProjectScores`, `useDashboard`)
- #329 `NavBreadcrumb`: `stack = []`
- #444 `GradeBoundaryBar`: `thresholds = []`

The four were dismissed in run `fa56db32` (verified unreachable from real callers).

## Tests

New: `tests/shared/test_prereqs.py::TestProviderInjection`, `tests/api/test_rate_limit_hardening.py`, cache traversal test. One follow-up fix to `test_persist_dispatch_results_markers.py` (a synthetic dotted key the #45 guard correctly rejected). Full Python suite **3295 passed**; UI suite node:test 202 + vitest 404 passed.

## Out of scope

The 535 major / 996 minor findings (future passes). Separately worth a follow-up issue: 4/6 "criticals" being false positives is a signal the analyzer over-flags defensive patterns without call-graph awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)