### PR TITLE
fix(reliability): three out-of-scope followups from PR #634 review

### DIFF
--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -23,7 +23,11 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
     seen = set(result)
     for _p in evaluators_dir.glob("*.json"):
         try:
-            _eid = _json.loads(_p.read_text(encoding="utf-8")).get("id")
+            _parsed = _json.loads(_p.read_text(encoding="utf-8"))
+            if not isinstance(_parsed, dict):
+                log_warning(f"Skipping custom evaluator {_p.name}: not a JSON object")
+                continue
+            _eid = _parsed.get("id")
             if _eid and _eid not in seen:
                 result.append(_eid)
                 seen.add(_eid)

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -39,7 +39,7 @@ def _load_evaluation_rules() -> str:
     for name in ("evaluation_rules.md", "finding_format.md"):
         try:
             parts.append(load_template(template_name=name))
-        except (OSError, FileNotFoundError):
+        except OSError:
             _logger.warning("Failed to load prompt template %s, skipping", name)
             continue
     return "\n\n".join(p for p in parts if p)

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -173,8 +173,9 @@ class SQLiteStateStore:
     ) -> None:
         """Clear all grade tables and insert new rows in a single transaction.
 
-        The clear + all inserts are committed atomically: a mid-batch failure
-        rolls back the entire operation, leaving any pre-existing rows intact.
+        The clear + all inserts are committed atomically: on a mid-batch
+        failure the transaction is never committed and is discarded when the
+        connection closes, leaving any pre-existing rows intact.
 
         Args:
             principle_rows: Sequence of ``(dimension, principle_grade_dict)``

--- a/tests/analysis/test_analysis_context_coverage.py
+++ b/tests/analysis/test_analysis_context_coverage.py
@@ -64,3 +64,21 @@ class TestLoadCustomDimensions:
         assert result == []
         assert "Skipping custom evaluator" in caplog.text
         assert "malformed.json" in caplog.text
+
+    def test_non_dict_json_logs_warning_and_skips(self, tmp_path: Path, caplog):
+        """A top-level JSON array (or any non-dict) must not crash on .get("id")."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "array.json").write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, ["existing"])
+        finally:
+            quodeq_logger.propagate = orig
+
+        # Pre-existing dimensions are preserved; the bad file is skipped, not fatal.
+        assert result == ["existing"]
+        assert "Skipping custom evaluator" in caplog.text
+        assert "array.json" in caplog.text

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -22,7 +22,7 @@ src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
-src/quodeq/data/sqlite/state_store.py:239:services
+src/quodeq/data/sqlite/state_store.py:240:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis


### PR DESCRIPTION
Three small reliability cleanups the final review of `fix/reliability-hardening` ([#634](https://github.com/quodeq/quodeq/pull/634)) flagged as out-of-scope follow-ups. They were not among the 42 triaged findings, so they were left for this later sweep.

## Changes

1. **`_analysis_context.py` — guard non-dict custom-evaluator JSON.** `_load_custom_dimensions` chained `.get("id")` directly on `json.loads(...)`. A top-level JSON array (or any non-dict) raised `AttributeError`, which is *not* caught by the surrounding `(OSError, ValueError, KeyError)` handler, so a single malformed evaluator file crashed dimension loading. Added an `isinstance(_parsed, dict)` guard that skips the file with a logged warning, mirroring the cluster-2 pattern from [#634](https://github.com/quodeq/quodeq/pull/634). Same bug class as the other fixes in the sweep. Includes a regression test feeding a top-level array.

2. **`prompts/builder.py` — simplify redundant except clause.** `except (OSError, FileNotFoundError)` → `except OSError`. `FileNotFoundError` subclasses `OSError`, so the second clause was dead. Behavior is identical; the existing #157 logging test still covers it.

3. **`state_store.py` — tighten `batch_rewrite_grades` docstring.** It claimed the transaction "rolls back" on failure, but there is no explicit `rollback()` call — `open_evaluation_db` only `conn.close()`s in its `finally`, so an uncommitted transaction is discarded on close. Reworded for precision. Docstring-only.

Also rebaselined `tools/import_baseline.txt` for a pure line shift: the grandfathered `state_store.py` deferred import moved 239 → 240 because the docstring grew one line. No new import, same forbidden target.

## Verification

- `uv run pytest` — **3371 passed**
- `python tools/check_imports.py` — OK, no new import violations (32 grandfathered)

## Note (out of scope here)

`pyproject.toml` pins `pytest==9.1.0` but the committed `uv.lock` still resolves `9.0.3` (dependabot [#630](https://github.com/quodeq/quodeq/pull/630) bumped the manifest but not the lockfile). `uv run` auto-corrects this locally. Left out of this PR to keep scope clean; tracked separately for a `uv lock` resync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)