### PR TITLE
feat(analysis): enforce the critical provenance gate deterministically (#639)

### DIFF
--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Callable, Protocol, runtime_checkable
 
 from quodeq.analysis.mcp.enrichment import enrich_code
+from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
 from quodeq.analysis.mcp.ref_scoring import select_best_refs
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
 from quodeq.context.precedent import fingerprint as _precedent_fingerprint
@@ -179,5 +180,6 @@ class FindingEnricher:
         _apply_path_role_downweight(finding)
         _apply_shape_downweight(finding, self._project_shape)
         _apply_precedent_downweight(finding, self._precedent_fingerprints)
+        apply_provenance_gate(finding)  # deterministic critical-severity gate (#639)
 
         return finding

--- a/src/quodeq/analysis/mcp/provenance_gate.py
+++ b/src/quodeq/analysis/mcp/provenance_gate.py
@@ -1,0 +1,70 @@
+"""Deterministic provenance gate for the critical-severity bar (issue #639).
+
+The prompt-level gate in ``evaluation_rules.md`` asks the model not to mark an
+unguarded-access (R-FT-2) or path-from-string (S-AUT-3) finding ``critical``
+unless a reachable EXTERNAL source is named. That gate is advisory. This module
+enforces it deterministically at the finding sink: a critical R-FT-2/S-AUT-3
+finding whose evidence names no external source is de-escalated to ``major``.
+
+Generality (a hard requirement): the decision keys off TRUST-BOUNDARY SOURCE
+CONCEPTS in the model's natural-language reason -- universal and language-
+independent -- never code syntax (``sys.argv``) or project specifics. The
+vocabulary is curated to SPECIFIC INGRESS CHANNELS and deliberately EXCLUDES:
+  - rhetorical words that appear in false-positive reasons too ("attacker",
+    "file", "untrusted", "caller"), and
+  - the unguarded-access pattern's own words ("argument", "parameter", "param"),
+    which would otherwise make an R-FT-2 FP look externally sourced.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+_log = logging.getLogger(__name__)
+
+# The standard requirement IDs whose critical bar depends on reachable input
+# provenance: R-FT-2 (unguarded access) and S-AUT-3 (path/key from a value).
+# Stable across all scans (they are ISO25010 standard IDs, not project-specific).
+PROVENANCE_GATED_REQS: frozenset[str] = frozenset({"R-FT-2", "S-AUT-3"})
+
+# Marker stamped on a finding the gate de-escalates (additive output field).
+DOWNGRADE_MARKER = "provenance_downgrade"
+
+# Language-neutral trust-boundary INGRESS-CHANNEL concepts. Matched as whole
+# words/phrases. NEVER code syntax, never rhetoric, never the FP pattern's words.
+EXTERNAL_SOURCE_TERMS: frozenset[str] = frozenset({
+    # web / network ingress
+    "request", "http request", "request body", "request header",
+    "request parameter", "query string", "query parameter", "query param",
+    "route param", "url param", "path parameter", "header", "response header",
+    "http header", "cookie", "form data", "multipart", "payload", "post data",
+    "webhook", "websocket", "grpc", "network request", "network input", "socket",
+    # process / cli
+    "command-line", "command line", "command-line argument", "cli argument",
+    "cli arg", "argv",
+    # environment
+    "environment variable", "env var",
+    # io / ipc
+    "stdin", "standard input", "upload", "uploaded file", "file upload",
+    "message queue", "queue message",
+    # explicit untrusted-user phrasing
+    "user input", "user-supplied", "user-controlled", "user-provided",
+})
+
+# Whole-word/phrase pattern; longer phrases first so they win in the alternation.
+# Trailing ``s?`` tolerates plurals ("header" -> "headers") without enumerating
+# every plural form.
+_TERM_PATTERN = re.compile(
+    "|".join(
+        rf"\b{re.escape(term)}s?\b"
+        for term in sorted(EXTERNAL_SOURCE_TERMS, key=len, reverse=True)
+    ),
+    re.IGNORECASE,
+)
+
+
+def names_external_source(text: str | None) -> bool:
+    """True if *text* mentions any trust-boundary external ingress concept."""
+    if not text:
+        return False
+    return _TERM_PATTERN.search(text) is not None

--- a/src/quodeq/analysis/mcp/provenance_gate.py
+++ b/src/quodeq/analysis/mcp/provenance_gate.py
@@ -68,3 +68,30 @@ def names_external_source(text: str | None) -> bool:
     if not text:
         return False
     return _TERM_PATTERN.search(text) is not None
+
+
+def apply_provenance_gate(finding: dict) -> bool:
+    """De-escalate a critical R-FT-2/S-AUT-3 finding that names no external
+    source to ``major``, in place. Returns True iff it downgraded.
+
+    Only touches violations at ``critical`` for the gated reqs; everything else
+    (other reqs, ``major``/``minor``, compliance) is left untouched. Never drops.
+    Detection reads the model's prose (``reason`` + title ``w``) only, so it is
+    language-independent; the code ``snippet`` is intentionally not consulted.
+    """
+    if finding.get("t") != "violation":
+        return False
+    if finding.get("req") not in PROVENANCE_GATED_REQS:
+        return False
+    if finding.get("severity") != "critical":
+        return False
+    haystack = " ".join(str(finding.get(k) or "") for k in ("reason", "w"))
+    if names_external_source(haystack):
+        return False
+    finding["severity"] = "major"
+    finding[DOWNGRADE_MARKER] = True
+    _log.debug(
+        "provenance gate: downgraded %s finding to major (no external source named): %s",
+        finding.get("req"), finding.get("file"),
+    )
+    return True

--- a/src/quodeq/analysis/mcp/provenance_gate.py
+++ b/src/quodeq/analysis/mcp/provenance_gate.py
@@ -43,7 +43,7 @@ EXTERNAL_SOURCE_TERMS: frozenset[str] = frozenset({
     "command-line", "command line", "command-line argument", "cli argument",
     "cli arg", "argv",
     # environment
-    "environment variable", "env var",
+    "environment variable", "env var", "env variable",
     # io / ipc
     "stdin", "standard input", "upload", "uploaded file", "file upload",
     "message queue", "queue message",

--- a/tests/analysis/mcp/test_provenance_gate.py
+++ b/tests/analysis/mcp/test_provenance_gate.py
@@ -5,10 +5,10 @@ import pytest
 
 from quodeq.analysis.mcp.provenance_gate import (
     EXTERNAL_SOURCE_TERMS,
+    PROVENANCE_GATED_REQS,
+    apply_provenance_gate,
     names_external_source,
 )
-# NOTE: `apply_provenance_gate` and `PROVENANCE_GATED_REQS` are added to this
-# import in Task 2 (they do not exist until then).
 
 # Reasons that DO name a reachable external source -> external.
 _EXTERNAL_REASONS = [
@@ -60,3 +60,59 @@ def test_rhetoric_words_are_not_in_vocabulary():
     # These appear in false-positive reasons and must not be treated as sources.
     for forbidden in ("attacker", "file", "argument", "parameter", "untrusted", "caller"):
         assert forbidden not in EXTERNAL_SOURCE_TERMS
+
+
+def _finding(**kw) -> dict:
+    base = {"t": "violation", "req": "S-AUT-3", "severity": "critical",
+            "w": "Path traversal", "reason": "builds a path from the key"}
+    base.update(kw)
+    return base
+
+
+def test_downgrades_critical_internal_to_major():
+    f = _finding(req="S-AUT-3", reason="builds a path from a SHA-256 cache key")
+    assert apply_provenance_gate(f) is True
+    assert f["severity"] == "major"
+    assert f["provenance_downgrade"] is True
+
+
+def test_downgrades_real_fa56db32_cache_fp():
+    f = _finding(req="S-AUT-3", reason=_INTERNAL_REASONS[0])  # the "attacker/file" reason
+    assert apply_provenance_gate(f) is True
+    assert f["severity"] == "major"
+
+
+def test_downgrades_unguarded_arg_fp():
+    f = _finding(req="R-FT-2", reason="the function argument is dereferenced without a guard")
+    assert apply_provenance_gate(f) is True
+    assert f["severity"] == "major"
+
+
+def test_keeps_critical_when_external_source_named():
+    f = _finding(req="S-AUT-3", reason="path built from the HTTP request filename")
+    assert apply_provenance_gate(f) is False
+    assert f["severity"] == "critical"
+    assert "provenance_downgrade" not in f
+
+
+def test_ignores_non_gated_req():
+    f = _finding(req="S-CON-1", severity="critical", reason="hardcoded secret in source")
+    assert apply_provenance_gate(f) is False
+    assert f["severity"] == "critical"
+
+
+def test_ignores_non_critical_severity():
+    f = _finding(req="R-FT-2", severity="major", reason="builds a path from the key")
+    assert apply_provenance_gate(f) is False
+    assert f["severity"] == "major"
+    assert "provenance_downgrade" not in f
+
+
+def test_ignores_compliance():
+    f = _finding(t="compliance", req="S-AUT-3", severity="critical", reason="validated path")
+    assert apply_provenance_gate(f) is False
+    assert f["severity"] == "critical"
+
+
+def test_gated_reqs_are_the_two_patterns():
+    assert PROVENANCE_GATED_REQS == frozenset({"R-FT-2", "S-AUT-3"})

--- a/tests/analysis/mcp/test_provenance_gate.py
+++ b/tests/analysis/mcp/test_provenance_gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 
+from quodeq.analysis.mcp.enricher import CompiledContext, FindingEnricher
 from quodeq.analysis.mcp.provenance_gate import (
     DOWNGRADE_MARKER,
     EXTERNAL_SOURCE_TERMS,
@@ -122,3 +123,31 @@ def test_gated_reqs_are_the_two_patterns():
 def test_plural_sources_detected():
     assert names_external_source("query parameters were not validated") is True
     assert names_external_source("reads multiple HTTP headers") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: gate wired into FindingEnricher.enrich (issue #639)
+# ---------------------------------------------------------------------------
+
+def _enrich(args: dict) -> dict:
+    return FindingEnricher(CompiledContext()).enrich(args)
+
+
+def test_enrich_downgrades_internal_critical():
+    result = _enrich({
+        "t": "violation", "req": "S-AUT-3", "severity": "critical",
+        "file": "src/cache/local.py", "line": 59, "w": "Path traversal",
+        "reason": "builds a path from a SHA-256 cache key with no external input",
+    })
+    assert result["severity"] == "major"
+    assert result["provenance_downgrade"] is True
+
+
+def test_enrich_keeps_external_critical():
+    result = _enrich({
+        "t": "violation", "req": "S-AUT-3", "severity": "critical",
+        "file": "src/server/download.py", "line": 10, "w": "Path traversal",
+        "reason": "path built from the HTTP request filename, unvalidated",
+    })
+    assert result["severity"] == "critical"
+    assert "provenance_downgrade" not in result

--- a/tests/analysis/mcp/test_provenance_gate.py
+++ b/tests/analysis/mcp/test_provenance_gate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import pytest
 
 from quodeq.analysis.mcp.provenance_gate import (
+    DOWNGRADE_MARKER,
     EXTERNAL_SOURCE_TERMS,
     PROVENANCE_GATED_REQS,
     apply_provenance_gate,
@@ -73,7 +74,7 @@ def test_downgrades_critical_internal_to_major():
     f = _finding(req="S-AUT-3", reason="builds a path from a SHA-256 cache key")
     assert apply_provenance_gate(f) is True
     assert f["severity"] == "major"
-    assert f["provenance_downgrade"] is True
+    assert f[DOWNGRADE_MARKER] is True
 
 
 def test_downgrades_real_fa56db32_cache_fp():
@@ -92,7 +93,7 @@ def test_keeps_critical_when_external_source_named():
     f = _finding(req="S-AUT-3", reason="path built from the HTTP request filename")
     assert apply_provenance_gate(f) is False
     assert f["severity"] == "critical"
-    assert "provenance_downgrade" not in f
+    assert DOWNGRADE_MARKER not in f
 
 
 def test_ignores_non_gated_req():
@@ -105,7 +106,7 @@ def test_ignores_non_critical_severity():
     f = _finding(req="R-FT-2", severity="major", reason="builds a path from the key")
     assert apply_provenance_gate(f) is False
     assert f["severity"] == "major"
-    assert "provenance_downgrade" not in f
+    assert DOWNGRADE_MARKER not in f
 
 
 def test_ignores_compliance():
@@ -116,3 +117,8 @@ def test_ignores_compliance():
 
 def test_gated_reqs_are_the_two_patterns():
     assert PROVENANCE_GATED_REQS == frozenset({"R-FT-2", "S-AUT-3"})
+
+
+def test_plural_sources_detected():
+    assert names_external_source("query parameters were not validated") is True
+    assert names_external_source("reads multiple HTTP headers") is True

--- a/tests/analysis/mcp/test_provenance_gate.py
+++ b/tests/analysis/mcp/test_provenance_gate.py
@@ -1,0 +1,62 @@
+"""Tests for the deterministic provenance gate (issue #639)."""
+from __future__ import annotations
+
+import pytest
+
+from quodeq.analysis.mcp.provenance_gate import (
+    EXTERNAL_SOURCE_TERMS,
+    names_external_source,
+)
+# NOTE: `apply_provenance_gate` and `PROVENANCE_GATED_REQS` are added to this
+# import in Task 2 (they do not exist until then).
+
+# Reasons that DO name a reachable external source -> external.
+_EXTERNAL_REASONS = [
+    "The filename is read from the inbound HTTP request and never validated.",
+    "Value comes straight from a query parameter with no sanitisation.",
+    "Dereferences the x-active-users response header which may be absent.",
+    "Path built from a command-line argument supplied by the caller.",
+    "Reads the destination from an environment variable.",
+    "The uploaded file name flows into the path unchecked.",
+    "Splits a value taken from request body JSON.",
+    "Reads a cookie value and uses it as a key.",
+]
+
+# Reasons that name NO external source (internal value, or only rhetoric) ->
+# must NOT count as external. These include the real fa56db32 FP phrasings,
+# which use "attacker" and "file access" rhetorically and say "argument".
+_INTERNAL_REASONS = [
+    "Constructs a path from slices of the 'key' string without validating that "
+    "the key does not contain traversal sequences. This allows an attacker to "
+    "provide a crafted key leading to unauthorized file access.",
+    "The function argument is dereferenced without a null guard and could throw.",
+    "Spreads the thresholds prop without checking it is defined first.",
+    "Destructures the hook options object; a missing field would be undefined.",
+    "Uses a SHA-256 content hash to build the cache directory path.",
+    "Opens a path built from a hardcoded constant.",
+]
+
+
+@pytest.mark.parametrize("reason", _EXTERNAL_REASONS)
+def test_external_reasons_detected(reason):
+    assert names_external_source(reason) is True
+
+
+@pytest.mark.parametrize("reason", _INTERNAL_REASONS)
+def test_internal_reasons_not_detected(reason):
+    assert names_external_source(reason) is False
+
+
+def test_empty_text_is_not_external():
+    assert names_external_source("") is False
+    assert names_external_source(None) is False  # type: ignore[arg-type]
+
+
+def test_match_is_case_insensitive():
+    assert names_external_source("Reads the HTTP REQUEST body") is True
+
+
+def test_rhetoric_words_are_not_in_vocabulary():
+    # These appear in false-positive reasons and must not be treated as sources.
+    for forbidden in ("attacker", "file", "argument", "parameter", "untrusted", "caller"):
+        assert forbidden not in EXTERNAL_SOURCE_TERMS

--- a/tests/analysis/mcp/test_provenance_gate.py
+++ b/tests/analysis/mcp/test_provenance_gate.py
@@ -151,3 +151,36 @@ def test_enrich_keeps_external_critical():
     })
     assert result["severity"] == "critical"
     assert "provenance_downgrade" not in result
+
+
+def test_downgraded_finding_retains_all_other_fields():
+    """No-drop invariant: a downgrade mutates only severity (+marker), never
+    removes the finding or its other fields."""
+    f = _finding(
+        req="S-AUT-3", file="src/cache/local.py", line=59,
+        w="Path traversal", reason="builds a path from a SHA-256 cache key",
+    )
+    assert apply_provenance_gate(f) is True
+    assert f["severity"] == "major"
+    # every other field survives intact
+    assert f["t"] == "violation"
+    assert f["req"] == "S-AUT-3"
+    assert f["file"] == "src/cache/local.py"
+    assert f["line"] == 59
+    assert f["w"] == "Path traversal"
+    assert f["reason"] == "builds a path from a SHA-256 cache key"
+
+
+def test_non_referential_source_word_intentionally_kept_critical():
+    """KNOWN, INTENTIONAL conservative bias (pinned so a future vocab edit cannot
+    silently change it): the gate keeps `critical` whenever a vocabulary term
+    appears at all, even used non-referentially (here "header" inside "file
+    header bytes"). The gate never tries to disambiguate prose; it only ever
+    errs toward keeping critical, never toward an unjustified downgrade."""
+    f = _finding(
+        req="S-AUT-3",
+        reason="splits the file header bytes, a 4-byte internal magic number",
+    )
+    assert apply_provenance_gate(f) is False
+    assert f["severity"] == "critical"
+    assert "provenance_downgrade" not in f

--- a/tests/analysis/test_prompt_provenance_gate.py
+++ b/tests/analysis/test_prompt_provenance_gate.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from quodeq.analysis.api_prompt_assembly import assemble_api_prompt
+from quodeq.analysis.mcp.provenance_gate import EXTERNAL_SOURCE_TERMS
 from quodeq.analysis.prompts.builder import PromptContext, build_analysis_prompt
 from quodeq.analysis.prompts._template import load_template
 from quodeq.context.path_role import Role, path_role
@@ -169,3 +170,14 @@ def test_internal_fixture_prompt_has_no_role_label(case):
     )
     assert "(role:" not in prompt
     assert "test_fixture" not in prompt
+
+
+def test_vocabulary_concepts_present_in_rules():
+    """The deterministic gate's source vocabulary must stay in sync with the
+    prompt gate's source taxonomy, so the two cannot silently diverge.
+    """
+    lower = RULES.lower()
+    # Representative concepts that the rules' source taxonomy lists.
+    for concept in ("request", "header", "cookie", "cli argument", "environment variable"):
+        assert concept in lower, f"rules no longer mention source concept {concept!r}"
+        assert concept in EXTERNAL_SOURCE_TERMS, f"vocabulary dropped {concept!r}"

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -5,9 +5,9 @@ src/quodeq/analysis/_api_runner.py:36:context
 src/quodeq/analysis/_api_runner.py:37:context
 src/quodeq/analysis/api_prompt_assembly.py:14:context
 src/quodeq/analysis/api_prompt_assembly.py:15:context
-src/quodeq/analysis/mcp/enricher.py:15:context
 src/quodeq/analysis/mcp/enricher.py:16:context
 src/quodeq/analysis/mcp/enricher.py:17:context
+src/quodeq/analysis/mcp/enricher.py:18:context
 src/quodeq/analysis/mcp/findings_server.py:20:context
 src/quodeq/analysis/mcp/findings_server.py:21:context
 src/quodeq/analysis/subprocess.py:232:llm_bridge


### PR DESCRIPTION
## What

Makes the **provenance gate enforced, not advisory** (closes #639).

PR #636 added a prompt rule: a `critical` finding for unguarded access (`R-FT-2`) or path-from-string (`S-AUT-3`) must name a reachable *external* source. That gate lives only in the prompt, so a model can ignore it (exactly what the compliance-blind `gemma4:26b-mlx` did in run fa56db32). This adds a **deterministic backstop** that does not depend on the model behaving.

## How

A new module `src/quodeq/analysis/mcp/provenance_gate.py` and a one-line call in `FindingEnricher.enrich()` — the single sink every finding flows through (both the MCP/CLI subagent path and the local-API runner converge on `FindingsRouter.receive` → `enrich`). For a `critical` R-FT-2/S-AUT-3 violation whose prose (`reason` + title) names no external source, severity is de-escalated to `major` and the finding is stamped `provenance_downgrade: true`. It runs before the JSONL write, so the persisted (and scored) severity is the gated one.

- **Severity, not confidence.** The gate changes `severity` (which drives the grade: critical→0.0 floor + 4.0 weight). The existing enricher downweights only touch `confidence`, which is cosmetic for the grade (#640). Orthogonal.
- **Never drops.** Only `critical → major`, in place; all other fields preserved. `major`/`minor`/compliance/non-gated reqs are untouched.

## Generality (the hard requirement)

Detection keys off **trust-boundary source *concepts*** in the model's natural-language reason — universal across all 24 languages — never code syntax or project specifics. The vocabulary (`EXTERNAL_SOURCE_TERMS`) is specific ingress channels (request, header, cookie, query parameter, command-line argument, environment variable, stdin, socket, upload, message queue, user-supplied…). It deliberately **excludes**:

- rhetorical words that also appear in *false-positive* reasons — `attacker`, `file`, `untrusted`, `caller` (the real fa56db32 cache FP reason says "allows an *attacker*… unauthorized *file* access");
- the unguarded-access pattern's own words — `argument`, `parameter`, `param` (an R-FT-2 FP reason says "the *argument* is dereferenced").

Including those would make the gate keep the very FPs it must drop. A sync-guard test pins the vocabulary against the `evaluation_rules.md` source taxonomy so the prompt gate and deterministic gate can't silently diverge.

## Testing

- 30 unit/integration tests in `tests/analysis/mcp/test_provenance_gate.py` (matcher, gate logic, the real fa56db32 FP reasons → major, external reasons → stay critical, plural matching, exclusions, no-drop invariant, conservative-keep behavior, end-to-end through `enrich`).
- Prompt↔vocabulary sync guard in `tests/analysis/test_prompt_provenance_gate.py`.
- Full deterministic suite: **3552 passed**, 13 deselected.

All deterministic — runs in normal CI, no model required. (`tools/import_baseline.txt` is a 1-line shift because the new import pushed enricher's grandfathered `context` imports down a line; regenerated per the import-layer test's own guidance.)

## Accepted tradeoffs (called out for reviewers)

- **Conservative bias by design.** A curated-vocabulary heuristic has both error directions, but every error is `critical → major` (never a drop): a true critical whose source is phrased outside the vocabulary is demoted to `major` (still reported), and an internal FP whose reason mentions a channel word non-referentially ("file *header* bytes") stays `critical`. Both pinned by tests so a future vocab edit is a conscious change. We keep the vocabulary **tight on purpose** — broadening it would keep *more* findings critical, working against the FP-suppression goal of #638/#639.
- **Marker is forensic.** `provenance_downgrade` is JSONL-only; it isn't a `Judgment` field, so it doesn't reach the SQL projection/dashboard. The severity flip itself is fully effective. Promoting the marker to a first-class field is a possible follow-up.
- **Stale cache.** Findings written by this version already carry the gated severity (the cache is populated post-`enrich`). Entries cached by *prior* quodeq versions replay verbatim on incremental runs and skip the gate (the cache key excludes version); this self-heals on `--clean-scan` or re-dispatch. We chose not to bump the cache schema version (that would nuke the whole cache for an unrelated reason).

Pairs with the advisory prompt gate (#636) and the #641 regression matrix (whose internal cases now stay non-critical even if a future model over-rates). Closes #639.
