### PR TITLE
fix(cache): re-gate findings replayed from a pre-#639 cache (#657)

### DIFF
--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -53,6 +53,7 @@ from quodeq.analysis.cache.dimension_helpers import (
 )
 from quodeq.analysis.cache.gc import maybe_collect_legacy_entries
 from quodeq.analysis.cache.local import LocalFileBackend
+from quodeq.analysis.mcp.provenance_gate import apply_provenance_gate
 from quodeq.analysis.subagents._source_files import _list_source_files
 from quodeq.analysis.subagents.runner import (
     DimensionCallbacks,
@@ -196,6 +197,15 @@ def _write_findings(
     jsonl: Path, findings: list[dict], *, append: bool,
     emit_events: bool = True,
 ) -> None:
+    # Re-gate cached findings on the replay path (issue #657). The live
+    # finding path gates in FindingEnricher.enrich(); cache replay bypasses
+    # enrich(), so a stale, un-gated critical R-FT-2/S-AUT-3 finding written
+    # by a pre-#639 quodeq version would otherwise replay at critical and
+    # inflate the grade. The gate only touches un-gated criticals, so
+    # re-gating an already-gated (or non-critical) finding is a no-op --
+    # safe to apply unconditionally to every cached finding.
+    for finding in findings:
+        apply_provenance_gate(finding)
     jsonl.parent.mkdir(parents=True, exist_ok=True)
     mode = "a" if append else "w"
     with jsonl.open(mode, encoding="utf-8") as out:

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -1003,6 +1003,111 @@ class TestEvidenceFileCreatedBeforeBreaker:
         )
 
 
+class TestCacheReplayAppliesProvenanceGate:
+    """Issue #657: findings replayed from a pre-#639 cache entry must pass
+    through the deterministic provenance gate too.
+
+    The live finding path gates in ``FindingEnricher.enrich()``, but cache
+    replay (``_write_findings``) writes cached findings straight to the
+    per-dim JSONL and the event log, bypassing ``enrich()``. A stale,
+    un-gated ``critical`` R-FT-2 / S-AUT-3 finding produced by an older
+    quodeq version would otherwise replay at ``critical`` and inflate the
+    grade. Re-gating on the replay write path keeps cached and
+    freshly-dispatched findings consistent.
+    """
+
+    @staticmethod
+    def _cached_critical(file: str, reason: str) -> dict:
+        return {
+            "file": file, "line": 1, "t": "violation",
+            "w": "Unguarded index access", "p": "Fault Tolerance",
+            "d": "security", "req": "R-FT-2", "severity": "critical",
+            "snippet": "arr[idx]", "reason": reason,
+        }
+
+    @staticmethod
+    def _findings_in(jsonl: Path) -> list[dict]:
+        return [
+            json.loads(ln) for ln in jsonl.read_text().splitlines()
+            if ln.strip() and "_marker" not in ln
+        ]
+
+    def _replay_all_hits(
+        self, tmp_path: Path, cache: LocalFileBackend, reason: str,
+    ) -> tuple[RunConfig, FakeDispatcher]:
+        config, src = _setup(tmp_path, {"a.py": "x"})
+        key = build_cache_key_for_file(config, "a.py", "security")
+        cache.put(key, CacheEntry(
+            key=key, schema_version=1,
+            findings=[self._cached_critical("a.py", reason)],
+            files_read=1, file_path="a.py", dimension="security",
+            model_id="test-model",
+        ))
+        dispatcher = FakeDispatcher(src)
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=dispatcher,
+        ):
+            process_dimension_with_cache(
+                config, "security", idx=1, ctx=_make_ctx(),
+                callbacks=_make_callbacks(), cache=cache,
+            )
+        assert dispatcher.calls == [], "all-hits path must not dispatch"
+        return config, dispatcher
+
+    def test_cached_critical_without_external_source_is_downgraded(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # A pre-#639 critical R-FT-2 whose reason names no external ingress
+        # source -- "argument" is deliberately NOT a trust-boundary term.
+        config, _ = self._replay_all_hits(
+            tmp_path, cache,
+            "Index derived from a function argument with no bounds check.",
+        )
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        findings = self._findings_in(jsonl)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "major", (
+            "cache-replayed critical R-FT-2 without an external source must "
+            "be downgraded to major by the provenance gate"
+        )
+        assert findings[0].get("provenance_downgrade") is True
+
+        # The gated severity must also reach the event log -- that's the
+        # path the SQL projection / grade reads, so a stale critical here
+        # would still inflate the score even after the JSONL was fixed.
+        events_log = (config.work_dir or config.src).parent / "events.jsonl"
+        events = [
+            json.loads(ln) for ln in events_log.read_text().splitlines()
+            if ln.strip()
+        ] if events_log.exists() else []
+        judgments = [e for e in events if e.get("event_type") == "JUDGMENT_CREATED"]
+        assert judgments, "cache replay must emit a JUDGMENT_CREATED event"
+        assert judgments[0]["payload"]["severity"] == "major", (
+            "the gated severity must reach events.jsonl, not the stale critical"
+        )
+
+    def test_cached_critical_naming_external_source_is_preserved(
+        self, tmp_path: Path, cache: LocalFileBackend,
+    ):
+        # Same finding, but the reason names a reachable external source --
+        # the gate must leave it critical.
+        config, _ = self._replay_all_hits(
+            tmp_path, cache,
+            "Index taken straight from the HTTP request body, unvalidated.",
+        )
+
+        jsonl = (config.work_dir or config.src) / "security_evidence.jsonl"
+        findings = self._findings_in(jsonl)
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "critical", (
+            "a cache-replayed critical naming an external source must NOT be "
+            "downgraded"
+        )
+        assert "provenance_downgrade" not in findings[0]
+
+
 class TestFilesReadReflectsAnalyzedCount:
     """files_read on the returned Evidence must equal the number of source
     files reproducible from cache at run end — NOT len(input_files)."""


### PR DESCRIPTION
Closes #657.

## Problem
The deterministic provenance gate (#639) runs in `FindingEnricher.enrich()` on the **live** finding path (`FindingsRouter.receive`). But cache replay takes a different route: `analysis/cache/dimension_runner.py:_write_findings` writes cached findings straight to the per-dim JSONL and the event log, bypassing `enrich()`.

Because the cache key (`dimension_helpers._SCHEMA_VERSION`) excludes `quodeq_version`/`prompts_hash`, a **stale, un-gated `critical` R-FT-2 / S-AUT-3 finding written by a pre-#639 quodeq version replays at `critical`** on incremental runs and inflates the grade. It self-heals only on `--clean-scan` or when the file is re-dispatched.

## Fix (issue's option 2)
Apply `apply_provenance_gate()` to every cached finding in `_write_findings`, before it is written to the JSONL and emitted to `events.jsonl`. This is the single funnel for all cache-replay writes (all-hits short-circuit + pre-dispatch carry write).

The gate only touches **un-gated criticals** for the two gated reqs, so re-gating an already-gated or non-critical finding is a no-op — safe to apply unconditionally. The gated severity now reaches both the JSONL and `events.jsonl` (the source the SQL projection and grade read from), so cached and freshly-dispatched findings stay consistent.

## Tests
New `TestCacheReplayAppliesProvenanceGate` in `tests/analysis/cache/test_dimension_runner.py`:
- a cache-replayed `critical` R-FT-2 with **no** external source named → downgraded to `major`, `provenance_downgrade: true` stamped, and the gated severity reaches `events.jsonl`;
- a cache-replayed `critical` naming an external source (`HTTP request body`) → **preserved** at `critical` (no over-gating).

Verified RED→GREEN. Full cache + mcp + provenance-gate suites: 295 passed.

## Notes
- `provenance_downgrade` reaching the SQLite projection / dashboard is the separate follow-up #656.