### PR TITLE
fix: resolve the 5 real contested findings (fa56db32 tie-break)

### DIFF
--- a/src/quodeq/analysis/stream/counters.py
+++ b/src/quodeq/analysis/stream/counters.py
@@ -35,6 +35,8 @@ def parse_stream_event(line: str) -> dict | None:
 
 def extract_files_from_event(data: dict) -> set[str]:
     """Dispatch to the appropriate file extractor based on event type."""
+    if not isinstance(data, dict):
+        return set()
     etype = data.get("type", "")
     if etype == "assistant":
         return extract_files_from_blocks(data.get("message", {}).get("content", []))

--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -28,7 +28,7 @@ from quodeq.api.zip import (
     _max_zip_size_bytes,
 )
 from quodeq.data.fs._index_io import _load_index, _save_index
-from quodeq.data.fs._models import ProjectIdentity
+from quodeq.data.fs._models import ProjectIdentity, ProjectRepository
 from quodeq.data.fs._resolution import _index_key
 
 _logger = logging.getLogger(__name__)
@@ -289,12 +289,24 @@ def _rewrite_repository_info(project_dir: Path, new_uuid: str) -> None:
         _logger.warning("import: could not rewrite repository_info.json: %s", exc)
 
 
-def _update_index(reports_root: Path, identity: ProjectIdentity, project_uuid: str) -> None:
-    """Best-effort: register the imported project in project_index.json."""
+def _update_index(
+    reports_root: Path,
+    identity: ProjectIdentity,
+    project_uuid: str,
+    repository: ProjectRepository | None = None,
+) -> None:
+    """Best-effort: register the imported project in project_index.json.
+
+    When *repository* is provided its ``load_index``/``save_index`` methods
+    are used instead of the default filesystem helpers, keeping the storage
+    layer injectable for testing or alternative backends.
+    """
+    load_fn = repository.load_index if repository is not None else _load_index
+    save_fn = repository.save_index if repository is not None else _save_index
     try:
-        index = _load_index(reports_root)
+        index = load_fn(reports_root)
         index[_index_key(identity)] = project_uuid
-        _save_index(reports_root, index)
+        save_fn(reports_root, index)
     except OSError as exc:
         _logger.warning("import: could not update project_index.json: %s", exc)
 

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -35,9 +35,16 @@ def default_write_json(path: Path, data: dict) -> None:
 
 
 def count_principles_and_requirements(data: dict) -> tuple[int, int]:
-    """Return (principle_count, requirement_count) from a standard's JSON."""
+    """Return (principle_count, requirement_count) from a standard's JSON.
+
+    Malformed payloads (principles not a list, or items not dicts) are
+    tolerated: non-list values are treated as empty, non-dict items are skipped.
+    """
     principles = data.get("principles", [])
-    return len(principles), sum(len(p.get("requirements", [])) for p in principles)
+    if not isinstance(principles, list):
+        principles = []
+    valid = [p for p in principles if isinstance(p, dict)]
+    return len(valid), sum(len(p.get("requirements", [])) for p in valid)
 
 
 def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDetail:

--- a/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
+++ b/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
@@ -82,8 +82,8 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
       }
       return { x: size.w / 2, y: size.h / 2, z: fz };
     }
-    if (nav.depth === 1 && nav.dim !== null) { const s = scene.stars[nav.dim]; return { x: s.x, y: s.y, z: 5 }; }
-    if (nav.depth === 2 && nav.dim !== null && nav.prin !== null) { const p = scene.principles[nav.dim][nav.prin]; return { x: p.x, y: p.y, z: 50 }; }
+    if (nav.depth === 1 && nav.dim !== null) { const s = scene.stars?.[nav.dim]; if (!s) return { x: size.w / 2, y: size.h / 2, z: fz }; return { x: s.x, y: s.y, z: 5 }; }
+    if (nav.depth === 2 && nav.dim !== null && nav.prin !== null) { const s = scene.stars?.[nav.dim]; const p = s ? scene.principles?.[nav.dim]?.[nav.prin] : null; if (!p) return { x: size.w / 2, y: size.h / 2, z: fz }; return { x: p.x, y: p.y, z: 50 }; }
     return camRef.current;
   }, [scene, size.w, size.h, getFitZoom, navRef]);
 
@@ -120,7 +120,8 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
       const rPrin = nav.prin ?? prev?.prin ?? null;
 
       if (rDim !== null) {
-        updatePrinciplePositions(scene.principles[rDim], scene.stars[rDim], t);
+        const rStar = scene.stars[rDim];
+        if (rStar) updatePrinciplePositions(scene.principles[rDim], rStar, t);
       }
 
       const tg = getTarget();

--- a/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.test.jsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock drawFrame before the hook module is imported so the animation loop
+// does not hit real canvas / DOM APIs (parseCSSColor, getThemeColors).
+vi.mock('./galaxyViewDraw.js', () => ({
+  drawFrame: vi.fn(() => ({ hovered: null })),
+}));
+
+import { useGalaxyCamera } from './useGalaxyCamera.js';
+
+// Minimal scene factory — build a scene with `n` stars each having one principle.
+function makeScene(n) {
+  const stars = Array.from({ length: n }, (_, i) => ({
+    x: 100 + i * 10,
+    y: 200 + i * 10,
+    ba: 0,
+    j: 5,
+    _clusterCx: undefined,
+  }));
+  const principles = stars.map((s) => [
+    { x: s.x + 5, y: s.y + 5, ba: 0, od: 10 },
+  ]);
+  return { stars, principles, _maxExtent: 150, constellations: [] };
+}
+
+function makeRefs(navValue) {
+  return {
+    canvasRef: { current: null },       // no real canvas needed for getTarget tests
+    savedNavRef: { current: null },
+    savedCamRef: { current: null },
+    navRef: { current: navValue },
+    prevNavRef: { current: null },
+    animRef: { current: null },
+    mouseRef: { current: { x: 0, y: 0 } },
+    hoveredRef: { current: null },
+    frameRef: { current: null },
+  };
+}
+
+describe('useGalaxyCamera — getTarget stale-index guard (#387)', () => {
+  it('returns safe center/zoom default at depth 1 when nav.dim is out of range for the current scene', () => {
+    // Simulate: nav was set when scene had 5 stars (dim=4); a new scene with only 2 stars is received.
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 1, dim: 4, prin: null, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    // Must not throw; must fall back to center
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns safe center/zoom default at depth 2 when nav.dim is out of range', () => {
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 2, dim: 4, prin: 0, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns safe center/zoom default at depth 2 when nav.prin is out of range', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    // dim=1 is valid (scene has 3 stars) but prin=5 is out of range (only 1 principle per star)
+    const refs = makeRefs({ depth: 2, dim: 1, prin: 5, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns the correct star target at depth 1 for a valid in-range index', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 1, dim: 1, prin: null, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    // The hook renders without a canvas so stars won't have been position-updated,
+    // but their initial x/y are set in makeScene.
+    expect(target).toMatchObject({ z: 5 });
+  });
+
+  it('returns the correct principle target at depth 2 for valid in-range indices', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 2, dim: 0, prin: 0, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toMatchObject({ z: 50 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePrinciplePositions stale-star guard in the animation loop (#387 follow-up)
+// ---------------------------------------------------------------------------
+// The animation loop calls updatePrinciplePositions(scene.principles[rDim], scene.stars[rDim], t).
+// rDim comes from nav.dim ?? prev?.dim ?? null and can be a stale index after a scene rebuild
+// (scene.stars[rDim] === undefined). We can't drive requestAnimationFrame directly in jsdom,
+// so we test the guard at the unit level: the internal helper must not throw when the star
+// lookup yields undefined. We verify this by calling the hook with a canvas stub that lets
+// one rAF tick fire and asserting no error is thrown even when prevNavRef.dim is out of range.
+describe('useGalaxyCamera — animation-loop stale-star guard', () => {
+  let rafCallbacks;
+  let rafSpy;
+  let cancelSpy;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      const id = rafCallbacks.push(cb);
+      return id;
+    });
+    cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  function makeCanvasRef() {
+    const ctx = {
+      clearRect: vi.fn(),
+      save: vi.fn(), restore: vi.fn(),
+      beginPath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn(),
+      fillText: vi.fn(), measureText: vi.fn(() => ({ width: 10 })),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      drawImage: vi.fn(),
+      canvas: { width: 800, height: 600 },
+    };
+    const canvas = {
+      getContext: vi.fn(() => ctx),
+      width: 800,
+      height: 600,
+      parentElement: null,
+    };
+    return { current: canvas };
+  }
+
+  it('does not throw when rDim from prevNavRef is out of range for the current scene', () => {
+    // scene has 2 stars; prevNavRef.dim = 4 (stale from previous larger scene)
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+
+    const refs = {
+      ...makeRefs({ depth: 0, dim: null, prin: null, clusterCx: null, clusterCy: null }),
+      canvasRef: makeCanvasRef(),
+      // prevNavRef carries the stale dim that drives rDim in the animation loop
+      prevNavRef: { current: { dim: 4, prin: null } },
+    };
+
+    // Rendering the hook registers the animation loop via useEffect.
+    expect(() => {
+      renderHook(() =>
+        useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+      );
+      // Fire one animation frame tick — this is where the crash would occur.
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[0]();
+      }
+    }).not.toThrow();
+  });
+
+  it('does not throw when nav.dim itself is out of range for the current scene', () => {
+    // scene has 2 stars; nav.dim = 5 (stale)
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+
+    const refs = {
+      ...makeRefs({ depth: 1, dim: 5, prin: null, clusterCx: null, clusterCy: null }),
+      canvasRef: makeCanvasRef(),
+    };
+
+    expect(() => {
+      renderHook(() =>
+        useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+      );
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[0]();
+      }
+    }).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
@@ -1,9 +1,10 @@
 import { useCallback, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { listLibrary, importFromLibrary } from '../../../api/index.js';
+import { useApi } from '../../../api/ApiContext.jsx';
 import { standardsKeys } from '../../../api/queryKeys.js';
 
 export function useLibrary() {
+  const { listLibrary, importFromLibrary } = useApi();
   const [importError, setImportError] = useState(null);
 
   const { data, isLoading, error } = useQuery({
@@ -19,7 +20,7 @@ export function useLibrary() {
       setImportError(err.message || 'Failed to import standard');
       throw err;
     }
-  }, []);
+  }, [importFromLibrary]);
 
   return {
     libraryStandards: data || [],

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
@@ -1,30 +1,50 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { useLibrary } from './useLibrary.js';
 
-vi.mock('../../../api/index.js', () => ({
+const fakeApi = {
   listLibrary: vi.fn(),
   importFromLibrary: vi.fn(),
-}));
+};
 
-import { listLibrary, importFromLibrary } from '../../../api/index.js';
-import { useLibrary } from './useLibrary.js';
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
 
 describe('useLibrary', () => {
   beforeEach(() => {
-    listLibrary.mockReset();
-    importFromLibrary.mockReset();
-  });
-  afterEach(() => {
-    vi.restoreAllMocks();
+    Object.values(fakeApi).forEach((fn) => fn.mockReset());
   });
 
-  it('loads the library list on mount', async () => {
-    listLibrary.mockResolvedValue([
+  it('calls the injected listLibrary from ApiContext, not a hard import', async () => {
+    fakeApi.listLibrary.mockResolvedValue([
       { id: 's1', name: 'Standard 1' },
       { id: 's2', name: 'Standard 2' },
     ]);
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.libraryStandards).toHaveLength(2);
+    });
+    expect(fakeApi.listLibrary).toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('loads the library list on mount', async () => {
+    fakeApi.listLibrary.mockResolvedValue([
+      { id: 's1', name: 'Standard 1' },
+      { id: 's2', name: 'Standard 2' },
+    ]);
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => {
       expect(result.current.libraryStandards).toHaveLength(2);
     });
@@ -32,17 +52,29 @@ describe('useLibrary', () => {
   });
 
   it('exposes the error message when listLibrary fails', async () => {
-    listLibrary.mockRejectedValue(new Error('library down'));
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    fakeApi.listLibrary.mockRejectedValue(new Error('library down'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => {
       expect(result.current.error).toBe('library down');
     });
   });
 
+  it('importStandard calls the injected importFromLibrary from ApiContext', async () => {
+    fakeApi.listLibrary.mockResolvedValue([]);
+    fakeApi.importFromLibrary.mockResolvedValue({});
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.importStandard('foo.yaml');
+    });
+    expect(fakeApi.importFromLibrary).toHaveBeenCalledWith('foo.yaml');
+  });
+
   it('importStandard surfaces the import error and re-throws', async () => {
-    listLibrary.mockResolvedValue([]);
-    importFromLibrary.mockRejectedValue(new Error('cannot import'));
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    fakeApi.listLibrary.mockResolvedValue([]);
+    fakeApi.importFromLibrary.mockRejectedValue(new Error('cannot import'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     let thrown = null;

--- a/tests/analysis/test_stream_counters_nondict.py
+++ b/tests/analysis/test_stream_counters_nondict.py
@@ -1,0 +1,59 @@
+"""#380 — extract_files_from_event / count_files_in_stream must not raise on non-dict JSON lines."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.stream.counters import count_files_in_stream, extract_files_from_event
+
+
+class TestExtractFilesFromEventNonDict:
+    """extract_files_from_event must tolerate any non-dict value without raising."""
+
+    @pytest.mark.parametrize("value", [42, "foo", [1, 2, 3], True, None])
+    def test_non_dict_returns_empty_set(self, value) -> None:
+        assert extract_files_from_event(value) == set()
+
+    def test_dict_still_extracts_files(self) -> None:
+        event = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/a/b.py"}},
+                ]
+            },
+        }
+        assert extract_files_from_event(event) == {"/a/b.py"}
+
+
+class TestCountFilesInStreamNonDict:
+    """count_files_in_stream must skip non-dict JSON lines and count correctly."""
+
+    def test_non_dict_lines_are_skipped(self, tmp_path: Path) -> None:
+        stream = tmp_path / "stream.json"
+        lines = [
+            json.dumps(42),
+            json.dumps("hello"),
+            json.dumps([1, 2, 3]),
+            json.dumps(True),
+            # A valid assistant event that reads one file
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": "/x/y.py"}},
+                    ]
+                },
+            }),
+        ]
+        stream.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = count_files_in_stream(stream)
+        assert result == {"/x/y.py"}
+
+    def test_all_non_dict_returns_empty(self, tmp_path: Path) -> None:
+        stream = tmp_path / "stream.json"
+        stream.write_text(json.dumps(99) + "\n" + json.dumps([]) + "\n", encoding="utf-8")
+        result = count_files_in_stream(stream)
+        assert result == set()

--- a/tests/api/test_project_import.py
+++ b/tests/api/test_project_import.py
@@ -432,3 +432,60 @@ def test_import_export_roundtrip(app_client):
         resp = _post_zip(c, zip_bytes)
     assert resp.status_code == 200, resp.get_json()
     assert (eval_dir / src_uuid / "scan.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# #2494 — _update_index must use an injected repository when provided
+# ---------------------------------------------------------------------------
+
+class TestUpdateIndexDI:
+    """_update_index must delegate to the injected ProjectRepository when given."""
+
+    def test_injected_repository_is_used_not_filesystem(self, tmp_path):
+        """When a repository is injected, load_index/save_index on it are called
+        instead of the default _load_index/_save_index filesystem helpers."""
+        from pathlib import Path
+        from quodeq.api.import_project import _update_index
+        from quodeq.data.fs._models import ProjectIdentity
+        from quodeq.data.fs._resolution import _index_key
+
+        captured_loads: list = []
+        captured_saves: list = []
+
+        class SpyRepository:
+            def load_index(self, reports_dir: Path) -> dict[str, str]:
+                captured_loads.append(reports_dir)
+                return {}
+
+            def save_index(self, reports_dir: Path, index: dict[str, str]) -> None:
+                captured_saves.append((reports_dir, dict(index)))
+
+        identity = ProjectIdentity(project_name="myrepo", repo_path="/tmp/myrepo")
+        project_uuid = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+        spy = SpyRepository()
+
+        _update_index(tmp_path, identity, project_uuid, repository=spy)
+
+        assert len(captured_loads) == 1
+        assert captured_loads[0] == tmp_path
+        assert len(captured_saves) == 1
+        saved_dir, saved_index = captured_saves[0]
+        assert saved_dir == tmp_path
+        assert saved_index[_index_key(identity)] == project_uuid
+
+    def test_no_repository_uses_filesystem(self, tmp_path):
+        """Without a repository, _update_index writes to project_index.json on disk."""
+        import json
+        from quodeq.api.import_project import _update_index
+        from quodeq.data.fs._models import ProjectIdentity
+        from quodeq.data.fs._resolution import _index_key
+
+        identity = ProjectIdentity(project_name="testrepo", repo_path="/tmp/testrepo")
+        project_uuid = "11112222-3333-4444-5555-666677778888"
+
+        _update_index(tmp_path, identity, project_uuid)
+
+        index_file = tmp_path / "project_index.json"
+        assert index_file.exists()
+        data = json.loads(index_file.read_text())
+        assert data[_index_key(identity)] == project_uuid

--- a/tests/services/test_standards_io_coverage.py
+++ b/tests/services/test_standards_io_coverage.py
@@ -67,6 +67,40 @@ class TestCountPrinciplesAndRequirements:
         data = {"principles": [{"name": "P1", "requirements": []}]}
         assert count_principles_and_requirements(data) == (1, 0)
 
+    # --- #293: malformed persisted data must not crash ---
+
+    def test_principles_not_a_list_returns_zero_counts(self):
+        """principles as a dict (not a list) must not raise."""
+        data = {"principles": {"P1": {"requirements": []}}}
+        assert count_principles_and_requirements(data) == (0, 0)
+
+    def test_principles_string_returns_zero_counts(self):
+        data = {"principles": "bad value"}
+        assert count_principles_and_requirements(data) == (0, 0)
+
+    def test_non_dict_items_in_principles_are_skipped(self):
+        """Non-dict items in the principles list are silently skipped."""
+        data = {
+            "principles": [
+                "not a dict",
+                42,
+                {"name": "P1", "requirements": [{"id": "R1"}]},
+                None,
+            ]
+        }
+        # Only the one valid dict counts
+        assert count_principles_and_requirements(data) == (1, 1)
+
+    def test_mix_of_valid_and_invalid_principles(self):
+        data = {
+            "principles": [
+                {"name": "P1", "requirements": [{"id": "R1"}, {"id": "R2"}]},
+                "garbage",
+                {"name": "P2", "requirements": []},
+            ]
+        }
+        assert count_principles_and_requirements(data) == (2, 2)
+
 
 class TestBuildDetail:
     def test_minimal(self):


### PR DESCRIPTION
Closes the **contested** bucket from the majors triage of run `fa56db32`. A tie-break pass (one adversarial agent per finding, against current develop) settled the 14 contested findings: **5 already fixed** by prior PRs (#16 by #644, #27/#69 by the held-security id guard, #1904 + #2385 by reliability/a11y), **4 false positives**, and **5 genuinely real** — fixed here. The 9 non-real were dismissed in the run.

## The 5 fixes
- **#387** (major) `useGalaxyCamera.js` — stale nav index after a scene rebuild crashed the galaxy view when dimensions change mid-session. Guarded the index derefs in `getTarget` (both depths) with a safe center/fit-zoom fallback, and closed the **same crash class in the animation loop** (`scene.stars[rDim]`) that a review caught.
- **#293** (major) `_standards_io.py` — the `POST /api/standards` create path writes a raw payload without `validate_import`, so malformed persisted `principles` crashed on later read. Type-guarded the read site (`count_principles_and_requirements`) to skip non-list/non-dict data.
- **#380** (minor) `stream/counters.py` — a valid-JSON non-dict line raised an uncaught `AttributeError`; added an `isinstance(data, dict)` guard in `extract_files_from_event` (root-cause, also protects the `progress_reader` callers).
- **#2494** (minor) `import_project.py` — `_update_index` now takes an optional injectable `ProjectRepository` (matching the existing `project_resolver` seam), default behavior unchanged.
- **#2515** (minor) `useLibrary.js` — migrated from a direct API import to the `useApi()` DI pattern every sibling hook uses (also fixed a stale `useCallback` dep).

## Tests
New regression tests per fix (stale-index no-throw scenarios, malformed-data guards, DI dispatch spies). Full Python suite **3477 passed**; UI **510 passed**. Each cluster passed spec + code-quality review.

## Out of scope
The 75 needs-judgment + 996 untriaged minors. The 5 fixed findings are real (not dismissed) and will clear on the next nightly scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)