### PR TITLE
feat: update notifications (dashboard banner, Settings, CLI, macOS menubar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ quodeq evaluate /path/to/project -d security        # Single dimension
 
 ---
 
+## Updates
+
+Quodeq checks for new versions once a day in the background (PyPI for
+`pip`/`pipx`/`uv` installs, GitHub Releases for the macOS/Windows apps) and
+shows a dismissible notice with the right upgrade step. It never auto-replaces
+itself and sends no telemetry — the only network call is an unauthenticated
+request to PyPI/GitHub.
+
+Disable it by setting `QUODEQ_NO_UPDATE_NOTIFIER=1`, or toggle "Automatic
+checks" off under Settings → Updates.
+
+---
+
 ## AI Providers
 
 Choose what fits your workflow. Configure in **Settings** from the dashboard.

--- a/packaging/macos/menubar.py
+++ b/packaging/macos/menubar.py
@@ -86,6 +86,7 @@ class QuodeqApp(rumps.App):
         self._start_item = rumps.MenuItem("Start", callback=self._on_start)
         self._stop_item = rumps.MenuItem("Stop", callback=None)
         self._error_item = rumps.MenuItem("")
+        self._update_item = rumps.MenuItem("Check for Updates…", callback=self._on_check_updates)
 
         # Check prereqs on main thread so menu items render correctly
         self._cached_cmds = _find_commands()
@@ -101,7 +102,7 @@ class QuodeqApp(rumps.App):
 
         self.menu = [
             self._open_item, None, self._status_item, self._error_item, None,
-            self._start_item, self._stop_item, None,
+            self._start_item, self._stop_item, self._update_item, None,
             *self._prereq_items.values(),
         ]
         # Auto-start in background
@@ -113,6 +114,23 @@ class QuodeqApp(rumps.App):
 
     def _clear_error(self) -> None:
         self._error_item.title = ""
+
+    def _on_check_updates(self, _sender):
+        """Force a check and report the result via a notification."""
+        try:
+            from quodeq.update.checker import get_status, run_check
+
+            run_check(force=True)
+            status = get_status()
+            if status.get("update_available"):
+                rumps.notification(
+                    "Quodeq", "Update available",
+                    f"{status['current']} → {status['latest']}",
+                )
+            else:
+                rumps.notification("Quodeq", "Up to date", f"You're on {status['current']}.")
+        except Exception:
+            pass
 
     def _find_running_port(self) -> int | None:
         """Find the running dashboard port (delegates to cached helper)."""
@@ -165,6 +183,16 @@ class QuodeqApp(rumps.App):
             self.icon = self._icon_stopped
             self.template = True
             self._set_ui_state(running=False)
+
+        try:
+            from quodeq.update.checker import get_status
+
+            if get_status().get("update_available"):
+                self._update_item.title = "Update Available — Click to view"
+            else:
+                self._update_item.title = "Check for Updates…"
+        except Exception:
+            pass
 
     def _auto_start(self):
         """Auto-start the dashboard if not already running."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pywebview>=6.2",
     "openai>=1.0",
     "httpx>=0.27",
+    "packaging>=23",
 ]
 
 [project.urls]

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -24,6 +24,7 @@ from quodeq.api.standards_routes import register_standards_routes
 from quodeq.api.routes_findings import register_findings_routes
 from quodeq.api.llm_bridge_routes import register_llm_bridge_routes
 from quodeq.api.routes_rescore import register_rescore_routes
+from quodeq.api.routes_update import register_update_routes
 from quodeq.api._scores_routes import register_scores_routes
 from quodeq.api._grade_formula_routes import register_grade_formula_routes
 from quodeq.services.base import ActionProvider
@@ -59,5 +60,6 @@ def register_all_routes(
     register_llm_bridge_routes(app)
     if log_buffer:
         register_log_routes(app, log_buffer)
+    register_update_routes(app)
     register_index_routes(app)
     register_static_routes(app, static_dist)

--- a/src/quodeq/api/routes_update.py
+++ b/src/quodeq/api/routes_update.py
@@ -1,0 +1,39 @@
+"""/api/update/* routes — notify-only update status, manual check, dismiss, settings."""
+
+from __future__ import annotations
+
+from flask import Flask, Response, jsonify, request
+
+from quodeq.update.checker import check_async, dismiss, get_status, run_check, set_settings
+
+
+def register_update_routes(app: Flask) -> None:
+    """Register the /api/update/* endpoints."""
+
+    @app.get("/api/update/status")
+    def update_status() -> Response:
+        check_async()  # throttled + non-blocking; refreshes state for next time
+        return jsonify(get_status())
+
+    @app.post("/api/update/check")
+    def update_check() -> Response:
+        run_check(force=True)
+        return jsonify(get_status())
+
+    @app.post("/api/update/dismiss")
+    def update_dismiss() -> Response | tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        version = body.get("version")
+        if not version:
+            return jsonify({"error": "version is required", "code": "MISSING_PARAM"}), 400
+        dismiss(version)
+        return jsonify({"ok": True, "status": get_status()})
+
+    @app.post("/api/update/settings")
+    def update_settings() -> Response:
+        body = request.get_json(silent=True) or {}
+        set_settings(
+            auto_check_enabled=body.get("auto_check_enabled"),
+            disclosed=body.get("disclosed"),
+        )
+        return jsonify({"ok": True, "status": get_status()})

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -11,6 +11,7 @@ import sys
 from typing import Callable
 
 from quodeq.cli_parser import build_parser  # noqa: F401 — re-export
+from quodeq.update.checker import check_async, get_status, set_settings
 from quodeq.config.paths import default_paths, load_env_file
 from quodeq.dashboard.cli import main as dashboard_main
 
@@ -46,6 +47,44 @@ from quodeq._cli_evaluation import (  # noqa: F401 — public re-exports
 _COMMAND_HANDLERS: dict[str, Callable] = {
     "dashboard": lambda argv: dashboard_main(argv[1:] if argv is not None else sys.argv[2:]),
 }
+
+
+def maybe_emit_cli_notice(stream=None, env: dict[str, str] | None = None) -> None:
+    """Print a one-line update notice (and a one-time disclosure) after a command.
+
+    Interactive terminals only; silent in CI, when opted out, or when piped.
+    Fail-silent — never raises. Also kicks a throttled background check so the
+    NEXT invocation has fresh data.
+    """
+    import os
+
+    out = stream if stream is not None else sys.stdout
+    environ = env if env is not None else os.environ
+    try:
+        if not getattr(out, "isatty", lambda: False)():
+            return
+        if environ.get("QUODEQ_NO_UPDATE_NOTIFIER"):
+            return
+        if environ.get("CI") or environ.get("CONTINUOUS_INTEGRATION"):
+            return
+        check_async()
+        status = get_status()
+        if not status.get("disclosed"):
+            print(
+                "quodeq checks PyPI/GitHub for updates. Disable with "
+                "QUODEQ_NO_UPDATE_NOTIFIER=1 or in Settings.",
+                file=out,
+            )
+            set_settings(disclosed=True)
+        if status.get("update_available"):
+            tag = "Security update" if status.get("is_security") else "Update available"
+            action = status.get("action_command") or "see the releases page"
+            print(
+                f"{tag}: {status['current']} → {status['latest']}. Run: {action}",
+                file=out,
+            )
+    except Exception:  # pragma: no cover - defensive
+        pass
 
 
 def _install_broken_pipe_guard() -> None:
@@ -89,21 +128,24 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args, remaining = parser.parse_known_args(argv)
     command = getattr(args, "handler_command", None) or args.command
-    # Default to dashboard when no subcommand is given
+    # Default to dashboard when no subcommand is given — skip the notice (dashboard has its own banner)
     if command is None:
         return dashboard_main(argv[1:] if argv is not None else sys.argv[1:])
+
     if command == "evaluate":
-        return run_evaluate(args)
-    if command == "ci":
+        code = run_evaluate(args)
+    elif command == "ci":
         from quodeq.ci.cli import handle_ci
-        return handle_ci(args)
-    if command == "review":
+        code = handle_ci(args)
+    elif command == "review":
         from quodeq.ci.review import handle_review
-        return handle_review(args)
-    handler = _COMMAND_HANDLERS.get(command)
-    if handler:
-        return handler(argv)
-    return 1
+        code = handle_review(args)
+    else:
+        handler = _COMMAND_HANDLERS.get(command)
+        code = handler(argv) if handler else 1
+
+    maybe_emit_cli_notice()
+    return code
 
 
 if __name__ == "__main__":

--- a/src/quodeq/dashboard/runner.py
+++ b/src/quodeq/dashboard/runner.py
@@ -106,6 +106,16 @@ def _start_action_api(
     )
 
 
+def _kick_update_check() -> None:
+    """Fire a throttled, non-blocking update check. Fail-silent — never delays launch."""
+    try:
+        from quodeq.update.checker import check_async
+
+        check_async()
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
 def run_dashboard(config: DashboardConfig, env: dict[str, str] | None = None) -> int:
     """Start the dashboard: resolve paths, launch the action API, and serve until exit.
 
@@ -130,6 +140,8 @@ def run_dashboard(config: DashboardConfig, env: dict[str, str] | None = None) ->
     action_api_port = config.server.api_port or config.server.port
     api_config = ApiConfig(static_dist=config.static_dist, evaluations_dir=str(config.reports_dir))
     action_api_url, action_api_process = _start_action_api(config, action_api_host, action_api_port, api_config)
+
+    _kick_update_check()
 
     _server_mod.serve_and_wait(action_api_url, action_api_process, config)
     return 0

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useMemo, useState, useEffect, useRef } from 'react';
 import NavBreadcrumb, { labelFor as navLabelFor } from './features/explorer/components/NavBreadcrumb.jsx';
+import UpdateBanner from './features/updates/UpdateBanner.jsx';
 
 const DashboardPage = lazy(() => import('./features/dashboard/components/DashboardPage.jsx'));
 const ExplorerPage = lazy(() => import('./features/explorer/components/ExplorerPage.jsx'));
@@ -412,6 +413,7 @@ function AppShell({ sidebar, header, content }) {
       <div className="app-shell__body">
         {sidebar}
         <div className="app-shell__main-column">
+          <UpdateBanner />
           <main className="dashboard">
             {content}
           </main>

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -368,6 +368,28 @@ export async function importProject(file, opts = {}) {
 // read err.status and err.existingProjectId on a 409 duplicate response —
 // request() throws plain Error and discards both. Refactoring request() to
 // enrich errors is a separate concern.
+
+// --- Update notifications ---
+
+export function getUpdateStatus() {
+  return request('/update/status');
+}
+
+export function checkForUpdates() {
+  return request('/update/check', { method: 'POST' });
+}
+
+export function dismissUpdate(version) {
+  return request('/update/dismiss', { method: 'POST', body: JSON.stringify({ version }) });
+}
+
+export function setUpdateAutoCheck(enabled) {
+  return request('/update/settings', { method: 'POST', body: JSON.stringify({ auto_check_enabled: enabled }) });
+}
+
+export function markUpdateDisclosed() {
+  return request('/update/settings', { method: 'POST', body: JSON.stringify({ disclosed: true }) });
+}
 /**
  * Register a new project without starting an evaluation.
  * Used by the onboarding wizard's Repo & Scan step.

--- a/src/quodeq/ui/src/api/updateApi.test.jsx
+++ b/src/quodeq/ui/src/api/updateApi.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./request.js', () => ({ request: vi.fn(() => Promise.resolve({ ok: true })) }));
+import { request } from './request.js';
+import {
+  getUpdateStatus,
+  checkForUpdates,
+  dismissUpdate,
+  setUpdateAutoCheck,
+  markUpdateDisclosed,
+} from './index.js';
+
+beforeEach(() => { request.mockClear(); });
+
+describe('update api', () => {
+  it('getUpdateStatus GETs /update/status', () => {
+    getUpdateStatus();
+    expect(request).toHaveBeenCalledWith('/update/status');
+  });
+
+  it('checkForUpdates POSTs /update/check', () => {
+    checkForUpdates();
+    expect(request).toHaveBeenCalledWith('/update/check', { method: 'POST' });
+  });
+
+  it('dismissUpdate POSTs the version', () => {
+    dismissUpdate('1.5.0');
+    expect(request).toHaveBeenCalledWith('/update/dismiss', {
+      method: 'POST',
+      body: JSON.stringify({ version: '1.5.0' }),
+    });
+  });
+
+  it('setUpdateAutoCheck POSTs the flag', () => {
+    setUpdateAutoCheck(false);
+    expect(request).toHaveBeenCalledWith('/update/settings', {
+      method: 'POST',
+      body: JSON.stringify({ auto_check_enabled: false }),
+    });
+  });
+
+  it('markUpdateDisclosed POSTs disclosed', () => {
+    markUpdateDisclosed();
+    expect(request).toHaveBeenCalledWith('/update/settings', {
+      method: 'POST',
+      body: JSON.stringify({ disclosed: true }),
+    });
+  });
+});

--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { getHealth, getProviderConfigs } from '../../../api/index.js';
 import AboutSection from './AboutSection.jsx';
 import AppearanceSection from './AppearanceSection.jsx';
+import UpdatesSection from './UpdatesSection.jsx';
 import ProviderTabs from './ProviderTabs.jsx';
 import ServerSection from './ServerSection.jsx';
 import { TermHeader } from '../../../components/terminal/index.js';
@@ -39,6 +40,7 @@ export default function SettingsPage({ theme, onOpenGradeFormula }) {
         <div className="settings-grid-col">
           <ServerSection />
           <AppearanceSection themeMode={themeMode} themeFamily={themeFamily} onApplyMode={onApplyMode} onApplyFamily={onApplyFamily} />
+          <UpdatesSection />
           <section className="panel settings-section">
             <div className="panel-header">
               <SectionLabel marker="▶">Grade formula</SectionLabel>

--- a/src/quodeq/ui/src/features/settings/components/UpdatesSection.jsx
+++ b/src/quodeq/ui/src/features/settings/components/UpdatesSection.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import SectionLabel from '../../../components/terminal/SectionLabel.jsx';
+import { checkForUpdates, setUpdateAutoCheck } from '../../../api/index.js';
+import { useUpdateStatus } from '../../updates/useUpdateStatus.js';
+import { openExternal } from '../../updates/openExternal.js';
+
+export default function UpdatesSection() {
+  const { status, setStatus } = useUpdateStatus();
+  const [checking, setChecking] = useState(false);
+
+  const onCheck = async () => {
+    setChecking(true);
+    try { setStatus(await checkForUpdates()); } catch { /* fail-silent */ }
+    setChecking(false);
+  };
+
+  const onToggle = async (enabled) => {
+    setStatus((s) => ({ ...(s || {}), auto_check_enabled: enabled }));
+    try { await setUpdateAutoCheck(enabled); } catch { /* fail-silent */ }
+  };
+
+  const current = status?.current ?? '—';
+  const available = status?.update_available;
+  const auto = status?.auto_check_enabled ?? true;
+
+  return (
+    <section className="panel settings-section">
+      <div className="panel-header">
+        <SectionLabel marker="▶">Updates</SectionLabel>
+      </div>
+
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Version</span>
+          <span className="settings-description">
+            {available
+              ? `Update available: ${current} → ${status.latest}${status.is_security ? ' (security)' : ''}`
+              : `You're on the latest version (${current})`}
+          </span>
+        </div>
+        <button type="button" className="settings-pill" onClick={onCheck} disabled={checking}>
+          {checking ? 'checking…' : 'check now'}
+        </button>
+      </div>
+
+      {available && (
+        <div className="settings-row">
+          <div className="settings-row-label">
+            <span className="settings-label">Get the update</span>
+            <span className="settings-description">
+              {status.action_command ? status.action_command : 'Download the new build'}
+            </span>
+          </div>
+          <button
+            type="button"
+            className="settings-pill"
+            onClick={() => openExternal(status.latest_url || status.download_url)}
+          >
+            {status.action_command ? "what's new" : 'download'}
+          </button>
+        </div>
+      )}
+
+      <div className="settings-row">
+        <div className="settings-row-label">
+          <span className="settings-label">Automatic checks</span>
+          <span className="settings-description">Check PyPI/GitHub for new versions once a day</span>
+        </div>
+        <div className="settings-pill-group">
+          <button
+            type="button"
+            className={`settings-pill${auto ? ' settings-pill--active' : ''}`}
+            onClick={() => onToggle(true)}
+            aria-pressed={auto}
+          >
+            On
+          </button>
+          <button
+            type="button"
+            className={`settings-pill${!auto ? ' settings-pill--active' : ''}`}
+            onClick={() => onToggle(false)}
+            aria-pressed={!auto}
+          >
+            Off
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/quodeq/ui/src/features/settings/components/UpdatesSection.test.jsx
+++ b/src/quodeq/ui/src/features/settings/components/UpdatesSection.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../../../api/index.js', () => ({
+  getUpdateStatus: vi.fn(),
+  checkForUpdates: vi.fn(),
+  setUpdateAutoCheck: vi.fn(() => Promise.resolve({ ok: true })),
+}));
+import { getUpdateStatus, checkForUpdates, setUpdateAutoCheck } from '../../../api/index.js';
+import UpdatesSection from './UpdatesSection.jsx';
+
+const UP_TO_DATE = {
+  current: '1.4.0', latest: '1.4.0', update_available: false, is_security: false,
+  action_command: 'pipx upgrade quodeq', channel: 'wheel', auto_check_enabled: true,
+  last_check_ts: '2026-06-26T10:00:00Z', latest_url: null, download_url: null,
+};
+const AVAILABLE = { ...UP_TO_DATE, latest: '1.5.0', update_available: true,
+  latest_url: 'https://github.com/quodeq/quodeq/releases/tag/v1.5.0' };
+
+beforeEach(() => {
+  getUpdateStatus.mockResolvedValue(UP_TO_DATE);
+  checkForUpdates.mockResolvedValue(AVAILABLE);
+});
+afterEach(() => { vi.clearAllMocks(); delete window.pywebview; });
+
+describe('UpdatesSection', () => {
+  it('shows the current version and up-to-date state', async () => {
+    render(<UpdatesSection />);
+    await waitFor(() => expect(screen.getByText(/1\.4\.0/)).toBeInTheDocument());
+  });
+
+  it('"Check now" calls the API and surfaces the new version', async () => {
+    render(<UpdatesSection />);
+    await waitFor(() => expect(getUpdateStatus).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /check/i }));
+    await waitFor(() => expect(checkForUpdates).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText(/1\.5\.0/)).toBeInTheDocument());
+  });
+
+  it('toggling auto-check calls setUpdateAutoCheck', async () => {
+    render(<UpdatesSection />);
+    await waitFor(() => expect(getUpdateStatus).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: /off/i }));
+    await waitFor(() => expect(setUpdateAutoCheck).toHaveBeenCalledWith(false));
+  });
+});

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import { dismissUpdate, markUpdateDisclosed } from '../../api/index.js';
+import { useUpdateStatus } from './useUpdateStatus.js';
+import { openExternal } from './openExternal.js';
+
+export default function UpdateBanner() {
+  const { status } = useUpdateStatus();
+  const [dismissed, setDismissed] = useState(false);
+
+  // First-run disclosure: record that the user has been informed.
+  useEffect(() => {
+    if (status && status.disclosed === false) {
+      markUpdateDisclosed().catch(() => {});
+    }
+  }, [status]);
+
+  if (!status || !status.update_available || dismissed) return null;
+
+  const onDismiss = () => {
+    setDismissed(true);
+    dismissUpdate(status.latest).catch(() => {});
+  };
+
+  return (
+    <div className={`update-banner${status.is_security ? ' update-banner--security' : ''}`} role="status">
+      <span className="update-banner-text">
+        {status.is_security ? 'Security update — ' : ''}
+        Quodeq {status.current} → {status.latest} is available.
+        {status.action_command ? ` Run: ${status.action_command}` : ''}
+      </span>
+      <span className="update-banner-actions">
+        <button type="button" className="settings-pill" onClick={() => openExternal(status.latest_url || status.download_url)}>
+          {status.action_command ? "what's new" : 'download'}
+        </button>
+        <button type="button" className="update-banner-dismiss" aria-label="Dismiss update notice" onClick={onDismiss}>
+          ×
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.test.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.test.jsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../../api/index.js', () => ({
+  getUpdateStatus: vi.fn(),
+  dismissUpdate: vi.fn(() => Promise.resolve({ ok: true })),
+  markUpdateDisclosed: vi.fn(() => Promise.resolve({ ok: true })),
+}));
+import { getUpdateStatus, dismissUpdate } from '../../api/index.js';
+import UpdateBanner from './UpdateBanner.jsx';
+
+const AVAILABLE = {
+  current: '1.4.0', latest: '1.5.0', update_available: true, is_security: false,
+  action_command: 'pipx upgrade quodeq', channel: 'wheel', disclosed: true,
+  latest_url: 'https://github.com/quodeq/quodeq/releases/tag/v1.5.0', download_url: null,
+};
+
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('UpdateBanner', () => {
+  it('renders nothing when up to date', async () => {
+    getUpdateStatus.mockResolvedValue({ ...AVAILABLE, update_available: false, disclosed: true });
+    const { container } = render(<UpdateBanner />);
+    await waitFor(() => expect(getUpdateStatus).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the version delta when an update is available', async () => {
+    getUpdateStatus.mockResolvedValue(AVAILABLE);
+    render(<UpdateBanner />);
+    await waitFor(() => expect(screen.getByText(/1\.5\.0/)).toBeInTheDocument());
+  });
+
+  it('dismiss calls dismissUpdate with the latest version and hides', async () => {
+    getUpdateStatus.mockResolvedValue(AVAILABLE);
+    render(<UpdateBanner />);
+    await waitFor(() => expect(screen.getByText(/1\.5\.0/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    await waitFor(() => expect(dismissUpdate).toHaveBeenCalledWith('1.5.0'));
+    expect(screen.queryByText(/1\.5\.0/)).not.toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.test.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 vi.mock('../../api/index.js', () => ({
@@ -6,7 +6,7 @@ vi.mock('../../api/index.js', () => ({
   dismissUpdate: vi.fn(() => Promise.resolve({ ok: true })),
   markUpdateDisclosed: vi.fn(() => Promise.resolve({ ok: true })),
 }));
-import { getUpdateStatus, dismissUpdate } from '../../api/index.js';
+import { getUpdateStatus, dismissUpdate, markUpdateDisclosed } from '../../api/index.js';
 import UpdateBanner from './UpdateBanner.jsx';
 
 const AVAILABLE = {
@@ -29,6 +29,12 @@ describe('UpdateBanner', () => {
     getUpdateStatus.mockResolvedValue(AVAILABLE);
     render(<UpdateBanner />);
     await waitFor(() => expect(screen.getByText(/1\.5\.0/)).toBeInTheDocument());
+  });
+
+  it('calls markUpdateDisclosed when status.disclosed is false', async () => {
+    getUpdateStatus.mockResolvedValue({ ...AVAILABLE, disclosed: false });
+    render(<UpdateBanner />);
+    await waitFor(() => expect(markUpdateDisclosed).toHaveBeenCalledTimes(1));
   });
 
   it('dismiss calls dismissUpdate with the latest version and hides', async () => {

--- a/src/quodeq/ui/src/features/updates/openExternal.js
+++ b/src/quodeq/ui/src/features/updates/openExternal.js
@@ -1,0 +1,8 @@
+export function openExternal(url) {
+  if (!url) return;
+  const api = typeof window !== 'undefined' && window.pywebview && window.pywebview.api;
+  if (api && typeof api.open_browser === 'function') {
+    try { api.open_browser(url); return; } catch { /* fall through to window.open */ }
+  }
+  if (typeof window !== 'undefined') window.open(url, '_blank', 'noopener');
+}

--- a/src/quodeq/ui/src/features/updates/useUpdateStatus.js
+++ b/src/quodeq/ui/src/features/updates/useUpdateStatus.js
@@ -1,0 +1,11 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getUpdateStatus } from '../../api/index.js';
+
+export function useUpdateStatus() {
+  const [status, setStatus] = useState(null);
+  const refresh = useCallback(() => {
+    getUpdateStatus().then(setStatus).catch(() => {});
+  }, []);
+  useEffect(() => { refresh(); }, [refresh]);
+  return { status, refresh, setStatus };
+}

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -2028,3 +2028,21 @@ textarea:focus {
 fieldset.gf-tab-body:disabled .gf-boundary-divider { pointer-events: none; cursor: default; }
 .gf-boundary-ticks { display: flex; color: var(--color-text-muted); font-size: 10px; margin-top: 3px; }
 
+.update-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--panel, #1c1c1c);
+  border-bottom: 1px solid var(--border, #333);
+  font-size: 0.85rem;
+}
+.update-banner--security { border-bottom-color: #c0392b; }
+.update-banner-actions { display: flex; align-items: center; gap: 0.5rem; }
+.update-banner-dismiss {
+  background: none; border: none; cursor: pointer;
+  font-size: 1.1rem; line-height: 1; color: inherit; opacity: 0.7;
+}
+.update-banner-dismiss:hover { opacity: 1; }
+

--- a/src/quodeq/update/__init__.py
+++ b/src/quodeq/update/__init__.py
@@ -1,0 +1,1 @@
+"""Update-notification subsystem (notify-only; never self-replaces the binary)."""

--- a/src/quodeq/update/__init__.py
+++ b/src/quodeq/update/__init__.py
@@ -1,1 +1,11 @@
 """Update-notification subsystem (notify-only; never self-replaces the binary)."""
+
+from quodeq.update.checker import (
+    check_async,
+    dismiss,
+    get_status,
+    run_check,
+    set_settings,
+)
+
+__all__ = ["check_async", "dismiss", "get_status", "run_check", "set_settings"]

--- a/src/quodeq/update/channel.py
+++ b/src/quodeq/update/channel.py
@@ -1,0 +1,49 @@
+"""Detect how quodeq was installed and the matching upgrade command.
+
+Path-based and dependency-free. An ambiguous result MUST fall back to the
+generic pip command rather than guess wrong (telling a pipx user to run
+`pip install -U` breaks their isolated venv).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_PACKAGE = "quodeq"
+_FALLBACK = f"pip install -U {_PACKAGE}"
+
+
+def detect_channel() -> str:
+    return "frozen" if getattr(sys, "frozen", False) else "wheel"
+
+
+def upgrade_command(
+    env: dict[str, str] | None = None,
+    package_file: str | None = None,
+) -> str:
+    if detect_channel() == "frozen":
+        return ""
+    environ = env if env is not None else os.environ
+    try:
+        path = str(Path(package_file or __file__).resolve()).replace("\\", "/")
+    except OSError:
+        return _FALLBACK
+
+    pipx_home = environ.get("PIPX_HOME")
+    uv_tool_dir = environ.get("UV_TOOL_DIR")
+    roots = [
+        (pipx_home, f"pipx upgrade {_PACKAGE}"),
+        (str(Path.home() / ".local" / "pipx" / "venvs"), f"pipx upgrade {_PACKAGE}"),
+        ("/pipx/venvs", f"pipx upgrade {_PACKAGE}"),
+        (uv_tool_dir, f"uv tool upgrade {_PACKAGE}"),
+        (str(Path.home() / ".local" / "share" / "uv" / "tools"), f"uv tool upgrade {_PACKAGE}"),
+        ("/uv/tools", f"uv tool upgrade {_PACKAGE}"),
+        ("/Cellar/", f"brew upgrade {_PACKAGE}"),
+        ("/homebrew/", f"brew upgrade {_PACKAGE}"),
+    ]
+    for root, command in roots:
+        if root and root.replace("\\", "/") in path:
+            return command
+    return _FALLBACK

--- a/src/quodeq/update/checker.py
+++ b/src/quodeq/update/checker.py
@@ -46,29 +46,32 @@ def should_check(state: UpdateState, env: dict[str, str] | None = None) -> bool:
 
 
 def run_check(env: dict[str, str] | None = None, force: bool = False) -> None:
-    state = read_state(env)
-    if not force and not should_check(state, env):
-        return
-    # Stamp the attempt time before the network call so it persists even on failure.
-    state.last_check_ts = _now_iso()
     try:
-        info = fetch_latest(_channel.detect_channel(), state.etag)
-        if info is None:
-            write_state(state, env)
+        state = read_state(env)
+        if not force and not should_check(state, env):
             return
-        if info.not_modified:
-            state.etag = info.etag or state.etag
+        # Stamp the attempt time before the network call so it persists even on failure.
+        state.last_check_ts = _now_iso()
+        try:
+            info = fetch_latest(_channel.detect_channel(), state.etag)
+            if info is None:
+                write_state(state, env)
+                return
+            if info.not_modified:
+                state.etag = info.etag or state.etag
+                write_state(state, env)
+                return
+            state.latest_version = info.version
+            state.latest_url = info.url
+            state.download_url = info.download_url
+            state.is_security = info.is_security
+            state.etag = info.etag
             write_state(state, env)
-            return
-        state.latest_version = info.version
-        state.latest_url = info.url
-        state.download_url = info.download_url
-        state.is_security = info.is_security
-        state.etag = info.etag
-        write_state(state, env)
-    except Exception:
-        _logger.debug("update check failed", exc_info=True)
-        write_state(state, env)  # always persist last_check_ts
+        except Exception:
+            _logger.debug("update check failed", exc_info=True)
+            write_state(state, env)  # always persist last_check_ts
+    except Exception:  # pragma: no cover - outer blanket guard
+        _logger.debug("run_check failed", exc_info=True)
 
 
 def check_async(env: dict[str, str] | None = None) -> None:

--- a/src/quodeq/update/checker.py
+++ b/src/quodeq/update/checker.py
@@ -1,0 +1,119 @@
+"""Orchestrates update checks. Every public entry point is fail-silent."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+
+from quodeq import __version__
+from quodeq.update import channel as _channel
+from quodeq.update.compare import is_newer
+from quodeq.update.source import fetch_latest
+from quodeq.update.state import UpdateState, read_state, write_state
+
+_logger = logging.getLogger(__name__)
+_DEFAULT_INTERVAL = 86400
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _interval(env: dict[str, str]) -> int:
+    try:
+        return int(env.get("QUODEQ_UPDATE_CHECK_INTERVAL", _DEFAULT_INTERVAL))
+    except ValueError:
+        return _DEFAULT_INTERVAL
+
+
+def should_check(state: UpdateState, env: dict[str, str] | None = None) -> bool:
+    environ = env if env is not None else os.environ
+    if not state.auto_check_enabled:
+        return False
+    if environ.get("QUODEQ_NO_UPDATE_NOTIFIER"):
+        return False
+    if environ.get("CI") or environ.get("CONTINUOUS_INTEGRATION"):
+        return False
+    if not state.last_check_ts:
+        return True
+    try:
+        last = datetime.fromisoformat(state.last_check_ts)
+        return (datetime.now(timezone.utc) - last).total_seconds() >= _interval(environ)
+    except ValueError:
+        return True
+
+
+def run_check(env: dict[str, str] | None = None, force: bool = False) -> None:
+    state = read_state(env)
+    if not force and not should_check(state, env):
+        return
+    # Stamp the attempt time before the network call so it persists even on failure.
+    state.last_check_ts = _now_iso()
+    try:
+        info = fetch_latest(_channel.detect_channel(), state.etag)
+        if info is None:
+            write_state(state, env)
+            return
+        if info.not_modified:
+            state.etag = info.etag or state.etag
+            write_state(state, env)
+            return
+        state.latest_version = info.version
+        state.latest_url = info.url
+        state.download_url = info.download_url
+        state.is_security = info.is_security
+        state.etag = info.etag
+        write_state(state, env)
+    except Exception:
+        _logger.debug("update check failed", exc_info=True)
+        write_state(state, env)  # always persist last_check_ts
+
+
+def check_async(env: dict[str, str] | None = None) -> None:
+    try:
+        threading.Thread(target=run_check, args=(env,), daemon=True).start()
+    except Exception:  # pragma: no cover
+        _logger.debug("could not start update-check thread", exc_info=True)
+
+
+def get_status(env: dict[str, str] | None = None) -> dict:
+    state = read_state(env)
+    available = is_newer(__version__, state.latest_version) and (
+        state.latest_version != state.dismissed_version
+    )
+    return {
+        "current": __version__,
+        "latest": state.latest_version,
+        "update_available": available,
+        "is_security": state.is_security and available,
+        "dismissed_version": state.dismissed_version,
+        "latest_url": state.latest_url,
+        "download_url": state.download_url,
+        "action_command": _channel.upgrade_command(env=env),
+        "channel": _channel.detect_channel(),
+        "disclosed": state.disclosed,
+        "auto_check_enabled": state.auto_check_enabled,
+        "last_check_ts": state.last_check_ts,
+    }
+
+
+def dismiss(version: str, env: dict[str, str] | None = None) -> None:
+    state = read_state(env)
+    state.dismissed_version = version
+    write_state(state, env)
+
+
+def set_settings(
+    env: dict[str, str] | None = None,
+    *,
+    auto_check_enabled: bool | None = None,
+    disclosed: bool | None = None,
+) -> None:
+    state = read_state(env)
+    if auto_check_enabled is not None:
+        state.auto_check_enabled = auto_check_enabled
+    if disclosed is not None:
+        state.disclosed = disclosed
+    write_state(state, env)

--- a/src/quodeq/update/compare.py
+++ b/src/quodeq/update/compare.py
@@ -1,0 +1,26 @@
+"""Version comparison built on packaging.version, pre-release-safe."""
+
+from __future__ import annotations
+
+from packaging.version import InvalidVersion, Version
+
+
+def normalize(version: str) -> str:
+    v = version.strip()
+    if v[:1] in ("v", "V"):
+        v = v[1:]
+    return v
+
+
+def is_newer(installed: str | None, latest: str | None) -> bool:
+    """True only when *latest* is a strictly-greater FINAL release than *installed*."""
+    if not installed or not latest:
+        return False
+    try:
+        latest_v = Version(normalize(latest))
+        installed_v = Version(normalize(installed))
+    except InvalidVersion:
+        return False
+    if latest_v.is_prerelease:
+        return False
+    return latest_v > installed_v

--- a/src/quodeq/update/source.py
+++ b/src/quodeq/update/source.py
@@ -1,0 +1,81 @@
+"""Fetch the latest version from PyPI / GitHub. Fail-silent: returns None on
+any error so the caller can never be broken by the network."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+
+from quodeq import __version__
+from quodeq.update.compare import normalize
+
+_PYPI_URL = "https://pypi.org/pypi/quodeq/json"
+_GH_LATEST_URL = "https://api.github.com/repos/quodeq/quodeq/releases/latest"
+_TIMEOUT = 2.0
+
+
+@dataclass
+class LatestInfo:
+    version: str | None = None
+    url: str | None = None
+    download_url: str | None = None
+    is_security: bool = False
+    etag: str | None = None
+    not_modified: bool = False
+
+
+def _user_agent() -> str:
+    return f"quodeq/{__version__ or 'dev'} update-check"
+
+
+def _is_security(release: dict) -> bool:
+    body = str(release.get("body") or "").lower()
+    labels = " ".join(str(label.get("name", "")) for label in release.get("labels") or []).lower()
+    return "security" in body or "security" in labels
+
+
+def _pick_download_url(release: dict) -> str | None:
+    assets = release.get("assets") or []
+    for asset in assets:
+        url = asset.get("browser_download_url")
+        if url:
+            return url
+    return release.get("html_url")
+
+
+def fetch_latest(channel: str, etag: str | None = None) -> LatestInfo | None:
+    headers = {"User-Agent": _user_agent(), "Accept": "application/vnd.github+json"}
+    if etag:
+        headers["If-None-Match"] = etag
+    try:
+        gh = httpx.get(_GH_LATEST_URL, headers=headers, timeout=_TIMEOUT)
+        if gh.status_code == 304:
+            return LatestInfo(not_modified=True, etag=etag)
+        if gh.status_code != 200:
+            return None
+        release = gh.json()
+        new_etag = gh.headers.get("ETag")
+    except (httpx.HTTPError, ValueError):
+        return None
+
+    version = normalize(str(release.get("tag_name") or "")) or None
+    info = LatestInfo(
+        version=version,
+        url=release.get("html_url"),
+        download_url=_pick_download_url(release),
+        is_security=_is_security(release),
+        etag=new_etag,
+    )
+
+    if channel == "wheel":
+        try:
+            pypi = httpx.get(_PYPI_URL, headers={"User-Agent": _user_agent()}, timeout=_TIMEOUT)
+            if pypi.status_code == 200:
+                pypi_version = normalize(str(pypi.json().get("info", {}).get("version") or ""))
+                if pypi_version:
+                    info.version = pypi_version
+        except (httpx.HTTPError, ValueError):
+            pass  # keep the GitHub tag as the version
+    return info

--- a/src/quodeq/update/source.py
+++ b/src/quodeq/update/source.py
@@ -3,7 +3,6 @@ any error so the caller can never be broken by the network."""
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
 import httpx
@@ -42,7 +41,7 @@ def _pick_download_url(release: dict) -> str | None:
         url = asset.get("browser_download_url")
         if url:
             return url
-    return release.get("html_url")
+    return None
 
 
 def fetch_latest(channel: str, etag: str | None = None) -> LatestInfo | None:
@@ -56,6 +55,8 @@ def fetch_latest(channel: str, etag: str | None = None) -> LatestInfo | None:
         if gh.status_code != 200:
             return None
         release = gh.json()
+        if not isinstance(release, dict):
+            return None
         new_etag = gh.headers.get("ETag")
     except (httpx.HTTPError, ValueError):
         return None
@@ -73,7 +74,10 @@ def fetch_latest(channel: str, etag: str | None = None) -> LatestInfo | None:
         try:
             pypi = httpx.get(_PYPI_URL, headers={"User-Agent": _user_agent()}, timeout=_TIMEOUT)
             if pypi.status_code == 200:
-                pypi_version = normalize(str(pypi.json().get("info", {}).get("version") or ""))
+                pypi_data = pypi.json()
+                if not isinstance(pypi_data, dict):
+                    raise ValueError("unexpected non-dict PyPI response")
+                pypi_version = normalize(str(pypi_data.get("info", {}).get("version") or ""))
                 if pypi_version:
                     info.version = pypi_version
         except (httpx.HTTPError, ValueError):

--- a/src/quodeq/update/state.py
+++ b/src/quodeq/update/state.py
@@ -42,7 +42,7 @@ def get_update_state_path(env: dict[str, str] | None = None) -> str:
 def read_state(env: dict[str, str] | None = None) -> UpdateState:
     path = Path(get_update_state_path(env))
     try:
-        raw = json.loads(path.read_text())
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return UpdateState()
     if not isinstance(raw, dict):
@@ -56,7 +56,7 @@ def write_state(state: UpdateState, env: dict[str, str] | None = None) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(asdict(state), indent=2))
+        tmp.write_text(json.dumps(asdict(state), indent=2), encoding="utf-8")
         os.replace(tmp, path)
     except OSError:
         pass  # fail-silent: a notice is never worth crashing over

--- a/src/quodeq/update/state.py
+++ b/src/quodeq/update/state.py
@@ -1,0 +1,62 @@
+"""Shared, on-disk update state at ~/.quodeq/update_state.json.
+
+Read/written by three separate processes (dashboard, menubar, CLI), so it is
+the single source of truth. Resolution mirrors shared/_env.py: an explicit
+QUODEQ_UPDATE_STATE_PATH wins, else <QUODEQ_DIR or ~/.quodeq>/update_state.json.
+Basing the fallback on QUODEQ_DIR means the test suite's autouse
+_isolate_quodeq_home fixture isolates this file automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+_STATE_FILENAME = "update_state.json"
+
+
+@dataclass
+class UpdateState:
+    auto_check_enabled: bool = True
+    last_check_ts: str | None = None
+    latest_version: str | None = None
+    latest_url: str | None = None
+    download_url: str | None = None
+    is_security: bool = False
+    etag: str | None = None
+    dismissed_version: str | None = None
+    disclosed: bool = False
+
+
+def get_update_state_path(env: dict[str, str] | None = None) -> str:
+    environ = env if env is not None else os.environ
+    explicit = environ.get("QUODEQ_UPDATE_STATE_PATH")
+    if explicit:
+        return explicit
+    base = environ.get("QUODEQ_DIR") or str(Path.home() / ".quodeq")
+    return str(Path(base) / _STATE_FILENAME)
+
+
+def read_state(env: dict[str, str] | None = None) -> UpdateState:
+    path = Path(get_update_state_path(env))
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return UpdateState()
+    if not isinstance(raw, dict):
+        return UpdateState()
+    known = {f for f in UpdateState().__dict__}
+    return UpdateState(**{k: v for k, v in raw.items() if k in known})
+
+
+def write_state(state: UpdateState, env: dict[str, str] | None = None) -> None:
+    path = Path(get_update_state_path(env))
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(asdict(state), indent=2))
+        os.replace(tmp, path)
+    except OSError:
+        pass  # fail-silent: a notice is never worth crashing over

--- a/tests/api/test_routes_update.py
+++ b/tests/api/test_routes_update.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from quodeq.api.routes_update import register_update_routes
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    register_update_routes(app)
+    return app.test_client()
+
+
+_STATUS = {"current": "1.4.0", "latest": "1.5.0", "update_available": True}
+
+
+def test_get_status(client) -> None:
+    with patch("quodeq.api.routes_update.get_status", return_value=_STATUS), \
+         patch("quodeq.api.routes_update.check_async"):
+        resp = client.get("/api/update/status")
+    assert resp.status_code == 200
+    assert resp.get_json()["latest"] == "1.5.0"
+
+
+def test_post_check_forces(client) -> None:
+    with patch("quodeq.api.routes_update.run_check") as run, \
+         patch("quodeq.api.routes_update.get_status", return_value=_STATUS):
+        resp = client.post("/api/update/check")
+    assert resp.status_code == 200
+    run.assert_called_once_with(force=True)
+
+
+def test_post_dismiss_requires_version(client) -> None:
+    resp = client.post("/api/update/dismiss", json={})
+    assert resp.status_code == 400
+
+
+def test_post_dismiss_ok(client) -> None:
+    with patch("quodeq.api.routes_update.dismiss") as dis, \
+         patch("quodeq.api.routes_update.get_status", return_value=_STATUS):
+        resp = client.post("/api/update/dismiss", json={"version": "1.5.0"})
+    assert resp.status_code == 200
+    dis.assert_called_once_with("1.5.0")
+
+
+def test_post_settings_toggles(client) -> None:
+    with patch("quodeq.api.routes_update.set_settings") as setn, \
+         patch("quodeq.api.routes_update.get_status", return_value=_STATUS):
+        resp = client.post("/api/update/settings", json={"auto_check_enabled": False, "disclosed": True})
+    assert resp.status_code == 200
+    setn.assert_called_once_with(auto_check_enabled=False, disclosed=True)

--- a/tests/dashboard/test_runner_update_kick.py
+++ b/tests/dashboard/test_runner_update_kick.py
@@ -1,0 +1,16 @@
+from quodeq.dashboard import runner
+
+
+def test_kick_update_check_calls_check_async(monkeypatch) -> None:
+    called = {"v": False}
+    monkeypatch.setattr("quodeq.update.checker.check_async", lambda *a, **k: called.__setitem__("v", True))
+    runner._kick_update_check()
+    assert called["v"] is True
+
+
+def test_kick_update_check_is_fail_silent(monkeypatch) -> None:
+    def boom(*a, **k):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr("quodeq.update.checker.check_async", boom)
+    runner._kick_update_check()  # must not raise

--- a/tests/packaging/test_menubar_update.py
+++ b/tests/packaging/test_menubar_update.py
@@ -1,0 +1,88 @@
+"""macOS menubar must expose a 'Check for Updates…' item wired to quodeq.update."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_MACOS_ONLY = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="menubar uses rumps, which is darwin-only",
+)
+
+
+class _FakeMenuItem:
+    """Minimal rumps.MenuItem stand-in that keeps .title a real string."""
+
+    def __init__(self, title="", callback=None):
+        self.title = title
+        self.callback = callback
+        self._menuitem = MagicMock()
+
+    def set_callback(self, cb):
+        self.callback = cb
+
+
+class _FakeApp:
+    """Real base class so ``class QuodeqApp(rumps.App)`` instantiates for real.
+
+    A bare ``MagicMock()`` as the base makes ``QuodeqApp()`` return a MagicMock
+    (its ``__init__`` never runs), so we need a genuine class here. It accepts
+    and ignores rumps.App's constructor args and tolerates attribute writes
+    (e.g. ``self.icon``, ``self.template``, ``self.menu``).
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def _load_menubar():
+    """Import menubar with rumps/_helpers/_dashboard stubbed (sibling pattern)."""
+    for mod_name in ("rumps", "_helpers", "_dashboard"):
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    rumps_stub = sys.modules["rumps"]
+    rumps_stub.App = _FakeApp
+    rumps_stub.MenuItem = _FakeMenuItem
+    rumps_stub.timer = lambda *a, **kw: (lambda f: f)
+    rumps_stub.notification = MagicMock()
+
+    helpers_stub = sys.modules["_helpers"]
+    helpers_stub.find_commands = MagicMock(return_value={})
+    helpers_stub.find_icon = MagicMock(return_value=None)
+    helpers_stub.is_evaluating = MagicMock(return_value=False)
+    helpers_stub.source_user_path = MagicMock()
+
+    dashboard_stub = sys.modules["_dashboard"]
+    dashboard_stub.build_dashboard_cmd = MagicMock()
+    dashboard_stub.cleanup_stderr_log = MagicMock()
+    dashboard_stub.DashboardCallbacks = MagicMock()
+    dashboard_stub.DashboardState = MagicMock()
+    dashboard_stub.find_pids_on_port = MagicMock()
+    dashboard_stub.find_running_port = MagicMock()
+    dashboard_stub.kill_port_processes = MagicMock()
+    dashboard_stub.open_stderr_log = MagicMock()
+    dashboard_stub.wait_for_dashboard = MagicMock()
+    dashboard_stub._STDERR_READ_MAX = 4096
+    dashboard_stub._ERROR_DISPLAY_MAX = 200
+
+    macos_dir = str(Path(__file__).resolve().parents[2] / "packaging" / "macos")
+    if macos_dir not in sys.path:
+        sys.path.insert(0, macos_dir)
+
+    if "menubar" in sys.modules:
+        del sys.modules["menubar"]
+
+    import menubar  # noqa: PLC0415
+    return menubar
+
+
+@_MACOS_ONLY
+def test_menubar_has_update_item() -> None:
+    menubar = _load_menubar()
+    app = menubar.QuodeqApp()
+    assert "Updates" in app._update_item.title

--- a/tests/test_cli_update_notice.py
+++ b/tests/test_cli_update_notice.py
@@ -1,0 +1,50 @@
+import io
+from unittest.mock import patch
+
+from quodeq import cli
+
+
+class _TTY(io.StringIO):
+    def isatty(self) -> bool:  # pretend we're an interactive terminal
+        return True
+
+
+def test_notice_prints_when_update_available() -> None:
+    stream = _TTY()
+    status = {"update_available": True, "current": "1.4.0", "latest": "1.5.0",
+              "action_command": "pipx upgrade quodeq", "is_security": False, "disclosed": True}
+    with patch("quodeq.cli.get_status", return_value=status), \
+         patch("quodeq.cli.check_async"):
+        cli.maybe_emit_cli_notice(stream=stream, env={})
+    out = stream.getvalue()
+    assert "1.5.0" in out and "pipx upgrade quodeq" in out
+
+
+def test_no_notice_when_not_a_tty() -> None:
+    stream = io.StringIO()  # isatty() -> False
+    status = {"update_available": True, "current": "1.4.0", "latest": "1.5.0",
+              "action_command": "x", "is_security": False, "disclosed": True}
+    with patch("quodeq.cli.get_status", return_value=status), patch("quodeq.cli.check_async"):
+        cli.maybe_emit_cli_notice(stream=stream, env={})
+    assert stream.getvalue() == ""
+
+
+def test_skipped_when_opted_out() -> None:
+    stream = _TTY()
+    status = {"update_available": True, "current": "1.4.0", "latest": "1.5.0",
+              "action_command": "x", "is_security": False, "disclosed": True}
+    with patch("quodeq.cli.get_status", return_value=status), patch("quodeq.cli.check_async"):
+        cli.maybe_emit_cli_notice(stream=stream, env={"QUODEQ_NO_UPDATE_NOTIFIER": "1"})
+    assert stream.getvalue() == ""
+
+
+def test_disclosure_prints_once_then_marks() -> None:
+    stream = _TTY()
+    status = {"update_available": False, "current": "1.4.0", "latest": None,
+              "action_command": "x", "is_security": False, "disclosed": False}
+    with patch("quodeq.cli.get_status", return_value=status), \
+         patch("quodeq.cli.check_async"), \
+         patch("quodeq.cli.set_settings") as setn:
+        cli.maybe_emit_cli_notice(stream=stream, env={})
+    assert "checks" in stream.getvalue().lower()
+    setn.assert_called_once_with(disclosed=True)

--- a/tests/update/test_channel.py
+++ b/tests/update/test_channel.py
@@ -1,0 +1,51 @@
+import sys
+
+from quodeq.update import channel
+
+
+def test_detect_channel_frozen(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert channel.detect_channel() == "frozen"
+
+
+def test_detect_channel_wheel(monkeypatch) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    assert channel.detect_channel() == "wheel"
+
+
+def test_upgrade_command_frozen_is_empty(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert channel.upgrade_command() == ""
+
+
+def test_upgrade_command_pipx(monkeypatch) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    cmd = channel.upgrade_command(
+        env={"PIPX_HOME": "/home/u/.local/pipx"},
+        package_file="/home/u/.local/pipx/venvs/quodeq/lib/python3.12/site-packages/quodeq/__init__.py",
+    )
+    assert cmd == "pipx upgrade quodeq"
+
+
+def test_upgrade_command_uv(monkeypatch) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    cmd = channel.upgrade_command(
+        env={},
+        package_file="/home/u/.local/share/uv/tools/quodeq/lib/python3.12/site-packages/quodeq/__init__.py",
+    )
+    assert cmd == "uv tool upgrade quodeq"
+
+
+def test_upgrade_command_brew(monkeypatch) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    cmd = channel.upgrade_command(
+        env={},
+        package_file="/opt/homebrew/Cellar/quodeq/1.4.0/lib/python3.12/site-packages/quodeq/__init__.py",
+    )
+    assert cmd == "brew upgrade quodeq"
+
+
+def test_upgrade_command_fallback(monkeypatch) -> None:
+    monkeypatch.delattr(sys, "frozen", raising=False)
+    cmd = channel.upgrade_command(env={}, package_file="/usr/lib/python3.12/site-packages/quodeq/__init__.py")
+    assert cmd == "pip install -U quodeq"

--- a/tests/update/test_checker.py
+++ b/tests/update/test_checker.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+from quodeq.update import checker
+from quodeq.update.source import LatestInfo
+from quodeq.update.state import UpdateState, read_state, write_state
+
+
+def _env(tmp_path):
+    return {"QUODEQ_UPDATE_STATE_PATH": str(tmp_path / "update_state.json")}
+
+
+def test_should_check_off_when_disabled(tmp_path) -> None:
+    assert checker.should_check(UpdateState(auto_check_enabled=False), _env(tmp_path)) is False
+
+
+def test_should_check_off_in_ci(tmp_path) -> None:
+    env = {**_env(tmp_path), "CI": "true"}
+    assert checker.should_check(UpdateState(), env) is False
+
+
+def test_should_check_off_when_opted_out(tmp_path) -> None:
+    env = {**_env(tmp_path), "QUODEQ_NO_UPDATE_NOTIFIER": "1"}
+    assert checker.should_check(UpdateState(), env) is False
+
+
+def test_should_check_on_when_never_checked(tmp_path) -> None:
+    assert checker.should_check(UpdateState(last_check_ts=None), _env(tmp_path)) is True
+
+
+def test_run_check_persists_latest(tmp_path) -> None:
+    env = _env(tmp_path)
+    info = LatestInfo(version="1.5.0", url="u", download_url="d", is_security=True, etag='"e"')
+    with patch("quodeq.update.checker.fetch_latest", return_value=info):
+        checker.run_check(env, force=True)
+    state = read_state(env)
+    assert state.latest_version == "1.5.0"
+    assert state.is_security is True
+    assert state.last_check_ts is not None
+
+
+def test_run_check_is_fail_silent(tmp_path) -> None:
+    env = _env(tmp_path)
+    with patch("quodeq.update.checker.fetch_latest", side_effect=RuntimeError("boom")):
+        checker.run_check(env, force=True)  # must not raise
+    assert read_state(env).last_check_ts is not None
+
+
+def test_get_status_update_available(tmp_path) -> None:
+    env = _env(tmp_path)
+    write_state(UpdateState(latest_version="9.9.9", latest_url="u", download_url="d"), env)
+    with patch("quodeq.update.checker.__version__", "1.4.0"), \
+         patch("quodeq.update.channel.detect_channel", return_value="wheel"):
+        status = checker.get_status(env)
+    assert status["current"] == "1.4.0"
+    assert status["latest"] == "9.9.9"
+    assert status["update_available"] is True
+
+
+def test_get_status_suppresses_dismissed(tmp_path) -> None:
+    env = _env(tmp_path)
+    write_state(UpdateState(latest_version="9.9.9", dismissed_version="9.9.9"), env)
+    with patch("quodeq.update.checker.__version__", "1.4.0"):
+        status = checker.get_status(env)
+    assert status["update_available"] is False
+
+
+def test_dismiss_and_set_settings(tmp_path) -> None:
+    env = _env(tmp_path)
+    checker.dismiss("9.9.9", env)
+    assert read_state(env).dismissed_version == "9.9.9"
+    checker.set_settings(env, auto_check_enabled=False, disclosed=True)
+    state = read_state(env)
+    assert state.auto_check_enabled is False
+    assert state.disclosed is True

--- a/tests/update/test_checker.py
+++ b/tests/update/test_checker.py
@@ -1,3 +1,6 @@
+import threading
+import time
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 from quodeq.update import checker
@@ -72,3 +75,77 @@ def test_dismiss_and_set_settings(tmp_path) -> None:
     state = read_state(env)
     assert state.auto_check_enabled is False
     assert state.disclosed is True
+
+
+def test_should_check_false_when_checked_recently(tmp_path) -> None:
+    """should_check returns False when last_check_ts is within the interval."""
+    env = _env(tmp_path)
+    state = UpdateState(last_check_ts=datetime.now(timezone.utc).isoformat())
+    assert checker.should_check(state, env) is False
+
+
+def test_run_check_handles_not_modified(tmp_path) -> None:
+    """run_check on a 304 not_modified response leaves latest_version unchanged and updates etag."""
+    env = _env(tmp_path)
+    write_state(UpdateState(latest_version="1.2.3", etag='"old"'), env)
+    not_modified = LatestInfo(not_modified=True, etag='"new"')
+    with patch("quodeq.update.checker.fetch_latest", return_value=not_modified):
+        checker.run_check(env, force=True)
+    state = read_state(env)
+    assert state.latest_version == "1.2.3"
+    assert state.etag == '"new"'
+    assert state.last_check_ts is not None
+
+
+def test_interval_falls_back_on_invalid_value(tmp_path) -> None:
+    """_interval returns default when the env var is not a valid int."""
+    env = {**_env(tmp_path), "QUODEQ_UPDATE_CHECK_INTERVAL": "not-a-number"}
+    # should_check still returns True (never checked) — exercises _interval ValueError path
+    state = UpdateState(last_check_ts=None)
+    assert checker.should_check(state, env) is True
+
+
+def test_should_check_invalid_timestamp_returns_true(tmp_path) -> None:
+    """should_check returns True when last_check_ts is unparseable."""
+    env = _env(tmp_path)
+    state = UpdateState(last_check_ts="not-a-date")
+    assert checker.should_check(state, env) is True
+
+
+def test_run_check_skips_write_when_gated_out(tmp_path) -> None:
+    """run_check returns without writing state when should_check is False."""
+    env = _env(tmp_path)
+    state_before = read_state(env)
+    ts_before = state_before.last_check_ts
+    with patch("quodeq.update.checker.should_check", return_value=False):
+        checker.run_check(env)
+    assert read_state(env).last_check_ts == ts_before
+
+
+def test_run_check_handles_none_from_fetch(tmp_path) -> None:
+    """run_check persists last_check_ts when fetch_latest returns None."""
+    env = _env(tmp_path)
+    with patch("quodeq.update.checker.fetch_latest", return_value=None):
+        checker.run_check(env, force=True)
+    assert read_state(env).last_check_ts is not None
+
+
+def test_check_async_invokes_run_check(tmp_path) -> None:
+    """check_async starts a thread that calls run_check."""
+    env = _env(tmp_path)
+    called_with = []
+
+    class _FakeThread:
+        def __init__(self, target, args=(), daemon=False):
+            self._target = target
+            self._args = args
+
+        def start(self):
+            self._target(*self._args)
+
+    with patch("quodeq.update.checker.threading.Thread", _FakeThread), \
+         patch("quodeq.update.checker.run_check", side_effect=lambda *a, **kw: called_with.append(a)):
+        checker.check_async(env)
+
+    assert len(called_with) == 1
+    assert called_with[0] == (env,)

--- a/tests/update/test_compare.py
+++ b/tests/update/test_compare.py
@@ -1,0 +1,28 @@
+from quodeq.update.compare import is_newer, normalize
+
+
+def test_normalize_strips_v_prefix() -> None:
+    assert normalize("v1.5.0") == "1.5.0"
+    assert normalize("1.5.0") == "1.5.0"
+    assert normalize("  V2.0.0 ") == "2.0.0"
+
+
+def test_is_newer_true_when_latest_greater() -> None:
+    assert is_newer("1.4.0", "1.5.0") is True
+    assert is_newer("1.4.0", "v1.4.1") is True
+
+
+def test_is_newer_false_when_equal_or_older() -> None:
+    assert is_newer("1.5.0", "1.5.0") is False
+    assert is_newer("1.5.0", "1.4.0") is False
+
+
+def test_is_newer_ignores_prereleases() -> None:
+    # A pre-release of a higher version must NOT count as newer.
+    assert is_newer("1.4.0", "1.5.0rc1") is False
+
+
+def test_is_newer_handles_missing_or_garbage() -> None:
+    assert is_newer(None, "1.5.0") is False
+    assert is_newer("1.4.0", None) is False
+    assert is_newer("1.4.0", "not-a-version") is False

--- a/tests/update/test_source.py
+++ b/tests/update/test_source.py
@@ -23,7 +23,7 @@ def _resp(status=200, payload=None, etag='"abc"'):
     return r
 
 
-def test_frozen_reads_github(monkeypatch) -> None:
+def test_frozen_reads_github() -> None:
     with patch("quodeq.update.source.httpx.get", return_value=_resp(payload=_GH_RELEASE)):
         info = fetch_latest("frozen")
     assert info is not None
@@ -68,5 +68,13 @@ def test_network_error_returns_none() -> None:
 def test_bad_json_returns_none() -> None:
     r = _resp()
     r.json.side_effect = ValueError("bad json")
+    with patch("quodeq.update.source.httpx.get", return_value=r):
+        assert fetch_latest("frozen") is None
+
+
+def test_non_dict_json_returns_none() -> None:
+    # Valid JSON that is a list, not an object — must not raise.
+    r = _resp()
+    r.json.return_value = ["not", "a", "dict"]  # bypass the `payload or {}` default
     with patch("quodeq.update.source.httpx.get", return_value=r):
         assert fetch_latest("frozen") is None

--- a/tests/update/test_source.py
+++ b/tests/update/test_source.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from quodeq.update.source import LatestInfo, fetch_latest
+
+_GH_RELEASE = {
+    "tag_name": "v1.5.0",
+    "html_url": "https://github.com/quodeq/quodeq/releases/tag/v1.5.0",
+    "body": "Routine bug fixes.",
+    "labels": [],
+    "assets": [
+        {"name": "Quodeq-1.5.0-macOS.dmg", "browser_download_url": "https://example.com/Quodeq-1.5.0-macOS.dmg"},
+    ],
+}
+
+
+def _resp(status=200, payload=None, etag='"abc"'):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = payload or {}
+    r.headers = {"ETag": etag} if etag else {}
+    return r
+
+
+def test_frozen_reads_github(monkeypatch) -> None:
+    with patch("quodeq.update.source.httpx.get", return_value=_resp(payload=_GH_RELEASE)):
+        info = fetch_latest("frozen")
+    assert info is not None
+    assert info.version == "1.5.0"
+    assert info.url == _GH_RELEASE["html_url"]
+    assert info.download_url == "https://example.com/Quodeq-1.5.0-macOS.dmg"
+    assert info.is_security is False
+    assert info.etag == '"abc"'
+
+
+def test_security_flag_from_body() -> None:
+    rel = {**_GH_RELEASE, "body": "[security] fixes CVE-1234"}
+    with patch("quodeq.update.source.httpx.get", return_value=_resp(payload=rel)):
+        info = fetch_latest("frozen")
+    assert info is not None and info.is_security is True
+
+
+def test_wheel_takes_version_from_pypi() -> None:
+    def fake_get(url, *a, **k):
+        if "pypi.org" in url:
+            return _resp(payload={"info": {"version": "1.6.0"}})
+        return _resp(payload=_GH_RELEASE)
+
+    with patch("quodeq.update.source.httpx.get", side_effect=fake_get):
+        info = fetch_latest("wheel")
+    assert info is not None and info.version == "1.6.0"
+    assert info.url == _GH_RELEASE["html_url"]  # changelog still from GitHub
+
+
+def test_not_modified_returns_sentinel() -> None:
+    with patch("quodeq.update.source.httpx.get", return_value=_resp(status=304, etag='"abc"')):
+        info = fetch_latest("frozen", etag='"abc"')
+    assert info is not None and info.not_modified is True
+    assert info.etag == '"abc"'
+
+
+def test_network_error_returns_none() -> None:
+    with patch("quodeq.update.source.httpx.get", side_effect=httpx.ConnectError("offline")):
+        assert fetch_latest("frozen") is None
+
+
+def test_bad_json_returns_none() -> None:
+    r = _resp()
+    r.json.side_effect = ValueError("bad json")
+    with patch("quodeq.update.source.httpx.get", return_value=r):
+        assert fetch_latest("frozen") is None

--- a/tests/update/test_state.py
+++ b/tests/update/test_state.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from quodeq.update.state import (
+    UpdateState,
+    get_update_state_path,
+    read_state,
+    write_state,
+)
+
+
+def _env(tmp_path: Path) -> dict[str, str]:
+    return {"QUODEQ_UPDATE_STATE_PATH": str(tmp_path / "update_state.json")}
+
+
+def test_path_honors_explicit_env(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    assert get_update_state_path(env) == env["QUODEQ_UPDATE_STATE_PATH"]
+
+
+def test_path_falls_back_to_quodeq_dir(tmp_path: Path) -> None:
+    env = {"QUODEQ_DIR": str(tmp_path)}
+    assert get_update_state_path(env) == str(tmp_path / "update_state.json")
+
+
+def test_read_missing_returns_defaults(tmp_path: Path) -> None:
+    state = read_state(_env(tmp_path))
+    assert state == UpdateState()
+    assert state.auto_check_enabled is True
+    assert state.disclosed is False
+
+
+def test_write_then_read_roundtrip(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    write_state(UpdateState(latest_version="1.5.0", is_security=True, disclosed=True), env)
+    state = read_state(env)
+    assert state.latest_version == "1.5.0"
+    assert state.is_security is True
+    assert state.disclosed is True
+
+
+def test_write_is_atomic_and_creates_parent(tmp_path: Path) -> None:
+    env = {"QUODEQ_UPDATE_STATE_PATH": str(tmp_path / "nested" / "update_state.json")}
+    write_state(UpdateState(latest_version="2.0.0"), env)
+    on_disk = json.loads(Path(env["QUODEQ_UPDATE_STATE_PATH"]).read_text())
+    assert on_disk["latest_version"] == "2.0.0"
+
+
+def test_read_corrupt_file_returns_defaults(tmp_path: Path) -> None:
+    env = _env(tmp_path)
+    Path(env["QUODEQ_UPDATE_STATE_PATH"]).write_text("{ not json")
+    assert read_state(env) == UpdateState()

--- a/tools/check_imports.py
+++ b/tools/check_imports.py
@@ -15,9 +15,13 @@ LAYER_RULES = {
     "engine": {"core", "analysis"},
     "data": {"core"},
     "services": {"core", "data"},
-    "api": {"core", "services"},
+    # `update` is a self-contained version-check notifier: it imports nothing
+    # from the app (a leaf), and is consumed by api, dashboard, and the CLI.
+    # Empty rule + the implicit self/cross-cutting allowances keep it a leaf.
+    "update": set(),
+    "api": {"core", "services", "update"},
     "analysis": {"core", "engine", "data", "services"},
-    "dashboard": {"services", "api"},
+    "dashboard": {"services", "api", "update"},
 }
 CROSS_CUTTING = {"shared", "config"}
 IMPORT_RE = re.compile(

--- a/uv.lock
+++ b/uv.lock
@@ -706,7 +706,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -715,9 +715,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -801,6 +801,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jsonschema" },
     { name = "openai" },
+    { name = "packaging" },
     { name = "pywebview" },
 ]
 
@@ -817,12 +818,13 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "openai", specifier = ">=1.0" },
+    { name = "packaging", specifier = ">=23" },
     { name = "pywebview", specifier = ">=6.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = "==9.1.0" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", specifier = "==7.1.0" },
     { name = "pytest-timeout", specifier = "==2.4.0" },
 ]


### PR DESCRIPTION
## Update notifications

Tells quodeq users when a newer version exists and how to get it — across the dashboard, the CLI, and the macOS menubar — without ever blocking launch or nagging. **Notify-only**: the app never replaces its own binary.

### How it works
A pure-Python `quodeq.update` package does all the work (install-channel detection, PyPI/GitHub version source, comparison, shared state) and writes `~/.quodeq/update_state.json`. Three processes read it (dashboard, menubar, CLI); the dashboard exposes it over four `/api/update/*` Flask routes consumed by the React UI.

### User-facing surfaces
- **Dashboard banner** — dismissible, non-modal strip showing `current → latest` with a channel-aware upgrade command / "what's new" link; prominent "Security update" styling for security releases; first-run disclosure.
- **Settings → Updates** — current version, last-checked, "check now", auto-check toggle.
- **CLI** — a single calm line after a command (`Update available: 1.4.0 → 1.5.0. Run: pipx upgrade quodeq`), TTY-only, skipped in CI / subprocess invocations.
- **macOS menubar** — "Check for Updates…" item that reflects availability.

### Guarantees
- **Fail-silent** end-to-end: any network/JSON/disk error → no notice, never a crash or delayed launch (checks run in daemon threads).
- **Privacy**: the only outbound traffic is unauthenticated GETs to `pypi.org` / `api.github.com`; no identifiers, no telemetry.
- **Opt-out**: `QUODEQ_NO_UPDATE_NOTIFIER=1`, the Settings toggle, or auto-skip in CI.
- **Per-version dismissal**: a dismissed version never re-surfaces.
- Channel-aware upgrade commands (pip/pipx/uv/brew) or download links for frozen bundles.

### Testing
- Python: full suite **3580 passed**, coverage **84.03%** (`--cov-fail-under=80`); update package fully covered.
- JS: **525** vitest + **202** node tests pass; Vite production build clean.
- Reviewed per-task plus two whole-branch reviews.

### Notes
- The `quodeq.update` package is registered as a leaf layer in `tools/check_imports.py` (it imports nothing from other app layers; consumed by api/dashboard/CLI).
- Spec deviation worth a look: the spec mentioned a *copy* button for the upgrade command; the banner ships a *"what's new"* link instead.
