### PR TITLE
fix(analysis): require input provenance before critical severity

### DIFF
--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -51,6 +51,8 @@ Report ALL violations AND ALL compliance you observe — do not bias toward eith
 
 Skip generated, vendored, compiled, and dependency directories. Use the project type to decide what matters: a backend API has different concerns than a mobile app or CLI tool.
 
+{{EVALUATION_RULES}}
+
 ## Standards Checklist
 
 Use the **exact requirement ID** (e.g. `M-MOD-1`) as `req`. Do NOT create your own IDs.

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -26,19 +26,19 @@ Compliance uses the same scale to mark importance of what's done right.
 
 ## Reachable input (provenance)
 
-A missing null/guard check (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can reach the flagged line. Name the caller or source that delivers it.
+A missing null/undefined guard (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can actually reach the flagged line. Name the source that delivers it. (The target language is named at the top of this prompt; read the patterns below in that language's idiom.)
 
-Internal input is NOT `critical`. The value is internal when it is a content hash or digest, a module-level constant or enum, a parameter with a default, or a value every visible call site passes valid (a React prop from a hook/default, an argument always given a literal). A missing guard on internal input is a hardening gap → `major` if 1–4 hold and the guard is genuinely worth adding, else drop.
+External source → stays `critical`. The value crosses a trust boundary: an HTTP request, query/route param, header, cookie, or body; a CLI argument; an environment variable; file, network, or message-queue payload; or any argument an untrusted caller controls.
 
-External input stays `critical`. The value reaches the line from an HTTP request, query string, request body, CLI argument, environment variable, file contents, or any caller across a trust boundary.
+Internal source → NOT `critical`, a hardening gap (`major` if 1–4 hold and the guard is worth adding, else drop). The value cannot be attacker-controlled: a content hash or digest (e.g. a SHA-256 hex string); a literal, constant, or enum; a parameter with a default that every visible call site relies on or passes a literal; or a value already validated (charset-restricted, length-checked, allow-listed) before this line.
 
-Not `critical`:
-- `stack.forEach(...)` on a prop with no null guard, where the prop is supplied by a hook or a default at every call site.
-- `[...thresholds]` or destructuring a hook argument whose value is backfilled from defaults.
-- a cache path `root / key[:2] / key[2:]` where `key` is a SHA-256 hex digest (or validated against a safe charset); the digest is not attacker-controlled.
+If you cannot name an external source, treat the value as internal; do not assume one off-screen.
 
-Genuinely `critical`:
-- a path built from `request.args["file"]`, or a dereference of a value parsed from an HTTP request body; provenance is external.
+Worked example (any language). A line opens or dereferences `x` with no check:
+- `x` comes from a request field or CLI arg, e.g. `open(request["file"])` → external → `critical`.
+- `x` is a digest, e.g. `open(cacheDir + "/" + sha256(content))` → internal, a hex digest no caller can choose → `major` or drop.
+
+Same code, opposite verdict: the source decides the severity.
 
 ## Test files
 

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -24,6 +24,22 @@ DROP speculative concerns: "could", "might", "should consider".
 
 Compliance uses the same scale to mark importance of what's done right.
 
+## Reachable input (provenance)
+
+A missing null/guard check (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can reach the flagged line. Name the caller or source that delivers it.
+
+Internal input is NOT `critical`. The value is internal when it is a content hash or digest, a module-level constant or enum, a parameter with a default, or a value every visible call site passes valid (a React prop from a hook/default, an argument always given a literal). A missing guard on internal input is a hardening gap → `major` if 1–4 hold and the guard is genuinely worth adding, else drop.
+
+External input stays `critical`. The value reaches the line from an HTTP request, query string, request body, CLI argument, environment variable, file contents, or any caller across a trust boundary.
+
+Not `critical`:
+- `stack.forEach(...)` on a prop with no null guard, where the prop is supplied by a hook or a default at every call site.
+- `[...thresholds]` or destructuring a hook argument whose value is backfilled from defaults.
+- a cache path `root / key[:2] / key[2:]` where `key` is a SHA-256 hex digest (or validated against a safe charset); the digest is not attacker-controlled.
+
+Genuinely `critical`:
+- a path built from `request.args["file"]`, or a dereference of a value parsed from an HTTP request body; provenance is external.
+
 ## Test files
 
 Test file → max severity `minor`. Never `critical`/`major` on tests, fixtures, mocks, or specs.
@@ -41,7 +57,8 @@ For `critical`/`major` also:
 
 5. **Attack/failure** — Describe specific attack or failure this code enables as written. Hedge words → `minor` only if 1–4 hold; else drop.
 6. **Reachable** — Production code path. Tests, examples, dev scaffolding are not `critical`.
+7. **Provenance** (unguarded access & path-from-string only) — Name the caller or external source that delivers a bad or attacker-controlled value to this line. Can't, because the value is a content hash, a constant, a defaulted parameter, or always a literal at the call sites you see? Not `critical` → `major` if 1–4 hold, else drop.
 
-**Decision**: 1–4 fail → DROP entirely. 5–6 fail → `minor` only if 1–4 hold, else drop. `minor` is not a fallback bucket.
+**Decision**: 1–4 fail → DROP entirely. 5–6 fail → `minor` only if 1–4 hold, else drop. 7 fail → `major` (or drop) per the item. `minor` is not a fallback bucket.
 
 Fewer sharper findings beats long reports padded with speculation.

--- a/tests/analysis/test_prompt_provenance_gate.py
+++ b/tests/analysis/test_prompt_provenance_gate.py
@@ -1,0 +1,69 @@
+"""The critical-severity bar must require reachable input provenance.
+
+Run fa56db32 marked 4 of 6 'critical' findings as false positives: unguarded
+prop/arg dereferences (R-FT-2) and a path-from-string (S-AUT-3) where the value
+is provably internal (a hook default, a literal, a SHA-256 cache key). A finding
+is only `critical` when a bad/attacker-controlled value can actually reach the
+line. These tests guard the rubric text AND that it reaches the default
+per-dimension producer path (compass.md), which historically dropped the rubric
+because it had no {{EVALUATION_RULES}} placeholder.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt
+from quodeq.analysis.prompts._template import load_template
+
+RULES = Path("src/quodeq/data/prompts/evaluation_rules.md").read_text()
+COMPASS = Path("src/quodeq/data/prompts/compass.md").read_text()
+
+
+def test_rules_define_provenance_selfcheck():
+    """The self-check must add a provenance gate beyond the test-file carve-out."""
+    lower = RULES.lower()
+    assert "provenance" in lower
+    assert "attacker-controlled" in lower
+    # The gate must name the escape hatch for provably-internal values.
+    assert "hardening gap" in lower
+
+
+def test_rules_show_internal_input_examples():
+    """Concrete internal-input examples anchor the gate for weaker local models."""
+    lower = RULES.lower()
+    # A content hash / SHA-256 key is the canonical non-attacker-controlled path.
+    assert "content hash" in lower or "sha-256" in lower
+    # A defaulted prop/arg is the canonical unguarded-access false positive.
+    assert "default" in lower
+
+
+def test_rules_keep_external_input_critical():
+    """The contrast example must keep genuinely external provenance critical."""
+    lower = RULES.lower()
+    # An HTTP request / query string is the canonical attacker-controlled source.
+    assert "request" in lower
+
+
+def test_compass_injects_evaluation_rules():
+    """compass.md (default per-dimension template) must carry the rubric slot.
+
+    Without the placeholder the rubric value is computed in builder.py and
+    silently dropped, so the default path scores severity with no guidance.
+    """
+    assert "{{EVALUATION_RULES}}" in COMPASS
+
+
+def test_compass_prompt_renders_provenance_gate_end_to_end():
+    """Building the default template must land the provenance gate in the output."""
+    template = load_template()  # defaults to compass.md
+    ctx = PromptContext(
+        language="python",
+        repo_name="test-repo",
+        date_str="2026-06-19",
+        dimension="security",
+        source_file_count=50,
+        dimensions_data={"applies": [{"id": "security"}], "excludes": []},
+    )
+    result = build_analysis_prompt(template, ctx).lower()
+    assert "provenance" in result
+    assert "attacker-controlled" in result


### PR DESCRIPTION
## Problem
Self-analysis run fa56db32 marked 4 of 6 `critical` findings as false positives. The analyzer flagged defensive-coding patterns without modeling provenance: unguarded prop/arg dereferences (R-FT-2) and a path-from-string (S-AUT-3) where the value is provably internal (a hook default, a literal, a SHA-256 cache key). The critical bar tested for a local guard, not whether a bad value could actually reach the line.

## Change (rubric only — no scoring-semantics change)
- **evaluation_rules.md**: add a "Reachable input (provenance)" section + self-check #7. `critical` for unguarded-access / path-from-string now requires naming the caller or external source of a bad/attacker-controlled value. Content hashes, constants, and defaulted props/args are hardening gaps (`major` or drop); HTTP/CLI/env/file-sourced values stay `critical`. Contrast examples keep genuinely external provenance critical.
- **compass.md**: inject `{{EVALUATION_RULES}}`. The default per-dimension template had no placeholder, so `build_analysis_prompt` computed the rubric but `render_template` discarded it — the default path shipped with no severity rubric, self-check, or test-file cap at all.
- **test_prompt_provenance_gate.py**: assert the rubric text and that it reaches the rendered compass output end-to-end.

## Why not the enricher/confidence path
Per-finding `confidence` is cosmetic for the grade: `tally_types()` counts by `vt`/`reason`+`severity` and never reads `confidence`, and it is absent from `_VIOLATION_FIELDS`. `severity_grade_floor` (critical -> 0.0) and the 4.0 critical weight fire regardless. So severity (set inline by the analysis LLM) is the only effective lever; a new enricher heuristic would be a no-op for the score.

## Testing
- New test file, 5 tests, written test-first (RED -> GREEN), including an end-to-end render through `build_analysis_prompt`.
- Full suite: 3300 passed.
- Limitation: there is no offline LLM-eval harness for the analysis prompt, so these tests guard rubric wiring/content; the behavioral win needs a manual re-scan of fa56db32's target (requires the local model).

## Dedupe note
Branches `fix/analyzer-prompt-tightening`, `prompt/tighten-eval-rules`, and `fix/eval-prompt-tighten-minor` may touch the same eval rules — worth deduping before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)