### PR TITLE
docs(scoring): document per-finding confidence as UI-only, pin grade invariance (#640)

### DIFF
--- a/src/quodeq/analysis/_report_constants.py
+++ b/src/quodeq/analysis/_report_constants.py
@@ -10,6 +10,10 @@ _FIELD_WEIGHTED_SCORE_SNAKE = "weighted_score"
 _FIELD_CONFIDENCE_INTERVAL = "confidenceInterval"
 _FIELD_CONFIDENCE_INTERVAL_SNAKE = "confidence_interval"
 
+# Fields the report/scoring path reads from a finding. `confidence` is
+# intentionally NOT here (#640): it is a UI/triage signal (it drives the
+# dashboard's "Low confidence" grouping), not a grade input. Keeping it out
+# keeps the grade objective and non-gameable. See tests/core/test_confidence_not_scored.py.
 _VIOLATION_FIELDS = (
     "file", "line", "end_line", "title", "reason",
     "snippet", "context", "scope", "severity", "req", "req_refs",

--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -18,6 +18,11 @@ from quodeq.context.precedent import fingerprint as _precedent_fingerprint
 from quodeq.context.project_shape import Deployment, ProjectShape
 
 _FINDING_SCHEMA_VERSION = 1
+# These downweights set `confidence`, a UI/triage signal ONLY: confidence drives
+# the dashboard's "Low confidence" grouping and does NOT affect the grade (it is
+# excluded from the scoring fields -- see _report_constants._VIOLATION_FIELDS and
+# #640). Severity, set by the analysis LLM and enforced by the provenance gate
+# (#639), is the lever that moves the score.
 _NON_PROD_DOWNWEIGHT = 50
 _SHAPE_DOWNWEIGHT = 40
 _PRECEDENT_DOWNWEIGHT = 25

--- a/tests/core/test_confidence_not_scored.py
+++ b/tests/core/test_confidence_not_scored.py
@@ -1,0 +1,69 @@
+"""Contract: per-finding ``confidence`` is a UI/triage signal, never a grade input (#640).
+
+``confidence`` (0-100) is set by the ``FindingEnricher`` downweights (non-prod path
+-> 50, project-shape mismatch -> 40, prior-dismissal precedent -> 25) and powers the
+dashboard's collapsible "Low confidence" grouping. It deliberately does NOT affect
+the grade: the score reflects the code objectively, not heuristic false-positive
+judgement or which findings a user has dismissed (letting dismissals raise a grade
+would be gameable and would conflate "this was a false positive" with "I don't care
+about this"). These tests pin that invariance so it cannot change silently.
+
+If false-positive-aware grading is ever wanted, it should be designed on the
+detection/severity side (cf. the deterministic provenance gate, #639), not bolted on
+by weighting the grade with ``confidence``.
+"""
+from __future__ import annotations
+
+from quodeq.analysis._report_constants import _COMPLIANCE_FIELDS, _VIOLATION_FIELDS
+from quodeq.core.scoring._principle import compute_tallies
+from quodeq.core.types.finding import Finding
+from quodeq.services.scoring.projector_scoring import compute_principle_grade
+
+
+def test_confidence_absent_from_scored_fields():
+    """Structural guard: confidence is not among the fields scoring reads."""
+    assert "confidence" not in _VIOLATION_FIELDS
+    assert "confidence" not in _COMPLIANCE_FIELDS
+
+
+def _v(severity: str, reason: str, confidence: int) -> dict:
+    return {"severity": severity, "reason": reason, "confidence": confidence}
+
+
+def test_tally_is_invariant_to_confidence():
+    """The per-severity tally that feeds scoring ignores confidence entirely."""
+    high = [_v("critical", "a", 100), _v("major", "b", 100), _v("minor", "c", 100)]
+    low = [_v("critical", "a", 25), _v("major", "b", 40), _v("minor", "c", 50)]
+    assert compute_tallies(high, []) == compute_tallies(low, [])
+
+
+def _f(severity: str, reason: str, confidence: int) -> Finding:
+    return Finding(
+        practice_id="Modularity", verdict="violation", file="a.py", line=1,
+        end_line=1, title="t", reason=reason, snippet="s", severity=severity,
+        cwe=None, req="R1", req_refs=[], context="", dimension="maintainability",
+        violation_type=None, scope="", confidence=confidence,
+    )
+
+
+def test_principle_grade_is_invariant_to_confidence():
+    """The end-to-end principle grade must be identical regardless of confidence."""
+    spec = [
+        ("critical", "critical defect"),
+        ("major", "major defect one"),
+        ("major", "major defect two"),
+        ("minor", "minor defect"),
+    ]
+    full_conf = [_f(sev, reason, 100) for sev, reason in spec]
+    low_conf = [_f(sev, reason, 25) for sev, reason in spec]
+
+    graded_full = compute_principle_grade(
+        principle_id="Modularity", findings=full_conf, compliance=[],
+    )
+    graded_low = compute_principle_grade(
+        principle_id="Modularity", findings=low_conf, compliance=[],
+    )
+
+    assert graded_full["score"] == graded_low["score"]
+    assert graded_full["grade"] == graded_low["grade"]
+    assert graded_full["finding_count"] == graded_low["finding_count"] == len(spec)


### PR DESCRIPTION
## What

Resolves #640 by **deciding and pinning** that per-finding `confidence` is a UI/triage signal, not a grade input.

## Background

`confidence` (0-100) is set by the `FindingEnricher` downweights — non-prod path → 50, project-shape mismatch → 40, prior-dismissal precedent → 25 — and powers the dashboard's collapsible **"Low confidence"** group. But the grade tally (`_VIOLATION_FIELDS`) never reads it, so #640 asked: wire it into scoring, or document it as UI-only?

## Decision: document as UI-only (don't wire into the grade)

- **The grade should be objective and non-gameable.** Confidence encodes heuristic FP-judgement and, at its lowest tier, recorded user *dismissals*. If those moved the grade, dismissing findings would raise your score — conflating "this was a false positive" with "I don't care about this."
- **FP-drag is better fixed at the source** — which we just did: the deterministic severity gate (#639). Confidence-weighting the grade would be a second, fuzzier FP lever with double-counting risk (non-prod path is already handled by path-role caps) and unpredictable interaction with the severity floors.
- **It avoids worsening score-central-compression** (the grade already barely discriminates); injecting heuristic weighting into the aggregation is exactly the kind of change that distorts it unpredictably.

If FP-aware grading is ever wanted, it should be designed on the detection/severity side, not bolted on by weighting the grade with `confidence`.

## Changes

- **Behavioral contract test** (`tests/core/test_confidence_not_scored.py`): the principle grade via `compute_principle_grade` is **identical regardless of confidence** (full-confidence vs low-confidence finding sets → same score + grade); plus a tally-invariance test and a structural guard that `confidence` is absent from the scored fields. If anyone later wires confidence into scoring, this fails — forcing a conscious decision.
- **Intent documented** at `_report_constants._VIOLATION_FIELDS` and at the enricher downweights.

No behavior change. Full deterministic suite green (3555 passed).

Closes #640.