### PR TITLE
fix(scoring): drop phantom non-standard principle (the "N/A" maintainability card)

### DIFF
--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
 from quodeq.core.events.models import Judgment
+
+_logger = logging.getLogger(__name__)
 
 _SEV_RANKS = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 
@@ -47,18 +50,45 @@ def _build_req_to_principle_map(dimension: str, evaluators_dir: Path | None = No
         return {}
 
 
+def principle_names_for_dimension(
+    dimension: str, evaluators_dir: Path | None = None,
+) -> set[str]:
+    """Return the principle names defined by *dimension*'s standard.
+
+    Empty when the standard is unavailable, so callers stay permissive (no
+    standard to validate against) rather than dropping everything. The
+    *evaluators_dir* must be supplied by the caller; the core layer does not
+    resolve paths itself.
+    """
+    return {p for p in _build_req_to_principle_map(dimension, evaluators_dir).values() if p}
+
+
 def _group_judgments(
     judgments: list[Judgment],
     dimension: str = "",
     evaluators_dir: Path | None = None,
 ) -> _GroupedJudgments:
     req_to_principle = _build_req_to_principle_map(dimension, evaluators_dir) if dimension else {}
+    canonical = {p for p in req_to_principle.values() if p}
     sc_violations: dict[str, list[Judgment]] = {}
     sc_compliance: dict[str, list[Judgment]] = {}
     sc_severity: dict[str, str] = {}
 
     for j in judgments:
         principle = req_to_principle.get(j.practice_id, j.practice_id)
+        # When the dimension has a standard, a finding whose principle is not
+        # one the standard defines is unmappable: quarantine it (keep it out of
+        # principle scoring) and log, so a misfiled finding -- a critical, in the
+        # worst case -- is never silently turned into a phantom principle (e.g.
+        # an "N/A" card on the dashboard). Without a standard (canonical empty),
+        # stay permissive and group by the raw principle.
+        if canonical and principle not in canonical:
+            _logger.warning(
+                "Quarantining unmapped %s finding in dimension %r: principle %r "
+                "not in standard (practice_id=%r, req=%r, file=%s)",
+                j.severity or "?", dimension, principle, j.practice_id, j.req, j.file,
+            )
+            continue
         if j.verdict == "violation":
             sc_violations.setdefault(principle, []).append(j)
         elif j.verdict == "compliance":

--- a/src/quodeq/data/fs/report_parser/_eval_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_eval_parsing.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from quodeq.core.types._serialization import to_camel_dict
+from quodeq.core.evidence._req_mapping import principle_names_for_dimension
 from quodeq.shared.utils import read_json
 from quodeq.data.fs.report_parser._report_parsing import build_finding, empty_severity_buckets
 from quodeq.data.fs.report_parser._principle_map import build_principle_map
@@ -15,13 +16,30 @@ _logger = logging.getLogger(__name__)
 _OVERALL_PRINCIPLE = "Overall"
 
 
-def parse_eval_from_json(json_path: Path, project: str, run_id: str, dimension: str) -> dict[str, Any] | None:
-    """Parse a JSON evaluation file into a detailed report with principle breakdowns."""
+def parse_eval_from_json(
+    json_path: Path, project: str, run_id: str, dimension: str,
+    *, compiled_dir: Path | None = None,
+) -> dict[str, Any] | None:
+    """Parse a JSON evaluation file into a detailed report with principle breakdowns.
+
+    When *compiled_dir* is supplied, principles absent from the dimension's
+    standard are dropped from the result, so a stale per-dimension JSON that
+    carries a phantom principle (e.g. an unmapped "N/A" group) no longer renders
+    as an extra dashboard card or radial vertex. Because the dashboard re-parses
+    the frozen JSON on every read, this also corrects already-written runs
+    without rewriting them.
+    """
     try:
         data = read_json(json_path)
     except (OSError, ValueError, UnicodeDecodeError) as exc:
         _logger.warning("Failed to parse evaluation %s: %s", json_path.name, exc)
         return None
+
+    canonical = principle_names_for_dimension(dimension, compiled_dir)
+
+    def _in_standard(name: Any) -> bool:
+        # Permissive when no standard is available (canonical empty).
+        return not canonical or name in canonical
 
     principle_grades = [
         {
@@ -31,6 +49,7 @@ def parse_eval_from_json(json_path: Path, project: str, run_id: str, dimension: 
             "isOverall": False,
         }
         for p in data.get("principles", [])
+        if _in_standard(p.get("name"))
     ]
     principle_grades.append(
         {
@@ -42,6 +61,8 @@ def parse_eval_from_json(json_path: Path, project: str, run_id: str, dimension: 
     )
 
     principle_map = build_principle_map(data)
+    if canonical:
+        principle_map = {k: v for k, v in principle_map.items() if k in canonical}
 
     # Intentional full materialization: these lists are included in a dict that
     # gets JSON-serialized by the caller, so lazy iteration would not help.

--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -137,7 +137,7 @@ def resolve_dimension_eval(
     eval_path = base / "evaluation" / f"{dimension}.json"
     if _exists(eval_path):
         return _filter_dismissed_from_result(
-            parse_eval_from_json(eval_path, project, run_id, dimension),
+            parse_eval_from_json(eval_path, project, run_id, dimension, compiled_dir=compiled_dir),
             dkeys, delkeys, dimension,
         )
 

--- a/tests/data/fs/report_parser/test_eval_parsing_standard_guard.py
+++ b/tests/data/fs/report_parser/test_eval_parsing_standard_guard.py
@@ -1,0 +1,75 @@
+"""parse_eval_from_json drops principles that are not in the dimension's
+standard, so a stale per-dimension JSON carrying a phantom "N/A" principle no
+longer renders as an extra dashboard card / radial vertex.
+
+Read-time guard: this also fixes already-written runs, since the dashboard
+re-parses the frozen evaluation/<dim>.json on every view.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.data.fs.report_parser._eval_parsing import parse_eval_from_json
+
+
+def _write_compiled_standard(
+    compiled_dir: Path, dimension: str, principle_names: list[str],
+) -> None:
+    compiled_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": dimension,
+        "name": dimension,
+        "principles": [
+            {"name": name, "requirements": [{"id": f"{name[:3].upper()}-1"}]}
+            for name in principle_names
+        ],
+    }
+    (compiled_dir / f"{dimension}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _write_eval(json_path: Path) -> None:
+    json_path.write_text(json.dumps({
+        "dimension": "maintainability",
+        "overallScore": "6.7/10",
+        "overallGrade": "Adequate",
+        "principles": [
+            {"name": "Modularity", "score": "5.2/10", "grade": "Adequate"},
+            {"name": "Testability", "score": "8.7/10", "grade": "Good"},
+            {"name": "N/A", "score": None, "grade": "Insufficient"},
+        ],
+        "violations": [
+            {"principle": "Modularity", "file": "b.py", "line": 1,
+             "title": "x", "reason": "", "severity": "minor"},
+            {"principle": "N/A", "file": "c.py", "line": 1,
+             "title": "arbitrary file read", "reason": "", "severity": "critical"},
+        ],
+        "compliance": [],
+    }), encoding="utf-8")
+
+
+def test_drops_non_standard_principle(tmp_path):
+    compiled = tmp_path / "compiled"
+    _write_compiled_standard(compiled, "maintainability", ["Modularity", "Testability"])
+    eval_path = tmp_path / "maintainability.json"
+    _write_eval(eval_path)
+
+    result = parse_eval_from_json(
+        eval_path, "proj", "run", "maintainability", compiled_dir=compiled,
+    )
+
+    graded = [pg["principle"] for pg in result["principleGrades"] if not pg["isOverall"]]
+    assert "N/A" not in graded
+    assert set(graded) == {"Modularity", "Testability"}
+    assert "N/A" not in {p["name"] for p in result["principles"]}
+
+
+def test_keeps_all_principles_without_standard(tmp_path):
+    """No compiled_dir -> permissive, backward-compatible behavior."""
+    eval_path = tmp_path / "maintainability.json"
+    _write_eval(eval_path)
+
+    result = parse_eval_from_json(eval_path, "proj", "run", "maintainability")
+
+    graded = [pg["principle"] for pg in result["principleGrades"] if not pg["isOverall"]]
+    assert "N/A" in graded

--- a/tests/engine/test_evidence_parser_unmapped_principle.py
+++ b/tests/engine/test_evidence_parser_unmapped_principle.py
@@ -1,0 +1,101 @@
+"""A finding whose principle is not in the dimension's standard must not
+become a phantom principle. It is quarantined (excluded from principle
+grouping) and logged so a misfiled critical is never silently lost.
+
+Regression for the dashboard showing a 6th maintainability principle named
+"N/A": a critical security finding was emitted under maintainability with an
+unresolvable requirement (req="N/A"), and the raw "N/A" string was grouped as
+its own principle.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from quodeq.core.evidence.parser import (
+    EvidenceContext,
+    parse_jsonl_to_evidence_by_dimension,
+)
+
+
+def _write_compiled_standard(
+    compiled_dir: Path, dimension: str, principles: dict[str, list[str]],
+) -> None:
+    """Write a minimal compiled standard: principle name -> requirement ids."""
+    compiled_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": dimension,
+        "name": dimension,
+        "principles": [
+            {"name": name, "requirements": [{"id": rid} for rid in reqs]}
+            for name, reqs in principles.items()
+        ],
+    }
+    (compiled_dir / f"{dimension}.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _ctx() -> EvidenceContext:
+    return EvidenceContext(
+        language="python", repository="t", date_str="2026-06-29",
+        source_file_count=10, files_read=2,
+    )
+
+
+def test_unmappable_finding_not_grouped_as_phantom_principle(tmp_path):
+    compiled = tmp_path / "compiled"
+    _write_compiled_standard(compiled, "maintainability", {
+        "Modularity": ["M-MOD-1"],
+        "Testability": ["M-TST-1"],
+    })
+    jsonl = tmp_path / "evidence.jsonl"
+    findings = [
+        {"schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+         "req": "M-MOD-1", "file": "b.py", "line": 10, "w": "high complexity",
+         "severity": "major", "snippet": "def big(): ..."},
+        # Orphan: no principle, req does not resolve -> practice_id becomes "N/A"
+        {"schema_version": 1, "d": "maintainability", "t": "violation",
+         "req": "N/A", "file": "c.py", "line": 1, "w": "arbitrary file read",
+         "severity": "critical", "snippet": "open(os.environ['X'])"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(f) for f in findings) + "\n", encoding="utf-8")
+
+    result = parse_jsonl_to_evidence_by_dimension(jsonl, _ctx(), evaluators_dir=compiled)
+
+    maint = result["maintainability"]
+    assert "N/A" not in maint.principles
+    assert set(maint.principles.keys()) == {"Modularity"}
+
+
+def test_unmappable_finding_is_logged(tmp_path, caplog):
+    compiled = tmp_path / "compiled"
+    _write_compiled_standard(compiled, "maintainability", {"Modularity": ["M-MOD-1"]})
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text(json.dumps({
+        "schema_version": 1, "d": "maintainability", "t": "violation",
+        "req": "N/A", "file": "c.py", "line": 1, "w": "arbitrary file read",
+        "severity": "critical", "snippet": "x",
+    }) + "\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        parse_jsonl_to_evidence_by_dimension(jsonl, _ctx(), evaluators_dir=compiled)
+
+    assert any(
+        "N/A" in r.getMessage() or "unmapped" in r.getMessage().lower()
+        for r in caplog.records
+    )
+
+
+def test_no_standard_keeps_all_principles(tmp_path):
+    """Without a standard (no evaluators_dir) the guard must stay permissive,
+    grouping by raw principle so legacy/standard-less callers are unaffected."""
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text(json.dumps({
+        "schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+        "req": "M-MOD-1", "file": "a.py", "line": 1, "w": "x", "severity": "minor",
+        "snippet": "y",
+    }) + "\n", encoding="utf-8")
+
+    result = parse_jsonl_to_evidence_by_dimension(jsonl, _ctx())
+
+    assert set(result["maintainability"].principles.keys()) == {"Modularity"}

--- a/tests/services/test_action_provider_fs_evaluations.py
+++ b/tests/services/test_action_provider_fs_evaluations.py
@@ -71,8 +71,11 @@ def test_get_dimension_eval_from_json(tmp_path: Path) -> None:
             "dimension": "maintainability",
             "overallScore": "4/10",
             "overallGrade": "Poor",
+            # Use a real maintainability principle: get_dimension_eval applies
+            # the standard guard (drops principles not in the dimension's
+            # standard), so a fictional name would be filtered out.
             "principles": [
-                {"name": "Separation of Concerns", "score": "4/10", "grade": "Poor"}
+                {"name": "Modularity", "score": "4/10", "grade": "Poor"}
             ],
         },
     )
@@ -83,7 +86,7 @@ def test_get_dimension_eval_from_json(tmp_path: Path) -> None:
     assert payload["dimension"] == "maintainability"
     grades = payload["principleGrades"]
     assert any(item["principle"] == "Overall" for item in grades)
-    assert any(item["principle"] == "Separation of Concerns" for item in grades)
+    assert any(item["principle"] == "Modularity" for item in grades)
 
 
 def test_browse_repo_filters_hidden(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## What

The dashboard rendered a **6th maintainability principle named "N/A"** even though the ISO-25010 maintainability standard defines exactly 5 (Modularity, Reusability, Analyzability, Modifiability, Testability).

## Root cause (two layers)

A single **critical security finding** ("Arbitrary file read via environment variable", `src/quodeq/api/_llamacpp_log_routes.py:73`) was emitted under the *maintainability* dimension with an unresolvable requirement (`req="N/A"`, no principle). Two bugs compounded:

1. **Source:** `_group_judgments` grouped findings by their raw principle string. With `practice_id` falling back to `"N/A"`, it created an `"N/A"` principle group. The two scoring engines then diverged — the SQL `principle_grades` table stayed clean at 5 (it is keyed to the standard), but the per-dimension `maintainability.json` carried 6.
2. **Read:** `parse_eval_from_json` builds the dashboard's `principleGrades` (cards + radial) straight from `data["principles"]`, which contained the phantom. The SQL overlay is grade-only and never prunes a JSON principle absent from SQL, so the phantom survived.

The misfiled critical was also silently contributing to no principle score on either path (empty `practice_id`).

## Fix

- **Source (quarantine + log):** `_group_judgments` now excludes a finding whose principle is not in the dimension's standard from principle grouping and logs a WARNING, so a misfiled finding (a critical, worst case) is never silently turned into a phantom principle. Stays permissive when no standard is loaded.
- **Read (standard guard):** `parse_eval_from_json` takes `compiled_dir` and drops principles absent from the dimension's standard from `principleGrades` and the principle map. Because the dashboard re-parses the frozen JSON on every read, **already-written runs are corrected with no migration**. Threaded `compiled_dir` through `resolve_dimension_eval` (already available).
- New `principle_names_for_dimension` helper reads the canonical set from the compiled standard (standard-driven, not hardcoded).

## Verification

- New tests: source-side quarantine + log, read-side drop, and two permissive (no-standard) guards. All red-first.
- Real run data: `maintainability.json` goes **6 → 5** principles, phantom `N/A` gone, the 5 canonical ones intact.
- Full suite green (3538 passed), ruff clean. One pre-existing test that used a fictional principle name ("Separation of Concerns", actually a clean-architecture principle) updated to a real maintainability principle, since the guard now correctly drops non-standard names.

## Not in scope (follow-ups)

- No validation gate enforcing a finding's dimension matches its requirement's dimension (the model emitting a security issue under maintainability isn't caught upstream).
- The misfiled critical still also exists correctly under security/Authenticity but rated *major* there; reconciling cross-dimension severity is separate.