### PR TITLE
fix(reliability): silence failure-streak watcher startup warnings on new dimensions

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -343,6 +343,20 @@ def process_dimension_with_cache(
     )
     watcher.start()
 
+    # Create the evidence JSONL up front so the failure-streak watcher's
+    # first poll reads an existing (empty) file instead of logging a
+    # "Could not read ... No such file" warning every poll interval until
+    # the first finding lands. The file is otherwise created lazily when a
+    # worker emits its first finding; on a large dimension that startup
+    # window is seconds of misleading warnings. An empty file is safe: every
+    # downstream reader treats a 0-byte JSONL identically to a missing one
+    # (size guard, or line-by-line iteration that yields zero results).
+    # Only create when absent so a prior phase's pre-written cached findings
+    # (above) are left untouched.
+    jsonl.parent.mkdir(parents=True, exist_ok=True)
+    if not jsonl.exists():
+        jsonl.touch()
+
     breaker = FailureStreakWatcher(
         jsonl, threshold=_resolve_failure_streak_threshold(config.options),
     )

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -935,6 +935,74 @@ class TestCachedFindingsReachEventLog:
 # the next run will re-dispatch.
 
 
+class TestEvidenceFileCreatedBeforeBreaker:
+    """A fresh dimension (all misses, no cached findings) must not spam
+    'Could not read failure-streak JSONL' warnings at startup.
+
+    Repro: in the window before any finding lands, the per-dim evidence
+    JSONL doesn't exist yet. The FailureStreakWatcher polls it anyway and
+    every scan of the missing file logs a WARNING (the user saw this once
+    per heartbeat on a 1324-file dimension). The runner now touches the
+    evidence file before starting the breaker, so the watcher always reads
+    an existing (possibly empty) file and stays silent.
+    """
+
+    def test_no_startup_warning_when_dispatch_writes_nothing(
+        self, tmp_path: Path, cache: LocalFileBackend, monkeypatch,
+    ):
+        from quodeq.shared import cancellation
+        cancellation.reset()
+        # QUODEQ_FAILURE_STREAK overrides the options field, so clear it to
+        # keep threshold=5 below authoritative — otherwise a stray `=0` in
+        # the environment would disable the breaker and false-green this.
+        monkeypatch.delenv("QUODEQ_FAILURE_STREAK", raising=False)
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        # Breaker must be enabled (threshold > 0) so the watcher actually
+        # scans the JSONL — a disabled breaker runs a no-op thread.
+        config = replace(
+            config, options=replace(config.options, failure_streak_threshold=5),
+        )
+
+        # Dispatcher that writes NOTHING to the JSONL and returns None,
+        # mirroring the fresh-dimension window before any finding is emitted.
+        def silent_dispatcher(cfg, dim_id, idx, ctx, callbacks):
+            return None
+
+        # Capture WARNING+ only, so the assertion isn't coupled to the exact
+        # warning string — any startup warning from the breaker fails the test.
+        handler = _ListHandler()
+        handler.setLevel(logging.WARNING)
+        breaker_logger = logging.getLogger(
+            "quodeq.analysis.cache._failure_streak"
+        )
+        breaker_logger.addHandler(handler)
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=silent_dispatcher,
+            ):
+                process_dimension_with_cache(
+                    config, "security", idx=1, ctx=_make_ctx(),
+                    callbacks=_make_callbacks(), cache=cache,
+                )
+        finally:
+            breaker_logger.removeHandler(handler)
+            cancellation.reset()
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        assert jsonl.exists(), (
+            "evidence JSONL must be created before the breaker starts so the "
+            "watcher never reads a missing file"
+        )
+        # Happy path (empty file, no error markers): the breaker emits no
+        # WARNING+ records at all — not the missing-file warning, nothing.
+        assert handler.messages == [], (
+            "failure-streak watcher logged unexpected warning(s) at startup; "
+            f"messages={handler.messages}"
+        )
+
+
 class TestFilesReadReflectsAnalyzedCount:
     """files_read on the returned Evidence must equal the number of source
     files reproducible from cache at run end — NOT len(input_files)."""


### PR DESCRIPTION
## Problem

Starting a new dimension floods the log with this WARNING, repeated on every poll until the first finding lands:

```
Could not read failure-streak JSONL .../<dim>_evidence.jsonl: [Errno 2] No such file or directory
```

The failure-streak circuit breaker (`FailureStreakWatcher`) starts polling the per-dimension evidence JSONL (`<dim>_evidence.jsonl`) every 0.5s the moment dispatch begins. That file is created **lazily** — only when the first finding is emitted. So during the startup window (scout agent sampling, `0 v · 0 c`), every poll catches `FileNotFoundError` and logs at WARNING level. On a large dimension (reporter saw 1324 files) that's seconds of alarming-but-benign noise.

## Fix

Touch the evidence JSONL right before starting the watcher, so its first poll reads an existing (empty) file:

```python
jsonl.parent.mkdir(parents=True, exist_ok=True)
if not jsonl.exists():
    jsonl.touch()
```

- **Create-only-when-absent** so a prior phase's pre-written cached findings are never truncated.
- **An empty file is behavior-preserving:** every downstream reader treats a 0-byte JSONL identically to a missing one (size guard, or line-by-line iteration that yields zero results), and the file's mtime is read nowhere. Verified `_compute_files_read` returns `n_hits` for both missing and empty files.
- Scoped to the touch only — `FailureStreakWatcher` has exactly one production caller, so no broader change is warranted.

## Tests

New regression test `TestEvidenceFileCreatedBeforeBreaker` that reproduces the exact warning without the fix (RED), then passes with it (GREEN). It clears `QUODEQ_FAILURE_STREAK` for hermeticity and captures at WARNING+ so it isn't coupled to the exact message string.

- 178 tests pass across the cache, dimension-runner, and cancel/resume suites.
- Adversarial review (regression-skeptic, concurrency/edge-cases, test-quality lenses) found **no** regressions; one reviewer reverted the touch and confirmed the bug returns, another stress-ran the new test 40×/40 pass.