### PR TITLE
test(analysis): behavioral regression matrix for the provenance gate (#641)

### DIFF
--- a/tests/analysis/_provenance_gate_support.py
+++ b/tests/analysis/_provenance_gate_support.py
@@ -1,0 +1,119 @@
+"""Shared helpers for the provenance-gate regression tests (issue #641).
+
+Dependency-light on purpose (only pathlib/json) so BOTH the always-on
+structural tests (``test_prompt_provenance_gate.py``) and the opt-in live
+behavioral test (``test_provenance_gate_behavioral.py``) can import it,
+including in a CI environment that has no ollama and never imports the
+model-calling code.
+
+The fixtures under ``fixtures/provenance_gate/`` are a matrix of cases:
+
+  internal_*  — code that run fa56db32 rated `critical` but whose flagged
+                value is provably INTERNAL (a defaulted prop/arg, a content
+                hash). Vendored byte-for-byte from commit a84ab6f8 (before the
+                later code-hardening at c0edcd6f / 521f46c6) so the fixture is
+                the exact code that was rated critical. Expected: not critical.
+  external_*  — synthetic code whose flagged value is genuinely ATTACKER-
+                CONTROLLED (an HTTP field, a CLI arg, a response header).
+                Expected: stays critical — the guard that the gate does not
+                over-relax.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+FIXTURES_ROOT = Path(__file__).resolve().parent / "fixtures" / "provenance_gate"
+
+_SEVERITY_ORDER = {"minor": 1, "major": 2, "critical": 3}
+
+
+@dataclass(frozen=True)
+class GateCase:
+    """One row of the provenance-gate matrix."""
+
+    name: str
+    repo_dir: Path  # the repo/ root, passed as assemble_api_prompt(repo_root=...)
+    source_file: Path  # the single source file under repo/
+    expected: dict
+
+
+def discover_cases() -> list[GateCase]:
+    """Glob the fixture matrix. Returns [] if the dir is missing (never raises)."""
+    cases: list[GateCase] = []
+    if not FIXTURES_ROOT.is_dir():
+        return cases
+    for entry in sorted(FIXTURES_ROOT.iterdir()):
+        if not entry.is_dir():
+            continue
+        expected_file = entry / "expected.json"
+        repo_dir = entry / "repo"
+        if not expected_file.is_file() or not repo_dir.is_dir():
+            continue
+        meta = json.loads(expected_file.read_text(encoding="utf-8"))
+        source_file = repo_dir / meta["display_file"]
+        cases.append(
+            GateCase(
+                name=entry.name,
+                repo_dir=repo_dir,
+                source_file=source_file,
+                expected=meta,
+            )
+        )
+    return cases
+
+
+def severity_str(finding: dict) -> str | None:
+    """Normalise a finding's severity to a plain string ('critical'/'major'/'minor').
+
+    ``_call_api`` returns ``_Finding.model_dump()`` dicts whose ``severity`` is a
+    ``(str, Enum)`` member; ``.value`` yields the bare string. Falls back to the
+    value as-is if it is already a string.
+    """
+    sev = finding.get("severity")
+    if sev is None:
+        return None
+    return getattr(sev, "value", sev)
+
+
+def target_severity(
+    findings: list[dict], expected: dict, *, allow_req_only: bool = False
+) -> tuple[str | None, list[dict]]:
+    """Worst severity among findings that match the case's target construct.
+
+    A finding matches when (robust to line drift / the model quoting a
+    neighbouring line):
+      - the case ``construct`` token appears in its snippet / title / reason, OR
+      - its line span covers the case ``target_line``.
+
+    ``allow_req_only`` additionally matches any finding whose requirement id
+    equals the case ``req``. That is a deliberately LOOSE catch for the external
+    controls, whose single-purpose fixtures contain exactly one issue, so any
+    same-req critical is the one we want. It is OFF for internal cases: those
+    fixtures (e.g. GradeBoundaryBar) contain other genuine same-req sites, and a
+    bare req match would let an unrelated critical there spuriously fail the
+    'gate kept the target non-critical' assertion.
+
+    Returns ``(worst_severity | None, matching_findings)``. ``None`` means the
+    construct was not flagged at all this run.
+    """
+    req = expected.get("req")
+    construct = expected.get("construct") or ""
+    target_line = expected.get("target_line") or 0
+    matches: list[dict] = []
+    for f in findings:
+        blob = " ".join(str(f.get(k) or "") for k in ("snippet", "w", "reason"))
+        line = f.get("line") or 0
+        end = f.get("end_line") or line
+        line_hit = bool(line) and line <= target_line <= end
+        construct_hit = bool(construct) and construct in blob
+        req_hit = allow_req_only and bool(req) and f.get("req") == req
+        if construct_hit or line_hit or req_hit:
+            matches.append(f)
+    worst: str | None = None
+    for f in matches:
+        sev = severity_str(f)
+        if sev in _SEVERITY_ORDER and (worst is None or _SEVERITY_ORDER[sev] > _SEVERITY_ORDER[worst]):
+            worst = sev
+    return worst, matches

--- a/tests/analysis/fixtures/provenance_gate/README.md
+++ b/tests/analysis/fixtures/provenance_gate/README.md
@@ -1,0 +1,55 @@
+# Provenance-gate regression matrix (issue #641)
+
+Fixtures for the critical-severity **provenance gate** (added in PR #636, verified
+in #638). Each subdirectory is one case:
+
+```
+<case>/
+  expected.json     # dimension, req, target line + construct, expected verdict
+  repo/             # a minimal repo root; the source file lives under repo/src/...
+```
+
+`repo/` is passed as `assemble_api_prompt(repo_root=...)` so the source renders as a
+production path (`src/...`, role = PROD), not a fixture (which would carry a
+"tone down" label and confound the result).
+
+## The matrix
+
+| case | dimension | req | provenance | expectation |
+|------|-----------|-----|------------|-------------|
+| `internal_nav_breadcrumb`    | reliability | R-FT-2 | internal | not critical |
+| `internal_grade_boundary_bar`| reliability | R-FT-2 | internal | not critical |
+| `internal_use_project_scores`| reliability | R-FT-2 | internal | not critical |
+| `internal_local_cache`       | security    | S-AUT-3| internal | not critical |
+| `external_request_path`      | security    | S-AUT-3| external | stays critical |
+| `external_cli_arg_open`      | security    | S-AUT-3| external | stays critical |
+| `external_header_deref`      | reliability | R-FT-2 | external | stays critical |
+
+## ⚠️ Do not "fix" the internal fixtures
+
+The four `internal_*` source files are **verbatim from commit `a84ab6f8`** — the
+exact code that run `fa56db32` rated `critical`, captured *before* the later
+code-level guards (`_SAFE_KEY_RE` in `c0edcd6f`, `= {}` default args in `521f46c6`).
+Keeping them guard-free preserves the exact construct that was flagged. Adding a
+null check, default, or validation makes the fixture stop representing the FP.
+`test_fixture_construct_anchored_at_target_line` pins the construct + line to catch
+such drift.
+
+The three `external_*` files are synthetic controls: the flagged value is genuinely
+attacker-controlled (an HTTP field, a CLI arg, a response header). They must stay
+`critical` — the guard that the gate does not over-relax.
+
+## Running the live check
+
+The behavioral test (`../test_provenance_gate_behavioral.py`) is `integration`-marked
+and skipped unless a standard (non-mlx) `gemma4:26b` is reachable:
+
+```
+ollama serve &
+ollama pull gemma4:26b
+AI_MODEL=gemma4:26b uv run pytest \
+    tests/analysis/test_provenance_gate_behavioral.py -v -m integration
+```
+
+The structural guards in `../test_prompt_provenance_gate.py` run in normal CI with
+no model.

--- a/tests/analysis/fixtures/provenance_gate/external_cli_arg_open/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/external_cli_arg_open/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "external_cli_arg_open",
+  "dimension": "security",
+  "req": "S-AUT-3",
+  "display_file": "src/cli/export.py",
+  "target_line": 8,
+  "construct": "argv",
+  "provenance": "external",
+  "expectation": "stays_critical",
+  "baseline_severity": "critical",
+  "source": "synthetic",
+  "note": "Path built from a CLI argument (attacker-influenced). The gate must NOT relax this: it stays critical. Second external source class; validated as a hard assert against gemma4:26b (3/3 critical)."
+}

--- a/tests/analysis/fixtures/provenance_gate/external_cli_arg_open/repo/src/cli/export.py
+++ b/tests/analysis/fixtures/provenance_gate/external_cli_arg_open/repo/src/cli/export.py
@@ -1,0 +1,18 @@
+"""Export command: writes a report to a user-supplied path."""
+import sys
+from pathlib import Path
+
+
+def main():
+    # dest is read from a command-line argument.
+    dest = sys.argv[1]
+    report = build_report()
+    Path(dest).write_text(report, encoding="utf-8")
+
+
+def build_report() -> str:
+    return "report contents"
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/analysis/fixtures/provenance_gate/external_header_deref/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/external_header_deref/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "external_header_deref",
+  "dimension": "reliability",
+  "req": "R-FT-2",
+  "display_file": "src/ui/ActiveUsers.jsx",
+  "target_line": 11,
+  "construct": "split",
+  "provenance": "external",
+  "expectation": "stays_critical",
+  "baseline_severity": "critical",
+  "source": "synthetic",
+  "note": "Unguarded deref (.split) of a response header that may be absent and is network-controlled. The gate must NOT relax this: it stays critical. Reliability-dimension external control; validated as a hard assert against gemma4:26b (3/3 critical)."
+}

--- a/tests/analysis/fixtures/provenance_gate/external_header_deref/repo/src/ui/ActiveUsers.jsx
+++ b/tests/analysis/fixtures/provenance_gate/external_header_deref/repo/src/ui/ActiveUsers.jsx
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+// Renders the active-user list parsed from a response header.
+export function ActiveUsers() {
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    fetch("/api/heartbeat").then((resp) => {
+      // raw is read from a response header and may be absent.
+      const raw = resp.headers.get("x-active-users");
+      const names = raw.split(",").map((s) => s.trim());
+      setUsers(names);
+    });
+  }, []);
+
+  return <ul>{users.map((u) => <li key={u}>{u}</li>)}</ul>;
+}

--- a/tests/analysis/fixtures/provenance_gate/external_request_path/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/external_request_path/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "external_request_path",
+  "dimension": "security",
+  "req": "S-AUT-3",
+  "display_file": "src/server/download.py",
+  "target_line": 10,
+  "construct": "os.path.join",
+  "provenance": "external",
+  "expectation": "stays_critical",
+  "baseline_severity": "critical",
+  "source": "synthetic",
+  "note": "Path built directly from an HTTP request field. The gate must NOT relax this: it stays critical. Validated 3/3 critical in the #638 harness."
+}

--- a/tests/analysis/fixtures/provenance_gate/external_request_path/repo/src/server/download.py
+++ b/tests/analysis/fixtures/provenance_gate/external_request_path/repo/src/server/download.py
@@ -1,0 +1,12 @@
+"""File download endpoint."""
+import os
+
+BASE_DIR = "/srv/data"
+
+
+def handle_download(request):
+    # `file` is read from the inbound HTTP request.
+    name = request["file"]
+    path = os.path.join(BASE_DIR, name)
+    with open(path, "rb") as fh:
+        return fh.read()

--- a/tests/analysis/fixtures/provenance_gate/internal_grade_boundary_bar/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/internal_grade_boundary_bar/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "internal_grade_boundary_bar",
+  "dimension": "reliability",
+  "req": "R-FT-2",
+  "display_file": "src/ui/GradeBoundaryBar.jsx",
+  "target_line": 19,
+  "construct": "thresholds",
+  "provenance": "internal",
+  "expectation": "not_critical",
+  "baseline_severity": "critical",
+  "source": "a84ab6f8 verbatim (pre-hardening)",
+  "note": "DO NOT add guards/defaults to repo/. `thresholds` is backfilled from DEFAULT_PARAMS; no external source reaches the spread, so the gate must keep it non-critical."
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_grade_boundary_bar/repo/src/ui/GradeBoundaryBar.jsx
+++ b/tests/analysis/fixtures/provenance_gate/internal_grade_boundary_bar/repo/src/ui/GradeBoundaryBar.jsx
@@ -1,0 +1,96 @@
+import { useRef } from 'react';
+
+const SEG_LABELS = ['CRITICAL', 'POOR', 'ADEQUATE', 'GOOD', 'EXEMPLARY'];
+const GRADE_COLOR_VARS = [
+  'var(--color-grade-bottom-text)', 'var(--color-grade-low-text)',
+  'var(--color-grade-mid-text)', 'var(--color-grade-high-text)',
+  'var(--color-grade-top-text)',
+];
+const MIN_GAP = 0.5;
+
+/**
+ * Segmented 0-10 bar; thresholds = [[9,'Exemplary'],[7,..],[5,..],[3,..]]
+ * (descending). Dragging divider i moves the ascending boundary i.
+ * onChange receives a full new thresholds array (descending, labels preserved).
+ */
+export default function GradeBoundaryBar({ thresholds, onChange }) {
+  const barRef = useRef(null);
+  // ascending boundary values, e.g. [3,5,7,9]
+  const asc = [...thresholds].map(([t]) => t).reverse();
+  const edges = [0, ...asc, 10];
+
+  // Keep the latest ascending values in a ref so the pointermove closure reads
+  // fresh clamps across re-renders during one continuous drag (avoids stale-closure
+  // clamps from the asc captured at the drag's start).
+  const ascRef = useRef(asc);
+  ascRef.current = asc;
+
+  const startDrag = (dividerIdx) => (downEvent) => {
+    if (downEvent.currentTarget.closest('fieldset[disabled]')) return;
+    downEvent.preventDefault();
+    const rect = barRef.current.getBoundingClientRect();
+    const move = (e) => {
+      const clientX = e.touches ? e.touches[0].clientX : e.clientX;
+      const live = ascRef.current;
+      let value = ((clientX - rect.left) / rect.width) * 10;
+      const lo = (dividerIdx === 0 ? 0 : live[dividerIdx - 1]) + MIN_GAP;
+      const hi = (dividerIdx === live.length - 1 ? 10 : live[dividerIdx + 1]) - MIN_GAP;
+      value = Math.round(Math.min(hi, Math.max(lo, value)) * 10) / 10;
+      const nextAsc = [...live];
+      nextAsc[dividerIdx] = value;
+      const desc = [...nextAsc].reverse();
+      onChange(thresholds.map(([, label], i) => [desc[i], label]));
+    };
+    const stop = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', stop);
+      window.removeEventListener('pointercancel', stop);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', stop);
+    window.addEventListener('pointercancel', stop);
+  };
+
+  return (
+    <div>
+      <div className="gf-boundary-bar" ref={barRef}>
+        {edges.slice(0, -1).map((edge, i) => (
+          <Segment
+            key={SEG_LABELS[i]}
+            i={i}
+            width={edges[i + 1] - edge}
+            hasDivider={i < asc.length}
+            onDrag={startDrag}
+          />
+        ))}
+      </div>
+      <div className="gf-boundary-ticks">
+        {edges.slice(0, -1).map((edge, i) => (
+          <span key={`tick${i}`} style={{ flex: edges[i + 1] - edge }}>{edge}</span>
+        ))}
+        <span>10</span>
+      </div>
+    </div>
+  );
+}
+
+function Segment({ i, width, hasDivider, onDrag }) {
+  return (
+    <>
+      <div
+        className="gf-boundary-seg"
+        style={{ flex: width, background: GRADE_COLOR_VARS[i] }}
+      >
+        {SEG_LABELS[i]}
+      </div>
+      {hasDivider ? (
+        <div
+          className="gf-boundary-divider"
+          role="slider"
+          aria-label={`Boundary ${i + 1}`}
+          onPointerDown={onDrag(i)}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_local_cache/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/internal_local_cache/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "internal_local_cache",
+  "dimension": "security",
+  "req": "S-AUT-3",
+  "display_file": "src/cache/local.py",
+  "target_line": 59,
+  "construct": "key[:2]",
+  "provenance": "internal",
+  "expectation": "not_critical",
+  "baseline_severity": "critical",
+  "source": "a84ab6f8 verbatim (pre-hardening; _SAFE_KEY_RE charset validation added later in c0edcd6f)",
+  "note": "DO NOT add guards to repo/. `key` is an internal SHA-256 hex digest, not attacker-controllable; the gate must keep this path-build non-critical. Twin of external_request_path (same construct, opposite provenance)."
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_local_cache/repo/src/cache/local.py
+++ b/tests/analysis/fixtures/provenance_gate/internal_local_cache/repo/src/cache/local.py
@@ -1,0 +1,122 @@
+"""Local filesystem cache backend.
+
+Layout (git-style two-char sharding to keep each directory bounded):
+
+    <root>/<sha[:2]>/<sha[2:]>/entry.json
+
+Writes go via temp file + ``os.rename``, which is atomic on POSIX and on
+NTFS for same-volume renames. A reader either sees the previous contents
+or the new contents, never a partial. A crash mid-write leaves an
+orphaned ``.tmp.*`` file that's skipped by readers and cleaned up on the
+next visit to the same directory.
+
+Cache root resolution mirrors ``context/online_cache.py``:
+``QUODEQ_CACHE_ROOT`` overrides ``~/.quodeq/cache`` so tests can sandbox.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from quodeq.analysis.cache.backend import CacheStats
+from quodeq.analysis.cache.entry import CacheEntry
+
+_logger = logging.getLogger(__name__)
+
+_ROOT_ENV = "QUODEQ_CACHE_ROOT"
+_RESULTS_SUBDIR = "results"
+_ENTRY_FILENAME = "entry.json"
+_TMP_PREFIX = ".tmp."
+
+
+def default_cache_root() -> Path:
+    """Resolve the result cache root, honouring ``QUODEQ_CACHE_ROOT``.
+
+    Returns ``<base>/results`` so this cache is a sibling of the online
+    repo cache under the same shared parent directory.
+    """
+    raw = os.environ.get(_ROOT_ENV, "").strip()
+    base = Path(raw) if raw else Path.home() / ".quodeq" / "cache"
+    return base / _RESULTS_SUBDIR
+
+
+class LocalFileBackend:
+    """Sharded filesystem cache with atomic writes."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = root if root is not None else default_cache_root()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _dir_for(self, key: str) -> Path:
+        if len(key) < 3:
+            raise ValueError(f"cache key too short: {key!r}")
+        return self._root / key[:2] / key[2:]
+
+    def _entry_path(self, key: str) -> Path:
+        return self._dir_for(key) / _ENTRY_FILENAME
+
+    def get(self, key: str) -> CacheEntry | None:
+        path = self._entry_path(key)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            _logger.warning("cache read failed for %s: %s", key, exc)
+            return None
+        try:
+            return CacheEntry.from_json(text)
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
+            # Corrupt entry — treat as miss and remove so the next put can heal.
+            _logger.warning("cache entry corrupt at %s, removing: %s", path, exc)
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return None
+
+    def put(self, key: str, entry: CacheEntry) -> None:
+        target_dir = self._dir_for(key)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / _ENTRY_FILENAME
+        tmp = target_dir / f"{_TMP_PREFIX}{os.getpid()}.{id(entry):x}"
+        try:
+            tmp.write_text(entry.to_json(), encoding="utf-8")
+            os.replace(tmp, target)
+        except OSError as exc:
+            _logger.warning("cache write failed for %s: %s", key, exc)
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    def has(self, key: str) -> bool:
+        return self._entry_path(key).is_file()
+
+    def delete(self, key: str) -> None:
+        target_dir = self._dir_for(key)
+        if not target_dir.exists():
+            return
+        try:
+            shutil.rmtree(target_dir)
+        except OSError as exc:
+            _logger.warning("cache delete failed for %s: %s", key, exc)
+
+    def stats(self) -> CacheStats:
+        if not self._root.exists():
+            return CacheStats(entries=0, bytes=0)
+        entries = 0
+        total_bytes = 0
+        for entry_path in self._root.rglob(_ENTRY_FILENAME):
+            try:
+                total_bytes += entry_path.stat().st_size
+                entries += 1
+            except OSError:
+                continue
+        return CacheStats(entries=entries, bytes=total_bytes)

--- a/tests/analysis/fixtures/provenance_gate/internal_nav_breadcrumb/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/internal_nav_breadcrumb/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "internal_nav_breadcrumb",
+  "dimension": "reliability",
+  "req": "R-FT-2",
+  "display_file": "src/ui/NavBreadcrumb.jsx",
+  "target_line": 48,
+  "construct": "stack.forEach",
+  "provenance": "internal",
+  "expectation": "not_critical",
+  "baseline_severity": "critical",
+  "source": "a84ab6f8 verbatim (pre-hardening; `= {}` default added later in 521f46c6)",
+  "note": "DO NOT add guards/defaults to repo/. Fixture must stay byte-for-byte a84ab6f8 so the prompt gate is the only variable. `stack` is an internal prop from useNavStack; no external source reaches this line, so the gate must keep it non-critical."
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_nav_breadcrumb/repo/src/ui/NavBreadcrumb.jsx
+++ b/tests/analysis/fixtures/provenance_gate/internal_nav_breadcrumb/repo/src/ui/NavBreadcrumb.jsx
@@ -1,0 +1,74 @@
+import { Fragment } from 'react';
+
+const PAGE_LABELS = {
+  overview: 'overview',
+  violations: 'violations',
+  map: 'map',
+  history: 'history',
+  evaluate: 'evaluate',
+  standards: 'standards',
+  settings: 'settings',
+  'grade-formula': 'grade formula',
+  projects: 'repositories',
+  help: 'help',
+};
+
+export function labelFor(entry) {
+  if (PAGE_LABELS[entry.page]) return PAGE_LABELS[entry.page];
+  switch (entry.page) {
+    case 'run':           return entry.label || entry.runId || 'run';
+    case 'history-run':   return entry.dateLabel || entry.runId || 'run';
+    case 'explorer':      return entry.dimension
+      ? entry.dimension.toLowerCase()
+      : 'dimension';
+    case 'violation':     return entry.label || entry.principle?.name || 'violation';
+    case 'file':          return entry.label || entry.file?.path || 'file';
+    case 'principle':     return entry.label || 'principle';
+    case 'evalprinciple': return entry.label || entry.principleName || 'principle';
+    case 'finding':       return entry.label || 'finding';
+    default:              return entry.label || entry.page;
+  }
+}
+
+/**
+ * NavBreadcrumb — the app's single breadcrumb bar.
+ *
+ * Renders as a thin strip under the topbar / right of the sidebar (the
+ * AppShell places it directly above page content). Always visible while
+ * navigating in a project; falls back to showing just the project root +
+ * current tab when the user hasn't drilled in yet.
+ *
+ * Style: slash-separated plain text, monospace, muted. Intermediate
+ * segments are clickable to pop the nav stack; the current segment is
+ * accent-colored and non-interactive.
+ */
+export default function NavBreadcrumb({ stack, onGoTo, projectName }) {
+  const crumbs = [];
+  if (projectName) crumbs.push({ label: projectName, index: -1 });
+  stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <nav className="nav-breadcrumb" aria-label="Breadcrumb">
+      <ol className="nav-breadcrumb__crumbs">
+        {crumbs.map((seg, i) => {
+          const isLast = i === crumbs.length - 1;
+          const isClickable = !isLast && seg.index >= 0;
+          return (
+            <Fragment key={`${seg.label}-${i}`}>
+              {i > 0 && <li className="nav-breadcrumb__sep" aria-hidden="true">/</li>}
+              <li className={`nav-breadcrumb__crumb${isLast ? ' is-current' : ''}`}>
+                {isClickable ? (
+                  <button type="button" onClick={() => onGoTo(seg.index)}>{seg.label}</button>
+                ) : (
+                  <span>{seg.label}</span>
+                )}
+              </li>
+            </Fragment>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_use_project_scores/expected.json
+++ b/tests/analysis/fixtures/provenance_gate/internal_use_project_scores/expected.json
@@ -1,0 +1,13 @@
+{
+  "case": "internal_use_project_scores",
+  "dimension": "reliability",
+  "req": "R-FT-2",
+  "display_file": "src/ui/useProjectScores.js",
+  "target_line": 24,
+  "construct": "useProjectScores",
+  "provenance": "internal",
+  "expectation": "not_critical",
+  "baseline_severity": "critical",
+  "source": "a84ab6f8 verbatim (pre-hardening; `= {}` default added later in 521f46c6)",
+  "note": "DO NOT add guards/defaults to repo/. The hook is called with a static object literal; `keepPlaceholder` already has an internal default. No external source reaches the destructure, so the gate must keep it non-critical."
+}

--- a/tests/analysis/fixtures/provenance_gate/internal_use_project_scores/repo/src/ui/useProjectScores.js
+++ b/tests/analysis/fixtures/provenance_gate/internal_use_project_scores/repo/src/ui/useProjectScores.js
@@ -1,0 +1,93 @@
+/**
+ * useProjectScores -- single hook for all score data.
+ *
+ * Two queries: scores at a specific run (when asOf is set), plus latest
+ * scores. TanStack Query handles caching, abort, and refresh.
+ *
+ * To force a refresh after a mutation (dismiss/restore), call:
+ *   queryClient.invalidateQueries({ queryKey: projectKeys.project(p) });
+ */
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getProjectScores } from "../api/index.js";
+import { projectKeys } from "../api/queryKeys.js";
+
+/**
+ * @param {{
+ *   selectedProject: string,
+ *   selectedRun: string,
+ *   keepPlaceholder?: boolean,
+ * }} opts
+ *
+ * keepPlaceholder (default true): see useDashboard for rationale.
+ */
+export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder = true }) {
+  const queryClient = useQueryClient();
+
+  const latestQuery = useQuery({
+    queryKey: projectKeys.scores(selectedProject || "_none_", null),
+    queryFn: () => getProjectScores(selectedProject),
+    enabled: !!selectedProject,
+    staleTime: 60_000,
+    // Latest scores are project-wide (no per-run swap), so prev-data
+    // flashing isn't a concern — keep placeholder unconditionally.
+    placeholderData: (prev) => prev,
+  });
+
+  // Overview is anchored on completed runs. If selectedRun points at an
+  // in-progress run (or one that hasn't shown up in availableRuns yet),
+  // fall back to 'latest' so the cards keep showing the last finished
+  // evaluation instead of going blank mid-flight. Resolution waits for
+  // latestQuery so we never fire the scoped query with a stale asOf.
+  const isLatestSelection = !selectedRun || selectedRun === "latest";
+  const asOf = useMemo(() => {
+    if (isLatestSelection) return null;
+    const runs = latestQuery.data?.availableRuns;
+    if (!runs) return null;
+    const match = runs.find((r) => r.runId === selectedRun);
+    if (!match) return null;
+    if (match.status === "in_progress") return null;
+    return selectedRun;
+  }, [isLatestSelection, selectedRun, latestQuery.data]);
+
+  const scoresQuery = useQuery({
+    queryKey: projectKeys.scores(selectedProject || "_none_", asOf),
+    queryFn: () => getProjectScores(selectedProject, asOf),
+    // Wait for the latest run-status list before issuing a scoped fetch —
+    // otherwise we'd briefly call with the raw selectedRun and only later
+    // correct it, leaking a stale-asOf request.
+    enabled: !!selectedProject && (isLatestSelection || latestQuery.isSuccess),
+    staleTime: 60_000,
+    // Keep prior scores visible while switching runs — see useDashboard for rationale.
+    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
+  });
+
+  const availableRuns = useMemo(() => {
+    const fromPayload =
+      scoresQuery.data?.availableRuns || latestQuery.data?.availableRuns;
+    if (fromPayload && fromPayload.length > 0) return fromPayload;
+    const trend = scoresQuery.data?.trend || latestQuery.data?.trend || [];
+    return trend.map((row) => ({
+      runId: row.runId,
+      dateLabel: row.dateLabel || row.runId,
+      status: "complete",
+    }));
+  }, [scoresQuery.data, latestQuery.data]);
+
+  const refreshScores = useCallback(() => {
+    if (!selectedProject) return;
+    queryClient.invalidateQueries({ queryKey: projectKeys.project(selectedProject) });
+  }, [queryClient, selectedProject]);
+
+  return {
+    scores: scoresQuery.data ?? null,
+    latestScores: latestQuery.data ?? null,
+    loading: scoresQuery.isLoading || latestQuery.isLoading,
+    error:
+      (scoresQuery.isError || latestQuery.isError)
+        ? "Failed to load score data. Check your connection and try refreshing."
+        : null,
+    availableRuns,
+    refreshScores,
+  };
+}

--- a/tests/analysis/test_prompt_provenance_gate.py
+++ b/tests/analysis/test_prompt_provenance_gate.py
@@ -12,11 +12,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
 from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt
 from quodeq.analysis.prompts._template import load_template
+from quodeq.context.path_role import Role, path_role
+from tests.analysis._provenance_gate_support import discover_cases
 
 RULES = Path("src/quodeq/data/prompts/evaluation_rules.md").read_text()
 COMPASS = Path("src/quodeq/data/prompts/compass.md").read_text()
+
+_CASES = discover_cases()
+_CASE_IDS = [c.name for c in _CASES]
 
 
 def test_rules_define_provenance_selfcheck():
@@ -67,3 +75,97 @@ def test_compass_prompt_renders_provenance_gate_end_to_end():
     result = build_analysis_prompt(template, ctx).lower()
     assert "provenance" in result
     assert "attacker-controlled" in result
+
+
+def test_api_prompt_renders_provenance_gate_end_to_end(tmp_path):
+    """The DIRECT-API path (assemble_api_prompt) must also carry the gate.
+
+    The existing tests only prove the compass.md producer path carries the
+    rubric. ``assemble_api_prompt`` is the prompt the ollama/api provider path
+    actually sends (``subprocess.py:_run_api_analysis_bridge``); it loads the
+    rules itself via ``_load_evaluation_rules``, a separate seam that could
+    regress independently. This is the structural backstop for the live
+    behavioral matrix.
+    """
+    src = tmp_path / "sample.py"
+    src.write_text("def f(x):\n    return open(x)\n", encoding="utf-8")
+    prompt = assemble_api_prompt(
+        source_files=[src],
+        standards_text="",
+        dimension="security",
+        repo_name="sample",
+        repo_root=tmp_path,
+    ).lower()
+    assert "provenance" in prompt
+    assert "attacker-controlled" in prompt
+
+
+def test_fixture_matrix_is_well_formed():
+    """Guardrail: a misconfigured fixtures dir must fail loudly, not pass zero cases.
+
+    Mirrors tests/config/test_discipline_corpus.py. Requires both provenance
+    classes AND both dimensions to be represented, so a discovery-glob bug that
+    silently drops half the matrix is caught here in normal CI.
+    """
+    assert _CASES, "no provenance-gate fixtures discovered"
+    internal = [c for c in _CASES if c.expected["provenance"] == "internal"]
+    external = [c for c in _CASES if c.expected["provenance"] == "external"]
+    assert len(internal) >= 4, f"expected >=4 internal FP fixtures, got {len(internal)}"
+    assert any(c.expected["dimension"] == "reliability" for c in external), "no reliability external control"
+    assert any(c.expected["dimension"] == "security" for c in external), "no security external control"
+    for case in _CASES:
+        for key in ("dimension", "req", "display_file", "target_line", "construct", "provenance", "expectation"):
+            assert key in case.expected, f"{case.name}: expected.json missing {key!r}"
+        assert case.source_file.is_file(), f"{case.name}: source file missing at {case.source_file}"
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_fixture_display_path_is_prod(case):
+    """Fixture display paths must classify as PROD (no `(role:` toning-down label).
+
+    ``_build_files_block`` appends ``(role: test_fixture)`` and tells the model
+    to tone down findings for any path under ``**/fixtures/**``. The behavioral
+    test avoids that confound by passing ``repo_root=<case>/repo`` so the display
+    path renders as ``src/...`` (PROD). This pins that invariant: if it breaks,
+    a de-escalation could come from the role label, not the gate.
+    """
+    assert path_role(case.expected["display_file"]) is Role.PROD
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_fixture_construct_anchored_at_target_line(case):
+    """The construct token must sit at the declared target line (catches fixture drift).
+
+    If someone edits a vendored fixture (e.g. adds a guard) and the construct or
+    line shifts, this fails in normal CI before the live test ever runs.
+    """
+    lines = case.source_file.read_text(encoding="utf-8").splitlines()
+    target = case.expected["target_line"]
+    construct = case.expected["construct"]
+    window = "\n".join(lines[max(0, target - 3): target + 2])
+    assert construct in window, (
+        f"{case.name}: construct {construct!r} not found within +/-2 lines of "
+        f"target_line {target} in {case.expected['display_file']}"
+    )
+
+
+@pytest.mark.parametrize(
+    "case", [c for c in _CASES if c.expected["provenance"] == "internal"],
+    ids=[c.name for c in _CASES if c.expected["provenance"] == "internal"],
+)
+def test_internal_fixture_prompt_has_no_role_label(case):
+    """The assembled production prompt for an internal fixture must not tone down.
+
+    Deterministic proof (no model) that the load-bearing repo_root choice keeps
+    the fixture rendered as production code: the prompt must not contain a
+    `(role:` label that would instruct the model to discount the finding.
+    """
+    prompt = assemble_api_prompt(
+        source_files=[case.source_file],
+        standards_text="",
+        dimension=case.expected["dimension"],
+        repo_name="provenance-gate-fixture",
+        repo_root=case.repo_dir,
+    )
+    assert "(role:" not in prompt
+    assert "test_fixture" not in prompt

--- a/tests/analysis/test_provenance_gate_behavioral.py
+++ b/tests/analysis/test_provenance_gate_behavioral.py
@@ -1,0 +1,163 @@
+"""Live behavioral regression for the critical-severity provenance gate (issue #641).
+
+Run fa56db32 (model ``gemma4:26b-mlx``) rated 4 findings ``critical`` that are
+false positives: the flagged value is provably INTERNAL (a defaulted prop/arg, a
+SHA-256 cache key). PR #636 added a provenance gate to ``evaluation_rules.md`` so
+those drop to ``major``/``minor`` while genuinely EXTERNAL input stays ``critical``.
+Issue #638 verified this once by hand; this module makes the OUTCOME a durable matrix.
+
+What this tier pins (and what it does NOT):
+    It pins the OUTCOME on the real fixtures -- the known internal-provenance
+    constructs never surface as ``critical`` (``test_internal_*``), and genuinely
+    external input stays ``critical`` (``test_external_*``). It does NOT try to
+    isolate the gate as the cause. We measured the gate-off counterfactual on a
+    standard ``gemma4:26b``: with the provenance gate stripped, the four internal
+    constructs still came back major / minor / not-flagged (only 1 of 12 runs was
+    critical). A capable model does not reproduce these FPs even without the gate
+    -- they were a ``gemma4:26b-mlx`` over-rating artifact, and the general
+    severity rules already de-escalate them. So a gate-on/off behavioral A/B has
+    no signal here; the gate's PRESENCE across every prompt path is guarded
+    deterministically in ``test_prompt_provenance_gate.py`` (no model needed),
+    and this tier guards that the corrected outcome holds on the real code.
+    A run where the model drops an internal finding entirely is a pass -- the gate
+    explicitly permits "major OR drop" for an internal value.
+
+Faithfulness: this drives the exact local-provider path
+(``assemble_api_prompt`` -> ``_call_api``) that ``subprocess.py`` uses. Downstream
+enrichment only downweights confidence and never escalates severity, so the
+emitted severity is a faithful, slightly conservative proxy for the full pipeline.
+
+Opt-in: marked ``integration`` (excluded from the PR/publish ``-m "not integration"``
+gates) and skipped unless a standard (non-mlx) ``gemma4:26b`` is reachable. The
+``gemma4:26b-mlx`` build is compliance-blind (a known issue) and is explicitly
+rejected. Run it locally::
+
+    ollama serve &
+    ollama pull gemma4:26b
+    AI_MODEL=gemma4:26b uv run pytest \\
+        tests/analysis/test_provenance_gate_behavioral.py -v -m integration
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openai", reason="requires the openai SDK")
+
+import quodeq
+from quodeq.analysis._api_runner import ApiRunnerConfig, _call_api
+from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
+from quodeq.analysis.subprocess import _load_standards_text
+from quodeq.llm_bridge._ollama import get_ollama_status, list_ollama_models
+from tests.analysis._provenance_gate_support import discover_cases, target_severity
+
+# Standard build only. The mlx build is compliance-blind; reject it explicitly so
+# a box that sourced quodeq.env (AI_MODEL=gemma4:26b-mlx) skips with a clear reason
+# rather than running against the wrong model.
+_GATE_MODEL = os.environ.get("AI_MODEL") or "gemma4:26b"
+# Resolve the runner base from OLLAMA_BASE_URL so it targets the SAME server the
+# readiness probe (_ollama.py, which also honours OLLAMA_BASE_URL) checks. When
+# unset this is the standard local base, on which _call_api skips validate_url_safe.
+_OLLAMA_BASE = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+_API_BASE = f"{_OLLAMA_BASE}/v1"
+
+_RUNS_INTERNAL = int(os.environ.get("QGATE_RUNS_INTERNAL", "3"))
+_RUNS_EXTERNAL = int(os.environ.get("QGATE_RUNS_EXTERNAL", "3"))
+_MIN_VALID = 2  # need at least this many non-lossy runs to conclude
+
+_COMPILED_DIR = Path(quodeq.__file__).parent / "data" / "standards" / "compiled"
+
+
+def _gate_runnable() -> tuple[bool, str]:
+    """(runnable, skip_reason). Probes are exception-safe and never raise."""
+    if _GATE_MODEL.endswith("-mlx"):
+        return False, (
+            f"resolved AI_MODEL={_GATE_MODEL!r} is the compliance-blind mlx build; "
+            "set AI_MODEL=gemma4:26b to exercise the gate's reasoning"
+        )
+    if not get_ollama_status().get("running"):
+        return False, "ollama server not reachable on the configured base URL"
+    names = {m["name"] for m in list_ollama_models()}
+    if _GATE_MODEL not in names:
+        return False, f"required model {_GATE_MODEL!r} not pulled (installed: {sorted(names)})"
+    return True, ""
+
+
+_RUNNABLE, _SKIP_REASON = _gate_runnable()
+
+pytestmark = [
+    pytest.mark.integration,
+    # Overrides the 60s global. A test makes _RUNS_* calls, each read-bounded at
+    # _LOCAL_TIMEOUT (500s) in _call_api; 3000s covers the pathological all-slow
+    # case without the marker killing a working run early.
+    pytest.mark.timeout(3000),
+    pytest.mark.skipif(not _RUNNABLE, reason=f"provenance-gate live test skipped: {_SKIP_REASON}"),
+]
+
+_CASES = discover_cases()
+_INTERNAL = [c for c in _CASES if c.expected["provenance"] == "internal"]
+_EXTERNAL = [c for c in _CASES if c.expected["provenance"] == "external"]
+
+
+def _run(case):
+    """One production-path model call. Returns (target_severity|None, was_lossy)."""
+    dimension = case.expected["dimension"]
+    standards = _load_standards_text(_COMPILED_DIR, dimension)
+    prompt = assemble_api_prompt(
+        source_files=[case.source_file],
+        standards_text=standards,
+        dimension=dimension,
+        repo_name="provenance-gate-fixture",
+        repo_root=case.repo_dir,
+    )
+    # Fail fast on the role-label confound: the production path must render the
+    # fixture as PROD code (no "tone down" label), else a de-escalation could come
+    # from the role label rather than the gate.
+    assert "(role:" not in prompt, f"{case.name}: fixture rendered with a role label (wrong repo_root)"
+    findings, lossy = _call_api(prompt, ApiRunnerConfig(model=_GATE_MODEL, api_base=_API_BASE, temperature=0.1))
+    # Loose req-only matching is for the single-issue external fixtures; internal
+    # fixtures hold other same-req sites, so they match on construct/line only.
+    allow_req_only = case.expected["provenance"] == "external"
+    severity, _matches = target_severity(findings, case.expected, allow_req_only=allow_req_only)
+    return severity, lossy
+
+
+@pytest.mark.parametrize("case", _INTERNAL, ids=[c.name for c in _INTERNAL])
+def test_internal_construct_not_critical(case):
+    """A known internal-provenance FP must never surface as critical.
+
+    Outcome pin on the #638 result. Absence of a finding is a pass (the gate
+    permits "major OR drop" for an internal value); the only failure is a
+    critical re-appearing on the construct.
+    """
+    runs = [_run(case) for _ in range(_RUNS_INTERNAL)]
+    valid = [s for (s, lossy) in runs if not lossy]
+    if len(valid) < _MIN_VALID:
+        pytest.skip(f"{case.name}: too many lossy runs ({len(valid)} valid); model unstable")
+    crit = sum(1 for s in valid if s == "critical")
+    assert crit == 0, (
+        f"{case.name}: REGRESSION - an internal-provenance construct came back "
+        f"critical in {crit}/{len(valid)} runs; it must stay <= major.\n  severities: {valid}"
+    )
+
+
+@pytest.mark.parametrize("case", _EXTERNAL, ids=[c.name for c in _EXTERNAL])
+def test_external_construct_stays_critical(case):
+    """External (attacker-controlled) input must stay critical: the gate must not over-relax.
+
+    Unlike the internal cases, here a finding is expected -- a MISSING critical is
+    the regression (the gate's carve-out leaking onto genuinely external input).
+    """
+    runs = [_run(case) for _ in range(_RUNS_EXTERNAL)]
+    valid = [s for (s, lossy) in runs if not lossy]
+    if len(valid) < _MIN_VALID:
+        pytest.skip(f"{case.name}: too many lossy runs ({len(valid)} valid); model unstable")
+    crit = sum(1 for s in valid if s == "critical")
+    majority = len(valid) // 2 + 1
+    assert crit >= majority, (
+        f"{case.name}: the gate OVER-RELAXED an external case - critical in only "
+        f"{crit}/{len(valid)} runs (need {majority}). Attacker-controlled input must "
+        f"stay critical.\n  severities: {valid}"
+    )


### PR DESCRIPTION
## What

Turns the one-off #638 verification into a durable **provenance-gate regression matrix** (closes #641).

The provenance gate (PR #636) stops the `critical` bar from firing on unguarded-access (R-FT-2) and path-from-string (S-AUT-3) findings whose value is provably *internal* (a defaulted prop/arg, a SHA-256 cache key), while keeping genuinely *external* input critical. #636 only tested that the gate **text** is wired into the prompt; this adds the behavioral coverage.

## Two tiers

**TIER 1 — always-on, deterministic (runs in normal CI), `test_prompt_provenance_gate.py`:**
- the gate renders into the **direct-API** prompt path (`assemble_api_prompt`), not just `compass.md`;
- the fixture matrix is well-formed (both provenance classes + both dimensions);
- every fixture path classifies `PROD` and the assembled prompt carries no `(role:` label (role-label confound guard);
- each construct is anchored at its declared line (fixture-drift guard).

This is the real guard that the gate is present in every prompt path. No model needed.

**TIER 2 — opt-in, live, `test_provenance_gate_behavioral.py`:** drives the real local-provider path (`assemble_api_prompt` → `_call_api`) over vendored fixtures with `gemma4:26b`. `integration`-marked + skipped unless a standard (non-mlx) `gemma4:26b` is reachable, so it never runs in the PR/publish gates. It pins **outcomes** on the real code:
- internal known-FP constructs never surface as `critical` (a drop is also a pass — the gate permits "major OR drop");
- genuinely external input stays `critical` (a *missing* critical is the regression).

### Why outcome pins, not a gate-on/off A/B
I first built this as an A/B (run with the gate, then with the provenance section stripped, and assert the gate flips the verdict). Measuring the gate-off counterfactual on standard `gemma4:26b` killed that design: with the gate stripped, the four internal constructs still came back `major` / `minor` / not-flagged — only **1 of 12** runs was critical. A capable model does not reproduce these FPs even without the gate; they were a `gemma4:26b-mlx` over-rating artifact, and the general severity rules already de-escalate them. So a behavioral A/B has no signal for this model. The gate's *presence* is therefore guarded deterministically in TIER 1; TIER 2 guards that the corrected #638 outcome holds on the real fixtures. (Takeaway worth noting: the provenance gate earns its keep mainly for weaker/over-rating models — the standard model rarely needs it.)

## Fixtures
- 4 `internal_*` cases = the exact a84ab6f8 code that run `fa56db32` rated critical, **verbatim, guard-free** (later code-hardening at `c0edcd6f`/`521f46c6` deliberately excluded so the fixture is the exact flagged construct).
- 3 `external_*` synthetic controls (HTTP field, CLI arg, response header) that must stay critical. Comments are descriptive only (no "untrusted/attacker-controlled" verdict) so the model must infer provenance from code shape.

## Verification
TIER 1: 25 deterministic tests pass; full suite green (3493 passed). TIER 2 against standard `gemma4:26b`: **7/7 passed** — all 4 internal FPs non-critical, all 3 external controls critical.

## Not included (deliberate)
No CI workflow change. The nightly/review jobs are pinned to the compliance-blind `gemma4:26b-mlx` and invoke the CLI, not pytest — wrong host for this test. An optional self-hosted `workflow_dispatch` job (`AI_MODEL=gemma4:26b`) is a reasonable follow-up, left out here rather than shipping a workflow against a runner that can't be verified in this PR.

Closes #641.
