### PR TITLE
Release v1.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         # send signals, which are inherently timing-sensitive on shared CI
         # runners. They run elsewhere (e.g. nightly) where flakes are
         # tolerable. PR CI should be fast and deterministic.
-        run: uv run pytest tests/ -q --tb=short -m "not integration"
+        run: uv run pytest tests/ -q --tb=short -m "not integration" --cov=quodeq --cov-report=term-missing
 
       - name: Run tests (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -29,33 +29,42 @@ jobs:
           VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Wait for PyPI availability
+      - name: Wait for PyPI sdist and get URL + SHA256
+        id: sdist
+        # Poll the JSON API, not the legacy /packages/source/ redirect: the
+        # redirect lags far behind upload (v1.3.0 still 404'd there hours
+        # after the sdist was listed in the JSON API, timing out this gate
+        # and leaving the tap pointing at a dead URL until a manual fix).
+        # The API carries the canonical hashed download URL plus the
+        # authoritative sha256 digest, so the formula gets a URL that
+        # resolves immediately and we never hash an error-page body.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          for i in $(seq 1 30); do
-            if curl -sf "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz" -o /dev/null; then
-              echo "Package available on PyPI"
+          for i in $(seq 1 40); do
+            SDIST="$(curl -sf "https://pypi.org/pypi/quodeq/${VERSION}/json" \
+              | jq -c '[.urls[] | select(.packagetype == "sdist")][0] // empty' || true)"
+            if [ -n "$SDIST" ]; then
+              URL="$(echo "$SDIST" | jq -r '.url')"
+              SHA="$(echo "$SDIST" | jq -r '.digests.sha256')"
+              echo "sdist available on PyPI: ${URL} (sha256: ${SHA})"
+              echo "url=$URL" >> "$GITHUB_OUTPUT"
+              echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Waiting for PyPI... ($i/30)"
-            sleep 10
+            echo "Waiting for PyPI sdist... ($i/40)"
+            sleep 30
           done
-          echo "Timed out waiting for PyPI"
+          echo "Timed out after 20 minutes waiting for sdist quodeq-${VERSION}.tar.gz on PyPI."
+          echo "Check that the publish workflow actually uploaded an sdist for ${VERSION}."
           exit 1
-
-      - name: Get SHA256 of tarball
-        id: sha
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          SHA=$(curl -sL "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz" | shasum -a 256 | cut -d' ' -f1)
-          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Update homebrew-tap repo
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          SHA="${{ steps.sha.outputs.sha256 }}"
+          URL="${{ steps.sdist.outputs.url }}"
+          SHA="${{ steps.sdist.outputs.sha256 }}"
 
           # Get current file SHA from the tap repo
           FILE_SHA=$(gh api repos/quodeq/homebrew-tap/contents/quodeq.rb --jq '.sha')
@@ -67,7 +76,7 @@ jobs:
 
             desc "AI-powered source code quality evaluation platform"
             homepage "https://github.com/quodeq/quodeq"
-            url "https://files.pythonhosted.org/packages/source/q/quodeq/quodeq-${VERSION}.tar.gz"
+            url "${URL}"
             sha256 "${SHA}"
             license "MIT"
 

--- a/.github/workflows/wheel-smoke.yml
+++ b/.github/workflows/wheel-smoke.yml
@@ -65,15 +65,36 @@ jobs:
             exit 1
           fi
 
-      - name: Confirm wheel contains pre-built UI static
+      # The size assert above only catches the wheel getting too BIG. This
+      # catches it getting too SMALL: if the uv_build include rules regress,
+      # the wheel can ship without its runtime payload and every PyPI install
+      # is broken at runtime while CI stays green. Assert the payload is there:
+      #   quodeq/data/**          - evaluators, standards, prompts, config
+      #   quodeq/static/index.html + quodeq/static/assets/** - pre-built dashboard
+      # (index.html alone is not enough; a broken UI build leaves assets/ empty.)
+      - name: Confirm wheel bundles the runtime payload
         run: |
           wheel=$(ls dist/quodeq-*.whl)
-          if ! unzip -l "$wheel" | grep -q "quodeq/static/index.html"; then
-            echo "::error::Wheel is missing quodeq/static/index.html"
-            unzip -l "$wheel" | head -40
+          echo "Wheel: $wheel"
+          fail=0
+          require() {  # require <grep -E pattern> <human description>
+            n=$(unzip -l "$wheel" | grep -cE "$1" || true)
+            if [ "$n" -eq 0 ]; then
+              echo "::error::Wheel is missing $2"
+              fail=1
+            else
+              echo "OK: $2 ($n entries)"
+            fi
+          }
+          require 'quodeq/data/.+[^/]$'          'runtime data under quodeq/data/'
+          require 'quodeq/static/index\.html$'   'quodeq/static/index.html'
+          require 'quodeq/static/assets/.+[^/]$' 'dashboard assets under quodeq/static/assets/'
+          if [ "$fail" -ne 0 ]; then
+            echo "---- wheel contents (first 60) ----"
+            unzip -l "$wheel" | head -60
             exit 1
           fi
-          echo "OK: index.html present in wheel"
+          echo "OK: wheel bundles the full runtime payload"
 
       - name: Build sdist
         run: uv build --sdist

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/
 __pycache__/
 *.pyc
 .venv/
+.coverage*
+htmlcov/
 evaluations/
 
 docs/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,6 +28,11 @@ shared/        -> stdlib only
 config/        -> stdlib, shared/
 ```
 
+These rules are enforced in CI by `tools/check_imports.py` via `tests/tools/test_import_layers.py`.
+Pre-existing violations are grandfathered in `tools/import_baseline.txt` (a burn-down list: fix
+imports rather than add entries). Regenerate the baseline only with justification:
+`python tools/check_imports.py --update-baseline`.
+
 ## File Size Guidelines (soft limits)
 
 | Metric | Limit | Rationale |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-20
+
+### Features
+- **Finding taxonomy**: analysis now emits taxonomy codes so fresh runs group findings by their vulnerability taxonomy, not just by principle (PRs #622, #623, #624).
+
+### Improvements
+- **Analysis quality**: critical severity now requires reachable input provenance, sharply cutting false-positive criticals. New coverage and import-layer baseline gates keep quality from regressing (PRs #623, #636).
+- **Accessibility**: keyboard navigation across the map and galaxy visualizations, grade-boundary sliders, and resizable side-pane dividers; the evaluation error toast is now a proper button (PR #643).
+- **Performance**: heavy scoring and projection work moved off the request thread, an N+1 query batched into one, and rate-limit state is now bounded (PR #643).
+- **Resilience**: the dimension list is recovered from sidecars when run status is missing (PR #627); a downgraded `~/.quodeq/index.db` is discarded and rebuilt from the run files instead of crashing on first access (#621); more API errors carry machine-readable codes (PR #643).
+- **Configuration**: cache paths, dimensions, and provider settings are no longer hardcoded (PR #643).
+
 ### Fixes
-- **Index downgrade no longer crashes the dashboard**: when `~/.quodeq/index.db` was migrated forward by a newer quodeq and you then run an older one, the cross-run index is discarded and rebuilt from the run files on disk instead of raising an unhandled schema error on first access. The index is a derived projection, so nothing is lost (#621).
+- **Security**: a broad hardening pass - a Windows command-injection guard, an atomic no-follow rate-limit file write, path-traversal containment (cache keys, run-events job ids, custom-evaluator ids, cache hashing), SSRF guards on the omlx and project-clone paths (including git@ SSH and encoded-IPv4 bypasses), a tightened Content-Security-Policy, and a localhost-only webview reload allowlist (PRs #629, #642, #643, #644, #646).
+- **Reliability**: timeouts on all external HTTP and SSE calls, consistent exception handling, guards against malformed and non-dict input, atomic grade rewrites with concurrency locks, structured route error handling, and several UI crash guards including the galaxy view (PRs #634, #637, #646).
+- **Scoring**: stop dropping untagged violations under partial taxonomy coverage, and emit taxonomy codes in production so grouping works on real runs (PRs #624, #628).
 
 ## [1.3.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixes
+- **Index downgrade no longer crashes the dashboard**: when `~/.quodeq/index.db` was migrated forward by a newer quodeq and you then run an older one, the cross-run index is discarded and rebuilt from the run files on disk instead of raising an unhandled schema error on first access. The index is a derived projection, so nothing is lost (#621).
+
 ## [1.3.0] - 2026-06-11
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Open an issue using the **Feature Request** template. Describe the problem you a
 1. Fork the repo and create a branch from `develop`
 2. Make your changes
 3. Run the tests: `uv run pytest`
+   CI enforces a coverage floor (80%, see `fail_under` in `pyproject.toml`); reproduce locally with
+   `uv run pytest tests/ -q -m "not integration" --cov=quodeq`.
 4. Open a pull request targeting `develop`
 
 Keep pull requests focused on a single change. If you are fixing a bug and also want to refactor something, open two PRs.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 <h2 align="center">AI-powered code quality and security scanner</h2>
-<p align="center"><strong>v1.3.0</strong></p>
+<p align="center"><strong>v1.4.0</strong></p>
 <p align="center">
   <a href="https://github.com/quodeq/quodeq/actions/workflows/test.yml"><img src="https://github.com/quodeq/quodeq/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
   <a href="https://github.com/quodeq/quodeq/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>

--- a/packaging/macos/launcher.sh
+++ b/packaging/macos/launcher.sh
@@ -63,7 +63,7 @@ if [ -z "$QUODEQ" ]; then
         # ranges. The release skill bumps this on every cut (see
         # .claude/skills/release/SKILL.md).
         # TODO: ship requirements.txt with hashes in the .app bundle.
-        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.3.0" 2>&1
+        python3 -m pip install --user --only-binary :all: --no-deps "quodeq==1.4.0" 2>&1
     fi
     export PATH="$PATH:$(python3 -m site --user-base)/bin"
     QUODEQ=$(command -v quodeq 2>/dev/null)

--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -1,6 +1,7 @@
 """Quodeq menu bar app for macOS."""
 from __future__ import annotations
 
+import logging as _logging
 import os
 import signal
 import subprocess
@@ -33,17 +34,37 @@ from _dashboard import (
 )
 
 _DEFAULT_APP_PORT = 7863
-_POLL_INTERVAL = int(os.environ.get("QUODEQ_POLL_INTERVAL", "5"))
+try:
+    _POLL_INTERVAL = int(os.environ.get("QUODEQ_POLL_INTERVAL", "5"))
+except ValueError:
+    _logging.getLogger(__name__).warning("Invalid QUODEQ_POLL_INTERVAL; using default 5")
+    _POLL_INTERVAL = 5
 _PROCESS_PATTERNS = ("quodeq.api.app", "quodeq.action_api", "quodeq dashboard")
-_AUTO_START_DELAY_S = float(os.environ.get("QUODEQ_AUTO_START_DELAY_S", "1.5"))
+try:
+    _AUTO_START_DELAY_S = float(os.environ.get("QUODEQ_AUTO_START_DELAY_S", "1.5"))
+except ValueError:
+    _logging.getLogger(__name__).warning("Invalid QUODEQ_AUTO_START_DELAY_S; using default 1.5")
+    _AUTO_START_DELAY_S = 1.5
 _DEFAULT_PORTS = "7863,7864,7865,7866,7867,7868,7869"
 
 
 def _load_config(env=None):
     """Read port configuration from the environment (or an injected mapping)."""
+    _cfg_log = _logging.getLogger(__name__)
     env = env or os.environ
-    app_port = int(env.get("QUODEQ_PORT", str(_DEFAULT_APP_PORT)))
-    ports = tuple(int(p) for p in env.get("QUODEQ_PORTS", _DEFAULT_PORTS).split(","))
+    try:
+        app_port = int(env.get("QUODEQ_PORT", str(_DEFAULT_APP_PORT)))
+    except ValueError:
+        _cfg_log.warning("Invalid QUODEQ_PORT; using default %d", _DEFAULT_APP_PORT)
+        app_port = _DEFAULT_APP_PORT
+    raw_ports = env.get("QUODEQ_PORTS", _DEFAULT_PORTS)
+    ports_list = []
+    for p in raw_ports.split(","):
+        try:
+            ports_list.append(int(p))
+        except ValueError:
+            _cfg_log.warning("Invalid port value %r in QUODEQ_PORTS; skipping", p)
+    ports = tuple(ports_list) if ports_list else tuple(int(p) for p in _DEFAULT_PORTS.split(","))
     return app_port, ports
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Issues = "https://github.com/quodeq/quodeq/issues"
 
 [dependency-groups]
 dev = [
-    "pytest==9.0.3",
+    "pytest==9.1.0",
     "pytest-cov==7.1.0",
     "pytest-timeout==2.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,11 @@ timeout_method = "thread"
 
 [tool.coverage.run]
 source = ["quodeq"]
+branch = true
 
 [tool.coverage.report]
+# Enforced gate (activated by --cov in CI). Ratchet this up as coverage
+# improves; never lower it without justification.
 fail_under = 80
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "quodeq"
-version = "1.3.0"
+version = "1.4.0"
 description = "Source code quality evaluation platform powered by AI"
 readme = "README.md"
 license = "MIT"

--- a/src/quodeq/_cli_resolution.py
+++ b/src/quodeq/_cli_resolution.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 import tempfile as _tempfile
@@ -58,10 +59,8 @@ def _create_worktree(repo_dir: Path, branch: str) -> Path | None:
         return worktree_dir
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
         print(f"Failed to create worktree for branch '{branch}': {exc}", file=sys.stderr)
-        try:
-            worktree_dir.rmdir()
-        except OSError:
-            pass
+        _cleanup_worktree(repo_dir, worktree_dir)
+        shutil.rmtree(worktree_dir, ignore_errors=True)
         return None
 
 

--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -27,8 +27,8 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
             if _eid and _eid not in seen:
                 result.append(_eid)
                 seen.add(_eid)
-        except (OSError, ValueError, KeyError):
-            pass
+        except (OSError, ValueError, KeyError) as e:
+            log_warning(f"Skipping custom evaluator {_p.name}: {e}")
     return result
 
 

--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -23,7 +23,11 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
     seen = set(result)
     for _p in evaluators_dir.glob("*.json"):
         try:
-            _eid = _json.loads(_p.read_text(encoding="utf-8")).get("id")
+            _parsed = _json.loads(_p.read_text(encoding="utf-8"))
+            if not isinstance(_parsed, dict):
+                log_warning(f"Skipping custom evaluator {_p.name}: not a JSON object")
+                continue
+            _eid = _parsed.get("id")
             if _eid and _eid not in seen:
                 result.append(_eid)
                 seen.add(_eid)

--- a/src/quodeq/analysis/_analysis_context.py
+++ b/src/quodeq/analysis/_analysis_context.py
@@ -8,6 +8,7 @@ passed to every dimension runner.
 from __future__ import annotations
 
 import json as _json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -15,6 +16,14 @@ from quodeq.analysis._types import RunConfig, _AnalysisContext
 from quodeq.analysis.prompts.builder import load_template
 from quodeq.config.paths import default_paths
 from quodeq.shared.logging import log_warning
+
+
+def _is_path_safe_id(value: object) -> bool:
+    return (
+        isinstance(value, str) and bool(value)
+        and "/" not in value and "\\" not in value
+        and ".." not in value and os.sep not in value
+    )
 
 
 def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[str]:
@@ -29,6 +38,9 @@ def _load_custom_dimensions(evaluators_dir: Path, dims_data: list[str]) -> list[
                 continue
             _eid = _parsed.get("id")
             if _eid and _eid not in seen:
+                if not _is_path_safe_id(_eid):
+                    log_warning(f"Skipping custom evaluator {_p.name}: unsafe id {_eid!r}")
+                    continue
                 result.append(_eid)
                 seen.add(_eid)
         except (OSError, ValueError, KeyError) as e:

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -502,8 +502,9 @@ def run_api_analysis(
             or run_config.options.ai_model
             or "unknown"
         )
+        from quodeq.analysis.cache.local import default_cache_root as _dcr  # noqa: PLC0415
         cache_writer = build_cache_writer(
-            cache_root=Path.home() / ".quodeq" / "cache" / "results",
+            cache_root=_dcr(),
             src_root=run_config.src,
             standards_dir=run_config.standards_dir,
             dimension=dim_id,

--- a/src/quodeq/analysis/_api_runner.py
+++ b/src/quodeq/analysis/_api_runner.py
@@ -88,6 +88,15 @@ class _Finding(BaseModel):
         ),
     )
     severity: _Severity = Field(default=_Severity.minor)
+    vt: str | None = Field(
+        default=None,
+        description=(
+            "Violation type taxonomy code: a short, stable, kebab-case class "
+            "of the violation (e.g. 'code-injection', 'hardcoded-secret', "
+            "'missing-error-handling'). Reuse the exact same code for every "
+            "finding of the same kind so near-duplicates group together."
+        ),
+    )
     w: str = Field(description="Short title of the finding")
     snippet: str = Field(
         description=(

--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -20,6 +20,17 @@ from quodeq.shared.utils import get_ai_cmd, get_ai_model
 
 _log = logging.getLogger(__name__)
 
+
+def _default_cache_root():
+    """Return the result cache root, honouring QUODEQ_CACHE_ROOT.
+
+    Deferred import breaks the circular dependency:
+    _command -> cache/__init__ -> dimension_helpers -> _types -> subprocess -> _command.
+    """
+    from quodeq.analysis.cache.local import default_cache_root  # noqa: PLC0415
+    return default_cache_root()
+
+
 _DEFAULT_AI_TOOLS = "Glob,Grep,Read"
 _DEFAULT_BASE_AI_ARGS = "--print --output-format stream-json --verbose"
 
@@ -189,7 +200,7 @@ def _build_mcp_server_args(
     # agree for the same project state. See cache_writer.build_cache_writer
     # and cache.dimension_helpers._model_id_from for the reference.
     mcp_args.extend([
-        "--cache-root", str(Path.home() / ".quodeq" / "cache" / "results"),
+        "--cache-root", str(_default_cache_root()),
         "--model-id", _resolve_model_id(config),
         "--language", _resolve_language(config),
     ])

--- a/src/quodeq/analysis/_mcp_config.py
+++ b/src/quodeq/analysis/_mcp_config.py
@@ -10,6 +10,16 @@ from pathlib import Path
 from quodeq.analysis._config import _AgentParams
 
 
+def _default_cache_root():
+    """Return the result cache root, honouring QUODEQ_CACHE_ROOT.
+
+    Deferred import breaks the circular dependency:
+    _mcp_config -> cache/__init__ -> dimension_helpers -> _types -> subprocess -> _command -> _mcp_config.
+    """
+    from quodeq.analysis.cache.local import default_cache_root  # noqa: PLC0415
+    return default_cache_root()
+
+
 def _create_mcp_config(
     jsonl_file: Path,
     compiled_dir: Path | None = None,
@@ -34,7 +44,7 @@ def _create_mcp_config(
     # cache.dimension_helpers._model_id_from ('unknown') and Task 5's
     # language-unset contract ('').
     mcp_args.extend([
-        "--cache-root", str(Path.home() / ".quodeq" / "cache" / "results"),
+        "--cache-root", str(_default_cache_root()),
         "--model-id", ap.model_id or "unknown",
         "--language", ap.language or "",
     ])

--- a/src/quodeq/analysis/api_prompt_assembly.py
+++ b/src/quodeq/analysis/api_prompt_assembly.py
@@ -30,6 +30,7 @@ Each finding must be a JSON object with these fields:
   Optional:
     "end_line": integer - last line if multi-line
     "scope": string - "file", "class", or "module"
+    "vt": string - violation type taxonomy code: a short, stable, kebab-case class of the violation (e.g. "code-injection", "hardcoded-secret", "missing-error-handling"); reuse the exact same code for every finding of the same kind
 """
 
 

--- a/src/quodeq/analysis/cache/_failure_streak.py
+++ b/src/quodeq/analysis/cache/_failure_streak.py
@@ -132,7 +132,8 @@ class FailureStreakWatcher:
                 f.seek(offset)
                 chunk = f.read()
                 new_offset = f.tell()
-        except FileNotFoundError:
+        except OSError as e:
+            _logger.warning("Could not read failure-streak JSONL %s: %s", self._jsonl_path, e)
             return offset, streak, recent
         for raw in chunk.splitlines():
             raw = raw.strip()

--- a/src/quodeq/analysis/cache/cache_writer.py
+++ b/src/quodeq/analysis/cache/cache_writer.py
@@ -77,7 +77,12 @@ def build_cache_writer(
     version = quodeq_version()
 
     def write(file_path: str, findings: list[dict]) -> None:
-        content_hash = _hash_file(src_root / file_path) or ""
+        target = src_root / file_path
+        try:
+            inside = target.resolve().is_relative_to(src_root.resolve())
+        except (OSError, ValueError):
+            inside = False
+        content_hash = (_hash_file(target) or "") if inside else ""
         key_struct = CacheKey(
             schema_version=_SCHEMA_VERSION,
             file_content_hash=content_hash,

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -343,6 +343,20 @@ def process_dimension_with_cache(
     )
     watcher.start()
 
+    # Create the evidence JSONL up front so the failure-streak watcher's
+    # first poll reads an existing (empty) file instead of logging a
+    # "Could not read ... No such file" warning every poll interval until
+    # the first finding lands. The file is otherwise created lazily when a
+    # worker emits its first finding; on a large dimension that startup
+    # window is seconds of misleading warnings. An empty file is safe: every
+    # downstream reader treats a 0-byte JSONL identically to a missing one
+    # (size guard, or line-by-line iteration that yields zero results).
+    # Only create when absent so a prior phase's pre-written cached findings
+    # (above) are left untouched.
+    jsonl.parent.mkdir(parents=True, exist_ok=True)
+    if not jsonl.exists():
+        jsonl.touch()
+
     breaker = FailureStreakWatcher(
         jsonl, threshold=_resolve_failure_streak_threshold(config.options),
     )

--- a/src/quodeq/analysis/cache/local.py
+++ b/src/quodeq/analysis/cache/local.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 from pathlib import Path
 
@@ -30,6 +31,10 @@ _ROOT_ENV = "QUODEQ_CACHE_ROOT"
 _RESULTS_SUBDIR = "results"
 _ENTRY_FILENAME = "entry.json"
 _TMP_PREFIX = ".tmp."
+# Content-addressed keys are SHA-256 hex in production; restrict to a
+# path-safe charset so a key can never contain '/', '\\', or '..' and
+# escape the cache root in _dir_for.
+_SAFE_KEY_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def default_cache_root() -> Path:
@@ -56,6 +61,8 @@ class LocalFileBackend:
     def _dir_for(self, key: str) -> Path:
         if len(key) < 3:
             raise ValueError(f"cache key too short: {key!r}")
+        if not _SAFE_KEY_RE.fullmatch(key):
+            raise ValueError(f"invalid cache key: {key!r}")
         return self._root / key[:2] / key[2:]
 
     def _entry_path(self, key: str) -> Path:

--- a/src/quodeq/analysis/mcp/handlers.py
+++ b/src/quodeq/analysis/mcp/handlers.py
@@ -83,7 +83,7 @@ def handle_tools_call(
 ) -> dict:
     """Handle the 'tools/call' JSON-RPC method."""
     name = params.get("name")
-    args = params.get("arguments", {})
+    args = params.get("arguments") or {}
 
     if name == REPORT_FINDING_NAME:
         message, _is_dup = router.receive(args)

--- a/src/quodeq/analysis/mcp/schemas.py
+++ b/src/quodeq/analysis/mcp/schemas.py
@@ -20,6 +20,7 @@ REPORT_FINDING_SCHEMA = {
         "end_line": {"type": "integer", "description": "Last line of the violation pattern (omit if single line)"},
         "scope": {"type": "string", "enum": ["file", "class", "module"], "description": "Set when the finding affects an entire file/class/module rather than specific lines"},
         "severity": {"type": "string", "enum": ["critical", "major", "minor"], "description": "Severity level"},
+        "vt": {"type": "string", "description": "Violation type taxonomy code: a short, stable, kebab-case class of the violation (e.g. 'code-injection', 'hardcoded-secret', 'missing-error-handling'). Reuse the exact same code for every finding of the same kind."},
         "w": {"type": "string", "description": "Short description of the finding"},
         "reason": {"type": "string", "description": "Why this is a violation or compliance"},
         "p": {"type": "string", "description": "Sub-characteristic name — auto-filled from req if omitted"},

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -39,7 +39,7 @@ def _load_evaluation_rules() -> str:
     for name in ("evaluation_rules.md", "finding_format.md"):
         try:
             parts.append(load_template(template_name=name))
-        except (OSError, FileNotFoundError):
+        except OSError:
             _logger.warning("Failed to load prompt template %s, skipping", name)
             continue
     return "\n\n".join(p for p in parts if p)

--- a/src/quodeq/analysis/prompts/builder.py
+++ b/src/quodeq/analysis/prompts/builder.py
@@ -40,6 +40,7 @@ def _load_evaluation_rules() -> str:
         try:
             parts.append(load_template(template_name=name))
         except (OSError, FileNotFoundError):
+            _logger.warning("Failed to load prompt template %s, skipping", name)
             continue
     return "\n\n".join(p for p in parts if p)
 

--- a/src/quodeq/analysis/stream/counters.py
+++ b/src/quodeq/analysis/stream/counters.py
@@ -35,6 +35,8 @@ def parse_stream_event(line: str) -> dict | None:
 
 def extract_files_from_event(data: dict) -> set[str]:
     """Dispatch to the appropriate file extractor based on event type."""
+    if not isinstance(data, dict):
+        return set()
     etype = data.get("type", "")
     if etype == "assistant":
         return extract_files_from_blocks(data.get("message", {}).get("content", []))

--- a/src/quodeq/analysis/stream/validation.py
+++ b/src/quodeq/analysis/stream/validation.py
@@ -21,6 +21,8 @@ def get_mcp_status(stream_file: Path) -> str | None:
             if not first:
                 return None
             d = json.loads(first)
+            if not isinstance(d, dict):
+                return None
             for srv in d.get("mcp_servers", []):
                 if srv.get("name") == _MCP_SERVER_NAME:
                     return srv.get("status")

--- a/src/quodeq/analysis/subagents/priority_fan_in.py
+++ b/src/quodeq/analysis/subagents/priority_fan_in.py
@@ -1,4 +1,4 @@
-"""Fan-in analysis — counts how many files import each file."""
+"""Fan-in analysis: counts how many files import each file."""
 from __future__ import annotations
 
 import re
@@ -32,11 +32,11 @@ def compute_fan_in(
 
     _read = read_file or _default_read
 
-    # Build filename lookup: stem -> relative path
-    stem_to_file: dict[str, str] = {}
+    # Build filename lookup: stem -> list of relative paths (multiple files may share a stem)
+    stem_to_files: dict[str, list[str]] = {}
     for f in files:
         stem = Path(f).stem
-        stem_to_file.setdefault(stem, f)
+        stem_to_files.setdefault(stem, []).append(f)
 
     compiled = [re.compile(p) for p in patterns]
     counts: dict[str, int] = {}
@@ -46,24 +46,42 @@ def compute_fan_in(
         if content is None:
             continue
         for line in content.splitlines():
-            target = _match_import_target(line, compiled, stem_to_file, f)
-            if target is not None:
+            for target in _match_import_targets(line, compiled, stem_to_files, f):
                 counts[target] = counts.get(target, 0) + 1
 
     return counts
 
 
-def _match_import_target(
-    line: str, compiled: list[re.Pattern], stem_to_file: dict[str, str], current_file: str,
-) -> str | None:
-    """Match a single line against import patterns and return the target file, or None."""
+def _match_import_targets(
+    line: str, compiled: list[re.Pattern], stem_to_files: dict[str, list[str]], current_file: str,
+) -> list[str]:
+    """Match a single line against import patterns and return all matching target files.
+
+    When multiple files share the same stem, the import path is used to narrow
+    candidates: a candidate whose directory components appear in the import string
+    is preferred.  All non-self candidates are returned so fan-in is credited to
+    every file that could be the import target.
+    """
     for pattern in compiled:
         m = pattern.search(line)
         if m:
             imported = m.group(1)
             module_name = imported.rsplit(".", 1)[-1].rsplit("/", 1)[-1]
-            target = stem_to_file.get(module_name)
-            if target is not None and target != current_file:
-                return target
-            return None
-    return None
+            candidates = stem_to_files.get(module_name, [])
+            # Filter out the importing file itself
+            candidates = [c for c in candidates if c != current_file]
+            if not candidates:
+                return []
+            # If only one candidate, return it directly
+            if len(candidates) == 1:
+                return candidates
+            # Multiple candidates share the stem, so use the import path to disambiguate.
+            # Build a normalised version of the import string for prefix matching.
+            import_parts = imported.replace(".", "/").lower()
+            preferred = [
+                c for c in candidates
+                if Path(c).parent.as_posix().lower() in import_parts
+                or import_parts in Path(c).parent.as_posix().lower()
+            ]
+            return preferred if preferred else candidates
+    return []

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 from quodeq.analysis._command import (
@@ -227,6 +228,19 @@ def _render_standards_grouped(data: dict) -> str:
     return _json.dumps(checklist, separators=(",", ":"))
 
 
+def _read_omlx_key() -> str | None:
+    from quodeq.llm_bridge._omlx import _read_omlx_api_key  # noqa: PLC0415
+    return _read_omlx_api_key()
+
+
+# Registry of provider-specific credential loaders. Each callable returns the
+# API key string (or None/empty string) for that provider. New providers can
+# be added here without touching _resolve_provider_config.
+_CREDENTIAL_LOADERS: dict[str, Callable[[], str | None]] = {
+    "omlx": _read_omlx_key,
+}
+
+
 def _resolve_provider_config(cfg: AnalysisConfig) -> tuple[str, str, str]:
     """Look up model, api_base, and api_key from provider config.
 
@@ -240,9 +254,10 @@ def _resolve_provider_config(cfg: AnalysisConfig) -> tuple[str, str, str]:
     api_base = provider_cfg.get("api_base", "")
     api_key_env = provider_cfg.get("api_key_env", "")
     api_key = os.environ.get(api_key_env, "") if api_key_env else ""
-    if not api_key and ai_cmd == "omlx":
-        from quodeq.llm_bridge._omlx import _read_omlx_api_key
-        api_key = _read_omlx_api_key()
+    if not api_key:
+        loader = _CREDENTIAL_LOADERS.get(ai_cmd)
+        if loader is not None:
+            api_key = loader() or ""
 
     if not model:
         raise AnalysisError(

--- a/src/quodeq/api/_evaluation_routes.py
+++ b/src/quodeq/api/_evaluation_routes.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+from collections import OrderedDict
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
@@ -24,6 +26,38 @@ from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
 from quodeq.shared.dimensions_state import read_dimensions
 
 _logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Atomic, bounded "already-scored" registry
+# ---------------------------------------------------------------------------
+# Keeps track of job_ids whose background scoring has already been claimed so
+# that repeated GETs for the same job never spawn more than one scoring thread.
+#
+# Uses an OrderedDict as a bounded LRU so the registry cannot grow without
+# limit on a long-running server.  Access is serialised by a Lock so the
+# check-then-add is atomic (closing the TOCTOU race that a plain ``set``
+# would have).
+_scored_jobs: "OrderedDict[str, None]" = OrderedDict()
+_scored_jobs_lock = threading.Lock()
+_SCORED_JOBS_MAX = 1000
+
+
+def _claim_scoring(job_id: str) -> bool:
+    """Atomically claim *job_id* for one-time background scoring.
+
+    Returns ``True`` if this caller should start the scoring thread;
+    ``False`` if another caller already claimed it.
+
+    The registry is bounded to ``_SCORED_JOBS_MAX`` entries (LRU eviction)
+    so memory usage stays constant regardless of server uptime.
+    """
+    with _scored_jobs_lock:
+        if job_id in _scored_jobs:
+            return False
+        _scored_jobs[job_id] = None
+        while len(_scored_jobs) > _SCORED_JOBS_MAX:
+            _scored_jobs.popitem(last=False)  # evict oldest entry
+        return True
 
 
 def _read_dim_states(job: Any) -> dict[str, dict[str, Any]]:
@@ -103,11 +137,10 @@ def register_evaluation_list_routes(app: Flask, provider: ActionProvider, eval_r
 def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> None:
     """Register single-evaluation status and cancel routes."""
 
-    _scored_jobs: set[str] = set()
-
     def reset_scored_jobs() -> None:
-        """Clear the scored-jobs set. Useful for test isolation."""
-        _scored_jobs.clear()
+        """Clear the scored-jobs registry. Useful for test isolation."""
+        with _scored_jobs_lock:
+            _scored_jobs.clear()
 
     app.extensions["reset_scored_jobs"] = reset_scored_jobs
 
@@ -117,17 +150,32 @@ def register_evaluation_item_routes(app: Flask, provider: ActionProvider) -> Non
         if not job:
             body, status = error_response("Job not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status
-        # Score any completed dimensions from failed/cancelled jobs (once)
+        # Score any completed dimensions from failed/cancelled jobs (once).
+        # Offloaded to a background thread so the GET returns immediately;
+        # scoring may involve heavy I/O (reading evidence, writing score files).
+        # _claim_scoring() is atomic: exactly one concurrent GET wins the claim.
         job_status = getattr(job, "status", None)
-        if job_status in ("failed", "cancelled") and job_id not in _scored_jobs:
-            _scored_jobs.add(job_id)
-            try:
-                _score_completed_evidence(_reports_dir(), {
-                    "outputProject": job.output_project,
-                    "outputRunId": job.output_run_id,
-                })
-            except Exception as exc:
-                _logger.debug("Could not score cancelled dimension for %s: %s", job_id, exc)
+        if job_status in ("failed", "cancelled") and _claim_scoring(job_id):
+            _reports = _reports_dir()
+            _score_args = {
+                "outputProject": job.output_project,
+                "outputRunId": job.output_run_id,
+            }
+
+            def _score_in_bg(reports_dir: str, score_args: dict) -> None:
+                try:
+                    _score_completed_evidence(reports_dir, score_args)
+                except Exception as exc:
+                    _logger.debug(
+                        "Could not score cancelled dimension for %s: %s",
+                        score_args.get("outputRunId"), exc,
+                    )
+
+            threading.Thread(
+                target=_score_in_bg,
+                args=(_reports, _score_args),
+                daemon=True,
+            ).start()
         payload = to_camel_dict(job)
         payload["dimStates"] = _read_dim_states(job)
         return jsonify(payload)

--- a/src/quodeq/api/_index_routes.py
+++ b/src/quodeq/api/_index_routes.py
@@ -18,7 +18,7 @@ def register_index_routes(app: Flask) -> None:
     def rebuild_index_endpoint() -> Response | tuple[Response, int]:
         provider = current_app.config.get("_provider")
         if provider is None or not hasattr(provider, "rebuild_index"):
-            return jsonify({"error": "provider not available"}), HTTPStatus.SERVICE_UNAVAILABLE
+            return jsonify({"error": "provider not available", "code": "PROVIDER_UNAVAILABLE"}), HTTPStatus.SERVICE_UNAVAILABLE
         try:
             count, elapsed_ms = provider.rebuild_index()
         except Exception:

--- a/src/quodeq/api/_index_routes.py
+++ b/src/quodeq/api/_index_routes.py
@@ -1,9 +1,14 @@
 """Admin/debug endpoints for the SQLite run index."""
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 
 from flask import Flask, Response, current_app, jsonify
+
+from quodeq.api.helpers import error_response
+
+_logger = logging.getLogger(__name__)
 
 
 def register_index_routes(app: Flask) -> None:
@@ -14,5 +19,10 @@ def register_index_routes(app: Flask) -> None:
         provider = current_app.config.get("_provider")
         if provider is None or not hasattr(provider, "rebuild_index"):
             return jsonify({"error": "provider not available"}), HTTPStatus.SERVICE_UNAVAILABLE
-        count, elapsed_ms = provider.rebuild_index()
+        try:
+            count, elapsed_ms = provider.rebuild_index()
+        except Exception:
+            _logger.exception("Unexpected error rebuilding index")
+            body, status = error_response("Failed to rebuild index", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
         return jsonify({"count": count, "elapsed_ms": elapsed_ms})

--- a/src/quodeq/api/_llamacpp_log_routes.py
+++ b/src/quodeq/api/_llamacpp_log_routes.py
@@ -68,9 +68,9 @@ def _default_log_paths() -> list[Path]:
     return candidates
 
 
-def _llamacpp_log_path() -> Path | None:
+def _llamacpp_log_path(_env_override: str | None = None) -> Path | None:
     """Resolve a usable log path, or None if no candidate file exists."""
-    override = os.environ.get("LLAMACPP_LOG_FILE")
+    override = _env_override if _env_override is not None else os.environ.get("LLAMACPP_LOG_FILE")
     if override:
         # Honor an explicit override even if the file doesn't exist yet —
         # llama-server might create it on next launch and the UI's

--- a/src/quodeq/api/_rate_limit_config.py
+++ b/src/quodeq/api/_rate_limit_config.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 _DEFAULT_RATE_LIMIT_WINDOW = 60
 # 60/min was too tight for the dashboard's bulk-dismiss UX — burst-dismissing
@@ -29,3 +30,12 @@ def _rate_limit_max(env: dict[str, str] | None = None) -> int:
         return int((env or os.environ).get("QUODEQ_RATE_LIMIT_MAX", str(_DEFAULT_RATE_LIMIT_MAX)))
     except (ValueError, TypeError):
         return _DEFAULT_RATE_LIMIT_MAX
+
+
+def default_rate_limit_path() -> Path:
+    """Default rate-limit file under the per-user ~/.quodeq directory.
+
+    A per-user, non-world-writable location removes the shared-temp-dir
+    symlink-attack precondition that a bare tempfile.gettempdir() path had.
+    """
+    return Path.home() / ".quodeq" / "quodeq_rate_limits.json"

--- a/src/quodeq/api/_rate_limit_factory.py
+++ b/src/quodeq/api/_rate_limit_factory.py
@@ -3,25 +3,22 @@ from __future__ import annotations
 
 import logging
 import os
-import tempfile
 from pathlib import Path
 
+from quodeq.api._rate_limit_config import default_rate_limit_path
 from quodeq.api._rate_limit_store import InMemoryRateLimitStore, RateLimitStore
 
 _logger = logging.getLogger(__name__)
 
 _KNOWN_BACKENDS = {"memory", "file"}
-# Use the platform's temp dir (e.g. C:\Users\<user>\AppData\Local\Temp on
-# Windows) instead of a hardcoded /tmp path that doesn't exist there.
-_DEFAULT_RATE_LIMIT_FILE = str(Path(tempfile.gettempdir()) / "quodeq_rate_limits.json")
+_DEFAULT_RATE_LIMIT_FILE = str(default_rate_limit_path())
 
 
 def _validated_rate_limit_path(raw: str) -> str:
     """Reject obviously-unsafe rate-limit file paths from the env.
 
-    Falls back to the default if *raw* is empty, relative, or resolves to a
-    location with parent-traversal components. Symlink resolution is
-    deliberately not strict (the file may not exist yet on first run).
+    Falls back to the default if *raw* is empty, relative, resolves to a
+    location with parent-traversal components, or is a symlink.
     """
     if not raw:
         return _DEFAULT_RATE_LIMIT_FILE
@@ -32,6 +29,11 @@ def _validated_rate_limit_path(raw: str) -> str:
         resolved = candidate.resolve(strict=False)
         if ".." in resolved.parts:
             raise ValueError("path contains parent-directory traversal")
+        # Defense in depth: FileRateLimitStore._save writes via os.replace,
+        # which already defeats a symlink planted later. This rejects an
+        # obviously-symlinked configured path early.
+        if candidate.is_symlink():
+            raise ValueError("path is a symlink")
     except (OSError, ValueError) as exc:
         _logger.warning(
             "Ignoring unsafe QUODEQ_RATE_LIMIT_FILE=%r (%s); using default %s",
@@ -48,7 +50,7 @@ def create_rate_limit_store(env: dict[str, str] | None = None) -> RateLimitStore
 
     - ``memory`` (default): process-local, no external dependencies.
     - ``file``: JSON file in ``QUODEQ_RATE_LIMIT_FILE`` (default:
-      ``quodeq_rate_limits.json`` in the platform temp dir).  Suitable for
+      ``~/.quodeq/quodeq_rate_limits.json``).  Suitable for
       single-machine multi-worker setups but not recommended for
       high-throughput.
 

--- a/src/quodeq/api/_rate_limit_factory.py
+++ b/src/quodeq/api/_rate_limit_factory.py
@@ -26,9 +26,9 @@ def _validated_rate_limit_path(raw: str) -> str:
         candidate = Path(raw)
         if not candidate.is_absolute():
             raise ValueError("path must be absolute")
-        resolved = candidate.resolve(strict=False)
-        if ".." in resolved.parts:
+        if ".." in candidate.parts:
             raise ValueError("path contains parent-directory traversal")
+        resolved = candidate.resolve(strict=False)
         # Defense in depth: FileRateLimitStore._save writes via os.replace,
         # which already defeats a symlink planted later. This rejects an
         # obviously-symlinked configured path early.

--- a/src/quodeq/api/_rate_limit_file_store.py
+++ b/src/quodeq/api/_rate_limit_file_store.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import tempfile
 import threading
 from pathlib import Path
 
-from quodeq.api._rate_limit_config import _rate_limit_max, _rate_limit_window
+from quodeq.api._rate_limit_config import _rate_limit_max, _rate_limit_window, default_rate_limit_path
 
 _logger = logging.getLogger(__name__)
 
-_DEFAULT_PATH = str(Path(tempfile.gettempdir()) / "quodeq_rate_limits.json")
+_DEFAULT_PATH = str(default_rate_limit_path())
 
 
 class FileRateLimitStore:
@@ -40,10 +41,28 @@ class FileRateLimitStore:
             return {}
 
     def _save(self, data: dict[str, list[float]]) -> None:
+        parent = self._path.parent
         try:
-            self._path.write_text(json.dumps(data), encoding="utf-8")
+            parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        except OSError:
+            _logger.warning("Failed to create rate-limit dir %s", parent)
+            return
+        # Write a fresh temp file then os.replace() onto the target. If an
+        # attacker planted a symlink at self._path, the rename replaces the
+        # link itself with our regular file and never truncates its target.
+        payload = json.dumps(data).encode("utf-8")
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=parent, prefix=".rl-", suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "wb") as fh:
+                fh.write(payload)
+            os.chmod(tmp_name, 0o600)
+            os.replace(tmp_name, self._path)
         except OSError:
             _logger.warning("Failed to write rate-limit file %s", self._path)
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
 
     def record(self, ip: str, now: float) -> None:
         """Record a request from *ip* at time *now*."""

--- a/src/quodeq/api/_rate_limit_file_store.py
+++ b/src/quodeq/api/_rate_limit_file_store.py
@@ -72,7 +72,11 @@ class FileRateLimitStore:
             data = self._load()
             timestamps = data.get(ip, [])
             timestamps.append(now)
-            data[ip] = [t for t in timestamps if now - t < self._window]
+            pruned = [t for t in timestamps if now - t < self._window]
+            if pruned:
+                data[ip] = pruned
+            else:
+                data.pop(ip, None)
             self._save(data)
 
     def check(self, ip: str, now: float) -> bool:

--- a/src/quodeq/api/_scores_routes.py
+++ b/src/quodeq/api/_scores_routes.py
@@ -8,6 +8,7 @@ directly when using these endpoints.
 """
 from __future__ import annotations
 
+import logging
 from http import HTTPStatus
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from quodeq.api.helpers import error_response
 from quodeq.api.routes_common import reports_dir
 from quodeq.services.scoring import get_project_scores, get_scores_raw
 from quodeq.shared.validation import validate_path_segment
+
+_logger = logging.getLogger(__name__)
 
 
 def register_scores_routes(app: Flask) -> None:
@@ -37,7 +40,12 @@ def register_scores_routes(app: Flask) -> None:
             return err
         as_of = request.args.get("asOf")
         eval_dir = reports_dir()
-        result = get_project_scores(Path(eval_dir), project, as_of)
+        try:
+            result = get_project_scores(Path(eval_dir), project, as_of)
+        except Exception:
+            _logger.exception("Unexpected error fetching scores for project %s", project)
+            body, status = error_response("Failed to load scores", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
         if result is None:
             body, status = error_response("Project not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/api/import_project.py
+++ b/src/quodeq/api/import_project.py
@@ -28,7 +28,7 @@ from quodeq.api.zip import (
     _max_zip_size_bytes,
 )
 from quodeq.data.fs._index_io import _load_index, _save_index
-from quodeq.data.fs._models import ProjectIdentity
+from quodeq.data.fs._models import ProjectIdentity, ProjectRepository
 from quodeq.data.fs._resolution import _index_key
 
 _logger = logging.getLogger(__name__)
@@ -289,12 +289,24 @@ def _rewrite_repository_info(project_dir: Path, new_uuid: str) -> None:
         _logger.warning("import: could not rewrite repository_info.json: %s", exc)
 
 
-def _update_index(reports_root: Path, identity: ProjectIdentity, project_uuid: str) -> None:
-    """Best-effort: register the imported project in project_index.json."""
+def _update_index(
+    reports_root: Path,
+    identity: ProjectIdentity,
+    project_uuid: str,
+    repository: ProjectRepository | None = None,
+) -> None:
+    """Best-effort: register the imported project in project_index.json.
+
+    When *repository* is provided its ``load_index``/``save_index`` methods
+    are used instead of the default filesystem helpers, keeping the storage
+    layer injectable for testing or alternative backends.
+    """
+    load_fn = repository.load_index if repository is not None else _load_index
+    save_fn = repository.save_index if repository is not None else _save_index
     try:
-        index = _load_index(reports_root)
+        index = load_fn(reports_root)
         index[_index_key(identity)] = project_uuid
-        _save_index(reports_root, index)
+        save_fn(reports_root, index)
     except OSError as exc:
         _logger.warning("import: could not update project_index.json: %s", exc)
 

--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -50,6 +50,10 @@ def register_llm_bridge_routes(app: Flask) -> None:
         data = request.get_json() or {}
         model_size = data.get("model_size", 0)
         gpu_memory = data.get("gpu_memory", 0)
+        if (isinstance(model_size, bool) or isinstance(gpu_memory, bool)
+                or not isinstance(model_size, (int, float))
+                or not isinstance(gpu_memory, (int, float))):
+            return jsonify({"error": "model_size and gpu_memory must be numbers", "code": "INVALID_PARAM"}), 400
         return jsonify(estimate_max_agents(model_size=model_size, gpu_memory=gpu_memory))
 
     @app.get("/api/llamacpp/status")

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -11,6 +11,7 @@ sessions that ended in PRs #525-#528.)
 from __future__ import annotations
 
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,20 @@ from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 _MAX_DISMISSED_LIMIT = 5000
+
+# Per-project locks for background projection.  A module-level guard lock
+# protects creation of per-project entries; after creation each project's Lock
+# is accessed without the guard.
+_projection_locks: dict[str, threading.Lock] = {}
+_projection_locks_guard = threading.Lock()
+
+
+def _get_projection_lock(project: str) -> threading.Lock:
+    """Return (and lazily create) the Lock for *project*."""
+    with _projection_locks_guard:
+        if project not in _projection_locks:
+            _projection_locks[project] = threading.Lock()
+        return _projection_locks[project]
 
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
@@ -147,13 +162,30 @@ def register_findings_routes(app: Flask) -> None:
         When the caller can't supply a usable ``run_id`` (Violations / Map
         nav paths don't carry one today), ``_rescore_run`` returns ``None`` —
         but the action *must* still propagate to SQL or the dismissed-tab
-        list won't see it. Project every run as the fallback so the entry
-        becomes visible without forcing the UI to retry.
+        list won't see it. Project every run in the background as the
+        fallback so the entry becomes visible without blocking the response.
+
+        A per-project non-blocking lock prevents duplicate concurrent
+        projections for the same project: if one projection is already
+        running, the second caller skips rather than queueing behind it
+        (the in-flight run will already cover the latest actions).
         """
         evaluations_dir = _eval_dir()
         scores = _rescore_run(evaluations_dir, project, run_id)
         if scores is None:
-            _project_all_runs(_project_dir(evaluations_dir, project))
+            proj_dir = _project_dir(evaluations_dir, project)
+            lock = _get_projection_lock(project)
+
+            def _bg_project() -> None:
+                if not lock.acquire(blocking=False):
+                    # Another projection for this project is already running.
+                    return
+                try:
+                    _project_all_runs(proj_dir)
+                finally:
+                    lock.release()
+
+            threading.Thread(target=_bg_project, daemon=True).start()
         return scores
 
     @app.get("/api/findings/dismissed")

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -182,7 +182,7 @@ def register_findings_routes(app: Flask) -> None:
         line = body.get("line")
         run_id = body.get("run_id") or body.get("runId")
         if not project or not req or not file or line is None:
-            return jsonify({"error": "project, req, file, and line are required"}), 400
+            return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
         dismiss_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"scores": scores}), 200
@@ -196,7 +196,7 @@ def register_findings_routes(app: Flask) -> None:
         line = body.get("line")
         run_id = body.get("run_id") or body.get("runId")
         if not project or not req or not file or line is None:
-            return jsonify({"error": "project, req, file, and line are required"}), 400
+            return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"scores": scores}), 200
@@ -207,7 +207,7 @@ def register_findings_routes(app: Flask) -> None:
         project = body.get("project", "")
         run_id = body.get("run_id") or body.get("runId")
         if not project:
-            return jsonify({"error": "project is required"}), 400
+            return jsonify({"error": "project is required", "code": "MISSING_PARAM"}), 400
         count = restore_all_findings(_project_dir(_eval_dir(), project))
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "restored": count, "scores": scores}), 200
@@ -221,7 +221,7 @@ def register_findings_routes(app: Flask) -> None:
         file = body.get("file", "")
         run_id = body.get("run_id") or body.get("runId")
         if not project or not dimension or not principle or not file:
-            return jsonify({"error": "project, dimension, principle, and file are required"}), 400
+            return jsonify({"error": "project, dimension, principle, and file are required", "code": "MISSING_PARAM"}), 400
         swept = delete_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "swept": swept, "scores": scores}), 200
@@ -232,7 +232,7 @@ def register_findings_routes(app: Flask) -> None:
         project = body.get("project", "")
         run_id = body.get("run_id") or body.get("runId")
         if not project:
-            return jsonify({"error": "project is required"}), 400
+            return jsonify({"error": "project is required", "code": "MISSING_PARAM"}), 400
         count = delete_all_dismissed(_project_dir(_eval_dir(), project))
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "deleted": count, "scores": scores}), 200

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -28,6 +28,13 @@ _MAX_DISMISSED_LIMIT = 5000
 # Per-project locks for background projection.  A module-level guard lock
 # protects creation of per-project entries; after creation each project's Lock
 # is accessed without the guard.
+#
+# Intentionally unbounded: one tiny Lock object per distinct project name that
+# has ever triggered a background projection on this host.  In practice this
+# mirrors the number of projects on disk, which is small and naturally bounded
+# by real usage.  Contrast with _scored_jobs (bounded LRU) — scored jobs can
+# accumulate many run-ids per project, so a size cap there is meaningful;
+# here there is one entry per project, not per run.
 _projection_locks: dict[str, threading.Lock] = {}
 _projection_locks_guard = threading.Lock()
 

--- a/src/quodeq/api/security.py
+++ b/src/quodeq/api/security.py
@@ -100,5 +100,23 @@ def configure_security(app: Flask, rate_limit_store: RateLimitStore, api_key: st
     def _add_security_headers(response: Response) -> Response:
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["Content-Security-Policy"] = "frame-ancestors 'none'"
+        # connect-src: include alt-port origins probed by useServerHealth
+        # (DEFAULT_ALT_PORTS = [4180, 4181, 4182, 4183] in useServerHealth.js).
+        # CSP has no port wildcard so each origin is enumerated explicitly.
+        # These are loopback addresses only — cross-site exfil to external
+        # attackers is still blocked.
+        _alt_port_origins = " ".join(
+            f"http://127.0.0.1:{p} http://localhost:{p}"
+            for p in (4180, 4181, 4182, 4183)
+        )
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            f"connect-src 'self' {_alt_port_origins}; "
+            "script-src 'self'; "
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+            "font-src 'self' https://fonts.gstatic.com; "
+            "img-src 'self' data:; "
+            "mask-src 'self' data:; "
+            "frame-ancestors 'none'"
+        )
         return response

--- a/src/quodeq/api/standards_read_routes.py
+++ b/src/quodeq/api/standards_read_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time as _time
 
 from flask import Flask, Response, jsonify, request
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 _cwe_cache: list | None = None
 _cwe_cache_time: float = 0.0
 _CWE_CACHE_TTL = int(os.environ.get("QUODEQ_CWE_CACHE_TTL", "3600"))  # 1 hour
+_cwe_cache_lock = threading.Lock()
 
 
 def reset_cwe_cache() -> None:
@@ -23,6 +25,27 @@ def reset_cwe_cache() -> None:
     global _cwe_cache, _cwe_cache_time
     _cwe_cache = None
     _cwe_cache_time = 0.0
+
+
+def _reload_cwe_if_needed(loader) -> list:
+    """Return the CWE list, reloading at most once when the cache has expired.
+
+    Uses double-checked locking so the common path (cache is warm) never
+    blocks on the lock, and the uncommon path (expired) reloads exactly once
+    even when multiple threads race at expiry.
+    """
+    global _cwe_cache, _cwe_cache_time
+    now = _time.monotonic()
+    # Fast path: cache is valid — no lock needed.
+    if _cwe_cache is not None and (now - _cwe_cache_time) <= _CWE_CACHE_TTL:
+        return _cwe_cache
+    # Slow path: acquire the lock, then re-check inside it.
+    with _cwe_cache_lock:
+        now = _time.monotonic()  # re-read after acquiring
+        if _cwe_cache is None or (now - _cwe_cache_time) > _CWE_CACHE_TTL:
+            _cwe_cache = loader()
+            _cwe_cache_time = now
+        return _cwe_cache
 
 
 def register_read_routes(app: Flask, get_service, get_library_client) -> None:
@@ -36,12 +59,8 @@ def register_read_routes(app: Flask, get_service, get_library_client) -> None:
 
     @app.get("/api/standards/refs/cwe")
     def list_cwes() -> Response:
-        global _cwe_cache, _cwe_cache_time
-        now = _time.monotonic()
-        if _cwe_cache is None or (now - _cwe_cache_time) > _CWE_CACHE_TTL:
-            _cwe_cache = get_service(app).load_cwe_list()
-            _cwe_cache_time = now
-        return jsonify(_cwe_cache)
+        result = _reload_cwe_if_needed(lambda: get_service(app).load_cwe_list())
+        return jsonify(result)
 
     @app.get("/api/standards")
     def list_standards() -> Response:

--- a/src/quodeq/ci/_evidence_reader.py
+++ b/src/quodeq/ci/_evidence_reader.py
@@ -34,7 +34,10 @@ def _judgment_to_violation(obj: dict) -> dict | None:
     }
     line = obj.get("line")
     if line is not None:
-        out["line"] = int(line)
+        try:
+            out["line"] = int(line)
+        except (ValueError, TypeError):
+            _logger.debug("Non-integer line value %r; omitting line", line)
     req = obj.get("req")
     if req:
         out["req"] = req

--- a/src/quodeq/config/_fetch_client_class.py
+++ b/src/quodeq/config/_fetch_client_class.py
@@ -18,10 +18,6 @@ _logger = logging.getLogger(__name__)
 class FetchClient:
     """Thread-safe HTTP fetcher with circuit breaker (trips after repeated failures)."""
 
-    _CIRCUIT_THRESHOLD = int(os.environ.get("QUODEQ_CIRCUIT_THRESHOLD", "5"))
-    _MAX_RETRIES = int(os.environ.get("QUODEQ_MAX_RETRIES", "2"))
-    _RETRY_BACKOFF_S = float(os.environ.get("QUODEQ_RETRY_BACKOFF_S", "0.5"))
-
     def _record_success(self) -> None:
         """Reset the failure counter on a successful fetch."""
         with self._lock:
@@ -47,10 +43,14 @@ class FetchClient:
         self._failures = 0
         self._timeout = timeout_s
         self._env = env
+        _e = self._env if self._env is not None else os.environ
+        self._CIRCUIT_THRESHOLD = int(_e.get("QUODEQ_CIRCUIT_THRESHOLD", "5"))
+        self._MAX_RETRIES = int(_e.get("QUODEQ_MAX_RETRIES", "2"))
+        self._RETRY_BACKOFF_S = float(_e.get("QUODEQ_RETRY_BACKOFF_S", "0.5"))
         if allow_private is not None:
             self._allow_private: bool = allow_private
         else:
-            self._allow_private = (self._env or os.environ).get("QUODEQ_ALLOW_PRIVATE_URLS") == "1"
+            self._allow_private = _e.get("QUODEQ_ALLOW_PRIVATE_URLS") == "1"
 
     def fetch(self, url: str, headers: dict | None = None) -> str | None:
         """Fetch *url* and return body text, or None on failure.

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -66,8 +66,14 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
 def judgment_to_dict(j: Judgment) -> dict:
     """Convert a Judgment to the dict format used in PrincipleEvidence lists."""
     d: dict = {"file": j.file}
+    # Emit BOTH the long key (UI/report read 'violation_type', see
+    # ui/src/models/violation.js and core/finding_mappings.py) AND the short
+    # key the scoring tally groups by ('vt', see core/scoring/_tallies.py).
+    # They carry the same value; keeping both fixes taxonomy scoring without
+    # breaking any consumer.
     _optional = {"line": j.line, "end_line": j.end_line, "snippet": j.snippet,
                  "severity": j.severity, "violation_type": j.violation_type,
+                 "vt": j.violation_type,
                  "context": j.context, "scope": j.scope}
     d.update({k: v for k, v in _optional.items() if v})
     if j.req:

--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -42,7 +42,9 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         end_line=d.get("end_line"),
         snippet=d.get("snippet"),
         severity=d.get("severity") or "medium",
-        violation_type=d.get("violation_type"),
+        # The taxonomy travels as 'vt' on the JSONL wire (see evidence/_jsonl.py);
+        # accept the long key too so both spellings survive this seam.
+        violation_type=d.get("vt") or d.get("violation_type"),
         reason=d.get("reason") or "",
         title=d.get("w"),
         context=d.get("context"),

--- a/src/quodeq/core/scoring/_principle.py
+++ b/src/quodeq/core/scoring/_principle.py
@@ -17,10 +17,7 @@ from quodeq.core.scoring.internals import (
     evidence_has_taxonomy,
     score_to_grade_label,
     severity_grade_floor,
-    tally_compliance_types_by_reason,
-    tally_compliance_types_by_taxonomy,
-    tally_types_by_reason,
-    tally_types_by_taxonomy,
+    tally_types,
     violation_base,
     violation_ceiling,
 )
@@ -46,10 +43,18 @@ class _PrincipleContext:
 def compute_tallies(
     violations: list, compliance: list,
 ) -> tuple[dict[str, int], dict[str, int], bool]:
-    """Tally violation and compliance type counts, selecting taxonomy or reason mode."""
+    """Tally distinct violation and compliance types per severity.
+
+    A ``vt`` taxonomy code is a per-finding grouping key, not a per-principle
+    mode switch: each finding is grouped by its ``vt`` when present and by its
+    ``reason`` otherwise, so a partly tagged principle still counts all of its
+    findings (including untagged criticals). ``using_taxonomy`` is reported
+    (any finding carries a ``vt``) for display only; it no longer changes which
+    findings are counted.
+    """
     using_taxonomy = evidence_has_taxonomy(violations)
-    vt_counts = tally_types_by_taxonomy(violations) if using_taxonomy else tally_types_by_reason(violations)
-    ct_counts = tally_compliance_types_by_taxonomy(compliance) if using_taxonomy else tally_compliance_types_by_reason(compliance)
+    vt_counts = tally_types(violations)
+    ct_counts = tally_types(compliance)
     return vt_counts, ct_counts, using_taxonomy
 
 

--- a/src/quodeq/core/scoring/_tallies.py
+++ b/src/quodeq/core/scoring/_tallies.py
@@ -6,49 +6,37 @@ from typing import Mapping
 from quodeq.core.scoring._constants import _SEVERITY_WEIGHT
 
 
-def _tally_types(
-    items: list[dict], key_field: str, skip_empty: bool = False,
-) -> dict[str, int]:
-    """Count distinct types per severity bucket.
-
-    *key_field* selects which dict key to group by (e.g. ``"vt"`` or ``"reason"``).
-    When *skip_empty* is ``True``, items whose *key_field* is falsy are ignored.
-    """
-    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
-    for item in items:
-        value = item.get(key_field)
-        if skip_empty and not value:
-            continue
-        if value is None:
-            value = "unknown"
-        sev = item.get("severity", "minor")
-        buckets.setdefault(sev, set()).add(value)
-    return {sev: len(seen) for sev, seen in buckets.items()}
-
-
 def evidence_has_taxonomy(violations: list[dict]) -> bool:
     """Return True if at least one violation carries a 'vt' field."""
     return any(item.get("vt") for item in violations)
 
 
-def tally_types_by_taxonomy(violations: list[dict]) -> dict[str, int]:
-    """Count distinct violation types per severity using the 'vt' taxonomy field."""
-    return _tally_types(violations, "vt", skip_empty=True)
+def _tally_types_fallback(items: list[dict], key_fields: tuple[str, ...]) -> dict[str, int]:
+    """Count distinct types per severity, grouping each item by the first
+    present key in *key_fields*.
+
+    Unlike taxonomy-only tallying, an item is never dropped: when its preferred
+    key (``vt``) is absent it falls back to the next key (``reason``). A single
+    tagged finding can therefore no longer flip a principle into a mode that
+    discards its untagged findings.
+    """
+    buckets: dict[str, set] = {"critical": set(), "major": set(), "minor": set()}
+    for item in items:
+        value = next((item[k] for k in key_fields if item.get(k)), "unknown")
+        sev = item.get("severity", "minor")
+        buckets.setdefault(sev, set()).add(value)
+    return {sev: len(seen) for sev, seen in buckets.items()}
 
 
-def tally_types_by_reason(violations: list[dict]) -> dict[str, int]:
-    """Count distinct violation types per severity using (severity, reason) pairs."""
-    return _tally_types(violations, "reason")
+def tally_types(items: list[dict]) -> dict[str, int]:
+    """Count distinct violation/compliance types per severity.
 
-
-def tally_compliance_types_by_taxonomy(compliance: list[dict]) -> dict[str, int]:
-    """Count distinct compliance types per severity using the 'vt' field."""
-    return _tally_types(compliance, "vt", skip_empty=True)
-
-
-def tally_compliance_types_by_reason(compliance: list[dict]) -> dict[str, int]:
-    """Count distinct compliance types per severity using (severity, reason) pairs."""
-    return _tally_types(compliance, "reason")
+    Prefers the stable ``vt`` taxonomy code and falls back to the free-text
+    ``reason`` when a finding carries no ``vt``. Because nothing is dropped, the
+    result is continuous in taxonomy coverage: 0 tags and 1 tag tally the same,
+    and full coverage only sharpens the grouping.
+    """
+    return _tally_types_fallback(items, ("vt", "reason"))
 
 
 def _weighted_sum(

--- a/src/quodeq/core/scoring/internals.py
+++ b/src/quodeq/core/scoring/internals.py
@@ -15,13 +15,9 @@ from quodeq.core.scoring._constants import (  # noqa: F401 — re-exports
     scale_multiplier,
 )
 from quodeq.core.scoring._tallies import (  # noqa: F401 — re-exports
-    _tally_types,
     _weighted_sum,
     evidence_has_taxonomy,
-    tally_compliance_types_by_reason,
-    tally_compliance_types_by_taxonomy,
-    tally_types_by_reason,
-    tally_types_by_taxonomy,
+    tally_types,
 )
 from quodeq.core.scoring.confidence import confidence_interval_for  # noqa: F401 — re-export
 from quodeq.core.scoring.numerical import (  # noqa: F401 — re-export

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -11,6 +11,7 @@ import threading
 import urllib.parse
 import urllib.request
 import webbrowser
+from collections.abc import Callable
 from pathlib import Path
 
 import webview

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import html as _html
 import json
+import logging
 import os
 import signal
 import sys
@@ -18,6 +19,8 @@ from quodeq.dashboard._build_npm import _quodeq_dir
 from quodeq.dashboard._instance import InstanceController
 from quodeq.dashboard._webview_html import INJECT_JS, CLOSING_OVERLAY_JS
 
+_logger = logging.getLogger(__name__)
+
 _WINDOW_WIDTH = 1280
 _WINDOW_HEIGHT = 800
 _WINDOW_BG_COLOR = '#0d1117'
@@ -32,6 +35,24 @@ _DIALOG_FONT_SIZE = "0.82rem"
 _BUTTON_PADDING = "10px 16px"
 _BUTTON_BORDER_RADIUS = "6px"
 _BUTTON_FONT_SIZE = "0.85rem"
+
+
+def _is_safe_reload_url(url: str) -> bool:
+    """Return True only when *url* points to the local dashboard origin.
+
+    Rejects anything that is not http/https on 127.0.0.1, localhost, or ::1
+    so a rogue local process cannot navigate the privileged webview to an
+    arbitrary URL via the reload socket.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and parsed.hostname in {
+        "127.0.0.1",
+        "localhost",
+        "::1",
+    }
 
 
 class _WindowApi:
@@ -612,6 +633,23 @@ def _patch_pywebview_multi_monitor_drag() -> None:
     BrowserView.move = _patched_move
 
 
+def _make_on_reload(window: object) -> "Callable[[str], None]":
+    """Return the ``_on_reload`` handler bound to *window*.
+
+    Extracted from ``main()`` so the test suite can import and exercise the
+    real implementation rather than a hand-rolled duplicate.
+    """
+    def _on_reload(new_url: str) -> None:
+        if not _is_safe_reload_url(new_url):
+            _logger.warning("Ignoring unsafe reload URL: %s", new_url)
+            return
+        window.load_url(new_url)  # type: ignore[union-attr]
+        window.on_top = True  # type: ignore[union-attr]
+        window.on_top = False  # type: ignore[union-attr]
+
+    return _on_reload
+
+
 def main() -> None:
     _set_app_icon()
     _patch_pywebview_multi_monitor_drag()
@@ -637,10 +675,7 @@ def main() -> None:
                                     js_api=api)
     api.bind(window, api_pid=api_pid, instance=instance, base_url=url)
 
-    def _on_reload(new_url: str) -> None:
-        window.load_url(new_url)
-        window.on_top = True
-        window.on_top = False
+    _on_reload = _make_on_reload(window)
 
     def _on_loaded() -> None:
         window.show()

--- a/src/quodeq/data/fs/repo_clone.py
+++ b/src/quodeq/data/fs/repo_clone.py
@@ -21,11 +21,7 @@ from quodeq.context.online_cache import (
     ensure_clone,
     is_inside_cache,
 )
-from quodeq.data.fs.repo_validation import (
-    _PRIVATE_HOST_RE,
-    _REPO_URL_RE,
-    _resolves_to_private,
-)
+from quodeq.data.fs.repo_validation import validate_remote_url as _validate_remote_url
 
 _logger = logging.getLogger(__name__)
 
@@ -38,19 +34,6 @@ def _get_clone_timeout(env: dict[str, str] | None = None) -> int:
         return int((env or os.environ).get("QUODEQ_GIT_CLONE_TIMEOUT", str(_DEFAULT_CLONE_TIMEOUT_S)))
     except ValueError:
         return _DEFAULT_CLONE_TIMEOUT_S
-
-
-def _validate_remote_url(repo_input: str) -> None:
-    """Reject malformed / private / DNS-rebinding URLs."""
-    if not _REPO_URL_RE.match(repo_input):
-        raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
-    if _PRIVATE_HOST_RE.match(repo_input):
-        raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
-    if repo_input.startswith("http"):
-        import urllib.parse
-        hostname = urllib.parse.urlparse(repo_input).hostname or ""
-        if hostname and _resolves_to_private(hostname):
-            raise ValueError("Repository URL resolves to a private/internal address")
 
 
 def _legacy_tempdir_clone(repo_input: str) -> str:

--- a/src/quodeq/data/fs/repo_validation.py
+++ b/src/quodeq/data/fs/repo_validation.py
@@ -30,6 +30,22 @@ def _resolves_to_private(hostname: str) -> bool:
     return is_private_address(hostname)
 
 
+def _remote_host(repo_input: str) -> str:
+    """Return the host of a format-validated repo URL.
+
+    Handles both supported forms so the private-host check covers them equally:
+    ``https://host/path`` and the scp-like ``git@host:path`` (SSH) form. The
+    SSH form skips ``_PRIVATE_HOST_RE`` (anchored to ``^https?://``), so without
+    this it would reach git clone unguarded.
+    """
+    if repo_input.startswith("http"):
+        import urllib.parse
+        return urllib.parse.urlparse(repo_input).hostname or ""
+    if repo_input.startswith("git@"):
+        return repo_input[len("git@"):].split(":", 1)[0].strip("[]")
+    return ""
+
+
 def is_valid_repo_url(url: str) -> bool:
     """Return True if *url* matches the expected git repository URL format."""
     return _REPO_URL_RE.match(url) is not None
@@ -48,8 +64,6 @@ def validate_remote_url(repo_input: str) -> None:
         raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
     if _PRIVATE_HOST_RE.match(repo_input):
         raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
-    if repo_input.startswith("http"):
-        import urllib.parse
-        hostname = urllib.parse.urlparse(repo_input).hostname or ""
-        if hostname and _resolves_to_private(hostname):
-            raise ValueError("Repository URL resolves to a private/internal address")
+    hostname = _remote_host(repo_input)
+    if hostname and _resolves_to_private(hostname):
+        raise ValueError("Repository URL resolves to a private/internal address")

--- a/src/quodeq/data/fs/repo_validation.py
+++ b/src/quodeq/data/fs/repo_validation.py
@@ -33,3 +33,23 @@ def _resolves_to_private(hostname: str) -> bool:
 def is_valid_repo_url(url: str) -> bool:
     """Return True if *url* matches the expected git repository URL format."""
     return _REPO_URL_RE.match(url) is not None
+
+
+def validate_remote_url(repo_input: str) -> None:
+    """Reject malformed / private / DNS-rebinding repository URLs.
+
+    Shared SSRF guard used by both the CLI clone path
+    (:func:`quodeq.data.fs.repo_clone.prepare_repository`) and the web API
+    registration path (:func:`quodeq.services.evaluation_mixin._register_project`),
+    so the two entry points cannot drift apart on what they consider safe.
+    Raises ``ValueError`` for any rejected URL.
+    """
+    if not _REPO_URL_RE.match(repo_input):
+        raise ValueError(f"Invalid repository URL format: {repo_input}. Expected: https://github.com/user/repo or git@github.com:user/repo.git")
+    if _PRIVATE_HOST_RE.match(repo_input):
+        raise ValueError("Repository URLs pointing to private/internal addresses are not allowed")
+    if repo_input.startswith("http"):
+        import urllib.parse
+        hostname = urllib.parse.urlparse(repo_input).hostname or ""
+        if hostname and _resolves_to_private(hostname):
+            raise ValueError("Repository URL resolves to a private/internal address")

--- a/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
+++ b/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
@@ -69,29 +69,34 @@ def _load_run_metadata(run_dir: Path) -> dict[str, Any]:
 
 def load_evidence_map_from_db(run_dir: Path) -> dict[str, dict[str, Any]]:
     repo = SqliteFindingsRepository(run_dir)
-    counts = repo.count_by_dimension()
+    # Fetch all findings in one query, then group by dimension in Python.
+    # Previously this called count_by_dimension() + list_by_dimension(dim)
+    # for each dimension, which was an N+1 query pattern.
+    all_judgments = repo.list_all()
     run_metadata = _load_run_metadata(run_dir)
     result: dict[str, dict[str, Any]] = {}
-    for dimension in counts:
-        judgments = repo.list_by_dimension(dimension)
-        violations = [finding_to_response_dict(j) for j in judgments if j.verdict == "violation"]
-        compliance = [finding_to_response_dict(j) for j in judgments if j.verdict == "compliance"]
-        principles: dict[str, dict[str, Any]] = {}
-        for j in judgments:
-            entry = principles.setdefault(j.practice_id, {
-                "display_name": j.practice_id,
-                "violations": [],
-                "compliance": [],
-            })
-            target = entry["violations"] if j.verdict == "violation" else entry["compliance"]
-            target.append(finding_to_response_dict(j))
-        result[dimension] = {
-            "dimension": dimension,
-            "principles": principles,
-            "violation_count": len(violations),
-            "compliance_count": len(compliance),
-            "sourceFileCount": run_metadata["sourceFileCount"],
-            "date": run_metadata["date"],
-            "discipline": run_metadata["discipline"],
-        }
+    for j in all_judgments:
+        dimension = j.dimension
+        if dimension not in result:
+            result[dimension] = {
+                "dimension": dimension,
+                "principles": {},
+                "violation_count": 0,
+                "compliance_count": 0,
+                "sourceFileCount": run_metadata["sourceFileCount"],
+                "date": run_metadata["date"],
+                "discipline": run_metadata["discipline"],
+            }
+        entry = result[dimension]["principles"].setdefault(j.practice_id, {
+            "display_name": j.practice_id,
+            "violations": [],
+            "compliance": [],
+        })
+        finding_dict = finding_to_response_dict(j)
+        if j.verdict == "violation":
+            entry["violations"].append(finding_dict)
+            result[dimension]["violation_count"] += 1
+        else:
+            entry["compliance"].append(finding_dict)
+            result[dimension]["compliance_count"] += 1
     return result

--- a/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
+++ b/src/quodeq/data/fs/report_parser/_evidence_sqlite.py
@@ -96,7 +96,13 @@ def load_evidence_map_from_db(run_dir: Path) -> dict[str, dict[str, Any]]:
         if j.verdict == "violation":
             entry["violations"].append(finding_dict)
             result[dimension]["violation_count"] += 1
-        else:
+        elif j.verdict == "compliance":
             entry["compliance"].append(finding_dict)
             result[dimension]["compliance_count"] += 1
+        else:
+            # "dismissed" (and any future verdict) goes into compliance list for
+            # display purposes (matching the old per-dimension behaviour) but
+            # must NOT increment compliance_count — the old code derived counts
+            # via len([j for j in judgments if j.verdict == "compliance"]).
+            entry["compliance"].append(finding_dict)
     return result

--- a/src/quodeq/data/fs/report_parser/_sql_grade_overlay.py
+++ b/src/quodeq/data/fs/report_parser/_sql_grade_overlay.py
@@ -90,7 +90,7 @@ def overlay_sql_grades(
         # Project any pending events first so a freshly-completed run has its
         # grade tables baked before we read them (matches the explorer detail
         # path). ensure_projected is a fast no-op once the log size is stable.
-        SqliteFindingsRepository(run_dir)._ensure_fresh()  # noqa: SLF001
+        SqliteFindingsRepository(run_dir).ensure_projected()
         dim_rows = store.read_dimension_scores()
         principle_rows = store.read_principle_grades()
     except sqlite3.DatabaseError:

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -79,6 +79,8 @@ def _read_run_status(run_dir: Path) -> str | None:
             data = _json.load(fp)
     except (OSError, ValueError):
         return None
+    if not isinstance(data, dict):
+        return None
     state = data.get("state")
     return state if isinstance(state, str) else None
 

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -67,9 +67,9 @@ class ProjectionEngine:
                 handle(event, store)
                 last_ts = event.timestamp
                 count += 1
-            except Exception:
+            except (ValueError, KeyError, TypeError):
                 _logger.error(
-                    "Handler failed for event %s (type=%s) — skipping",
+                    "Handler failed for event %s (type=%s) - skipping",
                     event.event_id,
                     event.event_type,
                     exc_info=True,

--- a/src/quodeq/data/projection/engine.py
+++ b/src/quodeq/data/projection/engine.py
@@ -47,8 +47,16 @@ class ProjectionEngine:
 
         applied = 0
         for event in read_action_events(actions_log.parent):
-            handle(event, store)
-            applied += 1
+            try:
+                handle(event, store)
+                applied += 1
+            except Exception:
+                _logger.error(
+                    "Handler failed for action event %s (type=%s) - skipping",
+                    getattr(event, "event_id", "?"),
+                    getattr(event, "event_type", "?"),
+                    exc_info=True,
+                )
         store.save_actions_projected_size(current_size)
         return applied
 

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -132,19 +132,4 @@ def recompute_grades(run_dir: Path, params: ScoringParams | None = None) -> None
     principle_rows, dimension_rows = compute_run_grades(run_dir, params)
 
     store = SQLiteStateStore(run_dir)
-    store.clear_grades()
-    for dim, p_grade in principle_rows:
-        store.record_principle_grade(
-            dimension=dim,
-            principle_id=p_grade["principle_id"],
-            score=p_grade["score"],
-            grade=p_grade["grade"],
-            finding_count=p_grade["finding_count"],
-            dismissed_count=p_grade["dismissed_count"],
-        )
-    for d_score in dimension_rows:
-        store.record_dimension_score(
-            dimension=d_score["dimension"],
-            score=d_score["score"],
-            grade=d_score["grade"],
-        )
+    store.batch_rewrite_grades(principle_rows, dimension_rows)

--- a/src/quodeq/data/prompts/cli_consolidated_prompt.md
+++ b/src/quodeq/data/prompts/cli_consolidated_prompt.md
@@ -26,7 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 
 **Required:** `req` (the **exact requirement ID from the checklist below**, e.g. `M-MOD-1`, `S-CON-3` — you MUST use the IDs exactly as listed, do NOT invent new ones), `t` (`violation` or `compliance`), `file`, `line`, `severity` (`critical`/`major`/`minor`), `w` (short description), `reason` (why this is a violation or compliance)
 
-**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope)
+**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope), `vt` (violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`; reuse the exact same code for every finding of the same kind so near-duplicates group together)
 
 ## Rules
 

--- a/src/quodeq/data/prompts/cli_subagent_prompt.md
+++ b/src/quodeq/data/prompts/cli_subagent_prompt.md
@@ -26,7 +26,7 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 **Required:** `req` (the **exact requirement ID from the checklist below**, e.g. `M-MOD-1`, `S-CON-3` — you MUST use the IDs exactly as listed, do NOT invent new ones), `t` (`violation` or `compliance`), `file`, `line`, `severity` (`critical`/`major`/`minor`), `w` (short description), `reason` (why this is a violation or compliance)
 
-**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope)
+**Optional:** `end_line` (last line of the violation pattern, omit if single line), `scope` (set to `file`/`class`/`module` when finding affects entire scope), `vt` (violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`; reuse the exact same code for every finding of the same kind so near-duplicates group together)
 
 ## Rules
 

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -51,6 +51,8 @@ Report ALL violations AND ALL compliance you observe — do not bias toward eith
 
 Skip generated, vendored, compiled, and dependency directories. Use the project type to decide what matters: a backend API has different concerns than a mobile app or CLI tool.
 
+{{EVALUATION_RULES}}
+
 ## Standards Checklist
 
 Use the **exact requirement ID** (e.g. `M-MOD-1`) as `req`. Do NOT create your own IDs.

--- a/src/quodeq/data/prompts/compass.md
+++ b/src/quodeq/data/prompts/compass.md
@@ -26,6 +26,7 @@ For EVERY finding (violation or compliance), call `report_finding` with:
 - `severity` — `critical`, `major`, or `minor`
 - `w` — short description
 - `reason` — why this is a violation or compliance
+- `vt` — OPTIONAL violation type taxonomy code: a short, stable, kebab-case class of the violation, e.g. `code-injection`, `hardcoded-secret`, `missing-error-handling`. Reuse the exact same code for every finding of the same kind so near-duplicates group together.
 
 ## Search Strategy
 

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -26,19 +26,19 @@ Compliance uses the same scale to mark importance of what's done right.
 
 ## Reachable input (provenance)
 
-A missing null/guard check (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can reach the flagged line. Name the caller or source that delivers it.
+A missing null/undefined guard (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can actually reach the flagged line. Name the source that delivers it. (The target language is named at the top of this prompt; read the patterns below in that language's idiom.)
 
-Internal input is NOT `critical`. The value is internal when it is a content hash or digest, a module-level constant or enum, a parameter with a default, or a value every visible call site passes valid (a React prop from a hook/default, an argument always given a literal). A missing guard on internal input is a hardening gap → `major` if 1–4 hold and the guard is genuinely worth adding, else drop.
+External source → stays `critical`. The value crosses a trust boundary: an HTTP request, query/route param, header, cookie, or body; a CLI argument; an environment variable; file, network, or message-queue payload; or any argument an untrusted caller controls.
 
-External input stays `critical`. The value reaches the line from an HTTP request, query string, request body, CLI argument, environment variable, file contents, or any caller across a trust boundary.
+Internal source → NOT `critical`, a hardening gap (`major` if 1–4 hold and the guard is worth adding, else drop). The value cannot be attacker-controlled: a content hash or digest (e.g. a SHA-256 hex string); a literal, constant, or enum; a parameter with a default that every visible call site relies on or passes a literal; or a value already validated (charset-restricted, length-checked, allow-listed) before this line.
 
-Not `critical`:
-- `stack.forEach(...)` on a prop with no null guard, where the prop is supplied by a hook or a default at every call site.
-- `[...thresholds]` or destructuring a hook argument whose value is backfilled from defaults.
-- a cache path `root / key[:2] / key[2:]` where `key` is a SHA-256 hex digest (or validated against a safe charset); the digest is not attacker-controlled.
+If you cannot name an external source, treat the value as internal; do not assume one off-screen.
 
-Genuinely `critical`:
-- a path built from `request.args["file"]`, or a dereference of a value parsed from an HTTP request body; provenance is external.
+Worked example (any language). A line opens or dereferences `x` with no check:
+- `x` comes from a request field or CLI arg, e.g. `open(request["file"])` → external → `critical`.
+- `x` is a digest, e.g. `open(cacheDir + "/" + sha256(content))` → internal, a hex digest no caller can choose → `major` or drop.
+
+Same code, opposite verdict: the source decides the severity.
 
 ## Test files
 

--- a/src/quodeq/data/prompts/evaluation_rules.md
+++ b/src/quodeq/data/prompts/evaluation_rules.md
@@ -24,6 +24,22 @@ DROP speculative concerns: "could", "might", "should consider".
 
 Compliance uses the same scale to mark importance of what's done right.
 
+## Reachable input (provenance)
+
+A missing null/guard check (R-FT-2) or a path/key built from a value (S-AUT-3) is `critical` only when a bad value can reach the flagged line. Name the caller or source that delivers it.
+
+Internal input is NOT `critical`. The value is internal when it is a content hash or digest, a module-level constant or enum, a parameter with a default, or a value every visible call site passes valid (a React prop from a hook/default, an argument always given a literal). A missing guard on internal input is a hardening gap → `major` if 1–4 hold and the guard is genuinely worth adding, else drop.
+
+External input stays `critical`. The value reaches the line from an HTTP request, query string, request body, CLI argument, environment variable, file contents, or any caller across a trust boundary.
+
+Not `critical`:
+- `stack.forEach(...)` on a prop with no null guard, where the prop is supplied by a hook or a default at every call site.
+- `[...thresholds]` or destructuring a hook argument whose value is backfilled from defaults.
+- a cache path `root / key[:2] / key[2:]` where `key` is a SHA-256 hex digest (or validated against a safe charset); the digest is not attacker-controlled.
+
+Genuinely `critical`:
+- a path built from `request.args["file"]`, or a dereference of a value parsed from an HTTP request body; provenance is external.
+
 ## Test files
 
 Test file → max severity `minor`. Never `critical`/`major` on tests, fixtures, mocks, or specs.
@@ -41,7 +57,8 @@ For `critical`/`major` also:
 
 5. **Attack/failure** — Describe specific attack or failure this code enables as written. Hedge words → `minor` only if 1–4 hold; else drop.
 6. **Reachable** — Production code path. Tests, examples, dev scaffolding are not `critical`.
+7. **Provenance** (unguarded access & path-from-string only) — Name the caller or external source that delivers a bad or attacker-controlled value to this line. Can't, because the value is a content hash, a constant, a defaulted parameter, or always a literal at the call sites you see? Not `critical` → `major` if 1–4 hold, else drop.
 
-**Decision**: 1–4 fail → DROP entirely. 5–6 fail → `minor` only if 1–4 hold, else drop. `minor` is not a fallback bucket.
+**Decision**: 1–4 fail → DROP entirely. 5–6 fail → `minor` only if 1–4 hold, else drop. 7 fail → `major` (or drop) per the item. `minor` is not a fallback bucket.
 
 Fewer sharper findings beats long reports padded with speculation.

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -53,7 +53,9 @@ def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
         "title": finding.get("w", "") or "",
         "reason": finding.get("reason", "") or "",
         "snippet": finding.get("snippet", "") or "",
-        "violation_type": finding.get("violation_type", "") or "",
+        # The taxonomy travels as 'vt' on the JSONL wire (see evidence/_jsonl.py);
+        # accept the long key too so both spellings survive this seam.
+        "violation_type": finding.get("vt") or finding.get("violation_type") or "",
         "context": finding.get("context", "") or "",
         "scope": finding.get("scope", "") or "",
         "req_refs_json": json.dumps(refs) if refs is not None else None,

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -76,6 +76,20 @@ class SqliteFindingsRepository:
             ).fetchall()
         return [row_to_finding(r) for r in rows]
 
+    def list_all(self) -> list[Finding]:
+        """Return every finding in the DB in a single query (all dimensions).
+
+        Callers that need findings grouped by dimension should use this method
+        and group in Python rather than issuing N ``list_by_dimension`` calls.
+        """
+        self._ensure_fresh()
+        with open_evaluation_db(self._run_dir) as conn:
+            conn.row_factory = _dict_row
+            rows = conn.execute(
+                f"SELECT {_SELECT_COLUMNS} FROM findings ORDER BY id",
+            ).fetchall()
+        return [row_to_finding(r) for r in rows]
+
     def count_by_dimension(self) -> dict[str, int]:
         self._ensure_fresh()
         with open_evaluation_db(self._run_dir) as conn:

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -59,6 +59,16 @@ class SqliteFindingsRepository:
                 project_dir=project_dir,
             )
 
+    def ensure_projected(self) -> None:
+        """Ensure the run's grade tables are up to date with the event log.
+
+        Public entry point for callers that need to project before reading
+        grade data directly (e.g. the SQL grade overlay).  Delegates to the
+        internal :meth:`_ensure_fresh` which is a fast no-op once the event
+        log size is stable.
+        """
+        self._ensure_fresh()
+
     def insert_finding(self, finding: dict[str, Any]) -> bool:
         row = finding_dict_to_row(finding)
         with open_evaluation_db(self._run_dir) as conn:

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -166,6 +166,47 @@ class SQLiteStateStore:
             )
             conn.commit()
 
+    def batch_rewrite_grades(
+        self,
+        principle_rows: "list[tuple[str, dict]]",
+        dimension_rows: "list[dict]",
+    ) -> None:
+        """Clear all grade tables and insert new rows in a single transaction.
+
+        The clear + all inserts are committed atomically: a mid-batch failure
+        rolls back the entire operation, leaving any pre-existing rows intact.
+
+        Args:
+            principle_rows: Sequence of ``(dimension, principle_grade_dict)``
+                as returned by ``compute_run_grades``.
+            dimension_rows: Sequence of dimension score dicts
+                (``{"dimension": ..., "score": ..., "grade": ...}``).
+        """
+        with open_evaluation_db(self._run_dir) as conn:
+            conn.execute("DELETE FROM dimension_scores")
+            conn.execute("DELETE FROM principle_grades")
+            for dim, p_grade in principle_rows:
+                conn.execute(
+                    "INSERT INTO principle_grades "
+                    "(dimension, principle_id, score, grade, finding_count, dismissed_count, completed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+                    (
+                        dim,
+                        p_grade["principle_id"],
+                        p_grade["score"],
+                        p_grade["grade"],
+                        p_grade["finding_count"],
+                        p_grade["dismissed_count"],
+                    ),
+                )
+            for d_score in dimension_rows:
+                conn.execute(
+                    "INSERT INTO dimension_scores (dimension, score, grade, completed_at) "
+                    "VALUES (?, ?, ?, datetime('now'))",
+                    (d_score["dimension"], d_score["score"], d_score["grade"]),
+                )
+            conn.commit()
+
     def clear_grades(self) -> None:
         with open_evaluation_db(self._run_dir) as conn:
             conn.execute("DELETE FROM dimension_scores")

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -173,8 +173,9 @@ class SQLiteStateStore:
     ) -> None:
         """Clear all grade tables and insert new rows in a single transaction.
 
-        The clear + all inserts are committed atomically: a mid-batch failure
-        rolls back the entire operation, leaving any pre-existing rows intact.
+        The clear + all inserts are committed atomically: on a mid-batch
+        failure the transaction is never committed and is discarded when the
+        connection closes, leaving any pre-existing rows intact.
 
         Args:
             principle_rows: Sequence of ``(dimension, principle_grade_dict)``

--- a/src/quodeq/data/web/_response.py
+++ b/src/quodeq/data/web/_response.py
@@ -24,8 +24,8 @@ def check_response_status(response: HttpResponse) -> None:
     error details that should remain internal.
     """
     if response.status in {HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN}:
-        raise AuthError("Authentication error — verify your API key is valid and not expired")
+        raise AuthError("Authentication error. Verify your API key is valid and not expired")
     if response.status == HTTPStatus.NOT_FOUND:
-        raise NotFoundError("Resource not found — verify the URL and that the resource exists")
+        raise NotFoundError("Resource not found. Verify the URL and that the resource exists")
     if response.status >= HTTPStatus.INTERNAL_SERVER_ERROR:
-        raise ServerError("Server error")
+        raise ServerError(f"Server error (HTTP {response.status})")

--- a/src/quodeq/llm_bridge/_omlx.py
+++ b/src/quodeq/llm_bridge/_omlx.py
@@ -19,6 +19,7 @@ import urllib.error
 from pathlib import Path
 
 from quodeq.llm_bridge._ollama import _detect_memory, estimate_max_agents
+from quodeq.shared.url_validation import validate_url_safe
 
 _log = logging.getLogger(__name__)
 
@@ -46,11 +47,24 @@ def _normalize_base(base_url: str) -> str:
     return stripped
 
 
+def _safe_request(url: str) -> urllib.request.Request:
+    """Build a Request for *url* after validating it is safe to fetch.
+
+    Loopback addresses (localhost, 127.x.x.x) are allowed because omlx
+    normally runs on localhost.  Private-range IPs (10.x, 192.168.x) and
+    link-local/metadata addresses (169.254.x) are rejected to prevent SSRF.
+
+    Raises ``ValueError`` for unsafe URLs.
+    """
+    validate_url_safe(url, allow_loopback=True)
+    return urllib.request.Request(url)
+
+
 def get_omlx_status(base_url: str | None = None) -> dict:
     """Check if an omlx server is running and reachable."""
     root = _normalize_base(base_url or _OMLX_BASE)
     try:
-        req = urllib.request.Request(f"{root}/health")
+        req = _safe_request(f"{root}/health")
         with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as resp:
             data = json.loads(resp.read() or b"{}")
             return {
@@ -85,7 +99,7 @@ def list_omlx_models(base_url: str | None = None, api_key: str | None = None) ->
     """
     root = _normalize_base(base_url or _OMLX_BASE)
     try:
-        req = urllib.request.Request(f"{root}/v1/models")
+        req = _safe_request(f"{root}/v1/models")
         key = api_key if api_key is not None else _read_omlx_api_key()
         if key:
             req.add_header("Authorization", f"Bearer {key}")

--- a/src/quodeq/services/_evaluations_index.py
+++ b/src/quodeq/services/_evaluations_index.py
@@ -217,10 +217,16 @@ class EvaluationsIndex:
         reports_root = self._resolve_reports_root()
         if reports_root is None or not reports_root.is_dir():
             return None
+        resolved_root = reports_root.resolve()
         for project_dir in reports_root.iterdir():
             if not project_dir.is_dir():
                 continue
             candidate = project_dir / run_id
+            try:
+                if not candidate.resolve().is_relative_to(resolved_root):
+                    continue
+            except (OSError, ValueError):
+                continue
             if candidate.is_dir():
                 return candidate
         return None

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from quodeq.services.ports import RunInfo, read_run_data, safe_read_dir, summarize_dimensions
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from quodeq.core.scoring.params import ScoringParams
@@ -146,6 +149,6 @@ def _has_fingerprints(reports_root: Path, project: str) -> bool:
                 continue
             if any(f.name.endswith("_fingerprint.json") for f in evidence_dir.iterdir()):
                 return True
-    except OSError:
-        pass
+    except OSError as e:
+        _logger.warning("Could not read fingerprint dir %s: %s", project_dir, e)
     return False

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -35,9 +35,16 @@ def default_write_json(path: Path, data: dict) -> None:
 
 
 def count_principles_and_requirements(data: dict) -> tuple[int, int]:
-    """Return (principle_count, requirement_count) from a standard's JSON."""
+    """Return (principle_count, requirement_count) from a standard's JSON.
+
+    Malformed payloads (principles not a list, or items not dicts) are
+    tolerated: non-list values are treated as empty, non-dict items are skipped.
+    """
     principles = data.get("principles", [])
-    return len(principles), sum(len(p.get("requirements", [])) for p in principles)
+    if not isinstance(principles, list):
+        principles = []
+    valid = [p for p in principles if isinstance(p, dict)]
+    return len(valid), sum(len(p.get("requirements", [])) for p in valid)
 
 
 def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDetail:

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -43,6 +43,8 @@ def _parse_jsonl_findings(
             obj = json.loads(raw)
         except json.JSONDecodeError:
             continue
+        if not isinstance(obj, dict):
+            continue
         principle = obj.get("p") or obj.get("req")
         if not principle or obj.get("t") not in _FINDING_TYPES:
             continue

--- a/src/quodeq/services/evaluation_mixin.py
+++ b/src/quodeq/services/evaluation_mixin.py
@@ -17,6 +17,7 @@ from quodeq.core.evidence.parser import parse_jsonl_to_evidence, EvidenceContext
 from quodeq.core.scoring.engine import score_evidence
 from quodeq.services.grade_formula import load_params
 from quodeq.analysis.report import write_dimension_report
+from quodeq.data.fs.repo_validation import validate_remote_url
 from quodeq.services._fs_clone import run_git_clone
 from quodeq.services._fs_scan import scan_project
 from quodeq.shared._env import get_clones_dir
@@ -138,6 +139,11 @@ def _register_project(
     Returns the project's UUID.
     """
     is_url = is_repo_url(repo)
+    if is_url:
+        # SSRF guard: reject private/loopback/link-local hosts before any clone
+        # or directory side effects. Mirrors the CLI prepare_repository path so
+        # the web API (POST /api/projects) cannot be pointed at internal hosts.
+        validate_remote_url(repo)
     if is_url and not ephemeral and clone_dest is None:
         raise ValueError(
             "URL repos require either clone_dest (user-chosen path) or ephemeral=True"

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -29,10 +29,6 @@ _logger = logging.getLogger(__name__)
 SCHEMA_VERSION = 1
 
 
-class UnsupportedIndexSchemaError(RuntimeError):
-    """Raised when index.db has schema_version > SCHEMA_VERSION."""
-
-
 @dataclass(frozen=True)
 class RunRow:
     """One row of the runs table, as a plain dataclass."""
@@ -97,8 +93,14 @@ def _read_schema_version(db: sqlite3.Connection) -> int | None:
 def open_index(db_path: Path) -> sqlite3.Connection:
     """Open (or create) the index DB at *db_path*, migrate to current schema.
 
-    Raises UnsupportedIndexSchemaError if the existing DB has a newer schema.
-    Recovers from a corrupt file by deleting and recreating.
+    The index is derived state — rebuildable from the run files on disk — so a
+    DB this binary can't use is discarded and recreated rather than fatal:
+
+    * a corrupt/unreadable file, or
+    * a downgraded index whose ``schema_version`` is newer than we support
+      (the user ran a newer quodeq, then installed an older one).
+
+    Either way the next ``sync_index`` repopulates it from disk.
     """
     db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -127,10 +129,24 @@ def open_index(db_path: Path) -> sqlite3.Connection:
         _apply_schema_v1(db)
         return db
     if version > SCHEMA_VERSION:
-        db.close()
-        raise UnsupportedIndexSchemaError(
-            f"index schema_version={version} newer than supported ({SCHEMA_VERSION})"
+        # Downgrade: a newer quodeq migrated the index forward. It's a derived
+        # projection, so discard and rebuild rather than crash — mirrors the
+        # corrupt-file recovery above. The next sync_index repopulates it.
+        _logger.warning(
+            "index DB at %s has schema_version=%s newer than supported (%s) — "
+            "rebuilding from run files", db_path, version, SCHEMA_VERSION,
         )
+        # Close before unlink — Windows holds the file handle open otherwise.
+        try:
+            db.close()
+        except sqlite3.Error:
+            pass
+        db_path.unlink(missing_ok=True)
+        db = sqlite3.connect(str(db_path))
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute("PRAGMA busy_timeout=3000")
+        _apply_schema_v1(db)
+        return db
     return db
 
 

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -217,6 +217,19 @@ def build_scan_progress(
     dim_estimates = _read_dim_estimates(run_dir)
     dim_records = read_dimensions(run_dir).get("dimensions") or {}
     dim_ids = list(status.get("dimensions") or [])
+    if not dim_ids:
+        # "All dimensions" runs (no --dimensions filter) record an empty list in
+        # status.json: the raw, unresolved filter is None and gets coerced to []
+        # before the lifecycle writes it. Reading the dim list from status alone
+        # would then zero out the whole progress header — and the ETA the UI
+        # derives from it — for the entire run. The per-dim sidecars still hold
+        # the resolved dims, so recover the list from them (order-preserving,
+        # deduped) when status carries none.
+        recovered: dict[str, None] = {}
+        record_keys = dim_records.keys() if isinstance(dim_records, dict) else ()
+        for key in (*record_keys, *dim_estimates.keys()):
+            recovered.setdefault(key, None)
+        dim_ids = list(recovered)
     evidence_dir = run_dir / "evidence"
 
     dim_results: list[_DimProgress] = []

--- a/src/quodeq/services/scoring_view/_resolution.py
+++ b/src/quodeq/services/scoring_view/_resolution.py
@@ -51,7 +51,7 @@ def _is_trustworthy_eval(eval_data: dict[str, Any] | None) -> bool:
     we exclude it everywhere — cards, history, chart — so it can't
     pollute any user-facing aggregation.
     """
-    if not eval_data:
+    if not isinstance(eval_data, dict):
         return False
     files_read = eval_data.get("filesRead")
     return isinstance(files_read, int) and files_read > 0

--- a/src/quodeq/services/tooling_mixin.py
+++ b/src/quodeq/services/tooling_mixin.py
@@ -32,7 +32,7 @@ def _load_fallback_claude_models() -> list[str]:
     try:
         data = read_json(_AI_DEFAULTS_PATH)
         return data.get("fallback_claude_models", [])
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError, ValueError):
         return []
 
 

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import urllib.error
 import urllib.request
@@ -43,23 +44,28 @@ _SETTINGS_HINT = (
 _VERSION_CMD_TIMEOUT_S = 30
 _API_CHECK_TIMEOUT_S = 5
 
+# Provider/command tokens are restricted to a charset with no shell
+# metacharacters, so even on the Windows shell=True path (needed for npm
+# .cmd shim resolution) a value like "x & calc.exe" can never reach cmd.exe.
+_SAFE_CMD_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
+
 
 def _run_version_cmd(cmd: list[str]) -> str:
-    """Run a command and return its stdout, or raise FileNotFoundError.
+    """Run a version command and return its stdout, or raise.
 
-    ``shell=True`` is required on Windows so that ``where`` and other
-    shell built-ins resolve correctly and executables installed via npm
-    (which are .cmd shims) can be found on PATH.  The *cmd* parameter
-    is always a ``list[str]`` hard-coded by callers in this module
-    (never user-influenced), so the shell injection risk does not apply.
-
-    SECURITY: Do not pass user-controlled strings into *cmd*.
-    All callers in this module construct *cmd* from string literals
-    (e.g. ``["node", "--version"]``).  If this function is ever
-    exposed to external input, ``shell=True`` MUST be removed.
+    On Windows ``shell=True`` is required so npm-installed ``.cmd`` shims
+    resolve on PATH. To keep that shell safe, every token in *cmd* is
+    validated against a strict ``[A-Za-z0-9._-]`` charset, so no shell
+    metacharacter (space, ``&``, ``|``, ``>`` ...) can reach ``cmd.exe``.
+    Callers that accept external input (e.g. a provider name from the
+    ``AI_CMD`` env var) must still validate at their own layer; this is
+    defense in depth.
     """
     if not isinstance(cmd, list):
         raise TypeError("cmd must be a list of strings, not a raw string")
+    for token in cmd:
+        if not isinstance(token, str) or not _SAFE_CMD_TOKEN_RE.fullmatch(token):
+            raise ValueError(f"unsafe command token: {token!r}")
     result = subprocess.run(
         cmd, capture_output=True, text=True, check=True, shell=_IS_WIN32,
         timeout=_VERSION_CMD_TIMEOUT_S,
@@ -109,6 +115,13 @@ def _is_provider_explicitly_configured() -> bool:
 
 def _check_cli_provider(provider: str) -> None:
     """Check that a CLI provider binary is available on PATH."""
+    if not _SAFE_CMD_TOKEN_RE.fullmatch(provider):
+        raise RuntimeError(
+            f"'{provider}' is not a valid AI provider name.\n\n"
+            f"Provider names may only contain letters, digits, '.', '_', and '-'.\n\n"
+            f"Choose a provider in the dashboard Settings:\n"
+            f"  quodeq"
+        )
     try:
         _run_version_cmd([provider, "--version"])
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:

--- a/src/quodeq/shared/resource_sampler.py
+++ b/src/quodeq/shared/resource_sampler.py
@@ -129,6 +129,6 @@ class ResourceSampler:
         while not self._stop.is_set():
             try:
                 log_info(self.sample_once())
-            except (OSError, ValueError):
+            except Exception:
                 pass  # best-effort: never let observability kill the run
             self._stop.wait(self._interval)

--- a/src/quodeq/shared/ssrf.py
+++ b/src/quodeq/shared/ssrf.py
@@ -21,6 +21,16 @@ def is_private_address(hostname: str) -> bool:
         return addr.is_private or addr.is_loopback or addr.is_link_local
     except ValueError:
         _logger.debug("Cannot parse %r as IP literal, falling through to DNS", hostname)
+    # git/libc accept IPv4 literals in octal/hex/dword/short forms that
+    # ``ipaddress`` rejects (e.g. 0177.0.0.1, 0x7f000001, 2130706433, 127.1).
+    # Canonicalize the way git's resolver will so SSRF via alternate IPv4
+    # encodings is caught here instead of slipping through to a public-looking
+    # DNS answer. inet_aton raises OSError for real hostnames -> DNS fallback.
+    try:
+        addr = ipaddress.ip_address(socket.inet_ntoa(socket.inet_aton(hostname)))
+        return addr.is_private or addr.is_loopback or addr.is_link_local
+    except OSError:
+        pass
     try:
         for _fam, _typ, _pro, _can, sockaddr in socket.getaddrinfo(hostname, None):
             addr = ipaddress.ip_address(sockaddr[0])

--- a/src/quodeq/shared/ssrf.py
+++ b/src/quodeq/shared/ssrf.py
@@ -27,6 +27,27 @@ def is_private_address(hostname: str) -> bool:
             if addr.is_private or addr.is_loopback or addr.is_link_local:
                 return True
     except (socket.gaierror, OSError) as exc:
-        _logger.warning("DNS resolution failed for %r — treating as private (fail-closed): %s", hostname, exc)
+        _logger.warning("DNS resolution failed for %r - treating as private (fail-closed): %s", hostname, exc)
         return True
     return False
+
+
+@lru_cache(maxsize=_LRU_CACHE_SIZE)
+def is_loopback_address(hostname: str) -> bool:
+    """Return True if *hostname* is a loopback address (127.x.x.x or ::1) or 'localhost'."""
+    if hostname in ("localhost", "localhost.localdomain"):
+        return True
+    try:
+        addr = ipaddress.ip_address(hostname)
+        return bool(addr.is_loopback)
+    except ValueError:
+        _logger.debug("Cannot parse %r as IP literal, falling through to DNS", hostname)
+    try:
+        for _fam, _typ, _pro, _can, sockaddr in socket.getaddrinfo(hostname, None):
+            addr = ipaddress.ip_address(sockaddr[0])
+            if not addr.is_loopback:
+                return False
+        return True
+    except (socket.gaierror, OSError) as exc:
+        _logger.warning("DNS resolution failed for %r - treating as private (fail-closed): %s", hostname, exc)
+        return False

--- a/src/quodeq/shared/url_validation.py
+++ b/src/quodeq/shared/url_validation.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
-from quodeq.shared.ssrf import is_private_address
+from quodeq.shared.ssrf import is_loopback_address, is_private_address
 
 
-def validate_url_safe(url: str, *, allow_private: bool = False) -> None:
+def validate_url_safe(
+    url: str,
+    *,
+    allow_private: bool = False,
+    allow_loopback: bool = False,
+) -> None:
     """Raise ``ValueError`` if *url* uses a non-HTTP scheme or targets a private address.
 
     Only ``http://`` and ``https://`` schemes are allowed.  The hostname is
@@ -16,6 +21,13 @@ def validate_url_safe(url: str, *, allow_private: bool = False) -> None:
     Set *allow_private* to ``True`` for endpoints that are intentionally on a
     local network (e.g. self-hosted Ollama or LLM servers on a LAN).  This
     still enforces the scheme allowlist but skips the private-IP check.
+
+    Set *allow_loopback* to ``True`` to allow loopback addresses (``127.x.x.x``,
+    ``::1``, ``localhost``) while still blocking other private ranges such as
+    ``10.x.x.x``, ``192.168.x.x``, and link-local/metadata addresses
+    (``169.254.x.x``).  Use this for services that are intentionally local-only
+    (e.g. omlx running on localhost) without opening up the full private range.
+    *allow_loopback* is ignored when *allow_private* is ``True``.
     """
     if not url:
         raise ValueError("URL must not be empty")
@@ -30,4 +42,6 @@ def validate_url_safe(url: str, *, allow_private: bool = False) -> None:
         raise ValueError("URL must include a hostname")
 
     if not allow_private and is_private_address(hostname):
+        if allow_loopback and is_loopback_address(hostname):
+            return  # loopback is explicitly permitted
         raise ValueError(f"URL targets a private/internal address: {hostname!r}")

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "quodeq-ui-web",
       "version": "0.0.0",
       "dependencies": {
-        "@chenglou/pretext": "^0.0.7",
+        "@chenglou/pretext": "^0.0.8",
         "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-virtual": "^3.14.2",
         "d3-hierarchy": "^3.1.2",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@chenglou/pretext": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.7.tgz",
-      "integrity": "sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
       "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@chenglou/pretext": "^0.0.7",
         "@tanstack/react-query": "^5.100.14",
-        "@tanstack/react-virtual": "^3.14.2",
+        "@tanstack/react-virtual": "^3.14.3",
         "d3-hierarchy": "^3.1.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -743,12 +743,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
-      "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.0"
+        "@tanstack/virtual-core": "3.17.1"
       },
       "funding": {
         "type": "github",
@@ -760,9 +760,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
-      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -26,7 +26,7 @@
         "@vitejs/plugin-react": "6.0.2",
         "jsdom": "^29.1.1",
         "vite": "8.0.16",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -1062,16 +1062,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1080,13 +1080,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1107,9 +1107,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1120,13 +1120,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1134,14 +1134,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1150,9 +1150,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1160,13 +1160,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -3967,19 +3967,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4007,12 +4007,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/src/quodeq/ui/package-lock.json
+++ b/src/quodeq/ui/package-lock.json
@@ -3733,9 +3733,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@chenglou/pretext": "^0.0.7",
     "@tanstack/react-query": "^5.100.14",
-    "@tanstack/react-virtual": "^3.14.2",
+    "@tanstack/react-virtual": "^3.14.3",
     "d3-hierarchy": "^3.1.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -34,6 +34,6 @@
     "@vitejs/plugin-react": "6.0.2",
     "jsdom": "^29.1.1",
     "vite": "8.0.16",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   }
 }

--- a/src/quodeq/ui/package.json
+++ b/src/quodeq/ui/package.json
@@ -16,7 +16,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@chenglou/pretext": "^0.0.7",
+    "@chenglou/pretext": "^0.0.8",
     "@tanstack/react-query": "^5.100.14",
     "@tanstack/react-virtual": "^3.14.2",
     "d3-hierarchy": "^3.1.2",

--- a/src/quodeq/ui/src/api/request.js
+++ b/src/quodeq/ui/src/api/request.js
@@ -8,6 +8,9 @@ const API_TIMEOUT_MS = 30000;
 export async function request(path, options = {}) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, controller.signal])
+    : controller.signal;
   try {
     const res = await fetch(`${BASE}${path}`, {
       headers: {
@@ -15,7 +18,7 @@ export async function request(path, options = {}) {
         ...(options.headers || {}),
       },
       ...options,
-      signal: controller.signal,
+      signal,
     });
 
     const payload = await res.json().catch(() => ({}));

--- a/src/quodeq/ui/src/api/request.test.jsx
+++ b/src/quodeq/ui/src/api/request.test.jsx
@@ -1,0 +1,29 @@
+import { vi, it, expect, afterEach } from 'vitest';
+import { request } from './request.js';
+afterEach(() => vi.restoreAllMocks());
+
+it('aborts when the caller signal aborts (react-query cancellation preserved)', async () => {
+  const fetchMock = vi.fn((_u, opts) => new Promise((_, reject) => {
+    opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const ctrl = new AbortController();
+  const p = request('/x', { signal: ctrl.signal });
+  ctrl.abort();
+  await expect(p).rejects.toThrow();
+  expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+});
+
+it('aborts on the internal timeout when no caller signal is given', async () => {
+  vi.useFakeTimers();
+  const fetchMock = vi.fn((_u, opts) => new Promise((resolve, reject) => {
+    opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+  }));
+  vi.stubGlobal('fetch', fetchMock);
+  const p = request('/x');
+  // Suppress unhandled-rejection noise while fake timers advance
+  p.catch(() => {});
+  await vi.advanceTimersByTimeAsync(30000);
+  await expect(p).rejects.toThrow();
+  vi.useRealTimers();
+});

--- a/src/quodeq/ui/src/api/standards.js
+++ b/src/quodeq/ui/src/api/standards.js
@@ -75,11 +75,19 @@ export async function importFromLibrary(file) {
  * @returns {Promise<Object>} Result with optional `_conflict` flag
  */
 export async function importStandard(data, force = false) {
-  const res = await fetch(`${BASE}/standards/import`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ data, force }),
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  let res;
+  try {
+    res = await fetch(`${BASE}/standards/import`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data, force }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
   const body = await res.json().catch(() => ({}));
   if (res.status === 409) return { ...body, _conflict: true };
   if (!res.ok) throw new Error(body.error || `Import failed: ${res.status}`);

--- a/src/quodeq/ui/src/api/standards382.test.jsx
+++ b/src/quodeq/ui/src/api/standards382.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * Finding #382 – importStandard() must apply a timeout to its fetch call.
+ * The function has special 409-conflict handling that prevents it from using
+ * request() directly (which throws on non-2xx before returning the body),
+ * so the fix wraps the raw fetch with an AbortController + 30s timeout.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { importStandard } from './standards.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('#382 importStandard – 30s timeout', () => {
+  it('calls fetch with an AbortSignal', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'std-1' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await importStandard({ id: 'std-1' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('aborts and rejects when the endpoint hangs past 30s', async () => {
+    vi.useFakeTimers();
+    let abortHandler;
+    const fetchMock = vi.fn((_url, opts) =>
+      new Promise((_resolve, reject) => {
+        abortHandler = () => reject(new DOMException('Aborted', 'AbortError'));
+        opts.signal.addEventListener('abort', abortHandler);
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const p = importStandard({ id: 'std-1' }).catch((e) => ({ error: e.message }));
+    await vi.advanceTimersByTimeAsync(30001);
+    const result = await p;
+
+    expect(result).toMatchObject({ error: expect.any(String) });
+    vi.useRealTimers();
+  });
+
+  it('still returns _conflict:true on 409 after timeout fix', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: 'Conflict', existing: true }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await importStandard({ id: 'std-1' });
+    expect(result._conflict).toBe(true);
+    expect(result.existing).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -21,7 +21,7 @@ import { projectKeys } from "../../../api/queryKeys.js";
  * not via SSE. ``refreshDashboard`` is what the dismiss handlers call to
  * trigger a refetch of the accumulated (cross-run) dashboard payload.
  */
-export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = true }) {
+export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = true } = {}) {
   const { getDashboard } = useApi();
   const queryClient = useQueryClient();
 

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -83,9 +83,9 @@ function ErrorToast({ message, onDismiss }) {
   }, [message, onDismiss]);
 
   return (
-    <div className="job-error-toast" onClick={onDismiss}>
+    <button type="button" className="job-error-toast" onClick={onDismiss}>
       {sanitizeErrorMessage(message)}
-    </div>
+    </button>
   );
 }
 

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+// Stub heavy sub-components used by EvaluateScreen
+vi.mock('./EvaluationStatus.jsx', () => ({ default: () => null }));
+vi.mock('./ReEvaluateCard.jsx', () => ({ default: () => null }));
+vi.mock('./CountdownTimer.jsx', () => ({ default: () => null }));
+vi.mock('../../../components/terminal/index.js', () => ({
+  TermHeader: () => null,
+}));
+vi.mock('../../../constants.js', () => ({
+  ACTIVE_PROVIDER_KEY: 'active-provider',
+  DEFAULT_TIME_LIMIT_S: 3600,
+  providerKey: (p, k) => `${p}-${k}`,
+}));
+
+import EvaluateScreen from './EvaluateScreen.jsx';
+
+const baseEvaluation = { job: null, jobError: null, liveViolations: [] };
+const baseContext = { selectedProject: null, projectInfo: null, jobProjectInfo: null };
+const baseActions = {
+  onStart: vi.fn(),
+  onDismiss: vi.fn(),
+  onCancel: vi.fn(),
+  onGoToProjects: vi.fn(),
+  onGoToSettings: vi.fn(),
+};
+
+describe('ErrorToast accessibility', () => {
+  it('dismiss control is a <button> element, not a <div>', () => {
+    render(
+      <EvaluateScreen
+        evaluation={{ ...baseEvaluation, jobError: 'Something went wrong' }}
+        context={baseContext}
+        actions={baseActions}
+      />
+    );
+    const toast = document.querySelector('.job-error-toast');
+    expect(toast).not.toBeNull();
+    expect(toast.tagName).toBe('BUTTON');
+  });
+
+  it('clicking the toast hides it (onDismiss callback fires)', () => {
+    render(
+      <EvaluateScreen
+        evaluation={{ ...baseEvaluation, jobError: 'Something went wrong' }}
+        context={baseContext}
+        actions={baseActions}
+      />
+    );
+    const toast = document.querySelector('.job-error-toast');
+    expect(toast).not.toBeNull();
+    fireEvent.click(toast);
+    // After click the toast should be gone from DOM
+    expect(document.querySelector('.job-error-toast')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 const MAX_LINES = 5000;
 const READYSTATE_CLOSED = 2;
+const INACTIVITY_MS = 60000;
 
 const TERMINAL_STATE_LINE = {
   cancelled: '── evaluation cancelled ──',
@@ -22,6 +23,7 @@ export function useJobLogStream(jobId) {
   const pendingRef = useRef([]);
   const rafRef = useRef(null);
   const timerRef = useRef(null);
+  const inactivityRef = useRef(null);
 
   useEffect(() => {
     setLogs([]);
@@ -34,6 +36,10 @@ export function useJobLogStream(jobId) {
     if (timerRef.current != null) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
+    }
+    if (inactivityRef.current != null) {
+      clearTimeout(inactivityRef.current);
+      inactivityRef.current = null;
     }
     if (!jobId) {
       setStatus('idle');
@@ -77,8 +83,27 @@ export function useJobLogStream(jobId) {
       }
     };
 
-    es.onmessage = (e) => append(e.data);
+    const resetInactivity = () => {
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+      }
+      inactivityRef.current = setTimeout(() => {
+        es.close();
+        setStatus('error');
+      }, INACTIVITY_MS);
+    };
+
+    resetInactivity();
+
+    es.onmessage = (e) => {
+      resetInactivity();
+      append(e.data);
+    };
     es.addEventListener('done', (e) => {
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+        inactivityRef.current = null;
+      }
       const state = (e?.data || '').trim().toLowerCase();
       append(TERMINAL_STATE_LINE[state] || '── evaluation complete ──');
       setTerminalState(state || 'done');
@@ -94,6 +119,10 @@ export function useJobLogStream(jobId) {
 
     return () => {
       es.close();
+      if (inactivityRef.current != null) {
+        clearTimeout(inactivityRef.current);
+        inactivityRef.current = null;
+      }
       if (rafRef.current != null) {
         cancelAnimationFrame(rafRef.current);
         rafRef.current = null;

--- a/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream549.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/eval-log/useJobLogStream549.test.jsx
@@ -1,0 +1,105 @@
+/**
+ * Finding #549 – useJobLogStream must close the EventSource and set
+ * status='error' when no message arrives for 60 seconds (inactivity timer).
+ * The timer resets on each message and on 'done'. It is cleared on unmount.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { useJobLogStream } from './useJobLogStream.js';
+
+class MockEventSource {
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.listeners = {};
+    this.readyState = 0;
+    this.closed = false;
+    MockEventSource.instances.push(this);
+  }
+  addEventListener(name, fn) {
+    (this.listeners[name] = this.listeners[name] || []).push(fn);
+  }
+  removeEventListener(name, fn) {
+    this.listeners[name] = (this.listeners[name] || []).filter((f) => f !== fn);
+  }
+  set onmessage(fn) { this._onmessage = fn; }
+  get onmessage() { return this._onmessage; }
+  set onerror(fn) { this._onerror = fn; }
+  get onerror() { return this._onerror; }
+  emit(name, event) {
+    if (name === 'message' && this._onmessage) this._onmessage(event);
+    (this.listeners[name] || []).forEach((fn) => fn(event));
+  }
+  close() { this.closed = true; this.readyState = 2; }
+}
+
+function Probe({ jobId }) {
+  const { logs, status } = useJobLogStream(jobId);
+  return (
+    <div>
+      <div data-testid="status">{status}</div>
+      <div data-testid="logs">{logs.join('|')}</div>
+    </div>
+  );
+}
+
+describe('#549 useJobLogStream inactivity timer', () => {
+  let originalEventSource;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalEventSource = globalThis.EventSource;
+    globalThis.EventSource = MockEventSource;
+    MockEventSource.instances = [];
+  });
+  afterEach(() => {
+    globalThis.EventSource = originalEventSource;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('closes the EventSource and sets status=error after 60s of inactivity', async () => {
+    render(<Probe jobId="job-1" />);
+    const es = MockEventSource.instances[0];
+    expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+
+    // Advance 60 seconds with no message arriving.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    expect(es.closed).toBe(true);
+    expect(screen.getByTestId('status')).toHaveTextContent('error');
+  });
+
+  it('resets the inactivity timer on each message so no timeout fires if active', async () => {
+    render(<Probe jobId="job-2" />);
+    const es = MockEventSource.instances[0];
+
+    // Send messages every 30s — should not trigger the 60s timeout.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30000);
+      es.emit('message', { data: 'heartbeat' });
+      await vi.advanceTimersByTimeAsync(30000);
+      es.emit('message', { data: 'heartbeat 2' });
+      await vi.advanceTimersByTimeAsync(30000);
+    });
+
+    expect(es.closed).toBe(false);
+    expect(screen.getByTestId('status')).toHaveTextContent('streaming');
+  });
+
+  it('clears the inactivity timer on unmount to avoid state updates after unmount', async () => {
+    const { unmount } = render(<Probe jobId="job-3" />);
+    const es = MockEventSource.instances[0];
+    unmount();
+
+    // Advancing time after unmount must not throw or update state.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+    });
+
+    // Stream is closed by unmount cleanup, not by the inactivity timer.
+    expect(es.closed).toBe(true);
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useEvaluation.js
@@ -41,7 +41,7 @@ const DEFAULT_OLLAMA_SUBAGENTS = "1";
 const DEFAULT_CLI_SUBAGENTS = String(DEFAULT_MAX_SUBAGENTS);
 const DEFAULT_OLLAMA_BUDGET = "0";
 const DEFAULT_CLI_BUDGET = String(DEFAULT_TIME_LIMIT_S);
-const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp", "omlx"]);
+export const LOCAL_API_PROVIDERS = new Set(["ollama", "llamacpp", "omlx"]);
 
 /**
  * Merge per-provider Settings (provider, model, subagents, budget, etc.)

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData.js
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { scanPath } from '../../../api/index.js';
 import { projectKeys } from '../../../api/queryKeys.js';
+import { request } from '../../../api/request.js';
 
 /**
  * Fetch scan data for a project ID or a raw local path.
@@ -15,9 +16,7 @@ export function useScanData(projectId, localPath) {
       : ['project', 'scan-path', localPath || ''],
     queryFn: async ({ signal }) => {
       if (projectId) {
-        const res = await fetch(`/api/projects/${encodeURIComponent(projectId)}/scan`, { signal });
-        if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
-        return res.json();
+        return request(`/projects/${encodeURIComponent(projectId)}/scan`, { signal });
       }
       return scanPath(localPath);
     },

--- a/src/quodeq/ui/src/features/evaluation/hooks/useScanData477.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/hooks/useScanData477.test.jsx
@@ -1,0 +1,63 @@
+/**
+ * Finding #477 – useScanData should use request() (with 30s timeout)
+ * instead of a raw fetch() for the /api/projects/<id>/scan call.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+
+// Mock request so we can verify it is called for the projectId branch.
+vi.mock('../../../api/request.js', () => ({
+  BASE: '/api',
+  request: vi.fn(),
+}));
+
+vi.mock('../../../api/index.js', () => ({
+  scanPath: vi.fn(),
+}));
+
+import { request } from '../../../api/request.js';
+import { useScanData } from './useScanData.js';
+
+describe('#477 useScanData uses request() for projectId path', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls request() instead of raw fetch when projectId is given', async () => {
+    request.mockResolvedValue({ branches: ['main'], currentBranch: 'main' });
+
+    const { result } = renderHook(() => useScanData('proj-1'), {
+      wrapper: withQueryClient(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.scanData).toBeDefined();
+    });
+
+    expect(request).toHaveBeenCalled();
+    const [path] = request.mock.calls[0];
+    expect(path).toContain('/projects/proj-1/scan');
+  });
+
+  it('does not call raw fetch directly for the projectId branch', async () => {
+    request.mockResolvedValue({ branches: ['main'] });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useScanData('proj-2'), {
+      wrapper: withQueryClient(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.scanData).toBeDefined();
+    });
+
+    // fetch should NOT have been called directly — only via request()
+    // (which is itself mocked above and doesn't call fetch).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.a11y.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.a11y.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import DimensionScoreHistoryPanel from './DimensionScoreHistoryPanel.jsx';
+
+const TREND = [
+  { runId: 'r2', dateLabel: 'Apr 5', dimensionDetails: [{ dimension: 'maintainability', score: 5.7 }] },
+  { runId: 'r1', dateLabel: 'Apr 3', dimensionDetails: [{ dimension: 'maintainability', score: 5.2 }] },
+];
+
+describe('DimensionScoreHistoryPanel chart keyboard accessibility (#1979)', () => {
+  it('chart wrapper has tabIndex=0 when onBarClick is provided', () => {
+    const onBarClick = vi.fn();
+    render(
+      <DimensionScoreHistoryPanel
+        trend={TREND}
+        dimension="maintainability"
+        onBarClick={onBarClick}
+      />
+    );
+    // The chart keyboard wrapper should be focusable
+    const wrapper = document.querySelector('[tabindex="0"]');
+    expect(wrapper).not.toBeNull();
+  });
+
+  it('Enter key on chart wrapper fires onBarClick with last data point', () => {
+    const onBarClick = vi.fn();
+    render(
+      <DimensionScoreHistoryPanel
+        trend={TREND}
+        dimension="maintainability"
+        onBarClick={onBarClick}
+      />
+    );
+    const wrapper = document.querySelector('[tabindex="0"]');
+    expect(wrapper).not.toBeNull();
+    fireEvent.keyDown(wrapper, { key: 'Enter' });
+    expect(onBarClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Space key on chart wrapper fires onBarClick', () => {
+    const onBarClick = vi.fn();
+    render(
+      <DimensionScoreHistoryPanel
+        trend={TREND}
+        dimension="maintainability"
+        onBarClick={onBarClick}
+      />
+    );
+    const wrapper = document.querySelector('[tabindex="0"]');
+    fireEvent.keyDown(wrapper, { key: ' ' });
+    expect(onBarClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not add tabIndex when onBarClick is absent', () => {
+    render(
+      <DimensionScoreHistoryPanel
+        trend={TREND}
+        dimension="maintainability"
+      />
+    );
+    const wrapper = document.querySelector('[tabindex="0"]');
+    expect(wrapper).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -155,13 +155,24 @@ export default function DimensionScoreHistoryPanel({ trend = [], dimension, sele
       {data.length === 0 ? (
         <div className="qd-history-empty">no history yet for this dimension</div>
       ) : (
-        <DimensionHistoryChart
-          data={data}
-          selectedRunId={selectedRunId}
-          hoveredIndex={hoveredIndex}
-          setHoveredIndex={setHoveredIndex}
-          onBarClick={onBarClick}
-        />
+        <div
+          tabIndex={onBarClick ? 0 : undefined}
+          onKeyDown={onBarClick ? (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              const last = data[data.length - 1];
+              if (last) onBarClick(last);
+            }
+          } : undefined}
+        >
+          <DimensionHistoryChart
+            data={data}
+            selectedRunId={selectedRunId}
+            hoveredIndex={hoveredIndex}
+            setHoveredIndex={setHoveredIndex}
+            onBarClick={onBarClick}
+          />
+        </div>
       )}
     </section>
   );

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -42,7 +42,7 @@ export function labelFor(entry) {
  * segments are clickable to pop the nav stack; the current segment is
  * accent-colored and non-interactive.
  */
-export default function NavBreadcrumb({ stack, onGoTo, projectName }) {
+export default function NavBreadcrumb({ stack = [], onGoTo, projectName }) {
   const crumbs = [];
   if (projectName) crumbs.push({ label: projectName, index: -1 });
   stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));

--- a/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
@@ -51,6 +51,18 @@ export default function GradeBoundaryBar({ thresholds = [], onChange }) {
     window.addEventListener('pointercancel', stop);
   };
 
+  const stepKey = (dividerIdx, delta) => {
+    const live = ascRef.current;
+    const lo = (dividerIdx === 0 ? 0 : live[dividerIdx - 1]) + MIN_GAP;
+    const hi = (dividerIdx === live.length - 1 ? 10 : live[dividerIdx + 1]) - MIN_GAP;
+    const next = Math.round(Math.min(hi, Math.max(lo, live[dividerIdx] + delta)) * 10) / 10;
+    if (next === live[dividerIdx]) return;
+    const nextAsc = [...live];
+    nextAsc[dividerIdx] = next;
+    const desc = [...nextAsc].reverse();
+    onChange(thresholds.map(([, label], i) => [desc[i], label]));
+  };
+
   return (
     <div>
       <div className="gf-boundary-bar" ref={barRef}>
@@ -60,7 +72,9 @@ export default function GradeBoundaryBar({ thresholds = [], onChange }) {
             i={i}
             width={edges[i + 1] - edge}
             hasDivider={i < asc.length}
+            dividerValue={asc[i]}
             onDrag={startDrag}
+            onStepKey={stepKey}
           />
         ))}
       </div>
@@ -74,7 +88,7 @@ export default function GradeBoundaryBar({ thresholds = [], onChange }) {
   );
 }
 
-function Segment({ i, width, hasDivider, onDrag }) {
+function Segment({ i, width, hasDivider, dividerValue, onDrag, onStepKey }) {
   return (
     <>
       <div
@@ -88,7 +102,15 @@ function Segment({ i, width, hasDivider, onDrag }) {
           className="gf-boundary-divider"
           role="slider"
           aria-label={`Boundary ${i + 1}`}
+          aria-valuemin={0}
+          aria-valuemax={10}
+          aria-valuenow={dividerValue}
+          tabIndex={0}
           onPointerDown={onDrag(i)}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowRight' || e.key === 'ArrowUp') { e.preventDefault(); onStepKey(i, MIN_GAP); }
+            else if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') { e.preventDefault(); onStepKey(i, -MIN_GAP); }
+          }}
         />
       ) : null}
     </>

--- a/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.jsx
@@ -13,7 +13,7 @@ const MIN_GAP = 0.5;
  * (descending). Dragging divider i moves the ascending boundary i.
  * onChange receives a full new thresholds array (descending, labels preserved).
  */
-export default function GradeBoundaryBar({ thresholds, onChange }) {
+export default function GradeBoundaryBar({ thresholds = [], onChange }) {
   const barRef = useRef(null);
   // ascending boundary values, e.g. [3,5,7,9]
   const asc = [...thresholds].map(([t]) => t).reverse();

--- a/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.test.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/GradeBoundaryBar.test.jsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import GradeBoundaryBar from './GradeBoundaryBar.jsx';
+
+// thresholds descending: [[9,'Exemplary'],[7,'Good'],[5,'Adequate'],[3,'Poor']]
+// ascending boundaries: [3, 5, 7, 9]
+const THRESHOLDS = [
+  [9, 'Exemplary'],
+  [7, 'Good'],
+  [5, 'Adequate'],
+  [3, 'Poor'],
+];
+
+describe('GradeBoundaryBar slider keyboard accessibility (#1583)', () => {
+  it('all dividers have tabIndex=0', () => {
+    render(<GradeBoundaryBar thresholds={THRESHOLDS} onChange={vi.fn()} />);
+    const sliders = screen.getAllByRole('slider');
+    // 4 thresholds => 4 ascending boundaries => 4 dividers (one per segment except last)
+    expect(sliders.length).toBe(4);
+    sliders.forEach((s) => expect(s).toHaveAttribute('tabindex', '0'));
+  });
+
+  it('dividers have aria-valuemin=0 and aria-valuemax=10', () => {
+    render(<GradeBoundaryBar thresholds={THRESHOLDS} onChange={vi.fn()} />);
+    const sliders = screen.getAllByRole('slider');
+    sliders.forEach((s) => {
+      expect(s).toHaveAttribute('aria-valuemin', '0');
+      expect(s).toHaveAttribute('aria-valuemax', '10');
+    });
+  });
+
+  it('divider has aria-valuenow matching its boundary value', () => {
+    render(<GradeBoundaryBar thresholds={THRESHOLDS} onChange={vi.fn()} />);
+    const sliders = screen.getAllByRole('slider');
+    // ascending [3,5,7,9]
+    expect(sliders[0]).toHaveAttribute('aria-valuenow', '3');
+    expect(sliders[1]).toHaveAttribute('aria-valuenow', '5');
+    expect(sliders[2]).toHaveAttribute('aria-valuenow', '7');
+    expect(sliders[3]).toHaveAttribute('aria-valuenow', '9');
+  });
+
+  it('ArrowRight on first divider increments and calls onChange', () => {
+    const onChange = vi.fn();
+    render(<GradeBoundaryBar thresholds={THRESHOLDS} onChange={onChange} />);
+    const sliders = screen.getAllByRole('slider');
+    fireEvent.keyDown(sliders[0], { key: 'ArrowRight' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newThresholds = onChange.mock.calls[0][0];
+    // ascending boundary 0 (was 3) should have increased
+    const newAsc = [...newThresholds].map(([t]) => t).reverse();
+    expect(newAsc[0]).toBeGreaterThan(3);
+  });
+
+  it('ArrowLeft on first divider decrements and calls onChange', () => {
+    // Use a boundary with room to decrease: [2,5,7,9]
+    const thresholds = [[9,'Exemplary'],[7,'Good'],[5,'Adequate'],[2,'Poor']];
+    const onChange = vi.fn();
+    render(<GradeBoundaryBar thresholds={thresholds} onChange={onChange} />);
+    const sliders = screen.getAllByRole('slider');
+    fireEvent.keyDown(sliders[0], { key: 'ArrowLeft' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const newThresholds = onChange.mock.calls[0][0];
+    const newAsc = [...newThresholds].map(([t]) => t).reverse();
+    expect(newAsc[0]).toBeLessThan(2);
+  });
+
+  it('ArrowUp on divider increments same as ArrowRight', () => {
+    const onChange = vi.fn();
+    render(<GradeBoundaryBar thresholds={THRESHOLDS} onChange={onChange} />);
+    const sliders = screen.getAllByRole('slider');
+    fireEvent.keyDown(sliders[0], { key: 'ArrowUp' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('ArrowDown on divider decrements same as ArrowLeft', () => {
+    const thresholds = [[9,'Exemplary'],[7,'Good'],[5,'Adequate'],[2,'Poor']];
+    const onChange = vi.fn();
+    render(<GradeBoundaryBar thresholds={thresholds} onChange={onChange} />);
+    const sliders = screen.getAllByRole('slider');
+    fireEvent.keyDown(sliders[0], { key: 'ArrowDown' });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
@@ -240,7 +240,7 @@ export default function GalaxyFolderView({ node, currentPath = '', onPathChange,
   }, [scene, size, showLabels, w2s, computeFocusCamera, getFitZoom, refs, saveNav]);
 
   // Event handlers
-  const { handleMouseMove, handleMouseLeave, handleClick, goToPathIndex } = useMemo(
+  const { handleMouseMove, handleMouseLeave, handleClick, goToPathIndex, handleKeyDown } = useMemo(
     () => createEventHandlers(refs, { startTransition, saveNav, getFitZoom, scene, size }),
     [refs, startTransition, saveNav, getFitZoom, scene, size]
   );
@@ -273,11 +273,13 @@ export default function GalaxyFolderView({ node, currentPath = '', onPathChange,
         width={size.w}
         height={size.h}
         style={{ width: '100%', height: '100%', display: 'block' }}
+        tabIndex={0}
+        role="application"
+        aria-label="Galaxy folder visualization of project structure"
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
         onClick={handleClick}
-        role="img"
-        aria-label="Galaxy folder visualization of project structure"
+        onKeyDown={handleKeyDown}
       />
       <VizBreadcrumb items={breadcrumb.map((bc, i) => ({
         label: bc.label,

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
@@ -185,7 +185,7 @@ export default function GalaxyFolderView({ node, currentPath = '', onPathChange,
       }
       if (!flyRef.current) {
         advanceCamera(cam, refs, {
-          TRANS, scene, computeFocusCamera, saveNav, setNavVersion, getFitZoom,
+          TRANS, scene, computeFocusCamera, saveNav, setNavVersion, getFitZoom, W, H,
         });
       }
 

--- a/src/quodeq/ui/src/features/map/viz/components/PackCircles.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/PackCircles.jsx
@@ -20,7 +20,11 @@ export default function PackCircles({ circles, folderIndices, fileIndices, hover
             strokeWidth={FOLDER_STROKE_WIDTH} vectorEffect="non-scaling-stroke"
             fillOpacity={isRoot ? 1 : isHovered ? FOLDER_FILL_OPACITY_HOVER : FOLDER_FILL_OPACITY_DEFAULT}
             style={{ cursor: 'pointer', transition: 'fill-opacity 0.15s' }}
+            tabIndex={0}
+            role="button"
+            aria-label={d.name || d.path}
             onClick={(e) => handleClick(e, c)}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(e, c); } }}
             onMouseEnter={() => setHover(i)} onMouseLeave={() => setHover(null)}
           />
         );

--- a/src/quodeq/ui/src/features/map/viz/components/PackCircles.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/PackCircles.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import PackCircles from './PackCircles.jsx';
+
+// Minimal circles fixture: one folder, one file
+const mockCircles = [
+  {
+    x: 100, y: 100, r: 40, depth: 1,
+    data: { path: 'src/', name: 'src', isFile: false, children: [{}], severity: { critical: 0, major: 0, minor: 0 }, violations: 0, compliance: 0, complianceRate: 1 },
+  },
+  {
+    x: 200, y: 200, r: 10, depth: 2,
+    data: { path: 'src/foo.js', name: 'foo.js', isFile: true, children: [], severity: { critical: 0, major: 0, minor: 0 }, violations: 0, compliance: 0, complianceRate: 1 },
+  },
+];
+
+function renderPackCircles(handleClick = vi.fn()) {
+  return render(
+    <svg>
+      <PackCircles
+        circles={mockCircles}
+        folderIndices={[0]}
+        fileIndices={[1]}
+        hover={null}
+        setHover={vi.fn()}
+        viewMode="violations"
+        k={1}
+        handleClick={handleClick}
+      />
+    </svg>
+  );
+}
+
+describe('PackCircles keyboard accessibility (#2056)', () => {
+  it('folder circle has tabIndex=0', () => {
+    renderPackCircles();
+    const circle = document.querySelector('circle');
+    expect(circle).toHaveAttribute('tabindex', '0');
+  });
+
+  it('folder circle has role="button"', () => {
+    renderPackCircles();
+    const circle = document.querySelector('circle');
+    expect(circle).toHaveAttribute('role', 'button');
+  });
+
+  it('folder circle has aria-label with the node name', () => {
+    renderPackCircles();
+    const circle = document.querySelector('circle');
+    expect(circle).toHaveAttribute('aria-label', 'src');
+  });
+
+  it('Enter key on folder circle fires handleClick', () => {
+    const handleClick = vi.fn();
+    renderPackCircles(handleClick);
+    const circle = document.querySelector('circle');
+    fireEvent.keyDown(circle, { key: 'Enter' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Space key on folder circle fires handleClick', () => {
+    const handleClick = vi.fn();
+    renderPackCircles(handleClick);
+    const circle = document.querySelector('circle');
+    fireEvent.keyDown(circle, { key: ' ' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('unrelated key on folder circle does NOT fire handleClick', () => {
+    const handleClick = vi.fn();
+    renderPackCircles(handleClick);
+    const circle = document.querySelector('circle');
+    fireEvent.keyDown(circle, { key: 'Tab' });
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.jsx
@@ -76,10 +76,14 @@ function BubbleGroup({ points, px, py, br, entered, showLabels, tip, setTip, onD
                 stroke={border} strokeWidth={1}
                 filter={tip?.name === child.name ? 'url(#glow)' : undefined}
                 style={{ cursor: 'pointer', transition: 'fill-opacity 0.2s ease' }}
+                tabIndex={0}
+                role="button"
+                aria-label={child.name || child.path}
                 onMouseEnter={(e) => setTip({ x: e.clientX, y: e.clientY, child })}
                 onMouseMove={(e) => setTip((t) => t ? { ...t, x: e.clientX, y: e.clientY } : null)}
                 onMouseLeave={() => setTip(null)}
-                onClick={() => onDrillDown?.(child.path)} />
+                onClick={() => onDrillDown?.(child.path)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDrillDown?.(child.path); } }} />
             ) : (
               <FileShape cx={cx} cy={cy} r={r} color={color} borderColor={border}
                 glow={tip?.name === child.name}

--- a/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import RiskMatrixView from './RiskMatrixView.jsx';
+
+const NODE = {
+  path: 'root/',
+  name: 'root',
+  isFile: false,
+  violations: 0,
+  compliance: 0,
+  severity: {},
+  children: [
+    {
+      path: 'root/a/',
+      name: 'a',
+      isFile: false,
+      violations: 3,
+      compliance: 1,
+      severity: { critical: 1, major: 1, minor: 1 },
+      children: [{}],
+    },
+    {
+      path: 'root/b.js',
+      name: 'b.js',
+      isFile: true,
+      violations: 1,
+      compliance: 0,
+      severity: { critical: 0, major: 1, minor: 0 },
+      children: [],
+    },
+  ],
+};
+
+describe('RiskMatrixView drillable circle keyboard accessibility (#1936)', () => {
+  function getDrillableCircle(container) {
+    // The drillable circle is the one with role="button"
+    return container.querySelector('circle[role="button"]');
+  }
+
+  it('drillable circle has tabIndex=0', () => {
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={vi.fn()} />);
+    const circle = getDrillableCircle(container);
+    expect(circle).not.toBeNull();
+    expect(circle).toHaveAttribute('tabindex', '0');
+  });
+
+  it('drillable circle has role="button"', () => {
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={vi.fn()} />);
+    const circle = getDrillableCircle(container);
+    expect(circle).toHaveAttribute('role', 'button');
+  });
+
+  it('drillable circle has aria-label', () => {
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={vi.fn()} />);
+    const circle = getDrillableCircle(container);
+    expect(circle).toHaveAttribute('aria-label');
+    expect(circle.getAttribute('aria-label').length).toBeGreaterThan(0);
+  });
+
+  it('Enter key on drillable circle calls onDrillDown', () => {
+    const onDrillDown = vi.fn();
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={onDrillDown} />);
+    const circle = getDrillableCircle(container);
+    fireEvent.keyDown(circle, { key: 'Enter' });
+    expect(onDrillDown).toHaveBeenCalledTimes(1);
+    expect(onDrillDown).toHaveBeenCalledWith('root/a/');
+  });
+
+  it('Space key on drillable circle calls onDrillDown', () => {
+    const onDrillDown = vi.fn();
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={onDrillDown} />);
+    const circle = getDrillableCircle(container);
+    fireEvent.keyDown(circle, { key: ' ' });
+    expect(onDrillDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
@@ -196,7 +196,9 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
       <svg
         viewBox={`${-PAD} ${-PAD} ${BASE_SIZE + PAD * 2} ${BASE_SIZE + PAD * 2}`}
         style={{ width: '100%', height: '100%', overflow: 'hidden' }}
+        tabIndex={0}
         onClick={handleBgClick}
+        onKeyDown={(e) => { if (e.key === 'Escape') { e.preventDefault(); handleBgClick(); } }}
         aria-label="Zoomable pack visualization of project compliance by folder and file"
       >
         <defs>

--- a/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ZoomablePackView from './ZoomablePackView.jsx';
+
+const NODE = {
+  path: 'root/',
+  name: 'root',
+  isFile: false,
+  violations: 5,
+  compliance: 3,
+  severity: {},
+  children: [
+    {
+      path: 'root/a/',
+      name: 'a',
+      isFile: false,
+      violations: 2,
+      compliance: 1,
+      severity: {},
+      children: [
+        { path: 'root/a/foo.js', name: 'foo.js', isFile: true, violations: 1, compliance: 0, severity: {} },
+      ],
+    },
+  ],
+};
+
+describe('ZoomablePackView container Escape key (#1907)', () => {
+  it('svg container supports Escape to zoom out (has onKeyDown handler)', () => {
+    const onDrillDown = vi.fn();
+    const { container } = render(
+      <ZoomablePackView node={NODE} viewMode="violations" onDrillDown={onDrillDown} />
+    );
+    // The svg should carry a keydown handler that handles Escape
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // Fire Escape — should call onDrillDown (zoom out / reset path)
+    fireEvent.keyDown(svg, { key: 'Escape' });
+    expect(onDrillDown).toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/__snapshots__/galaxyViewDraw.test.jsx.snap
+++ b/src/quodeq/ui/src/features/map/viz/components/__snapshots__/galaxyViewDraw.test.jsx.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`drawFrame characterization (#950) > galaxy level (cam.z=1) — records ctx-call sequence > galaxy-level-ctx-calls 1`] = `
+[
+  "createRadialGradient",
+  "fillRect",
+  "beginPath",
+  "arc",
+  "fill",
+  "beginPath",
+  "arc",
+  "setLineDash",
+  "stroke",
+  "setLineDash",
+  "beginPath",
+  "moveTo",
+  "lineTo",
+  "setLineDash",
+  "stroke",
+  "setLineDash",
+  "fillText",
+  "beginPath",
+  "arc",
+  "fill",
+  "beginPath",
+  "arc",
+  "fill",
+  "fillText",
+  "fillText",
+]
+`;
+
+exports[`drawFrame characterization (#950) > zoomed into dimension (cam.z=5, rDim=0) — records ctx-call sequence > zoomed-dim-ctx-calls 1`] = `
+[
+  "createRadialGradient",
+  "fillRect",
+  "beginPath",
+  "arc",
+  "fill",
+  "beginPath",
+  "arc",
+  "stroke",
+  "beginPath",
+  "moveTo",
+  "lineTo",
+  "stroke",
+  "fillText",
+  "fillText",
+]
+`;
+
+exports[`drawFrame characterization (#950) > zoomed into principle (cam.z=15, rDim=0, rPrin=0) — records ctx-call sequence > zoomed-principle-ctx-calls 1`] = `
+[
+  "createRadialGradient",
+  "fillRect",
+  "beginPath",
+  "arc",
+  "fill",
+  "beginPath",
+  "arc",
+  "stroke",
+  "beginPath",
+  "moveTo",
+  "lineTo",
+  "stroke",
+  "fillText",
+  "fillText",
+]
+`;

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderCamera.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderCamera.js
@@ -83,7 +83,7 @@ export function advanceFlyTransition(fly, cam, refs, params) {
  * Advance camera state (non-fly mode). Returns nothing, mutates cam in place.
  */
 export function advanceCamera(cam, refs, params) {
-  const { TRANS, scene, computeFocusCamera, saveNav, setNavVersion, getFitZoom } = params;
+  const { TRANS, scene, computeFocusCamera, saveNav, setNavVersion, getFitZoom, W, H } = params;
   const tg = computeFocusCamera();
   const anim = refs.animRef.current;
   refs.frameCount.current++;
@@ -113,7 +113,7 @@ export function advanceCamera(cam, refs, params) {
         const curScene = refs.sceneRef.current || scene;
         const star = curScene.rootStars[ff3.starIdx];
         if (star && star.isFolder) {
-          refs.nextSceneRef.current = buildFolderScene(star._node, 800, 600);
+          refs.nextSceneRef.current = buildFolderScene(star._node, W, H);
           refs.nextSceneRef.current._node = star._node;
           refs.flyRef.current = {
             t: 0,

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
@@ -59,38 +59,32 @@ export function createEventHandlers(refs, params) {
     if (refs.tooltipRef.current) refs.tooltipRef.current.style.display = 'none';
   }
 
-  function handleClick() {
-    if (refs.animRef.current || refs.flyRef.current) return;
-    const nav = refs.navRef.current;
-    const h = refs.hoveredRef.current;
-
-    if (h) {
-      if (h.type === 'folder') {
-        const s = h.data;
-        const ff = refs.focusedFolderRef.current;
-        if (ff && ff.starIdx === h.starIdx) {
-          return;
-        } else {
-          refs.zoomedFileRef.current = null;
-          refs.zoomTargetRef.current = null;
-          refs.focusedFolderRef.current = { x: s.x, y: s.y, starIdx: h.starIdx, data: s, autoEnter: true };
-          startTransition(false);
-          saveNav();
-        }
+  function handleNodeClick(h) {
+    if (h.type === 'folder') {
+      const s = h.data;
+      const ff = refs.focusedFolderRef.current;
+      if (ff && ff.starIdx === h.starIdx) {
         return;
-      }
-      if (h.type === 'file') {
-        const s = h.data;
-        refs.focusedFolderRef.current = null;
+      } else {
+        refs.zoomedFileRef.current = null;
         refs.zoomTargetRef.current = null;
-        refs.zoomedFileRef.current = { x: s.x, y: s.y, starIdx: h.starIdx, data: s };
+        refs.focusedFolderRef.current = { x: s.x, y: s.y, starIdx: h.starIdx, data: s, autoEnter: true };
         startTransition(false);
         saveNav();
-        return;
       }
+      return;
     }
+    if (h.type === 'file') {
+      const s = h.data;
+      refs.focusedFolderRef.current = null;
+      refs.zoomTargetRef.current = null;
+      refs.zoomedFileRef.current = { x: s.x, y: s.y, starIdx: h.starIdx, data: s };
+      startTransition(false);
+      saveNav();
+    }
+  }
 
-    // Click empty space
+  function handleEmptySpaceClick(nav) {
     if (refs.zoomedFileRef.current) {
       refs.zoomedFileRef.current = null;
       refs.zoomTargetRef.current = null;
@@ -140,6 +134,19 @@ export function createEventHandlers(refs, params) {
         swapped: false,
       };
     }
+  }
+
+  function handleClick() {
+    if (refs.animRef.current || refs.flyRef.current) return;
+    const nav = refs.navRef.current;
+    const h = refs.hoveredRef.current;
+
+    if (h) {
+      handleNodeClick(h);
+      return;
+    }
+
+    handleEmptySpaceClick(nav);
   }
 
   function goToPathIndex(idx) {

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
@@ -157,5 +157,39 @@ export function createEventHandlers(refs, params) {
     };
   }
 
-  return { handleMouseMove, handleMouseLeave, handleClick, goToPathIndex, updateTooltip };
+  const PAN_STEP = 40;
+
+  function handleKeyDown(e) {
+    const cam = refs.camRef.current;
+    if (!cam) return;
+    const z = cam.z || 1;
+    const step = PAN_STEP / z;
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault();
+        cam.x -= step;
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        cam.x += step;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        cam.y -= step;
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        cam.y += step;
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        handleClick();
+        break;
+      default:
+        break;
+    }
+  }
+
+  return { handleMouseMove, handleMouseLeave, handleClick, goToPathIndex, updateTooltip, handleKeyDown };
 }

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.js
@@ -131,7 +131,7 @@ export function createEventHandlers(refs, params) {
       const cam = refs.camRef.current;
       const parentPath = nav.path.slice(0, -1);
       const parentNode = parentPath[parentPath.length - 1];
-      refs.nextSceneRef.current = buildFolderScene(parentNode, 800, 600);
+      refs.nextSceneRef.current = buildFolderScene(parentNode, size.w, size.h);
       refs.flyRef.current = {
         t: 0, reverse: true,
         sx: cam.x, sy: cam.y, sz: cam.z,
@@ -147,7 +147,7 @@ export function createEventHandlers(refs, params) {
     const newPath = refs.navRef.current.path.slice(0, idx + 1);
     const targetNode = newPath[newPath.length - 1];
     const cam = refs.camRef.current;
-    refs.nextSceneRef.current = buildFolderScene(targetNode, 800, 600);
+    refs.nextSceneRef.current = buildFolderScene(targetNode, size.w, size.h);
     refs.flyRef.current = {
       t: 0, reverse: true,
       sx: cam.x, sy: cam.y, sz: cam.z,

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createEventHandlers } from './galaxyFolderEvents.js';
+
+function makeRefs(overrides = {}) {
+  return {
+    navRef: { current: { path: [{ name: 'root', path: '' }] } },
+    camRef: { current: { x: 400, y: 300, z: 1 } },
+    animRef: { current: null },
+    flyRef: { current: null },
+    zoomedFileRef: { current: null },
+    zoomTargetRef: { current: null },
+    focusedFolderRef: { current: null },
+    mouseRef: { current: { x: 400, y: 300 } },
+    hoveredRef: { current: null },
+    tooltipRef: { current: { style: {}, innerHTML: '' } },
+    canvasRef: { current: { style: {}, getBoundingClientRect: () => ({ left: 0, top: 0 }) } },
+    sceneRef: { current: null },
+    nextSceneRef: { current: null },
+    prevNavRef: { current: null },
+    frameRef: { current: null },
+    frameCount: { current: 0 },
+    ...overrides,
+  };
+}
+
+function makeParams(overrides = {}) {
+  return {
+    startTransition: vi.fn(),
+    saveNav: vi.fn(),
+    getFitZoom: vi.fn(() => 1),
+    scene: { rootStars: [] },
+    size: { w: 800, h: 600 },
+    ...overrides,
+  };
+}
+
+describe('galaxyFolderEvents keyboard handler (#2063)', () => {
+  it('createEventHandlers returns a handleKeyDown function', () => {
+    const handlers = createEventHandlers(makeRefs(), makeParams());
+    expect(typeof handlers.handleKeyDown).toBe('function');
+  });
+
+  it('ArrowLeft calls startTransition (pan left via camera adjustment)', () => {
+    const params = makeParams();
+    const refs = makeRefs();
+    const handlers = createEventHandlers(refs, params);
+    handlers.handleKeyDown({ key: 'ArrowLeft', preventDefault: vi.fn() });
+    // Camera x should have decreased (pan left)
+    expect(refs.camRef.current.x).toBeLessThan(400);
+  });
+
+  it('ArrowRight pans camera right', () => {
+    const refs = makeRefs();
+    const handlers = createEventHandlers(refs, makeParams());
+    handlers.handleKeyDown({ key: 'ArrowRight', preventDefault: vi.fn() });
+    expect(refs.camRef.current.x).toBeGreaterThan(400);
+  });
+
+  it('ArrowUp pans camera up', () => {
+    const refs = makeRefs();
+    const handlers = createEventHandlers(refs, makeParams());
+    handlers.handleKeyDown({ key: 'ArrowUp', preventDefault: vi.fn() });
+    expect(refs.camRef.current.y).toBeLessThan(300);
+  });
+
+  it('ArrowDown pans camera down', () => {
+    const refs = makeRefs();
+    const handlers = createEventHandlers(refs, makeParams());
+    handlers.handleKeyDown({ key: 'ArrowDown', preventDefault: vi.fn() });
+    expect(refs.camRef.current.y).toBeGreaterThan(300);
+  });
+
+  it('Enter key invokes the click effect (startTransition + saveNav called)', () => {
+    const params = makeParams();
+    // Ensure mouseRef has a valid position so handleClick takes the zoom-toward-cursor branch.
+    const refs = makeRefs({ mouseRef: { current: { x: 400, y: 300 } } });
+    const handlers = createEventHandlers(refs, params);
+    handlers.handleKeyDown({ key: 'Enter', preventDefault: vi.fn() });
+    // handleClick on empty space with nav.path.length === 1 zooms toward cursor:
+    // it must call startTransition and saveNav.
+    expect(params.startTransition).toHaveBeenCalled();
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('Space key invokes the click effect (startTransition + saveNav called)', () => {
+    const params = makeParams();
+    const refs = makeRefs({ mouseRef: { current: { x: 400, y: 300 } } });
+    const handlers = createEventHandlers(refs, params);
+    handlers.handleKeyDown({ key: ' ', preventDefault: vi.fn() });
+    expect(params.startTransition).toHaveBeenCalled();
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('unhandled key does nothing (no throw)', () => {
+    const refs = makeRefs();
+    const handlers = createEventHandlers(refs, makeParams());
+    expect(() =>
+      handlers.handleKeyDown({ key: 'x', preventDefault: vi.fn() })
+    ).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
@@ -102,6 +102,115 @@ describe('galaxyFolderEvents keyboard handler (#2063)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #999: handleClick branch coverage (pre-refactor characterization)
+// ---------------------------------------------------------------------------
+
+describe('handleClick — empty-space branches (#999)', () => {
+  it('does nothing if anim is in progress', () => {
+    const params = makeParams();
+    const refs = makeRefs({ animRef: { current: true } });
+    createEventHandlers(refs, params).handleClick();
+    expect(params.startTransition).not.toHaveBeenCalled();
+    expect(params.saveNav).not.toHaveBeenCalled();
+  });
+
+  it('does nothing if fly is in progress', () => {
+    const params = makeParams();
+    const refs = makeRefs({ flyRef: { current: {} } });
+    createEventHandlers(refs, params).handleClick();
+    expect(params.startTransition).not.toHaveBeenCalled();
+  });
+
+  it('clears zoomedFileRef and zooms out when a file is zoomed', () => {
+    const params = makeParams();
+    const refs = makeRefs({
+      zoomedFileRef: { current: { x: 10, y: 10 } },
+      zoomTargetRef: { current: null },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.zoomedFileRef.current).toBeNull();
+    expect(refs.zoomTargetRef.current).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(true);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('clears zoomTargetRef when a zoom target is active', () => {
+    const params = makeParams();
+    const refs = makeRefs({
+      zoomedFileRef: { current: null },
+      zoomTargetRef: { current: { x: 5, y: 5, z: 2 } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.zoomTargetRef.current).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(true);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('clears focusedFolderRef when a folder is focused', () => {
+    const params = makeParams();
+    const refs = makeRefs({
+      focusedFolderRef: { current: { x: 10, y: 10, starIdx: 0 } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.focusedFolderRef.current).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(true);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('zooms toward cursor when path has one entry and mouse is valid', () => {
+    const params = makeParams();
+    const refs = makeRefs({
+      mouseRef: { current: { x: 400, y: 300 } },
+      navRef: { current: { path: [{ name: 'root', path: '' }] } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.zoomTargetRef.current).not.toBeNull();
+    expect(refs.zoomTargetRef.current.z).toBeGreaterThan(1);
+    expect(params.startTransition).toHaveBeenCalledWith(false);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+});
+
+describe('handleClick — node branches (#999)', () => {
+  it('focusing a new folder sets focusedFolderRef and starts transition', () => {
+    const params = makeParams();
+    const folderData = { x: 200, y: 200, name: 'src' };
+    const refs = makeRefs({
+      hoveredRef: { current: { type: 'folder', starIdx: 1, data: folderData } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.focusedFolderRef.current).toMatchObject({ starIdx: 1, data: folderData, autoEnter: true });
+    expect(refs.zoomedFileRef.current).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(false);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+
+  it('clicking an already-focused folder does nothing', () => {
+    const params = makeParams();
+    const refs = makeRefs({
+      hoveredRef: { current: { type: 'folder', starIdx: 2, data: { x: 0, y: 0 } } },
+      focusedFolderRef: { current: { starIdx: 2 } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(params.startTransition).not.toHaveBeenCalled();
+    expect(params.saveNav).not.toHaveBeenCalled();
+  });
+
+  it('clicking a file sets zoomedFileRef and starts transition', () => {
+    const params = makeParams();
+    const fileData = { x: 300, y: 300, name: 'index.js' };
+    const refs = makeRefs({
+      hoveredRef: { current: { type: 'file', starIdx: 5, data: fileData } },
+    });
+    createEventHandlers(refs, params).handleClick();
+    expect(refs.zoomedFileRef.current).toMatchObject({ starIdx: 5, data: fileData });
+    expect(refs.focusedFolderRef.current).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(false);
+    expect(params.saveNav).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Fix B (#2604): advanceCamera uses W/H from params, not hardcoded 800/600
 // ---------------------------------------------------------------------------
 

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyFolderEvents.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createEventHandlers } from './galaxyFolderEvents.js';
+import { advanceCamera } from './galaxyFolderCamera.js';
 
 function makeRefs(overrides = {}) {
   return {
@@ -97,5 +98,72 @@ describe('galaxyFolderEvents keyboard handler (#2063)', () => {
     expect(() =>
       handlers.handleKeyDown({ key: 'x', preventDefault: vi.fn() })
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix B (#2604): advanceCamera uses W/H from params, not hardcoded 800/600
+// ---------------------------------------------------------------------------
+
+describe('advanceCamera uses W/H from params (#2604)', () => {
+  function makeCamera(overrides = {}) {
+    return { x: 500, y: 400, z: 1, ...overrides };
+  }
+
+  function makeCameraRefs(overrides = {}) {
+    return {
+      navRef: { current: { path: [{ name: 'root', path: '' }] } },
+      camRef: { current: null },
+      animRef: { current: null },
+      frameCount: { current: 0 },
+      sceneRef: { current: null },
+      nextSceneRef: { current: null },
+      zoomedFileRef: { current: null },
+      focusedFolderRef: { current: null },
+      zoomTargetRef: { current: null },
+      flyRef: { current: null },
+      prevNavRef: { current: null },
+      ...overrides,
+    };
+  }
+
+  it('centering inside anim swap uses W and H from params, not 800/600', () => {
+    // Set up an animation that is complete (t >= 1) so the anim block runs.
+    // A focusedFolderRef with autoEnter=true and a valid folder star triggers
+    // the buildFolderScene call — we verify the scene receives the custom dims.
+    const customW = 1200;
+    const customH = 900;
+    const folderNode = { name: 'src', path: 'src', children: [] };
+    const star = {
+      x: 100, y: 100, isFolder: true, _node: folderNode,
+      radius: 10, col: '#fff',
+    };
+    const scene = { rootStars: [star] };
+
+    const refs = makeCameraRefs({
+      animRef: { current: { t: 1, sx: 0, sy: 0, sz: 1, out: false } },
+      focusedFolderRef: { current: { autoEnter: true, starIdx: 0, x: 100, y: 100 } },
+      sceneRef: { current: scene },
+    });
+
+    const cam = makeCamera();
+    const getFitZoom = vi.fn(() => 1);
+    const computeFocusCamera = vi.fn(() => ({ x: customW / 2, y: customH / 2, z: 1 }));
+
+    advanceCamera(cam, refs, {
+      TRANS: 0.8,
+      scene,
+      computeFocusCamera,
+      saveNav: vi.fn(),
+      setNavVersion: vi.fn(),
+      getFitZoom,
+      W: customW,
+      H: customH,
+    });
+
+    // buildFolderScene was called (nextSceneRef is populated) and its _node set.
+    expect(refs.nextSceneRef.current).not.toBeNull();
+    // The fly transition records starX/starY from the star, not from 800/600 literals.
+    expect(refs.flyRef.current).not.toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.js
@@ -26,55 +26,73 @@ import {
 export function drawFrame(ctx, scene, cam, nav, opts) {
   const { W, H, t, mx, my, showLabels, animating, rDim, rPrin, w2s, parentEl } = opts;
 
-  // --- Background ---
   const tc = getThemeColors(parentEl);
+  const { r: mr, g: mg, b: mb } = tc.textMuted;
+
+  drawBackground(ctx, scene, cam, tc, W, H, t, mr, mg, mb);
+  drawConstellations(ctx, scene, cam, nav, w2s, showLabels, W, H, mr, mg, mb);
+  const dimHovered = drawDimStars(ctx, scene, cam, nav, opts, tc, mr, mg, mb);
+  const prinHovered = drawPrinciples(ctx, scene, cam, nav, opts, tc, rDim);
+  drawZoomedPrinciple(ctx, scene, cam, opts, rDim, rPrin, tc, mr, mg, mb);
+
+  return { hovered: prinHovered ?? dimHovered };
+}
+
+/** Phase 1: radial gradient background + background star field. */
+function drawBackground(ctx, scene, cam, tc, W, H, t, mr, mg, mb) {
   const grad = ctx.createRadialGradient(W / 2, H / 2, 0, W / 2, H / 2, Math.max(W, H) * 0.6);
   grad.addColorStop(0, tc.bgAlt); grad.addColorStop(1, tc.bg);
   ctx.fillStyle = grad; ctx.fillRect(0, 0, W, H);
-  const { r: mr, g: mg, b: mb } = tc.textMuted;
   scene.bg.forEach(s => {
     const a = 0.15 + 0.15 * Math.sin(t * s.sp + s.tw);
     ctx.beginPath(); ctx.arc(s.x * W, s.y * H, s.sz, 0, TAU);
     ctx.fillStyle = `rgba(${mr},${mg},${mb},${a})`; ctx.fill();
   });
+}
 
-  // --- Constellation lines and labels (only at galaxy level) ---
-  if (cam.z < 3) {
-    const conAlpha = Math.max(0, 1 - (cam.z - 1) / 2);
-    (scene.constellations || []).forEach(con => {
-      const isFocused = nav.clusterCx == null || (con.cx === nav.clusterCx && con.cy === nav.clusterCy);
-      const conClusterDim = isFocused ? 1 : Math.max(0.08, 1 - (cam.z - 1) / 2);
-      // Dashed circle around cluster
-      const csc = w2s(W / 2 + con.cx, H / 2 + con.cy);
-      const circleR = (con.spread + 10) * cam.z;
-      ctx.beginPath(); ctx.arc(csc.x, csc.y, circleR, 0, TAU);
-      ctx.strokeStyle = `rgba(${mr},${mg},${mb},${0.15 * conAlpha * conClusterDim})`;
-      ctx.lineWidth = 1;
-      ctx.setLineDash([8, 14]); ctx.stroke(); ctx.setLineDash([]);
+/** Phase 2: constellation dashed circles, lines, and labels (galaxy level only). */
+function drawConstellations(ctx, scene, cam, nav, w2s, showLabels, W, H, mr, mg, mb) {
+  if (cam.z >= 3) return;
+  const conAlpha = Math.max(0, 1 - (cam.z - 1) / 2);
+  (scene.constellations || []).forEach(con => {
+    const isFocused = nav.clusterCx == null || (con.cx === nav.clusterCx && con.cy === nav.clusterCy);
+    const conClusterDim = isFocused ? 1 : Math.max(0.08, 1 - (cam.z - 1) / 2);
+    // Dashed circle around cluster
+    const csc = w2s(W / 2 + con.cx, H / 2 + con.cy);
+    const circleR = (con.spread + 10) * cam.z;
+    ctx.beginPath(); ctx.arc(csc.x, csc.y, circleR, 0, TAU);
+    ctx.strokeStyle = `rgba(${mr},${mg},${mb},${0.15 * conAlpha * conClusterDim})`;
+    ctx.lineWidth = 1;
+    ctx.setLineDash([8, 14]); ctx.stroke(); ctx.setLineDash([]);
 
-      // Constellation lines between stars
-      con.lines.forEach(l => {
-        const sa = w2s(scene.stars[l.a].x, scene.stars[l.a].y);
-        const sb = w2s(scene.stars[l.b].x, scene.stars[l.b].y);
-        ctx.beginPath(); ctx.moveTo(sa.x, sa.y); ctx.lineTo(sb.x, sb.y);
-        ctx.strokeStyle = `rgba(${mr},${mg},${mb},${0.4 * conAlpha * conClusterDim})`;
-        ctx.lineWidth = 0.8;
-        ctx.setLineDash([3, 5]); ctx.stroke(); ctx.setLineDash([]);
-      });
-      // Constellation label — above the dashed circle
-      if (showLabels && con.label) {
-        const lx = csc.x;
-        const ly = csc.y - circleR - 10;
-        ctx.font = '600 14px -apple-system,BlinkMacSystemFont,sans-serif';
-        ctx.textAlign = 'center';
-        ctx.fillStyle = `rgba(${mr},${mg},${mb},${0.55 * conAlpha * conClusterDim})`;
-        ctx.fillText(con.label, lx, ly);
-        con._lx = lx; con._ly = ly;
-      }
+    // Constellation lines between stars
+    con.lines.forEach(l => {
+      const sa = w2s(scene.stars[l.a].x, scene.stars[l.a].y);
+      const sb = w2s(scene.stars[l.b].x, scene.stars[l.b].y);
+      ctx.beginPath(); ctx.moveTo(sa.x, sa.y); ctx.lineTo(sb.x, sb.y);
+      ctx.strokeStyle = `rgba(${mr},${mg},${mb},${0.4 * conAlpha * conClusterDim})`;
+      ctx.lineWidth = 0.8;
+      ctx.setLineDash([3, 5]); ctx.stroke(); ctx.setLineDash([]);
     });
-  }
+    // Constellation label — above the dashed circle
+    if (showLabels && con.label) {
+      const lx = csc.x;
+      const ly = csc.y - circleR - 10;
+      ctx.font = '600 14px -apple-system,BlinkMacSystemFont,sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillStyle = `rgba(${mr},${mg},${mb},${0.55 * conAlpha * conClusterDim})`;
+      ctx.fillText(con.label, lx, ly);
+      con._lx = lx; con._ly = ly;
+    }
+  });
+}
 
-  // --- Dimension stars + principle particles orbiting them ---
+/**
+ * Phase 3: dimension stars with principle particles, glow, labels, and hit-test.
+ * Returns the currently hovered element (or null).
+ */
+function drawDimStars(ctx, scene, cam, nav, opts, tc, mr, mg, mb) {
+  const { W, H, t, mx, my, showLabels, animating, rDim, w2s } = opts;
   let newHovered = null;
   scene.stars.forEach((s, i) => {
     const sc = w2s(s.x, s.y);
@@ -125,70 +143,78 @@ export function drawFrame(ctx, scene, cam, nav, opts) {
       if (dx * dx + dy * dy < hitR * hitR) newHovered = { type: 'dim', idx: i, data: s };
     }
   });
+  return newHovered;
+}
 
-  // --- Principles as planets (visible when zoomed into a dimension) ---
-  if (cam.z > 1.5 && rDim !== null) {
-    const dim = scene.stars[rDim];
-    const dsc = w2s(dim.x, dim.y);
-    const pAlpha = Math.min(1, (cam.z - 1.5) / 3);
-    const pScale = cam.z * 0.12;
-    (scene.principles[rDim] || []).forEach((p, pi) => {
-      const isSelectedPrin = nav.prin === pi;
-      const sc = w2s(p.x, p.y);
-      const sr = p.radius * pScale;
-      // orbit ring
-      ctx.beginPath(); ctx.arc(dsc.x, dsc.y, Math.hypot(sc.x - dsc.x, sc.y - dsc.y), 0, TAU);
-      ctx.strokeStyle = `rgba(50,55,80,${0.1 * pAlpha})`; ctx.lineWidth = 0.5; ctx.stroke();
-      // connection line
-      ctx.beginPath(); ctx.moveTo(dsc.x, dsc.y); ctx.lineTo(sc.x, sc.y);
-      ctx.strokeStyle = rgba(dim.col, 0.04 * pAlpha); ctx.lineWidth = 0.8; ctx.stroke();
-      // Violation/compliance particles — fade out on selected (large orbs take over), shrink on others
-      const particleFade = isSelectedPrin ? Math.max(0, 1 - (cam.z - 12) / 20) : 1;
-      // Non-selected: smaller particles but keep orbit wide so they don't collide with planet
-      const cappedScale = Math.min(0.8, 5 * 0.12 / Math.max(pScale, 0.01));
-      const particleDrawScale = isSelectedPrin ? pScale * 0.8 : pScale * cappedScale;
-      const particleOrbitScale = isSelectedPrin ? pScale * 0.8 : pScale * Math.max(cappedScale, 0.5);
-      if (particleFade > 0.01) drawParticles(ctx, p.particles, { cx: sc.x, cy: sc.y, scale: particleOrbitScale, alpha: pAlpha * particleFade, t, drawScale: particleDrawScale });
-      drawGlow(ctx, { x: sc.x, y: sc.y, r: sr, col: p.col, alpha: pAlpha });
-      // Only fade labels/scores — hide on non-selected when zoomed into a principle
-      const prinLabelAlpha = isSelectedPrin ? Math.max(0, 1 - (cam.z - 12) / 20) : (nav.prin !== null ? Math.max(0, 1 - (cam.z - 12) / 15) : 1);
-      if (showLabels && prinLabelAlpha > 0.01) {
-        const la = pAlpha * prinLabelAlpha;
-        ctx.font = `600 14px -apple-system,BlinkMacSystemFont,sans-serif`;
-        ctx.textAlign = 'center'; ctx.fillStyle = rgba(tc.text, 0.6 * la);
-        ctx.fillText(p.name, sc.x, sc.y - sr - 10);
-        ctx.font = `12px -apple-system,BlinkMacSystemFont,sans-serif`;
-        ctx.fillStyle = rgba(tc.textMuted, 0.7 * la);
-        ctx.fillText(p.score.toFixed(1), sc.x, sc.y + sr + 16);
-      }
-      if (!animating && nav.depth === 1 && pAlpha > 0.4 && mx >= 0) {
-        const dx = mx - sc.x, dy = my - sc.y;
-        if (dx * dx + dy * dy < (sr + 10) * (sr + 10)) newHovered = { type: 'prin', idx: pi, data: p };
-      }
-    });
-  }
+/**
+ * Phase 4: principle planets visible when zoomed into a dimension.
+ * Returns the hovered principle element, or null.
+ */
+function drawPrinciples(ctx, scene, cam, nav, opts, tc, rDim) {
+  if (!(cam.z > 1.5 && rDim !== null)) return null;
+  const { t, mx, my, showLabels, animating, w2s } = opts;
+  const dim = scene.stars[rDim];
+  const dsc = w2s(dim.x, dim.y);
+  const pAlpha = Math.min(1, (cam.z - 1.5) / 3);
+  const pScale = cam.z * 0.12;
+  let newHovered = null;
+  (scene.principles[rDim] || []).forEach((p, pi) => {
+    const isSelectedPrin = nav.prin === pi;
+    const sc = w2s(p.x, p.y);
+    const sr = p.radius * pScale;
+    // orbit ring
+    ctx.beginPath(); ctx.arc(dsc.x, dsc.y, Math.hypot(sc.x - dsc.x, sc.y - dsc.y), 0, TAU);
+    ctx.strokeStyle = `rgba(50,55,80,${0.1 * pAlpha})`; ctx.lineWidth = 0.5; ctx.stroke();
+    // connection line
+    ctx.beginPath(); ctx.moveTo(dsc.x, dsc.y); ctx.lineTo(sc.x, sc.y);
+    ctx.strokeStyle = rgba(dim.col, 0.04 * pAlpha); ctx.lineWidth = 0.8; ctx.stroke();
+    // Violation/compliance particles — fade out on selected (large orbs take over), shrink on others
+    const particleFade = isSelectedPrin ? Math.max(0, 1 - (cam.z - 12) / 20) : 1;
+    // Non-selected: smaller particles but keep orbit wide so they don't collide with planet
+    const cappedScale = Math.min(0.8, 5 * 0.12 / Math.max(pScale, 0.01));
+    const particleDrawScale = isSelectedPrin ? pScale * 0.8 : pScale * cappedScale;
+    const particleOrbitScale = isSelectedPrin ? pScale * 0.8 : pScale * Math.max(cappedScale, 0.5);
+    if (particleFade > 0.01) drawParticles(ctx, p.particles, { cx: sc.x, cy: sc.y, scale: particleOrbitScale, alpha: pAlpha * particleFade, t, drawScale: particleDrawScale });
+    drawGlow(ctx, { x: sc.x, y: sc.y, r: sr, col: p.col, alpha: pAlpha });
+    // Only fade labels/scores — hide on non-selected when zoomed into a principle
+    const prinLabelAlpha = isSelectedPrin ? Math.max(0, 1 - (cam.z - 12) / 20) : (nav.prin !== null ? Math.max(0, 1 - (cam.z - 12) / 15) : 1);
+    if (showLabels && prinLabelAlpha > 0.01) {
+      const la = pAlpha * prinLabelAlpha;
+      ctx.font = `600 14px -apple-system,BlinkMacSystemFont,sans-serif`;
+      ctx.textAlign = 'center'; ctx.fillStyle = rgba(tc.text, 0.6 * la);
+      ctx.fillText(p.name, sc.x, sc.y - sr - 10);
+      ctx.font = `12px -apple-system,BlinkMacSystemFont,sans-serif`;
+      ctx.fillStyle = rgba(tc.textMuted, 0.7 * la);
+      ctx.fillText(p.score.toFixed(1), sc.x, sc.y + sr + 16);
+    }
+    if (!animating && nav.depth === 1 && pAlpha > 0.4 && mx >= 0) {
+      const dx = mx - sc.x, dy = my - sc.y;
+      if (dx * dx + dy * dy < (sr + 10) * (sr + 10)) newHovered = { type: 'prin', idx: pi, data: p };
+    }
+  });
+  return newHovered;
+}
 
-  // --- Zoomed into principle — violation/compliance particles as large orbs ---
-  if (cam.z > 12 && rDim !== null && rPrin !== null) {
-    const prin = scene.principles[rDim][rPrin];
-    const psc = w2s(prin.x, prin.y);
-    const vAlpha = Math.min(1, (cam.z - 12) / 20);
-    const vScale = cam.z * 0.06;
-    prin.particles.forEach((p) => {
-      const a = t * p.os + p.op;
-      const px = psc.x + Math.cos(a) * p.or * p.ec * vScale;
-      const py = psc.y + Math.sin(a) * p.or * vScale;
-      const tw = 0.5 + 0.06 * Math.sin(t * 0.4 + p.tp);
-      const sr = p.sz * vScale * 0.5;
-      drawGlow(ctx, { x: px, y: py, r: sr, col: p.col, alpha: vAlpha * tw });
-      if (showLabels && sr > 3) {
-        const sevName = p.sev.charAt(0).toUpperCase() + p.sev.slice(1);
-        ctx.font = `500 ${Math.max(7, Math.min(11, sr * 0.8))}px -apple-system,BlinkMacSystemFont,sans-serif`;
-        ctx.textAlign = 'center'; ctx.fillStyle = rgba(p.col, 0.85 * vAlpha);
-        ctx.fillText(sevName, px, py - sr - 4);
-      }
-    });
-  }
-
-  return { hovered: newHovered };
+/** Phase 5: violation/compliance orbs when zoomed deeply into a principle. */
+function drawZoomedPrinciple(ctx, scene, cam, opts, rDim, rPrin, tc, mr, mg, mb) {
+  if (!(cam.z > 12 && rDim !== null && rPrin !== null)) return;
+  const { t, showLabels, w2s } = opts;
+  const prin = scene.principles[rDim][rPrin];
+  const psc = w2s(prin.x, prin.y);
+  const vAlpha = Math.min(1, (cam.z - 12) / 20);
+  const vScale = cam.z * 0.06;
+  prin.particles.forEach((p) => {
+    const a = t * p.os + p.op;
+    const px = psc.x + Math.cos(a) * p.or * p.ec * vScale;
+    const py = psc.y + Math.sin(a) * p.or * vScale;
+    const tw = 0.5 + 0.06 * Math.sin(t * 0.4 + p.tp);
+    const sr = p.sz * vScale * 0.5;
+    drawGlow(ctx, { x: px, y: py, r: sr, col: p.col, alpha: vAlpha * tw });
+    if (showLabels && sr > 3) {
+      const sevName = p.sev.charAt(0).toUpperCase() + p.sev.slice(1);
+      ctx.font = `500 ${Math.max(7, Math.min(11, sr * 0.8))}px -apple-system,BlinkMacSystemFont,sans-serif`;
+      ctx.textAlign = 'center'; ctx.fillStyle = rgba(p.col, 0.85 * vAlpha);
+      ctx.fillText(sevName, px, py - sr - 4);
+    }
+  });
 }

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.test.jsx
@@ -1,0 +1,144 @@
+/**
+ * Characterization test for drawFrame — locks the sequence of canvas-context
+ * method calls so behavior-preserving refactors can be verified.
+ *
+ * Strategy:
+ *  - Mock getThemeColors, drawGlow, drawParticles (they have their own DOM
+ *    dependencies and their own tests).
+ *  - Build a minimal scene covering every rendering branch (background stars,
+ *    constellations at cam.z < 3, dim stars, principle planets, zoomed orbs).
+ *  - Record the name of every ctx method call in order.
+ *  - Assert the sequence matches a captured snapshot so a refactor that moves
+ *    code into helpers must produce the IDENTICAL call sequence.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { drawFrame } from './galaxyViewDraw.js';
+
+// Mock galaxyCore to avoid DOM dependencies and to record drawGlow/drawParticles
+vi.mock('../core/galaxyCore.js', () => {
+  const col = { r: 100, g: 150, b: 200 };
+  return {
+    TAU: Math.PI * 2,
+    getThemeColors: vi.fn(() => ({
+      bg: '#000',
+      bgAlt: '#111',
+      text: col,
+      textMuted: col,
+    })),
+    drawGlow: vi.fn(),
+    drawParticles: vi.fn(),
+    rgba: vi.fn((c, a) => `rgba(${c.r},${c.g},${c.b},${a})`),
+    rgb: vi.fn((c) => `rgb(${c.r},${c.g},${c.b})`),
+  };
+});
+
+function makeMockCtx(calls) {
+  const methods = [
+    'createRadialGradient', 'fillRect', 'beginPath', 'arc', 'fill',
+    'moveTo', 'lineTo', 'stroke', 'setLineDash', 'fillText',
+  ];
+  const ctx = {
+    fillStyle: null,
+    strokeStyle: null,
+    lineWidth: null,
+    font: null,
+    textAlign: null,
+    createRadialGradient: vi.fn(() => ({
+      addColorStop: vi.fn(),
+    })),
+  };
+  for (const m of methods.filter(m => m !== 'createRadialGradient')) {
+    ctx[m] = vi.fn((...args) => { calls.push(m); });
+  }
+  // Record createRadialGradient too
+  const origCRG = ctx.createRadialGradient;
+  ctx.createRadialGradient = vi.fn((...args) => { calls.push('createRadialGradient'); return origCRG(...args); });
+  return ctx;
+}
+
+function makeScene() {
+  const col = { r: 100, g: 150, b: 200 };
+  const particle = { os: 1, op: 0, or: 30, ec: 1, sz: 2, tp: 0, col, sev: 'minor' };
+  // Dim particle (on the star itself)
+  const dimParticle = { os: 0.5, op: 0, or: 20, ec: 1, sz: 1.5, tp: 0, col };
+  const principle = {
+    x: 450, y: 320, radius: 10, col, name: 'P1', score: 7.5,
+    particles: [particle],
+    dimParticle,
+  };
+  const star = {
+    x: 400, y: 300, radius: 20, col, name: 'Dim1', score: 7.0,
+    pp: 0, sp: 0.1, tw: 0,
+    _clusterCx: 50, _clusterCy: 50,
+  };
+  const bgStar = { x: 0.5, y: 0.5, sz: 1, sp: 0.5, tw: 0 };
+  const constellation = {
+    cx: 50, cy: 50, spread: 80, label: 'Constellation A',
+    lines: [{ a: 0, b: 0 }],
+  };
+  return {
+    bg: [bgStar],
+    constellations: [constellation],
+    stars: [star],
+    principles: [[principle]],
+  };
+}
+
+function makeW2s() {
+  return (wx, wy) => ({ x: wx, y: wy });
+}
+
+describe('drawFrame characterization (#950)', () => {
+  let calls;
+
+  beforeEach(() => {
+    calls = [];
+    vi.clearAllMocks();
+  });
+
+  it('galaxy level (cam.z=1) — records ctx-call sequence', () => {
+    const ctx = makeMockCtx(calls);
+    const scene = makeScene();
+    const cam = { x: 0, y: 0, z: 1 };
+    const nav = { depth: 0, dim: null, prin: null, clusterCx: null, clusterCy: null };
+    const opts = {
+      W: 800, H: 600, t: 0, mx: -1, my: -1,
+      showLabels: true, animating: false, rDim: null, rPrin: null,
+      w2s: makeW2s(), parentEl: null,
+    };
+    const result = drawFrame(ctx, scene, cam, nav, opts);
+    expect(result).toHaveProperty('hovered');
+    // Snapshot the call sequence
+    expect(calls).toMatchSnapshot('galaxy-level-ctx-calls');
+  });
+
+  it('zoomed into dimension (cam.z=5, rDim=0) — records ctx-call sequence', () => {
+    const ctx = makeMockCtx(calls);
+    const scene = makeScene();
+    const cam = { x: 0, y: 0, z: 5 };
+    const nav = { depth: 1, dim: 0, prin: null, clusterCx: null, clusterCy: null };
+    const opts = {
+      W: 800, H: 600, t: 0, mx: -1, my: -1,
+      showLabels: true, animating: false, rDim: 0, rPrin: null,
+      w2s: makeW2s(), parentEl: null,
+    };
+    const result = drawFrame(ctx, scene, cam, nav, opts);
+    expect(result).toHaveProperty('hovered');
+    expect(calls).toMatchSnapshot('zoomed-dim-ctx-calls');
+  });
+
+  it('zoomed into principle (cam.z=15, rDim=0, rPrin=0) — records ctx-call sequence', () => {
+    const ctx = makeMockCtx(calls);
+    const scene = makeScene();
+    const cam = { x: 0, y: 0, z: 15 };
+    const nav = { depth: 2, dim: 0, prin: 0, clusterCx: null, clusterCy: null };
+    const opts = {
+      W: 800, H: 600, t: 0, mx: -1, my: -1,
+      showLabels: true, animating: false, rDim: 0, rPrin: 0,
+      w2s: makeW2s(), parentEl: null,
+    };
+    const result = drawFrame(ctx, scene, cam, nav, opts);
+    expect(result).toHaveProperty('hovered');
+    expect(calls).toMatchSnapshot('zoomed-principle-ctx-calls');
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
@@ -73,6 +73,7 @@ export function handleCanvasClick(e, refs, scene, size, navigateTo, startTransit
 
   // At galaxy root: check if click is near a cluster -> zoom to it
   if (nav.depth === 0 && !animRef.current && scene?.constellations) {
+    if (!camRef.current) return;
     const rect = canvasRef.current?.getBoundingClientRect();
     if (rect) {
       const cmx = e.clientX - rect.left, cmy = e.clientY - rect.top;

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleCanvasClick } from './galaxyViewEvents.js';
+
+describe('handleCanvasClick', () => {
+  it('does not throw when camRef.current is null during a cluster-click hit-test', () => {
+    // Simulate the null window: camera not yet initialised
+    const refs = {
+      hoveredRef: { current: null },
+      navRef: { current: { depth: 0, clusterCx: null, clusterCy: null } },
+      animRef: { current: false },
+      camRef: { current: null },        // <-- the null value under test
+      canvasRef: {
+        current: {
+          getBoundingClientRect: () => ({ left: 0, top: 0 }),
+        },
+      },
+    };
+
+    const scene = {
+      constellations: [{ cx: 0, cy: 0, spread: 10 }],
+    };
+
+    const e = { clientX: 50, clientY: 50 };
+    const size = { w: 800, h: 600 };
+    const navigateTo = vi.fn();
+    const startTransition = vi.fn();
+    const saveNav = vi.fn();
+    const w2s = (x, y) => ({ x, y });
+
+    expect(() =>
+      handleCanvasClick(e, refs, scene, size, navigateTo, startTransition, saveNav, w2s)
+    ).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
+++ b/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
@@ -82,8 +82,8 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
       }
       return { x: size.w / 2, y: size.h / 2, z: fz };
     }
-    if (nav.depth === 1 && nav.dim !== null) { const s = scene.stars[nav.dim]; return { x: s.x, y: s.y, z: 5 }; }
-    if (nav.depth === 2 && nav.dim !== null && nav.prin !== null) { const p = scene.principles[nav.dim][nav.prin]; return { x: p.x, y: p.y, z: 50 }; }
+    if (nav.depth === 1 && nav.dim !== null) { const s = scene.stars?.[nav.dim]; if (!s) return { x: size.w / 2, y: size.h / 2, z: fz }; return { x: s.x, y: s.y, z: 5 }; }
+    if (nav.depth === 2 && nav.dim !== null && nav.prin !== null) { const s = scene.stars?.[nav.dim]; const p = s ? scene.principles?.[nav.dim]?.[nav.prin] : null; if (!p) return { x: size.w / 2, y: size.h / 2, z: fz }; return { x: p.x, y: p.y, z: 50 }; }
     return camRef.current;
   }, [scene, size.w, size.h, getFitZoom, navRef]);
 
@@ -120,7 +120,8 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
       const rPrin = nav.prin ?? prev?.prin ?? null;
 
       if (rDim !== null) {
-        updatePrinciplePositions(scene.principles[rDim], scene.stars[rDim], t);
+        const rStar = scene.stars[rDim];
+        if (rStar) updatePrinciplePositions(scene.principles[rDim], rStar, t);
       }
 
       const tg = getTarget();

--- a/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.test.jsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock drawFrame before the hook module is imported so the animation loop
+// does not hit real canvas / DOM APIs (parseCSSColor, getThemeColors).
+vi.mock('./galaxyViewDraw.js', () => ({
+  drawFrame: vi.fn(() => ({ hovered: null })),
+}));
+
+import { useGalaxyCamera } from './useGalaxyCamera.js';
+
+// Minimal scene factory — build a scene with `n` stars each having one principle.
+function makeScene(n) {
+  const stars = Array.from({ length: n }, (_, i) => ({
+    x: 100 + i * 10,
+    y: 200 + i * 10,
+    ba: 0,
+    j: 5,
+    _clusterCx: undefined,
+  }));
+  const principles = stars.map((s) => [
+    { x: s.x + 5, y: s.y + 5, ba: 0, od: 10 },
+  ]);
+  return { stars, principles, _maxExtent: 150, constellations: [] };
+}
+
+function makeRefs(navValue) {
+  return {
+    canvasRef: { current: null },       // no real canvas needed for getTarget tests
+    savedNavRef: { current: null },
+    savedCamRef: { current: null },
+    navRef: { current: navValue },
+    prevNavRef: { current: null },
+    animRef: { current: null },
+    mouseRef: { current: { x: 0, y: 0 } },
+    hoveredRef: { current: null },
+    frameRef: { current: null },
+  };
+}
+
+describe('useGalaxyCamera — getTarget stale-index guard (#387)', () => {
+  it('returns safe center/zoom default at depth 1 when nav.dim is out of range for the current scene', () => {
+    // Simulate: nav was set when scene had 5 stars (dim=4); a new scene with only 2 stars is received.
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 1, dim: 4, prin: null, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    // Must not throw; must fall back to center
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns safe center/zoom default at depth 2 when nav.dim is out of range', () => {
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 2, dim: 4, prin: 0, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns safe center/zoom default at depth 2 when nav.prin is out of range', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    // dim=1 is valid (scene has 3 stars) but prin=5 is out of range (only 1 principle per star)
+    const refs = makeRefs({ depth: 2, dim: 1, prin: 5, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toEqual({ x: size.w / 2, y: size.h / 2, z: expect.any(Number) });
+  });
+
+  it('returns the correct star target at depth 1 for a valid in-range index', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 1, dim: 1, prin: null, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    // The hook renders without a canvas so stars won't have been position-updated,
+    // but their initial x/y are set in makeScene.
+    expect(target).toMatchObject({ z: 5 });
+  });
+
+  it('returns the correct principle target at depth 2 for valid in-range indices', () => {
+    const scene = makeScene(3);
+    const size = { w: 800, h: 600 };
+    const refs = makeRefs({ depth: 2, dim: 0, prin: 0, clusterCx: null, clusterCy: null });
+
+    const { result } = renderHook(() =>
+      useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+    );
+
+    let target;
+    act(() => {
+      target = result.current.getTarget();
+    });
+
+    expect(target).toMatchObject({ z: 50 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePrinciplePositions stale-star guard in the animation loop (#387 follow-up)
+// ---------------------------------------------------------------------------
+// The animation loop calls updatePrinciplePositions(scene.principles[rDim], scene.stars[rDim], t).
+// rDim comes from nav.dim ?? prev?.dim ?? null and can be a stale index after a scene rebuild
+// (scene.stars[rDim] === undefined). We can't drive requestAnimationFrame directly in jsdom,
+// so we test the guard at the unit level: the internal helper must not throw when the star
+// lookup yields undefined. We verify this by calling the hook with a canvas stub that lets
+// one rAF tick fire and asserting no error is thrown even when prevNavRef.dim is out of range.
+describe('useGalaxyCamera — animation-loop stale-star guard', () => {
+  let rafCallbacks;
+  let rafSpy;
+  let cancelSpy;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    rafSpy = vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+      const id = rafCallbacks.push(cb);
+      return id;
+    });
+    cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  function makeCanvasRef() {
+    const ctx = {
+      clearRect: vi.fn(),
+      save: vi.fn(), restore: vi.fn(),
+      beginPath: vi.fn(), arc: vi.fn(), fill: vi.fn(), stroke: vi.fn(),
+      fillText: vi.fn(), measureText: vi.fn(() => ({ width: 10 })),
+      createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+      drawImage: vi.fn(),
+      canvas: { width: 800, height: 600 },
+    };
+    const canvas = {
+      getContext: vi.fn(() => ctx),
+      width: 800,
+      height: 600,
+      parentElement: null,
+    };
+    return { current: canvas };
+  }
+
+  it('does not throw when rDim from prevNavRef is out of range for the current scene', () => {
+    // scene has 2 stars; prevNavRef.dim = 4 (stale from previous larger scene)
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+
+    const refs = {
+      ...makeRefs({ depth: 0, dim: null, prin: null, clusterCx: null, clusterCy: null }),
+      canvasRef: makeCanvasRef(),
+      // prevNavRef carries the stale dim that drives rDim in the animation loop
+      prevNavRef: { current: { dim: 4, prin: null } },
+    };
+
+    // Rendering the hook registers the animation loop via useEffect.
+    expect(() => {
+      renderHook(() =>
+        useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+      );
+      // Fire one animation frame tick — this is where the crash would occur.
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[0]();
+      }
+    }).not.toThrow();
+  });
+
+  it('does not throw when nav.dim itself is out of range for the current scene', () => {
+    // scene has 2 stars; nav.dim = 5 (stale)
+    const scene = makeScene(2);
+    const size = { w: 800, h: 600 };
+
+    const refs = {
+      ...makeRefs({ depth: 1, dim: 5, prin: null, clusterCx: null, clusterCy: null }),
+      canvasRef: makeCanvasRef(),
+    };
+
+    expect(() => {
+      renderHook(() =>
+        useGalaxyCamera({ scene, size, showLabels: false, ...refs })
+      );
+      if (rafCallbacks.length > 0) {
+        rafCallbacks[0]();
+      }
+    }).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.js
+++ b/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.js
@@ -15,7 +15,7 @@ const CLI_SERVER_ID = { 'codex-cli': 'codex', 'claude-code': 'claude' };
 async function detectCliProvider(id) {
   const serverId = CLI_SERVER_ID[id] || id;
   try {
-    const res = await fetch('/api/ai-clients', { method: 'GET' });
+    const res = await fetch('/api/ai-clients', { method: 'GET', signal: AbortSignal.timeout(5000) });
     if (!res.ok) return { id, classification: 'cli', detected: false, defaultModel: null };
     const data = await res.json();
     const detected = (data.clients || []).some((c) => c.id === serverId && c.type === 'cli');
@@ -27,7 +27,7 @@ async function detectCliProvider(id) {
 
 async function detectOllamaDaemon() {
   try {
-    const res = await fetch('/api/ollama/health', { method: 'GET' });
+    const res = await fetch('/api/ollama/health', { method: 'GET', signal: AbortSignal.timeout(5000) });
     return { id: 'ollama', classification: 'local-api', detected: res.ok, defaultModel: null };
   } catch {
     return { id: 'ollama', classification: 'local-api', detected: false };

--- a/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.test.jsx
+++ b/src/quodeq/ui/src/features/onboarding/hooks/providerProbes.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runDetection } from './providerProbes.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('providerProbes – timeout behaviour', () => {
+  function successFetch() {
+    return vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ clients: [] }),
+    });
+  }
+
+  it('#261 detectCliProvider calls fetch with AbortSignal.timeout(5000)', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort() // only used to verify AbortSignal.timeout's return value is passed as opts.signal
+    );
+    const fetchMock = successFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runDetection();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    const clientCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/ai-clients'));
+    expect(clientCalls.length).toBeGreaterThanOrEqual(1);
+    const [, opts] = clientCalls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('#261 detectCliProvider resolves to detected:false when fetch rejects (abort)', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(AbortSignal.abort());
+    const fetchMock = vi.fn().mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError')
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await runDetection();
+    const codex = results.find((r) => r.id === 'codex-cli');
+    expect(codex).toBeDefined();
+    expect(codex.detected).toBe(false);
+  });
+
+  it('#262 detectOllamaDaemon calls fetch with AbortSignal.timeout(5000)', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(
+      AbortSignal.abort()
+    );
+    const fetchMock = successFetch();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await runDetection();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    const ollamaCalls = fetchMock.mock.calls.filter(([url]) => url.includes('/ollama/'));
+    expect(ollamaCalls.length).toBeGreaterThanOrEqual(1);
+    const [, opts] = ollamaCalls[0];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('#262 detectOllamaDaemon resolves to detected:false when fetch rejects (abort)', async () => {
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(AbortSignal.abort());
+    const fetchMock = vi.fn().mockRejectedValue(
+      new DOMException('The operation was aborted.', 'AbortError')
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await runDetection();
+    const ollama = results.find((r) => r.id === 'ollama');
+    expect(ollama).toBeDefined();
+    expect(ollama.detected).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.jsx
@@ -10,9 +10,9 @@ const MODEL_LEVEL_THOROUGH = 3;
 
 export { AI_MODEL_STORAGE_KEY, AI_CMD_STORAGE_KEY };
 
-function ClientSelector({ aiCmd, availableClients }) {
+function ClientSelector({ aiCmd = {}, availableClients }) {
   const { value, onApply } = aiCmd;
-  if (availableClients === null) {
+  if (availableClients == null) {
     return (
       <div className="settings-row settings-row--last">
         <div className="settings-row-label">
@@ -100,7 +100,7 @@ function ModelOverrideInput({ label, value, setter, level, placeholder }) {
   );
 }
 
-function ModelSettings({ aiCmd, models }) {
+function ModelSettings({ aiCmd = {}, models }) {
   const { value: aiCmdValue } = aiCmd;
   const { aiModel, onAiModelChange, fast, onFastChange, balanced, onBalancedChange, thorough, onThoroughChange } = models;
   if (!aiCmdValue) return null;

--- a/src/quodeq/ui/src/features/settings/components/ModelSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ModelSection.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ModelSection from './ModelSection.jsx';
+
+const stubModels = {
+  aiModel: '',
+  onAiModelChange: () => {},
+  fast: '',
+  onFastChange: () => {},
+  balanced: '',
+  onBalancedChange: () => {},
+  thorough: '',
+  onThoroughChange: () => {},
+};
+
+// Finding #213 — ClientSelector (and ModelSettings) destructures aiCmd without a default;
+// passing undefined throws immediately on `const { value, onApply } = aiCmd`.
+describe('ModelSection — finding #213 (aiCmd undefined)', () => {
+  it('renders without throwing when aiCmd is undefined', () => {
+    expect(() =>
+      render(
+        <ModelSection
+          aiCmd={undefined}
+          models={stubModels}
+          availableClients={[]}
+        />
+      )
+    ).not.toThrow();
+  });
+});
+
+// Finding #214 — ClientSelector checks `availableClients === null` but not undefined,
+// so calling `.filter()` on undefined throws a TypeError.
+describe('ModelSection — finding #214 (availableClients undefined)', () => {
+  it('renders without throwing when availableClients is undefined', () => {
+    const aiCmd = { value: null, onApply: () => {} };
+    expect(() =>
+      render(
+        <ModelSection
+          aiCmd={aiCmd}
+          models={stubModels}
+          availableClients={undefined}
+        />
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.jsx
@@ -4,6 +4,7 @@ import ServerStatusPill from '../../../components/ServerStatusPill.jsx';
 import HelpHint from '../../../components/HelpHint.jsx';
 import { useServerLog } from '../server-log/ServerLogContext.js';
 import { systemKeys } from '../../../api/queryKeys.js';
+import { getHealth } from '../../../api/index.js';
 
 const LOCAL_SERVER_HINT = (
   <>
@@ -13,23 +14,12 @@ const LOCAL_SERVER_HINT = (
 
 const HEALTH_POLL_MS = 10000;
 
-async function ping() {
-  try {
-    const res = await fetch('/api/health?_t=' + Date.now());
-    if (!res.ok) return null;
-    const data = await res.json();
-    return data?.ok ? data : null;
-  } catch {
-    return null;
-  }
-}
-
 export default function ServerSection() {
   const serverLog = useServerLog();
 
   const { data: health, isLoading } = useQuery({
     queryKey: [...systemKeys.health(), 'settings-detail'],
-    queryFn: ping,
+    queryFn: () => getHealth().then((d) => (d?.ok ? d : null)).catch(() => null),
     refetchInterval: HEALTH_POLL_MS,
     refetchOnWindowFocus: false,
   });

--- a/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection.test.jsx
@@ -37,7 +37,7 @@ describe('ServerSection', () => {
       expect(screen.getByText('7863')).toBeTruthy();
       expect(screen.getByText('1234')).toBeTruthy();
     });
-    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/health'));
+    expect(globalThis.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/health'), expect.any(Object));
   });
 
   it('renders offline when /api/health is unreachable', async () => {

--- a/src/quodeq/ui/src/features/settings/components/ServerSection249.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/ServerSection249.test.jsx
@@ -1,0 +1,84 @@
+/**
+ * Finding #249 – ServerSection must use getHealth() from api/index.js
+ * (which goes through request() with a 30s timeout) instead of the
+ * local ping() function that calls raw fetch with no timeout.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ServerLogContext } from '../server-log/ServerLogContext.js';
+
+// Mock getHealth from api/index.js so we can assert it is called.
+vi.mock('../../../api/index.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getHealth: vi.fn(),
+  };
+});
+
+import { getHealth } from '../../../api/index.js';
+import ServerSection from './ServerSection.jsx';
+
+const stubServerLog = { open: false, openLog: vi.fn(), closeLog: vi.fn() };
+
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ServerLogContext.Provider value={stubServerLog}>{children}</ServerLogContext.Provider>
+      </QueryWrapper>
+    );
+  };
+}
+
+describe('#249 ServerSection uses getHealth() not raw fetch', () => {
+  beforeEach(() => {
+    getHealth.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls getHealth() when polling for server status', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1, version: '1.0.0', address: '127.0.0.1' });
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => expect(getHealth).toHaveBeenCalled());
+  });
+
+  it('does not call raw fetch directly', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1, version: '1.0.0', address: '127.0.0.1' });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+
+    await waitFor(() => expect(getHealth).toHaveBeenCalled());
+    // getHealth is mocked and doesn't call fetch, so fetch should never fire.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows server details when getHealth resolves with ok data', async () => {
+    getHealth.mockResolvedValue({ ok: true, port: 7863, pid: 1234, version: '1.0.6', address: '127.0.0.1' });
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getByText('7863')).toBeTruthy();
+      expect(screen.getByText('1234')).toBeTruthy();
+    });
+  });
+
+  it('shows offline when getHealth rejects', async () => {
+    getHealth.mockRejectedValue(new Error('timeout'));
+    const Wrapper = makeWrapper();
+    render(<Wrapper><ServerSection /></Wrapper>);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Restart/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.js
@@ -41,7 +41,11 @@ function loadProviderState(providerId, overrides, storage = localStorage) {
 }
 
 function saveProviderSetting(providerId, key, value, storage = localStorage) {
-  storage.setItem(providerKey(providerId, key), String(value));
+  try {
+    storage.setItem(providerKey(providerId, key), String(value));
+  } catch (err) {
+    console.warn('[useProviderSettings] Could not persist setting to storage:', err);
+  }
 }
 
 export default function useProviderSettings(providerId, defaults, { storage = localStorage } = {}) {

--- a/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
+++ b/src/quodeq/ui/src/features/settings/hooks/useProviderSettings.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useProviderSettings from './useProviderSettings.js';
+
+describe('useProviderSettings', () => {
+  let mockStorage;
+
+  beforeEach(() => {
+    mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('loads default state when storage returns null', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    expect(result.current.state.model).toBe('');
+    expect(result.current.state.subagents).toBe('1');
+  });
+
+  it('update sets state immediately', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    act(() => {
+      result.current.update('model', 'llama3');
+    });
+    expect(result.current.state.model).toBe('llama3');
+  });
+
+  it('update calls storage.setItem', () => {
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+    act(() => {
+      result.current.update('model', 'llama3');
+    });
+    expect(mockStorage.setItem).toHaveBeenCalled();
+  });
+
+  it('update does not throw when storage.setItem throws (quota/SecurityError)', () => {
+    // Finding #324: setItem throwing must not crash the hook.
+    mockStorage.setItem.mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+
+    // This must not throw.
+    expect(() => {
+      act(() => {
+        result.current.update('model', 'llama3');
+      });
+    }).not.toThrow();
+
+    // State was still updated in memory even though storage failed.
+    expect(result.current.state.model).toBe('llama3');
+  });
+
+  it('update swallows storage error and warns via console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockStorage.setItem.mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() =>
+      useProviderSettings('ollama', {}, { storage: mockStorage })
+    );
+
+    act(() => {
+      result.current.update('api-key', 'secret');
+    });
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider.jsx
@@ -3,6 +3,7 @@ import { useSidePane } from '../../side-pane/SidePaneContext.jsx';
 import ConsoleLogViewer from '../../evaluation/components/ConsoleLogViewer.jsx';
 import { LlamaCppLogContext } from './LlamaCppLogContext.js';
 import { useLlamaCppLogStream } from './useLlamaCppLogStream.js';
+import { request } from '../../../api/request.js';
 
 const WINDOW_ID = 'llamacpp-log';
 
@@ -33,8 +34,7 @@ export function LlamaCppLogProvider({ children }) {
   // session since the env var is set at server-launch time.
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/llamacpp/logs/available')
-      .then((r) => (r.ok ? r.json() : { available: false }))
+    request('/llamacpp/logs/available')
       .then((data) => {
         if (!cancelled) setAvailable(Boolean(data?.available));
       })

--- a/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider588.test.jsx
+++ b/src/quodeq/ui/src/features/settings/llamacpp-log/LlamaCppLogProvider588.test.jsx
@@ -1,0 +1,70 @@
+/**
+ * Finding #588 – LlamaCppLogProvider must use request() (30s timeout)
+ * instead of raw fetch() for the /api/llamacpp/logs/available probe.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+// Mock request so we can detect it is called.
+vi.mock('../../../api/request.js', () => ({
+  BASE: '/api',
+  request: vi.fn(),
+}));
+
+// Mock the SSE stream hook so LlamaCppLogProvider doesn't open EventSource.
+vi.mock('./useLlamaCppLogStream.js', () => ({
+  useLlamaCppLogStream: () => ({ logs: [], status: 'idle' }),
+}));
+
+// Minimal SidePaneContext mock.
+vi.mock('../../side-pane/SidePaneContext.jsx', () => ({
+  useSidePane: () => ({
+    addWindow: vi.fn(),
+    removeWindow: vi.fn(),
+    replaceWindow: vi.fn(),
+    hasWindow: () => false,
+    windows: [],
+  }),
+}));
+
+import { request } from '../../../api/request.js';
+import { LlamaCppLogProvider } from './LlamaCppLogProvider.jsx';
+import { LlamaCppLogContext } from './LlamaCppLogContext.js';
+
+function renderProvider() {
+  const el = (
+    <LlamaCppLogProvider>
+      <span data-testid="child">ok</span>
+    </LlamaCppLogProvider>
+  );
+  return render(el);
+}
+
+describe('#588 LlamaCppLogProvider uses request() for availability probe', () => {
+  beforeEach(() => {
+    request.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls request() on mount to check availability', async () => {
+    request.mockResolvedValue({ available: true });
+    renderProvider();
+    // Let the effect fire (microtask flush).
+    await act(async () => { await Promise.resolve(); });
+    expect(request).toHaveBeenCalled();
+    const [path] = request.mock.calls[0];
+    expect(path).toContain('/llamacpp/logs/available');
+  });
+
+  it('does not call raw fetch directly', async () => {
+    request.mockResolvedValue({ available: false });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    renderProvider();
+    await act(async () => { await Promise.resolve(); });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/side-pane/SidePane.a11y.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.a11y.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SidePane } from './SidePane.jsx';
+import { SidePaneProvider } from './SidePaneProvider.jsx';
+import { useSidePane } from './SidePaneContext.jsx';
+
+function spec(id, title = id) {
+  return { id, type: 'report', title, render: () => <p>{`body:${id}`}</p> };
+}
+
+function Adder() {
+  const { addWindow } = useSidePane();
+  return (
+    <div>
+      <button onClick={() => addWindow(spec('alpha', 'Alpha'))}>add-a</button>
+      <button onClick={() => addWindow(spec('beta', 'Beta'))}>add-b</button>
+    </div>
+  );
+}
+
+// Reads paneWidth out of context so tests can assert the real state value.
+let capturedCtx = null;
+function CtxCapture() {
+  capturedCtx = useSidePane();
+  return null;
+}
+
+describe('SidePane divider keyboard accessibility', () => {
+  describe('#1909 - outer column resize divider', () => {
+    it('outer resize divider has tabIndex=0', () => {
+      render(<SidePaneProvider><Adder /><SidePane /></SidePaneProvider>);
+      fireEvent.click(screen.getByText('add-a'));
+      const divider = screen.getByRole('separator', { name: /resize side pane/i });
+      expect(divider).toHaveAttribute('tabindex', '0');
+    });
+
+    it('ArrowRight on outer divider increases paneWidth by ~16px', () => {
+      capturedCtx = null;
+      render(
+        <SidePaneProvider>
+          <CtxCapture />
+          <Adder />
+          <SidePane />
+        </SidePaneProvider>,
+      );
+      fireEvent.click(screen.getByText('add-a'));
+      const divider = screen.getByRole('separator', { name: /resize side pane/i });
+      const widthBefore = capturedCtx.paneWidth;
+      act(() => { fireEvent.keyDown(divider, { key: 'ArrowRight' }); });
+      expect(capturedCtx.paneWidth).toBeGreaterThan(widthBefore);
+    });
+
+    it('ArrowLeft on outer divider decreases paneWidth by ~16px', () => {
+      capturedCtx = null;
+      render(
+        <SidePaneProvider>
+          <CtxCapture />
+          <Adder />
+          <SidePane />
+        </SidePaneProvider>,
+      );
+      fireEvent.click(screen.getByText('add-a'));
+      const divider = screen.getByRole('separator', { name: /resize side pane/i });
+      const widthBefore = capturedCtx.paneWidth;
+      act(() => { fireEvent.keyDown(divider, { key: 'ArrowLeft' }); });
+      expect(capturedCtx.paneWidth).toBeLessThan(widthBefore);
+    });
+  });
+
+  describe('#1910 - inner row resize divider', () => {
+    it('row divider has tabIndex=0', () => {
+      render(<SidePaneProvider><Adder /><SidePane /></SidePaneProvider>);
+      fireEvent.click(screen.getByText('add-a'));
+      fireEvent.click(screen.getByText('add-b'));
+      const rowDividers = screen.getAllByRole('separator', { name: /resize between window/i });
+      expect(rowDividers.length).toBeGreaterThan(0);
+      rowDividers.forEach((d) => expect(d).toHaveAttribute('tabindex', '0'));
+    });
+
+    it('ArrowDown on row divider increases aria-valuenow (ratio goes up)', () => {
+      render(<SidePaneProvider><Adder /><SidePane /></SidePaneProvider>);
+      fireEvent.click(screen.getByText('add-a'));
+      fireEvent.click(screen.getByText('add-b'));
+      const rowDivider = screen.getAllByRole('separator', { name: /resize between window/i })[0];
+      // Starts at ratio 0.5 -> aria-valuenow=50
+      const valueBefore = parseInt(rowDivider.getAttribute('aria-valuenow'), 10);
+      act(() => { fireEvent.keyDown(rowDivider, { key: 'ArrowDown' }); });
+      const valueAfter = parseInt(rowDivider.getAttribute('aria-valuenow'), 10);
+      // ArrowDown increases ratio by 0.05 -> aria-valuenow goes from 50 to 55
+      expect(valueAfter).toBeGreaterThan(valueBefore);
+    });
+
+    it('ArrowUp on row divider decreases aria-valuenow (ratio goes down)', () => {
+      render(<SidePaneProvider><Adder /><SidePane /></SidePaneProvider>);
+      fireEvent.click(screen.getByText('add-a'));
+      fireEvent.click(screen.getByText('add-b'));
+      const rowDivider = screen.getAllByRole('separator', { name: /resize between window/i })[0];
+      const valueBefore = parseInt(rowDivider.getAttribute('aria-valuenow'), 10);
+      act(() => { fireEvent.keyDown(rowDivider, { key: 'ArrowUp' }); });
+      const valueAfter = parseInt(rowDivider.getAttribute('aria-valuenow'), 10);
+      // ArrowUp decreases ratio by 0.05 -> aria-valuenow goes from 50 to 45
+      expect(valueAfter).toBeLessThan(valueBefore);
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -29,6 +29,15 @@ export function SidePane() {
     else delete root.dataset.paneResizing;
   }, []);
 
+  // Holds the cleanup function for the active drag, if any.
+  // Set on pointer-down, cleared on pointer-up or unmount.
+  const activeDragCleanupRef = useRef(null);
+
+  // Run any active drag cleanup on unmount to remove leaked window listeners.
+  useEffect(() => {
+    return () => { activeDragCleanupRef.current?.(); };
+  }, []);
+
   // Outer pane (left-edge) drag — resizes the whole dock width.
   // pointermove can fire 100+ times/sec on a 120Hz trackpad. Coalesce
   // multiple events into one CSS-var write per frame via rAF — same
@@ -56,8 +65,16 @@ export function SidePane() {
       pendingNext = clampSidePaneWidth(startWidth + delta, viewport);
       if (rafId == null) rafId = requestAnimationFrame(apply);
     };
-    const onUp = (ev) => {
+    const cleanup = () => {
       if (rafId != null) cancelAnimationFrame(rafId);
+      setResizingFlag(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      activeDragCleanupRef.current = null;
+    };
+    const onUp = (ev) => {
       const delta = startX - ev.clientX;
       const finalWidth = clampSidePaneWidth(startWidth + delta, window.innerWidth);
       // Write final value to the var immediately so the column doesn't
@@ -65,14 +82,11 @@ export function SidePane() {
       document.documentElement.style.setProperty('--side-pane-width', `${finalWidth}px`);
       setPaneWidth(finalWidth);
       setIsDragging(false);
-      setResizingFlag(false);
-      document.body.style.cursor = prevCursor;
-      document.body.style.userSelect = prevSelect;
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      cleanup();
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    activeDragCleanupRef.current = cleanup;
   }, [paneWidth, setPaneWidth, setResizingFlag]);
 
   // Internal between-window resizer. Mutates the two adjacent slot
@@ -114,22 +128,27 @@ export function SidePane() {
       pendingRatio = Math.min(1 - MIN_WINDOW_RATIO, Math.max(MIN_WINDOW_RATIO, startRatio + delta / span));
       if (rafId == null) rafId = requestAnimationFrame(apply);
     };
-    const onUp = () => {
+    const cleanup = () => {
       if (rafId != null) cancelAnimationFrame(rafId);
+      setResizingFlag(false);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      activeDragCleanupRef.current = null;
+    };
+    const onUp = () => {
       apply();
       setRatios((prev) => {
         const out = [...prev];
         out[index] = pendingRatio;
         return out;
       });
-      setResizingFlag(false);
-      document.body.style.cursor = prevCursor;
-      document.body.style.userSelect = prevSelect;
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      cleanup();
     };
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
+    activeDragCleanupRef.current = cleanup;
   }, [ratios, setResizingFlag]);
 
   if (!isOpen) return null;

--- a/src/quodeq/ui/src/features/side-pane/SidePane.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePane.jsx
@@ -175,7 +175,18 @@ export function SidePane() {
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize side pane"
+        tabIndex={0}
         onPointerDown={onOuterDividerPointerDown}
+        onKeyDown={(e) => {
+          const STEP = 16;
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+            e.preventDefault();
+            const delta = e.key === 'ArrowLeft' ? -STEP : STEP;
+            const newWidth = clampSidePaneWidth(paneWidth + delta, window.innerWidth);
+            document.documentElement.style.setProperty('--side-pane-width', `${newWidth}px`);
+            setPaneWidth(newWidth);
+          }
+        }}
       />
       {windows.map((spec, i) => (
         <React.Fragment key={spec.id}>
@@ -188,7 +199,23 @@ export function SidePane() {
               role="separator"
               aria-orientation="horizontal"
               aria-label={`Resize between window ${i + 1} and ${i + 2}`}
+              aria-valuenow={Math.round((ratios[i] ?? 0.5) * 100)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              tabIndex={0}
               onPointerDown={onInnerDividerPointerDown(i)}
+              onKeyDown={(e) => {
+                const STEP = 0.05;
+                if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                  e.preventDefault();
+                  const delta = e.key === 'ArrowUp' ? -STEP : STEP;
+                  setRatios((prev) => {
+                    const out = [...prev];
+                    out[i] = Math.min(1 - MIN_WINDOW_RATIO, Math.max(MIN_WINDOW_RATIO, (out[i] ?? 0.5) + delta));
+                    return out;
+                  });
+                }
+              }}
             />
           )}
         </React.Fragment>

--- a/src/quodeq/ui/src/features/side-pane/SidePaneDragCleanup.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneDragCleanup.test.jsx
@@ -1,0 +1,75 @@
+/**
+ * Finding #514: SidePane global pointer listeners must be cleaned up on unmount.
+ *
+ * Without the fix, onPointerDown adds pointermove + pointerup to window and
+ * never removes them if the component unmounts mid-drag. This test proves the
+ * listeners are removed when the component unmounts during an active drag.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { SidePane } from './SidePane.jsx';
+import { SidePaneProvider } from './SidePaneProvider.jsx';
+import { useSidePane } from './SidePaneContext.jsx';
+
+function spec(id, title = id) {
+  return { id, type: 'report', title, render: () => <p>{`body:${id}`}</p> };
+}
+
+function Adder() {
+  const { addWindow } = useSidePane();
+  return <button onClick={() => addWindow(spec('w1', 'Window 1'))}>add</button>;
+}
+
+describe('SidePane drag cleanup on unmount (#514)', () => {
+  let addEventSpy;
+  let removeEventSpy;
+  let addedListeners;
+  let removedListeners;
+
+  beforeEach(() => {
+    addedListeners = [];
+    removedListeners = [];
+
+    addEventSpy = vi.spyOn(window, 'addEventListener').mockImplementation((type, handler, opts) => {
+      addedListeners.push({ type, handler });
+    });
+    removeEventSpy = vi.spyOn(window, 'removeEventListener').mockImplementation((type, handler) => {
+      removedListeners.push({ type, handler });
+    });
+  });
+
+  afterEach(() => {
+    addEventSpy.mockRestore();
+    removeEventSpy.mockRestore();
+  });
+
+  it('removes window listeners added during pointer-down drag when component unmounts', () => {
+    const { unmount, getByText, getByRole } = render(
+      <SidePaneProvider>
+        <Adder />
+        <SidePane />
+      </SidePaneProvider>
+    );
+
+    // Open the pane.
+    fireEvent.click(getByText('add'));
+
+    // Simulate pointer-down on the outer resize divider (starts the drag,
+    // adds pointermove + pointerup to window).
+    const divider = getByRole('separator', { name: /resize side pane/i });
+    fireEvent.pointerDown(divider, { clientX: 100, preventDefault: () => {} });
+
+    const addedTypes = addedListeners.map((l) => l.type);
+    expect(addedTypes).toContain('pointermove');
+    expect(addedTypes).toContain('pointerup');
+
+    // Unmount mid-drag — listeners must be removed.
+    act(() => { unmount(); });
+
+    const removedTypes = removedListeners.map((l) => l.type);
+    expect(removedTypes).toContain('pointermove');
+    expect(removedTypes).toContain('pointerup');
+  });
+});

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.jsx
@@ -33,7 +33,7 @@ function triggerDownload({ filename, body }) {
 class RenderBoundary extends React.Component {
   state = { failed: false };
   static getDerivedStateFromError() { return { failed: true }; }
-  componentDidCatch() { /* swallow — header still works */ }
+  componentDidCatch(error, info) { console.error('[SidePaneWindow] render error:', error, info); }
   componentDidUpdate(prev) {
     if (prev.contentKey !== this.props.contentKey && this.state.failed) {
       this.setState({ failed: false });

--- a/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
+++ b/src/quodeq/ui/src/features/side-pane/SidePaneWindow.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { SidePaneWindow } from './SidePaneWindow.jsx';
@@ -55,5 +55,47 @@ describe('SidePaneWindow', () => {
     render(<SidePaneWindow spec={makeSpec({ download: downloadFn })} onClose={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: /download/i }));
     expect(downloadFn).toHaveBeenCalled();
+  });
+});
+
+describe('RenderBoundary inside SidePaneWindow', () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    // Suppress React's own error boundary console output during the test
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('#454 — componentDidCatch calls console.error with the error and info', async () => {
+    // A child that throws during render
+    function ThrowingChild() {
+      throw new Error('render kaboom');
+    }
+
+    const throwingSpec = {
+      id: 'err-win',
+      type: 'report',
+      title: 'Error Window',
+      render: () => <ThrowingChild />,
+    };
+
+    render(<SidePaneWindow spec={throwingSpec} onClose={() => {}} />);
+
+    // Wait for the deferred body mount (SLIDE_MS = 220ms) so RenderBoundary renders
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to render report/i)).toBeInTheDocument();
+    }, { timeout: 1000 });
+
+    // console.error must have been called by componentDidCatch (not just React internals)
+    const boundaryCall = consoleErrorSpy.mock.calls.find(
+      (args) => typeof args[0] === 'string' && args[0].includes('[SidePaneWindow]')
+    );
+    expect(boundaryCall).toBeDefined();
+    expect(boundaryCall[0]).toContain('[SidePaneWindow] render error:');
+    expect(boundaryCall[1]).toBeInstanceOf(Error);
   });
 });

--- a/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
@@ -139,6 +139,7 @@ function isDeletableStandard(type) {
 function StandardRow({ standard, isVisible, onEdit, onDelete, onDuplicate, onToggleVisibility }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+  const [downloadError, setDownloadError] = useState(null);
   const principleCount = standard.principleCount ?? standard.principles?.length ?? 0;
   const requirementCount = standard.requirementCount ?? (standard.principles || []).reduce((sum, p) => sum + (p.requirements?.length ?? 0), 0);
   const isDeletable = isDeletableStandard(standard.type);
@@ -173,11 +174,21 @@ function StandardRow({ standard, isVisible, onEdit, onDelete, onDuplicate, onTog
             isEditable={isDeletable}
             onOpen={() => onEdit(standard.id)}
             onDuplicate={() => setShowDuplicateModal(true)}
-            onDownload={() => downloadStandard(standard.id)}
+            onDownload={() => {
+              setDownloadError(null);
+              downloadStandard(standard.id).catch((err) => {
+                setDownloadError(err?.message || 'Download failed');
+              });
+            }}
             onDelete={() => setShowDeleteModal(true)}
           />
         </div>
       </div>
+      {downloadError && (
+        <div role="alert" className="standards-row-error">
+          Could not download standard: {downloadError}
+        </div>
+      )}
       {showDeleteModal && (
         <ConfirmDeleteModal
           standardName={standard.name}

--- a/src/quodeq/ui/src/features/standards/components/StandardsTable.test.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsTable.test.jsx
@@ -1,0 +1,83 @@
+/**
+ * Finding #500: downloadStandard rejection must be handled -- no unhandled rejection,
+ * error surfaced to user.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+// Mock the api module before importing the component.
+vi.mock('../../../api/index.js', () => ({
+  exportStandard: vi.fn(),
+}));
+
+import { exportStandard } from '../../../api/index.js';
+import StandardsTable from './StandardsTable.jsx';
+
+const STANDARD = {
+  id: 'my-std',
+  name: 'My Standard',
+  type: 'custom',
+  description: 'desc',
+  principleCount: 1,
+  requirementCount: 2,
+};
+
+const actions = {
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+  onDuplicate: vi.fn(),
+  isVisible: () => true,
+  onToggleVisibility: vi.fn(),
+};
+
+describe('StandardsTable download error handling (#500)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not produce an unhandled promise rejection when download fails', async () => {
+    // Track unhandled rejections.
+    const unhandledErrors = [];
+    const handler = (event) => {
+      unhandledErrors.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', handler);
+
+    exportStandard.mockRejectedValue(new Error('network error'));
+
+    render(<StandardsTable grouped={{ custom: [STANDARD] }} actions={actions} />);
+
+    const downloadBtn = screen.getByRole('button', { name: /download my standard/i });
+    fireEvent.click(downloadBtn);
+
+    // Give the promise rejection a chance to propagate.
+    await new Promise((r) => setTimeout(r, 50));
+
+    window.removeEventListener('unhandledrejection', handler);
+
+    expect(unhandledErrors).toHaveLength(0);
+  });
+
+  it('surfaces the download error to the user when download fails', async () => {
+    exportStandard.mockRejectedValue(new Error('network error'));
+
+    render(<StandardsTable grouped={{ custom: [STANDARD] }} actions={actions} />);
+
+    const downloadBtn = screen.getByRole('button', { name: /download my standard/i });
+    fireEvent.click(downloadBtn);
+
+    // An error indicator (role="alert", aria-live, or error text) must appear.
+    await waitFor(() => {
+      const alert = document.querySelector('[role="alert"], [aria-live="assertive"], [aria-live="polite"]');
+      const errorText = screen.queryByText(/error|failed|could not/i);
+      expect(alert || errorText).not.toBeNull();
+    }, { timeout: 2000 });
+  });
+});

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.js
@@ -1,9 +1,10 @@
 import { useCallback, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { listLibrary, importFromLibrary } from '../../../api/index.js';
+import { useApi } from '../../../api/ApiContext.jsx';
 import { standardsKeys } from '../../../api/queryKeys.js';
 
 export function useLibrary() {
+  const { listLibrary, importFromLibrary } = useApi();
   const [importError, setImportError] = useState(null);
 
   const { data, isLoading, error } = useQuery({
@@ -19,7 +20,7 @@ export function useLibrary() {
       setImportError(err.message || 'Failed to import standard');
       throw err;
     }
-  }, []);
+  }, [importFromLibrary]);
 
   return {
     libraryStandards: data || [],

--- a/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
+++ b/src/quodeq/ui/src/features/standards/hooks/useLibrary.test.jsx
@@ -1,30 +1,50 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
 import { withQueryClient } from '../../../test-utils/withQueryClient.jsx';
+import { ApiProvider } from '../../../api/ApiContext.jsx';
+import { useLibrary } from './useLibrary.js';
 
-vi.mock('../../../api/index.js', () => ({
+const fakeApi = {
   listLibrary: vi.fn(),
   importFromLibrary: vi.fn(),
-}));
+};
 
-import { listLibrary, importFromLibrary } from '../../../api/index.js';
-import { useLibrary } from './useLibrary.js';
+function makeWrapper() {
+  const QueryWrapper = withQueryClient();
+  return function Wrapper({ children }) {
+    return (
+      <QueryWrapper>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryWrapper>
+    );
+  };
+}
 
 describe('useLibrary', () => {
   beforeEach(() => {
-    listLibrary.mockReset();
-    importFromLibrary.mockReset();
-  });
-  afterEach(() => {
-    vi.restoreAllMocks();
+    Object.values(fakeApi).forEach((fn) => fn.mockReset());
   });
 
-  it('loads the library list on mount', async () => {
-    listLibrary.mockResolvedValue([
+  it('calls the injected listLibrary from ApiContext, not a hard import', async () => {
+    fakeApi.listLibrary.mockResolvedValue([
       { id: 's1', name: 'Standard 1' },
       { id: 's2', name: 'Standard 2' },
     ]);
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.libraryStandards).toHaveLength(2);
+    });
+    expect(fakeApi.listLibrary).toHaveBeenCalled();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('loads the library list on mount', async () => {
+    fakeApi.listLibrary.mockResolvedValue([
+      { id: 's1', name: 'Standard 1' },
+      { id: 's2', name: 'Standard 2' },
+    ]);
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => {
       expect(result.current.libraryStandards).toHaveLength(2);
     });
@@ -32,17 +52,29 @@ describe('useLibrary', () => {
   });
 
   it('exposes the error message when listLibrary fails', async () => {
-    listLibrary.mockRejectedValue(new Error('library down'));
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    fakeApi.listLibrary.mockRejectedValue(new Error('library down'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => {
       expect(result.current.error).toBe('library down');
     });
   });
 
+  it('importStandard calls the injected importFromLibrary from ApiContext', async () => {
+    fakeApi.listLibrary.mockResolvedValue([]);
+    fakeApi.importFromLibrary.mockResolvedValue({});
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.importStandard('foo.yaml');
+    });
+    expect(fakeApi.importFromLibrary).toHaveBeenCalledWith('foo.yaml');
+  });
+
   it('importStandard surfaces the import error and re-throws', async () => {
-    listLibrary.mockResolvedValue([]);
-    importFromLibrary.mockRejectedValue(new Error('cannot import'));
-    const { result } = renderHook(() => useLibrary(), { wrapper: withQueryClient() });
+    fakeApi.listLibrary.mockResolvedValue([]);
+    fakeApi.importFromLibrary.mockRejectedValue(new Error('cannot import'));
+    const { result } = renderHook(() => useLibrary(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     let thrown = null;

--- a/src/quodeq/ui/src/hooks/localProviders.test.jsx
+++ b/src/quodeq/ui/src/hooks/localProviders.test.jsx
@@ -1,0 +1,27 @@
+/**
+ * Fix D (#2441): LOCAL_API_PROVIDERS is defined once in useEvaluation.js and
+ * re-exported — useEvaluationLifecycle.js must import it from there rather
+ * than maintaining its own copy.
+ */
+import { describe, it, expect } from 'vitest';
+import { LOCAL_API_PROVIDERS } from '../features/evaluation/hooks/useEvaluation.js';
+
+describe('LOCAL_API_PROVIDERS single source of truth (#2441)', () => {
+  it('is exported from useEvaluation.js', () => {
+    expect(LOCAL_API_PROVIDERS).toBeDefined();
+    expect(LOCAL_API_PROVIDERS).toBeInstanceOf(Set);
+  });
+
+  it('contains the expected local providers', () => {
+    expect(LOCAL_API_PROVIDERS.has('ollama')).toBe(true);
+    expect(LOCAL_API_PROVIDERS.has('llamacpp')).toBe(true);
+    expect(LOCAL_API_PROVIDERS.has('omlx')).toBe(true);
+  });
+
+  it('useEvaluationLifecycle imports the same Set object, not a separate copy', async () => {
+    // Importing useEvaluationLifecycle.js must not re-declare LOCAL_API_PROVIDERS.
+    // We verify indirectly: both modules resolve to the same exported reference.
+    const mod = await import('../features/evaluation/hooks/useEvaluation.js');
+    expect(mod.LOCAL_API_PROVIDERS).toBe(LOCAL_API_PROVIDERS);
+  });
+});

--- a/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
+++ b/src/quodeq/ui/src/hooks/useEvaluationLifecycle.js
@@ -1,11 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
-import { useEvaluation } from '../features/evaluation/hooks/useEvaluation.js';
+import { useEvaluation, LOCAL_API_PROVIDERS } from '../features/evaluation/hooks/useEvaluation.js';
 import { getLevels, STORAGE_KEY as POWER_KEY } from '../features/evaluation/components/powerLevels.js';
 import { ACTIVE_PROVIDER_KEY, providerKey } from '../constants.js';
 
-// Providers that run inference locally via an API. Extensible via server-side
-// provider config (ai_providers.json) which can flag additional local providers.
-const LOCAL_API_PROVIDERS = ['ollama'];
 const TIER_NAMES = ['fast', 'balanced', 'thorough'];
 const DEFAULT_ANALYSIS_POWER = 2;
 
@@ -76,7 +73,7 @@ export function useEvaluationLifecycle({ settings, navigation, projects, storage
   }
 
   const activeProvider = storage.getItem(ACTIVE_PROVIDER_KEY) || '';
-  const isLocalApi = LOCAL_API_PROVIDERS.includes(activeProvider);
+  const isLocalApi = LOCAL_API_PROVIDERS.has(activeProvider);
 
   return {
     job, jobError, liveViolations,

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -30,11 +30,9 @@ function handlePopState(e, setNavStack) {
 
 function createNavActions(setNavStack, navStackRef, history) {
   function navPush(entry) {
-    setNavStack((prev) => {
-      const next = [...prev, entry];
-      history.pushState({ navIndex: next.length - 1, entry }, '');
-      return next;
-    });
+    const next = [...navStackRef.current, entry];
+    setNavStack(next);
+    history.pushState({ navIndex: next.length - 1, entry }, '');
   }
 
   function navPop() {
@@ -47,20 +45,18 @@ function createNavActions(setNavStack, navStackRef, history) {
   }
 
   function navReset() {
-    setNavStack((prev) => {
-      const stepsBack = prev.length - 1;
-      if (stepsBack > 0) history.go(-stepsBack);
-      return [{ page: DEFAULT_PAGE }];
-    });
+    const stepsBack = navStackRef.current.length - 1;
+    setNavStack([{ page: DEFAULT_PAGE }]);
+    if (stepsBack > 0) history.go(-stepsBack);
   }
 
   function navTab(page) {
-    setNavStack((prev) => {
-      const stepsBack = prev.length - 1;
-      if (stepsBack > 0) history.go(-stepsBack);
-      const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
-      return [{ page, _tabKey: prevKey + 1 }];
-    });
+    const prev = navStackRef.current;
+    const stepsBack = prev.length - 1;
+    const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
+    const next = [{ page, _tabKey: prevKey + 1 }];
+    setNavStack(next);
+    if (stepsBack > 0) history.go(-stepsBack);
   }
 
   return { navPush, navPop, navGoTo, navReset, navTab };

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -1,0 +1,212 @@
+/**
+ * Finding #363: history.pushState inside setNavStack updater is a side effect
+ * that React may double-invoke in Strict Mode. The updater must be pure.
+ *
+ * Fix: compute next from the ref, call setNavStack(next) + history.pushState
+ * as two sequential statements outside the updater.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNavStack } from './useNavStack.js';
+
+/**
+ * React Strict Mode double-invokes state updaters to catch side effects.
+ * Wrap the hook in StrictMode to reproduce the double-invocation.
+ */
+function strictWrapper({ children }) {
+  return <React.StrictMode>{children}</React.StrictMode>;
+}
+
+describe('useNavStack navPush purity (#363)', () => {
+  let pushStateCalls;
+  let historyAdapter;
+
+  beforeEach(() => {
+    pushStateCalls = [];
+    historyAdapter = {
+      pushState: vi.fn((...args) => pushStateCalls.push(args)),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.pushState exactly once per navPush call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // React StrictMode double-invokes the updater fn passed to setState.
+    // If pushState is inside the updater, it fires twice.
+    act(() => {
+      result.current.navPush({ page: 'settings' });
+    });
+
+    // Must be exactly 1, even under double-invoke.
+    expect(pushStateCalls).toHaveLength(1);
+  });
+
+  it('navStack grows by exactly one entry per navPush in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    const initialLength = result.current.navStack.length;
+
+    act(() => { result.current.navPush({ page: 'project' }); });
+    expect(result.current.navStack).toHaveLength(initialLength + 1);
+
+    act(() => { result.current.navPush({ page: 'detail' }); });
+    expect(result.current.navStack).toHaveLength(initialLength + 2);
+
+    // 2 pushes = 2 pushState calls. In buggy code, double-invoke gives 4.
+    expect(pushStateCalls).toHaveLength(2);
+  });
+});
+
+/**
+ * Finding #363 follow-up: navReset and navTab had the identical bug —
+ * history.go() called inside the setNavStack updater, causing double-fire
+ * under React Strict Mode's double-invocation.
+ *
+ * Fix: read stepsBack from navStackRef.current before calling setNavStack,
+ * then call history.go() as a separate statement outside the updater.
+ */
+describe('useNavStack navReset purity (#363 follow-up)', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.go exactly once per navReset call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Push two entries so navReset has history entries to go back through.
+    act(() => { result.current.navPush({ page: 'a' }); });
+    act(() => { result.current.navPush({ page: 'b' }); });
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navReset(); });
+
+    // Must be exactly 1, not 2 from double-invoke.
+    expect(historyAdapter.go).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.go).toHaveBeenCalledWith(-2);
+  });
+
+  it('resets navStack to single default entry in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navReset(); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('overview');
+  });
+
+  it('does not call history.go when stack is already at root', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navReset(); });
+
+    expect(historyAdapter.go).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavStack navTab purity (#363 follow-up)', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls history.go exactly once per navTab call even in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Push entries so there is history to go back through.
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navPush({ page: 'detail' }); });
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navTab('projects'); });
+
+    // Must be exactly 1, not 2 from double-invoke.
+    expect(historyAdapter.go).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.go).toHaveBeenCalledWith(-2);
+  });
+
+  it('resets navStack to single tab entry in StrictMode', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    act(() => { result.current.navPush({ page: 'settings' }); });
+    act(() => { result.current.navTab('projects'); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('projects');
+  });
+
+  it('increments _tabKey when navigating to the same tab', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+
+    // Start at 'overview' (the default). Navigate to the same tab.
+    const initialKey = result.current.navStack[0]._tabKey || 0;
+    act(() => { result.current.navTab('overview'); });
+
+    expect(result.current.navStack[0]._tabKey).toBe(initialKey + 1);
+  });
+
+  it('does not call history.go when stack is already at root', () => {
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
+    historyAdapter.go.mockClear();
+
+    act(() => { result.current.navTab('projects'); });
+
+    expect(historyAdapter.go).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -21,7 +21,7 @@ import { projectKeys } from "../api/queryKeys.js";
  *
  * keepPlaceholder (default true): see useDashboard for rationale.
  */
-export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true }) {
+export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true } = {}) {
   const queryClient = useQueryClient();
 
   const latestQuery = useQuery({

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -569,6 +569,13 @@ textarea:focus {
 }
 
 .job-error-toast {
+  /* button resets — keeps appearance identical to the previous div */
+  border: none;
+  font: inherit;
+  color: inherit;
+  width: auto;
+  display: block;
+  /* original styles */
   position: fixed;
   bottom: var(--space-6, 24px);
   left: 50%;

--- a/src/quodeq/ui/src/utils/clipboard.js
+++ b/src/quodeq/ui/src/utils/clipboard.js
@@ -5,7 +5,7 @@
  * @param {string} text
  */
 export function copyToClipboard(text) {
-  return navigator.clipboard.writeText(text).catch((err) =>
+  return navigator.clipboard?.writeText(text)?.catch((err) =>
     console.warn('Clipboard write failed:', err)
-  );
+  ) ?? Promise.resolve();
 }

--- a/src/quodeq/ui/src/utils/clipboard.test.jsx
+++ b/src/quodeq/ui/src/utils/clipboard.test.jsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { copyToClipboard } from './clipboard.js';
+
+describe('copyToClipboard', () => {
+  it('no-ops without throwing when clipboard is unavailable', async () => {
+    const orig = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    await expect(copyToClipboard('x')).resolves.toBeUndefined();
+    Object.defineProperty(navigator, 'clipboard', { value: orig, configurable: true });
+  });
+});

--- a/tests/analysis/cache/test_cache_writer.py
+++ b/tests/analysis/cache/test_cache_writer.py
@@ -204,3 +204,47 @@ def test_cache_writer_key_matches_classify_files_via_cache(tmp_path):
     )
     assert entry.file_path == "Foo.kt"
     assert len(entry.findings) == 1
+
+
+def test_cache_writer_path_traversal_yields_empty_hash(tmp_path):
+    """A traversal file_path (e.g. '../outside/secret.txt') must NOT hash a
+    file outside src_root. The resulting cache entry's file_content_hash must
+    be empty, not a real hash of the escaped file."""
+    import json
+
+    from quodeq.analysis.cache.cache_writer import build_cache_writer
+
+    # Create a sentinel file OUTSIDE src_root with known content.
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    sentinel = outside_dir / "secret.txt"
+    sentinel.write_text("TOP SECRET")
+
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+
+    cache_root = tmp_path / "cache"
+    write = build_cache_writer(
+        cache_root=cache_root,
+        src_root=src_root,
+        standards_dir=None,
+        dimension="flexibility",
+        model_id="sonnet",
+        language="kotlin",
+    )
+
+    # Craft a traversal path that resolves to the sentinel outside src_root.
+    traversal_path = "../outside/secret.txt"
+    write(traversal_path, [])
+
+    entries = list(cache_root.rglob("entry.json"))
+    assert len(entries) == 1, f"Expected 1 cache entry, found {len(entries)}"
+    # Read the entry JSON directly -- the key computed with an empty hash
+    # differs from build_cache_key_for_file (which still reads the outside file),
+    # so we inspect the stored JSON rather than doing a cache.get() lookup.
+    entry_data = json.loads(entries[0].read_text())
+    # The hash must be empty -- the outside file must NOT have been read.
+    assert entry_data.get("file_content_hash") == "", (
+        f"Expected empty content hash for traversal path, "
+        f"got {entry_data.get('file_content_hash')!r}"
+    )

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -935,6 +935,74 @@ class TestCachedFindingsReachEventLog:
 # the next run will re-dispatch.
 
 
+class TestEvidenceFileCreatedBeforeBreaker:
+    """A fresh dimension (all misses, no cached findings) must not spam
+    'Could not read failure-streak JSONL' warnings at startup.
+
+    Repro: in the window before any finding lands, the per-dim evidence
+    JSONL doesn't exist yet. The FailureStreakWatcher polls it anyway and
+    every scan of the missing file logs a WARNING (the user saw this once
+    per heartbeat on a 1324-file dimension). The runner now touches the
+    evidence file before starting the breaker, so the watcher always reads
+    an existing (possibly empty) file and stays silent.
+    """
+
+    def test_no_startup_warning_when_dispatch_writes_nothing(
+        self, tmp_path: Path, cache: LocalFileBackend, monkeypatch,
+    ):
+        from quodeq.shared import cancellation
+        cancellation.reset()
+        # QUODEQ_FAILURE_STREAK overrides the options field, so clear it to
+        # keep threshold=5 below authoritative — otherwise a stray `=0` in
+        # the environment would disable the breaker and false-green this.
+        monkeypatch.delenv("QUODEQ_FAILURE_STREAK", raising=False)
+
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        # Breaker must be enabled (threshold > 0) so the watcher actually
+        # scans the JSONL — a disabled breaker runs a no-op thread.
+        config = replace(
+            config, options=replace(config.options, failure_streak_threshold=5),
+        )
+
+        # Dispatcher that writes NOTHING to the JSONL and returns None,
+        # mirroring the fresh-dimension window before any finding is emitted.
+        def silent_dispatcher(cfg, dim_id, idx, ctx, callbacks):
+            return None
+
+        # Capture WARNING+ only, so the assertion isn't coupled to the exact
+        # warning string — any startup warning from the breaker fails the test.
+        handler = _ListHandler()
+        handler.setLevel(logging.WARNING)
+        breaker_logger = logging.getLogger(
+            "quodeq.analysis.cache._failure_streak"
+        )
+        breaker_logger.addHandler(handler)
+        try:
+            with patch(
+                "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+                new=silent_dispatcher,
+            ):
+                process_dimension_with_cache(
+                    config, "security", idx=1, ctx=_make_ctx(),
+                    callbacks=_make_callbacks(), cache=cache,
+                )
+        finally:
+            breaker_logger.removeHandler(handler)
+            cancellation.reset()
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        assert jsonl.exists(), (
+            "evidence JSONL must be created before the breaker starts so the "
+            "watcher never reads a missing file"
+        )
+        # Happy path (empty file, no error markers): the breaker emits no
+        # WARNING+ records at all — not the missing-file warning, nothing.
+        assert handler.messages == [], (
+            "failure-streak watcher logged unexpected warning(s) at startup; "
+            f"messages={handler.messages}"
+        )
+
+
 class TestFilesReadReflectsAnalyzedCount:
     """files_read on the returned Evidence must equal the number of source
     files reproducible from cache at run end — NOT len(input_files)."""

--- a/tests/analysis/cache/test_failure_streak_oserror.py
+++ b/tests/analysis/cache/test_failure_streak_oserror.py
@@ -1,0 +1,71 @@
+"""Tests for _failure_streak.py — OSError handling in _scan_once."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.shared import cancellation
+from quodeq.analysis.cache._failure_streak import FailureStreakWatcher
+
+
+def _append(jsonl: Path, line: dict) -> None:
+    with jsonl.open("a") as f:
+        f.write(json.dumps(line) + "\n")
+
+
+def _enable_propagation():
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+class TestScanOnceOSError:
+    def test_permission_error_returns_unchanged_state_and_logs_warning(
+        self, tmp_path: Path, caplog
+    ):
+        """#377 — PermissionError (OSError subclass) on open must log WARNING and
+        return the unchanged (offset, streak, recent) state, not only catch FileNotFoundError."""
+        jsonl = tmp_path / "evidence.jsonl"
+        jsonl.touch()
+
+        watcher = FailureStreakWatcher(jsonl, threshold=10)
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch.object(
+                Path, "open", side_effect=PermissionError("access denied")
+            ):
+                with caplog.at_level(
+                    logging.WARNING, logger="quodeq.analysis.cache._failure_streak"
+                ):
+                    offset, streak, recent = watcher._scan_once(0, 3, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        # State is unchanged
+        assert offset == 0
+        assert streak == 3
+        assert recent == []
+        # Warning was logged
+        assert "Could not read failure-streak JSONL" in caplog.text
+
+    def test_filenot_found_still_returns_unchanged_state(self, tmp_path: Path):
+        """FileNotFoundError (already handled) still returns unchanged state."""
+        jsonl = tmp_path / "missing.jsonl"
+        watcher = FailureStreakWatcher(jsonl, threshold=5)
+        offset, streak, recent = watcher._scan_once(99, 2, [])
+        assert offset == 99
+        assert streak == 2
+        assert recent == []

--- a/tests/analysis/cache/test_local_backend.py
+++ b/tests/analysis/cache/test_local_backend.py
@@ -55,6 +55,11 @@ class TestSharding:
         with pytest.raises(ValueError):
             backend.has("ab")
 
+    def test_traversal_key_rejected(self, backend: LocalFileBackend):
+        for bad in ["../../etc/passwd", "ab/cd", "abc.def", "/abcdef"]:
+            with pytest.raises(ValueError):
+                backend.has(bad)
+
 
 class TestAtomicity:
     def test_put_overwrites_atomically(self, backend: LocalFileBackend):

--- a/tests/analysis/cache/test_persist_dispatch_results_markers.py
+++ b/tests/analysis/cache/test_persist_dispatch_results_markers.py
@@ -40,14 +40,14 @@ class TestPersistFiltersByOkMarker:
             # c.py: explicit error
             {"_marker": "file_done", "file": "c.py", "status": "error", "reason": "token_limit"},
         ])
-        miss_keys = {f: f"key-{f}" for f in ("a.py", "b.py", "c.py")}
+        miss_keys = {f: f"key-{f}".replace(".", "-") for f in ("a.py", "b.py", "c.py")}
         persist_dispatch_results(
             config, "security", miss_files=["a.py", "b.py", "c.py"],
             jsonl_path=jsonl, miss_keys=miss_keys, cache=cache,
         )
-        assert cache.get("key-a.py") is not None
-        assert cache.get("key-b.py") is None
-        assert cache.get("key-c.py") is None
+        assert cache.get("key-a-py") is not None
+        assert cache.get("key-b-py") is None
+        assert cache.get("key-c-py") is None
 
     def test_clean_file_with_ok_marker_is_cached_empty(
         self, tmp_path: Path, cache: LocalFileBackend,

--- a/tests/analysis/mcp/test_handlers_marker.py
+++ b/tests/analysis/mcp/test_handlers_marker.py
@@ -4,6 +4,37 @@ from unittest.mock import MagicMock
 from quodeq.analysis.mcp.handlers import handle_tools_list, handle_tools_call
 
 
+# ---------------------------------------------------------------------------
+# #207 — null 'arguments' in params must be treated as {} (not raise TypeError)
+# ---------------------------------------------------------------------------
+
+class TestToolsCallNullArguments:
+    def test_null_arguments_for_report_finding_does_not_raise(self) -> None:
+        """params.arguments = null must not crash handle_tools_call."""
+        router = MagicMock()
+        router.receive.return_value = ("ok", False)
+        # Simulate a JSON-RPC caller that sends {"arguments": null}
+        result = handle_tools_call(
+            request_id=1,
+            params={"name": "report_finding", "arguments": None},
+            router=router,
+        )
+        # Should return a valid ok-response (not a 500/AttributeError)
+        assert "result" in result
+        router.receive.assert_called_once_with({})
+
+    def test_missing_arguments_key_still_works(self) -> None:
+        router = MagicMock()
+        router.receive.return_value = ("ok", False)
+        result = handle_tools_call(
+            request_id=2,
+            params={"name": "report_finding"},
+            router=router,
+        )
+        assert "result" in result
+        router.receive.assert_called_once_with({})
+
+
 class TestToolsListIncludesMarker:
     def test_marker_listed(self):
         result = handle_tools_list(request_id=1, has_queue=True)

--- a/tests/analysis/mcp/test_schemas.py
+++ b/tests/analysis/mcp/test_schemas.py
@@ -4,7 +4,19 @@ from quodeq.analysis.mcp.schemas import (
     MARK_FILE_DONE_NAME,
     MARK_FILE_DONE_DESC,
     MARK_FILE_DONE_SCHEMA,
+    REPORT_FINDING_SCHEMA,
 )
+
+
+class TestReportFindingSchema:
+    def test_vt_is_optional_taxonomy_string(self):
+        vt = REPORT_FINDING_SCHEMA["properties"]["vt"]
+        assert vt["type"] == "string"
+        assert "vt" not in REPORT_FINDING_SCHEMA["required"]
+
+    def test_vt_description_mentions_taxonomy(self):
+        desc = REPORT_FINDING_SCHEMA["properties"]["vt"]["description"].lower()
+        assert "taxonomy" in desc
 
 
 class TestMarkFileDoneSchema:

--- a/tests/analysis/subagents/test_priority_fan_in_stem_collision.py
+++ b/tests/analysis/subagents/test_priority_fan_in_stem_collision.py
@@ -1,0 +1,103 @@
+"""Tests for stem-collision dedup in compute_fan_in (finding #522).
+
+When two files share the same stem (e.g. a/util.py and b/util.py) the original
+setdefault(stem, path) map kept only the FIRST; the second was silently dropped
+from import-target resolution, giving it a permanent fan-in of zero.
+
+Fix: the map value is now a list/set of all paths sharing a stem; the resolution
+consumer checks all candidates and returns the one that matches.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import pytest
+
+from quodeq.analysis.subagents.priority_fan_in import compute_fan_in
+
+
+class TestStemCollisionDedup:
+    """Both files with the same stem must be resolvable as import targets."""
+
+    def test_both_stems_counted_when_different_dirs(self, tmp_path: Path) -> None:
+        """a/util.py and b/util.py both get fan-in credit when imported."""
+        (tmp_path / "a").mkdir()
+        (tmp_path / "b").mkdir()
+        # importer_a imports from a/util
+        (tmp_path / "importer_a.py").write_text("from a.util import something\n")
+        # importer_b imports from b/util
+        (tmp_path / "importer_b.py").write_text("from b.util import other\n")
+        (tmp_path / "a" / "util.py").write_text("# util in a\n")
+        (tmp_path / "b" / "util.py").write_text("# util in b\n")
+
+        files = [
+            "importer_a.py",
+            "importer_b.py",
+            "a/util.py",
+            "b/util.py",
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        # Both util files must appear with non-zero fan-in, not just the first one
+        a_util = fan_in.get("a/util.py", 0)
+        b_util = fan_in.get("b/util.py", 0)
+        assert a_util >= 1, (
+            f"a/util.py has fan-in {a_util}; stem-collision dropped it (got {fan_in})"
+        )
+        assert b_util >= 1, (
+            f"b/util.py has fan-in {b_util}; stem-collision dropped it (got {fan_in})"
+        )
+
+    def test_second_registered_stem_not_silently_dropped(self, tmp_path: Path) -> None:
+        """The file registered SECOND for a given stem must not be zero-count
+        when it is the only file being imported under that stem."""
+        (tmp_path / "x").mkdir()
+        (tmp_path / "y").mkdir()
+        # Only y/models is imported; x/models is never referenced.
+        (tmp_path / "main.py").write_text("from y.models import Foo\n")
+        (tmp_path / "x" / "models.py").write_text("")
+        (tmp_path / "y" / "models.py").write_text("")
+
+        files = [
+            "main.py",
+            "x/models.py",  # registered first — old bug would keep only this
+            "y/models.py",  # registered second — old bug dropped this
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        y_models = fan_in.get("y/models.py", 0)
+        assert y_models >= 1, (
+            f"y/models.py (registered second) has fan-in {y_models}; "
+            f"stem-collision dedup is not working (got {fan_in})"
+        )
+
+    def test_unique_stems_unaffected(self, tmp_path: Path) -> None:
+        """Files with unique stems continue to work correctly after the fix."""
+        (tmp_path / "main.py").write_text("import auth\nfrom utils import helper\n")
+        (tmp_path / "auth.py").write_text("")
+        (tmp_path / "utils.py").write_text("")
+
+        files = ["main.py", "auth.py", "utils.py"]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+
+        assert fan_in.get("auth.py", 0) >= 1
+        assert fan_in.get("utils.py", 0) >= 1
+
+    def test_three_way_stem_collision(self, tmp_path: Path) -> None:
+        """Three files with the same stem across three directories all get credit."""
+        for d in ("p1", "p2", "p3"):
+            (tmp_path / d).mkdir()
+        (tmp_path / "use_p1.py").write_text("from p1.helpers import foo\n")
+        (tmp_path / "use_p2.py").write_text("from p2.helpers import bar\n")
+        (tmp_path / "use_p3.py").write_text("from p3.helpers import baz\n")
+        for d in ("p1", "p2", "p3"):
+            (tmp_path / d / "helpers.py").write_text("")
+
+        files = [
+            "use_p1.py", "use_p2.py", "use_p3.py",
+            "p1/helpers.py", "p2/helpers.py", "p3/helpers.py",
+        ]
+        fan_in = compute_fan_in(files, tmp_path, "python")
+        for path in ("p1/helpers.py", "p2/helpers.py", "p3/helpers.py"):
+            assert fan_in.get(path, 0) >= 1, (
+                f"{path} has fan-in {fan_in.get(path, 0)} — stem-collision fix incomplete"
+            )

--- a/tests/analysis/test_analysis_context_coverage.py
+++ b/tests/analysis/test_analysis_context_coverage.py
@@ -1,0 +1,66 @@
+"""Tests for _analysis_context.py — error logging in _load_custom_dimensions."""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis._analysis_context import _load_custom_dimensions
+
+
+def _enable_propagation():
+    """Return the quodeq logger with propagate=True (restored by caller)."""
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+class TestLoadCustomDimensions:
+    def test_valid_json_files_are_included(self, tmp_path: Path):
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "custom.json").write_text(json.dumps({"id": "custom-dim"}), encoding="utf-8")
+        result = _load_custom_dimensions(ev, ["existing"])
+        assert "custom-dim" in result
+
+    def test_oserror_reading_file_logs_warning_and_skips(self, tmp_path: Path, monkeypatch, caplog):
+        """#538 — OSError while reading evaluator file must be logged, not swallowed."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        bad_file = ev / "broken.json"
+        bad_file.write_text("{}", encoding="utf-8")
+
+        def _bad_read_text(self, *args, **kwargs):
+            raise OSError("read error")
+
+        monkeypatch.setattr(Path, "read_text", _bad_read_text)
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == []
+        assert "Skipping custom evaluator" in caplog.text
+        assert "broken.json" in caplog.text
+
+    def test_invalid_json_logs_warning_and_skips(self, tmp_path: Path, caplog):
+        """#538 — ValueError (bad JSON) must be logged, not swallowed."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "malformed.json").write_text("NOT JSON", encoding="utf-8")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, [])
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == []
+        assert "Skipping custom evaluator" in caplog.text
+        assert "malformed.json" in caplog.text

--- a/tests/analysis/test_analysis_context_coverage.py
+++ b/tests/analysis/test_analysis_context_coverage.py
@@ -64,3 +64,21 @@ class TestLoadCustomDimensions:
         assert result == []
         assert "Skipping custom evaluator" in caplog.text
         assert "malformed.json" in caplog.text
+
+    def test_non_dict_json_logs_warning_and_skips(self, tmp_path: Path, caplog):
+        """A top-level JSON array (or any non-dict) must not crash on .get("id")."""
+        ev = tmp_path / "evaluators"
+        ev.mkdir()
+        (ev / "array.json").write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.analysis._analysis_context"):
+                result = _load_custom_dimensions(ev, ["existing"])
+        finally:
+            quodeq_logger.propagate = orig
+
+        # Pre-existing dimensions are preserved; the bad file is skipped, not fatal.
+        assert result == ["existing"]
+        assert "Skipping custom evaluator" in caplog.text
+        assert "array.json" in caplog.text

--- a/tests/analysis/test_api_prompt.py
+++ b/tests/analysis/test_api_prompt.py
@@ -66,6 +66,16 @@ class TestAssembleApiPrompt:
         assert '"severity"' in prompt
         assert '"violation"' in prompt
 
+    def test_schema_offers_vt_taxonomy_field(self, src_dir, standards_text):
+        prompt = assemble_api_prompt(
+            source_files=[src_dir / "main.py"],
+            standards_text=standards_text,
+            dimension="security",
+            repo_name="test-repo",
+        )
+        assert '"vt"' in prompt
+        assert "code-injection" in prompt  # concrete example anchors the format
+
     def test_constant_instructions_precede_variable_file_content(self, src_dir, standards_text):
         """Constant task instructions and the finding schema must come BEFORE the
         variable file content.

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -176,6 +176,26 @@ class TestParserDropAccounting:
         assert dropped == 0
 
 
+class TestFindingVtTaxonomy:
+    """The optional 'vt' taxonomy code must survive _Finding validation, or
+    every fresh API run scores with taxonomy_used=False (free-text reason
+    grouping counts near-duplicates as distinct types and depresses scores)."""
+
+    _BASE = {
+        "req": "S-CON-3", "t": "violation", "file": "src/a.py", "line": 3,
+        "severity": "critical", "w": "eval usage",
+        "snippet": "eval(x)", "reason": "Direct code injection via eval.",
+    }
+
+    def test_vt_survives_validate_and_dump(self):
+        dumped = _Finding.model_validate({**self._BASE, "vt": "code-injection"}).model_dump()
+        assert dumped["vt"] == "code-injection"
+
+    def test_vt_defaults_to_none_when_absent(self):
+        dumped = _Finding.model_validate(self._BASE).model_dump()
+        assert dumped["vt"] is None
+
+
 class TestTruncationDetection:
     """A length-truncated response is incomplete: mark the call lossy so the
     file re-dispatches instead of being cached as a clean analysis."""

--- a/tests/analysis/test_api_runner.py
+++ b/tests/analysis/test_api_runner.py
@@ -371,15 +371,11 @@ class TestSyncCacheWrite:
         src_root.mkdir()
         (src_root / "Foo.kt").write_text("class Foo")
 
-        # build_cache_writer hardcodes Path.home() / ".quodeq/cache/results",
-        # so redirect the user-home lookup to keep this test self-contained.
-        # POSIX's expanduser reads HOME; Windows' reads USERPROFILE first and
-        # ignores HOME when USERPROFILE is set (which it always is on CI).
-        # Setting both keeps the test cross-platform.
-        fake_home = tmp_path / "home"
-        monkeypatch.setenv("HOME", str(fake_home))
-        monkeypatch.setenv("USERPROFILE", str(fake_home))
-        cache_root = fake_home / ".quodeq" / "cache" / "results"
+        # default_cache_root() honours QUODEQ_CACHE_ROOT (Fix A, #2419/#2340),
+        # so redirect via that env var to keep this test self-contained.
+        fake_cache_base = tmp_path / "cache"
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(fake_cache_base))
+        cache_root = fake_cache_base / "results"
 
         run_config = RunConfig(
             src=src_root,

--- a/tests/analysis/test_api_runner_coverage.py
+++ b/tests/analysis/test_api_runner_coverage.py
@@ -391,3 +391,17 @@ class TestRunApiAnalysisAppend:
             args = mock_ctx.call_args.args
             assert args[0] == tmp_path  # compiled_dir
             assert args[1] == "security"  # dimension
+
+
+# ---------------------------------------------------------------------------
+# Fix A (#2340): cache root in _api_runner honours QUODEQ_CACHE_ROOT
+# ---------------------------------------------------------------------------
+
+class TestApiRunnerCacheRootEnv:
+    def test_cache_root_honours_quodeq_cache_root_env(self, tmp_path, monkeypatch):
+        """QUODEQ_CACHE_ROOT must propagate to the cache_writer built inside
+        run_api_analysis so all three call sites agree on the same root."""
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path))
+        # default_cache_root() should now return tmp_path / "results"
+        from quodeq.analysis.cache.local import default_cache_root
+        assert default_cache_root() == tmp_path / "results"

--- a/tests/analysis/test_command_coverage.py
+++ b/tests/analysis/test_command_coverage.py
@@ -246,12 +246,10 @@ class TestBuildMcpServerArgs:
         assert args[model_idx + 1] == "sonnet"
         lang_idx = args.index("--language")
         assert args[lang_idx + 1] == "kotlin"
-        # Cache root defaults to ~/.quodeq/cache/results. Compare via
-        # Path so the assertion is platform-agnostic — on Windows the
-        # produced path uses backslashes, so a literal forward-slash
-        # tail check would fail there.
+        # Cache root ends with /cache/results regardless of whether the
+        # default (~/.quodeq/cache) or QUODEQ_CACHE_ROOT override is used.
         cr_idx = args.index("--cache-root")
-        expected_tail = str(Path(".quodeq") / "cache" / "results")
+        expected_tail = str(Path("cache") / "results")
         assert args[cr_idx + 1].endswith(expected_tail)
 
     def test_cache_flags_fall_back_when_no_run_config(self, tmp_path):
@@ -290,5 +288,24 @@ class TestMcpServerName:
         config = AnalysisConfig()
         name = _mcp_server_name(config)
         assert name == "quodeq-findings"
+
+
+# ---------------------------------------------------------------------------
+# Fix A (#2419): cache root honours QUODEQ_CACHE_ROOT via default_cache_root()
+# ---------------------------------------------------------------------------
+
+class TestBuildMcpServerArgsCacheRootEnv:
+    def test_cache_root_honours_quodeq_cache_root_env(self, tmp_path, monkeypatch):
+        """QUODEQ_CACHE_ROOT is forwarded through _build_mcp_server_args so
+        the subprocess cache writer resolves under the same sandbox root as
+        classify_files_via_cache."""
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path))
+        jsonl = tmp_path / "findings.jsonl"
+        config = AnalysisConfig(jsonl_file=jsonl, ai_model="test-model")
+        args = _build_mcp_server_args(config)
+
+        cr_idx = args.index("--cache-root")
+        resolved = Path(args[cr_idx + 1])
+        assert resolved == tmp_path / "results"
 
 

--- a/tests/analysis/test_custom_dimension_id_guard.py
+++ b/tests/analysis/test_custom_dimension_id_guard.py
@@ -1,0 +1,12 @@
+import json
+from pathlib import Path
+from quodeq.analysis._analysis_context import _load_custom_dimensions
+
+def test_traversal_evaluator_id_is_skipped(tmp_path: Path):
+    (tmp_path / "evil.json").write_text(json.dumps({"id": "../../etc/passwd"}), encoding="utf-8")
+    (tmp_path / "slash.json").write_text(json.dumps({"id": "a/b"}), encoding="utf-8")
+    (tmp_path / "ok.json").write_text(json.dumps({"id": "my-eval"}), encoding="utf-8")
+    result = _load_custom_dimensions(tmp_path, [])
+    assert "my-eval" in result
+    assert "../../etc/passwd" not in result
+    assert "a/b" not in result

--- a/tests/analysis/test_mcp_config_coverage.py
+++ b/tests/analysis/test_mcp_config_coverage.py
@@ -125,12 +125,27 @@ class TestCreateMcpConfig:
             assert args[model_idx + 1] == "sonnet"
             lang_idx = args.index("--language")
             assert args[lang_idx + 1] == "kotlin"
-            # Cache root path uses platform-native separators (backslash
-            # on Windows); compare via Path so the tail check holds on
-            # every OS.
+            # Cache root ends with /cache/results regardless of whether the
+            # default (~/.quodeq/cache) or QUODEQ_CACHE_ROOT override is used.
+            # Compare via Path so the tail check holds on every OS.
             cr_idx = args.index("--cache-root")
-            expected_tail = str(Path(".quodeq") / "cache" / "results")
+            expected_tail = str(Path("cache") / "results")
             assert args[cr_idx + 1].endswith(expected_tail)
+        finally:
+            config_path.unlink(missing_ok=True)
+
+    def test_cache_root_honours_quodeq_cache_root_env(self, tmp_path, monkeypatch):
+        """Fix A (#2419): QUODEQ_CACHE_ROOT overrides the default cache root in
+        the generated MCP config so the subprocess uses the same sandbox path."""
+        monkeypatch.setenv("QUODEQ_CACHE_ROOT", str(tmp_path))
+        jsonl = tmp_path / "findings.jsonl"
+        jsonl.touch()
+        config_path = _create_mcp_config(jsonl)
+        try:
+            data = json.loads(config_path.read_text())
+            args = data["mcpServers"]["findings"]["args"]
+            cr_idx = args.index("--cache-root")
+            assert Path(args[cr_idx + 1]) == tmp_path / "results"
         finally:
             config_path.unlink(missing_ok=True)
 

--- a/tests/analysis/test_prompt_builder_logging.py
+++ b/tests/analysis/test_prompt_builder_logging.py
@@ -1,0 +1,62 @@
+"""Tests for builder.py — _load_evaluation_rules logs on template load failure."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.analysis.prompts.builder import _load_evaluation_rules
+
+
+def _enable_propagation():
+    logger = logging.getLogger("quodeq")
+    original = logger.propagate
+    logger.propagate = True
+    return logger, original
+
+
+class TestLoadEvaluationRulesLogging:
+    def test_oserror_loading_template_logs_warning(self, caplog):
+        """#157 — OSError on template load must be logged before continuing."""
+
+        def _bad_load(template_name):
+            raise OSError(f"Cannot read {template_name}")
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch(
+                "quodeq.analysis.prompts.builder.load_template", side_effect=_bad_load
+            ):
+                with caplog.at_level(logging.WARNING, logger="quodeq.analysis.prompts.builder"):
+                    result = _load_evaluation_rules()
+        finally:
+            quodeq_logger.propagate = orig
+
+        # Result is empty (both templates failed) — safe fallback preserved
+        assert result == ""
+        assert "Failed to load prompt template" in caplog.text
+
+    def test_returns_content_when_one_template_loads(self, caplog):
+        """#157 — partial load still returns the available template content."""
+        call_count = [0]
+
+        def _partial_load(template_name):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise OSError("missing first file")
+            return "format rules"
+
+        quodeq_logger, orig = _enable_propagation()
+        try:
+            with patch(
+                "quodeq.analysis.prompts.builder.load_template", side_effect=_partial_load
+            ):
+                with caplog.at_level(logging.WARNING, logger="quodeq.analysis.prompts.builder"):
+                    result = _load_evaluation_rules()
+        finally:
+            quodeq_logger.propagate = orig
+
+        assert result == "format rules"
+        assert "Failed to load prompt template" in caplog.text

--- a/tests/analysis/test_prompt_provenance_gate.py
+++ b/tests/analysis/test_prompt_provenance_gate.py
@@ -1,0 +1,69 @@
+"""The critical-severity bar must require reachable input provenance.
+
+Run fa56db32 marked 4 of 6 'critical' findings as false positives: unguarded
+prop/arg dereferences (R-FT-2) and a path-from-string (S-AUT-3) where the value
+is provably internal (a hook default, a literal, a SHA-256 cache key). A finding
+is only `critical` when a bad/attacker-controlled value can actually reach the
+line. These tests guard the rubric text AND that it reaches the default
+per-dimension producer path (compass.md), which historically dropped the rubric
+because it had no {{EVALUATION_RULES}} placeholder.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt
+from quodeq.analysis.prompts._template import load_template
+
+RULES = Path("src/quodeq/data/prompts/evaluation_rules.md").read_text()
+COMPASS = Path("src/quodeq/data/prompts/compass.md").read_text()
+
+
+def test_rules_define_provenance_selfcheck():
+    """The self-check must add a provenance gate beyond the test-file carve-out."""
+    lower = RULES.lower()
+    assert "provenance" in lower
+    assert "attacker-controlled" in lower
+    # The gate must name the escape hatch for provably-internal values.
+    assert "hardening gap" in lower
+
+
+def test_rules_show_internal_input_examples():
+    """Concrete internal-input examples anchor the gate for weaker local models."""
+    lower = RULES.lower()
+    # A content hash / SHA-256 key is the canonical non-attacker-controlled path.
+    assert "content hash" in lower or "sha-256" in lower
+    # A defaulted prop/arg is the canonical unguarded-access false positive.
+    assert "default" in lower
+
+
+def test_rules_keep_external_input_critical():
+    """The contrast example must keep genuinely external provenance critical."""
+    lower = RULES.lower()
+    # An HTTP request / query string is the canonical attacker-controlled source.
+    assert "request" in lower
+
+
+def test_compass_injects_evaluation_rules():
+    """compass.md (default per-dimension template) must carry the rubric slot.
+
+    Without the placeholder the rubric value is computed in builder.py and
+    silently dropped, so the default path scores severity with no guidance.
+    """
+    assert "{{EVALUATION_RULES}}" in COMPASS
+
+
+def test_compass_prompt_renders_provenance_gate_end_to_end():
+    """Building the default template must land the provenance gate in the output."""
+    template = load_template()  # defaults to compass.md
+    ctx = PromptContext(
+        language="python",
+        repo_name="test-repo",
+        date_str="2026-06-19",
+        dimension="security",
+        source_file_count=50,
+        dimensions_data={"applies": [{"id": "security"}], "excludes": []},
+    )
+    result = build_analysis_prompt(template, ctx).lower()
+    assert "provenance" in result
+    assert "attacker-controlled" in result

--- a/tests/analysis/test_prompt_vt_taxonomy.py
+++ b/tests/analysis/test_prompt_vt_taxonomy.py
@@ -1,0 +1,46 @@
+"""The CLI prompts must offer the optional 'vt' taxonomy parameter.
+
+Without the prompt instruction no MCP-path producer ever emits a taxonomy,
+so fresh runs score with taxonomy_used=False (free-text reason grouping).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SUBAGENT = Path("src/quodeq/data/prompts/cli_subagent_prompt.md").read_text()
+CONSOLIDATED = Path("src/quodeq/data/prompts/cli_consolidated_prompt.md").read_text()
+COMPASS = Path("src/quodeq/data/prompts/compass.md").read_text()
+
+
+def _optional_params_line(prompt: str) -> str:
+    return next(line for line in prompt.splitlines() if line.startswith("**Optional:**"))
+
+
+def _vt_field_line(prompt: str) -> str:
+    return next(line for line in prompt.splitlines() if line.startswith("- `vt`"))
+
+
+def test_subagent_prompt_offers_vt_param():
+    assert "`vt`" in _optional_params_line(SUBAGENT)
+
+
+def test_consolidated_prompt_offers_vt_param():
+    assert "`vt`" in _optional_params_line(CONSOLIDATED)
+
+
+def test_compass_prompt_offers_vt_param():
+    # compass.md is the default per-dimension analysis template, the
+    # most-exercised MCP/CLI producer path. Its report_finding field list
+    # must offer 'vt' too, or the default path never emits a taxonomy.
+    line = _vt_field_line(COMPASS)
+    assert "`vt`" in line
+
+
+def test_prompts_explain_stable_taxonomy_codes():
+    for prompt in (SUBAGENT, CONSOLIDATED):
+        line = _optional_params_line(prompt)
+        assert "taxonomy" in line.lower()
+        assert "code-injection" in line  # concrete example anchors the format
+    compass_line = _vt_field_line(COMPASS)
+    assert "taxonomy" in compass_line.lower()
+    assert "code-injection" in compass_line

--- a/tests/analysis/test_stream_counters_nondict.py
+++ b/tests/analysis/test_stream_counters_nondict.py
@@ -1,0 +1,59 @@
+"""#380 — extract_files_from_event / count_files_in_stream must not raise on non-dict JSON lines."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.analysis.stream.counters import count_files_in_stream, extract_files_from_event
+
+
+class TestExtractFilesFromEventNonDict:
+    """extract_files_from_event must tolerate any non-dict value without raising."""
+
+    @pytest.mark.parametrize("value", [42, "foo", [1, 2, 3], True, None])
+    def test_non_dict_returns_empty_set(self, value) -> None:
+        assert extract_files_from_event(value) == set()
+
+    def test_dict_still_extracts_files(self) -> None:
+        event = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/a/b.py"}},
+                ]
+            },
+        }
+        assert extract_files_from_event(event) == {"/a/b.py"}
+
+
+class TestCountFilesInStreamNonDict:
+    """count_files_in_stream must skip non-dict JSON lines and count correctly."""
+
+    def test_non_dict_lines_are_skipped(self, tmp_path: Path) -> None:
+        stream = tmp_path / "stream.json"
+        lines = [
+            json.dumps(42),
+            json.dumps("hello"),
+            json.dumps([1, 2, 3]),
+            json.dumps(True),
+            # A valid assistant event that reads one file
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": "/x/y.py"}},
+                    ]
+                },
+            }),
+        ]
+        stream.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = count_files_in_stream(stream)
+        assert result == {"/x/y.py"}
+
+    def test_all_non_dict_returns_empty(self, tmp_path: Path) -> None:
+        stream = tmp_path / "stream.json"
+        stream.write_text(json.dumps(99) + "\n" + json.dumps([]) + "\n", encoding="utf-8")
+        result = count_files_in_stream(stream)
+        assert result == set()

--- a/tests/analysis/test_stream_validation_nondict.py
+++ b/tests/analysis/test_stream_validation_nondict.py
@@ -1,0 +1,38 @@
+"""#176 — get_mcp_status must not raise when json.loads returns a non-dict."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+
+class TestGetMcpStatusNonDict:
+    def _write_stream(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "stream.json"
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_list_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, json.dumps([1, 2, 3]) + "\n")
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_string_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, '"just a string"\n')
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_null_payload_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, "null\n")
+        result = get_mcp_status(p)
+        assert result is None
+
+    def test_valid_dict_still_works(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        payload = {"mcp_servers": [{"name": "findings", "status": "ok"}]}
+        p = self._write_stream(tmp_path, json.dumps(payload) + "\n")
+        result = get_mcp_status(p)
+        assert result == "ok"

--- a/tests/analysis/test_subprocess_coverage.py
+++ b/tests/analysis/test_subprocess_coverage.py
@@ -313,6 +313,30 @@ class TestResolveProviderConfig:
             _, _, key = _resolve_provider_config(cfg)
         assert key == ""
 
+    def test_credential_registry_dispatches_registered_provider(self, monkeypatch):
+        """Fix C (#2291): a provider registered in _CREDENTIAL_LOADERS is
+        dispatched through the registry rather than via a hard-coded branch."""
+        from quodeq.analysis.subprocess import _CREDENTIAL_LOADERS
+        # Patch a fake provider into the registry for the duration of the test.
+        _CREDENTIAL_LOADERS["testprovider"] = lambda: "registry-key"
+        try:
+            provider = {"testprovider": {"type": "api", "model": "m", "api_base": "http://tp/v1"}}
+            cfg = AnalysisConfig(ai_cmd="testprovider", ai_model="m")
+            with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
+                _, _, key = _resolve_provider_config(cfg)
+            assert key == "registry-key"
+        finally:
+            _CREDENTIAL_LOADERS.pop("testprovider", None)
+
+    def test_unknown_provider_not_in_registry_returns_empty_key(self):
+        """Fix C: an unknown provider not in _CREDENTIAL_LOADERS falls through
+        to an empty key (existing behavior preserved)."""
+        provider = {"newprovider": {"type": "api", "model": "m", "api_base": "http://np/v1"}}
+        cfg = AnalysisConfig(ai_cmd="newprovider", ai_model="m")
+        with patch("quodeq.analysis.subprocess.get_provider_configs", return_value=provider):
+            _, _, key = _resolve_provider_config(cfg)
+        assert key == ""
+
 
 # ---------------------------------------------------------------------------
 # run_analysis dispatch

--- a/tests/api/test_cluster4_index_error.py
+++ b/tests/api/test_cluster4_index_error.py
@@ -1,0 +1,38 @@
+"""Finding #523 — /api/index/rebuild must return structured JSON 500 on failure.
+
+When provider.rebuild_index() raises, the route previously let the exception
+propagate as a plain 500. After the fix it must return
+{"error": ..., "code": "INTERNAL_ERROR"} with status 500.
+"""
+from __future__ import annotations
+
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path / "reports"))
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(tmp_path / "idx.db"))
+    broken_provider = MagicMock()
+    broken_provider.rebuild_index.side_effect = RuntimeError("index exploded")
+    # Pass provider directly so create_app stores it in app.config["_provider"];
+    # passing via test_config is overwritten by the provider= assignment in app.py.
+    app = create_app(provider=broken_provider, test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_rebuild_index_returns_json_500_on_unexpected_error(client):
+    """rebuild_index() raising must yield a structured JSON 500, not a bare exception."""
+    resp = client.post("/api/index/rebuild", headers={"Origin": "http://localhost"})
+
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    data = resp.get_json()
+    assert data is not None, "Response body must be JSON"
+    assert "error" in data
+    assert "code" in data

--- a/tests/api/test_cluster4_scores_error.py
+++ b/tests/api/test_cluster4_scores_error.py
@@ -1,0 +1,34 @@
+"""Finding #441 — /api/projects/<project>/scores route must return structured JSON 500.
+
+When get_project_scores raises an unexpected exception the route previously
+propagated it as a plain 500 with no JSON body. After the fix it must return
+{"error": ..., "code": "INTERNAL_ERROR"} with status 500.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.api.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path / "reports"))
+    app = create_app(test_config={"TESTING": True})
+    with app.test_client() as c:
+        yield c
+
+
+def test_project_scores_returns_json_500_on_unexpected_error(client, monkeypatch):
+    """get_project_scores raising must yield a structured JSON 500, not a bare exception."""
+    import quodeq.api._scores_routes as scores_mod
+
+    monkeypatch.setattr(scores_mod, "get_project_scores", lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("db exploded")))
+
+    resp = client.get("/api/projects/myproject/scores")
+
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data is not None, "Response body must be JSON"
+    assert "error" in data
+    assert "code" in data

--- a/tests/api/test_cluster6_projection_offthread.py
+++ b/tests/api/test_cluster6_projection_offthread.py
@@ -1,0 +1,127 @@
+"""#1389 - _project_all_runs must run off the request thread with dedup lock.
+
+Two concurrent POST /api/findings/dismiss calls for the same project (without
+a usable run_id) must NOT run two concurrent projections. The per-project
+non-blocking lock ensures the second caller skips if one is already running.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+from flask import Flask
+
+from quodeq.api.routes_findings import register_findings_routes, _projection_locks
+
+
+@pytest.fixture()
+def app(tmp_path):
+    a = Flask(__name__)
+    a.config["TESTING"] = True
+    a.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_findings_routes(a)
+    return a
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_dismiss_returns_without_waiting_for_projection(client, tmp_path):
+    """POST /dismiss returns 200 without blocking on _project_all_runs."""
+    (tmp_path / "my-project").mkdir()
+
+    projection_started = threading.Event()
+    projection_may_finish = threading.Event()
+
+    def _slow_project(project_dir):
+        projection_started.set()
+        projection_may_finish.wait(timeout=5)
+
+    with patch(
+        "quodeq.api.routes_findings._project_all_runs",
+        side_effect=_slow_project,
+    ):
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-1",
+            "file": "foo.py",
+            "line": 1,
+        })
+
+    # Response must arrive before the projection finishes.
+    assert resp.status_code == 200
+
+    # Unblock background thread.
+    projection_may_finish.set()
+
+    # Confirm the thread was actually launched.
+    assert projection_started.wait(timeout=2), (
+        "Background projection thread never started."
+    )
+
+
+def test_concurrent_dismisses_same_project_call_project_all_runs_once(
+    tmp_path,
+):
+    """Two simultaneous dismiss POSTs for the same project run projection once.
+
+    The per-project non-blocking lock causes the second background thread to
+    skip projection when the first is still running.
+    """
+    # Clear any leftover lock state from previous tests.
+    _projection_locks.clear()
+
+    (tmp_path / "proj").mkdir()
+
+    a = Flask(__name__)
+    a.config["TESTING"] = True
+    a.config["EVALUATIONS_DIR"] = str(tmp_path)
+    register_findings_routes(a)
+    client = a.test_client()
+
+    call_count = 0
+    projection_first_started = threading.Event()
+    projection_first_may_finish = threading.Event()
+
+    def _blocking_project(project_dir):
+        nonlocal call_count
+        call_count += 1
+        projection_first_started.set()
+        # Hold the lock while the second request fires.
+        projection_first_may_finish.wait(timeout=5)
+
+    with patch(
+        "quodeq.api.routes_findings._project_all_runs",
+        side_effect=_blocking_project,
+    ):
+        # Fire first request and wait until projection has started (lock held).
+        r1 = client.post("/api/findings/dismiss", json={
+            "project": "proj", "req": "R1", "file": "a.py", "line": 1,
+        })
+        assert projection_first_started.wait(timeout=2), (
+            "First projection never started."
+        )
+
+        # Fire second request while first projection holds the lock.
+        r2 = client.post("/api/findings/dismiss", json={
+            "project": "proj", "req": "R2", "file": "b.py", "line": 2,
+        })
+
+        # Allow first projection to finish.
+        projection_first_may_finish.set()
+
+        # Give background threads a moment to settle.
+        time.sleep(0.1)
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+    assert call_count == 1, (
+        f"Expected _project_all_runs to be called exactly once for the same "
+        f"project (second caller should skip via non-blocking acquire), "
+        f"but it was called {call_count} time(s)."
+    )

--- a/tests/api/test_cluster6_rate_limit_dead_keys.py
+++ b/tests/api/test_cluster6_rate_limit_dead_keys.py
@@ -1,0 +1,112 @@
+"""#1458 - rate-limit store must not accumulate dead (empty) IP keys.
+
+The fix: after pruning per-IP timestamps, if the list is empty the key is
+removed with data.pop(ip) rather than stored as data[ip] = [].
+
+In the current implementation record() appends the new timestamp before
+pruning, so the pruned list is never empty in normal operation (now is
+always within the window of itself). The guard is still correct to have:
+it prevents the edge-case where a clock going backwards or a caller
+deliberately passing a very-old ``now`` could store an empty list.
+
+The main behavioural assertion is: old timestamps are pruned on each record
+call, and the surviving list contains exactly the timestamps within the window.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quodeq.api._rate_limit_file_store import FileRateLimitStore
+
+
+def _read_data(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_old_timestamps_pruned_on_same_ip_record(tmp_path: Path):
+    """When the same IP records again after its window expires, old timestamps
+    are pruned and the key contains only the new timestamp.
+    """
+    store_path = tmp_path / "rl.json"
+    store = FileRateLimitStore(path=store_path, window=60.0)
+
+    store.record("10.0.0.1", now=0.0)
+    assert _read_data(store_path)["10.0.0.1"] == [0.0]
+
+    # Same IP at t=120 — the t=0 entry is 120s old, past the 60s window.
+    store.record("10.0.0.1", now=120.0)
+    data = _read_data(store_path)
+    assert "10.0.0.1" in data
+    assert data["10.0.0.1"] == [120.0], (
+        "Expired timestamp at t=0 must be pruned; only t=120 survives."
+    )
+
+
+def test_no_empty_list_stored_when_all_prior_timestamps_expire(tmp_path: Path):
+    """If all stored timestamps for an IP expire and a new one is added,
+    the list must not be empty — exactly the new timestamp is stored.
+    This guards against the bug where data[ip] = [] was written.
+    """
+    store_path = tmp_path / "rl.json"
+    store = FileRateLimitStore(path=store_path, window=10.0)
+
+    # Record several timestamps.
+    for t in [0.0, 1.0, 2.0]:
+        store.record("192.168.1.1", now=t)
+
+    assert len(_read_data(store_path)["192.168.1.1"]) == 3
+
+    # Record at t=10000 — all prior entries are far outside the window.
+    store.record("192.168.1.1", now=10000.0)
+    data = _read_data(store_path)
+
+    assert "192.168.1.1" in data
+    timestamps = data["192.168.1.1"]
+    assert len(timestamps) == 1, (
+        f"Expected exactly one timestamp (the new one), got {timestamps}."
+    )
+    assert timestamps[0] == 10000.0
+
+
+def test_active_timestamps_all_retained_within_window(tmp_path: Path):
+    """Multiple records within the window are all kept."""
+    store_path = tmp_path / "rl.json"
+    store = FileRateLimitStore(path=store_path, window=300.0)
+
+    store.record("1.2.3.4", now=100.0)
+    store.record("1.2.3.4", now=150.0)
+    store.record("1.2.3.4", now=200.0)
+
+    data = _read_data(store_path)
+    assert data["1.2.3.4"] == [100.0, 150.0, 200.0]
+
+
+def test_ip_key_removed_when_pop_branch_taken(tmp_path: Path):
+    """data.pop(ip) is taken when pruned is empty (guarding against clock edge-cases).
+
+    We simulate this by planting a stale entry directly in the file and
+    verifying the pop path: plant ip=[stale], call record() for that ip at
+    a time far in the future. The new 'now' is added then pruned — since now
+    is within the window of itself, the list is [now], not empty.
+    The pop() branch is actually unreachable in normal use because append(now)
+    ensures pruned is never empty. This test confirms the normal path: no
+    empty list is ever written.
+    """
+    store_path = tmp_path / "rl.json"
+    # Plant a stale entry manually.
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps({"ghost": [0.0]}), encoding="utf-8")
+
+    store = FileRateLimitStore(path=store_path, window=60.0)
+    # Record at t=1000 — ghost's old entry expires, but new one survives.
+    store.record("ghost", now=1000.0)
+
+    data = _read_data(store_path)
+    assert "ghost" in data
+    assert data["ghost"] == [1000.0], "Only the new in-window timestamp must survive."
+    # No empty lists anywhere.
+    for ip, ts in data.items():
+        assert ts, f"IP {ip!r} has an empty timestamp list — fix must remove such keys."

--- a/tests/api/test_cluster6_score_offthread.py
+++ b/tests/api/test_cluster6_score_offthread.py
@@ -1,0 +1,215 @@
+"""#1404 - _score_completed_evidence must run off the request thread.
+
+The GET /api/evaluations/<id> handler should return immediately when a
+job is failed/cancelled, without waiting for the (potentially slow) scoring
+I/O to complete.
+"""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.api._evaluation_routes import (
+    _claim_scoring,
+    _scored_jobs,
+    _scored_jobs_lock,
+    _SCORED_JOBS_MAX,
+)
+from quodeq.services.base import ActionProvider, EvaluationOptions
+from quodeq.services._job_model import JobSnapshot
+
+
+@pytest.fixture(autouse=True)
+def _disable_auth(monkeypatch):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+
+
+@pytest.fixture()
+def reports_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+    yield tmp_path
+
+
+class _FailedJobProvider(ActionProvider):
+    """Minimal provider returning a single 'failed' job."""
+
+    def list_projects(self, reports_dir):
+        return {"projects": []}
+
+    def get_project_info(self, reports_dir, project):
+        return {}
+
+    def get_dashboard(self, reports_dir, project, run):
+        return {}
+
+    def get_accumulated(self, reports_dir, project, as_of):
+        return {"summary": {"dimensionCount": 0}}
+
+    def get_dimension_eval(self, reports_dir, project, run_id, dimension):
+        return {}
+
+    def get_run_plan(self, reports_dir, project, run_id):
+        return {}
+
+    def get_violations(self, reports_dir, project, run_id):
+        return {"total": 0, "critical": 0, "major": 0, "minor": 0, "files": []}
+
+    def start_evaluation(self, repo, reports_dir, options):
+        return {"jobId": "j1", "status": "failed", "logs": []}
+
+    def get_evaluation_status(self, job_id, reports_dir=None):
+        if job_id != "j1":
+            return None
+        return JobSnapshot(
+            job_id="j1",
+            status="failed",
+            logs=[],
+            output_project="proj",
+            output_run_id="run-1",
+        )
+
+    def cancel_evaluation(self, job_id, reports_dir=None, *, discard_partial=False):
+        return False
+
+    def list_evaluations(self, *, limit=0, reports_dir=None, states=None):
+        return []
+
+    def delete_project(self, reports_dir, project):
+        return False
+
+    def browse_repo(self, path=None):
+        return {"current": "/", "parent": None, "directories": [], "isGitRepo": False}
+
+    def get_ai_clients(self):
+        return {"clients": []}
+
+    def get_client_models(self, client_id):
+        return {"models": []}
+
+
+@pytest.fixture()
+def client(reports_root):
+    return create_app(_FailedJobProvider()).test_client()
+
+
+def test_get_evaluation_returns_before_scoring_completes(client):
+    """GET returns 200 without waiting for _score_completed_evidence to finish."""
+    scoring_started = threading.Event()
+    scoring_may_finish = threading.Event()
+
+    def _slow_score(reports_dir, args):
+        scoring_started.set()
+        # Block until the test releases it — if the handler waited for this
+        # the test would deadlock.
+        scoring_may_finish.wait(timeout=5)
+
+    with patch(
+        "quodeq.api._evaluation_routes._score_completed_evidence",
+        side_effect=_slow_score,
+    ):
+        resp = client.get("/api/evaluations/j1")
+
+    # Response must have arrived before (or independently of) scoring finishing.
+    assert resp.status_code == 200
+
+    # Unblock the background thread so the test process can exit cleanly.
+    scoring_may_finish.set()
+
+    # Wait briefly for the thread to actually start, confirming it was launched.
+    assert scoring_started.wait(timeout=2), (
+        "Background scoring thread never started — check that the thread is "
+        "actually launched in the handler."
+    )
+
+
+def test_get_evaluation_scores_only_once_for_same_job(client):
+    """_score_completed_evidence is called at most once per job_id."""
+    call_count = 0
+
+    def _count_score(reports_dir, args):
+        nonlocal call_count
+        call_count += 1
+
+    with patch(
+        "quodeq.api._evaluation_routes._score_completed_evidence",
+        side_effect=_count_score,
+    ):
+        client.get("/api/evaluations/j1")
+        client.get("/api/evaluations/j1")
+        # Give background threads time to finish.
+        import time; time.sleep(0.1)
+
+    assert call_count == 1, (
+        f"Expected scoring to run exactly once (dedup via _scored_jobs), "
+        f"got {call_count} calls."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _claim_scoring (race-closure + bounded-registry guarantees)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_claim_registry():
+    """Ensure each test starts with a clean _scored_jobs registry."""
+    with _scored_jobs_lock:
+        _scored_jobs.clear()
+    yield
+    with _scored_jobs_lock:
+        _scored_jobs.clear()
+
+
+def test_claim_scoring_exactly_once_under_concurrency():
+    """_claim_scoring returns True exactly once when N threads race on the same job_id.
+
+    A threading.Barrier lines all N threads up so they enter _claim_scoring as
+    simultaneously as possible, maximising the chance of exposing a race.
+    Only one thread should win the claim; all others must get False.
+    """
+    n_threads = 10
+    job_id = "race-job-concurrent"
+    barrier = threading.Barrier(n_threads)
+    results: list[bool] = []
+    results_lock = threading.Lock()
+
+    def _try_claim():
+        barrier.wait()  # synchronize all threads to the same starting line
+        claimed = _claim_scoring(job_id)
+        with results_lock:
+            results.append(claimed)
+
+    threads = [threading.Thread(target=_try_claim) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert len(results) == n_threads, "Not all threads reported a result"
+    true_count = sum(1 for r in results if r)
+    assert true_count == 1, (
+        f"Expected exactly 1 thread to win the claim, got {true_count}. "
+        "TOCTOU race is still present."
+    )
+
+
+def test_claim_scoring_registry_bounded():
+    """Registry never exceeds _SCORED_JOBS_MAX entries.
+
+    Claims more than _SCORED_JOBS_MAX distinct job_ids and verifies that
+    the registry size stays at or below the cap (oldest entries are evicted).
+    """
+    overflow = _SCORED_JOBS_MAX + 50
+    for i in range(overflow):
+        _claim_scoring(f"bounded-job-{i}")
+
+    with _scored_jobs_lock:
+        size = len(_scored_jobs)
+
+    assert size <= _SCORED_JOBS_MAX, (
+        f"Registry grew to {size}, exceeding the cap of {_SCORED_JOBS_MAX}. "
+        "Memory leak is still present."
+    )

--- a/tests/api/test_csp_header.py
+++ b/tests/api/test_csp_header.py
@@ -1,0 +1,84 @@
+"""CSP header hardening regression tests (held security fix #40)."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.api.app import create_app
+
+# Alt-port origins probed by useServerHealth.js (DEFAULT_ALT_PORTS = [4180..4183]).
+_ALT_PORT_ORIGINS = [
+    f"http://127.0.0.1:{p}" for p in (4180, 4181, 4182, 4183)
+] + [
+    f"http://localhost:{p}" for p in (4180, 4181, 4182, 4183)
+]
+
+
+@pytest.fixture(scope="module")
+def csp():
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.get("/api/health")
+        return resp.headers["Content-Security-Policy"]
+
+
+def _directive(csp: str, name: str) -> str | None:
+    """Return the first CSP directive whose keyword exactly equals *name*."""
+    for d in csp.split(";"):
+        parts = d.strip().split()
+        if parts and parts[0] == name:
+            return d.strip()
+    return None
+
+
+def test_csp_restricts_egress(csp):
+    """CSP must cap exfiltration of the API key stored in localStorage."""
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp   # keep existing
+
+
+def test_csp_no_unsafe_eval_or_inline_scripts(csp):
+    """script-src must not permit unsafe-inline or unsafe-eval (defeats XSS protection)."""
+    # These would open the door to XSS-based exfil
+    assert "'unsafe-eval'" not in csp
+
+    # script-src must not carry unsafe-inline (style-src may, for React).
+    # Match by exact directive keyword to avoid accidentally matching script-src-elem.
+    script_src = _directive(csp, "script-src")
+    assert script_src is not None, "script-src must be present in CSP"
+    assert "'unsafe-inline'" not in script_src, "script-src must not contain 'unsafe-inline'"
+    assert "'unsafe-eval'" not in script_src, "script-src must not contain 'unsafe-eval'"
+
+
+def test_csp_allows_google_fonts(csp):
+    """CSP must allow Google Fonts (used by the dashboard) to avoid breaking the UI."""
+    assert "fonts.googleapis.com" in csp
+    assert "fonts.gstatic.com" in csp
+
+
+def test_csp_connect_src_includes_alt_port_origins(csp):
+    """connect-src must list the alt-port loopback origins probed by useServerHealth.js.
+
+    DEFAULT_ALT_PORTS = [4180, 4181, 4182, 4183] in useServerHealth.js.
+    The hook calls fetch(`${baseUrl}:${port}/api/health`) where baseUrl
+    defaults to http://127.0.0.1, so each probe is a cross-origin request
+    that requires an explicit connect-src entry.
+    """
+    connect_src = _directive(csp, "connect-src")
+    assert connect_src is not None, "connect-src must be present in CSP"
+    assert "'self'" in connect_src, "connect-src must keep 'self'"
+    for origin in _ALT_PORT_ORIGINS:
+        assert origin in connect_src, (
+            f"connect-src must include alt-port origin {origin!r} "
+            f"(probed by useServerHealth.js)"
+        )
+
+
+def test_csp_mask_src_allows_data_uris(csp):
+    """mask-src must allow data: URIs for inline SVG mask icons (evaluation.css).
+
+    Without mask-src the directive falls back to default-src 'self', which
+    blocks data: URIs and breaks the folder icon in the evaluation view.
+    """
+    mask_src = _directive(csp, "mask-src")
+    assert mask_src is not None, "mask-src must be present in CSP"
+    assert "data:" in mask_src, "mask-src must include data: to allow inline SVG masks"

--- a/tests/api/test_cwe_cache_lock.py
+++ b/tests/api/test_cwe_cache_lock.py
@@ -1,0 +1,77 @@
+"""Test that concurrent CWE cache expiry triggers exactly ONE reload (finding #235)."""
+from __future__ import annotations
+
+import threading
+import time as _time
+
+import pytest
+
+import quodeq.api.standards_read_routes as _mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _mod.reset_cwe_cache()
+    yield
+    _mod.reset_cwe_cache()
+
+
+def test_reload_cwe_if_needed_exists():
+    """_reload_cwe_if_needed must exist as the synchronized reload helper."""
+    assert callable(_mod._reload_cwe_if_needed)
+
+
+def test_concurrent_expiry_reloads_exactly_once():
+    """Two threads racing at cache expiry must trigger exactly one loader call.
+
+    Strategy: force cache expiry, then release both threads simultaneously
+    using an event so both see the stale cache and race to reload.
+    The lock inside _reload_cwe_if_needed must ensure only one reload happens.
+    """
+    call_count = 0
+    # Slow down the loader so the second thread genuinely races.
+    slow_start = threading.Event()
+    load_started = threading.Event()
+
+    def _loader():
+        nonlocal call_count
+        load_started.set()        # signal that loading has begun
+        slow_start.wait(timeout=5)  # wait for test harness to let it proceed
+        call_count += 1
+        return [{"id": "CWE-79", "name": "XSS"}]
+
+    # Force expiry.
+    _mod._cwe_cache = None
+    _mod._cwe_cache_time = 0.0
+
+    results = []
+    errors = []
+
+    start_gate = threading.Barrier(3)  # main + 2 worker threads
+
+    def _thread():
+        try:
+            start_gate.wait(timeout=5)  # all three release together
+            result = _mod._reload_cwe_if_needed(_loader)
+            results.append(result)
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=_thread)
+    t2 = threading.Thread(target=_thread)
+    t1.start()
+    t2.start()
+
+    # Release all three (main + 2 workers) simultaneously.
+    start_gate.wait(timeout=5)
+    # Let the loader proceed after threads are racing.
+    slow_start.set()
+
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert call_count == 1, f"Expected exactly 1 reload, got {call_count}"
+    assert len(results) == 2
+    # Both threads must see the same cached result.
+    assert results[0] == results[1] == [{"id": "CWE-79", "name": "XSS"}]

--- a/tests/api/test_index_routes.py
+++ b/tests/api/test_index_routes.py
@@ -26,6 +26,23 @@ def test_rebuild_endpoint_registered(monkeypatch, tmp_path) -> None:
     assert "/api/index/rebuild" in rules
 
 
+def test_rebuild_no_provider_returns_503_with_code(monkeypatch, tmp_path) -> None:
+    """When no provider is configured the endpoint returns 503 PROVIDER_UNAVAILABLE."""
+    from quodeq.api._index_routes import register_index_routes
+    from flask import Flask
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    # Deliberately do NOT set _provider — simulates missing provider.
+    register_index_routes(app)
+    client = app.test_client()
+    resp = client.post("/api/index/rebuild", headers={"Origin": "http://localhost"})
+    assert resp.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    data = resp.get_json()
+    assert data["code"] == "PROVIDER_UNAVAILABLE"
+    assert "error" in data
+
+
 def test_rebuild_returns_count_and_elapsed(monkeypatch, tmp_path) -> None:
     from quodeq.api.app import create_app
     reports = tmp_path / "reports"

--- a/tests/api/test_llamacpp_log_routes.py
+++ b/tests/api/test_llamacpp_log_routes.py
@@ -65,6 +65,27 @@ class TestAvailability:
         assert resp.get_json() == {"available": True}
 
 
+class TestLlamacppLogPathEnvOverride:
+    def test_env_override_is_honoured_over_os_environ(self, tmp_path, monkeypatch):
+        """_env_override takes precedence over os.environ LLAMACPP_LOG_FILE."""
+        from quodeq.api._llamacpp_log_routes import _llamacpp_log_path
+
+        # Point os.environ at a non-existent path to confirm it is NOT used.
+        monkeypatch.setenv("LLAMACPP_LOG_FILE", str(tmp_path / "env-file.log"))
+        injected = str(tmp_path / "injected.log")
+        result = _llamacpp_log_path(_env_override=injected)
+        assert result == tmp_path / "injected.log"
+
+    def test_default_falls_back_to_os_environ_when_no_override(self, monkeypatch, tmp_path):
+        """Without _env_override, os.environ is consulted as before."""
+        from quodeq.api._llamacpp_log_routes import _llamacpp_log_path
+
+        log = tmp_path / "via-env.log"
+        monkeypatch.setenv("LLAMACPP_LOG_FILE", str(log))
+        result = _llamacpp_log_path()
+        assert result == log
+
+
 class TestStream:
     def test_unconfigured_returns_404(self, client, isolated_defaults):
         resp = client.get("/api/llamacpp/logs/stream")

--- a/tests/api/test_llm_bridge_routes.py
+++ b/tests/api/test_llm_bridge_routes.py
@@ -96,3 +96,55 @@ class TestKnownModels:
         assert resp.status_code == 200
         data = resp.get_json()
         assert "claude" in data
+
+
+# ---------------------------------------------------------------------------
+# #335 — estimate-agents must return 400 when model_size/gpu_memory are
+#         non-numeric (e.g. strings from a crafted JSON body)
+# ---------------------------------------------------------------------------
+
+class TestEstimateAgentsValidation:
+    def test_string_model_size_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": "big", "gpu_memory": 32},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_string_gpu_memory_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": 7, "gpu_memory": "all"},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_null_model_size_returns_400(self, client):
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": None, "gpu_memory": 32},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+
+    def test_valid_numeric_inputs_pass_through(self, client):
+        with patch("quodeq.api.llm_bridge_routes.estimate_max_agents") as mock:
+            mock.return_value = {"agents": 3}
+            resp = client.post(
+                "/api/ollama/estimate-agents",
+                json={"model_size": 7, "gpu_memory": 32},
+                headers={"Origin": "http://localhost"},
+            )
+        assert resp.status_code == 200
+        mock.assert_called_once_with(model_size=7, gpu_memory=32)
+
+    def test_bool_model_size_returns_400(self, client):
+        # bool is a subclass of int in Python; must be rejected explicitly.
+        resp = client.post(
+            "/api/ollama/estimate-agents",
+            json={"model_size": True, "gpu_memory": 32000000000},
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "INVALID_PARAM"

--- a/tests/api/test_project_import.py
+++ b/tests/api/test_project_import.py
@@ -432,3 +432,60 @@ def test_import_export_roundtrip(app_client):
         resp = _post_zip(c, zip_bytes)
     assert resp.status_code == 200, resp.get_json()
     assert (eval_dir / src_uuid / "scan.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# #2494 — _update_index must use an injected repository when provided
+# ---------------------------------------------------------------------------
+
+class TestUpdateIndexDI:
+    """_update_index must delegate to the injected ProjectRepository when given."""
+
+    def test_injected_repository_is_used_not_filesystem(self, tmp_path):
+        """When a repository is injected, load_index/save_index on it are called
+        instead of the default _load_index/_save_index filesystem helpers."""
+        from pathlib import Path
+        from quodeq.api.import_project import _update_index
+        from quodeq.data.fs._models import ProjectIdentity
+        from quodeq.data.fs._resolution import _index_key
+
+        captured_loads: list = []
+        captured_saves: list = []
+
+        class SpyRepository:
+            def load_index(self, reports_dir: Path) -> dict[str, str]:
+                captured_loads.append(reports_dir)
+                return {}
+
+            def save_index(self, reports_dir: Path, index: dict[str, str]) -> None:
+                captured_saves.append((reports_dir, dict(index)))
+
+        identity = ProjectIdentity(project_name="myrepo", repo_path="/tmp/myrepo")
+        project_uuid = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+        spy = SpyRepository()
+
+        _update_index(tmp_path, identity, project_uuid, repository=spy)
+
+        assert len(captured_loads) == 1
+        assert captured_loads[0] == tmp_path
+        assert len(captured_saves) == 1
+        saved_dir, saved_index = captured_saves[0]
+        assert saved_dir == tmp_path
+        assert saved_index[_index_key(identity)] == project_uuid
+
+    def test_no_repository_uses_filesystem(self, tmp_path):
+        """Without a repository, _update_index writes to project_index.json on disk."""
+        import json
+        from quodeq.api.import_project import _update_index
+        from quodeq.data.fs._models import ProjectIdentity
+        from quodeq.data.fs._resolution import _index_key
+
+        identity = ProjectIdentity(project_name="testrepo", repo_path="/tmp/testrepo")
+        project_uuid = "11112222-3333-4444-5555-666677778888"
+
+        _update_index(tmp_path, identity, project_uuid)
+
+        index_file = tmp_path / "project_index.json"
+        assert index_file.exists()
+        data = json.loads(index_file.read_text())
+        assert data[_index_key(identity)] == project_uuid

--- a/tests/api/test_rate_limit_hardening.py
+++ b/tests/api/test_rate_limit_hardening.py
@@ -48,3 +48,23 @@ def test_validated_path_rejects_symlink(tmp_path: Path):
     link = tmp_path / "link.json"
     os.symlink(real, link)
     assert _validated_rate_limit_path(str(link)) == _DEFAULT_RATE_LIMIT_FILE
+
+
+# ---------------------------------------------------------------------------
+# #81 -- dead path-traversal validation: ".." check ran on resolved path
+# ---------------------------------------------------------------------------
+
+def test_validated_path_rejects_dotdot_in_raw_path(tmp_path: Path):
+    """A path containing '..' must fall back to default even if it resolves cleanly.
+
+    Before the fix, ``".." in resolved.parts`` ran on the already-resolved path
+    (where ``..`` has already been collapsed by ``Path.resolve()``), so inputs
+    like ``/tmp/foo/../bar`` were incorrectly accepted.
+    """
+    # Build a path that contains ".." lexically but resolves to a real location.
+    # /tmp/foo/../bar resolves to /tmp/bar, so resolved.parts has no "..".
+    # The pre-fix code accepts this; the fixed code must reject it.
+    raw = str(tmp_path / "subdir" / ".." / "rate_limits.json")
+    assert ".." in Path(raw).parts, "precondition: '..' must be in raw parts"
+    assert ".." not in Path(raw).resolve().parts, "precondition: resolve() removes '..'"
+    assert _validated_rate_limit_path(raw) == _DEFAULT_RATE_LIMIT_FILE

--- a/tests/api/test_rate_limit_hardening.py
+++ b/tests/api/test_rate_limit_hardening.py
@@ -1,0 +1,50 @@
+"""Hardening regression tests for the file rate-limit store (crit #94)."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from quodeq.api._rate_limit_file_store import FileRateLimitStore
+from quodeq.api._rate_limit_factory import _validated_rate_limit_path, _DEFAULT_RATE_LIMIT_FILE
+
+_skip_no_symlink = pytest.mark.skipif(
+    sys.platform == "win32", reason="symlink/POSIX-mode semantics differ on Windows"
+)
+
+
+@_skip_no_symlink
+def test_save_does_not_follow_symlink(tmp_path: Path):
+    sentinel = tmp_path / "victim.txt"
+    sentinel.write_text("DO NOT TRUNCATE", encoding="utf-8")
+    target = tmp_path / "quodeq_rate_limits.json"
+    os.symlink(sentinel, target)  # attacker plants a symlink at the predictable name
+
+    store = FileRateLimitStore(path=target)
+    store.record("1.2.3.4", 1000.0)
+
+    # The victim file the symlink pointed at is untouched ...
+    assert sentinel.read_text(encoding="utf-8") == "DO NOT TRUNCATE"
+    # ... and the target is now a real file holding our JSON, not a link.
+    assert not target.is_symlink()
+    assert "1.2.3.4" in json.loads(target.read_text(encoding="utf-8"))
+
+
+@_skip_no_symlink
+def test_save_writes_0600_permissions(tmp_path: Path):
+    target = tmp_path / "rl.json"
+    FileRateLimitStore(path=target).record("1.2.3.4", 1000.0)
+    assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+
+@_skip_no_symlink
+def test_validated_path_rejects_symlink(tmp_path: Path):
+    real = tmp_path / "real.json"
+    real.write_text("{}", encoding="utf-8")
+    link = tmp_path / "link.json"
+    os.symlink(real, link)
+    assert _validated_rate_limit_path(str(link)) == _DEFAULT_RATE_LIMIT_FILE

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -60,6 +60,13 @@ class TestDismissEndpoint:
         resp = client.post("/api/findings/dismiss", json={"project": "x"})
         assert resp.status_code == 400
 
+    def test_dismiss_missing_fields_returns_missing_param_code(self, client):
+        resp = client.post("/api/findings/dismiss", json={"project": "x"})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["code"] == "MISSING_PARAM"
+        assert "error" in data
+
     def test_dismiss_with_run_id_returns_rescored_payload(self, client, tmp_path):
         """When the client supplies ``run_id``, the dismiss response carries
         the rescored ``/scores`` payload for that run. The UI applies it
@@ -99,6 +106,14 @@ class TestDismissEndpoint:
 
 
 class TestRestoreEndpoint:
+    def test_restore_missing_fields_returns_missing_param_code(self, client):
+        resp = client.post("/api/findings/restore", json={"project": "x"})
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["code"] == "MISSING_PARAM"
+        assert "error" in data
+
+
     def test_restore_returns_200_with_scores_envelope(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
         project_dir.mkdir()

--- a/tests/api/test_routes_project_create.py
+++ b/tests/api/test_routes_project_create.py
@@ -92,6 +92,24 @@ def test_post_projects_url_ephemeral_skips_clone_dest(client, tmp_path):
     assert resp.status_code == 200, resp.get_json()
 
 
+def test_post_projects_rejects_metadata_endpoint_ssrf(client):
+    """SSRF: POST /api/projects pointed at a cloud metadata endpoint is rejected
+    with 400 and never reaches git clone."""
+    clone_calls = []
+    with patch(
+        "quodeq.services.evaluation_mixin.run_git_clone",
+        side_effect=lambda url, dest: clone_calls.append(url),
+    ):
+        resp = client.post(
+            "/api/projects",
+            json={"repo": "https://169.254.169.254/latest/meta-data", "ephemeral": True},
+            headers=_ORIGIN,
+        )
+    assert resp.status_code == 400, resp.get_json()
+    assert resp.get_json()["code"] == "INVALID_REPO"
+    assert clone_calls == [], "SSRF: git clone must never run for a metadata-endpoint URL"
+
+
 def test_post_projects_clone_dest_must_exist(client, tmp_path):
     nonexistent = tmp_path / "no-such-dir"
     resp = client.post(

--- a/tests/api/test_run_events_routes.py
+++ b/tests/api/test_run_events_routes.py
@@ -11,6 +11,8 @@ from flask import Flask
 from quodeq.api._run_events_routes import register_run_events_routes
 from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
 from quodeq.core.events.writer import EventLogWriter
+from quodeq.services._evaluations_index import EvaluationsIndex
+from quodeq.services.jobs import JobManager
 
 
 @pytest.fixture
@@ -90,3 +92,36 @@ def test_route_honors_last_event_id_header(app: Flask):
     assert len(finding_lines) == 1
     data = json.loads(next(l for l in finding_lines[0].splitlines() if l.startswith("data: "))[6:])
     assert data["practice_id"] == "P2"
+
+
+# ---------------------------------------------------------------------------
+# #14 -- path traversal via job_id in get_log_run_dir filesystem scan
+# ---------------------------------------------------------------------------
+
+def test_get_log_run_dir_rejects_traversal_in_run_id(tmp_path: Path):
+    """A job_id containing '..' must not resolve to a directory outside reports_root."""
+    reports_root = tmp_path / "reports"
+    reports_root.mkdir()
+    project_dir = reports_root / "my-project"
+    project_dir.mkdir()
+
+    # Create a directory *outside* reports_root that the traversal would escape to
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+
+    # Craft a run_id that, when appended to project_dir, traverses outside reports_root:
+    # project_dir / "../../outside" resolves to tmp_path / "outside"
+    traversal_job_id = "../../outside"
+
+    index = EvaluationsIndex(
+        jobs=JobManager(),
+        reports_root=reports_root,
+    )
+    result = index.get_log_run_dir(traversal_job_id)
+    # The result must not be outside reports_root (use resolve() for canonical comparison)
+    outside_resolved = outside_dir.resolve()
+    reports_resolved = reports_root.resolve()
+    assert result is None or (
+        result.resolve() != outside_resolved
+        and result.resolve().is_relative_to(reports_resolved)
+    )

--- a/tests/ci/test_evidence_reader.py
+++ b/tests/ci/test_evidence_reader.py
@@ -60,3 +60,33 @@ def test_skips_malformed_lines(tmp_path: Path) -> None:
     result = load_violations_from_evidence(evidence_dir)
     assert len(result) == 1
     assert result[0]["file"] == "x.py"
+
+
+# ---------------------------------------------------------------------------
+# #448 — int(line) must not raise ValueError on non-integer line values
+# ---------------------------------------------------------------------------
+
+def test_non_integer_line_value_is_skipped_gracefully(tmp_path: Path) -> None:
+    """A violation with a non-integer 'line' value must not crash the reader."""
+    evidence_dir = tmp_path / "evidence"
+    evidence_dir.mkdir()
+    rows = [
+        # non-integer line — should be dropped (None) or coerced gracefully
+        {"p": "SEC", "t": "violation", "d": "security", "file": "a.py", "line": "not-a-number"},
+        # valid row without 'line' — should survive
+        {"p": "SEC", "t": "violation", "d": "security", "file": "b.py"},
+        # valid row with integer line — should survive
+        {"p": "SEC", "t": "violation", "d": "security", "file": "c.py", "line": 5},
+    ]
+    import json as _json
+    (evidence_dir / "security_evidence.jsonl").write_text(
+        "\n".join(_json.dumps(r) for r in rows) + "\n"
+    )
+    result = load_violations_from_evidence(evidence_dir)
+    files = {v["file"] for v in result}
+    assert "c.py" in files
+    assert "b.py" in files
+    # The non-integer line row must not raise; it may be skipped or have no 'line' key
+    for v in result:
+        if v.get("file") == "a.py":
+            assert "line" not in v or isinstance(v["line"], int)

--- a/tests/config/test_fetch_client_coverage.py
+++ b/tests/config/test_fetch_client_coverage.py
@@ -75,6 +75,26 @@ class TestFetchValidation:
             assert result is None  # fails on network, not on validation
 
 
+class TestFetchClientConfigInjection:
+    def test_circuit_threshold_from_injected_env(self):
+        c = FetchClient(env={"QUODEQ_CIRCUIT_THRESHOLD": "3"})
+        assert c._CIRCUIT_THRESHOLD == 3
+
+    def test_max_retries_from_injected_env(self):
+        c = FetchClient(env={"QUODEQ_MAX_RETRIES": "5"})
+        assert c._MAX_RETRIES == 5
+
+    def test_retry_backoff_from_injected_env(self):
+        c = FetchClient(env={"QUODEQ_RETRY_BACKOFF_S": "1.5"})
+        assert c._RETRY_BACKOFF_S == 1.5
+
+    def test_defaults_when_keys_absent(self):
+        c = FetchClient(env={})
+        assert c._CIRCUIT_THRESHOLD == 5
+        assert c._MAX_RETRIES == 2
+        assert c._RETRY_BACKOFF_S == 0.5
+
+
 class TestFetchRetry:
     def test_successful_fetch(self):
         c = FetchClient(allow_private=True)

--- a/tests/core/test_finding_mappings.py
+++ b/tests/core/test_finding_mappings.py
@@ -60,6 +60,23 @@ class TestWireDictToJudgment:
         )
         assert j.confidence == 50
 
+    def test_violation_type_read_from_short_vt_key(self):
+        """Regression: the JSONL wire format carries the taxonomy as 'vt'
+        (see core/evidence/_jsonl.py); this reader must not silently drop it
+        on the event-log/SQLite path when only the short key is present."""
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "vt": "code-injection"}
+        )
+        assert j.violation_type == "code-injection"
+
+    def test_violation_type_read_from_long_key(self):
+        j = wire_dict_to_judgment(
+            {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+             "reason": "r", "violation_type": "code-injection"}
+        )
+        assert j.violation_type == "code-injection"
+
     def test_round_trip_via_judgment_dump(self):
         """wire_dict → Judgment → dump preserves the long-name fields."""
         d = {"p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,

--- a/tests/core/test_judgment_to_dict_taxonomy.py
+++ b/tests/core/test_judgment_to_dict_taxonomy.py
@@ -1,0 +1,37 @@
+"""Regression: judgment_to_dict must emit the 'vt' key the scorer groups by.
+
+The scoring tally (core/scoring/_tallies.py) detects the violation taxonomy
+via item.get("vt"). If judgment_to_dict only emits "violation_type", taxonomy
+grouping silently disables on the production parse->score path.
+"""
+from __future__ import annotations
+
+from quodeq.core.events.models import Judgment
+from quodeq.core.evidence._jsonl import judgment_to_dict
+from quodeq.core.scoring._tallies import evidence_has_taxonomy
+
+
+def _violation(vt: str | None) -> Judgment:
+    return Judgment(
+        practice_id="ts-001", verdict="violation", dimension="security",
+        file="src/app.ts", line=10, reason="eval is dangerous",
+        severity="critical", violation_type=vt,
+    )
+
+
+def test_judgment_to_dict_emits_vt_key():
+    d = judgment_to_dict(_violation("code-injection"))
+    assert d["vt"] == "code-injection"
+    # Keep the long key too: the UI/report read 'violation_type'.
+    assert d["violation_type"] == "code-injection"
+
+
+def test_scorer_detects_taxonomy_from_judgment_to_dict_output():
+    dicts = [judgment_to_dict(_violation("code-injection"))]
+    assert evidence_has_taxonomy(dicts) is True
+
+
+def test_no_vt_key_when_violation_type_absent():
+    d = judgment_to_dict(_violation(None))
+    assert "vt" not in d
+    assert "violation_type" not in d

--- a/tests/core/test_partial_taxonomy_coverage.py
+++ b/tests/core/test_partial_taxonomy_coverage.py
@@ -1,0 +1,77 @@
+"""Regression: partial taxonomy coverage must not drop untagged violations.
+
+A real quodeq self-scan scored the Modularity principle 9.7/Exemplary while it
+held 2 critical and 22 major violations. Root cause: the scoring tally enters
+"taxonomy mode" as soon as *any* one violation carries a ``vt`` tag
+(``evidence_has_taxonomy``), and ``tally_types_by_taxonomy`` then drops every
+violation lacking a ``vt`` (``_tally_types(..., skip_empty=True)``). With only 1
+of 80 violations tagged, 79 of them -- including both criticals -- vanished from
+the score.
+
+The intended behaviour: a ``vt`` tag is a per-finding grouping key, not a
+per-principle mode switch. A tagged finding groups by its ``vt``; an untagged
+finding falls back to grouping by ``reason``. Nothing is ever dropped, so the
+score is continuous across tag coverage (0 tags and 1 tag score the same; full
+coverage just groups more precisely).
+"""
+from __future__ import annotations
+
+from quodeq.core.scoring._principle import compute_tallies
+from quodeq.core.types.finding import Finding
+from quodeq.services.scoring.projector_scoring import compute_principle_grade
+
+
+def _v(severity: str, reason: str, vt: str | None = None) -> dict:
+    item = {"severity": severity, "reason": reason}
+    if vt:
+        item["vt"] = vt
+    return item
+
+
+def test_partial_taxonomy_keeps_untagged_violations_in_tally():
+    """One tagged minor must not erase two untagged criticals from the tally."""
+    violations = [
+        _v("minor", "function has too many parameters", vt="excessive-parameters"),
+        _v("critical", "incorrect function call signature"),
+        _v("critical", "syntax error in jsx closing tag"),
+        _v("major", "circular dependency between modules"),
+    ]
+
+    vt_counts, _compliance_counts, _used_taxonomy = compute_tallies(violations, [])
+
+    # The bug produced {'critical': 0, 'major': 0, 'minor': 1}: the lone tag
+    # flipped the principle into taxonomy mode and skip_empty dropped the rest.
+    assert vt_counts["critical"] == 2  # two distinct untagged criticals (by reason)
+    assert vt_counts["major"] == 1
+    assert vt_counts["minor"] == 1     # the one tagged minor (by vt)
+
+
+def _f(severity: str, reason: str, vt: str | None = None) -> Finding:
+    return Finding(
+        practice_id="Modularity", verdict="violation", file="a.py", line=1,
+        end_line=1, title="t", reason=reason, snippet="s", severity=severity,
+        cwe=None, req="R1", req_refs=[], context="", dimension="maintainability",
+        violation_type=vt, scope="", confidence=100,
+    )
+
+
+def test_partial_taxonomy_does_not_inflate_principle_grade():
+    """Reproduces the self-scan: 1 tagged minor + 2 critical + 22 major + 55 minor.
+
+    Before the fix this scored 9.7/Exemplary because the untagged criticals and
+    majors were dropped; with them counted it must be a low, non-Exemplary grade.
+    """
+    findings = (
+        [_f("minor", "too many parameters", vt="excessive-parameters")]
+        + [_f("critical", f"critical defect {i}") for i in range(2)]
+        + [_f("major", f"major defect {i}") for i in range(22)]
+        + [_f("minor", f"minor defect {i}") for i in range(55)]
+    )
+
+    result = compute_principle_grade(
+        principle_id="Modularity", findings=findings, compliance=[],
+    )
+
+    assert result["finding_count"] == 80
+    assert result["grade"] != "Exemplary"
+    assert result["score"] < 7.0

--- a/tests/dashboard/test_reload_url_guard.py
+++ b/tests/dashboard/test_reload_url_guard.py
@@ -1,0 +1,84 @@
+"""Tests for the reload URL guard that restricts webview navigation to localhost."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from quodeq.dashboard._webview_window import _is_safe_reload_url, _make_on_reload
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure guard function
+# ---------------------------------------------------------------------------
+
+class TestIsSafeReloadUrl:
+    def test_localhost_http_allowed(self):
+        assert _is_safe_reload_url("http://localhost:7863") is True
+
+    def test_localhost_https_allowed(self):
+        assert _is_safe_reload_url("https://localhost:7863") is True
+
+    def test_127_0_0_1_http_allowed(self):
+        assert _is_safe_reload_url("http://127.0.0.1:7863") is True
+
+    def test_127_0_0_1_https_allowed(self):
+        assert _is_safe_reload_url("https://127.0.0.1:7863") is True
+
+    def test_ipv6_loopback_allowed(self):
+        assert _is_safe_reload_url("http://[::1]:7863") is True
+
+    def test_localhost_with_path_allowed(self):
+        assert _is_safe_reload_url("http://localhost:7863/some/path") is True
+
+    def test_remote_host_rejected(self):
+        assert _is_safe_reload_url("http://evil.example.com/payload") is False
+
+    def test_file_scheme_rejected(self):
+        assert _is_safe_reload_url("file:///etc/passwd") is False
+
+    def test_javascript_scheme_rejected(self):
+        assert _is_safe_reload_url("javascript:alert(1)") is False
+
+    def test_empty_string_rejected(self):
+        assert _is_safe_reload_url("") is False
+
+    def test_localhost_lookalike_rejected(self):
+        # attacker-controlled domain that contains "localhost"
+        assert _is_safe_reload_url("http://evillocalhost.com/") is False
+
+    def test_127_0_0_1_lookalike_with_extra_octet_rejected(self):
+        assert _is_safe_reload_url("http://127.0.0.1.evil.com/") is False
+
+    def test_no_scheme_rejected(self):
+        assert _is_safe_reload_url("localhost:7863") is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: the _on_reload closure must use the guard
+# ---------------------------------------------------------------------------
+
+class TestOnReloadGuard:
+    """Verify that the live _on_reload wiring in main() uses the guard.
+
+    Uses the real ``_make_on_reload`` factory (same code path as ``main()``)
+    so that removing the guard call from ``main()`` would cause these tests
+    to fail.
+    """
+
+    def _make_handler(self) -> tuple["Callable[[str], None]", MagicMock]:
+        window = MagicMock()
+        return _make_on_reload(window), window
+
+    def test_safe_url_navigates(self):
+        on_reload, window = self._make_handler()
+        on_reload("http://127.0.0.1:7863")
+        window.load_url.assert_called_once_with("http://127.0.0.1:7863")
+
+    def test_unsafe_url_does_not_navigate(self):
+        on_reload, window = self._make_handler()
+        on_reload("http://evil.example.com/steal-tokens")
+        window.load_url.assert_not_called()
+
+    def test_file_url_does_not_navigate(self):
+        on_reload, window = self._make_handler()
+        on_reload("file:///etc/passwd")
+        window.load_url.assert_not_called()

--- a/tests/data/fs/report_parser/test_cluster6_evidence_sqlite_batch.py
+++ b/tests/data/fs/report_parser/test_cluster6_evidence_sqlite_batch.py
@@ -96,6 +96,30 @@ def test_load_evidence_map_empty_db_returns_empty(tmp_path: Path):
     assert result == {}
 
 
+def test_dismissed_verdict_excluded_from_counts(tmp_path: Path):
+    """#1487 faithfulness: dismissed findings must not inflate compliance_count.
+
+    The old code derived counts via ``len([j for j in judgments if j.verdict == "compliance"])``
+    so dismissed findings were never counted.  The batched grouping loop must
+    match that behaviour exactly.
+    """
+    repo = SqliteFindingsRepository(tmp_path)
+    _insert(repo, "P1", "security", "violation", line=1)
+    _insert(repo, "P1", "security", "compliance", line=2)
+    _insert(repo, "P1", "security", "dismissed", line=3)
+
+    result = load_evidence_map_from_db(tmp_path)
+
+    sec = result["security"]
+    assert sec["violation_count"] == 1, (
+        "violation_count should count only verdict='violation' findings"
+    )
+    assert sec["compliance_count"] == 1, (
+        "compliance_count must NOT include dismissed findings — got "
+        f"{sec['compliance_count']}, expected 1"
+    )
+
+
 def test_list_all_method_exists_on_repository(tmp_path: Path):
     """SqliteFindingsRepository exposes list_all()."""
     repo = SqliteFindingsRepository(tmp_path)

--- a/tests/data/fs/report_parser/test_cluster6_evidence_sqlite_batch.py
+++ b/tests/data/fs/report_parser/test_cluster6_evidence_sqlite_batch.py
@@ -1,0 +1,106 @@
+"""#1487 - load_evidence_map_from_db must use a single query (list_all).
+
+The previous implementation called count_by_dimension() + list_by_dimension()
+per dimension (N+1 pattern). The fix introduces list_all() and groups by
+dimension in Python.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+from quodeq.data.fs.report_parser._evidence_sqlite import load_evidence_map_from_db
+
+
+def _insert(repo, practice_id, dimension, verdict="violation", line=1):
+    repo.insert_finding({
+        "p": practice_id,
+        "d": dimension,
+        "file": "src/x.py",
+        "line": line,
+        "t": verdict,
+        "severity": "minor",
+        "reason": "test reason",
+        "snippet": "code here",
+        "w": "test",
+    })
+
+
+def test_load_evidence_map_groups_correctly_across_dimensions(tmp_path: Path):
+    """Findings in multiple dimensions are grouped correctly by list_all()."""
+    repo = SqliteFindingsRepository(tmp_path)
+    _insert(repo, "P1", "security", "violation", line=1)
+    _insert(repo, "P1", "security", "violation", line=2)
+    _insert(repo, "P2", "security", "compliance", line=3)
+    _insert(repo, "Q1", "maintainability", "violation", line=4)
+    _insert(repo, "Q1", "maintainability", "compliance", line=5)
+
+    result = load_evidence_map_from_db(tmp_path)
+
+    assert set(result.keys()) == {"security", "maintainability"}
+
+    sec = result["security"]
+    assert sec["violation_count"] == 2
+    assert sec["compliance_count"] == 1
+    assert "P1" in sec["principles"]
+    assert "P2" in sec["principles"]
+    assert len(sec["principles"]["P1"]["violations"]) == 2
+    assert len(sec["principles"]["P2"]["compliance"]) == 1
+
+    maint = result["maintainability"]
+    assert maint["violation_count"] == 1
+    assert maint["compliance_count"] == 1
+    assert "Q1" in maint["principles"]
+
+
+def test_load_evidence_map_uses_list_all_not_loop(tmp_path: Path):
+    """load_evidence_map_from_db calls list_all() (not list_by_dimension N+1)."""
+    repo = SqliteFindingsRepository(tmp_path)
+    _insert(repo, "P1", "security", line=1)
+    _insert(repo, "Q1", "reliability", line=2)
+
+    list_all_calls = []
+    list_by_dim_calls = []
+
+    original_list_all = SqliteFindingsRepository.list_all
+
+    def _spy_list_all(self):
+        list_all_calls.append(1)
+        return original_list_all(self)
+
+    def _spy_list_by_dim(self, dim):
+        list_by_dim_calls.append(dim)
+        return []
+
+    with (
+        patch.object(SqliteFindingsRepository, "list_all", _spy_list_all),
+        patch.object(SqliteFindingsRepository, "list_by_dimension", _spy_list_by_dim),
+    ):
+        result = load_evidence_map_from_db(tmp_path)
+
+    assert len(list_all_calls) == 1, (
+        "Expected exactly one list_all() call — the N+1 loop should be gone."
+    )
+    assert list_by_dim_calls == [], (
+        f"list_by_dimension should not be called from load_evidence_map_from_db, "
+        f"but was called with: {list_by_dim_calls}"
+    )
+
+
+def test_load_evidence_map_empty_db_returns_empty(tmp_path: Path):
+    """An empty database returns an empty dict without error."""
+    result = load_evidence_map_from_db(tmp_path)
+    assert result == {}
+
+
+def test_list_all_method_exists_on_repository(tmp_path: Path):
+    """SqliteFindingsRepository exposes list_all()."""
+    repo = SqliteFindingsRepository(tmp_path)
+    _insert(repo, "P1", "security", line=1)
+    findings = repo.list_all()
+    assert len(findings) == 1
+    assert findings[0].dimension == "security"
+    assert findings[0].practice_id == "P1"

--- a/tests/data/fs/test_repo_validation.py
+++ b/tests/data/fs/test_repo_validation.py
@@ -1,0 +1,47 @@
+"""Tests for the shared repo-URL SSRF validator (validate_remote_url)."""
+import pytest
+
+from quodeq.data.fs.repo_validation import validate_remote_url
+
+
+class TestValidateRemoteUrlSsh:
+    """git@host:path (scp-like) URLs must get the same private-host guard as
+    https URLs. git clone of these drives SSH to the host, so an internal
+    target is an SSRF/probe vector that must be rejected."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "git@127.0.0.1:user/repo.git",
+            "git@10.0.0.5:team/app.git",
+            "git@192.168.1.10:x/y.git",
+            "git@169.254.169.254:latest/meta.git",
+            "git@localhost:user/repo.git",
+        ],
+    )
+    def test_ssh_form_internal_host_rejected(self, url):
+        with pytest.raises(ValueError):
+            validate_remote_url(url)
+
+    def test_ssh_form_encoded_loopback_rejected(self):
+        # git's inet_aton reads 0177 as octal 127 -> dials 127.0.0.1 over SSH.
+        with pytest.raises(ValueError):
+            validate_remote_url("git@0177.0.0.1:user/repo.git")
+
+
+class TestValidateRemoteUrlHttps:
+    def test_https_loopback_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://127.0.0.1/x.git")
+
+    def test_https_link_local_metadata_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://169.254.169.254/latest/meta-data")
+
+    def test_https_octal_encoded_loopback_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("https://0177.0.0.1/repo.git")
+
+    def test_malformed_url_rejected(self):
+        with pytest.raises(ValueError):
+            validate_remote_url("not a url")

--- a/tests/data/fs/test_runs.py
+++ b/tests/data/fs/test_runs.py
@@ -1,6 +1,43 @@
 """Tests for list_runs() run discovery and status detection."""
+import json
 import os
 from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# #144 — _read_run_status must not raise when status.json parses to a non-dict
+# ---------------------------------------------------------------------------
+
+class TestReadRunStatusNonDict:
+    def _make_run(self, tmp_path: Path, run_id: str) -> Path:
+        run_dir = tmp_path / "proj" / run_id
+        (run_dir / "evidence").mkdir(parents=True)
+        (run_dir / "evidence" / "manifest.json").write_text("{}")
+        return run_dir
+
+    def test_list_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-list")
+        (run_dir / "status.json").write_text(json.dumps([1, 2, 3]))
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
+
+    def test_string_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-string")
+        (run_dir / "status.json").write_text('"cancelled"')
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
+
+    def test_null_payload_returns_complete(self, tmp_path: Path) -> None:
+        from quodeq.data.fs.report_parser.runs import list_runs
+        run_dir = self._make_run(tmp_path, "run-null")
+        (run_dir / "status.json").write_text("null")
+        runs = list_runs(tmp_path, "proj")
+        assert len(runs) == 1
+        assert runs[0].status == "complete"
 
 
 def test_list_runs_marks_in_progress_when_pid_is_live(tmp_path: Path) -> None:

--- a/tests/data/projection/test_engine_except_breadth.py
+++ b/tests/data/projection/test_engine_except_breadth.py
@@ -1,0 +1,60 @@
+"""Tests for engine.py — except breadth narrowing (#528).
+
+The handler's broad `except Exception` must be narrowed to
+`(ValueError, KeyError, TypeError)` so OS/SQLite errors surface instead of
+being silently logged and skipped.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.data.projection.engine import ProjectionEngine
+from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+from quodeq.core.events.writer import EventLogWriter
+
+
+def _write_one_event(log: Path) -> None:
+    writer = EventLogWriter(log)
+    writer.emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+        practice_id="P1", verdict="violation", dimension="Security",
+        file="f.py", line=1, reason="r",
+    )))
+
+
+class TestProjectionEngineExceptBreadth:
+    def test_value_error_in_handler_is_caught_and_logged(self, tmp_path: Path, caplog):
+        """ValueError from a handler is swallowed and the next event proceeds."""
+        import logging
+        log = tmp_path / "events.jsonl"
+        _write_one_event(log)
+        engine = ProjectionEngine()
+
+        with patch("quodeq.data.projection.engine.handle", side_effect=ValueError("bad value")):
+            import logging as _logging
+            qlog = _logging.getLogger("quodeq")
+            orig = qlog.propagate
+            qlog.propagate = True
+            try:
+                with caplog.at_level(logging.ERROR, logger="quodeq.data.projection.engine"):
+                    count = engine.rebuild(log, tmp_path)
+            finally:
+                qlog.propagate = orig
+
+        # Event was attempted but failed; count = 0 (skipped)
+        assert count == 0
+        assert "Handler failed" in caplog.text
+
+    def test_os_error_in_handler_propagates(self, tmp_path: Path):
+        """#528 — OSError must NOT be swallowed by the narrowed except clause."""
+        log = tmp_path / "events.jsonl"
+        _write_one_event(log)
+        engine = ProjectionEngine()
+
+        with patch(
+            "quodeq.data.projection.engine.handle", side_effect=OSError("disk gone")
+        ):
+            with pytest.raises(OSError, match="disk gone"):
+                engine.rebuild(log, tmp_path)

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -132,6 +132,17 @@ def test_write_does_not_trigger_ensure(tmp_path: Path):
     assert spy.ensure_calls == 0
 
 
+def test_ensure_projected_triggers_projection(tmp_path: Path):
+    """Public ensure_projected() delegates to _ensure_fresh / projection."""
+    _write_event(tmp_path / "events.jsonl")
+    spy = _SpyProjector()
+    repo = SqliteFindingsRepository(tmp_path, projector=spy)
+
+    repo.ensure_projected()
+
+    assert spy.ensure_calls == 1
+
+
 def test_read_skips_ensure_when_no_event_log(tmp_path: Path):
     spy = _SpyProjector()
     repo = SqliteFindingsRepository(tmp_path, projector=spy)

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -46,6 +46,22 @@ def test_finding_dict_to_row_handles_missing_optionals():
     assert row["dedup_key"] == "P1||0|compliance"
 
 
+def test_finding_dict_to_row_reads_violation_type_from_short_vt_key():
+    """Regression: the JSONL wire format carries the taxonomy as 'vt'
+    (see core/evidence/_jsonl.py); the row mapper must accept both keys."""
+    finding = {"p": "P1", "t": "violation", "severity": "medium",
+               "vt": "missed_deadline"}
+    row = finding_dict_to_row(finding)
+    assert row["violation_type"] == "missed_deadline"
+
+
+def test_finding_dict_to_row_reads_violation_type_from_long_key():
+    finding = {"p": "P1", "t": "violation", "severity": "medium",
+               "violation_type": "missed_deadline"}
+    row = finding_dict_to_row(finding)
+    assert row["violation_type"] == "missed_deadline"
+
+
 def test_row_to_finding_roundtrip():
     finding = {
         "p": "P1", "d": "dim", "req": "R1", "t": "violation", "severity": "medium",

--- a/tests/data/test_cluster4_engine_continue_on_error.py
+++ b/tests/data/test_cluster4_engine_continue_on_error.py
@@ -1,0 +1,107 @@
+"""Finding #355 — update_actions must continue past a failing handler.
+
+When one event's handle() call raises, update_actions previously let the
+exception bubble up and abort the loop. After the fix the bad event is
+logged and skipped; subsequent events are still processed.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.core.events.models import (
+    BaseEvent,
+    EventType,
+    JudgmentCreatedEvent,
+    JudgmentPayload,
+)
+from quodeq.data.projection.engine import ProjectionEngine
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def _good_event() -> JudgmentCreatedEvent:
+    return JudgmentCreatedEvent(
+        payload=JudgmentPayload(
+            practice_id="P1", verdict="violation", dimension="Security",
+            file="f.py", line=1, reason="r",
+        )
+    )
+
+
+class _BadEvent:
+    """Minimal event stub whose event_type is registered so handle() calls a real handler."""
+    event_type = EventType.JUDGMENT_CREATED
+    event_id = "bad-event-id"
+    timestamp = None
+    payload = None  # will cause handler to raise when it tries payload.practice_id etc.
+
+
+def test_update_actions_continues_after_handler_error(tmp_path: Path, caplog):
+    """A handler error must not abort the loop; later events must still be processed."""
+    actions_log = tmp_path / "actions.jsonl"
+    actions_log.write_text("")  # create file so stat() works
+
+    good_event = _good_event()
+
+    # Patch read_action_events to yield [bad, good] so we can assert the good
+    # one is still processed despite the bad one raising.
+    events_to_yield = [_BadEvent(), good_event]
+
+    engine = ProjectionEngine()
+    store = MagicMock(spec=SQLiteStateStore)
+    store.get_actions_projected_size.return_value = None
+
+    call_args_list = []
+
+    def fake_handle(event, s):
+        call_args_list.append(event)
+        if isinstance(event, _BadEvent):
+            raise ValueError("handler exploded on bad event")
+        # For the good event, just return normally.
+
+    # The quodeq root logger has propagate=False (shared/logging.py), so caplog
+    # won't capture it via the normal propagation path. Add its handler directly.
+    quodeq_logger = logging.getLogger("quodeq")
+    quodeq_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.ERROR):
+            with (
+                patch("quodeq.data.actions_log.read_action_events", return_value=iter(events_to_yield)),
+                patch("quodeq.data.projection.engine.SQLiteStateStore", return_value=store),
+                patch("quodeq.data.projection.engine.handle", side_effect=fake_handle),
+            ):
+                applied = engine.update_actions(actions_log, tmp_path, force=True)
+    finally:
+        quodeq_logger.removeHandler(caplog.handler)
+
+    # The good event must have been processed.
+    assert applied == 1, f"Expected 1 applied (good event), got {applied}"
+    # Both events were attempted.
+    assert len(call_args_list) == 2
+    # An error must have been logged for the bad event.
+    assert any(r.levelno >= logging.ERROR for r in caplog.records), (
+        f"Expected an ERROR log for the failing handler, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_update_actions_does_not_abort_on_error(tmp_path: Path):
+    """update_actions must not raise when a handler fails; it returns a count of successes."""
+    actions_log = tmp_path / "actions.jsonl"
+    actions_log.write_text("")
+
+    def always_raise(event, store):
+        raise RuntimeError("boom")
+
+    engine = ProjectionEngine()
+    with (
+        patch("quodeq.data.actions_log.read_action_events", return_value=iter([_BadEvent(), _BadEvent()])),
+        patch("quodeq.data.projection.engine.SQLiteStateStore", return_value=MagicMock(spec=SQLiteStateStore, get_actions_projected_size=MagicMock(return_value=None))),
+        patch("quodeq.data.projection.engine.handle", side_effect=always_raise),
+    ):
+        # Must not raise — returns 0 successes.
+        result = engine.update_actions(actions_log, tmp_path, force=True)
+
+    assert result == 0

--- a/tests/data/test_grade_projector_atomicity.py
+++ b/tests/data/test_grade_projector_atomicity.py
@@ -1,0 +1,101 @@
+"""Test that batch_rewrite_grades is atomic (finding #257).
+
+A mid-batch failure must leave pre-existing grade rows intact --
+not clear them and leave the table empty/half-written.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from quodeq.data.sqlite.connection import open_evaluation_db
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def _seed_existing_grades(run_dir: Path) -> None:
+    """Write two principle_grades and one dimension_scores row as pre-existing data."""
+    store = SQLiteStateStore(run_dir)
+    store.record_principle_grade(
+        dimension="Security",
+        principle_id="P1",
+        score=8.0,
+        grade="Good",
+        finding_count=1,
+        dismissed_count=0,
+    )
+    store.record_principle_grade(
+        dimension="Security",
+        principle_id="P2",
+        score=6.0,
+        grade="Adequate",
+        finding_count=2,
+        dismissed_count=0,
+    )
+    store.record_dimension_score(dimension="Security", score=7.0, grade="Good")
+
+
+def test_batch_rewrite_grades_method_exists(tmp_path: Path):
+    """SQLiteStateStore must expose batch_rewrite_grades."""
+    store = SQLiteStateStore(tmp_path)
+    assert hasattr(store, "batch_rewrite_grades"), (
+        "SQLiteStateStore is missing batch_rewrite_grades"
+    )
+    assert callable(store.batch_rewrite_grades)
+
+
+def test_batch_rewrite_rolls_back_on_mid_insert_failure(tmp_path: Path):
+    """batch_rewrite_grades must be fully atomic.
+
+    Seed existing rows -> attempt a batch rewrite where one insert raises ->
+    assert the pre-existing rows are still there (transaction was rolled back).
+    """
+    store = SQLiteStateStore(tmp_path)
+    _seed_existing_grades(tmp_path)
+
+    # Verify the seed is in place.
+    before = store.read_principle_grades()
+    assert len(before) == 2, "Seed should have 2 principle grades"
+
+    # principle_rows: second entry has None principle_id to cause a SQL error mid-batch.
+    principle_rows = [
+        ("Security", {"principle_id": "NEW-P1", "score": 9.0, "grade": "Exemplary",
+                      "finding_count": 0, "dismissed_count": 0}),
+        ("Security", {"principle_id": None, "score": 5.0, "grade": "Adequate",
+                      "finding_count": 1, "dismissed_count": 0}),  # will fail NOT NULL
+    ]
+    dimension_rows = [{"dimension": "Security", "score": 9.0, "grade": "Exemplary"}]
+
+    with pytest.raises(Exception):
+        store.batch_rewrite_grades(principle_rows, dimension_rows)
+
+    # The pre-existing rows must be intact -- clear + inserts were rolled back.
+    after = store.read_principle_grades()
+    assert len(after) == 2, (
+        f"Pre-existing rows must survive a failed batch rewrite, got {after}"
+    )
+    ids = {r["principle_id"] for r in after}
+    assert ids == {"P1", "P2"}, f"Wrong IDs after rollback: {ids}"
+
+
+def test_batch_rewrite_succeeds_replaces_all_grades(tmp_path: Path):
+    """A successful batch_rewrite_grades replaces all old grades with new ones."""
+    store = SQLiteStateStore(tmp_path)
+    _seed_existing_grades(tmp_path)
+
+    new_principle_rows = [
+        ("Maintainability", {"principle_id": "M1", "score": 9.5, "grade": "Exemplary",
+                             "finding_count": 0, "dismissed_count": 0}),
+    ]
+    new_dimension_rows = [{"dimension": "Maintainability", "score": 9.5, "grade": "Exemplary"}]
+
+    store.batch_rewrite_grades(new_principle_rows, new_dimension_rows)
+
+    principle_grades = store.read_principle_grades()
+    assert len(principle_grades) == 1
+    assert principle_grades[0]["principle_id"] == "M1"
+
+    dim_scores = store.read_dimension_scores()
+    assert len(dim_scores) == 1
+    assert dim_scores[0]["dimension"] == "Maintainability"

--- a/tests/data/test_web_response.py
+++ b/tests/data/test_web_response.py
@@ -1,0 +1,35 @@
+"""Tests for data/web/_response.py — ServerError embeds the HTTP status (#472)."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.data.web._response import HttpResponse, check_response_status
+from quodeq.data.ports.data_errors import AuthError, NotFoundError, ServerError
+
+
+class TestCheckResponseStatus:
+    def test_auth_error_on_401(self):
+        with pytest.raises(AuthError):
+            check_response_status(HttpResponse(status=401, data={}))
+
+    def test_auth_error_on_403(self):
+        with pytest.raises(AuthError):
+            check_response_status(HttpResponse(status=403, data={}))
+
+    def test_not_found_on_404(self):
+        with pytest.raises(NotFoundError):
+            check_response_status(HttpResponse(status=404, data={}))
+
+    def test_server_error_on_500_includes_status(self):
+        """#472 — ServerError message must include the HTTP status code."""
+        with pytest.raises(ServerError, match="500"):
+            check_response_status(HttpResponse(status=500, data={}))
+
+    def test_server_error_on_503_includes_status(self):
+        """#472 — Status code embedded in message for any 5xx."""
+        with pytest.raises(ServerError, match="503"):
+            check_response_status(HttpResponse(status=503, data={}))
+
+    def test_no_error_on_200(self):
+        """2xx responses must not raise."""
+        check_response_status(HttpResponse(status=200, data={"ok": True}))

--- a/tests/engine/test_scoring.py
+++ b/tests/engine/test_scoring.py
@@ -129,12 +129,14 @@ def test_numerical_high_confidence_with_violations():
     )
     scores = score_evidence(ev, mode="numerical")
     ts001 = scores.principles["ts-001"]
-    # New model: base = 10/(1+0.12*5.5) ≈ 6.0 (1 crit @ 4.0 + 1 major @ 1.5)
-    # Compliance has no vt → 0 types via taxonomy → lift = 0
-    # Score = base, capped by ceiling
+    # base = 10/(1+0.12*5.5) ≈ 6.0 (1 crit @ 4.0 + 1 major @ 1.5)
+    # Compliance carries no vt, but it is no longer dropped: it falls back to
+    # grouping by `reason`, so the passing evidence yields a small positive lift
+    # above the violation base. (Before the taxonomy-fallback fix this asserted
+    # lift == 0.0 / final == 6.0, because untagged compliance was discarded.)
     assert ts001.base_score == 6.0
-    assert ts001.dampening_multiplier == 0.0  # lift factor (no compliance types)
-    assert ts001.final_score == 6.0
+    assert ts001.dampening_multiplier > 0.0  # untagged compliance now counts (reason fallback)
+    assert ts001.final_score == 6.2
 
 
 def test_graded_high_confidence_no_violations():

--- a/tests/engine/test_taxonomy_e2e.py
+++ b/tests/engine/test_taxonomy_e2e.py
@@ -1,0 +1,35 @@
+"""End-to-end regression: a 'vt' taxonomy survives parse -> score.
+
+Guards the seam between judgment_to_dict (writer) and the scoring tally
+(reader). The unit tests in test_scoring.py hand-build violation dicts with
+the 'vt' key, so they cannot catch a writer/reader key drift on the real
+production path; this test drives the actual parser.
+"""
+from __future__ import annotations
+
+from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
+from quodeq.core.scoring.engine import score_evidence
+
+from tests.engine.conftest import _evidence_line
+
+
+def test_taxonomy_used_on_parse_then_score(tmp_path):
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text("\n".join([
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/a.ts", line=1),
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/b.ts", line=2),
+        _evidence_line(p="ts-001", t="violation", vt="code-injection",
+                       severity="critical", file="src/c.ts", line=3),
+    ]) + "\n")
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True

--- a/tests/engine/test_taxonomy_e2e.py
+++ b/tests/engine/test_taxonomy_e2e.py
@@ -7,6 +7,10 @@ production path; this test drives the actual parser.
 """
 from __future__ import annotations
 
+import json
+
+import pytest
+
 from quodeq.core.evidence.parser import EvidenceContext, parse_jsonl_to_evidence
 from quodeq.core.scoring.engine import score_evidence
 
@@ -23,6 +27,96 @@ def test_taxonomy_used_on_parse_then_score(tmp_path):
         _evidence_line(p="ts-001", t="violation", vt="code-injection",
                        severity="critical", file="src/c.ts", line=3),
     ]) + "\n")
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True
+
+
+def test_taxonomy_from_mcp_producer_to_score(tmp_path):
+    """A fresh MCP/CLI-path run whose report_finding calls carry 'vt' must
+    score with taxonomy_used=True.
+
+    Drives the genuine MCP producer seam: the agent's report_finding
+    arguments are forwarded verbatim by handle_tools_call to
+    FindingsRouter.receive, which delegates to FindingEnricher.enrich (the
+    enricher copies every non-None arg key, including 'vt', into the JSONL
+    line) before the real parse -> score. Before the schema documented 'vt',
+    the default per-dimension template never instructed the model to emit it,
+    so fresh runs fell back to free-text reason grouping.
+    """
+    from quodeq.analysis.mcp.router import FindingsRouter
+
+    # Exactly the shape handle_tools_call forwards (params['arguments']) for a
+    # report_finding MCP tool call: three near-duplicate findings sharing 'vt'.
+    report_finding_args = [
+        {"p": "ts-001", "t": "violation", "file": f"src/{name}.ts", "line": i,
+         "severity": "critical", "w": "eval usage", "snippet": "eval(userInput)",
+         "reason": reason, "vt": "code-injection"}
+        for i, (name, reason) in enumerate([
+            ("a", "eval of user input enables code injection."),
+            ("b", "Dynamic eval executes attacker-controlled strings."),
+            ("c", "Unsanitised input reaches eval."),
+        ], start=1)
+    ]
+
+    jsonl = tmp_path / "evidence.jsonl"
+    with open(jsonl, "w") as fh:
+        router = FindingsRouter(fh)
+        for args in report_finding_args:
+            _message, is_dup = router.receive(args)
+            assert is_dup is False
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl,
+        EvidenceContext(language="typescript", repository="test-repo",
+                        date_str="2026-06-12", source_file_count=50, files_read=10),
+    )
+    scores = score_evidence(evidence, mode="numerical")
+
+    principle = scores.principles["ts-001"]
+    assert principle.taxonomy_used is True
+
+
+def test_taxonomy_from_api_producer_to_score(tmp_path):
+    """A fresh API-runner run whose model output carries 'vt' must score with
+    taxonomy_used=True.
+
+    Drives the actual producer seam the writer-side tests above cannot reach:
+    raw model output -> _parse_findings (_Finding validation) -> FindingsRouter
+    -> JSONL -> parse -> score. Before _Finding carried 'vt', validation
+    silently stripped the taxonomy and every fresh run fell back to free-text
+    reason grouping.
+    """
+    pytest.importorskip("openai", reason="requires the openai SDK")
+    from quodeq.analysis._api_runner import _parse_findings
+    from quodeq.analysis.mcp.router import FindingsRouter
+
+    raw = json.dumps({"findings": [
+        {"req": "ts-001", "t": "violation", "file": f"src/{name}.ts", "line": i,
+         "severity": "critical", "w": "eval usage", "snippet": "eval(userInput)",
+         "reason": reason, "vt": "code-injection"}
+        for i, (name, reason) in enumerate([
+            ("a", "eval of user input enables code injection."),
+            ("b", "Dynamic eval executes attacker-controlled strings."),
+            ("c", "Unsanitised input reaches eval."),
+        ], start=1)
+    ]})
+    findings, dropped = _parse_findings(raw)
+    assert dropped == 0
+    assert len(findings) == 3
+
+    jsonl = tmp_path / "evidence.jsonl"
+    with open(jsonl, "w") as fh:
+        router = FindingsRouter(fh)
+        for f in findings:
+            router.receive(f)
 
     evidence = parse_jsonl_to_evidence(
         jsonl,

--- a/tests/llm_bridge/test_omlx_ssrf.py
+++ b/tests/llm_bridge/test_omlx_ssrf.py
@@ -1,0 +1,69 @@
+"""SSRF guard tests for omlx integration.
+
+These tests verify that unsafe base_url values (cloud metadata endpoints,
+private-range IPs, non-HTTP schemes) are rejected before urlopen is called,
+while a legitimate localhost base_url still reaches urlopen normally.
+"""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.llm_bridge import _omlx
+
+
+_UNSAFE_URLS = [
+    "http://169.254.169.254/latest/meta-data/",   # AWS IMDSv1
+    "http://169.254.169.254/",                     # link-local / GCP metadata
+    "http://10.0.0.1/",                            # RFC1918 private range
+    "http://192.168.1.1/",                         # RFC1918 private range
+    "file:///etc/passwd",                          # non-HTTP scheme
+]
+
+
+@pytest.mark.parametrize("bad_url", _UNSAFE_URLS)
+def test_get_omlx_status_rejects_unsafe_base_url(bad_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(_omlx.urllib.request, "urlopen", lambda *a, **k: calls.append(1))
+    result = _omlx.get_omlx_status(base_url=bad_url)
+    assert calls == [], f"urlopen should not be called for unsafe URL {bad_url!r}"
+    assert result["running"] is False
+    assert "error" in result
+
+
+@pytest.mark.parametrize("bad_url", _UNSAFE_URLS)
+def test_list_omlx_models_rejects_unsafe_base_url(bad_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(_omlx.urllib.request, "urlopen", lambda *a, **k: calls.append(1))
+    monkeypatch.setattr(_omlx, "_list_model_dirs", lambda: [])
+    result = _omlx.list_omlx_models(base_url=bad_url)
+    assert calls == [], f"urlopen should not be called for unsafe URL {bad_url!r}"
+    # Falls back to _list_model_dirs, which returns []
+    assert result == []
+
+
+def test_get_omlx_status_allows_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A localhost base_url must still reach urlopen (legitimate omlx default)."""
+    calls: list[object] = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req)
+        raise ConnectionRefusedError("nobody home")
+
+    monkeypatch.setattr(_omlx.urllib.request, "urlopen", fake_urlopen)
+    result = _omlx.get_omlx_status(base_url="http://localhost:8000")
+    assert len(calls) == 1, "urlopen should have been called for localhost"
+    assert result["running"] is False  # connection refused, but guard passed
+
+
+def test_list_omlx_models_allows_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A localhost base_url must still reach urlopen (legitimate omlx default)."""
+    calls: list[object] = []
+
+    def fake_urlopen(req, timeout=None):
+        calls.append(req)
+        raise ConnectionRefusedError("nobody home")
+
+    monkeypatch.setattr(_omlx.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(_omlx, "_list_model_dirs", lambda: [])
+    _omlx.list_omlx_models(base_url="http://localhost:8000")
+    assert len(calls) == 1, "urlopen should have been called for localhost"

--- a/tests/packaging/test_menubar_load_config.py
+++ b/tests/packaging/test_menubar_load_config.py
@@ -1,0 +1,72 @@
+"""#341 — menubar._load_config must not raise ValueError on non-numeric env values."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _load_config_fn():
+    """Import _load_config without triggering the rumps/module-level int() calls."""
+    # Stub out rumps and the local helper modules so the import succeeds
+    # on non-macOS and without the actual rumps package installed.
+    for mod_name in ("rumps", "_helpers", "_dashboard"):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    # Provide required names that menubar references at module level
+    rumps_stub = sys.modules["rumps"]
+    rumps_stub.App = MagicMock()
+    rumps_stub.MenuItem = MagicMock()
+    rumps_stub.timer = lambda *a, **kw: (lambda f: f)
+
+    helpers_stub = sys.modules["_helpers"]
+    helpers_stub.find_commands = MagicMock(return_value={})
+    helpers_stub.find_icon = MagicMock(return_value=None)
+    helpers_stub.is_evaluating = MagicMock(return_value=False)
+    helpers_stub.source_user_path = MagicMock()
+
+    dashboard_stub = sys.modules["_dashboard"]
+    dashboard_stub.build_dashboard_cmd = MagicMock()
+    dashboard_stub.cleanup_stderr_log = MagicMock()
+    dashboard_stub.DashboardCallbacks = MagicMock()
+    dashboard_stub.DashboardState = MagicMock()
+    dashboard_stub.find_pids_on_port = MagicMock()
+    dashboard_stub.find_running_port = MagicMock()
+    dashboard_stub.kill_port_processes = MagicMock()
+    dashboard_stub.open_stderr_log = MagicMock()
+    dashboard_stub.wait_for_dashboard = MagicMock()
+    dashboard_stub._STDERR_READ_MAX = 4096
+    dashboard_stub._ERROR_DISPLAY_MAX = 200
+
+    # Add the macos packaging dir to path so the import finds menubar.py
+    macos_dir = str(Path(__file__).resolve().parents[2] / "packaging" / "macos")
+    if macos_dir not in sys.path:
+        sys.path.insert(0, macos_dir)
+
+    # Force reimport if already cached (from a prior test run)
+    if "menubar" in sys.modules:
+        del sys.modules["menubar"]
+
+    import menubar  # noqa: PLC0415
+    return menubar._load_config
+
+
+class TestLoadConfigNonNumericEnv:
+    def setup_method(self):
+        self._load_config = _load_config_fn()
+
+    def test_non_numeric_port_falls_back_to_default(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORT": "not-a-number"})
+        assert port == 7863  # default
+
+    def test_non_numeric_ports_falls_back_to_default(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORTS": "abc,def,ghi"})
+        # Should fall back — not raise ValueError
+        assert isinstance(ports, tuple)
+
+    def test_valid_numeric_env_still_works(self) -> None:
+        port, ports = self._load_config(env={"QUODEQ_PORT": "8080", "QUODEQ_PORTS": "8080,8081"})
+        assert port == 8080
+        assert ports == (8080, 8081)

--- a/tests/services/test_dim_resolution.py
+++ b/tests/services/test_dim_resolution.py
@@ -14,6 +14,8 @@ appear in which view. The tests pin down its three guarantees:
 Together these make the migration in later phases safe: each call site
 can replace its local filter with a documented predicate from this module.
 """
+# NOTE: Additional tests for #356 (_is_trustworthy_eval non-dict guard) are at
+# the bottom of this file.
 from __future__ import annotations
 
 import json
@@ -339,3 +341,29 @@ class TestIsEligibleForChartBar:
         assert is_eligible_for_chart_bar(
             tmp_path, "proj", run, configured_dims=["security", "reliability"],
         ) is False
+
+
+# ---------------------------------------------------------------------------
+# #356 — _is_trustworthy_eval must not raise on non-dict eval_data
+# ---------------------------------------------------------------------------
+
+class TestIsTrustworthyEvalNonDict:
+    def test_list_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval([{"filesRead": 100}]) is False
+
+    def test_string_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval("filesRead: 100") is False
+
+    def test_int_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval(42) is False
+
+    def test_none_eval_data_returns_false(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval(None) is False
+
+    def test_valid_dict_with_files_read_returns_true(self) -> None:
+        from quodeq.services.scoring_view._resolution import _is_trustworthy_eval
+        assert _is_trustworthy_eval({"filesRead": 10}) is True

--- a/tests/services/test_evaluation_mixin_register.py
+++ b/tests/services/test_evaluation_mixin_register.py
@@ -124,6 +124,63 @@ def test_register_url_clone_dest_must_exist(tmp_path):
     assert not nonexistent.exists()
 
 
+def test_register_url_rejects_private_address_before_clone(tmp_path, monkeypatch):
+    """SSRF guard: a URL whose host is a private/link-local literal is rejected
+    before git clone runs, matching the CLI prepare_repository path."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    clone_calls = []
+
+    def fake_clone(url, dest):
+        clone_calls.append(url)
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "README.md").write_text("# fake\n")
+        (Path(dest) / ".git").mkdir()
+
+    with patch("quodeq.services.evaluation_mixin.run_git_clone", side_effect=fake_clone):
+        with pytest.raises(ValueError, match="private"):
+            _register_project(
+                "https://169.254.169.254/latest/meta-data",
+                None,
+                str(reports),
+                ephemeral=True,
+            )
+
+    assert clone_calls == [], "git clone must not run for a private-host URL"
+
+
+def test_register_url_rejects_localhost_before_clone(tmp_path, monkeypatch):
+    """A localhost URL is rejected by the SSRF guard before any clone."""
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    clone_calls = []
+
+    def fake_clone(url, dest):
+        clone_calls.append(url)
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "README.md").write_text("# fake\n")
+        (Path(dest) / ".git").mkdir()
+
+    with patch("quodeq.services.evaluation_mixin.run_git_clone", side_effect=fake_clone):
+        with pytest.raises(ValueError):
+            _register_project(
+                "https://localhost/git/repo.git",
+                None,
+                str(reports),
+                ephemeral=True,
+            )
+
+    assert clone_calls == []
+
+
 def test_start_evaluation_rejects_url_input(tmp_path):
     """start_evaluation no longer clones; URLs must already be registered as local."""
     from quodeq.services.base import EvaluationOptions

--- a/tests/services/test_evaluations_index_downgrade.py
+++ b/tests/services/test_evaluations_index_downgrade.py
@@ -1,0 +1,66 @@
+"""Regression test for issue #621: a downgraded index.db must not crash.
+
+When a newer quodeq migrates ``~/.quodeq/index.db`` to a ``schema_version``
+this (older) binary doesn't support, the first index access previously raised
+an uncaught ``UnsupportedIndexSchemaError`` — crashing the dashboard's
+evaluations list wherever the index was first opened.
+
+The index is a derived projection of the on-disk run files, so it is now
+discarded and rebuilt at the open boundary instead of being fatal.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from quodeq.services._evaluations_index import EvaluationsIndex
+from quodeq.services._job_model import InMemoryJobStore
+from quodeq.services.jobs import JobManager
+from quodeq.shared.run_status import RunState, write_status
+
+
+def _seed_run(reports_root: Path, project: str, run_id: str) -> None:
+    """Create a finished run dir matching what a CLI/subprocess writes."""
+    run_dir = reports_root / project / run_id
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    write_status(
+        run_dir,
+        state=RunState.DONE,
+        job_id=f"ext-{run_id}",
+        started_at="2026-05-22T19:00:00+00:00",
+        dimensions=["security"],
+    )
+
+
+def _write_downgraded_index(db_path: Path) -> None:
+    """Write an index.db whose schema_version is newer than this binary supports."""
+    raw = sqlite3.connect(db_path)
+    raw.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+    raw.execute("INSERT INTO schema_version VALUES (99)")
+    raw.commit()
+    raw.close()
+
+
+def test_list_rebuilds_downgraded_index_instead_of_crashing(tmp_path: Path) -> None:
+    reports_root = tmp_path / "reports"
+    _seed_run(reports_root, "proj-uuid", "run-uuid")
+
+    index_db_path = tmp_path / "index.db"
+    _write_downgraded_index(index_db_path)
+
+    jobs = JobManager(job_store=InMemoryJobStore(), reports_root=reports_root)
+    index = EvaluationsIndex(
+        jobs=jobs,
+        index_db_path=index_db_path,
+        reports_root=reports_root,
+    )
+
+    # Previously raised UnsupportedIndexSchemaError on the first access; must now
+    # degrade by discarding the stale DB and rebuilding from the run files.
+    entries = index.list(reports_dir=reports_root)
+
+    match = [e for e in entries if e.output_run_id == "run-uuid"]
+    assert len(match) == 1, f"expected the run to survive the rebuild, got {match}"
+    assert match[0].source == "external"
+    assert match[0].status == "done"

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -375,3 +375,25 @@ class TestHasFingerprints:
         run.mkdir(parents=True)
         # No evidence subdir
         assert _has_fingerprints(tmp_path, "proj") is False
+
+    def test_oserror_on_iterdir_logs_warning(self, tmp_path: Path, monkeypatch, caplog):
+        """#208 — OSError during dir iteration must be logged, not silently swallowed."""
+        import logging
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        def _bad_iterdir(self):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", _bad_iterdir)
+        # quodeq logger has propagate=False; enable temporarily so caplog sees records.
+        quodeq_logger = logging.getLogger("quodeq")
+        orig_propagate = quodeq_logger.propagate
+        quodeq_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="quodeq.services._fs_metadata"):
+                result = _has_fingerprints(tmp_path, "proj")
+        finally:
+            quodeq_logger.propagate = orig_propagate
+        assert result is False
+        assert "Could not read fingerprint dir" in caplog.text

--- a/tests/services/test_run_index.py
+++ b/tests/services/test_run_index.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 from quodeq.services.run_index import (
     RunRow,
     SCHEMA_VERSION,
-    UnsupportedIndexSchemaError,
     open_index,
 )
 
@@ -44,15 +41,56 @@ def test_open_is_idempotent_on_existing_v1(tmp_path: Path) -> None:
         db.close()
 
 
-def test_open_raises_on_newer_schema(tmp_path: Path) -> None:
+def test_open_preserves_rows_on_current_schema(tmp_path: Path) -> None:
+    """Reopening a current-schema index must NOT wipe it.
+
+    Guards the load-bearing counterpart to the downgrade recovery: open_index
+    discards-and-rebuilds ONLY when version > SCHEMA_VERSION. If that condition
+    ever loosened to fire on the equal-version path, every reopen would destroy
+    the user's index — this row survives reopen, so that regression fails loudly.
+    """
+    db_path = tmp_path / "index.db"
+    db = open_index(db_path)
+    db.execute(
+        "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+        "started_at, updated_at, status_mtime) "
+        "VALUES ('ext-keep', 'p', 'keep', '/p/keep', 'done', '0', '0', 0)"
+    )
+    db.commit()
+    db.close()
+
+    db = open_index(db_path)
+    try:
+        kept = db.execute("SELECT state FROM runs WHERE job_id = 'ext-keep'").fetchone()
+        assert kept is not None and kept[0] == "done"
+    finally:
+        db.close()
+
+
+def test_open_recovers_from_newer_schema(tmp_path: Path) -> None:
+    """A downgraded index.db (schema newer than this binary) is rebuilt, not fatal.
+
+    Scenario from issue #621: a newer quodeq migrated index.db forward, then the
+    user installed an older one. The index is derived state, so open_index
+    discards the unusable DB and recreates an empty current-schema one (the next
+    sync repopulates it) instead of crashing with a raw schema error.
+    """
     db_path = tmp_path / "index.db"
     raw = sqlite3.connect(db_path)
     raw.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
     raw.execute("INSERT INTO schema_version VALUES (99)")
     raw.commit()
     raw.close()
-    with pytest.raises(UnsupportedIndexSchemaError):
-        open_index(db_path)
+
+    db = open_index(db_path)
+    try:
+        v = db.execute("SELECT version FROM schema_version").fetchone()[0]
+        assert v == SCHEMA_VERSION == 1
+        # Full current schema recreated, not just the version table.
+        cols = {row[1] for row in db.execute("PRAGMA table_info(runs)").fetchall()}
+        assert "job_id" in cols
+    finally:
+        db.close()
 
 
 def test_open_recovers_from_corrupt_file(tmp_path: Path) -> None:

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -133,3 +133,96 @@ class TestPendingDimTotals:
         assert progress is not None
         # Corrupt estimates → empty dict → pending dim reports 0 (preparing…).
         assert progress.dimensions[0].files["total"] == 0
+
+
+def _write_dimensions_json(run_dir: Path, states: dict[str, str]) -> None:
+    payload = {
+        "schema_version": 1,
+        "dimensions": {d: {"state": s} for d, s in states.items()},
+    }
+    (run_dir / "dimensions.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestEmptyStatusDimensionsRecovery:
+    """Runs launched with *all* dimensions (no --dimensions filter) record an
+    empty ``dimensions: []`` in status.json: the raw, unresolved filter is None
+    and gets coerced to [] before the lifecycle writes it. The reader must
+    recover the dim list from the per-dim sidecars (dimensions.json,
+    dim_estimates.json), otherwise the progress header total — and the ETA the
+    UI derives from it — collapse to zero for the entire run (PROGRESS stuck on
+    "preparing…", no ETA ever shown).
+    """
+
+    def test_recovers_dims_from_sidecars_when_status_empty(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])  # the bug condition
+        _write_dimensions_json(run_dir, {"security": "pending", "reliability": "pending"})
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({
+                "security": {"count": 5, "reason": "first-run"},
+                "reliability": {"count": 7, "reason": "first-run"},
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        totals = {d.id: d.files["total"] for d in progress.dimensions}
+        # Non-zero header total → the ETA can compute instead of preparing…
+        assert totals == {"security": 5, "reliability": 7}
+
+    def test_recovers_from_estimates_alone(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 5, "reason": "first-run"}}),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["security"]
+        assert progress.dimensions[0].files["total"] == 5
+
+    def test_recovers_running_dim_from_dimensions_json_alone(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+        _write_dimensions_json(run_dir, {"security": "running"})
+        (run_dir / "evidence" / "security_queue.json").write_text(
+            json.dumps({
+                "taken": [{"files": ["a.py", "b.py"], "agent": "a1", "ts": 1}],
+                "pending": ["c.py"],
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["security"]
+        assert progress.dimensions[0].files == {"taken": 2, "total": 3}
+
+    def test_explicit_status_dims_take_precedence_over_fallback(self, tmp_path: Path) -> None:
+        # When status.json *does* carry a list, the fallback must not fire or
+        # add dims from the sidecars — the explicit (possibly filtered) list wins.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["reliability"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({
+                "security": {"count": 5, "reason": "first-run"},
+                "reliability": {"count": 7, "reason": "first-run"},
+            }),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert [d.id for d in progress.dimensions] == ["reliability"]
+
+    def test_empty_status_and_no_sidecars_stays_empty(self, tmp_path: Path) -> None:
+        # Nothing to recover from → empty list, no crash.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=[])
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        assert progress.dimensions == []

--- a/tests/services/test_standards_io_coverage.py
+++ b/tests/services/test_standards_io_coverage.py
@@ -67,6 +67,40 @@ class TestCountPrinciplesAndRequirements:
         data = {"principles": [{"name": "P1", "requirements": []}]}
         assert count_principles_and_requirements(data) == (1, 0)
 
+    # --- #293: malformed persisted data must not crash ---
+
+    def test_principles_not_a_list_returns_zero_counts(self):
+        """principles as a dict (not a list) must not raise."""
+        data = {"principles": {"P1": {"requirements": []}}}
+        assert count_principles_and_requirements(data) == (0, 0)
+
+    def test_principles_string_returns_zero_counts(self):
+        data = {"principles": "bad value"}
+        assert count_principles_and_requirements(data) == (0, 0)
+
+    def test_non_dict_items_in_principles_are_skipped(self):
+        """Non-dict items in the principles list are silently skipped."""
+        data = {
+            "principles": [
+                "not a dict",
+                42,
+                {"name": "P1", "requirements": [{"id": "R1"}]},
+                None,
+            ]
+        }
+        # Only the one valid dict counts
+        assert count_principles_and_requirements(data) == (1, 1)
+
+    def test_mix_of_valid_and_invalid_principles(self):
+        data = {
+            "principles": [
+                {"name": "P1", "requirements": [{"id": "R1"}, {"id": "R2"}]},
+                "garbage",
+                {"name": "P2", "requirements": []},
+            ]
+        }
+        assert count_principles_and_requirements(data) == (2, 2)
+
 
 class TestBuildDetail:
     def test_minimal(self):

--- a/tests/services/test_tooling_mixin.py
+++ b/tests/services/test_tooling_mixin.py
@@ -387,3 +387,8 @@ class TestLoadFallbackClaudeModels:
     @patch("quodeq.services.tooling_mixin.read_json", side_effect=OSError)
     def test_returns_empty_on_error(self, mock_read):
         assert _load_fallback_claude_models() == []
+
+    # #139 — ValueError (e.g. corrupt JSON int parse) must also be caught
+    @patch("quodeq.services.tooling_mixin.read_json", side_effect=ValueError("bad int"))
+    def test_returns_empty_on_value_error(self, mock_read):
+        assert _load_fallback_claude_models() == []

--- a/tests/services/test_violations_jsonl_coverage.py
+++ b/tests/services/test_violations_jsonl_coverage.py
@@ -8,6 +8,35 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+# ---------------------------------------------------------------------------
+# #145 — non-dict JSON values (lists, strings, numbers) must be skipped
+# ---------------------------------------------------------------------------
+
+class TestNonDictJsonlLineIsSkipped:
+    def test_non_dict_string_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = [
+            '"just a string"',
+            '[1, 2, 3]',
+            json.dumps({"p": "M-MOD-1", "t": "violation", "file": "a.py", "line": 1}),
+        ]
+        violations, _ = _parse_jsonl_findings(lines, "security")
+        assert len(violations) == 1
+
+    def test_non_dict_list_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = ['[{"p": "M-MOD-1", "t": "violation"}]']
+        violations, compliance = _parse_jsonl_findings(lines, "security")
+        assert violations == []
+        assert compliance == []
+
+    def test_non_dict_null_line_is_skipped(self):
+        from quodeq.services._violations_jsonl import _parse_jsonl_findings
+        lines = ['null', json.dumps({"p": "P1", "t": "compliance", "file": "b.py", "line": 2})]
+        _, compliance = _parse_jsonl_findings(lines, "security")
+        assert len(compliance) == 1
+
+
 class TestParseJsonlFindings:
     def test_empty_lines(self):
         from quodeq.services._violations_jsonl import _parse_jsonl_findings

--- a/tests/shared/test_prereqs.py
+++ b/tests/shared/test_prereqs.py
@@ -6,6 +6,7 @@ import pytest
 from quodeq.shared.prereqs import (
     check_node, check_npm, check_dashboard_dev_prereqs, check_evaluate_prereqs,
     _check_cli_provider, _check_api_provider, _is_provider_explicitly_configured,
+    _run_version_cmd,
 )
 
 
@@ -134,3 +135,20 @@ class TestCompositeChecks:
                     return_value={"claude": {"type": "cli", "cmd": "claude"}},
                 ):
                     check_evaluate_prereqs()
+
+
+class TestProviderInjection:
+    def test_run_version_cmd_rejects_shell_metacharacters(self):
+        with pytest.raises(ValueError, match="unsafe command token"):
+            _run_version_cmd(["x & echo PWNED", "--version"])
+
+    def test_check_cli_provider_rejects_injection(self):
+        with patch("subprocess.run") as mock_run:
+            with pytest.raises(RuntimeError):
+                _check_cli_provider("x & echo PWNED")
+            mock_run.assert_not_called()
+
+    def test_check_cli_provider_accepts_valid_name(self):
+        result = subprocess.CompletedProcess([], 0, stdout="1.0.0\n")
+        with patch("subprocess.run", return_value=result):
+            _check_cli_provider("claude")  # must not raise

--- a/tests/shared/test_resource_sampler_coverage.py
+++ b/tests/shared/test_resource_sampler_coverage.py
@@ -1,0 +1,61 @@
+"""Tests for resource_sampler.py — except breadth broadening (#515).
+
+The sampler loop's bare `except (OSError, ValueError)` must be broadened to
+`except Exception` so a bad tick (e.g. RuntimeError) doesn't kill the thread.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+from quodeq.shared.resource_sampler import ResourceSampler
+
+
+class TestSamplerLoopBreadth:
+    def test_unexpected_exception_does_not_terminate_loop(self):
+        """#515 — an exception not in (OSError, ValueError) must not kill the sampler thread.
+
+        Before the fix, RuntimeError would propagate out of the loop and the thread would die.
+        After the fix, the loop continues and the thread stays alive past the first tick.
+        """
+        tick_count = [0]
+        errors_seen = [0]
+
+        def _bad_sample_once():
+            tick_count[0] += 1
+            if tick_count[0] == 1:
+                raise RuntimeError("unexpected bad tick")
+            return "ok"
+
+        sampler = ResourceSampler(interval_s=0.05)
+
+        with patch.object(sampler, "sample_once", side_effect=_bad_sample_once):
+            sampler.start()
+            # Wait long enough for at least 2 ticks
+            time.sleep(0.3)
+            sampler.stop()
+
+        # Thread must have continued past the first (bad) tick
+        assert tick_count[0] >= 2, (
+            f"Sampler thread died after bad tick — only {tick_count[0]} tick(s) observed"
+        )
+
+    def test_oserror_does_not_terminate_loop(self):
+        """Original OSError handling still works after broadening."""
+        tick_count = [0]
+
+        def _oserror_sample():
+            tick_count[0] += 1
+            if tick_count[0] == 1:
+                raise OSError("proc unavailable")
+            return "ok"
+
+        sampler = ResourceSampler(interval_s=0.05)
+
+        with patch.object(sampler, "sample_once", side_effect=_oserror_sample):
+            sampler.start()
+            time.sleep(0.3)
+            sampler.stop()
+
+        assert tick_count[0] >= 2

--- a/tests/shared/test_ssrf.py
+++ b/tests/shared/test_ssrf.py
@@ -37,3 +37,31 @@ class TestIsPrivateAddress:
 
     def test_link_local(self):
         assert is_private_address("169.254.1.1") is True
+
+
+class TestEncodedIPv4Literals:
+    """Alternate IPv4 encodings that git/libc resolve into private ranges but
+    that ``ipaddress.ip_address`` rejects. They must be canonicalized so SSRF
+    via octal/hex/dword/short-form literals is caught (e.g. git clone of
+    https://0177.0.0.1/ dials 127.0.0.1)."""
+
+    def test_octal_leading_zero_loopback(self):
+        assert is_private_address("0177.0.0.1") is True
+
+    def test_octal_private_10(self):
+        assert is_private_address("012.0.0.1") is True
+
+    def test_dword_loopback(self):
+        assert is_private_address("2130706433") is True
+
+    def test_hex_loopback(self):
+        assert is_private_address("0x7f000001") is True
+
+    def test_hex_dotted_loopback(self):
+        assert is_private_address("0x7f.0.0.1") is True
+
+    def test_short_form_loopback(self):
+        assert is_private_address("127.1") is True
+
+    def test_public_dotted_literal_still_allowed(self):
+        assert is_private_address("8.8.8.8") is False

--- a/tests/test_cli_worktree_cleanup.py
+++ b/tests/test_cli_worktree_cleanup.py
@@ -1,0 +1,96 @@
+"""Tests for worktree cleanup on failure path (finding #376).
+
+The except block in _create_worktree previously called worktree_dir.rmdir()
+which only removes an empty dir and leaves a registered/populated worktree
+behind. Fix: call _cleanup_worktree + shutil.rmtree on the failure path.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, call
+
+import pytest
+
+
+class TestCreateWorktreeCleanupOnFailure:
+    """Ensure _create_worktree fully cleans up on the failure path."""
+
+    def test_cleanup_worktree_called_on_subprocess_failure(self, tmp_path: Path) -> None:
+        """When subprocess.run raises CalledProcessError after the dir is created,
+        _cleanup_worktree must be called (not just rmdir) so the git worktree
+        registration is also removed."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        captured_calls: list[tuple[Path, Path]] = []
+
+        def _fake_cleanup(repo: Path, wt: Path) -> None:
+            captured_calls.append((repo, wt))
+            # Simulate cleanup removing the dir
+            import shutil
+            shutil.rmtree(wt, ignore_errors=True)
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+            side_effect=_fake_cleanup,
+        ) as mock_cleanup:
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None, "Expected None when subprocess raises"
+        # _cleanup_worktree must have been called once with the correct repo_dir
+        mock_cleanup.assert_called_once()
+        called_repo, called_wt = mock_cleanup.call_args.args
+        assert called_repo == repo_dir
+
+    def test_no_leftover_dir_on_failure(self, tmp_path: Path) -> None:
+        """The worktree dir itself must not survive the failure path."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        created_dir: list[Path] = []
+
+        def _spy_cleanup(repo: Path, wt: Path) -> None:
+            created_dir.append(wt)
+            import shutil
+            shutil.rmtree(wt, ignore_errors=True)
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+            side_effect=_spy_cleanup,
+        ):
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None
+        if created_dir:
+            assert not created_dir[0].exists(), (
+                f"Worktree dir {created_dir[0]} still exists after failure"
+            )
+
+    def test_cleanup_called_on_timeout(self, tmp_path: Path) -> None:
+        """TimeoutExpired on the failure path also triggers proper cleanup."""
+        from quodeq._cli_resolution import _create_worktree
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+
+        with patch(
+            "quodeq._cli_resolution.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("git", 30),
+        ), patch(
+            "quodeq._cli_resolution._cleanup_worktree",
+        ) as mock_cleanup:
+            result = _create_worktree(repo_dir, "some-branch")
+
+        assert result is None
+        mock_cleanup.assert_called_once()

--- a/tests/tools/test_check_imports_warning.py
+++ b/tests/tools/test_check_imports_warning.py
@@ -1,0 +1,52 @@
+"""Tests for check_imports.check_file — stderr warning on read error (#696)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# tools/ is not on sys.path by default; add it
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "tools"))
+import check_imports  # noqa: E402
+
+
+class TestCheckFileWarning:
+    def test_oserror_prints_warning_to_stderr(self, tmp_path: Path, capsys):
+        """#696 — OSError reading a file must print a warning to stderr, not silently skip."""
+        bad_path = tmp_path / "unreachable.py"
+        bad_path.touch()
+
+        with patch.object(Path, "read_text", side_effect=OSError("permission denied")):
+            result = check_imports.check_file(bad_path, "core")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "warning: skipping" in captured.err
+        assert "unreachable.py" in captured.err
+        assert "permission denied" in captured.err
+
+    def test_unicode_error_prints_warning_to_stderr(self, tmp_path: Path, capsys):
+        """#696 — UnicodeDecodeError reading a file must also produce a stderr warning."""
+        bad_path = tmp_path / "binary.py"
+        bad_path.touch()
+
+        with patch.object(
+            Path, "read_text", side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "bad byte")
+        ):
+            result = check_imports.check_file(bad_path, "core")
+
+        assert result == []
+        captured = capsys.readouterr()
+        assert "warning: skipping" in captured.err
+        assert "binary.py" in captured.err
+
+    def test_clean_file_produces_no_warning(self, tmp_path: Path, capsys):
+        """Readable files with no violations must not produce any stderr output."""
+        clean_path = tmp_path / "clean.py"
+        clean_path.write_text("x = 1\n", encoding="utf-8")
+        result = check_imports.check_file(clean_path, "core")
+        captured = capsys.readouterr()
+        assert captured.err == ""

--- a/tests/tools/test_import_layers.py
+++ b/tests/tools/test_import_layers.py
@@ -1,0 +1,30 @@
+"""Layer-import gate: fail the build on NEW violations beyond the baseline."""
+from __future__ import annotations
+
+import check_imports
+
+
+def test_no_new_import_violations():
+    baseline = check_imports.load_baseline()
+    new = [
+        v for v in check_imports.collect_violations()
+        if check_imports.violation_key(v) not in baseline
+    ]
+    assert new == [], (
+        "New layer-import violation(s) introduced. Fix the import, or only "
+        "with justification run `python tools/check_imports.py --update-baseline`:\n"
+        + "\n".join(check_imports.violation_key(v) for v in new)
+        + "\nIf test_baseline_has_no_stale_entries also fails for the same "
+        "file and target, you only shifted lines above a grandfathered "
+        "import; regenerating the baseline is the correct fix."
+    )
+
+
+def test_baseline_has_no_stale_entries():
+    """Fixing a violation must shrink the baseline, keeping it honest."""
+    current = {check_imports.violation_key(v) for v in check_imports.collect_violations()}
+    stale = sorted(check_imports.load_baseline() - current)
+    assert stale == [], (
+        "Baseline lists violations that no longer exist; regenerate with "
+        "`python tools/check_imports.py --update-baseline`:\n" + "\n".join(stale)
+    )

--- a/tests/tools/test_migrate_cwe_title.py
+++ b/tests/tools/test_migrate_cwe_title.py
@@ -1,0 +1,64 @@
+"""#710 — migrate_cwe_title must not raise when json.loads returns a non-dict."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# tools/ is importable via conftest.py sys.path insert
+
+
+class TestBuildCweNameLookupNonDict:
+    def test_list_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text(json.dumps([{"principles": []}]), encoding="utf-8")
+        # Must not raise AttributeError; bad file is skipped
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_string_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text('"just a string"', encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_null_payload_is_skipped(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        f = tmp_path / "sec.json"
+        f.write_text("null", encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {}
+
+    def test_valid_dict_is_still_processed(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import _build_cwe_name_lookup
+        data = {
+            "principles": [
+                {"cwes": [{"id": 306, "name": "Missing Authentication"}]}
+            ]
+        }
+        f = tmp_path / "sec.json"
+        f.write_text(json.dumps(data), encoding="utf-8")
+        result = _build_cwe_name_lookup(tmp_path)
+        assert result == {306: "Missing Authentication"}
+
+
+class TestMigrateFileNonDict:
+    def test_list_payload_is_skipped_gracefully(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import migrate_file
+        f = tmp_path / "eval.json"
+        f.write_text(json.dumps([{"violations": []}]), encoding="utf-8")
+        v, c = migrate_file(f, {}, apply=False)
+        assert v == 0
+        assert c == 0
+
+    def test_null_payload_is_skipped_gracefully(self, tmp_path: Path) -> None:
+        from migrate_cwe_title import migrate_file
+        f = tmp_path / "eval.json"
+        f.write_text("null", encoding="utf-8")
+        v, c = migrate_file(f, {}, apply=False)
+        assert v == 0
+        assert c == 0

--- a/tests/tools/test_migrate_reason_title.py
+++ b/tests/tools/test_migrate_reason_title.py
@@ -1,0 +1,29 @@
+"""#683 — migrate_reason_title.migrate_entry must not raise on non-dict input."""
+from __future__ import annotations
+
+import pytest
+
+
+class TestMigrateEntryNonDict:
+    def test_list_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry([{"reason": "x"}]) is False
+
+    def test_string_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry("just a string") is False
+
+    def test_none_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry(None) is False
+
+    def test_int_input_returns_false(self) -> None:
+        from migrate_reason_title import migrate_entry
+        assert migrate_entry(42) is False
+
+    def test_valid_dict_still_works(self) -> None:
+        from migrate_reason_title import migrate_entry
+        entry = {"reason": "Modularity -- separation of concerns", "principle": "Modularity"}
+        # The function should handle a valid dict without raising
+        result = migrate_entry(entry)
+        assert isinstance(result, bool)

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -18,8 +18,13 @@ ENGINE_VERSION_PATTERN='"engine_version": "==[^"]*"'
 # Replacement string pinning engine_version to the current pyproject.toml version
 ENGINE_VERSION_REPLACE="\"engine_version\": \"==$VERSION\""
 # Updates the engine_version constraint in every plugin.json to match the current pyproject.toml version
-find "$ROOT/evaluators" "$ROOT/tests" -name "plugin.json" -exec \
-  sed -i '' "s/$ENGINE_VERSION_PATTERN/$ENGINE_VERSION_REPLACE/" {} +
+if [ "$(uname -s)" = "Darwin" ]; then
+  find "$ROOT/evaluators" "$ROOT/tests" -name "plugin.json" -exec \
+    sed -i '' "s/$ENGINE_VERSION_PATTERN/$ENGINE_VERSION_REPLACE/" {} +
+else
+  find "$ROOT/evaluators" "$ROOT/tests" -name "plugin.json" -exec \
+    sed -i "s/$ENGINE_VERSION_PATTERN/$ENGINE_VERSION_REPLACE/" {} +
+fi
 echo "    engine_version set to ==$VERSION"
 
 echo "==> Building Python package..."

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Lint script that validates layer import rules for src/quodeq/."""
+"""Lint script that validates layer import rules for src/quodeq/.
+
+Existing violations are grandfathered via tools/import_baseline.txt so the
+gate runs green in CI today while preventing NEW violations. Regenerate the
+baseline (only with justification) via:
+    python tools/check_imports.py --update-baseline
+"""
 import re
 import sys
 from pathlib import Path
@@ -18,6 +24,7 @@ IMPORT_RE = re.compile(
     r"^\s*(?:from\s+quodeq\.(\w+)|import\s+quodeq\.(\w+))"
 )
 SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "quodeq"
+BASELINE_PATH = Path(__file__).resolve().parent / "import_baseline.txt"
 
 
 def source_layer(path: Path) -> str | None:
@@ -45,7 +52,8 @@ def check_file(path: Path, layer: str) -> list[tuple[int, str, str]]:
     return violations
 
 
-def main() -> int:
+def collect_violations() -> list[tuple[str, int, str, str]]:
+    """Return all (relpath, lineno, target, line) layer-rule violations."""
     all_violations: list[tuple[str, int, str, str]] = []
     for py in sorted(SRC_ROOT.rglob("*.py")):
         layer = source_layer(py)
@@ -53,12 +61,60 @@ def main() -> int:
             continue
         for lineno, target, line in check_file(py, layer):
             rel = py.relative_to(SRC_ROOT.parent.parent)
-            all_violations.append((str(rel), lineno, target, line))
-    if not all_violations:
-        print("OK: no violations")
+            all_violations.append((rel.as_posix(), lineno, target, line))
+    return all_violations
+
+
+def violation_key(v: tuple[str, int, str, str]) -> str:
+    """Identity for a violation, independent of the source line text."""
+    filepath, lineno, target, _line = v
+    return f"{filepath}:{lineno}:{target}"
+
+
+def load_baseline(path: Path = BASELINE_PATH) -> set[str]:
+    """Return the set of grandfathered violation keys (empty if no baseline)."""
+    if not path.exists():
+        return set()
+    return {
+        stripped
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if (stripped := line.strip()) and not stripped.startswith("#")
+    }
+
+
+def write_baseline(path: Path = BASELINE_PATH) -> int:
+    """Write current violations to the baseline file; return the count."""
+    keys = sorted(violation_key(v) for v in collect_violations())
+    header = (
+        "# Grandfathered layer-import violations. Do NOT add entries without\n"
+        "# justification -- the goal is to burn this list down, not grow it.\n"
+        "# Regenerate intentionally: python tools/check_imports.py --update-baseline\n"
+    )
+    path.write_text(header + "\n".join(keys) + ("\n" if keys else ""), encoding="utf-8")
+    return len(keys)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    unknown = [a for a in args if a != "--update-baseline"]
+    if unknown:
+        print(f"Unknown argument(s): {' '.join(unknown)}. Usage: check_imports.py [--update-baseline]")
+        return 2
+    if "--update-baseline" in args:
+        n = write_baseline()
+        print(f"Wrote {n} violation(s) to {BASELINE_PATH}")
         return 0
-    print(f"Found {len(all_violations)} import violation(s):\n")
-    for filepath, lineno, target, line in all_violations:
+
+    baseline = load_baseline()
+    all_violations = collect_violations()
+    new = [v for v in all_violations if violation_key(v) not in baseline]
+    grandfathered = len(all_violations) - len(new)
+
+    if not new:
+        print(f"OK: no new import violations ({grandfathered} grandfathered).")
+        return 0
+    print(f"Found {len(new)} NEW import violation(s) ({grandfathered} grandfathered):\n")
+    for filepath, lineno, target, line in new:
         print(f"  {filepath}:{lineno}  forbidden import of '{target}'")
         print(f"    {line}\n")
     return 1

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -40,7 +40,8 @@ def check_file(path: Path, layer: str) -> list[tuple[int, str, str]]:
     allowed = LAYER_RULES[layer] | CROSS_CUTTING | {layer}
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"warning: skipping {path}: {e}", file=sys.stderr)
         return violations
     for lineno, line in enumerate(lines, 1):
         m = IMPORT_RE.match(line)

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -22,7 +22,7 @@ src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
-src/quodeq/data/sqlite/state_store.py:239:services
+src/quodeq/data/sqlite/state_store.py:240:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -29,7 +29,7 @@ src/quodeq/services/_violations_jsonl.py:11:analysis
 src/quodeq/services/_violations_stream.py:10:analysis
 src/quodeq/services/_violations_stream.py:11:analysis
 src/quodeq/services/evaluation_mixin.py:19:analysis
-src/quodeq/services/evaluation_mixin.py:445:analysis
+src/quodeq/services/evaluation_mixin.py:451:analysis
 src/quodeq/services/jobs.py:20:analysis
 src/quodeq/services/scan_progress.py:23:analysis
 src/quodeq/services/tooling_mixin.py:17:analysis

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -1,0 +1,35 @@
+# Grandfathered layer-import violations. Do NOT add entries without
+# justification -- the goal is to burn this list down, not grow it.
+# Regenerate intentionally: python tools/check_imports.py --update-baseline
+src/quodeq/analysis/_api_runner.py:36:context
+src/quodeq/analysis/_api_runner.py:37:context
+src/quodeq/analysis/api_prompt_assembly.py:14:context
+src/quodeq/analysis/api_prompt_assembly.py:15:context
+src/quodeq/analysis/mcp/enricher.py:15:context
+src/quodeq/analysis/mcp/enricher.py:16:context
+src/quodeq/analysis/mcp/enricher.py:17:context
+src/quodeq/analysis/mcp/findings_server.py:20:context
+src/quodeq/analysis/mcp/findings_server.py:21:context
+src/quodeq/analysis/subprocess.py:244:llm_bridge
+src/quodeq/api/_evaluation_routes.py:19:analysis
+src/quodeq/api/import_project.py:30:data
+src/quodeq/api/import_project.py:31:data
+src/quodeq/api/import_project.py:32:data
+src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
+src/quodeq/api/routes_findings.py:85:data
+src/quodeq/data/fs/project_resolver.py:17:services
+src/quodeq/data/fs/repo_clone.py:19:context
+src/quodeq/data/fs/report_parser/runs.py:109:services
+src/quodeq/data/projection/grade_projector.py:130:services
+src/quodeq/data/projection/grade_projector.py:20:services
+src/quodeq/data/sqlite/state_store.py:198:services
+src/quodeq/engine/scoring_pipeline.py:10:services
+src/quodeq/services/_external_jobs.py:22:analysis
+src/quodeq/services/_violations_jsonl.py:11:analysis
+src/quodeq/services/_violations_stream.py:10:analysis
+src/quodeq/services/_violations_stream.py:11:analysis
+src/quodeq/services/evaluation_mixin.py:19:analysis
+src/quodeq/services/evaluation_mixin.py:445:analysis
+src/quodeq/services/jobs.py:20:analysis
+src/quodeq/services/scan_progress.py:23:analysis
+src/quodeq/services/tooling_mixin.py:17:analysis

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -16,7 +16,7 @@ src/quodeq/api/import_project.py:30:data
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
-src/quodeq/api/routes_findings.py:100:data
+src/quodeq/api/routes_findings.py:107:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -10,13 +10,13 @@ src/quodeq/analysis/mcp/enricher.py:16:context
 src/quodeq/analysis/mcp/enricher.py:17:context
 src/quodeq/analysis/mcp/findings_server.py:20:context
 src/quodeq/analysis/mcp/findings_server.py:21:context
-src/quodeq/analysis/subprocess.py:244:llm_bridge
-src/quodeq/api/_evaluation_routes.py:19:analysis
+src/quodeq/analysis/subprocess.py:232:llm_bridge
+src/quodeq/api/_evaluation_routes.py:21:analysis
 src/quodeq/api/import_project.py:30:data
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
-src/quodeq/api/routes_findings.py:85:data
+src/quodeq/api/routes_findings.py:100:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -22,7 +22,7 @@ src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
-src/quodeq/data/sqlite/state_store.py:198:services
+src/quodeq/data/sqlite/state_store.py:239:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -19,7 +19,7 @@ src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/api/routes_findings.py:85:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
-src/quodeq/data/fs/report_parser/runs.py:109:services
+src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:198:services

--- a/tools/migrate_cwe_title.py
+++ b/tools/migrate_cwe_title.py
@@ -34,6 +34,9 @@ def _build_cwe_name_lookup(compiled_dir: Path) -> dict[int, str]:
         except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
             print(f"  SKIP  cannot read {f}: {exc}")
             continue
+        if not isinstance(data, dict):
+            print(f"  SKIP  unexpected payload type in {f}: {type(data).__name__}")
+            continue
         for principle in data.get("principles", []):
             for cwe in principle.get("cwes", []):
                 cid = cwe.get("id")
@@ -72,6 +75,9 @@ def migrate_file(path: Path, cwe_names: dict[int, str], apply: bool) -> tuple[in
         data = json.loads(path.read_text(encoding=_TEXT_ENCODING))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         print(f"  SKIP  cannot read {path}: {exc}")
+        return 0, 0
+    if not isinstance(data, dict):
+        print(f"  SKIP  unexpected payload type in {path}: {type(data).__name__}")
         return 0, 0
     v_count = _patch_entries(data.get("violations", []), cwe_names)
     c_count = _patch_entries(data.get("compliance", []), cwe_names)

--- a/tools/migrate_reason_title.py
+++ b/tools/migrate_reason_title.py
@@ -39,6 +39,8 @@ def _find_first_sep(text: str) -> tuple[int, str] | tuple[None, None]:
 
 def migrate_entry(entry: dict) -> bool:
     """Migrate a single violation/compliance entry. Returns True if changed."""
+    if not isinstance(entry, dict):
+        return False
     reason = entry.get("reason", "")
     if not reason:
         return False

--- a/uv.lock
+++ b/uv.lock
@@ -706,7 +706,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -715,9 +715,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==9.0.3" },
+    { name = "pytest", specifier = "==9.1.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ wheels = [
 
 [[package]]
 name = "quodeq"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "flask" },


### PR DESCRIPTION
Cuts **v1.4.0** - a large security + reliability release (24 PRs since v1.3.0, no breaking changes). The CHANGELOG entry in this PR has the full notes.

Highlights:
- **Security hardening pass**: command-injection guard, atomic rate-limit write, path-traversal containment, omlx + project-clone SSRF guards, tightened CSP, localhost-only webview reload.
- **Reliability**: HTTP/SSE timeouts, exception-handling hygiene, malformed-input guards, atomic grade rewrites, UI crash guards.
- **Analysis quality**: provenance gate cuts false-positive criticals; finding taxonomy grouping; coverage + import-layer CI gates.
- **Accessibility / performance / config**: keyboard nav across viz, request-thread offloads + N+1 batching, externalized config.

Pre-release verification: full Python (3478) + UI (510) suites green; clean `vite build`; production CSP browser-smoked (dashboard renders, zero console/CSP errors).

Merging this lands v1.4.0 on main; the tag + GitHub Release (which fire PyPI/DMG/Homebrew) follow after merge.