### PR TITLE
fix(reliability): resolve 42 confirmed-real reliability findings (fa56db32)

### DIFF
--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -1,6 +1,7 @@
 """Quodeq menu bar app for macOS."""
 from __future__ import annotations
 
+import logging as _logging
 import os
 import signal
 import subprocess
@@ -33,17 +34,37 @@ from _dashboard import (
 )
 
 _DEFAULT_APP_PORT = 7863
-_POLL_INTERVAL = int(os.environ.get("QUODEQ_POLL_INTERVAL", "5"))
+try:
+    _POLL_INTERVAL = int(os.environ.get("QUODEQ_POLL_INTERVAL", "5"))
+except ValueError:
+    _logging.getLogger(__name__).warning("Invalid QUODEQ_POLL_INTERVAL; using default 5")
+    _POLL_INTERVAL = 5
 _PROCESS_PATTERNS = ("quodeq.api.app", "quodeq.action_api", "quodeq dashboard")
-_AUTO_START_DELAY_S = float(os.environ.get("QUODEQ_AUTO_START_DELAY_S", "1.5"))
+try:
+    _AUTO_START_DELAY_S = float(os.environ.get("QUODEQ_AUTO_START_DELAY_S", "1.5"))
+except ValueError:
+    _logging.getLogger(__name__).warning("Invalid QUODEQ_AUTO_START_DELAY_S; using default 1.5")
+    _AUTO_START_DELAY_S = 1.5
 _DEFAULT_PORTS = "7863,7864,7865,7866,7867,7868,7869"
 
 
 def _load_config(env=None):
     """Read port configuration from the environment (or an injected mapping)."""
+    _cfg_log = _logging.getLogger(__name__)
     env = env or os.environ
-    app_port = int(env.get("QUODEQ_PORT", str(_DEFAULT_APP_PORT)))
-    ports = tuple(int(p) for p in env.get("QUODEQ_PORTS", _DEFAULT_PORTS).split(","))
+    try:
+        app_port = int(env.get("QUODEQ_PORT", str(_DEFAULT_APP_PORT)))
+    except ValueError:
+        _cfg_log.warning("Invalid QUODEQ_PORT; using default %d", _DEFAULT_APP_PORT)
+        app_port = _DEFAULT_APP_PORT
+    raw_ports = env.get("QUODEQ_PORTS", _DEFAULT_PORTS)
+    ports_list = []
+    for p in raw_ports.split(","):
+        try:
+            ports_list.append(int(p))
+        except ValueError:
+            _cfg_log.warning("Invalid port value %r in QUODEQ_PORTS; skipping", p)
+    ports = tuple(ports_list) if ports_list else tuple(int(p) for p in _DEFAULT_PORTS.split(","))
     return app_port, ports
 
 

--- a/src/quodeq/_cli_resolution.py
+++ b/src/quodeq/_cli_resolution.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 import tempfile as _tempfile
@@ -58,10 +59,8 @@ def _create_worktree(repo_dir: Path, branch: str) -> Path | None:
         return worktree_dir
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         print(f"Failed to create worktree for branch '{branch}': {exc}", file=sys.stderr)
-        try:
-            worktree_dir.rmdir()
-        except OSError:
-            pass
+        _cleanup_worktree(repo_dir, worktree_dir)
+        shutil.rmtree(worktree_dir, ignore_errors=True)
         return None
 
 

--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -27,8 +27,8 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
             if _eid and _eid not in seen:
                 result.append(_eid)
                 seen.add(_eid)
-        except (OSError, ValueError, KeyError):
-            pass
+        except (OSError, ValueError, KeyError) as e:
+            log_warning(f"Skipping custom evaluator {_p.name}: {e}")
     return result
 
 

--- a/src/quodeq/analysis/cache/_failure_streak.py
+++ b/src/quodeq/analysis/cache/_failure_streak.py
@@ -132,7 +132,8 @@ class FailureStreakWatcher:
                 f.seek(offset)
                 chunk = f.read()
                 new_offset = f.tell()
-        except FileNotFoundError:
+        except OSError as e:
+            _logger.warning("Could not read failure-streak JSONL %s: %s", self._jsonl_path, e)
             return offset, streak, recent
         for raw in chunk.splitlines():
             raw = raw.strip()

--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -83,7 +83,7 @@ def handle_tools_call(
 ) -> dict:
     """Handle the 'tools/call' JSON-RPC method."""
     name = params.get("name")
-    args = params.get("arguments", {})
+    args = params.get("arguments") or {}
 
     if name == REPORT_FINDING_NAME:
         message, _is_dup = router.receive(args)

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -40,6 +40,7 @@ def _load_evaluation_rules() -> str:
         try:
             parts.append(load_template(template_name=name))
         except (OSError, FileNotFoundError):
+            _logger.warning("Failed to load prompt template %s, skipping", name)
             continue
     return "\n\n".join(p for p in parts if p)
 

--- a/src/quodeq/analysis/stream/validation.py
+++ b/src/quodeq/analysis/stream/validation.py
@@ -21,6 +21,8 @@ def get_mcp_status(stream_file: Path) -> str | None:
             if not first:
                 return None
             d = json.loads(first)
+            if not isinstance(d, dict):
+                return None
             for srv in d.get("mcp_servers", []):
                 if srv.get("name") == _MCP_SERVER_NAME:
                     return srv.get("status")

--- a/src/quodeq/analysis/subagents/priority_fan_in.py
+++ b/src/quodeq/analysis/subagents/priority_fan_in.py
@@ -1,4 +1,4 @@
-"""Fan-in analysis — counts how many files import each file."""
+"""Fan-in analysis: counts how many files import each file."""
 from __future__ import annotations
 
 import re
@@ -32,11 +32,11 @@ def compute_fan_in(
 
     _read = read_file or _default_read
 
-    # Build filename lookup: stem -> relative path
-    stem_to_file: dict[str, str] = {}
+    # Build filename lookup: stem -> list of relative paths (multiple files may share a stem)
+    stem_to_files: dict[str, list[str]] = {}
     for f in files:
         stem = Path(f).stem
-        stem_to_file.setdefault(stem, f)
+        stem_to_files.setdefault(stem, []).append(f)
 
     compiled = [re.compile(p) for p in patterns]
     counts: dict[str, int] = {}
@@ -46,24 +46,42 @@ def compute_fan_in(
         if content is None:
             continue
         for line in content.splitlines():
-            target = _match_import_target(line, compiled, stem_to_file, f)
-            if target is not None:
+            for target in _match_import_targets(line, compiled, stem_to_files, f):
                 counts[target] = counts.get(target, 0) + 1
 
     return counts
 
 
-def _match_import_target(
-    line: str, compiled: list[re.Pattern], stem_to_file: dict[str, str], current_file: str,
-) -> str | None:
-    """Match a single line against import patterns and return the target file, or None."""
+def _match_import_targets(
+    line: str, compiled: list[re.Pattern], stem_to_files: dict[str, list[str]], current_file: str,
+) -> list[str]:
+    """Match a single line against import patterns and return all matching target files.
+
+    When multiple files share the same stem, the import path is used to narrow
+    candidates: a candidate whose directory components appear in the import string
+    is preferred.  All non-self candidates are returned so fan-in is credited to
+    every file that could be the import target.
+    """
     for pattern in compiled:
         m = pattern.search(line)
         if m:
             imported = m.group(1)
             module_name = imported.rsplit(".", 1)[-1].rsplit("/", 1)[-1]
-            target = stem_to_file.get(module_name)
-            if target is not None and target != current_file:
-                return target
-            return None
-    return None
+            candidates = stem_to_files.get(module_name, [])
+            # Filter out the importing file itself
+            candidates = [c for c in candidates if c != current_file]
+            if not candidates:
+                return []
+            # If only one candidate, return it directly
+            if len(candidates) == 1:
+                return candidates
+            # Multiple candidates share the stem, so use the import path to disambiguate.
+            # Build a normalised version of the import string for prefix matching.
+            import_parts = imported.replace(".", "/").lower()
+            preferred = [
+                c for c in candidates
+                if Path(c).parent.as_posix().lower() in import_parts
+                or import_parts in Path(c).parent.as_posix().lower()
+            ]
+            return preferred if preferred else candidates
+    return []

--- a/src/quodeq/api/_index_routes.py
+++ b/src/quodeq/api/_index_routes.py
@@ -1,9 +1,14 @@
 """Admin/debug endpoints for the SQLite run index."""
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 
 from flask import Flask, Response, current_app, jsonify
+
+from quodeq.api.helpers import error_response
+
+_logger = logging.getLogger(__name__)
 
 
 def register_index_routes(app: Flask) -> None:
@@ -14,5 +19,10 @@ def register_index_routes(app: Flask) -> None:
         provider = current_app.config.get("_provider")
         if provider is None or not hasattr(provider, "rebuild_index"):
             return jsonify({"error": "provider not available"}), HTTPStatus.SERVICE_UNAVAILABLE
-        count, elapsed_ms = provider.rebuild_index()
+        try:
+            count, elapsed_ms = provider.rebuild_index()
+        except Exception:
+            _logger.exception("Unexpected error rebuilding index")
+            body, status = error_response("Failed to rebuild index", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
         return jsonify({"count": count, "elapsed_ms": elapsed_ms})

--- a/src/quodeq/api/_scores_routes.py
+++ b/src/quodeq/api/_scores_routes.py
@@ -8,6 +8,7 @@ directly when using these endpoints.
 """
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from quodeq.api.helpers import error_response
 from quodeq.api.routes_common import reports_dir
 from quodeq.services.scoring import get_project_scores, get_scores_raw
 from quodeq.shared.validation import validate_path_segment
+
+_logger = logging.getLogger(__name__)
 
 
 def register_scores_routes(app: Flask) -> None:
@@ -37,7 +40,12 @@ def register_scores_routes(app: Flask) -> None:
             return err
         as_of = request.args.get("asOf")
         eval_dir = reports_dir()
-        result = get_project_scores(Path(eval_dir), project, as_of)
+        try:
+            result = get_project_scores(Path(eval_dir), project, as_of)
+        except Exception:
+            _logger.exception("Unexpected error fetching scores for project %s", project)
+            body, status = error_response("Failed to load scores", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
         if result is None:
             body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -50,6 +50,10 @@ def register_llm_bridge_routes(app: Flask) -> None:
         data = request.get_json() or {}
         model_size = data.get("model_size", 0)
         gpu_memory = data.get("gpu_memory", 0)
+        if (isinstance(model_size, bool) or isinstance(gpu_memory, bool)
+                or not isinstance(model_size, (int, float))
+                or not isinstance(gpu_memory, (int, float))):
+            return jsonify({"error": "model_size and gpu_memory must be numbers", "code": "INVALID_PARAM"}), 400
         return jsonify(estimate_max_agents(model_size=model_size, gpu_memory=gpu_memory))
 
     @app.get("/api/llamacpp/status")

--- a/src/quodeq/api/standards_read_routes.py
+++ b/src/quodeq/api/standards_read_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time as _time
 
 from flask import Flask, Response, jsonify, request
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 _cwe_cache: list | None = None
 _cwe_cache_time: float = 0.0
 _CWE_CACHE_TTL = int(os.environ.get("QUODEQ_CWE_CACHE_TTL", "3600"))  # 1 hour
+_cwe_cache_lock = threading.Lock()
 
 
 def reset_cwe_cache() -> None:
@@ -23,6 +25,27 @@ def reset_cwe_cache() -> None:
     global _cwe_cache, _cwe_cache_time
     _cwe_cache = None
     _cwe_cache_time = 0.0
+
+
+def _reload_cwe_if_needed(loader) -> list:
+    """Return the CWE list, reloading at most once when the cache has expired.
+
+    Uses double-checked locking so the common path (cache is warm) never
+    blocks on the lock, and the uncommon path (expired) reloads exactly once
+    even when multiple threads race at expiry.
+    """
+    global _cwe_cache, _cwe_cache_time
+    now = _time.monotonic()
+    # Fast path: cache is valid — no lock needed.
+    if _cwe_cache is not None and (now - _cwe_cache_time) <= _CWE_CACHE_TTL:
+        return _cwe_cache
+    # Slow path: acquire the lock, then re-check inside it.
+    with _cwe_cache_lock:
+        now = _time.monotonic()  # re-read after acquiring
+        if _cwe_cache is None or (now - _cwe_cache_time) > _CWE_CACHE_TTL:
+            _cwe_cache = loader()
+            _cwe_cache_time = now
+        return _cwe_cache
 
 
 def register_read_routes(app: Flask, get_service, get_library_client) -> None:
@@ -36,12 +59,8 @@ def register_read_routes(app: Flask, get_service, get_library_client) -> None:
 
     @app.get("/api/standards/refs/cwe")
     def list_cwes() -> Response:
-        global _cwe_cache, _cwe_cache_time
-        now = _time.monotonic()
-        if _cwe_cache is None or (now - _cwe_cache_time) > _CWE_CACHE_TTL:
-            _cwe_cache = get_service(app).load_cwe_list()
-            _cwe_cache_time = now
-        return jsonify(_cwe_cache)
+        result = _reload_cwe_if_needed(lambda: get_service(app).load_cwe_list())
+        return jsonify(result)
 
     @app.get("/api/standards")
     def list_standards() -> Response:

--- a/src/quodeq/ci/_evidence_reader.py
+++ b/src/quodeq/ci/_evidence_reader.py
@@ -34,7 +34,10 @@ def _judgment_to_violation(obj: dict) -> dict | None:
     }
     line = obj.get("line")
     if line is not None:
-        out["line"] = int(line)
+        try:
+            out["line"] = int(line)
+        except (ValueError, TypeError):
+            _logger.debug("Non-integer line value %r; omitting line", line)
     req = obj.get("req")
     if req:
         out["req"] = req

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -79,6 +79,8 @@ def _read_run_status(run_dir: Path) -> str | None:
             data = _json.load(fp)
     except (OSError, ValueError):
         return None
+    if not isinstance(data, dict):
+        return None
     state = data.get("state")
     return state if isinstance(state, str) else None
 

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -67,9 +67,9 @@ class ProjectionEngine:
                 handle(event, store)
                 last_ts = event.timestamp
                 count += 1
-            except Exception:
+            except (ValueError, KeyError, TypeError):
                 _logger.error(
-                    "Handler failed for event %s (type=%s) — skipping",
+                    "Handler failed for event %s (type=%s) - skipping",
                     event.event_id,
                     event.event_type,
                     exc_info=True,

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -47,8 +47,16 @@ class ProjectionEngine:
 
         applied = 0
         for event in read_action_events(actions_log.parent):
-            handle(event, store)
-            applied += 1
+            try:
+                handle(event, store)
+                applied += 1
+            except Exception:
+                _logger.error(
+                    "Handler failed for action event %s (type=%s) - skipping",
+                    getattr(event, "event_id", "?"),
+                    getattr(event, "event_type", "?"),
+                    exc_info=True,
+                )
         store.save_actions_projected_size(current_size)
         return applied
 

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -132,19 +132,4 @@ def recompute_grades(run_dir: Path, params: ScoringParams | None = None) -> None
     principle_rows, dimension_rows = compute_run_grades(run_dir, params)
 
     store = SQLiteStateStore(run_dir)
-    store.clear_grades()
-    for dim, p_grade in principle_rows:
-        store.record_principle_grade(
-            dimension=dim,
-            principle_id=p_grade["principle_id"],
-            score=p_grade["score"],
-            grade=p_grade["grade"],
-            finding_count=p_grade["finding_count"],
-            dismissed_count=p_grade["dismissed_count"],
-        )
-    for d_score in dimension_rows:
-        store.record_dimension_score(
-            dimension=d_score["dimension"],
-            score=d_score["score"],
-            grade=d_score["grade"],
-        )
+    store.batch_rewrite_grades(principle_rows, dimension_rows)

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -166,6 +166,47 @@ class SQLiteStateStore:
             )
             conn.commit()
 
+    def batch_rewrite_grades(
+        self,
+        principle_rows: "list[tuple[str, dict]]",
+        dimension_rows: "list[dict]",
+    ) -> None:
+        """Clear all grade tables and insert new rows in a single transaction.
+
+        The clear + all inserts are committed atomically: a mid-batch failure
+        rolls back the entire operation, leaving any pre-existing rows intact.
+
+        Args:
+            principle_rows: Sequence of ``(dimension, principle_grade_dict)``
+                as returned by ``compute_run_grades``.
+            dimension_rows: Sequence of dimension score dicts
+                (``{"dimension": ..., "score": ..., "grade": ...}``).
+        """
+        with open_evaluation_db(self._run_dir) as conn:
+            conn.execute("DELETE FROM dimension_scores")
+            conn.execute("DELETE FROM principle_grades")
+            for dim, p_grade in principle_rows:
+                conn.execute(
+                    "INSERT INTO principle_grades "
+                    "(dimension, principle_id, score, grade, finding_count, dismissed_count, completed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+                    (
+                        dim,
+                        p_grade["principle_id"],
+                        p_grade["score"],
+                        p_grade["grade"],
+                        p_grade["finding_count"],
+                        p_grade["dismissed_count"],
+                    ),
+                )
+            for d_score in dimension_rows:
+                conn.execute(
+                    "INSERT INTO dimension_scores (dimension, score, grade, completed_at) "
+                    "VALUES (?, ?, ?, datetime('now'))",
+                    (d_score["dimension"], d_score["score"], d_score["grade"]),
+                )
+            conn.commit()
+
     def clear_grades(self) -> None:
         with open_evaluation_db(self._run_dir) as conn:
             conn.execute("DELETE FROM dimension_scores")

--- a/src/quodeq/data/web/_response.py
+++ b/src/quodeq/data/web/_response.py
@@ -24,8 +24,8 @@ def check_response_status(response: HttpResponse) -> None:
     error details that should remain internal.
     """
     if response.status in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}:
-        raise AuthError("Authentication error — verify your API key is valid and not expired")
+        raise AuthError("Authentication error. Verify your API key is valid and not expired")
     if response.status == HTTPStatus.NOT_FOUND:
-        raise NotFoundError("Resource not found — verify the URL and that the resource exists")
+        raise NotFoundError("Resource not found. Verify the URL and that the resource exists")
     if response.status >= HTTPStatus.INTERNAL_SERVER_ERROR:
-        raise ServerError("Server error")
+        raise ServerError(f"Server error (HTTP {response.status})")

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from quodeq.services.ports import RunInfo, read_run_data, safe_read_dir, summarize_dimensions
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from quodeq.core.scoring.params import ScoringParams
@@ -146,6 +149,6 @@ def _has_fingerprints(reports_root: Path, project: str) -> bool:
                 continue
             if any(f.name.endswith("_fingerprint.json") for f in evidence_dir.iterdir()):
                 return True
-    except OSError:
-        pass
+    except OSError as e:
+        _logger.warning("Could not read fingerprint dir %s: %s", project_dir, e)
     return False

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -43,6 +43,8 @@ def _parse_jsonl_findings(
             obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        if not isinstance(obj, dict):
+            continue
         principle = obj.get("p") or obj.get("req")
         if not principle or obj.get("t") not in _FINDING_TYPES:
             continue

--- a/src/quodeq/services/scoring_view/_resolution.py
+++ b/src/quodeq/services/scoring_view/_resolution.py
@@ -51,7 +51,7 @@ def _is_trustworthy_eval(eval_data: dict[str, Any] | None) -> bool:
     we exclude it everywhere — cards, history, chart — so it can't
     pollute any user-facing aggregation.
     """
-    if not eval_data:
+    if not isinstance(eval_data, dict):
         return False
     files_read = eval_data.get("filesRead")
     return isinstance(files_read, int) and files_read > 0

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -32,7 +32,7 @@ def _load_fallback_claude_models() -> list[str]:
     try:
         data = read_json(_AI_DEFAULTS_PATH)
         return data.get("fallback_claude_models", [])
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, ValueError):
         return []
 
 

--- a/src/quodeq/shared/resource_sampler.py
+++ b/src/quodeq/shared/resource_sampler.py
@@ -129,6 +129,6 @@ class ResourceSampler:
         while not self._stop.is_set():
             try:
                 log_info(self.sample_once())
-            except (OSError, ValueError):
+            except Exception:
                 pass  # best-effort: never let observability kill the run
             self._stop.wait(self._interval)

--- a/src/quodeq/ui/src/api/request.js
+++ b/src/quodeq/ui/src/api/request.js
@@ -8,6 +8,9 @@ const API_TIMEOUT_MS = 30000;
 export async function request(path, options = {}) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, controller.signal])
+    : controller.signal;
   try {
     const res = await fetch(`${BASE}${path}`, {
       headers: {
@@ -15,7 +18,7 @@ export async function request(path, options = {}) {
         ...(options.headers || {}),
       },
       ...options,
-      signal: controller.signal,
+      signal,
     });
 
     const payload = await res.json().catch(() => ({}));

--- a/src/quodeq/ui/src/api/request.test.jsx
+++ b/src/quodeq/ui/src/api/request.test.jsx
@@ -1,0 +1,29 @@
+import { vi, it, expect, afterEach } from 'vitest';
+import { request } from './request.js';
+afterEach(() => vi.restoreAllMocks());
+
+it('aborts when the caller signal aborts (react-query cancellation preserved)', async () => {
+  const fetchMock = vi.fn((_u, opts) => new Promise((_, reject) => {
+    opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const ctrl = new AbortController();
+  const p = request('/x', { signal: ctrl.signal });
+  ctrl.abort();
+  await expect(p).rejects.toThrow();
+  expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+});
+
+it('aborts on the internal timeout when no caller signal is given', async () => {
+  vi.useFakeTimers();
+  const fetchMock = vi.fn((_u, opts) => new Promise((resolve, reject) => {
+    opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const p = request('/x');
+  // Suppress unhandled-rejection noise while fake timers advance
+  p.catch(() => {});
+  await vi.advanceTimersByTimeAsync(30000);
+  await expect(p).rejects.toThrow();
+  vi.useRealTimers();
+});

--- a/src/quodeq/ui/src/api/standards.js
+++ b/src/quodeq/ui/src/api/standards.js
@@ -75,11 +75,19 @@ export async function importFromLibrary(file) {
  * @returns {Promise<Object>} Result with optional `_conflict` flag
  */
 export async function importStandard(data, force = false) {
-  const res = await fetch(`${BASE}/standards/import`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ data, force }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  let res;
+  try {
+    res = await fetch(`${BASE}/standards/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data, force }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
   const body = await res.json().catch(() => ({}));
   if (res.status === 409) return { ...body, _conflict: true };
   if (!res.ok) throw new Error(body.error || `Import failed: ${res.status}`);

--- a/src/quodeq/ui/src/api/standards382.test.jsx
+++ b/src/quodeq/ui/src/api/standards382.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * Finding #382 – importStandard() must apply a timeout to its fetch call.
+ * The function has special 409-conflict handling that prevents it from using
+ * request() directly (which throws on non-2xx before returning the body),
+ * so the fix wraps the raw fetch with an AbortController + 30s timeout.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { importStandard } from './standards.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('#382 importStandard – 30s timeout', () => {
+  it('calls fetch with an AbortSignal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'std-1' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await importStandard({ id: 'std-1' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts and rejects when the endpoint hangs past 30s', async () => {
+    vi.useFakeTimers();
+    let abortHandler;
+    const fetchMock = vi.fn((_url, opts) =>
+      new Promise((_resolve, reject) => {
+        abortHandler = () => reject(new DOMException('Aborted', 'AbortError'));
+        opts.signal.addEventListener('abort', abortHandler);
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p = importStandard({ id: 'std-1' }).catch((e) => ({ error: e.message }));
+    await vi.advanceTimersByTimeAsync(30001);
+    const result = await p;
+
+    expect(result).toMatchObject({ error: expect.any(String) });
+    vi.useRealTimers();
+  });
+
+  it('still returns _conflict:true on 409 after timeout fix', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'Conflict', existing: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await importStandard({ id: 'std-1' });
+    expect(result._conflict).toBe(true);
+    expect(result.existing).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 const MAX_LINES = 5000;
 const READYSTATE_CLOSED = 2;
+const INACTIVITY_MS = 60000;
 
 const TERMINAL_STATE_LINE = {
   cancelled: '── evaluation cancelled ──',
@@ -22,6 +23,7 @@ export function useJobLogStream(jobId) {
   const pendingRef = useRef([]);
   const rafRef = useRef(null);
   const timerRef = useRef(null);
+  const inactivityRef = useRef(null);
 
   useEffect(() => {
     setLogs([]);
@@ -34,6 +36,10 @@ export function useJobLogStream(jobId) {
     if (timerRef.current != null) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
+    }
+    if (inactivityRef.current != null) {
+      clearTimeout(inactivityRef.current);
+      inactivityRef.current = null;
     }
     if (!jobId) {
       setStatus('idle');
@@ -77,8 +83,27 @@ export function useJobLogStream(jobId) {
       }
     };
 
-    es.onmessage = (e) => append(e.data);
+    const resetInactivity = () => {
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+      }
+      inactivityRef.current = setTimeout(() => {
+        es.close();
+        setStatus('error');
+      }, INACTIVITY_MS);
+    };
+
+    resetInactivity();
+
+    es.onmessage = (e) => {
+      resetInactivity();
+      append(e.data);
+    };
     es.addEventListener('done', (e) => {
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+        inactivityRef.current = null;
+      }
       const state = (e?.data || '').trim().toLowerCase();
       append(TERMINAL_STATE_LINE[state] || '── evaluation complete ──');
       setTerminalState(state || 'done');
@@ -94,6 +119,10 @@ export function useJobLogStream(jobId) {
 
     return () => {
       es.close();
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+        inactivityRef.current = null;
+      }
       if (rafRef.current != null) {
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream549.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream549.test.jsx
@@ -1,0 +1,105 @@
+/**
+ * Finding #549 – useJobLogStream must close the EventSource and set
+ * status='error' when no message arrives for 60 seconds (inactivity timer).
+ * The timer resets on each message and on 'done'. It is cleared on unmount.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { useJobLogStream } from './useJobLogStream.js';
+
+class MockEventSource {
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    this.readyState = 0;
+    this.closed = false;
+    MockEventSource.instances.push(this);
+  }
+  addEventListener(name, fn) {
+    (this.listeners[name] = this.listeners[name] || []).push(fn);
+  }
+  removeEventListener(name, fn) {
+    this.listeners[name] = (this.listeners[name] || []).filter((f) => f !== fn);
+  }
+  set onmessage(fn) { this._onmessage = fn; }
+  get onmessage() { return this._onmessage; }
+  set onerror(fn) { this._onerror = fn; }
+  get onerror() { return this._onerror; }
+  emit(name, event) {
+    if (name === 'message' && this._onmessage) this._onmessage(event);
+    (this.listeners[name] || []).forEach((fn) => fn(event));
+  }
+  close() { this.closed = true; this.readyState = 2; }
+}
+
+function Probe({ jobId }) {
+  const { logs, status } = useJobLogStream(jobId);
+  return (
+    <div>
+      <div data-testid="status">{status}</div>
+      <div data-testid="logs">{logs.join('|')}</div>
+    </div>
+  );
+}
+
+describe('#549 useJobLogStream inactivity timer', () => {
+  let originalEventSource;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = MockEventSource;
+    MockEventSource.instances = [];
+  });
+  afterEach(() => {
+    globalThis.EventSource = originalEventSource;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('closes the EventSource and sets status=error after 60s of inactivity', async () => {
+    render(<Probe jobId="job-1" />);
+    const es = MockEventSource.instances[0];
+    expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+
+    // Advance 60 seconds with no message arriving.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(es.closed).toBe(true);
+    expect(screen.getByTestId('status')).toHaveTextContent('error');
+  });
+
+  it('resets the inactivity timer on each message so no timeout fires if active', async () => {
+    render(<Probe jobId="job-2" />);
+    const es = MockEventSource.instances[0];
+
+    // Send messages every 30s — should not trigger the 60s timeout.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+      es.emit('message', { data: 'heartbeat' });
+      await vi.advanceTimersByTimeAsync(30000);
+      es.emit('message', { data: 'heartbeat 2' });
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+
+    expect(es.closed).toBe(false);
+    expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+  });
+
+  it('clears the inactivity timer on unmount to avoid state updates after unmount', async () => {
+    const { unmount } = render(<Probe jobId="job-3" />);
+    const es = MockEventSource.instances[0];
+    unmount();
+
+    // Advancing time after unmount must not throw or update state.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    // Stream is closed by unmount cleanup, not by the inactivity timer.
+    expect(es.closed).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { scanPath } from '../../../api/index.js';
 import { projectKeys } from '../../../api/queryKeys.js';
+import { request } from '../../../api/request.js';
 
 /**
  * Fetch scan data for a project ID or a raw local path.
@@ -15,9 +16,7 @@ export function useScanData(projectId, localPath) {
       : ['project', 'scan-path', localPath || ''],
     queryFn: async ({ signal }) => {
       if (projectId) {
-        const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`, { signal });
-        if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
-        return res.json();
+        return request(`/projects/${encodeURIComponent(projectId)}/scan`, { signal });
       }
       return scanPath(localPath);
     },

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData477.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData477.test.jsx
@@ -1,0 +1,63 @@
+/**
+ * Finding #477 – useScanData should use request() (with 30s timeout)
+ * instead of a raw fetch() for the /api/projects/<id>/scan call.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+
+// Mock request so we can verify it is called for the projectId branch.
+vi.mock('../../../api/request.js', () => ({
+  BASE: '/api',
+  request: vi.fn(),
+}));
+
+vi.mock('../../../api/index.js', () => ({
+  scanPath: vi.fn(),
+}));
+
+import { request } from '../../../api/request.js';
+import { useScanData } from './useScanData.js';
+
+describe('#477 useScanData uses request() for projectId path', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls request() instead of raw fetch when projectId is given', async () => {
+    request.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+    const { result } = renderHook(() => useScanData('proj-1'), {
+      wrapper: withQueryClient(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.scanData).toBeDefined();
+    });
+
+    expect(request).toHaveBeenCalled();
+    const [path] = request.mock.calls[0];
+    expect(path).toContain('/projects/proj-1/scan');
+  });
+
+  it('does not call raw fetch directly for the projectId branch', async () => {
+    request.mockResolvedValue({ branches: ['main'] });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useScanData('proj-2'), {
+      wrapper: withQueryClient(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.scanData).toBeDefined();
+    });
+
+    // fetch should NOT have been called directly — only via request()
+    // (which is itself mocked above and doesn't call fetch).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
@@ -73,6 +73,7 @@ export function handleCanvasClick(e, refs, scene, size, navigateTo, startTransit
 
   // At galaxy root: check if click is near a cluster -> zoom to it
   if (nav.depth === 0 && !animRef.current && scene?.constellations) {
+    if (!camRef.current) return;
     const rect = canvasRef.current?.getBoundingClientRect();
     if (rect) {
       const cmx = e.clientX - rect.left, cmy = e.clientY - rect.top;

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleCanvasClick } from './galaxyViewEvents.js';
+
+describe('handleCanvasClick', () => {
+  it('does not throw when camRef.current is null during a cluster-click hit-test', () => {
+    // Simulate the null window: camera not yet initialised
+    const refs = {
+      hoveredRef: { current: null },
+      navRef: { current: { depth: 0, clusterCx: null, clusterCy: null } },
+      animRef: { current: false },
+      camRef: { current: null },        // <-- the null value under test
+      canvasRef: {
+        current: {
+          getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        },
+      },
+    };
+
+    const scene = {
+      constellations: [{ cx: 0, cy: 0, spread: 10 }],
+    };
+
+    const e = { clientX: 50, clientY: 50 };
+    const size = { w: 800, h: 600 };
+    const navigateTo = vi.fn();
+    const startTransition = vi.fn();
+    const saveNav = vi.fn();
+    const w2s = (x, y) => ({ x, y });
+
+    expect(() =>
+      handleCanvasClick(e, refs, scene, size, navigateTo, startTransition, saveNav, w2s)
+    ).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.js
+++ b/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.js
@@ -15,7 +15,7 @@ const CLI_SERVER_ID = { 'codex-cli': 'codex', 'claude-code': 'claude' };
 async function detectCliProvider(id) {
   const serverId = CLI_SERVER_ID[id] || id;
   try {
-    const res = await fetch('/api/ai-clients', { method: 'GET' });
+    const res = await fetch('/api/ai-clients', { method: 'GET', signal: AbortSignal.timeout(5000) });
     if (!res.ok) return { id, classification: 'cli', detected: false, defaultModel: null };
     const data = await res.json();
     const detected = (data.clients || []).some((c) => c.id === serverId && c.type === 'cli');
@@ -27,7 +27,7 @@ async function detectCliProvider(id) {
 
 async function detectOllamaDaemon() {
   try {
-    const res = await fetch('/api/ollama/health', { method: 'GET' });
+    const res = await fetch('/api/ollama/health', { method: 'GET', signal: AbortSignal.timeout(5000) });
     return { id: 'ollama', classification: 'local-api', detected: res.ok, defaultModel: null };
   } catch {
     return { id: 'ollama', classification: 'local-api', detected: false };

--- a/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runDetection } from './providerProbes.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('providerProbes – timeout behaviour', () => {
+  function successFetch() {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ clients: [] }),
+    });
+  }
+
+  it('#261 detectCliProvider calls fetch with AbortSignal.timeout(5000)', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort() // only used to verify AbortSignal.timeout's return value is passed as opts.signal
+    );
+    const fetchMock = successFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runDetection();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    const clientCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/ai-clients'));
+    expect(clientCalls.length).toBeGreaterThanOrEqual(1);
+    const [, opts] = clientCalls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('#261 detectCliProvider resolves to detected:false when fetch rejects (abort)', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(AbortSignal.abort());
+    const fetchMock = vi.fn().mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError')
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await runDetection();
+    const codex = results.find((r) => r.id === 'codex-cli');
+    expect(codex).toBeDefined();
+    expect(codex.detected).toBe(false);
+  });
+
+  it('#262 detectOllamaDaemon calls fetch with AbortSignal.timeout(5000)', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort()
+    );
+    const fetchMock = successFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runDetection();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    const ollamaCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/ollama/'));
+    expect(ollamaCalls.length).toBeGreaterThanOrEqual(1);
+    const [, opts] = ollamaCalls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('#262 detectOllamaDaemon resolves to detected:false when fetch rejects (abort)', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(AbortSignal.abort());
+    const fetchMock = vi.fn().mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError')
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await runDetection();
+    const ollama = results.find((r) => r.id === 'ollama');
+    expect(ollama).toBeDefined();
+    expect(ollama.detected).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
@@ -10,9 +10,9 @@ const MODEL_LEVEL_THOROUGH = 3;
 
 export { AI_MODEL_STORAGE_KEY, AI_CMD_STORAGE_KEY };
 
-function ClientSelector({ aiCmd, availableClients }) {
+function ClientSelector({ aiCmd = {}, availableClients }) {
   const { value, onApply } = aiCmd;
-  if (availableClients === null) {
+  if (availableClients == null) {
     return (
       <div className="settings-row settings-row--last">
         <div className="settings-row-label">
@@ -100,7 +100,7 @@ function ModelOverrideInput({ label, value, setter, level, placeholder }) {
   );
 }
 
-function ModelSettings({ aiCmd, models }) {
+function ModelSettings({ aiCmd = {}, models }) {
   const { value: aiCmdValue } = aiCmd;
   const { aiModel, onAiModelChange, fast, onFastChange, balanced, onBalancedChange, thorough, onThoroughChange } = models;
   if (!aiCmdValue) return null;

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ModelSection from './ModelSection.jsx';
+
+const stubModels = {
+  aiModel: '',
+  onAiModelChange: () => {},
+  fast: '',
+  onFastChange: () => {},
+  balanced: '',
+  onBalancedChange: () => {},
+  thorough: '',
+  onThoroughChange: () => {},
+};
+
+// Finding #213 — ClientSelector (and ModelSettings) destructures aiCmd without a default;
+// passing undefined throws immediately on `const { value, onApply } = aiCmd`.
+describe('ModelSection — finding #213 (aiCmd undefined)', () => {
+  it('renders without throwing when aiCmd is undefined', () => {
+    expect(() =>
+      render(
+        <ModelSection
+          aiCmd={undefined}
+          models={stubModels}
+          availableClients={[]}
+        />
+      )
+    ).not.toThrow();
+  });
+});
+
+// Finding #214 — ClientSelector checks `availableClients === null` but not undefined,
+// so calling `.filter()` on undefined throws a TypeError.
+describe('ModelSection — finding #214 (availableClients undefined)', () => {
+  it('renders without throwing when availableClients is undefined', () => {
+    const aiCmd = { value: null, onApply: () => {} };
+    expect(() =>
+      render(
+        <ModelSection
+          aiCmd={aiCmd}
+          models={stubModels}
+          availableClients={undefined}
+        />
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -4,6 +4,7 @@ import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
 import { useServerLog } from '../server-log/ServerLogContext.js';
 import { systemKeys } from '../../../api/queryKeys.js';
+import { getHealth } from '../../../api/index.js';
 
 const LOCAL_SERVER_HINT = (
   <>
@@ -13,23 +14,12 @@ const LOCAL_SERVER_HINT = (
 
 const HEALTH_POLL_MS = 10000;
 
-async function ping() {
-  try {
-    const res = await fetch('/api/health?_t=' + Date.now());
-    if (!res.ok) return null;
-    const data = await res.json();
-    return data?.ok ? data : null;
-  } catch {
-    return null;
-  }
-}
-
 export default function ServerSection() {
   const serverLog = useServerLog();
 
   const { data: health, isLoading } = useQuery({
     queryKey: [...systemKeys.health(), 'settings-detail'],
-    queryFn: ping,
+    queryFn: () => getHealth().then((d) => (d?.ok ? d : null)).catch(() => null),
     refetchInterval: HEALTH_POLL_MS,
     refetchOnWindowFocus: false,
   });

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
@@ -37,7 +37,7 @@ describe('ServerSection', () => {
       expect(screen.getByText('7863')).toBeTruthy();
       expect(screen.getByText('1234')).toBeTruthy();
     });
-    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/health'));
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/health'), expect.any(Object));
   });
 
   it('renders offline when /api/health is unreachable', async () => {

--- a/src/quodeq/ui/src/features/settings/components/ServerSection249.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection249.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * Finding #249 – ServerSection must use getHealth() from api/index.js
+ * (which goes through request() with a 30s timeout) instead of the
+ * local ping() function that calls raw fetch with no timeout.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ServerLogContext } from '../server-log/ServerLogContext.js';
+
+// Mock getHealth from api/index.js so we can assert it is called.
+vi.mock('../../../api/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getHealth: vi.fn(),
+  };
+});
+
+import { getHealth } from '../../../api/index.js';
+import ServerSection from './ServerSection.jsx';
+
+const stubServerLog = { open: false, openLog: vi.fn(), closeLog: vi.fn() };
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ServerLogContext.Provider value={stubServerLog}>{children}</ServerLogContext.Provider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('#249 ServerSection uses getHealth() not raw fetch', () => {
+  beforeEach(() => {
+    getHealth.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls getHealth() when polling for server status', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1, version: '1.0.0', address: '127.0.0.1' });
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => expect(getHealth).toHaveBeenCalled());
+  });
+
+  it('does not call raw fetch directly', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1, version: '1.0.0', address: '127.0.0.1' });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+
+    await waitFor(() => expect(getHealth).toHaveBeenCalled());
+    // getHealth is mocked and doesn't call fetch, so fetch should never fire.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows server details when getHealth resolves with ok data', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1234, version: '1.0.6', address: '127.0.0.1' });
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getByText('7863')).toBeTruthy();
+      expect(screen.getByText('1234')).toBeTruthy();
+    });
+  });
+
+  it('shows offline when getHealth rejects', async () => {
+    getHealth.mockRejectedValue(new Error('timeout'));
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Restart/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -41,7 +41,11 @@ function loadProviderState(providerId, overrides, storage = localStorage) {
 }
 
 function saveProviderSetting(providerId, key, value, storage = localStorage) {
-  storage.setItem(providerKey(providerId, key), String(value));
+  try {
+    storage.setItem(providerKey(providerId, key), String(value));
+  } catch (err) {
+    console.warn('[useProviderSettings] Could not persist setting to storage:', err);
+  }
 }
 
 export default function useProviderSettings(providerId, defaults, { storage = localStorage } = {}) {

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useProviderSettings from './useProviderSettings.js';
+
+describe('useProviderSettings', () => {
+  let mockStorage;
+
+  beforeEach(() => {
+    mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads default state when storage returns null', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    expect(result.current.state.model).toBe('');
+    expect(result.current.state.subagents).toBe('1');
+  });
+
+  it('update sets state immediately', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    act(() => {
+      result.current.update('model', 'llama3');
+    });
+    expect(result.current.state.model).toBe('llama3');
+  });
+
+  it('update calls storage.setItem', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    act(() => {
+      result.current.update('model', 'llama3');
+    });
+    expect(mockStorage.setItem).toHaveBeenCalled();
+  });
+
+  it('update does not throw when storage.setItem throws (quota/SecurityError)', () => {
+    // Finding #324: setItem throwing must not crash the hook.
+    mockStorage.setItem.mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+
+    // This must not throw.
+    expect(() => {
+      act(() => {
+        result.current.update('model', 'llama3');
+      });
+    }).not.toThrow();
+
+    // State was still updated in memory even though storage failed.
+    expect(result.current.state.model).toBe('llama3');
+  });
+
+  it('update swallows storage error and warns via console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockStorage.setItem.mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+
+    act(() => {
+      result.current.update('api-key', 'secret');
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
@@ -3,6 +3,7 @@ import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
 import ConsoleLogViewer from '../../evaluation/components/ConsoleLogViewer.jsx';
 import { LlamaCppLogContext } from './LlamaCppLogContext.js';
 import { useLlamaCppLogStream } from './useLlamaCppLogStream.js';
+import { request } from '../../../api/request.js';
 
 const WINDOW_ID = 'llamacpp-log';
 
@@ -33,8 +34,7 @@ export function LlamaCppLogProvider({ children }) {
   // session since the env var is set at server-launch time.
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/llamacpp/logs/available')
-      .then((r) => (r.ok ? r.json() : { available: false }))
+    request('/llamacpp/logs/available')
       .then((data) => {
         if (!cancelled) setAvailable(Boolean(data?.available));
       })

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider588.test.jsx
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider588.test.jsx
@@ -1,0 +1,70 @@
+/**
+ * Finding #588 – LlamaCppLogProvider must use request() (30s timeout)
+ * instead of raw fetch() for the /api/llamacpp/logs/available probe.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+// Mock request so we can detect it is called.
+vi.mock('../../../api/request.js', () => ({
+  BASE: '/api',
+  request: vi.fn(),
+}));
+
+// Mock the SSE stream hook so LlamaCppLogProvider doesn't open EventSource.
+vi.mock('./useLlamaCppLogStream.js', () => ({
+  useLlamaCppLogStream: () => ({ logs: [], status: 'idle' }),
+}));
+
+// Minimal SidePaneContext mock.
+vi.mock('../../side-pane/SidePaneContext.jsx', () => ({
+  useSidePane: () => ({
+    addWindow: vi.fn(),
+    removeWindow: vi.fn(),
+    replaceWindow: vi.fn(),
+    hasWindow: () => false,
+    windows: [],
+  }),
+}));
+
+import { request } from '../../../api/request.js';
+import { LlamaCppLogProvider } from './LlamaCppLogProvider.jsx';
+import { LlamaCppLogContext } from './LlamaCppLogContext.js';
+
+function renderProvider() {
+  const el = (
+    <LlamaCppLogProvider>
+      <span data-testid="child">ok</span>
+    </LlamaCppLogProvider>
+  );
+  return render(el);
+}
+
+describe('#588 LlamaCppLogProvider uses request() for availability probe', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls request() on mount to check availability', async () => {
+    request.mockResolvedValue({ available: true });
+    renderProvider();
+    // Let the effect fire (microtask flush).
+    await act(async () => { await Promise.resolve(); });
+    expect(request).toHaveBeenCalled();
+    const [path] = request.mock.calls[0];
+    expect(path).toContain('/llamacpp/logs/available');
+  });
+
+  it('does not call raw fetch directly', async () => {
+    request.mockResolvedValue({ available: false });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    renderProvider();
+    await act(async () => { await Promise.resolve(); });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -29,6 +29,15 @@ export function SidePane() {
     else delete root.dataset.paneResizing;
   }, []);
 
+  // Holds the cleanup function for the active drag, if any.
+  // Set on pointer-down, cleared on pointer-up or unmount.
+  const activeDragCleanupRef = useRef(null);
+
+  // Run any active drag cleanup on unmount to remove leaked window listeners.
+  useEffect(() => {
+    return () => { activeDragCleanupRef.current?.(); };
+  }, []);
+
   // Outer pane (left-edge) drag — resizes the whole dock width.
   // pointermove can fire 100+ times/sec on a 120Hz trackpad. Coalesce
   // multiple events into one CSS-var write per frame via rAF — same
@@ -56,8 +65,16 @@ export function SidePane() {
       pendingNext = clampSidePaneWidth(startWidth + delta, viewport);
       if (rafId == null) rafId = requestAnimationFrame(apply);
     };
-    const onUp = (ev) => {
+    const cleanup = () => {
       if (rafId != null) cancelAnimationFrame(rafId);
+      setResizingFlag(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      activeDragCleanupRef.current = null;
+    };
+    const onUp = (ev) => {
       const delta = startX - ev.clientX;
       const finalWidth = clampSidePaneWidth(startWidth + delta, window.innerWidth);
       // Write final value to the var immediately so the column doesn't
@@ -65,14 +82,11 @@ export function SidePane() {
       document.documentElement.style.setProperty('--side-pane-width', `${finalWidth}px`);
       setPaneWidth(finalWidth);
       setIsDragging(false);
-      setResizingFlag(false);
-      document.body.style.cursor = prevCursor;
-      document.body.style.userSelect = prevSelect;
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      cleanup();
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    activeDragCleanupRef.current = cleanup;
   }, [paneWidth, setPaneWidth, setResizingFlag]);
 
   // Internal between-window resizer. Mutates the two adjacent slot
@@ -114,22 +128,27 @@ export function SidePane() {
       pendingRatio = Math.min(1 - MIN_WINDOW_RATIO, Math.max(MIN_WINDOW_RATIO, startRatio + delta / span));
       if (rafId == null) rafId = requestAnimationFrame(apply);
     };
-    const onUp = () => {
+    const cleanup = () => {
       if (rafId != null) cancelAnimationFrame(rafId);
+      setResizingFlag(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      activeDragCleanupRef.current = null;
+    };
+    const onUp = () => {
       apply();
       setRatios((prev) => {
         const out = [...prev];
         out[index] = pendingRatio;
         return out;
       });
-      setResizingFlag(false);
-      document.body.style.cursor = prevCursor;
-      document.body.style.userSelect = prevSelect;
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      cleanup();
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    activeDragCleanupRef.current = cleanup;
   }, [ratios, setResizingFlag]);
 
   if (!isOpen) return null;

--- a/src/quodeq/ui/src/features/side-pane/SidePaneDragCleanup.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneDragCleanup.test.jsx
@@ -1,0 +1,75 @@
+/**
+ * Finding #514: SidePane global pointer listeners must be cleaned up on unmount.
+ *
+ * Without the fix, onPointerDown adds pointermove + pointerup to window and
+ * never removes them if the component unmounts mid-drag. This test proves the
+ * listeners are removed when the component unmounts during an active drag.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SidePane } from './SidePane.jsx';
+import { SidePaneProvider } from './SidePaneProvider.jsx';
+import { useSidePane } from './SidePaneContext.jsx';
+
+function spec(id, title = id) {
+  return { id, type: 'report', title, render: () => <p>{`body:${id}`}</p> };
+}
+
+function Adder() {
+  const { addWindow } = useSidePane();
+  return <button onClick={() => addWindow(spec('w1', 'Window 1'))}>add</button>;
+}
+
+describe('SidePane drag cleanup on unmount (#514)', () => {
+  let addEventSpy;
+  let removeEventSpy;
+  let addedListeners;
+  let removedListeners;
+
+  beforeEach(() => {
+    addedListeners = [];
+    removedListeners = [];
+
+    addEventSpy = vi.spyOn(window, 'addEventListener').mockImplementation((type, handler, opts) => {
+      addedListeners.push({ type, handler });
+    });
+    removeEventSpy = vi.spyOn(window, 'removeEventListener').mockImplementation((type, handler) => {
+      removedListeners.push({ type, handler });
+    });
+  });
+
+  afterEach(() => {
+    addEventSpy.mockRestore();
+    removeEventSpy.mockRestore();
+  });
+
+  it('removes window listeners added during pointer-down drag when component unmounts', () => {
+    const { unmount, getByText, getByRole } = render(
+      <SidePaneProvider>
+        <Adder />
+        <SidePane />
+      </SidePaneProvider>
+    );
+
+    // Open the pane.
+    fireEvent.click(getByText('add'));
+
+    // Simulate pointer-down on the outer resize divider (starts the drag,
+    // adds pointermove + pointerup to window).
+    const divider = getByRole('separator', { name: /resize side pane/i });
+    fireEvent.pointerDown(divider, { clientX: 100, preventDefault: () => {} });
+
+    const addedTypes = addedListeners.map((l) => l.type);
+    expect(addedTypes).toContain('pointermove');
+    expect(addedTypes).toContain('pointerup');
+
+    // Unmount mid-drag — listeners must be removed.
+    act(() => { unmount(); });
+
+    const removedTypes = removedListeners.map((l) => l.type);
+    expect(removedTypes).toContain('pointermove');
+    expect(removedTypes).toContain('pointerup');
+  });
+});

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
@@ -33,7 +33,7 @@ function triggerDownload({ filename, body }) {
 class RenderBoundary extends React.Component {
   state = { failed: false };
   static getDerivedStateFromError() { return { failed: true }; }
-  componentDidCatch() { /* swallow — header still works */ }
+  componentDidCatch(error, info) { console.error('[SidePaneWindow] render error:', error, info); }
   componentDidUpdate(prev) {
     if (prev.contentKey !== this.props.contentKey && this.state.failed) {
       this.setState({ failed: false });

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { SidePaneWindow } from './SidePaneWindow.jsx';
@@ -55,5 +55,47 @@ describe('SidePaneWindow', () => {
     render(<SidePaneWindow spec={makeSpec({ download: downloadFn })} onClose={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: /download/i }));
     expect(downloadFn).toHaveBeenCalled();
+  });
+});
+
+describe('RenderBoundary inside SidePaneWindow', () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    // Suppress React's own error boundary console output during the test
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('#454 — componentDidCatch calls console.error with the error and info', async () => {
+    // A child that throws during render
+    function ThrowingChild() {
+      throw new Error('render kaboom');
+    }
+
+    const throwingSpec = {
+      id: 'err-win',
+      type: 'report',
+      title: 'Error Window',
+      render: () => <ThrowingChild />,
+    };
+
+    render(<SidePaneWindow spec={throwingSpec} onClose={() => {}} />);
+
+    // Wait for the deferred body mount (SLIDE_MS = 220ms) so RenderBoundary renders
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to render report/i)).toBeInTheDocument();
+    }, { timeout: 1000 });
+
+    // console.error must have been called by componentDidCatch (not just React internals)
+    const boundaryCall = consoleErrorSpy.mock.calls.find(
+      (args) => typeof args[0] === 'string' && args[0].includes('[SidePaneWindow]')
+    );
+    expect(boundaryCall).toBeDefined();
+    expect(boundaryCall[0]).toContain('[SidePaneWindow] render error:');
+    expect(boundaryCall[1]).toBeInstanceOf(Error);
   });
 });

--- a/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
@@ -139,6 +139,7 @@ function isDeletableStandard(type) {
 function StandardRow({ standard, isVisible, onEdit, onDelete, onDuplicate, onToggleVisibility }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+  const [downloadError, setDownloadError] = useState(null);
   const principleCount = standard.principleCount ?? standard.principles?.length ?? 0;
   const requirementCount = standard.requirementCount ?? (standard.principles || []).reduce((sum, p) => sum + (p.requirements?.length ?? 0), 0);
   const isDeletable = isDeletableStandard(standard.type);
@@ -173,11 +174,21 @@ function StandardRow({ standard, isVisible, onEdit, onDelete, onDuplicate, onTog
             isEditable={isDeletable}
             onOpen={() => onEdit(standard.id)}
             onDuplicate={() => setShowDuplicateModal(true)}
-            onDownload={() => downloadStandard(standard.id)}
+            onDownload={() => {
+              setDownloadError(null);
+              downloadStandard(standard.id).catch((err) => {
+                setDownloadError(err?.message || 'Download failed');
+              });
+            }}
             onDelete={() => setShowDeleteModal(true)}
           />
         </div>
       </div>
+      {downloadError && (
+        <div role="alert" className="standards-row-error">
+          Could not download standard: {downloadError}
+        </div>
+      )}
       {showDeleteModal && (
         <ConfirmDeleteModal
           standardName={standard.name}

--- a/src/quodeq/ui/src/features/standards/components/StandardsTable.test.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsTable.test.jsx
@@ -1,0 +1,83 @@
+/**
+ * Finding #500: downloadStandard rejection must be handled -- no unhandled rejection,
+ * error surfaced to user.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+// Mock the api module before importing the component.
+vi.mock('../../../api/index.js', () => ({
+  exportStandard: vi.fn(),
+}));
+
+import { exportStandard } from '../../../api/index.js';
+import StandardsTable from './StandardsTable.jsx';
+
+const STANDARD = {
+  id: 'my-std',
+  name: 'My Standard',
+  type: 'custom',
+  description: 'desc',
+  principleCount: 1,
+  requirementCount: 2,
+};
+
+const actions = {
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  onDuplicate: vi.fn(),
+  isVisible: () => true,
+  onToggleVisibility: vi.fn(),
+};
+
+describe('StandardsTable download error handling (#500)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not produce an unhandled promise rejection when download fails', async () => {
+    // Track unhandled rejections.
+    const unhandledErrors = [];
+    const handler = (event) => {
+      unhandledErrors.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', handler);
+
+    exportStandard.mockRejectedValue(new Error('network error'));
+
+    render(<StandardsTable grouped={{ custom: [STANDARD] }} actions={actions} />);
+
+    const downloadBtn = screen.getByRole('button', { name: /download my standard/i });
+    fireEvent.click(downloadBtn);
+
+    // Give the promise rejection a chance to propagate.
+    await new Promise((r) => setTimeout(r, 50));
+
+    window.removeEventListener('unhandledrejection', handler);
+
+    expect(unhandledErrors).toHaveLength(0);
+  });
+
+  it('surfaces the download error to the user when download fails', async () => {
+    exportStandard.mockRejectedValue(new Error('network error'));
+
+    render(<StandardsTable grouped={{ custom: [STANDARD] }} actions={actions} />);
+
+    const downloadBtn = screen.getByRole('button', { name: /download my standard/i });
+    fireEvent.click(downloadBtn);
+
+    // An error indicator (role="alert", aria-live, or error text) must appear.
+    await waitFor(() => {
+      const alert = document.querySelector('[role="alert"], [aria-live="assertive"], [aria-live="polite"]');
+      const errorText = screen.queryByText(/error|failed|could not/i);
+      expect(alert || errorText).not.toBeNull();
+    }, { timeout: 2000 });
+  });
+});

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -30,11 +30,9 @@ function handlePopState(e, setNavStack) {
 
 function createNavActions(setNavStack, navStackRef, history) {
   function navPush(entry) {
-    setNavStack((prev) => {
-      const next = [...prev, entry];
-      history.pushState({ navIndex: next.length - 1, entry }, '');
-      return next;
-    });
+    const next = [...navStackRef.current, entry];
+    setNavStack(next);
+    history.pushState({ navIndex: next.length - 1, entry }, '');
   }
 
   function navPop() {
@@ -47,20 +45,18 @@ function createNavActions(setNavStack, navStackRef, history) {
   }
 
   function navReset() {
-    setNavStack((prev) => {
-      const stepsBack = prev.length - 1;
-      if (stepsBack > 0) history.go(-stepsBack);
-      return [{ page: DEFAULT_PAGE }];
-    });
+    const stepsBack = navStackRef.current.length - 1;
+    setNavStack([{ page: DEFAULT_PAGE }]);
+    if (stepsBack > 0) history.go(-stepsBack);
   }
 
   function navTab(page) {
-    setNavStack((prev) => {
-      const stepsBack = prev.length - 1;
-      if (stepsBack > 0) history.go(-stepsBack);
-      const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
-      return [{ page, _tabKey: prevKey + 1 }];
-    });
+    const prev = navStackRef.current;
+    const stepsBack = prev.length - 1;
+    const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
+    const next = [{ page, _tabKey: prevKey + 1 }];
+    setNavStack(next);
+    if (stepsBack > 0) history.go(-stepsBack);
   }
 
   return { navPush, navPop, navGoTo, navReset, navTab };

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -1,0 +1,212 @@
+/**
+ * Finding #363: history.pushState inside setNavStack updater is a side effect
+ * that React may double-invoke in Strict Mode. The updater must be pure.
+ *
+ * Fix: compute next from the ref, call setNavStack(next) + history.pushState
+ * as two sequential statements outside the updater.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNavStack } from './useNavStack.js';
+
+/**
+ * React Strict Mode double-invokes state updaters to catch side effects.
+ * Wrap the hook in StrictMode to reproduce the double-invocation.
+ */
+function strictWrapper({ children }) {
+  return <React.StrictMode>{children}</React.StrictMode>;
+}
+
+describe('useNavStack navPush purity (#363)', () => {
+  let pushStateCalls;
+  let historyAdapter;
+
+  beforeEach(() => {
+    pushStateCalls = [];
+    historyAdapter = {
+      pushState: vi.fn((...args) => pushStateCalls.push(args)),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.pushState exactly once per navPush call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // React StrictMode double-invokes the updater fn passed to setState.
+    // If pushState is inside the updater, it fires twice.
+    act(() => {
+      result.current.navPush({ page: 'settings' });
+    });
+
+    // Must be exactly 1, even under double-invoke.
+    expect(pushStateCalls).toHaveLength(1);
+  });
+
+  it('navStack grows by exactly one entry per navPush in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    const initialLength = result.current.navStack.length;
+
+    act(() => { result.current.navPush({ page: 'project' }); });
+    expect(result.current.navStack).toHaveLength(initialLength + 1);
+
+    act(() => { result.current.navPush({ page: 'detail' }); });
+    expect(result.current.navStack).toHaveLength(initialLength + 2);
+
+    // 2 pushes = 2 pushState calls. In buggy code, double-invoke gives 4.
+    expect(pushStateCalls).toHaveLength(2);
+  });
+});
+
+/**
+ * Finding #363 follow-up: navReset and navTab had the identical bug —
+ * history.go() called inside the setNavStack updater, causing double-fire
+ * under React Strict Mode's double-invocation.
+ *
+ * Fix: read stepsBack from navStackRef.current before calling setNavStack,
+ * then call history.go() as a separate statement outside the updater.
+ */
+describe('useNavStack navReset purity (#363 follow-up)', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.go exactly once per navReset call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Push two entries so navReset has history entries to go back through.
+    act(() => { result.current.navPush({ page: 'a' }); });
+    act(() => { result.current.navPush({ page: 'b' }); });
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navReset(); });
+
+    // Must be exactly 1, not 2 from double-invoke.
+    expect(historyAdapter.go).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.go).toHaveBeenCalledWith(-2);
+  });
+
+  it('resets navStack to single default entry in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navReset(); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('overview');
+  });
+
+  it('does not call history.go when stack is already at root', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navReset(); });
+
+    expect(historyAdapter.go).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavStack navTab purity (#363 follow-up)', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.go exactly once per navTab call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Push entries so there is history to go back through.
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navPush({ page: 'detail' }); });
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navTab('projects'); });
+
+    // Must be exactly 1, not 2 from double-invoke.
+    expect(historyAdapter.go).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.go).toHaveBeenCalledWith(-2);
+  });
+
+  it('resets navStack to single tab entry in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navTab('projects'); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('projects');
+  });
+
+  it('increments _tabKey when navigating to the same tab', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Start at 'overview' (the default). Navigate to the same tab.
+    const initialKey = result.current.navStack[0]._tabKey || 0;
+    act(() => { result.current.navTab('overview'); });
+
+    expect(result.current.navStack[0]._tabKey).toBe(initialKey + 1);
+  });
+
+  it('does not call history.go when stack is already at root', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navTab('projects'); });
+
+    expect(historyAdapter.go).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/utils/clipboard.js
+++ b/src/quodeq/ui/src/utils/clipboard.js
@@ -5,7 +5,7 @@
  * @param {string} text
  */
 export function copyToClipboard(text) {
-  return navigator.clipboard.writeText(text).catch((err) =>
+  return navigator.clipboard?.writeText(text)?.catch((err) =>
     console.warn('Clipboard write failed:', err)
-  );
+  ) ?? Promise.resolve();
 }

--- a/src/quodeq/ui/src/utils/clipboard.test.jsx
+++ b/src/quodeq/ui/src/utils/clipboard.test.jsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { copyToClipboard } from './clipboard.js';
+
+describe('copyToClipboard', () => {
+  it('no-ops without throwing when clipboard is unavailable', async () => {
+    const orig = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    await expect(copyToClipboard('x')).resolves.toBeUndefined();
+    Object.defineProperty(navigator, 'clipboard', { value: orig, configurable: true });
+  });
+});

--- a/tests/analysis/cache/test_failure_streak_oserror.py
+++ b/tests/analysis/cache/test_failure_streak_oserror.py
@@ -1,0 +1,71 @@
+"""Tests for _failure_streak.py — OSError handling in _scan_once."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.shared import cancellation
+from quodeq.analysis.cache._failure_streak import FailureStreakWatcher
+
+
+def _append(jsonl: Path, line: dict) -> None:
+    with jsonl.open("a") as f:
+        f.write(json.dumps(line) + "\n")
+
+
+def _enable_propagation():
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+class TestScanOnceOSError:
+    def test_permission_error_returns_unchanged_state_and_logs_warning(
+        self, tmp_path: Path, caplog
+    ):
+        """#377 — PermissionError (OSError subclass) on open must log WARNING and
+        return the unchanged (offset, streak, recent) state, not only catch FileNotFoundError."""
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+
+        watcher = FailureStreakWatcher(jsonl, threshold=10)
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch.object(
+                Path, "open", side_effect=PermissionError("access denied")
+            ):
+                with caplog.at_level(
+                    logging.WARNING, logger="quodeq.analysis.cache._failure_streak"
+                ):
+                    offset, streak, recent = watcher._scan_once(0, 3, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        # State is unchanged
+        assert offset == 0
+        assert streak == 3
+        assert recent == []
+        # Warning was logged
+        assert "Could not read failure-streak JSONL" in caplog.text
+
+    def test_filenot_found_still_returns_unchanged_state(self, tmp_path: Path):
+        """FileNotFoundError (already handled) still returns unchanged state."""
+        jsonl = tmp_path / "missing.jsonl"
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        offset, streak, recent = watcher._scan_once(99, 2, [])
+        assert offset == 99
+        assert streak == 2
+        assert recent == []

--- a/tests/analysis/mcp/test_handlers_marker.py
+++ b/tests/analysis/mcp/test_handlers_marker.py
@@ -4,6 +4,37 @@ from unittest.mock import MagicMock
 from quodeq.analysis.mcp.handlers import handle_tools_list, handle_tools_call
 
 
+# ---------------------------------------------------------------------------
+# #207 — null 'arguments' in params must be treated as {} (not raise TypeError)
+# ---------------------------------------------------------------------------
+
+class TestToolsCallNullArguments:
+    def test_null_arguments_for_report_finding_does_not_raise(self) -> None:
+        """params.arguments = null must not crash handle_tools_call."""
+        router = MagicMock()
+        router.receive.return_value = ("ok", False)
+        # Simulate a JSON-RPC caller that sends {"arguments": null}
+        result = handle_tools_call(
+            request_id=1,
+            params={"name": "report_finding", "arguments": None},
+            router=router,
+        )
+        # Should return a valid ok-response (not a 500/AttributeError)
+        assert "result" in result
+        router.receive.assert_called_once_with({})
+
+    def test_missing_arguments_key_still_works(self) -> None:
+        router = MagicMock()
+        router.receive.return_value = ("ok", False)
+        result = handle_tools_call(
+            request_id=2,
+            params={"name": "report_finding"},
+            router=router,
+        )
+        assert "result" in result
+        router.receive.assert_called_once_with({})
+
+
 class TestToolsListIncludesMarker:
     def test_marker_listed(self):
         result = handle_tools_list(request_id=1, has_queue=True)

--- a/tests/analysis/subagents/test_priority_fan_in_stem_collision.py
+++ b/tests/analysis/subagents/test_priority_fan_in_stem_collision.py
@@ -1,0 +1,103 @@
+"""Tests for stem-collision dedup in compute_fan_in (finding #522).
+
+When two files share the same stem (e.g. a/util.py and b/util.py) the original
+setdefault(stem, path) map kept only the FIRST; the second was silently dropped
+from import-target resolution, giving it a permanent fan-in of zero.
+
+Fix: the map value is now a list/set of all paths sharing a stem; the resolution
+consumer checks all candidates and returns the one that matches.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from quodeq.analysis.subagents.priority_fan_in import compute_fan_in
+
+
+class TestStemCollisionDedup:
+    """Both files with the same stem must be resolvable as import targets."""
+
+    def test_both_stems_counted_when_different_dirs(self, tmp_path: Path) -> None:
+        """a/util.py and b/util.py both get fan-in credit when imported."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        # importer_a imports from a/util
+        (tmp_path / "importer_a.py").write_text("from a.util import something\n")
+        # importer_b imports from b/util
+        (tmp_path / "importer_b.py").write_text("from b.util import other\n")
+        (tmp_path / "a" / "util.py").write_text("# util in a\n")
+        (tmp_path / "b" / "util.py").write_text("# util in b\n")
+
+        files = [
+            "importer_a.py",
+            "importer_b.py",
+            "a/util.py",
+            "b/util.py",
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        # Both util files must appear with non-zero fan-in, not just the first one
+        a_util = fan_in.get("a/util.py", 0)
+        b_util = fan_in.get("b/util.py", 0)
+        assert a_util >= 1, (
+            f"a/util.py has fan-in {a_util}; stem-collision dropped it (got {fan_in})"
+        )
+        assert b_util >= 1, (
+            f"b/util.py has fan-in {b_util}; stem-collision dropped it (got {fan_in})"
+        )
+
+    def test_second_registered_stem_not_silently_dropped(self, tmp_path: Path) -> None:
+        """The file registered SECOND for a given stem must not be zero-count
+        when it is the only file being imported under that stem."""
+        (tmp_path / "x").mkdir()
+        (tmp_path / "y").mkdir()
+        # Only y/models is imported; x/models is never referenced.
+        (tmp_path / "main.py").write_text("from y.models import Foo\n")
+        (tmp_path / "x" / "models.py").write_text("")
+        (tmp_path / "y" / "models.py").write_text("")
+
+        files = [
+            "main.py",
+            "x/models.py",  # registered first — old bug would keep only this
+            "y/models.py",  # registered second — old bug dropped this
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        y_models = fan_in.get("y/models.py", 0)
+        assert y_models >= 1, (
+            f"y/models.py (registered second) has fan-in {y_models}; "
+            f"stem-collision dedup is not working (got {fan_in})"
+        )
+
+    def test_unique_stems_unaffected(self, tmp_path: Path) -> None:
+        """Files with unique stems continue to work correctly after the fix."""
+        (tmp_path / "main.py").write_text("import auth\nfrom utils import helper\n")
+        (tmp_path / "auth.py").write_text("")
+        (tmp_path / "utils.py").write_text("")
+
+        files = ["main.py", "auth.py", "utils.py"]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        assert fan_in.get("auth.py", 0) >= 1
+        assert fan_in.get("utils.py", 0) >= 1
+
+    def test_three_way_stem_collision(self, tmp_path: Path) -> None:
+        """Three files with the same stem across three directories all get credit."""
+        for d in ("p1", "p2", "p3"):
+            (tmp_path / d).mkdir()
+        (tmp_path / "use_p1.py").write_text("from p1.helpers import foo\n")
+        (tmp_path / "use_p2.py").write_text("from p2.helpers import bar\n")
+        (tmp_path / "use_p3.py").write_text("from p3.helpers import baz\n")
+        for d in ("p1", "p2", "p3"):
+            (tmp_path / d / "helpers.py").write_text("")
+
+        files = [
+            "use_p1.py", "use_p2.py", "use_p3.py",
+            "p1/helpers.py", "p2/helpers.py", "p3/helpers.py",
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+        for path in ("p1/helpers.py", "p2/helpers.py", "p3/helpers.py"):
+            assert fan_in.get(path, 0) >= 1, (
+                f"{path} has fan-in {fan_in.get(path, 0)} — stem-collision fix incomplete"
+            )

--- a/tests/analysis/test_analysis_context_coverage.py
+++ b/tests/analysis/test_analysis_context_coverage.py
@@ -1,0 +1,66 @@
+"""Tests for _analysis_context.py — error logging in _load_custom_dimensions."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._analysis_context import _load_custom_dimensions
+
+
+def _enable_propagation():
+    """Return the quodeq logger with propagate=True (restored by caller)."""
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+class TestLoadCustomDimensions:
+    def test_valid_json_files_are_included(self, tmp_path: Path):
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "custom.json").write_text(json.dumps({"id": "custom-dim"}), encoding="utf-8")
+        result = _load_custom_dimensions(ev, ["existing"])
+        assert "custom-dim" in result
+
+    def test_oserror_reading_file_logs_warning_and_skips(self, tmp_path: Path, monkeypatch, caplog):
+        """#538 — OSError while reading evaluator file must be logged, not swallowed."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        bad_file = ev / "broken.json"
+        bad_file.write_text("{}", encoding="utf-8")
+
+        def _bad_read_text(self, *args, **kwargs):
+            raise OSError("read error")
+
+        monkeypatch.setattr(Path, "read_text", _bad_read_text)
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == []
+        assert "Skipping custom evaluator" in caplog.text
+        assert "broken.json" in caplog.text
+
+    def test_invalid_json_logs_warning_and_skips(self, tmp_path: Path, caplog):
+        """#538 — ValueError (bad JSON) must be logged, not swallowed."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "malformed.json").write_text("NOT JSON", encoding="utf-8")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == []
+        assert "Skipping custom evaluator" in caplog.text
+        assert "malformed.json" in caplog.text

--- a/tests/analysis/test_prompt_builder_logging.py
+++ b/tests/analysis/test_prompt_builder_logging.py
@@ -1,0 +1,62 @@
+"""Tests for builder.py — _load_evaluation_rules logs on template load failure."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis.prompts.builder import _load_evaluation_rules
+
+
+def _enable_propagation():
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+class TestLoadEvaluationRulesLogging:
+    def test_oserror_loading_template_logs_warning(self, caplog):
+        """#157 — OSError on template load must be logged before continuing."""
+
+        def _bad_load(template_name):
+            raise OSError(f"Cannot read {template_name}")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch(
+                "quodeq.analysis.prompts.builder.load_template", side_effect=_bad_load
+            ):
+                with caplog.at_level(logging.WARNING, logger="quodeq.analysis.prompts.builder"):
+                    result = _load_evaluation_rules()
+        finally:
+            quodeq_logger.propagate = orig
+
+        # Result is empty (both templates failed) — safe fallback preserved
+        assert result == ""
+        assert "Failed to load prompt template" in caplog.text
+
+    def test_returns_content_when_one_template_loads(self, caplog):
+        """#157 — partial load still returns the available template content."""
+        call_count = [0]
+
+        def _partial_load(template_name):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError("missing first file")
+            return "format rules"
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch(
+                "quodeq.analysis.prompts.builder.load_template", side_effect=_partial_load
+            ):
+                with caplog.at_level(logging.WARNING, logger="quodeq.analysis.prompts.builder"):
+                    result = _load_evaluation_rules()
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == "format rules"
+        assert "Failed to load prompt template" in caplog.text

--- a/tests/analysis/test_stream_validation_nondict.py
+++ b/tests/analysis/test_stream_validation_nondict.py
@@ -1,0 +1,38 @@
+"""#176 — get_mcp_status must not raise when json.loads returns a non-dict."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+
+class TestGetMcpStatusNonDict:
+    def _write_stream(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "stream.json"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_list_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, json.dumps([1, 2, 3]) + "\n")
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_string_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, '"just a string"\n')
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_null_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, "null\n")
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_valid_dict_still_works(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        payload = {"mcp_servers": [{"name": "findings", "status": "ok"}]}
+        p = self._write_stream(tmp_path, json.dumps(payload) + "\n")
+        result = get_mcp_status(p)
+        assert result == "ok"

--- a/tests/api/test_cluster4_index_error.py
+++ b/tests/api/test_cluster4_index_error.py
@@ -1,0 +1,38 @@
+"""Finding #523 — /api/index/rebuild must return structured JSON 500 on failure.
+
+When provider.rebuild_index() raises, the route previously let the exception
+propagate as a plain 500. After the fix it must return
+{"error": ..., "code": "INTERNAL_ERROR"} with status 500.
+"""
+from __future__ import annotations
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path / "reports"))
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    broken_provider = MagicMock()
+    broken_provider.rebuild_index.side_effect = RuntimeError("index exploded")
+    # Pass provider directly so create_app stores it in app.config["_provider"];
+    # passing via test_config is overwritten by the provider= assignment in app.py.
+    app = create_app(provider=broken_provider, test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_rebuild_index_returns_json_500_on_unexpected_error(client):
+    """rebuild_index() raising must yield a structured JSON 500, not a bare exception."""
+    resp = client.post("/api/index/rebuild", headers={"Origin": "http://localhost"})
+
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    data = resp.get_json()
+    assert data is not None, "Response body must be JSON"
+    assert "error" in data
+    assert "code" in data

--- a/tests/api/test_cluster4_scores_error.py
+++ b/tests/api/test_cluster4_scores_error.py
@@ -1,0 +1,34 @@
+"""Finding #441 — /api/projects/<project>/scores route must return structured JSON 500.
+
+When get_project_scores raises an unexpected exception the route previously
+propagated it as a plain 500 with no JSON body. After the fix it must return
+{"error": ..., "code": "INTERNAL_ERROR"} with status 500.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path / "reports"))
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_project_scores_returns_json_500_on_unexpected_error(client, monkeypatch):
+    """get_project_scores raising must yield a structured JSON 500, not a bare exception."""
+    import quodeq.api._scores_routes as scores_mod
+
+    monkeypatch.setattr(scores_mod, "get_project_scores", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("db exploded")))
+
+    resp = client.get("/api/projects/myproject/scores")
+
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data is not None, "Response body must be JSON"
+    assert "error" in data
+    assert "code" in data

--- a/tests/api/test_cwe_cache_lock.py
+++ b/tests/api/test_cwe_cache_lock.py
@@ -1,0 +1,77 @@
+"""Test that concurrent CWE cache expiry triggers exactly ONE reload (finding #235)."""
+from __future__ import annotations
+
+import threading
+import time as _time
+
+import pytest
+
+import quodeq.api.standards_read_routes as _mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _mod.reset_cwe_cache()
+    yield
+    _mod.reset_cwe_cache()
+
+
+def test_reload_cwe_if_needed_exists():
+    """_reload_cwe_if_needed must exist as the synchronized reload helper."""
+    assert callable(_mod._reload_cwe_if_needed)
+
+
+def test_concurrent_expiry_reloads_exactly_once():
+    """Two threads racing at cache expiry must trigger exactly one loader call.
+
+    Strategy: force cache expiry, then release both threads simultaneously
+    using an event so both see the stale cache and race to reload.
+    The lock inside _reload_cwe_if_needed must ensure only one reload happens.
+    """
+    call_count = 0
+    # Slow down the loader so the second thread genuinely races.
+    slow_start = threading.Event()
+    load_started = threading.Event()
+
+    def _loader():
+        nonlocal call_count
+        load_started.set()        # signal that loading has begun
+        slow_start.wait(timeout=5)  # wait for test harness to let it proceed
+        call_count += 1
+        return [{"id": "CWE-79", "name": "XSS"}]
+
+    # Force expiry.
+    _mod._cwe_cache = None
+    _mod._cwe_cache_time = 0.0
+
+    results = []
+    errors = []
+
+    start_gate = threading.Barrier(3)  # main + 2 worker threads
+
+    def _thread():
+        try:
+            start_gate.wait(timeout=5)  # all three release together
+            result = _mod._reload_cwe_if_needed(_loader)
+            results.append(result)
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_thread)
+    t2 = threading.Thread(target=_thread)
+    t1.start()
+    t2.start()
+
+    # Release all three (main + 2 workers) simultaneously.
+    start_gate.wait(timeout=5)
+    # Let the loader proceed after threads are racing.
+    slow_start.set()
+
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert call_count == 1, f"Expected exactly 1 reload, got {call_count}"
+    assert len(results) == 2
+    # Both threads must see the same cached result.
+    assert results[0] == results[1] == [{"id": "CWE-79", "name": "XSS"}]

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -96,3 +96,55 @@ class TestKnownModels:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "claude" in data
+
+
+# ---------------------------------------------------------------------------
+# #335 — estimate-agents must return 400 when model_size/gpu_memory are
+#         non-numeric (e.g. strings from a crafted JSON body)
+# ---------------------------------------------------------------------------
+
+class TestEstimateAgentsValidation:
+    def test_string_model_size_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": "big", "gpu_memory": 32},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_string_gpu_memory_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": 7, "gpu_memory": "all"},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_null_model_size_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": None, "gpu_memory": 32},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_valid_numeric_inputs_pass_through(self, client):
+        with patch("quodeq.api.llm_bridge_routes.estimate_max_agents") as mock:
+            mock.return_value = {"agents": 3}
+            resp = client.post(
+                "/api/ollama/estimate-agents",
+                json={"model_size": 7, "gpu_memory": 32},
+                headers={"Origin": "http://localhost"},
+            )
+        assert resp.status_code == 200
+        mock.assert_called_once_with(model_size=7, gpu_memory=32)
+
+    def test_bool_model_size_returns_400(self, client):
+        # bool is a subclass of int in Python; must be rejected explicitly.
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": True, "gpu_memory": 32000000000},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"

--- a/tests/ci/test_evidence_reader.py
+++ b/tests/ci/test_evidence_reader.py
@@ -60,3 +60,33 @@ def test_skips_malformed_lines(tmp_path: Path) -> None:
     result = load_violations_from_evidence(evidence_dir)
     assert len(result) == 1
     assert result[0]["file"] == "x.py"
+
+
+# ---------------------------------------------------------------------------
+# #448 — int(line) must not raise ValueError on non-integer line values
+# ---------------------------------------------------------------------------
+
+def test_non_integer_line_value_is_skipped_gracefully(tmp_path: Path) -> None:
+    """A violation with a non-integer 'line' value must not crash the reader."""
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    rows = [
+        # non-integer line — should be dropped (None) or coerced gracefully
+        {"p": "SEC", "t": "violation", "d": "security", "file": "a.py", "line": "not-a-number"},
+        # valid row without 'line' — should survive
+        {"p": "SEC", "t": "violation", "d": "security", "file": "b.py"},
+        # valid row with integer line — should survive
+        {"p": "SEC", "t": "violation", "d": "security", "file": "c.py", "line": 5},
+    ]
+    import json as _json
+    (evidence_dir / "security_evidence.jsonl").write_text(
+        "\n".join(_json.dumps(r) for r in rows) + "\n"
+    )
+    result = load_violations_from_evidence(evidence_dir)
+    files = {v["file"] for v in result}
+    assert "c.py" in files
+    assert "b.py" in files
+    # The non-integer line row must not raise; it may be skipped or have no 'line' key
+    for v in result:
+        if v.get("file") == "a.py":
+            assert "line" not in v or isinstance(v["line"], int)

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -1,6 +1,43 @@
 """Tests for list_runs() run discovery and status detection."""
+import json
 import os
 from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# #144 — _read_run_status must not raise when status.json parses to a non-dict
+# ---------------------------------------------------------------------------
+
+class TestReadRunStatusNonDict:
+    def _make_run(self, tmp_path: Path, run_id: str) -> Path:
+        run_dir = tmp_path / "proj" / run_id
+        (run_dir / "evidence").mkdir(parents=True)
+        (run_dir / "evidence" / "manifest.json").write_text("{}")
+        return run_dir
+
+    def test_list_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-list")
+        (run_dir / "status.json").write_text(json.dumps([1, 2, 3]))
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
+
+    def test_string_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-string")
+        (run_dir / "status.json").write_text('"cancelled"')
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
+
+    def test_null_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-null")
+        (run_dir / "status.json").write_text("null")
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
 
 
 def test_list_runs_marks_in_progress_when_pid_is_live(tmp_path: Path) -> None:

--- a/tests/data/projection/test_engine_except_breadth.py
+++ b/tests/data/projection/test_engine_except_breadth.py
@@ -1,0 +1,60 @@
+"""Tests for engine.py — except breadth narrowing (#528).
+
+The handler's broad `except Exception` must be narrowed to
+`(ValueError, KeyError, TypeError)` so OS/SQLite errors surface instead of
+being silently logged and skipped.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.data.projection.engine import ProjectionEngine
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+
+
+def _write_one_event(log: Path) -> None:
+    writer = EventLogWriter(log)
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="f.py", line=1, reason="r",
+    )))
+
+
+class TestProjectionEngineExceptBreadth:
+    def test_value_error_in_handler_is_caught_and_logged(self, tmp_path: Path, caplog):
+        """ValueError from a handler is swallowed and the next event proceeds."""
+        import logging
+        log = tmp_path / "events.jsonl"
+        _write_one_event(log)
+        engine = ProjectionEngine()
+
+        with patch("quodeq.data.projection.engine.handle", side_effect=ValueError("bad value")):
+            import logging as _logging
+            qlog = _logging.getLogger("quodeq")
+            orig = qlog.propagate
+            qlog.propagate = True
+            try:
+                with caplog.at_level(logging.ERROR, logger="quodeq.data.projection.engine"):
+                    count = engine.rebuild(log, tmp_path)
+            finally:
+                qlog.propagate = orig
+
+        # Event was attempted but failed; count = 0 (skipped)
+        assert count == 0
+        assert "Handler failed" in caplog.text
+
+    def test_os_error_in_handler_propagates(self, tmp_path: Path):
+        """#528 — OSError must NOT be swallowed by the narrowed except clause."""
+        log = tmp_path / "events.jsonl"
+        _write_one_event(log)
+        engine = ProjectionEngine()
+
+        with patch(
+            "quodeq.data.projection.engine.handle", side_effect=OSError("disk gone")
+        ):
+            with pytest.raises(OSError, match="disk gone"):
+                engine.rebuild(log, tmp_path)

--- a/tests/data/test_cluster4_engine_continue_on_error.py
+++ b/tests/data/test_cluster4_engine_continue_on_error.py
@@ -1,0 +1,107 @@
+"""Finding #355 — update_actions must continue past a failing handler.
+
+When one event's handle() call raises, update_actions previously let the
+exception bubble up and abort the loop. After the fix the bad event is
+logged and skipped; subsequent events are still processed.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.core.events.models import (
+    BaseEvent,
+    EventType,
+    JudgmentCreatedEvent,
+    JudgmentPayload,
+)
+from quodeq.data.projection.engine import ProjectionEngine
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def _good_event() -> JudgmentCreatedEvent:
+    return JudgmentCreatedEvent(
+        payload=JudgmentPayload(
+            practice_id="P1", verdict="violation", dimension="Security",
+            file="f.py", line=1, reason="r",
+        )
+    )
+
+
+class _BadEvent:
+    """Minimal event stub whose event_type is registered so handle() calls a real handler."""
+    event_type = EventType.JUDGMENT_CREATED
+    event_id = "bad-event-id"
+    timestamp = None
+    payload = None  # will cause handler to raise when it tries payload.practice_id etc.
+
+
+def test_update_actions_continues_after_handler_error(tmp_path: Path, caplog):
+    """A handler error must not abort the loop; later events must still be processed."""
+    actions_log = tmp_path / "actions.jsonl"
+    actions_log.write_text("")  # create file so stat() works
+
+    good_event = _good_event()
+
+    # Patch read_action_events to yield [bad, good] so we can assert the good
+    # one is still processed despite the bad one raising.
+    events_to_yield = [_BadEvent(), good_event]
+
+    engine = ProjectionEngine()
+    store = MagicMock(spec=SQLiteStateStore)
+    store.get_actions_projected_size.return_value = None
+
+    call_args_list = []
+
+    def fake_handle(event, s):
+        call_args_list.append(event)
+        if isinstance(event, _BadEvent):
+            raise ValueError("handler exploded on bad event")
+        # For the good event, just return normally.
+
+    # The quodeq root logger has propagate=False (shared/logging.py), so caplog
+    # won't capture it via the normal propagation path. Add its handler directly.
+    quodeq_logger = logging.getLogger("quodeq")
+    quodeq_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.ERROR):
+            with (
+                patch("quodeq.data.actions_log.read_action_events", return_value=iter(events_to_yield)),
+                patch("quodeq.data.projection.engine.SQLiteStateStore", return_value=store),
+                patch("quodeq.data.projection.engine.handle", side_effect=fake_handle),
+            ):
+                applied = engine.update_actions(actions_log, tmp_path, force=True)
+    finally:
+        quodeq_logger.removeHandler(caplog.handler)
+
+    # The good event must have been processed.
+    assert applied == 1, f"Expected 1 applied (good event), got {applied}"
+    # Both events were attempted.
+    assert len(call_args_list) == 2
+    # An error must have been logged for the bad event.
+    assert any(r.levelno >= logging.ERROR for r in caplog.records), (
+        f"Expected an ERROR log for the failing handler, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_update_actions_does_not_abort_on_error(tmp_path: Path):
+    """update_actions must not raise when a handler fails; it returns a count of successes."""
+    actions_log = tmp_path / "actions.jsonl"
+    actions_log.write_text("")
+
+    def always_raise(event, store):
+        raise RuntimeError("boom")
+
+    engine = ProjectionEngine()
+    with (
+        patch("quodeq.data.actions_log.read_action_events", return_value=iter([_BadEvent(), _BadEvent()])),
+        patch("quodeq.data.projection.engine.SQLiteStateStore", return_value=MagicMock(spec=SQLiteStateStore, get_actions_projected_size=MagicMock(return_value=None))),
+        patch("quodeq.data.projection.engine.handle", side_effect=always_raise),
+    ):
+        # Must not raise — returns 0 successes.
+        result = engine.update_actions(actions_log, tmp_path, force=True)
+
+    assert result == 0

--- a/tests/data/test_grade_projector_atomicity.py
+++ b/tests/data/test_grade_projector_atomicity.py
@@ -1,0 +1,101 @@
+"""Test that batch_rewrite_grades is atomic (finding #257).
+
+A mid-batch failure must leave pre-existing grade rows intact --
+not clear them and leave the table empty/half-written.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def _seed_existing_grades(run_dir: Path) -> None:
+    """Write two principle_grades and one dimension_scores row as pre-existing data."""
+    store = SQLiteStateStore(run_dir)
+    store.record_principle_grade(
+        dimension="Security",
+        principle_id="P1",
+        score=8.0,
+        grade="Good",
+        finding_count=1,
+        dismissed_count=0,
+    )
+    store.record_principle_grade(
+        dimension="Security",
+        principle_id="P2",
+        score=6.0,
+        grade="Adequate",
+        finding_count=2,
+        dismissed_count=0,
+    )
+    store.record_dimension_score(dimension="Security", score=7.0, grade="Good")
+
+
+def test_batch_rewrite_grades_method_exists(tmp_path: Path):
+    """SQLiteStateStore must expose batch_rewrite_grades."""
+    store = SQLiteStateStore(tmp_path)
+    assert hasattr(store, "batch_rewrite_grades"), (
+        "SQLiteStateStore is missing batch_rewrite_grades"
+    )
+    assert callable(store.batch_rewrite_grades)
+
+
+def test_batch_rewrite_rolls_back_on_mid_insert_failure(tmp_path: Path):
+    """batch_rewrite_grades must be fully atomic.
+
+    Seed existing rows -> attempt a batch rewrite where one insert raises ->
+    assert the pre-existing rows are still there (transaction was rolled back).
+    """
+    store = SQLiteStateStore(tmp_path)
+    _seed_existing_grades(tmp_path)
+
+    # Verify the seed is in place.
+    before = store.read_principle_grades()
+    assert len(before) == 2, "Seed should have 2 principle grades"
+
+    # principle_rows: second entry has None principle_id to cause a SQL error mid-batch.
+    principle_rows = [
+        ("Security", {"principle_id": "NEW-P1", "score": 9.0, "grade": "Exemplary",
+                      "finding_count": 0, "dismissed_count": 0}),
+        ("Security", {"principle_id": None, "score": 5.0, "grade": "Adequate",
+                      "finding_count": 1, "dismissed_count": 0}),  # will fail NOT NULL
+    ]
+    dimension_rows = [{"dimension": "Security", "score": 9.0, "grade": "Exemplary"}]
+
+    with pytest.raises(Exception):
+        store.batch_rewrite_grades(principle_rows, dimension_rows)
+
+    # The pre-existing rows must be intact -- clear + inserts were rolled back.
+    after = store.read_principle_grades()
+    assert len(after) == 2, (
+        f"Pre-existing rows must survive a failed batch rewrite, got {after}"
+    )
+    ids = {r["principle_id"] for r in after}
+    assert ids == {"P1", "P2"}, f"Wrong IDs after rollback: {ids}"
+
+
+def test_batch_rewrite_succeeds_replaces_all_grades(tmp_path: Path):
+    """A successful batch_rewrite_grades replaces all old grades with new ones."""
+    store = SQLiteStateStore(tmp_path)
+    _seed_existing_grades(tmp_path)
+
+    new_principle_rows = [
+        ("Maintainability", {"principle_id": "M1", "score": 9.5, "grade": "Exemplary",
+                             "finding_count": 0, "dismissed_count": 0}),
+    ]
+    new_dimension_rows = [{"dimension": "Maintainability", "score": 9.5, "grade": "Exemplary"}]
+
+    store.batch_rewrite_grades(new_principle_rows, new_dimension_rows)
+
+    principle_grades = store.read_principle_grades()
+    assert len(principle_grades) == 1
+    assert principle_grades[0]["principle_id"] == "M1"
+
+    dim_scores = store.read_dimension_scores()
+    assert len(dim_scores) == 1
+    assert dim_scores[0]["dimension"] == "Maintainability"

--- a/tests/data/test_web_response.py
+++ b/tests/data/test_web_response.py
@@ -1,0 +1,35 @@
+"""Tests for data/web/_response.py — ServerError embeds the HTTP status (#472)."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.data.web._response import HttpResponse, check_response_status
+from quodeq.data.ports.data_errors import AuthError, NotFoundError, ServerError
+
+
+class TestCheckResponseStatus:
+    def test_auth_error_on_401(self):
+        with pytest.raises(AuthError):
+            check_response_status(HttpResponse(status=401, data={}))
+
+    def test_auth_error_on_403(self):
+        with pytest.raises(AuthError):
+            check_response_status(HttpResponse(status=403, data={}))
+
+    def test_not_found_on_404(self):
+        with pytest.raises(NotFoundError):
+            check_response_status(HttpResponse(status=404, data={}))
+
+    def test_server_error_on_500_includes_status(self):
+        """#472 — ServerError message must include the HTTP status code."""
+        with pytest.raises(ServerError, match="500"):
+            check_response_status(HttpResponse(status=500, data={}))
+
+    def test_server_error_on_503_includes_status(self):
+        """#472 — Status code embedded in message for any 5xx."""
+        with pytest.raises(ServerError, match="503"):
+            check_response_status(HttpResponse(status=503, data={}))
+
+    def test_no_error_on_200(self):
+        """2xx responses must not raise."""
+        check_response_status(HttpResponse(status=200, data={"ok": True}))

--- a/tests/packaging/test_menubar_load_config.py
+++ b/tests/packaging/test_menubar_load_config.py
@@ -1,0 +1,72 @@
+"""#341 — menubar._load_config must not raise ValueError on non-numeric env values."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_config_fn():
+    """Import _load_config without triggering the rumps/module-level int() calls."""
+    # Stub out rumps and the local helper modules so the import succeeds
+    # on non-macOS and without the actual rumps package installed.
+    for mod_name in ("rumps", "_helpers", "_dashboard"):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    # Provide required names that menubar references at module level
+    rumps_stub = sys.modules["rumps"]
+    rumps_stub.App = MagicMock()
+    rumps_stub.MenuItem = MagicMock()
+    rumps_stub.timer = lambda *a, **kw: (lambda f: f)
+
+    helpers_stub = sys.modules["_helpers"]
+    helpers_stub.find_commands = MagicMock(return_value={})
+    helpers_stub.find_icon = MagicMock(return_value=None)
+    helpers_stub.is_evaluating = MagicMock(return_value=False)
+    helpers_stub.source_user_path = MagicMock()
+
+    dashboard_stub = sys.modules["_dashboard"]
+    dashboard_stub.build_dashboard_cmd = MagicMock()
+    dashboard_stub.cleanup_stderr_log = MagicMock()
+    dashboard_stub.DashboardCallbacks = MagicMock()
+    dashboard_stub.DashboardState = MagicMock()
+    dashboard_stub.find_pids_on_port = MagicMock()
+    dashboard_stub.find_running_port = MagicMock()
+    dashboard_stub.kill_port_processes = MagicMock()
+    dashboard_stub.open_stderr_log = MagicMock()
+    dashboard_stub.wait_for_dashboard = MagicMock()
+    dashboard_stub._STDERR_READ_MAX = 4096
+    dashboard_stub._ERROR_DISPLAY_MAX = 200
+
+    # Add the macos packaging dir to path so the import finds menubar.py
+    macos_dir = str(Path(__file__).resolve().parents[2] / "packaging" / "macos")
+    if macos_dir not in sys.path:
+        sys.path.insert(0, macos_dir)
+
+    # Force reimport if already cached (from a prior test run)
+    if "menubar" in sys.modules:
+        del sys.modules["menubar"]
+
+    import menubar  # noqa: PLC0415
+    return menubar._load_config
+
+
+class TestLoadConfigNonNumericEnv:
+    def setup_method(self):
+        self._load_config = _load_config_fn()
+
+    def test_non_numeric_port_falls_back_to_default(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORT": "not-a-number"})
+        assert port == 7863  # default
+
+    def test_non_numeric_ports_falls_back_to_default(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORTS": "abc,def,ghi"})
+        # Should fall back — not raise ValueError
+        assert isinstance(ports, tuple)
+
+    def test_valid_numeric_env_still_works(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORT": "8080", "QUODEQ_PORTS": "8080,8081"})
+        assert port == 8080
+        assert ports == (8080, 8081)

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -14,6 +14,8 @@ appear in which view. The tests pin down its three guarantees:
 Together these make the migration in later phases safe: each call site
 can replace its local filter with a documented predicate from this module.
 """
+# NOTE: Additional tests for #356 (_is_trustworthy_eval non-dict guard) are at
+# the bottom of this file.
 from __future__ import annotations
 
 import json
@@ -339,3 +341,29 @@ class TestIsEligibleForChartBar:
         assert is_eligible_for_chart_bar(
             tmp_path, "proj", run, configured_dims=["security", "reliability"],
         ) is False
+
+
+# ---------------------------------------------------------------------------
+# #356 — _is_trustworthy_eval must not raise on non-dict eval_data
+# ---------------------------------------------------------------------------
+
+class TestIsTrustworthyEvalNonDict:
+    def test_list_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval([{"filesRead": 100}]) is False
+
+    def test_string_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval("filesRead: 100") is False
+
+    def test_int_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval(42) is False
+
+    def test_none_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval(None) is False
+
+    def test_valid_dict_with_files_read_returns_true(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval({"filesRead": 10}) is True

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -375,3 +375,25 @@ class TestHasFingerprints:
         run.mkdir(parents=True)
         # No evidence subdir
         assert _has_fingerprints(tmp_path, "proj") is False
+
+    def test_oserror_on_iterdir_logs_warning(self, tmp_path: Path, monkeypatch, caplog):
+        """#208 — OSError during dir iteration must be logged, not silently swallowed."""
+        import logging
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        def _bad_iterdir(self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _bad_iterdir)
+        # quodeq logger has propagate=False; enable temporarily so caplog sees records.
+        quodeq_logger = logging.getLogger("quodeq")
+        orig_propagate = quodeq_logger.propagate
+        quodeq_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.services._fs_metadata"):
+                result = _has_fingerprints(tmp_path, "proj")
+        finally:
+            quodeq_logger.propagate = orig_propagate
+        assert result is False
+        assert "Could not read fingerprint dir" in caplog.text

--- a/tests/services/test_tooling_mixin.py
+++ b/tests/services/test_tooling_mixin.py
@@ -387,3 +387,8 @@ class TestLoadFallbackClaudeModels:
     @patch("quodeq.services.tooling_mixin.read_json", side_effect=OSError)
     def test_returns_empty_on_error(self, mock_read):
         assert _load_fallback_claude_models() == []
+
+    # #139 — ValueError (e.g. corrupt JSON int parse) must also be caught
+    @patch("quodeq.services.tooling_mixin.read_json", side_effect=ValueError("bad int"))
+    def test_returns_empty_on_value_error(self, mock_read):
+        assert _load_fallback_claude_models() == []

--- a/tests/services/test_violations_jsonl_coverage.py
+++ b/tests/services/test_violations_jsonl_coverage.py
@@ -8,6 +8,35 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+# ---------------------------------------------------------------------------
+# #145 — non-dict JSON values (lists, strings, numbers) must be skipped
+# ---------------------------------------------------------------------------
+
+class TestNonDictJsonlLineIsSkipped:
+    def test_non_dict_string_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = [
+            '"just a string"',
+            '[1, 2, 3]',
+            json.dumps({"p": "M-MOD-1", "t": "violation", "file": "a.py", "line": 1}),
+        ]
+        violations, _ = _parse_jsonl_findings(lines, "security")
+        assert len(violations) == 1
+
+    def test_non_dict_list_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = ['[{"p": "M-MOD-1", "t": "violation"}]']
+        violations, compliance = _parse_jsonl_findings(lines, "security")
+        assert violations == []
+        assert compliance == []
+
+    def test_non_dict_null_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = ['null', json.dumps({"p": "P1", "t": "compliance", "file": "b.py", "line": 2})]
+        _, compliance = _parse_jsonl_findings(lines, "security")
+        assert len(compliance) == 1
+
+
 class TestParseJsonlFindings:
     def test_empty_lines(self):
         from quodeq.services._violations_jsonl import _parse_jsonl_findings

--- a/tests/shared/test_resource_sampler_coverage.py
+++ b/tests/shared/test_resource_sampler_coverage.py
@@ -1,0 +1,61 @@
+"""Tests for resource_sampler.py — except breadth broadening (#515).
+
+The sampler loop's bare `except (OSError, ValueError)` must be broadened to
+`except Exception` so a bad tick (e.g. RuntimeError) doesn't kill the thread.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+from quodeq.shared.resource_sampler import ResourceSampler
+
+
+class TestSamplerLoopBreadth:
+    def test_unexpected_exception_does_not_terminate_loop(self):
+        """#515 — an exception not in (OSError, ValueError) must not kill the sampler thread.
+
+        Before the fix, RuntimeError would propagate out of the loop and the thread would die.
+        After the fix, the loop continues and the thread stays alive past the first tick.
+        """
+        tick_count = [0]
+        errors_seen = [0]
+
+        def _bad_sample_once():
+            tick_count[0] += 1
+            if tick_count[0] == 1:
+                raise RuntimeError("unexpected bad tick")
+            return "ok"
+
+        sampler = ResourceSampler(interval_s=0.05)
+
+        with patch.object(sampler, "sample_once", side_effect=_bad_sample_once):
+            sampler.start()
+            # Wait long enough for at least 2 ticks
+            time.sleep(0.3)
+            sampler.stop()
+
+        # Thread must have continued past the first (bad) tick
+        assert tick_count[0] >= 2, (
+            f"Sampler thread died after bad tick — only {tick_count[0]} tick(s) observed"
+        )
+
+    def test_oserror_does_not_terminate_loop(self):
+        """Original OSError handling still works after broadening."""
+        tick_count = [0]
+
+        def _oserror_sample():
+            tick_count[0] += 1
+            if tick_count[0] == 1:
+                raise OSError("proc unavailable")
+            return "ok"
+
+        sampler = ResourceSampler(interval_s=0.05)
+
+        with patch.object(sampler, "sample_once", side_effect=_oserror_sample):
+            sampler.start()
+            time.sleep(0.3)
+            sampler.stop()
+
+        assert tick_count[0] >= 2

--- a/tests/test_cli_worktree_cleanup.py
+++ b/tests/test_cli_worktree_cleanup.py
@@ -1,0 +1,96 @@
+"""Tests for worktree cleanup on failure path (finding #376).
+
+The except block in _create_worktree previously called worktree_dir.rmdir()
+which only removes an empty dir and leaves a registered/populated worktree
+behind. Fix: call _cleanup_worktree + shutil.rmtree on the failure path.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, call
+
+import pytest
+
+
+class TestCreateWorktreeCleanupOnFailure:
+    """Ensure _create_worktree fully cleans up on the failure path."""
+
+    def test_cleanup_worktree_called_on_subprocess_failure(self, tmp_path: Path) -> None:
+        """When subprocess.run raises CalledProcessError after the dir is created,
+        _cleanup_worktree must be called (not just rmdir) so the git worktree
+        registration is also removed."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        captured_calls: list[tuple[Path, Path]] = []
+
+        def _fake_cleanup(repo: Path, wt: Path) -> None:
+            captured_calls.append((repo, wt))
+            # Simulate cleanup removing the dir
+            import shutil
+            shutil.rmtree(wt, ignore_errors=True)
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+            side_effect=_fake_cleanup,
+        ) as mock_cleanup:
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None, "Expected None when subprocess raises"
+        # _cleanup_worktree must have been called once with the correct repo_dir
+        mock_cleanup.assert_called_once()
+        called_repo, called_wt = mock_cleanup.call_args.args
+        assert called_repo == repo_dir
+
+    def test_no_leftover_dir_on_failure(self, tmp_path: Path) -> None:
+        """The worktree dir itself must not survive the failure path."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        created_dir: list[Path] = []
+
+        def _spy_cleanup(repo: Path, wt: Path) -> None:
+            created_dir.append(wt)
+            import shutil
+            shutil.rmtree(wt, ignore_errors=True)
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+            side_effect=_spy_cleanup,
+        ):
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None
+        if created_dir:
+            assert not created_dir[0].exists(), (
+                f"Worktree dir {created_dir[0]} still exists after failure"
+            )
+
+    def test_cleanup_called_on_timeout(self, tmp_path: Path) -> None:
+        """TimeoutExpired on the failure path also triggers proper cleanup."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("git", 30),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+        ) as mock_cleanup:
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None
+        mock_cleanup.assert_called_once()

--- a/tests/tools/test_check_imports_warning.py
+++ b/tests/tools/test_check_imports_warning.py
@@ -1,0 +1,52 @@
+"""Tests for check_imports.check_file — stderr warning on read error (#696)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# tools/ is not on sys.path by default; add it
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "tools"))
+import check_imports  # noqa: E402
+
+
+class TestCheckFileWarning:
+    def test_oserror_prints_warning_to_stderr(self, tmp_path: Path, capsys):
+        """#696 — OSError reading a file must print a warning to stderr, not silently skip."""
+        bad_path = tmp_path / "unreachable.py"
+        bad_path.touch()
+
+        with patch.object(Path, "read_text", side_effect=OSError("permission denied")):
+            result = check_imports.check_file(bad_path, "core")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "warning: skipping" in captured.err
+        assert "unreachable.py" in captured.err
+        assert "permission denied" in captured.err
+
+    def test_unicode_error_prints_warning_to_stderr(self, tmp_path: Path, capsys):
+        """#696 — UnicodeDecodeError reading a file must also produce a stderr warning."""
+        bad_path = tmp_path / "binary.py"
+        bad_path.touch()
+
+        with patch.object(
+            Path, "read_text", side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "bad byte")
+        ):
+            result = check_imports.check_file(bad_path, "core")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "warning: skipping" in captured.err
+        assert "binary.py" in captured.err
+
+    def test_clean_file_produces_no_warning(self, tmp_path: Path, capsys):
+        """Readable files with no violations must not produce any stderr output."""
+        clean_path = tmp_path / "clean.py"
+        clean_path.write_text("x = 1\n", encoding="utf-8")
+        result = check_imports.check_file(clean_path, "core")
+        captured = capsys.readouterr()
+        assert captured.err == ""

--- a/tests/tools/test_migrate_cwe_title.py
+++ b/tests/tools/test_migrate_cwe_title.py
@@ -1,0 +1,64 @@
+"""#710 — migrate_cwe_title must not raise when json.loads returns a non-dict."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# tools/ is importable via conftest.py sys.path insert
+
+
+class TestBuildCweNameLookupNonDict:
+    def test_list_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text(json.dumps([{"principles": []}]), encoding="utf-8")
+        # Must not raise AttributeError; bad file is skipped
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_string_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text('"just a string"', encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_null_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text("null", encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_valid_dict_is_still_processed(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        data = {
+            "principles": [
+                {"cwes": [{"id": 306, "name": "Missing Authentication"}]}
+            ]
+        }
+        f = tmp_path / "sec.json"
+        f.write_text(json.dumps(data), encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {306: "Missing Authentication"}
+
+
+class TestMigrateFileNonDict:
+    def test_list_payload_is_skipped_gracefully(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import migrate_file
+        f = tmp_path / "eval.json"
+        f.write_text(json.dumps([{"violations": []}]), encoding="utf-8")
+        v, c = migrate_file(f, {}, apply=False)
+        assert v == 0
+        assert c == 0
+
+    def test_null_payload_is_skipped_gracefully(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import migrate_file
+        f = tmp_path / "eval.json"
+        f.write_text("null", encoding="utf-8")
+        v, c = migrate_file(f, {}, apply=False)
+        assert v == 0
+        assert c == 0

--- a/tests/tools/test_migrate_reason_title.py
+++ b/tests/tools/test_migrate_reason_title.py
@@ -1,0 +1,29 @@
+"""#683 — migrate_reason_title.migrate_entry must not raise on non-dict input."""
+from __future__ import annotations
+
+import pytest
+
+
+class TestMigrateEntryNonDict:
+    def test_list_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry([{"reason": "x"}]) is False
+
+    def test_string_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry("just a string") is False
+
+    def test_none_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry(None) is False
+
+    def test_int_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry(42) is False
+
+    def test_valid_dict_still_works(self) -> None:
+        from migrate_reason_title import migrate_entry
+        entry = {"reason": "Modularity -- separation of concerns", "principle": "Modularity"}
+        # The function should handle a valid dict without raising
+        result = migrate_entry(entry)
+        assert isinstance(result, bool)

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -40,7 +40,8 @@ def check_file(path: Path, layer: str) -> list[tuple[int, str, str]]:
     allowed = LAYER_RULES[layer] | CROSS_CUTTING | {layer}
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"warning: skipping {path}: {e}", file=sys.stderr)
         return violations
     for lineno, line in enumerate(lines, 1):
         m = IMPORT_RE.match(line)

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -22,7 +22,7 @@ src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
-src/quodeq/data/sqlite/state_store.py:198:services
+src/quodeq/data/sqlite/state_store.py:239:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -19,7 +19,7 @@ src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/api/routes_findings.py:85:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
-src/quodeq/data/fs/report_parser/runs.py:109:services
+src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:198:services

--- a/tools/migrate_cwe_title.py
+++ b/tools/migrate_cwe_title.py
@@ -34,6 +34,9 @@ def _build_cwe_name_lookup(compiled_dir: Path) -> dict[int, str]:
         except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             print(f"  SKIP  cannot read {f}: {exc}")
             continue
+        if not isinstance(data, dict):
+            print(f"  SKIP  unexpected payload type in {f}: {type(data).__name__}")
+            continue
         for principle in data.get("principles", []):
             for cwe in principle.get("cwes", []):
                 cid = cwe.get("id")
@@ -72,6 +75,9 @@ def migrate_file(path: Path, cwe_names: dict[int, str], apply: bool) -> tuple[in
         data = json.loads(path.read_text(encoding=_TEXT_ENCODING))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         print(f"  SKIP  cannot read {path}: {exc}")
+        return 0, 0
+    if not isinstance(data, dict):
+        print(f"  SKIP  unexpected payload type in {path}: {type(data).__name__}")
         return 0, 0
     v_count = _patch_entries(data.get("violations", []), cwe_names)
     c_count = _patch_entries(data.get("compliance", []), cwe_names)

--- a/tools/migrate_reason_title.py
+++ b/tools/migrate_reason_title.py
@@ -39,6 +39,8 @@ def _find_first_sep(text: str) -> tuple[int, str] | tuple[None, None]:
 
 def migrate_entry(entry: dict) -> bool:
     """Migrate a single violation/compliance entry. Returns True if changed."""
+    if not isinstance(entry, dict):
+        return False
     reason = entry.get("reason", "")
     if not reason:
         return False


### PR DESCRIPTION
Fixes all 42 confirmed-real reliability findings from the majors triage of self-analysis run `fa56db32` (see the triage backlog). Each fix ships with a regression test (TDD). Organized into 7 thematic commits so the ~40-file diff reviews cluster-by-cluster. Every cluster passed an independent spec-compliance + code-quality review; a final whole-branch review cleared it as ready.

## Clusters

1. **HTTP/SSE timeouts (7)** — route raw `fetch`/SSE through the shared `request()` helper / `AbortSignal.timeout`; SSE gets an inactivity timer. Also hardened `request()` to compose the caller signal with its timeout via `AbortSignal.any` (preserves react-query cancellation).
2. **JSON/type guards (11)** — `isinstance` guards / widened `except` on parse paths that could receive a non-dict/None.
3. **Exception hygiene (9)** — log previously-swallowed errors; fix `except` breadth (narrow where errors must surface, broaden where a loop must survive).
4. **API route errors (3)** — wrap handlers in try/except returning a structured 500 via `error_response`; make action replay continue-on-error.
5. **UI null-safety (4)** — optional chaining / default props / nullish guards.
6. **Concurrency & atomicity (6)** — `threading.Lock` on a cache reload (double-checked); single-transaction grade rewrite (`batch_rewrite_grades`, rolls back on mid-batch failure); cleanup-on-unmount for pointer drags; pure state updaters in `useNavStack` (no history side effects inside `setState`, extended to `navReset`/`navTab`).
7. **Singletons (2)** — worktree force-cleanup on the failure path; stem-collision dedup in fan-in analysis.

Two extra commits update `tools/import_baseline.txt` for grandfathered deferred-import lines that shifted when guards were inserted (`runs.py`, `state_store.py`) — pure line-number rebaselines, no rule changes.

## Tests
~80 new regression tests. Full Python suite **3370 passed**; UI **446 passed** (node:test + vitest). No findings were force-fixed: implementers were free to flag a "real"-verdicted finding as a false positive instead; none needed to here.

## Known follow-ups (non-blocking, for a later sweep)
- `analysis/_analysis_context.py:26` has another unguarded `.get` on `json.loads` (same bug class, not in the 42).
- `analysis/prompts/builder.py:42` `except (OSError, FileNotFoundError)` is redundant (`FileNotFoundError` subclasses `OSError`).
- `batch_rewrite_grades` docstring could say "discards the uncommitted transaction on close" rather than "rolls back".

## Out of scope
The 8 held-security + 14 contested findings (separate review), and real findings in other dimensions (flexibility/perf/usability/maintainability) — future slices off the same triage backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)