### PR TITLE
fix(security): SSRF guard on web project-clone path

### DIFF
--- a/src/quodeq/data/fs/repo_clone.py
+++ b/src/quodeq/data/fs/repo_clone.py
@@ -21,11 +21,7 @@ from quodeq.context.online_cache import (
     ensure_clone,
     is_inside_cache,
 )
-from quodeq.data.fs.repo_validation import (
-    _PRIVATE_HOST_RE,
-    _REPO_URL_RE,
-    _resolves_to_private,
-)
+from quodeq.data.fs.repo_validation import validate_remote_url as _validate_remote_url
 
 _logger = logging.getLogger(__name__)
 
@@ -38,19 +34,6 @@ def _get_clone_timeout(env: dict[str, str] | None = None) -> int:
         return int((env or os.environ).get("QUODEQ_GIT_CLONE_TIMEOUT", str(_DEFAULT_CLONE_TIMEOUT_S)))
     except ValueError:
         return _DEFAULT_CLONE_TIMEOUT_S
-
-
-def _validate_remote_url(repo_input: str) -> None:
-    """Reject malformed / private / DNS-rebinding URLs."""
-    if not _REPO_URL_RE.match(repo_input):
-        raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
-    if _PRIVATE_HOST_RE.match(repo_input):
-        raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
-    if repo_input.startswith("http"):
-        import urllib.parse
-        hostname = urllib.parse.urlparse(repo_input).hostname or ""
-        if hostname and _resolves_to_private(hostname):
-            raise ValueError("Repository URL resolves to a private/internal address")
 
 
 def _legacy_tempdir_clone(repo_input: str) -> str:

--- a/src/quodeq/data/fs/repo_validation.py
+++ b/src/quodeq/data/fs/repo_validation.py
@@ -30,6 +30,22 @@ def _resolves_to_private(hostname: str) -> bool:
     return is_private_address(hostname)
 
 
+def _remote_host(repo_input: str) -> str:
+    """Return the host of a format-validated repo URL.
+
+    Handles both supported forms so the private-host check covers them equally:
+    ``https://host/path`` and the scp-like ``git@host:path`` (SSH) form. The
+    SSH form skips ``_PRIVATE_HOST_RE`` (anchored to ``^https?://``), so without
+    this it would reach git clone unguarded.
+    """
+    if repo_input.startswith("http"):
+        import urllib.parse
+        return urllib.parse.urlparse(repo_input).hostname or ""
+    if repo_input.startswith("git@"):
+        return repo_input[len("git@"):].split(":", 1)[0].strip("[]")
+    return ""
+
+
 def is_valid_repo_url(url: str) -> bool:
     """Return True if *url* matches the expected git repository URL format."""
     return _REPO_URL_RE.match(url) is not None
@@ -48,8 +64,6 @@ def validate_remote_url(repo_input: str) -> None:
         raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
     if _PRIVATE_HOST_RE.match(repo_input):
         raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
-    if repo_input.startswith("http"):
-        import urllib.parse
-        hostname = urllib.parse.urlparse(repo_input).hostname or ""
-        if hostname and _resolves_to_private(hostname):
-            raise ValueError("Repository URL resolves to a private/internal address")
+    hostname = _remote_host(repo_input)
+    if hostname and _resolves_to_private(hostname):
+        raise ValueError("Repository URL resolves to a private/internal address")

--- a/src/quodeq/data/fs/repo_validation.py
+++ b/src/quodeq/data/fs/repo_validation.py
@@ -33,3 +33,23 @@ def _resolves_to_private(hostname: str) -> bool:
 def is_valid_repo_url(url: str) -> bool:
     """Return True if *url* matches the expected git repository URL format."""
     return _REPO_URL_RE.match(url) is not None
+
+
+def validate_remote_url(repo_input: str) -> None:
+    """Reject malformed / private / DNS-rebinding repository URLs.
+
+    Shared SSRF guard used by both the CLI clone path
+    (:func:`quodeq.data.fs.repo_clone.prepare_repository`) and the web API
+    registration path (:func:`quodeq.services.evaluation_mixin._register_project`),
+    so the two entry points cannot drift apart on what they consider safe.
+    Raises ``ValueError`` for any rejected URL.
+    """
+    if not _REPO_URL_RE.match(repo_input):
+        raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
+    if _PRIVATE_HOST_RE.match(repo_input):
+        raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
+    if repo_input.startswith("http"):
+        import urllib.parse
+        hostname = urllib.parse.urlparse(repo_input).hostname or ""
+        if hostname and _resolves_to_private(hostname):
+            raise ValueError("Repository URL resolves to a private/internal address")

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -17,6 +17,7 @@ from quodeq.core.evidence.parser import parse_jsonl_to_evidence, EvidenceContext
 from quodeq.core.scoring.engine import score_evidence
 from quodeq.services.grade_formula import load_params
 from quodeq.analysis.report import write_dimension_report
+from quodeq.data.fs.repo_validation import validate_remote_url
 from quodeq.services._fs_clone import run_git_clone
 from quodeq.services._fs_scan import scan_project
 from quodeq.shared._env import get_clones_dir
@@ -138,6 +139,11 @@ def _register_project(
     Returns the project's UUID.
     """
     is_url = is_repo_url(repo)
+    if is_url:
+        # SSRF guard: reject private/loopback/link-local hosts before any clone
+        # or directory side effects. Mirrors the CLI prepare_repository path so
+        # the web API (POST /api/projects) cannot be pointed at internal hosts.
+        validate_remote_url(repo)
     if is_url and not ephemeral and clone_dest is None:
         raise ValueError(
             "URL repos require either clone_dest (user-chosen path) or ephemeral=True"

--- a/src/quodeq/shared/ssrf.py
+++ b/src/quodeq/shared/ssrf.py
@@ -21,6 +21,16 @@ def is_private_address(hostname: str) -> bool:
         return addr.is_private or addr.is_loopback or addr.is_link_local
     except ValueError:
         _logger.debug("Cannot parse %r as IP literal, falling through to DNS", hostname)
+    # git/libc accept IPv4 literals in octal/hex/dword/short forms that
+    # ``ipaddress`` rejects (e.g. 0177.0.0.1, 0x7f000001, 2130706433, 127.1).
+    # Canonicalize the way git's resolver will so SSRF via alternate IPv4
+    # encodings is caught here instead of slipping through to a public-looking
+    # DNS answer. inet_aton raises OSError for real hostnames -> DNS fallback.
+    try:
+        addr = ipaddress.ip_address(socket.inet_ntoa(socket.inet_aton(hostname)))
+        return addr.is_private or addr.is_loopback or addr.is_link_local
+    except OSError:
+        pass
     try:
         for _fam, _typ, _pro, _can, sockaddr in socket.getaddrinfo(hostname, None):
             addr = ipaddress.ip_address(sockaddr[0])

--- a/tests/api/test_routes_project_create.py
+++ b/tests/api/test_routes_project_create.py
@@ -92,6 +92,24 @@ def test_post_projects_url_ephemeral_skips_clone_dest(client, tmp_path):
     assert resp.status_code == 200, resp.get_json()
 
 
+def test_post_projects_rejects_metadata_endpoint_ssrf(client):
+    """SSRF: POST /api/projects pointed at a cloud metadata endpoint is rejected
+    with 400 and never reaches git clone."""
+    clone_calls = []
+    with patch(
+        "quodeq.services.evaluation_mixin.run_git_clone",
+        side_effect=lambda url, dest: clone_calls.append(url),
+    ):
+        resp = client.post(
+            "/api/projects",
+            json={"repo": "https://169.254.169.254/latest/meta-data", "ephemeral": True},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["code"] == "INVALID_REPO"
+    assert clone_calls == [], "SSRF: git clone must never run for a metadata-endpoint URL"
+
+
 def test_post_projects_clone_dest_must_exist(client, tmp_path):
     nonexistent = tmp_path / "no-such-dir"
     resp = client.post(

--- a/tests/data/fs/test_repo_validation.py
+++ b/tests/data/fs/test_repo_validation.py
@@ -1,0 +1,47 @@
+"""Tests for the shared repo-URL SSRF validator (validate_remote_url)."""
+import pytest
+
+from quodeq.data.fs.repo_validation import validate_remote_url
+
+
+class TestValidateRemoteUrlSsh:
+    """git@host:path (scp-like) URLs must get the same private-host guard as
+    https URLs. git clone of these drives SSH to the host, so an internal
+    target is an SSRF/probe vector that must be rejected."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@127.0.0.1:user/repo.git",
+            "git@10.0.0.5:team/app.git",
+            "git@192.168.1.10:x/y.git",
+            "git@169.254.169.254:latest/meta.git",
+            "git@localhost:user/repo.git",
+        ],
+    )
+    def test_ssh_form_internal_host_rejected(self, url):
+        with pytest.raises(ValueError):
+            validate_remote_url(url)
+
+    def test_ssh_form_encoded_loopback_rejected(self):
+        # git's inet_aton reads 0177 as octal 127 -> dials 127.0.0.1 over SSH.
+        with pytest.raises(ValueError):
+            validate_remote_url("git@0177.0.0.1:user/repo.git")
+
+
+class TestValidateRemoteUrlHttps:
+    def test_https_loopback_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://127.0.0.1/x.git")
+
+    def test_https_link_local_metadata_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://169.254.169.254/latest/meta-data")
+
+    def test_https_octal_encoded_loopback_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://0177.0.0.1/repo.git")
+
+    def test_malformed_url_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("not a url")

--- a/tests/services/test_evaluation_mixin_register.py
+++ b/tests/services/test_evaluation_mixin_register.py
@@ -124,6 +124,63 @@ def test_register_url_clone_dest_must_exist(tmp_path):
     assert not nonexistent.exists()
 
 
+def test_register_url_rejects_private_address_before_clone(tmp_path, monkeypatch):
+    """SSRF guard: a URL whose host is a private/link-local literal is rejected
+    before git clone runs, matching the CLI prepare_repository path."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    clone_calls = []
+
+    def fake_clone(url, dest):
+        clone_calls.append(url)
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "README.md").write_text("# fake\n")
+        (Path(dest) / ".git").mkdir()
+
+    with patch("quodeq.services.evaluation_mixin.run_git_clone", side_effect=fake_clone):
+        with pytest.raises(ValueError, match="private"):
+            _register_project(
+                "https://169.254.169.254/latest/meta-data",
+                None,
+                str(reports),
+                ephemeral=True,
+            )
+
+    assert clone_calls == [], "git clone must not run for a private-host URL"
+
+
+def test_register_url_rejects_localhost_before_clone(tmp_path, monkeypatch):
+    """A localhost URL is rejected by the SSRF guard before any clone."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    clone_calls = []
+
+    def fake_clone(url, dest):
+        clone_calls.append(url)
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "README.md").write_text("# fake\n")
+        (Path(dest) / ".git").mkdir()
+
+    with patch("quodeq.services.evaluation_mixin.run_git_clone", side_effect=fake_clone):
+        with pytest.raises(ValueError):
+            _register_project(
+                "https://localhost/git/repo.git",
+                None,
+                str(reports),
+                ephemeral=True,
+            )
+
+    assert clone_calls == []
+
+
 def test_start_evaluation_rejects_url_input(tmp_path):
     """start_evaluation no longer clones; URLs must already be registered as local."""
     from quodeq.services.base import EvaluationOptions

--- a/tests/shared/test_ssrf.py
+++ b/tests/shared/test_ssrf.py
@@ -37,3 +37,31 @@ class TestIsPrivateAddress:
 
     def test_link_local(self):
         assert is_private_address("169.254.1.1") is True
+
+
+class TestEncodedIPv4Literals:
+    """Alternate IPv4 encodings that git/libc resolve into private ranges but
+    that ``ipaddress.ip_address`` rejects. They must be canonicalized so SSRF
+    via octal/hex/dword/short-form literals is caught (e.g. git clone of
+    https://0177.0.0.1/ dials 127.0.0.1)."""
+
+    def test_octal_leading_zero_loopback(self):
+        assert is_private_address("0177.0.0.1") is True
+
+    def test_octal_private_10(self):
+        assert is_private_address("012.0.0.1") is True
+
+    def test_dword_loopback(self):
+        assert is_private_address("2130706433") is True
+
+    def test_hex_loopback(self):
+        assert is_private_address("0x7f000001") is True
+
+    def test_hex_dotted_loopback(self):
+        assert is_private_address("0x7f.0.0.1") is True
+
+    def test_short_form_loopback(self):
+        assert is_private_address("127.1") is True
+
+    def test_public_dotted_literal_still_allowed(self):
+        assert is_private_address("8.8.8.8") is False

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -29,7 +29,7 @@ src/quodeq/services/_violations_jsonl.py:11:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:19:analysis
-src/quodeq/services/evaluation_mixin.py:445:analysis
+src/quodeq/services/evaluation_mixin.py:451:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis


### PR DESCRIPTION
## Problem

`POST /api/projects` → `_register_project` → `run_git_clone` cloned any `https://` / `git@` URL after only the `is_repo_url` **prefix** check — no private-IP / loopback / link-local / DNS-rebinding protection. An attacker able to reach the local API server could point a clone at internal hosts:

```json
{"repo": "https://169.254.169.254/latest/meta-data", "ephemeral": true}
```

Same class of SSRF the **CLI** path already blocked (`prepare_repository` → `_validate_remote_url`); only the web path was unguarded. `run_git_clone` has a single caller, so this was the one hole.

## Fix (commit 1)

- Promote the validator to a shared **`quodeq.data.fs.repo_validation.validate_remote_url`**.
- Reuse it from **both** entry points: `repo_clone.prepare_repository` (CLI) delegates to it, and `_register_project` (web) calls it **early — before any clone or directory side effect**. No duplicated logic, so the two paths can't drift (the root cause of the gap).

## Hardening after adversarial review (commit 2)

A multi-agent adversarial review (5 bypass lenses, each candidate **empirically** run against the real validator) found two genuine bypasses **in the validator itself** — so they affected the CLI path too:

- **Gap A — `git@host:path` (SSH) form skipped every private-host check.** `_PRIVATE_HOST_RE` is anchored `^https?://` and the DNS check was gated on `startswith("http")`, so `git@127.0.0.1:r.git`, `git@10.0.0.5:…`, `git@localhost`, `git@169.254.169.254`, and internal hostnames all passed while `git clone` would open SSH to the internal host. Fix: extract the host for **both** forms (`_remote_host`) and run the same `_resolves_to_private` check.
- **Gap B — alternate IPv4 encodings** (octal `0177.0.0.1`, hex `0x7f000001`, dword `2130706433`, short `127.1`) that git/libc dial as loopback but `ipaddress` rejects, falling through to a DNS answer that on some platforms reads the octal octet as decimal (public). Fix: canonicalize via `inet_aton` in the shared `is_private_address` before the DNS fallback — deterministic and cross-platform.

## Residual risks (documented, **shared with the pre-existing CLI path**, not fixable by URL-string validation)

- **DNS rebinding / TOCTOU** — the validator resolves once; git re-resolves at clone time.
- **HTTP redirect-to-internal** — git follows redirects by default.

These need controls at the git-invocation layer (resolve-and-pin, `-c http.followRedirects=false`, `protocol.*.allow` allowlist) across all clone sinks. Recommended as a **separate defense-in-depth follow-up**, not a blocker for closing the SSRF hole on the primary web path.

## Tests

- Service layer: private-IP + localhost URLs rejected **before** `run_git_clone` (driven red-first).
- Route layer: the metadata-endpoint payload returns `400 INVALID_REPO`, never reaches `git clone`.
- Validator layer: `git@` internal/encoded hosts rejected; `is_private_address` canonicalizes octal/hex/dword/short IPv4 literals.
- IP-literal hosts used throughout so checks are deterministic and network-independent.

Full suite: **3315 passed, 0 failed**.