### PR TITLE
feat(dashboard): unified frameless titlebar on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 
 ### Fixes
-- **Dashboard window controls, native frame, and theme-driven titlebar**: the desktop window now uses native OS chrome on every platform, so the close/minimize/maximize controls always work. The strict CSP shipped in 1.4.0 had disabled the injected macOS controls — and, because pywebview builds its JS bridge with `new Function`, also broke the in-app `save_file` (Standards export) and `download_url` (project ZIP) actions; both are restored by serving the relaxed CSP only to the native webview. The native titlebar now follows the selected quodeq theme (dark/light, live, including OS-follow), cross-monitor dragging no longer flickers, and closing during a scan shows a native confirmation dialog (the scan keeps running in the background).
+- **Dashboard window controls and the in-app bridge**: the desktop window has working native close/minimize/maximize controls again. The strict CSP shipped in 1.4.0 had disabled the injected macOS controls — and, because pywebview builds its JS bridge with `new Function`, also broke the in-app `save_file` (Standards export) and `download_url` (project ZIP) actions; both are restored by serving the relaxed CSP only to the native webview. Closing during a scan now shows a native confirmation dialog (the scan keeps running in the background).
+
+### Improvements
+- **Unified macOS titlebar**: the macOS window now uses a frameless, full-height titlebar — the dashboard topbar runs to the top edge with the native traffic lights floating over it (accent-tinted to the active theme), for a seamless look. Windows and Linux keep native OS chrome with a dark/light titlebar that follows the theme.
 
 ## [1.4.0] - 2026-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Dashboard window controls and the in-app bridge**: the desktop window has working native close/minimize/maximize controls again. The strict CSP shipped in 1.4.0 had disabled the injected macOS controls — and, because pywebview builds its JS bridge with `new Function`, also broke the in-app `save_file` (Standards export) and `download_url` (project ZIP) actions; both are restored by serving the relaxed CSP only to the native webview. Closing during a scan now shows a native confirmation dialog (the scan keeps running in the background).
 
 ### Improvements
-- **Unified macOS titlebar**: the macOS window now uses a frameless, full-height titlebar — the dashboard topbar runs to the top edge with the native traffic lights floating over it (accent-tinted to the active theme), for a seamless look. Windows and Linux keep native OS chrome with a dark/light titlebar that follows the theme.
+- **Unified macOS titlebar**: the macOS window now uses a frameless titlebar — the dashboard topbar runs to the top edge with the native traffic lights floating, vertically centered, over it, for a seamless look. The topbar and sidebar share one plain surface color. In fullscreen the titlebar is dropped so content fills the screen cleanly (no leftover gray bar) and restored on exit. Windows and Linux keep native OS chrome with a dark/light titlebar that follows the theme.
 
 ## [1.4.0] - 2026-06-20
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -25,9 +25,6 @@ _WINDOW_BG_COLOR = '#0d1117'
 # Marker embedded in the webview's User-Agent so the API serves it the
 # relaxed CSP (see quodeq.api.security._WEBVIEW_UA_MARKER — must match).
 _WEBVIEW_UA_MARKER = "QuodeqDesktop"
-# Vertical center for the macOS traffic lights, matching the topbar midline
-# (--app-header-h is 52px in terminal.css, so its center is 26px from the top).
-_MACOS_TRAFFIC_LIGHT_CENTER_Y = 26.0
 _EVAL_CHECK_TIMEOUT_S = 0.5
 _DOWNLOAD_TIMEOUT_S = 120
 
@@ -442,21 +439,19 @@ def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
 
 
 def _show_macos_traffic_lights(window: object) -> None:
-    """Re-show and vertically center the native traffic lights on the
-    frameless macOS window.
+    """Re-show the native traffic lights on the frameless macOS window.
 
     pywebview hides the standard window buttons for frameless windows, but
     frameless is what enables NSFullSizeContentView (the app's topbar running
-    under the titlebar). Un-hiding them gives the unified look, and they are
-    re-centered onto the topbar's midline so they line up with the breadcrumb
-    rather than sitting at the very top. macOS re-lays the buttons out on
-    resize, so this is also wired to the window's ``resized`` event. Runs on
-    the UI thread; no-op before the native handle exists.
+    under the titlebar). Un-hiding them gives the unified look — the buttons
+    keep their native top-left position (the CSS lays the compact macOS topbar
+    out to line up with them), so nothing is repositioned and there is nothing
+    to re-apply on resize. Runs on the UI thread; no-op before the native
+    handle exists.
     """
     if sys.platform != "darwin":
         return
     try:
-        import AppKit  # noqa: PLC0415
         from PyObjCTools import AppHelper  # noqa: PLC0415
     except ImportError:
         return
@@ -469,18 +464,9 @@ def _show_macos_traffic_lights(window: object) -> None:
         for button_id in (0, 1, 2):
             try:
                 btn = nswindow.standardWindowButton_(button_id)
-                if btn is None:
-                    continue
-                btn.setHidden_(False)
-                frame = btn.frame()
-                # The frame view is flipped (y measured from the top), so
-                # centering on the topbar midline lines the lights up with the
-                # breadcrumb instead of pinning them to the very top.
-                btn.setFrameOrigin_(AppKit.NSPoint(
-                    frame.origin.x,
-                    _MACOS_TRAFFIC_LIGHT_CENTER_Y - frame.size.height / 2.0,
-                ))
-            except (AttributeError, ValueError, TypeError):
+                if btn is not None:
+                    btn.setHidden_(False)
+            except (AttributeError, ValueError):
                 pass
 
     AppHelper.callAfter(_apply)
@@ -638,9 +624,6 @@ def main() -> None:
 
     window.events.loaded += _on_loaded
     window.events.closing += _make_on_closing(api, window)
-    # macOS re-lays the traffic lights out on resize; re-center them (no-op
-    # off macOS).
-    window.events.resized += lambda *_a: _show_macos_traffic_lights(window)
 
     instance.start_listening(on_reload=_on_reload)
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import urllib.parse
 import urllib.request
 import webbrowser
@@ -267,6 +268,9 @@ def _set_macos_app_identity() -> None:
 _about_target: object | None = None  # keep delegate alive for the menu item's weak ref
 _about_override_installed = False  # the _AboutHandler ObjC class may only be defined once
 _macos_toolbar_installed = False  # the unified toolbar (taller titlebar) is added once
+_macos_fullscreen_observer: object | None = None  # keep the ObjC observer alive
+_macos_fullscreen_observer_installed = False  # register the notifications once
+_macos_fullscreen_handler_class = None  # the ObjC handler class is defined once per process
 
 
 def _diag_path() -> Path:
@@ -508,6 +512,90 @@ def _set_macos_unified_toolbar(window: object) -> None:
     AppHelper.callAfter(_apply)
 
 
+def _set_macos_fullscreen_class(window: object, is_full: bool) -> None:
+    """Toggle the `macos-fullscreen` class on <html> from off the main thread.
+
+    pywebview's evaluate_js blocks waiting on the JS engine, which deadlocks
+    when called on the AppKit main thread (where notifications fire), so run it
+    on a short-lived worker thread.
+    """
+    flag = "true" if is_full else "false"
+    js = f"document.documentElement.classList.toggle('macos-fullscreen', {flag})"
+
+    def _run() -> None:
+        try:
+            window.evaluate_js(js)  # type: ignore[union-attr]
+        except Exception:  # noqa: BLE001 — window may be tearing down
+            _logger.debug("fullscreen class toggle failed", exc_info=True)
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def _install_macos_fullscreen_observer(window: object) -> None:
+    """Toggle `macos-fullscreen` on <html> when the window enters/exits native
+    fullscreen, so CSS can drop the titlebar's bottom border and the
+    traffic-light reservation — both wrong once macOS hides the lights.
+
+    Uses NSWindow fullscreen notifications because they are the only reliable
+    signal: on a notched display a zoomed window and a fullscreen window report
+    identical inner/screen heights, so a JS heuristic can't tell them apart.
+
+    Registers the notifications once (the ObjC observer class may only be
+    defined a single time per process) but re-syncs the current state on every
+    call, so reloading the page while fullscreen keeps the chrome correct (the
+    notifications only fire on transitions). No-op off macOS or before the
+    native handle exists. Call from the ``loaded`` event.
+    """
+    global _macos_fullscreen_handler_class
+    if sys.platform != "darwin":
+        return
+    try:
+        import AppKit  # noqa: PLC0415
+        from Foundation import NSNotificationCenter  # noqa: PLC0415
+        from PyObjCTools import AppHelper  # noqa: PLC0415
+    except ImportError:
+        return
+    nswindow = getattr(window, "native", None) if window is not None else None
+    if nswindow is None:
+        return
+
+    # Define the ObjC handler class at most once: redefining an NSObject
+    # subclass in the same process raises objc.error (the same trap the About
+    # panel hit). It closes over this window, of which there is only one.
+    if _macos_fullscreen_handler_class is None:
+        class _FullScreenHandler(AppKit.NSObject):
+            def enteredFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
+                _set_macos_fullscreen_class(window, True)
+
+            def exitedFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
+                _set_macos_fullscreen_class(window, False)
+
+        _macos_fullscreen_handler_class = _FullScreenHandler
+
+    def _apply() -> None:
+        global _macos_fullscreen_observer, _macos_fullscreen_observer_installed
+        try:
+            if not _macos_fullscreen_observer_installed:
+                observer = _macos_fullscreen_handler_class.alloc().init()
+                center = NSNotificationCenter.defaultCenter()
+                center.addObserver_selector_name_object_(
+                    observer, "enteredFullScreen:",
+                    AppKit.NSWindowDidEnterFullScreenNotification, nswindow,
+                )
+                center.addObserver_selector_name_object_(
+                    observer, "exitedFullScreen:",
+                    AppKit.NSWindowDidExitFullScreenNotification, nswindow,
+                )
+                _macos_fullscreen_observer = observer  # keep it alive
+                _macos_fullscreen_observer_installed = True
+            is_full = bool(nswindow.styleMask() & AppKit.NSWindowStyleMaskFullScreen)
+            _set_macos_fullscreen_class(window, is_full)
+        except (AttributeError, ValueError, TypeError):
+            pass
+
+    AppHelper.callAfter(_apply)
+
+
 def _set_windows_titlebar(dark: bool, window_title: str = "quodeq") -> None:
     """Set the native Windows titlebar dark/light via DWM (attr 20, fallback 19)."""
     if sys.platform != "win32":
@@ -649,6 +737,9 @@ def main() -> None:
             _show_macos_traffic_lights(window)
             _set_macos_unified_toolbar(window)
             _set_macos_titlebar_appearance(window, True)
+            # Reflect fullscreen state in a CSS class so the topbar border and
+            # the traffic-light reservation drop when macOS hides the lights.
+            _install_macos_fullscreen_observer(window)
             # Re-apply the dock icon + bundle name now that pywebview's
             # NSApplication is live (the early call in main() targets the
             # pre-pywebview NSApp). Best-effort — never block the controls.

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -477,18 +477,33 @@ def _show_macos_traffic_lights(window: object) -> None:
     AppHelper.callAfter(_apply)
 
 
-def _set_macos_unified_toolbar(window: object) -> None:
-    """Add an empty unified-compact NSToolbar so the native titlebar grows just
-    enough to drop the traffic lights to ~20px from the top — vertically
+def _apply_unified_toolbar(nswindow: object) -> None:
+    """Attach an empty unified-compact NSToolbar so the native titlebar grows
+    just enough to drop the traffic lights to ~20px from the top — vertically
     centered in the 40px in-app topbar (--app-header-h). macOS keeps the lights
     centered across resize, so nothing is repositioned by hand (no jump).
-    Installed once; no-op off macOS or before the native handle exists.
+
+    Must run on the UI thread; AppKit failures are the caller's to swallow.
+    """
+    import AppKit  # noqa: PLC0415
+    toolbar = AppKit.NSToolbar.alloc().initWithIdentifier_("quodeq-titlebar")
+    toolbar.setShowsBaselineSeparator_(False)
+    nswindow.setToolbar_(toolbar)
+    nswindow.setToolbarStyle_(4)  # NSWindowToolbarStyleUnifiedCompact
+    # Remove the 1px separator line under the toolbar (most visible in
+    # fullscreen). NSTitlebarSeparatorStyleNone = 1 (macOS 11+).
+    nswindow.setTitlebarSeparatorStyle_(1)
+
+
+def _set_macos_unified_toolbar(window: object) -> None:
+    """Install the unified-compact toolbar (see _apply_unified_toolbar) on the
+    frameless macOS window. Installed once; no-op off macOS or before the
+    native handle exists.
     """
     global _macos_toolbar_installed
     if _macos_toolbar_installed or sys.platform != "darwin":
         return
     try:
-        import AppKit  # noqa: PLC0415
         from PyObjCTools import AppHelper  # noqa: PLC0415
     except ImportError:
         return
@@ -499,13 +514,7 @@ def _set_macos_unified_toolbar(window: object) -> None:
 
     def _apply() -> None:
         try:
-            toolbar = AppKit.NSToolbar.alloc().initWithIdentifier_("quodeq-titlebar")
-            toolbar.setShowsBaselineSeparator_(False)
-            nswindow.setToolbar_(toolbar)
-            nswindow.setToolbarStyle_(4)  # NSWindowToolbarStyleUnifiedCompact
-            # Remove the 1px separator line under the toolbar (most visible in
-            # fullscreen). NSTitlebarSeparatorStyleNone = 1 (macOS 11+).
-            nswindow.setTitlebarSeparatorStyle_(1)
+            _apply_unified_toolbar(nswindow)
         except (AttributeError, ValueError, TypeError):
             pass
 
@@ -531,10 +540,44 @@ def _set_macos_fullscreen_class(window: object, is_full: bool) -> None:
     threading.Thread(target=_run, daemon=True).start()
 
 
+def _apply_macos_fullscreen_chrome(
+    window: object, is_full: bool, *, restore_toolbar: bool = True,
+) -> None:
+    """Reflect fullscreen state in both the native and the web chrome.
+
+    In fullscreen macOS draws the unified toolbar as a persistent empty gray
+    bar across the top (the traffic lights it centers are hidden there), so
+    drop the toolbar in fullscreen and restore it windowed. Either way toggle
+    the `macos-fullscreen` CSS class, which also clears the topbar border and
+    the now-pointless traffic-light reservation.
+
+    The AppKit toolbar work runs inline — callers are on the UI thread (the
+    fullscreen notifications fire there) — while the JS class toggle is
+    dispatched off it (evaluate_js deadlocks on the main thread).
+
+    ``restore_toolbar=False`` skips re-adding the toolbar when windowed; the
+    initial install (_set_macos_unified_toolbar) already owns that, so the
+    load-time sync must not add a second one.
+    """
+    nswindow = getattr(window, "native", None) if window is not None else None
+    if nswindow is not None:
+        try:
+            if is_full:
+                nswindow.setToolbar_(None)
+            elif restore_toolbar:
+                _apply_unified_toolbar(nswindow)
+        except (AttributeError, ValueError, TypeError, ImportError):
+            pass
+    _set_macos_fullscreen_class(window, is_full)
+
+
 def _install_macos_fullscreen_observer(window: object) -> None:
-    """Toggle `macos-fullscreen` on <html> when the window enters/exits native
-    fullscreen, so CSS can drop the titlebar's bottom border and the
-    traffic-light reservation — both wrong once macOS hides the lights.
+    """React to native fullscreen transitions so the chrome stays clean.
+
+    On enter/exit fullscreen, drop/restore the unified toolbar (macOS otherwise
+    leaves an empty gray toolbar bar at the top) and toggle a `macos-fullscreen`
+    class on <html> (CSS then drops the topbar border and the traffic-light
+    reservation). See _apply_macos_fullscreen_chrome.
 
     Uses NSWindow fullscreen notifications because they are the only reliable
     signal: on a notched display a zoomed window and a fullscreen window report
@@ -564,11 +607,19 @@ def _install_macos_fullscreen_observer(window: object) -> None:
     # panel hit). It closes over this window, of which there is only one.
     if _macos_fullscreen_handler_class is None:
         class _FullScreenHandler(AppKit.NSObject):
-            def enteredFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
-                _set_macos_fullscreen_class(window, True)
+            def willEnterFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
+                # Drop the toolbar BEFORE the enter animation, not after: the
+                # *Did*EnterFullScreen notification only fires once the grow
+                # animation completes, so the toolbar would stay attached for
+                # the whole animation and flash as a gray bar. *Will*Enter runs
+                # first, so the animation has no toolbar to show.
+                _apply_macos_fullscreen_chrome(window, True)
 
-            def exitedFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
-                _set_macos_fullscreen_class(window, False)
+            def didExitFullScreen_(self, note):  # noqa: ARG002, N802 — ObjC selector
+                # Restore only once fully windowed — re-adding during the exit
+                # animation would briefly reattach the toolbar while still
+                # fullscreen and flash gray again.
+                _apply_macos_fullscreen_chrome(window, False)
 
         _macos_fullscreen_handler_class = _FullScreenHandler
 
@@ -579,17 +630,19 @@ def _install_macos_fullscreen_observer(window: object) -> None:
                 observer = _macos_fullscreen_handler_class.alloc().init()
                 center = NSNotificationCenter.defaultCenter()
                 center.addObserver_selector_name_object_(
-                    observer, "enteredFullScreen:",
-                    AppKit.NSWindowDidEnterFullScreenNotification, nswindow,
+                    observer, "willEnterFullScreen:",
+                    AppKit.NSWindowWillEnterFullScreenNotification, nswindow,
                 )
                 center.addObserver_selector_name_object_(
-                    observer, "exitedFullScreen:",
+                    observer, "didExitFullScreen:",
                     AppKit.NSWindowDidExitFullScreenNotification, nswindow,
                 )
                 _macos_fullscreen_observer = observer  # keep it alive
                 _macos_fullscreen_observer_installed = True
             is_full = bool(nswindow.styleMask() & AppKit.NSWindowStyleMaskFullScreen)
-            _set_macos_fullscreen_class(window, is_full)
+            # Don't re-add the toolbar windowed — _set_macos_unified_toolbar
+            # already installed it; a second one would race/flicker.
+            _apply_macos_fullscreen_chrome(window, is_full, restore_toolbar=False)
         except (AttributeError, ValueError, TypeError):
             pass
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -265,6 +265,7 @@ def _set_macos_app_identity() -> None:
 
 
 _about_target: object | None = None  # keep delegate alive for the menu item's weak ref
+_about_override_installed = False  # the _AboutHandler ObjC class may only be defined once
 
 
 def _diag_path() -> Path:
@@ -325,13 +326,20 @@ def _install_about_panel_override() -> None:
     On the first call from the `loaded` event it's typically still nil, so
     schedule a repeating NSTimer that retries until the About item exists
     (or we give up after ~5s).
+
+    Installs at most once: the ``_AboutHandler`` ObjC class can only be
+    defined once per process, so a second call (e.g. on a repeat ``loaded``
+    event) would raise ``objc.error`` and abort the caller.
     """
-    global _about_target
+    global _about_target, _about_override_installed
+    if _about_override_installed:
+        return
     try:
         from AppKit import NSApplication, NSObject  # type: ignore[import-untyped]
         from Foundation import NSTimer  # type: ignore[import-untyped]
     except ImportError:
         return
+    _about_override_installed = True
 
     import datetime as _dt  # noqa: PLC0415
     version = _quodeq_version()
@@ -596,13 +604,19 @@ def main() -> None:
 
     def _on_loaded() -> None:
         window.show()
-        # Re-apply the dock icon + bundle name now that pywebview's
-        # NSApplication instance is live. Calling this earlier in main()
-        # targets the pre-pywebview NSApp and gets overridden.
         if sys.platform == "darwin":
-            _set_macos_app_identity()
-            _set_macos_titlebar_appearance(window, True)
+            # Show the native traffic lights FIRST: they are the only window
+            # controls on the frameless macOS window, so they must not be
+            # skipped if the best-effort app-identity setup below raises.
             _show_macos_traffic_lights(window)
+            _set_macos_titlebar_appearance(window, True)
+            # Re-apply the dock icon + bundle name now that pywebview's
+            # NSApplication is live (the early call in main() targets the
+            # pre-pywebview NSApp). Best-effort — never block the controls.
+            try:
+                _set_macos_app_identity()
+            except Exception:
+                _logger.debug("macOS app-identity setup failed", exc_info=True)
         elif sys.platform == "win32":
             _set_windows_titlebar(True)
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -266,6 +266,7 @@ def _set_macos_app_identity() -> None:
 
 _about_target: object | None = None  # keep delegate alive for the menu item's weak ref
 _about_override_installed = False  # the _AboutHandler ObjC class may only be defined once
+_macos_toolbar_installed = False  # the unified toolbar (taller titlebar) is added once
 
 
 def _diag_path() -> Path:
@@ -472,6 +473,38 @@ def _show_macos_traffic_lights(window: object) -> None:
     AppHelper.callAfter(_apply)
 
 
+def _set_macos_unified_toolbar(window: object) -> None:
+    """Add an empty unified NSToolbar so the native titlebar is taller and the
+    traffic lights sit lower (~32px from the top, vertically centered) with
+    room around them — matching the taller in-app topbar. macOS keeps the
+    lights centered across resize, so nothing is repositioned by hand (no
+    jump). Installed once; no-op off macOS or before the native handle exists.
+    """
+    global _macos_toolbar_installed
+    if _macos_toolbar_installed or sys.platform != "darwin":
+        return
+    try:
+        import AppKit  # noqa: PLC0415
+        from PyObjCTools import AppHelper  # noqa: PLC0415
+    except ImportError:
+        return
+    nswindow = getattr(window, "native", None) if window is not None else None
+    if nswindow is None:
+        return
+    _macos_toolbar_installed = True
+
+    def _apply() -> None:
+        try:
+            toolbar = AppKit.NSToolbar.alloc().initWithIdentifier_("quodeq-titlebar")
+            toolbar.setShowsBaselineSeparator_(False)
+            nswindow.setToolbar_(toolbar)
+            nswindow.setToolbarStyle_(1)  # NSWindowToolbarStyleUnified
+        except (AttributeError, ValueError, TypeError):
+            pass
+
+    AppHelper.callAfter(_apply)
+
+
 def _set_windows_titlebar(dark: bool, window_title: str = "quodeq") -> None:
     """Set the native Windows titlebar dark/light via DWM (attr 20, fallback 19)."""
     if sys.platform != "win32":
@@ -611,6 +644,7 @@ def main() -> None:
             # controls on the frameless macOS window, so they must not be
             # skipped if the best-effort app-identity setup below raises.
             _show_macos_traffic_lights(window)
+            _set_macos_unified_toolbar(window)
             _set_macos_titlebar_appearance(window, True)
             # Re-apply the dock icon + bundle name now that pywebview's
             # NSApplication is live (the early call in main() targets the

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -499,6 +499,9 @@ def _set_macos_unified_toolbar(window: object) -> None:
             toolbar.setShowsBaselineSeparator_(False)
             nswindow.setToolbar_(toolbar)
             nswindow.setToolbarStyle_(4)  # NSWindowToolbarStyleUnifiedCompact
+            # Remove the 1px separator line under the toolbar (most visible in
+            # fullscreen). NSTitlebarSeparatorStyleNone = 1 (macOS 11+).
+            nswindow.setTitlebarSeparatorStyle_(1)
         except (AttributeError, ValueError, TypeError):
             pass
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -25,6 +25,9 @@ _WINDOW_BG_COLOR = '#0d1117'
 # Marker embedded in the webview's User-Agent so the API serves it the
 # relaxed CSP (see quodeq.api.security._WEBVIEW_UA_MARKER — must match).
 _WEBVIEW_UA_MARKER = "QuodeqDesktop"
+# Vertical center for the macOS traffic lights, matching the topbar midline
+# (--app-header-h is 52px in terminal.css, so its center is 26px from the top).
+_MACOS_TRAFFIC_LIGHT_CENTER_Y = 26.0
 _EVAL_CHECK_TIMEOUT_S = 0.5
 _DOWNLOAD_TIMEOUT_S = 120
 
@@ -439,17 +442,21 @@ def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
 
 
 def _show_macos_traffic_lights(window: object) -> None:
-    """Re-show the native traffic-light buttons on the frameless macOS window.
+    """Re-show and vertically center the native traffic lights on the
+    frameless macOS window.
 
     pywebview hides the standard window buttons for frameless windows, but
     frameless is what enables NSFullSizeContentView (the app's topbar running
-    under the titlebar). Un-hiding the buttons gives the unified look: the
-    topbar reaches the top edge with the native lights floating over it.
-    Runs on the UI thread; no-op before the native handle exists.
+    under the titlebar). Un-hiding them gives the unified look, and they are
+    re-centered onto the topbar's midline so they line up with the breadcrumb
+    rather than sitting at the very top. macOS re-lays the buttons out on
+    resize, so this is also wired to the window's ``resized`` event. Runs on
+    the UI thread; no-op before the native handle exists.
     """
     if sys.platform != "darwin":
         return
     try:
+        import AppKit  # noqa: PLC0415
         from PyObjCTools import AppHelper  # noqa: PLC0415
     except ImportError:
         return
@@ -462,9 +469,18 @@ def _show_macos_traffic_lights(window: object) -> None:
         for button_id in (0, 1, 2):
             try:
                 btn = nswindow.standardWindowButton_(button_id)
-                if btn is not None:
-                    btn.setHidden_(False)
-            except (AttributeError, ValueError):
+                if btn is None:
+                    continue
+                btn.setHidden_(False)
+                frame = btn.frame()
+                # The frame view is flipped (y measured from the top), so
+                # centering on the topbar midline lines the lights up with the
+                # breadcrumb instead of pinning them to the very top.
+                btn.setFrameOrigin_(AppKit.NSPoint(
+                    frame.origin.x,
+                    _MACOS_TRAFFIC_LIGHT_CENTER_Y - frame.size.height / 2.0,
+                ))
+            except (AttributeError, ValueError, TypeError):
                 pass
 
     AppHelper.callAfter(_apply)
@@ -622,6 +638,9 @@ def main() -> None:
 
     window.events.loaded += _on_loaded
     window.events.closing += _make_on_closing(api, window)
+    # macOS re-lays the traffic lights out on resize; re-center them (no-op
+    # off macOS).
+    window.events.resized += lambda *_a: _show_macos_traffic_lights(window)
 
     instance.start_listening(on_reload=_on_reload)
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -430,6 +430,38 @@ def _set_macos_titlebar_appearance(window: object, dark: bool) -> None:
     AppHelper.callAfter(_apply)
 
 
+def _show_macos_traffic_lights(window: object) -> None:
+    """Re-show the native traffic-light buttons on the frameless macOS window.
+
+    pywebview hides the standard window buttons for frameless windows, but
+    frameless is what enables NSFullSizeContentView (the app's topbar running
+    under the titlebar). Un-hiding the buttons gives the unified look: the
+    topbar reaches the top edge with the native lights floating over it.
+    Runs on the UI thread; no-op before the native handle exists.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        from PyObjCTools import AppHelper  # noqa: PLC0415
+    except ImportError:
+        return
+    nswindow = getattr(window, "native", None) if window is not None else None
+    if nswindow is None:
+        return
+
+    def _apply() -> None:
+        # NSWindowCloseButton=0, NSWindowMiniaturizeButton=1, NSWindowZoomButton=2
+        for button_id in (0, 1, 2):
+            try:
+                btn = nswindow.standardWindowButton_(button_id)
+                if btn is not None:
+                    btn.setHidden_(False)
+            except (AttributeError, ValueError):
+                pass
+
+    AppHelper.callAfter(_apply)
+
+
 def _set_windows_titlebar(dark: bool, window_title: str = "quodeq") -> None:
     """Set the native Windows titlebar dark/light via DWM (attr 20, fallback 19)."""
     if sys.platform != "win32":
@@ -504,16 +536,21 @@ def _webview_user_agent() -> str:
 
 
 def _create_window(url: str, api: "_WindowApi") -> "webview.Window":
-    """Create the dashboard window with native OS chrome on every platform.
+    """Create the dashboard window.
 
-    Native chrome gives the conventional min/max/close controls, OS-handled
-    (flicker-free) cross-monitor drag, Snap/Mission-Control integration, and
-    a native close path — so no in-page control injection is needed.
+    macOS uses a frameless window so NSFullSizeContentView lets the app's
+    topbar run under the titlebar; the native traffic lights are re-shown over
+    it (see _show_macos_traffic_lights) for a unified look, and the topbar acts
+    as the drag region via the ``pywebview-drag-region`` class. Windows and
+    Linux use native OS chrome.
+
+    easy_drag is disabled so only the topbar drags the window — otherwise it
+    would hijack the resize splitter (a plain <div>).
     """
     return webview.create_window(
         "quodeq", url, width=_WINDOW_WIDTH, height=_WINDOW_HEIGHT,
-        frameless=False, background_color=_WINDOW_BG_COLOR, hidden=True,
-        js_api=api,
+        frameless=(sys.platform == "darwin"), easy_drag=False,
+        background_color=_WINDOW_BG_COLOR, hidden=True, js_api=api,
     )
 
 
@@ -565,6 +602,7 @@ def main() -> None:
         if sys.platform == "darwin":
             _set_macos_app_identity()
             _set_macos_titlebar_appearance(window, True)
+            _show_macos_traffic_lights(window)
         elif sys.platform == "win32":
             _set_windows_titlebar(True)
 

--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -474,11 +474,11 @@ def _show_macos_traffic_lights(window: object) -> None:
 
 
 def _set_macos_unified_toolbar(window: object) -> None:
-    """Add an empty unified NSToolbar so the native titlebar is taller and the
-    traffic lights sit lower (~32px from the top, vertically centered) with
-    room around them — matching the taller in-app topbar. macOS keeps the
-    lights centered across resize, so nothing is repositioned by hand (no
-    jump). Installed once; no-op off macOS or before the native handle exists.
+    """Add an empty unified-compact NSToolbar so the native titlebar grows just
+    enough to drop the traffic lights to ~20px from the top — vertically
+    centered in the 40px in-app topbar (--app-header-h). macOS keeps the lights
+    centered across resize, so nothing is repositioned by hand (no jump).
+    Installed once; no-op off macOS or before the native handle exists.
     """
     global _macos_toolbar_installed
     if _macos_toolbar_installed or sys.platform != "darwin":
@@ -498,7 +498,7 @@ def _set_macos_unified_toolbar(window: object) -> None:
             toolbar = AppKit.NSToolbar.alloc().initWithIdentifier_("quodeq-titlebar")
             toolbar.setShowsBaselineSeparator_(False)
             nswindow.setToolbar_(toolbar)
-            nswindow.setToolbarStyle_(1)  # NSWindowToolbarStyleUnified
+            nswindow.setToolbarStyle_(4)  # NSWindowToolbarStyleUnifiedCompact
         except (AttributeError, ValueError, TypeError):
             pass
 

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -106,7 +106,7 @@ export default function TopBar({
   onToggleTheme,
 }) {
   return (
-    <header className="topbar">
+    <header className="topbar pywebview-drag-region">
       {/* Compact-mode back button. Hidden entirely at the root of the
           nav stack — showing a disabled arrow adds visual noise without
           giving the user anything to click. */}

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1521,6 +1521,18 @@ button.term-sev-badge--clickable:focus-visible {
 .platform-mac.in-webview .sidebar {
   background: var(--color-surface);
 }
+/* In macOS fullscreen the OS hides the traffic lights, so the light reservation
+   becomes a dead gap and the topbar's bottom border reads as a stray gray line
+   across the top. Drop both in fullscreen only — the windowed chrome above is
+   untouched. The `.macos-fullscreen` class is toggled by the native window's
+   fullscreen observer (see _webview_window.py _install_macos_fullscreen_observer);
+   a JS heuristic can't tell fullscreen from a zoomed window on a notched Mac. */
+.platform-mac.in-webview.macos-fullscreen .app-shell--with-topbar .topbar {
+  padding-left: var(--term-space-3);
+}
+.platform-mac.in-webview.macos-fullscreen .topbar {
+  border-bottom-color: transparent;
+}
 
 /* ============================================================
    Sidebar — collapsed by default (icon rail), expands on hover.

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1505,11 +1505,11 @@ button.term-sev-badge--clickable:focus-visible {
    space so the breadcrumb clears the lights, and tint the topbar toward the
    theme accent so the unified titlebar visibly carries the theme. */
 .platform-mac.in-webview {
-  /* Compact titlebar height so the native traffic lights (left at their OS
-     default top-left position, ~16px from the top) sit centered in the bar,
-     lining up with the breadcrumb — no native button repositioning, nothing
-     to jump on resize. 32px puts the breadcrumb's midline at the lights. */
-  --app-header-h: 32px;
+  /* Taller titlebar to match the macOS unified toolbar (added in
+     _webview_window.py), which drops the native traffic lights to ~32px and
+     keeps them centered there across resize (no per-frame repositioning).
+     A 64px bar centers the breadcrumb on the lights with room around them. */
+  --app-header-h: 64px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1508,7 +1508,7 @@ button.term-sev-badge--clickable:focus-visible {
   padding-left: 82px;
 }
 .platform-mac.in-webview .topbar {
-  background: color-mix(in srgb, var(--color-accent) 20%, var(--color-surface));
+  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
 }
 
 /* ============================================================

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1504,6 +1504,12 @@ button.term-sev-badge--clickable:focus-visible {
    the top edge with the native traffic lights floating over its left. Reserve
    space so the breadcrumb clears the lights, and tint the topbar toward the
    theme accent so the unified titlebar visibly carries the theme. */
+.platform-mac.in-webview {
+  /* Compact titlebar height so the native traffic lights (left at their OS
+     default top-left position) sit centered in the bar, lining up with the
+     breadcrumb — no native button repositioning, nothing to jump on resize. */
+  --app-header-h: 38px;
+}
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;
 }

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1509,9 +1509,8 @@ button.term-sev-badge--clickable:focus-visible {
      _webview_window.py), which drops the native traffic lights to ~32px and
      keeps them centered there across resize (no per-frame repositioning).
      The lights sit at ~32px; a 64px bar centers exactly on them, while a
-     shorter bar trades a few px of centering for a slimmer look. 52px is a
-     medium height with the lights just slightly below center. */
-  --app-header-h: 52px;
+     shorter bar trades a few px of centering for a slimmer look. */
+  --app-header-h: 48px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1508,10 +1508,10 @@ button.term-sev-badge--clickable:focus-visible {
   /* Taller titlebar to match the macOS unified toolbar (added in
      _webview_window.py), which drops the native traffic lights to ~32px and
      keeps them centered there across resize (no per-frame repositioning).
-     The lights sit at ~32px, so a 64px bar centers exactly on them — the one
-     height where the native lights are perfectly centered with zero
-     repositioning (robust, no jump on resize). */
-  --app-header-h: 64px;
+     With the unified-compact toolbar the native lights sit at ~20px, so a
+     40px bar centers them exactly — a slim, well-proportioned titlebar with
+     the lights perfectly centered, anchored (no repositioning, no jump). */
+  --app-header-h: 40px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1508,9 +1508,10 @@ button.term-sev-badge--clickable:focus-visible {
   /* Taller titlebar to match the macOS unified toolbar (added in
      _webview_window.py), which drops the native traffic lights to ~32px and
      keeps them centered there across resize (no per-frame repositioning).
-     The lights sit at ~32px; a 64px bar centers exactly on them, while a
-     shorter bar trades a few px of centering for a slimmer look. */
-  --app-header-h: 48px;
+     The lights sit at ~32px, so a 64px bar centers exactly on them — the one
+     height where the native lights are perfectly centered with zero
+     repositioning (robust, no jump on resize). */
+  --app-header-h: 64px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1514,10 +1514,10 @@ button.term-sev-badge--clickable:focus-visible {
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;
 }
-/* Topbar and sidebar share one cohesive chrome color (subtle theme tint). */
+/* Topbar and sidebar share one cohesive chrome color: plain surface, no tint. */
 .platform-mac.in-webview .topbar,
 .platform-mac.in-webview .sidebar {
-  background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
+  background: var(--color-surface);
 }
 
 /* ============================================================

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1508,8 +1508,10 @@ button.term-sev-badge--clickable:focus-visible {
   /* Taller titlebar to match the macOS unified toolbar (added in
      _webview_window.py), which drops the native traffic lights to ~32px and
      keeps them centered there across resize (no per-frame repositioning).
-     A 64px bar centers the breadcrumb on the lights with room around them. */
-  --app-header-h: 64px;
+     The lights sit at ~32px; a 64px bar centers exactly on them, while a
+     shorter bar trades a few px of centering for a slimmer look. 52px is a
+     medium height with the lights just slightly below center. */
+  --app-header-h: 52px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1500,6 +1500,16 @@ button.term-sev-badge--clickable:focus-visible {
 .app-shell--with-topbar .topbar {
   padding-left: var(--term-space-3);
 }
+/* In the macOS native shell the window is frameless and the topbar runs to
+   the top edge with the native traffic lights floating over its left. Reserve
+   space so the breadcrumb clears the lights, and tint the topbar toward the
+   theme accent so the unified titlebar visibly carries the theme. */
+.platform-mac.in-webview .app-shell--with-topbar .topbar {
+  padding-left: 82px;
+}
+.platform-mac.in-webview .topbar {
+  background: color-mix(in srgb, var(--color-accent) 20%, var(--color-surface));
+}
 
 /* ============================================================
    Sidebar — collapsed by default (icon rail), expands on hover.

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1514,7 +1514,9 @@ button.term-sev-badge--clickable:focus-visible {
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;
 }
-.platform-mac.in-webview .topbar {
+/* Topbar and sidebar share one cohesive chrome color (subtle theme tint). */
+.platform-mac.in-webview .topbar,
+.platform-mac.in-webview .sidebar {
   background: color-mix(in srgb, var(--color-accent) 8%, var(--color-surface));
 }
 

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1506,9 +1506,10 @@ button.term-sev-badge--clickable:focus-visible {
    theme accent so the unified titlebar visibly carries the theme. */
 .platform-mac.in-webview {
   /* Compact titlebar height so the native traffic lights (left at their OS
-     default top-left position) sit centered in the bar, lining up with the
-     breadcrumb — no native button repositioning, nothing to jump on resize. */
-  --app-header-h: 38px;
+     default top-left position, ~16px from the top) sit centered in the bar,
+     lining up with the breadcrumb — no native button repositioning, nothing
+     to jump on resize. 32px puts the breadcrumb's midline at the lights. */
+  --app-header-h: 32px;
 }
 .platform-mac.in-webview .app-shell--with-topbar .topbar {
   padding-left: 82px;

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -1,11 +1,21 @@
 """Native-chrome window: creation args, custom UA, and marker drift guard."""
 import inspect
+import sys
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 import webview as real_webview
 
 from quodeq.dashboard import _webview_window as ww
+
+# Some tests import PyObjCTools to patch AppHelper. pyobjc is darwin-only
+# (pywebview pulls it in under sys_platform == 'darwin'), so those tests can
+# only run on macOS — they would ModuleNotFoundError on Linux/Windows CI.
+_MACOS_ONLY = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="exercises macOS AppKit/PyObjC native chrome; pyobjc is darwin-only",
+)
 
 
 class TestWindowCreation:
@@ -121,6 +131,7 @@ class TestOnClosing:
         assert on_closing() is False
 
 
+@_MACOS_ONLY
 class TestMacTrafficLights:
     def test_unhides_three_buttons_on_macos(self):
         from PyObjCTools import AppHelper
@@ -194,6 +205,43 @@ class TestMacFullscreenClass:
         window.evaluate_js.assert_not_called()  # only the worker calls it
 
 
+class TestMacFullscreenChrome:
+    def test_fullscreen_drops_toolbar(self):
+        # macOS draws the unified toolbar as an empty gray bar at the top in
+        # fullscreen — drop it (the lights it centers are hidden there anyway).
+        window = MagicMock()
+        nswindow = window.native
+        with patch.object(ww.threading, "Thread", _SyncThread), \
+             patch.object(ww, "_apply_unified_toolbar") as restore:
+            ww._apply_macos_fullscreen_chrome(window, True)
+        nswindow.setToolbar_.assert_called_once_with(None)
+        restore.assert_not_called()
+        assert window.evaluate_js.call_args.args[0].endswith("true)")
+
+    def test_windowed_restores_toolbar(self):
+        window = MagicMock()
+        nswindow = window.native
+        with patch.object(ww.threading, "Thread", _SyncThread), \
+             patch.object(ww, "_apply_unified_toolbar") as restore:
+            ww._apply_macos_fullscreen_chrome(window, False)
+        restore.assert_called_once_with(nswindow)
+        nswindow.setToolbar_.assert_not_called()
+        assert window.evaluate_js.call_args.args[0].endswith("false)")
+
+    def test_load_sync_does_not_re_add_toolbar(self):
+        # The initial install owns the windowed toolbar; the load-time sync
+        # must not add a second one (restore_toolbar=False).
+        window = MagicMock()
+        nswindow = window.native
+        with patch.object(ww.threading, "Thread", _SyncThread), \
+             patch.object(ww, "_apply_unified_toolbar") as restore:
+            ww._apply_macos_fullscreen_chrome(window, False, restore_toolbar=False)
+        restore.assert_not_called()
+        nswindow.setToolbar_.assert_not_called()
+        assert window.evaluate_js.call_args.args[0].endswith("false)")
+
+
+@_MACOS_ONLY
 class TestMacFullscreenObserver:
     def test_noop_off_macos(self):
         from PyObjCTools import AppHelper

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -144,3 +144,13 @@ class TestMacTrafficLights:
              patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()) as ca:
             ww._show_macos_traffic_lights(window)
         ca.assert_not_called()
+
+
+class TestMacAppIdentityIdempotent:
+    def test_calling_twice_does_not_raise(self):
+        # Re-defining the _AboutHandler ObjC class raised objc.error and
+        # aborted _on_loaded before the traffic lights were shown. The
+        # one-time install guard must make repeat calls safe. (No-op off
+        # macOS, where AppKit isn't importable.)
+        ww._set_macos_app_identity()
+        ww._set_macos_app_identity()  # must not raise

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -154,3 +154,73 @@ class TestMacAppIdentityIdempotent:
         # macOS, where AppKit isn't importable.)
         ww._set_macos_app_identity()
         ww._set_macos_app_identity()  # must not raise
+
+
+class _SyncThread:
+    """Stand-in for threading.Thread that runs the target inline on start()."""
+    def __init__(self, target=None, daemon=None, **_):  # noqa: ARG002
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+class TestMacFullscreenClass:
+    def test_toggle_true_adds_class(self):
+        window = MagicMock()
+        with patch.object(ww.threading, "Thread", _SyncThread):
+            ww._set_macos_fullscreen_class(window, True)
+        window.evaluate_js.assert_called_once()
+        js = window.evaluate_js.call_args.args[0]
+        assert "macos-fullscreen" in js
+        assert js.endswith("true)")
+
+    def test_toggle_false_removes_class(self):
+        window = MagicMock()
+        with patch.object(ww.threading, "Thread", _SyncThread):
+            ww._set_macos_fullscreen_class(window, False)
+        js = window.evaluate_js.call_args.args[0]
+        assert js.endswith("false)")
+
+    def test_evaluate_runs_off_the_main_thread(self):
+        # evaluate_js on the AppKit main thread deadlocks, so the toggle must
+        # always be dispatched to a worker thread.
+        window = MagicMock()
+        with patch.object(ww.threading, "Thread") as thread_cls:
+            ww._set_macos_fullscreen_class(window, True)
+        thread_cls.assert_called_once()
+        thread_cls.return_value.start.assert_called_once()
+        window.evaluate_js.assert_not_called()  # only the worker calls it
+
+
+class TestMacFullscreenObserver:
+    def test_noop_off_macos(self):
+        from PyObjCTools import AppHelper
+        window = MagicMock()
+        window.native = MagicMock()
+        with patch.object(ww.sys, "platform", "win32"), \
+             patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()) as ca:
+            ww._install_macos_fullscreen_observer(window)
+        ca.assert_not_called()
+
+    def test_noop_without_native_handle(self):
+        from PyObjCTools import AppHelper
+        window = MagicMock()
+        window.native = None
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()) as ca:
+            ww._install_macos_fullscreen_observer(window)
+        ca.assert_not_called()
+
+    def test_install_twice_does_not_raise(self):
+        # The ObjC handler class may only be defined once per process;
+        # _on_loaded calls this on every (re)load, so repeat calls must not
+        # raise. (No-op off macOS, where AppKit isn't importable.)
+        from PyObjCTools import AppHelper
+        window = MagicMock()
+        window.native = MagicMock()
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()):
+            ww._install_macos_fullscreen_observer(window)
+            ww._install_macos_fullscreen_observer(window)  # must not raise

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -9,14 +9,30 @@ from quodeq.dashboard import _webview_window as ww
 
 
 class TestWindowCreation:
-    def test_create_window_uses_native_chrome(self):
+    def _kwargs_for_platform(self, platform):
+        with patch.object(ww.sys, "platform", platform), patch.object(ww, "webview") as wv:
+            ww._create_window("http://127.0.0.1:7863", MagicMock())
+        wv.create_window.assert_called_once()
+        return wv.create_window.call_args.kwargs
+
+    def test_frameless_on_macos_for_unified_titlebar(self):
+        # macOS goes frameless so NSFullSizeContentView lets the topbar run
+        # under the titlebar (the unified look).
+        assert self._kwargs_for_platform("darwin")["frameless"] is True
+
+    def test_native_chrome_off_macos(self):
+        assert self._kwargs_for_platform("win32")["frameless"] is False
+        assert self._kwargs_for_platform("linux")["frameless"] is False
+
+    def test_easy_drag_disabled(self):
+        # Only the topbar (pywebview-drag-region) drags the window.
+        assert self._kwargs_for_platform("darwin")["easy_drag"] is False
+
+    def test_js_api_bound(self):
         api = MagicMock()
         with patch.object(ww, "webview") as wv:
             ww._create_window("http://127.0.0.1:7863", api)
-        wv.create_window.assert_called_once()
-        kwargs = wv.create_window.call_args.kwargs
-        assert kwargs["frameless"] is False
-        assert kwargs["js_api"] is api
+        assert wv.create_window.call_args.kwargs["js_api"] is api
 
     def test_create_window_only_passes_supported_kwargs(self):
         """Guard against passing a kwarg the installed pywebview's
@@ -103,3 +119,28 @@ class TestOnClosing:
     def test_running_job_cancel_blocks_close(self):
         on_closing, window = self._wire(job={"jobId": "x"}, confirm=False)
         assert on_closing() is False
+
+
+class TestMacTrafficLights:
+    def test_unhides_three_buttons_on_macos(self):
+        from PyObjCTools import AppHelper
+        nswindow = MagicMock()
+        window = MagicMock()
+        window.native = nswindow
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()):
+            ww._show_macos_traffic_lights(window)
+        # one standardWindowButton_ lookup per traffic light (0,1,2), each un-hidden
+        assert nswindow.standardWindowButton_.call_count == 3
+        setter = nswindow.standardWindowButton_.return_value.setHidden_
+        assert setter.call_count == 3
+        assert all(c.args == (False,) for c in setter.call_args_list)
+
+    def test_noop_without_native_handle(self):
+        from PyObjCTools import AppHelper
+        window = MagicMock()
+        window.native = None
+        with patch.object(ww.sys, "platform", "darwin"), \
+             patch.object(AppHelper, "callAfter", side_effect=lambda f, *a: f()) as ca:
+            ww._show_macos_traffic_lights(window)
+        ca.assert_not_called()


### PR DESCRIPTION
## Summary

Gives macOS a **unified, Claude-desktop-style titlebar**: the window is frameless (so `NSFullSizeContentView` lets the dashboard **topbar run to the top edge**), and the **native traffic lights** float, **vertically centered**, over it. The topbar and sidebar share **one plain surface color** for a single cohesive chrome. The native titlebar appearance follows the active quodeq theme. Windows and Linux keep native OS chrome (dark/light titlebar following the theme).

Uses **public AppKit calls only** — no pywebview patching.

## How it works

- **Frameless + FSCV**: `frameless=(sys.platform == "darwin")` is what enables `NSFullSizeContentView`, so the topbar draws under the titlebar. `easy_drag=False` so only the topbar (`pywebview-drag-region`) drags the window.
- **Traffic lights, centered without jumping**: the standard window buttons are un-hidden (`standardWindowButton_(0/1/2).setHidden_(False)`), and an empty **unified-compact `NSToolbar`** grows the titlebar to ~40px so macOS centers the lights in it. macOS maintains that centering across resize/drag, so nothing is repositioned per-frame (an earlier hand-repositioning approach made the lights jump — removed).
- **One chrome color**: topbar and sidebar are both plain `--color-surface` (no accent tint).
- **Theme-aware titlebar**: a small JS→Python bridge (`set_titlebar_theme`) sets the native `NSAppearance` dark/light to match the quodeq theme, whether the theme follows the OS or is set manually. On Windows it maps to the DWM dark/light attribute.

## Fullscreen

macOS renders the unified toolbar as a separate **persistent** `NSToolbarFullScreenWindow` (an empty gray bar) once the lights it centers are hidden in fullscreen. A native `NSWindow` fullscreen **observer** drops the toolbar on `WillEnterFullScreen` (before the grow animation, so it never flashes) and restores it on `DidExitFullScreen`. With no toolbar, the titlebar **auto-hides** (reveal-on-hover) — the standard macOS fullscreen behavior — and content fills the screen. CSS scoped to a `macos-fullscreen` class (toggled by the same observer) also clears the topbar border and the now-pointless traffic-light reservation. The windowed look is untouched.

Notifications are the only reliable fullscreen signal: on a notched display a *zoomed* window and a *fullscreen* window report identical inner/screen heights, so a JS heuristic can't tell them apart.

## CSP / bridge (carried from the prior window-controls work)

The strict `script-src 'self'` shipped in 1.4.0 disabled the macOS window controls and, because pywebview builds its JS bridge with `new Function`, also broke `save_file` (Standards export) and `download_url` (project ZIP). Both are restored by serving the relaxed CSP **only** to the native webview, gated by a User-Agent marker (`QuodeqDesktop`). Closing during a scan shows a native confirmation dialog (the scan keeps running in the background).

## Cross-platform

All native titlebar/fullscreen code is **darwin-gated** at runtime; Windows and Linux are unchanged (native chrome; Windows titlebar follows the theme). The AppKit/PyObjC-dependent **tests** skip off-macOS via `skipif(sys.platform != "darwin")` — `pyobjc` is a darwin-only dependency (pywebview pulls it in under `sys_platform == 'darwin'`), so they previously `ModuleNotFoundError`'d on the Linux/Windows CI runners.

## Verification

- Screenshot spikes of the real config: lights centered in the 40px titlebar; fullscreen drops the toolbar with no gray flash and content fills the screen; windowed restore is clean.
- Tests: `_create_window` frameless per platform; `easy_drag` off; traffic lights un-hidden; the unified toolbar applied; the fullscreen observer drops/restores the toolbar and toggles the class off the main thread; idempotent install (the ObjC handler class is defined once per process). Full Python + JS suites green on macOS; Linux/Windows green with the macOS-only tests skipped.

## Tradeoff (noted honestly)

This uses a frameless window — the foundation that previously broke under the injected-controls + CSP combination. It's sturdier now (native lights and toolbar, not injected HTML; CSP-immune), but it does lean on pywebview's frameless/FSCV behavior. The fully-robust long-term path is an upstream pywebview `full_size_content` option.
