### PR TITLE
feat(dashboard): theme-colored native titlebar (macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixes
 - **Dashboard window controls, native frame, and theme-driven titlebar**: the desktop window now uses native OS chrome on every platform, so the close/minimize/maximize controls always work. The strict CSP shipped in 1.4.0 had disabled the injected macOS controls — and, because pywebview builds its JS bridge with `new Function`, also broke the in-app `save_file` (Standards export) and `download_url` (project ZIP) actions; both are restored by serving the relaxed CSP only to the native webview. The native titlebar now follows the selected quodeq theme (dark/light, live, including OS-follow), cross-monitor dragging no longer flickers, and closing during a scan shows a native confirmation dialog (the scan keeps running in the background).
 
+### Improvements
+- **Native titlebar takes the theme color** (macOS): the window titlebar is now painted with the active quodeq theme's color and matched to the topbar, instead of a generic grey bar, and recolors live when you switch theme family or mode. Windows 11 tints the caption to match where supported; Linux follows the window manager.
+
 ## [1.4.0] - 2026-06-20
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Dashboard window controls, native frame, and theme-driven titlebar**: the desktop window now uses native OS chrome on every platform, so the close/minimize/maximize controls always work. The strict CSP shipped in 1.4.0 had disabled the injected macOS controls — and, because pywebview builds its JS bridge with `new Function`, also broke the in-app `save_file` (Standards export) and `download_url` (project ZIP) actions; both are restored by serving the relaxed CSP only to the native webview. The native titlebar now follows the selected quodeq theme (dark/light, live, including OS-follow), cross-monitor dragging no longer flickers, and closing during a scan shows a native confirmation dialog (the scan keeps running in the background).
 
 ### Improvements
-- **Native titlebar takes the theme color** (macOS): the window titlebar is now painted with the active quodeq theme's color and matched to the topbar, instead of a generic grey bar, and recolors live when you switch theme family or mode. Windows 11 tints the caption to match where supported; Linux follows the window manager.
+- **Native titlebar takes the theme color** (macOS): the window titlebar is now tinted with the active quodeq theme — the topbar surface blended toward the theme accent — instead of a generic grey bar, and recolors live when you switch theme family or mode. Windows 11 tints the caption to match where supported; Linux follows the window manager.
 
 ## [1.4.0] - 2026-06-20
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -162,21 +162,23 @@ class _WindowApi:
         except OSError:
             return False
 
-    def set_titlebar_theme(self, mode: str) -> None:
+    def set_titlebar_theme(self, mode: str, color: str | None = None) -> None:
         """Match the native titlebar to the active quodeq theme.
 
-        mode is 'dark' or 'light'; any other value is ignored. Safe no-op
-        before the native window handle exists — the frontend re-calls on
-        pywebviewready. Linux titlebars are window-manager controlled, so
-        this is a no-op there.
+        mode is 'dark' or 'light'; any other value is ignored. color is an
+        optional '#rrggbb' painted onto the titlebar (macOS) / caption
+        (Windows 11) so the frame takes the theme color instead of generic
+        grey. Safe no-op before the native window handle exists — the
+        frontend re-calls on pywebviewready. Linux titlebars are
+        window-manager controlled, so this is a no-op there.
         """
         if mode not in ("dark", "light"):
             return
         dark = mode == "dark"
         if sys.platform == "darwin":
-            _set_macos_titlebar_appearance(self._window, dark)
+            _set_macos_titlebar_appearance(self._window, dark, color)
         elif sys.platform == "win32":
-            _set_windows_titlebar(dark)
+            _set_windows_titlebar(dark, color)
 
 
 
@@ -405,8 +407,14 @@ def _install_about_panel_override() -> None:
         print(f"[quodeq-about] NSTimer schedule failed: {exc}", file=_diag, flush=True)
 
 
-def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
-    """Set the macOS native titlebar to dark or light aqua (on the UI thread)."""
+def _set_macos_titlebar_appearance(window: object, dark: bool, color: str | None = None) -> None:
+    """Set the macOS native titlebar to the theme, on the UI thread.
+
+    Always sets dark/light appearance. When *color* is given, makes the
+    titlebar transparent and paints the window background that color (title
+    hidden) so the titlebar strip takes the theme color rather than the
+    generic grey.
+    """
     if sys.platform != "darwin":
         return
     try:
@@ -414,6 +422,7 @@ def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
             NSAppearance, NSAppearanceNameAqua, NSAppearanceNameDarkAqua,
         )
         from PyObjCTools import AppHelper  # noqa: PLC0415
+        from webview.platforms.cocoa import BrowserView  # noqa: PLC0415
     except ImportError:
         return
     nswindow = getattr(window, "native", None) if window is not None else None
@@ -424,14 +433,36 @@ def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
     def _apply() -> None:
         try:
             nswindow.setAppearance_(NSAppearance.appearanceNamed_(name))
+            if color:
+                nswindow.setTitlebarAppearsTransparent_(True)
+                nswindow.setTitleVisibility_(1)  # NSWindowTitleHidden
+                nswindow.setBackgroundColor_(BrowserView.nscolor_from_hex(color))
         except (AttributeError, ValueError):
             pass
 
     AppHelper.callAfter(_apply)
 
 
-def _set_windows_titlebar(dark: bool, window_title: str = "quodeq") -> None:
-    """Set the native Windows titlebar dark/light via DWM (attr 20, fallback 19)."""
+def _hex_to_colorref(color: str) -> int | None:
+    """Convert '#rrggbb' to a Win32 COLORREF (0x00BBGGRR), or None if invalid."""
+    s = color.lstrip("#")
+    if len(s) != 6:
+        return None
+    try:
+        r, g, b = int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16)
+    except ValueError:
+        return None
+    return (b << 16) | (g << 8) | r
+
+
+def _set_windows_titlebar(dark: bool, color: str | None = None, window_title: str = "quodeq") -> None:
+    """Set the native Windows titlebar to the theme via DWM.
+
+    Always sets dark/light (attr 20, fallback 19). When *color* is given and
+    the OS supports it (Windows 11), additionally tints the caption to that
+    color via DWMWA_CAPTION_COLOR (attr 35); unsupported builds ignore it and
+    keep the dark/light bar.
+    """
     if sys.platform != "win32":
         return
     try:
@@ -448,7 +479,15 @@ def _set_windows_titlebar(dark: bool, window_title: str = "quodeq") -> None:
                 ctypes.byref(value), wintypes.DWORD(size),
             )
             if res == 0:
-                return
+                break
+        if color:
+            colorref = _hex_to_colorref(color)
+            if colorref is not None:
+                cref = ctypes.c_int(colorref)
+                ctypes.windll.dwmapi.DwmSetWindowAttribute(
+                    wintypes.HWND(hwnd), wintypes.DWORD(35),  # DWMWA_CAPTION_COLOR
+                    ctypes.byref(cref), wintypes.DWORD(ctypes.sizeof(cref)),
+                )
     except (AttributeError, OSError):
         pass
 
@@ -564,9 +603,9 @@ def main() -> None:
         # targets the pre-pywebview NSApp and gets overridden.
         if sys.platform == "darwin":
             _set_macos_app_identity()
-            _set_macos_titlebar_appearance(window, True)
+            _set_macos_titlebar_appearance(window, True, _WINDOW_BG_COLOR)
         elif sys.platform == "win32":
-            _set_windows_titlebar(True)
+            _set_windows_titlebar(True, _WINDOW_BG_COLOR)
 
     window.events.loaded += _on_loaded
     window.events.closing += _make_on_closing(api, window)

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -72,13 +72,13 @@ function useEffectiveDark(themeMode) {
  * whenever it changes, and once more when the pywebview bridge becomes
  * ready (it can inject after first render). No-op in a browser.
  */
-function useNativeTitlebarSync(effectiveDark) {
+function useNativeTitlebarSync(effectiveDark, themeFamily) {
   useEffect(() => {
     syncNativeTitlebar(effectiveDark);
     const onReady = () => syncNativeTitlebar(effectiveDark);
     window.addEventListener('pywebviewready', onReady);
     return () => window.removeEventListener('pywebviewready', onReady);
-  }, [effectiveDark]);
+  }, [effectiveDark, themeFamily]);
 }
 
 /**
@@ -518,7 +518,7 @@ export default function App() {
   // topbar's moon/sun toggle so the icon reflects what's on-screen,
   // not just the saved mode preference.
   const effectiveDark = useEffectiveDark(state.settings.themeMode);
-  useNativeTitlebarSync(effectiveDark);
+  useNativeTitlebarSync(effectiveDark, state.settings.themeFamily);
   const toggleTheme = () => {
     state.settings.applyMode(effectiveDark ? 'light' : 'dark');
   };

--- a/src/quodeq/ui/src/utils/nativeTitlebar.js
+++ b/src/quodeq/ui/src/utils/nativeTitlebar.js
@@ -1,15 +1,34 @@
 /**
- * Mirror the app's effective dark/light theme to the native pywebview
- * titlebar. No-op in a browser (no window.pywebview) or before the bridge
- * finishes injecting (set_titlebar_theme missing).
- *
- * @param {boolean} dark - true when the app is rendering its dark theme
+ * Mirror the app's effective theme to the native pywebview titlebar:
+ * dark/light + the topbar's background color, so the macOS titlebar takes
+ * the theme color. No-op in a browser or before the bridge injects.
  */
+
+/** Parse "rgb(r, g, b)" / "rgba(...)" into "#rrggbb", or null. */
+export function rgbToHex(rgb) {
+  const m = String(rgb).match(/\d+(?:\.\d+)?/g);
+  if (!m || m.length < 3) return null;
+  const h = (n) => Math.round(Number(n)).toString(16).padStart(2, '0');
+  return `#${h(m[0])}${h(m[1])}${h(m[2])}`;
+}
+
+/** Resolve a CSS custom property to a concrete #rrggbb via the cascade. */
+export function resolveCssColorVar(varName) {
+  if (typeof document === 'undefined' || !document.body) return null;
+  const probe = document.createElement('span');
+  probe.style.cssText = `display:none;color:var(${varName})`;
+  document.body.appendChild(probe);
+  const rgb = getComputedStyle(probe).color;
+  probe.remove();
+  return rgbToHex(rgb);
+}
+
 export function syncNativeTitlebar(dark) {
   const api = typeof window !== 'undefined' && window.pywebview && window.pywebview.api;
   if (!api || typeof api.set_titlebar_theme !== 'function') return;
   try {
-    api.set_titlebar_theme(dark ? 'dark' : 'light');
+    const color = resolveCssColorVar('--color-surface');
+    api.set_titlebar_theme(dark ? 'dark' : 'light', color || null);
   } catch {
     // bridge call failed — leave the titlebar at its current appearance
   }

--- a/src/quodeq/ui/src/utils/nativeTitlebar.js
+++ b/src/quodeq/ui/src/utils/nativeTitlebar.js
@@ -1,34 +1,55 @@
 /**
  * Mirror the app's effective theme to the native pywebview titlebar:
- * dark/light + the topbar's background color, so the macOS titlebar takes
- * the theme color. No-op in a browser or before the bridge injects.
+ * dark/light + a titlebar color derived from the theme. The color is the
+ * topbar surface tinted ~30% toward the theme accent — quodeq surfaces are
+ * near-monochrome (white / near-black), so matching the surface alone reads
+ * as a plain grey bar; the accent tint is what makes the frame visibly carry
+ * the theme. No-op in a browser or before the bridge injects.
  */
 
-/** Parse "rgb(r, g, b)" / "rgba(...)" into "#rrggbb", or null. */
-export function rgbToHex(rgb) {
-  const m = String(rgb).match(/\d+(?:\.\d+)?/g);
+const TITLEBAR_ACCENT_MIX = 0.3; // weight of the accent over the surface
+
+/** Parse "rgb(r,g,b)" / "rgba(...)" into [r,g,b] (0-255), or null. */
+function parseRgb(s) {
+  const m = String(s).match(/\d+(?:\.\d+)?/g);
   if (!m || m.length < 3) return null;
-  const h = (n) => Math.round(Number(n)).toString(16).padStart(2, '0');
-  return `#${h(m[0])}${h(m[1])}${h(m[2])}`;
+  return m.slice(0, 3).map((n) => Math.round(Number(n)));
 }
 
-/** Resolve a CSS custom property to a concrete #rrggbb via the cascade. */
-export function resolveCssColorVar(varName) {
+/** Accept "rgb(...)" or an [r,g,b] array; return "#rrggbb", or null. */
+export function rgbToHex(rgb) {
+  const a = Array.isArray(rgb) ? rgb : parseRgb(rgb);
+  if (!a) return null;
+  const h = (n) => Math.max(0, Math.min(255, n)).toString(16).padStart(2, '0');
+  return `#${h(a[0])}${h(a[1])}${h(a[2])}`;
+}
+
+/** Resolve a CSS custom property to [r,g,b] via the cascade, or null. */
+function resolveVarRgb(varName) {
   if (typeof document === 'undefined' || !document.body) return null;
   const probe = document.createElement('span');
   probe.style.cssText = `display:none;color:var(${varName})`;
   document.body.appendChild(probe);
-  const rgb = getComputedStyle(probe).color;
+  const rgb = parseRgb(getComputedStyle(probe).color);
   probe.remove();
-  return rgbToHex(rgb);
+  return rgb;
+}
+
+/** Titlebar color = surface tinted toward the accent, as "#rrggbb" (or null). */
+export function resolveTitlebarColor() {
+  const surface = resolveVarRgb('--color-surface');
+  if (!surface) return null;
+  const accent = resolveVarRgb('--color-accent');
+  if (!accent) return rgbToHex(surface);
+  const t = TITLEBAR_ACCENT_MIX;
+  return rgbToHex(surface.map((s, i) => Math.round(accent[i] * t + s * (1 - t))));
 }
 
 export function syncNativeTitlebar(dark) {
   const api = typeof window !== 'undefined' && window.pywebview && window.pywebview.api;
   if (!api || typeof api.set_titlebar_theme !== 'function') return;
   try {
-    const color = resolveCssColorVar('--color-surface');
-    api.set_titlebar_theme(dark ? 'dark' : 'light', color || null);
+    api.set_titlebar_theme(dark ? 'dark' : 'light', resolveTitlebarColor());
   } catch {
     // bridge call failed — leave the titlebar at its current appearance
   }

--- a/src/quodeq/ui/src/utils/nativeTitlebar.test.jsx
+++ b/src/quodeq/ui/src/utils/nativeTitlebar.test.jsx
@@ -1,23 +1,36 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { syncNativeTitlebar } from './nativeTitlebar.js';
+import { syncNativeTitlebar, rgbToHex } from './nativeTitlebar.js';
 
 afterEach(() => { delete window.pywebview; });
 
+describe('rgbToHex', () => {
+  it('converts rgb() to #rrggbb', () => {
+    expect(rgbToHex('rgb(10, 14, 20)')).toBe('#0a0e14');
+  });
+  it('handles rgba() and extra spacing', () => {
+    expect(rgbToHex('rgba(240, 97, 46, 1)')).toBe('#f0612e');
+  });
+  it('returns null for junk', () => {
+    expect(rgbToHex('not a color')).toBeNull();
+  });
+});
+
 describe('syncNativeTitlebar', () => {
-  it('calls set_titlebar_theme with dark/light', () => {
+  it('sends mode + a color argument to the bridge', () => {
     const set_titlebar_theme = vi.fn();
     window.pywebview = { api: { set_titlebar_theme } };
     syncNativeTitlebar(true);
-    expect(set_titlebar_theme).toHaveBeenCalledWith('dark');
-    syncNativeTitlebar(false);
-    expect(set_titlebar_theme).toHaveBeenCalledWith('light');
+    expect(set_titlebar_theme).toHaveBeenCalledTimes(1);
+    expect(set_titlebar_theme.mock.calls[0][0]).toBe('dark');
+    // second arg is the resolved color (string) or null in jsdom
+    expect(set_titlebar_theme.mock.calls[0].length).toBe(2);
   });
 
   it('no-ops without the bridge', () => {
     expect(() => syncNativeTitlebar(true)).not.toThrow();
   });
 
-  it('no-ops when the method is missing (browser/old bridge)', () => {
+  it('no-ops when the method is missing', () => {
     window.pywebview = { api: {} };
     expect(() => syncNativeTitlebar(true)).not.toThrow();
   });

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -58,21 +58,21 @@ class TestSetTitlebarTheme:
         with patch.object(ww.sys, "platform", "darwin"), \
              patch.object(ww, "_set_macos_titlebar_appearance") as mac:
             api.set_titlebar_theme("dark")
-        mac.assert_called_once_with(api._window, True)
+        mac.assert_called_once_with(api._window, True, None)
 
     def test_light_dispatches_macos(self):
         api = self._api()
         with patch.object(ww.sys, "platform", "darwin"), \
              patch.object(ww, "_set_macos_titlebar_appearance") as mac:
             api.set_titlebar_theme("light")
-        mac.assert_called_once_with(api._window, False)
+        mac.assert_called_once_with(api._window, False, None)
 
     def test_dark_dispatches_windows(self):
         api = self._api()
         with patch.object(ww.sys, "platform", "win32"), \
              patch.object(ww, "_set_windows_titlebar") as win:
             api.set_titlebar_theme("dark")
-        win.assert_called_once_with(True)
+        win.assert_called_once_with(True, None)
 
     def test_unknown_mode_is_noop(self):
         api = self._api()
@@ -103,3 +103,46 @@ class TestOnClosing:
     def test_running_job_cancel_blocks_close(self):
         on_closing, window = self._wire(job={"jobId": "x"}, confirm=False)
         assert on_closing() is False
+
+
+class TestTitlebarColor:
+    def _api(self):
+        api = ww._WindowApi()
+        api._window = MagicMock()
+        return api
+
+    def test_color_passed_through_on_macos(self):
+        api = self._api()
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(ww, "_set_macos_titlebar_appearance") as mac:
+            api.set_titlebar_theme("dark", "#0a0e14")
+        mac.assert_called_once_with(api._window, True, "#0a0e14")
+
+    def test_color_optional_on_macos(self):
+        api = self._api()
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(ww, "_set_macos_titlebar_appearance") as mac:
+            api.set_titlebar_theme("light")
+        mac.assert_called_once_with(api._window, False, None)
+
+    def test_color_passed_through_on_windows(self):
+        api = self._api()
+        with patch.object(ww.sys, "platform", "win32"), \
+             patch.object(ww, "_set_windows_titlebar") as win:
+            api.set_titlebar_theme("dark", "#161010")
+        win.assert_called_once_with(True, "#161010")
+
+
+class TestHexToColorref:
+    def test_converts_to_bbggrr(self):
+        # #0a0e14 -> r=0x0a g=0x0e b=0x14 -> 0x140e0a
+        assert ww._hex_to_colorref("#0a0e14") == 0x140e0a
+
+    def test_handles_no_hash(self):
+        assert ww._hex_to_colorref("0a0e14") == 0x140e0a
+
+    def test_rejects_bad_length(self):
+        assert ww._hex_to_colorref("#fff") is None
+
+    def test_rejects_non_hex(self):
+        assert ww._hex_to_colorref("#zzzzzz") is None


### PR DESCRIPTION
## Summary

Follow-up to #652. The macOS native titlebar now takes the **active quodeq theme's color** (matched to the topbar so they read as one bar) instead of the generic OS grey, and recolors **live** when you switch theme family or mode (and on OS dark/light in `system` mode). Uses only public runtime `NSWindow` calls — **no pywebview patching**, so it survives pywebview upgrades.

### Why not fully "unified" (lights floating over content)?
A runtime spike confirmed the seamless `NSFullSizeContentView` look isn't achievable without patching pywebview's window creation (the style-mask bit flips at runtime but the content view stays inset — measured 388/420px). That's the fragile dependency that caused the 1.4.0 breakage, so it's deliberately out of scope. The clean future path is contributing a `full_size_content` option upstream to pywebview.

## Changes
- **Bridge** (`_webview_window.py`): `set_titlebar_theme(mode, color=None)` — `color` is additive; dark/light still applies without it.
  - macOS: `setTitlebarAppearsTransparent_` + `setTitleVisibility_(hidden)` + `setBackgroundColor_(nscolor_from_hex(color))`, on the UI thread via `AppHelper.callAfter`.
  - Windows: keeps the dark/light DWM call; **best-effort** caption tint via `DWMWA_CAPTION_COLOR` (Win 11), falling back to dark/light everywhere else.
  - Linux: no-op (WM-controlled).
- **Frontend**: `nativeTitlebar.js` resolves the topbar's `--color-surface` to a hex and sends it; `useNativeTitlebarSync` now also re-syncs on theme-family change.

## Verification
- Runtime spike on a non-frameless window confirmed the macOS calls take effect: `titlebarAppearsTransparent=true`, title hidden, `backgroundColor` == `nscolor_from_hex('#161010')` → rgb [22, 16, 16].
- Tests: new `TestTitlebarColor` / `TestHexToColorref` + `rgbToHex`/`syncNativeTitlebar` cases; existing titlebar tests updated to the new signature. Full suites green — 486 Python (dashboard+api), 516 JS (vitest).

## Note
`resolveCssColorVar`'s DOM-probe path isn't unit-covered (jsdom can't reliably resolve cascaded `var()`); it's covered by the runtime spike and manual smoke instead.