### PR TITLE
fix(analysis): make requirement authoritative for finding dimension (closes #661)

### DIFF
--- a/src/quodeq/analysis/mcp/enricher.py
+++ b/src/quodeq/analysis/mcp/enricher.py
@@ -6,6 +6,7 @@ all transformation here and keeps only routing concerns (dedup, I/O, events).
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Protocol, runtime_checkable
@@ -16,6 +17,8 @@ from quodeq.analysis.mcp.ref_scoring import select_best_refs
 from quodeq.context.path_role import NON_PROD_ROLES, path_role
 from quodeq.context.precedent import fingerprint as _precedent_fingerprint
 from quodeq.context.project_shape import Deployment, ProjectShape
+
+_logger = logging.getLogger(__name__)
 
 _FINDING_SCHEMA_VERSION = 1
 # These downweights set `confidence`, a UI/triage signal ONLY: confidence drives
@@ -170,11 +173,26 @@ class FindingEnricher:
         if not args.get("p") and req and req in self._reqs:
             finding["p"] = self._reqs[req]["principle"]
 
-        if not args.get("d"):
-            if req and req in self._req_to_dim:
-                finding["d"] = self._req_to_dim[req]
-            elif self._dimension:
-                finding["d"] = self._dimension
+        # The requirement is authoritative for a finding's dimension. When a
+        # requirement maps to a dimension (multi-dimension scans populate
+        # req_to_dim across standards), use it even if the model declared a
+        # different dimension -- this reroutes a misfiled finding to where it is
+        # actually scored, rather than letting a, say, security issue land under
+        # maintainability. Falls back to the model's value, then the scanned
+        # dimension. (An unresolvable requirement that cannot be rerouted is
+        # quarantined downstream at principle grouping.)
+        req_dim = self._req_to_dim.get(req) if req else None
+        declared = args.get("d")
+        if req_dim:
+            if declared and declared != req_dim:
+                _logger.warning(
+                    "Rerouting finding from declared dimension %r to %r per "
+                    "requirement %r (severity=%s, file=%s)",
+                    declared, req_dim, req, args.get("severity"), args.get("file"),
+                )
+            finding["d"] = req_dim
+        elif not declared and self._dimension:
+            finding["d"] = self._dimension
 
         if req and req in self._refs:
             finding["req_refs"] = select_best_refs(

--- a/tests/analysis/mcp/test_finding_enricher.py
+++ b/tests/analysis/mcp/test_finding_enricher.py
@@ -1,8 +1,6 @@
 """Tests for FindingEnricher — pure dict transformation, no file I/O."""
 from __future__ import annotations
 
-import pytest
-
 from quodeq.analysis.mcp.enricher import (
     CompiledContext,
     FindingEnricher,
@@ -197,3 +195,53 @@ def test_dedup_key_uses_explicit_principle() -> None:
         {"p": "Custom", "file": "a.py", "line": 1, "t": "violation"}
     )
     assert key[0] == "Custom"
+
+
+# ---------------------------------------------------------------------------
+# Dimension/requirement agreement gate (#661)
+# ---------------------------------------------------------------------------
+
+def test_reroutes_finding_to_requirement_dimension() -> None:
+    """The requirement is authoritative: a finding the model declared under
+    one dimension is rerouted to the dimension its requirement belongs to
+    (multi-dimension scans populate req_to_dim across standards)."""
+    req_to_dim = {"S-CON-1": "security"}
+    result = _enricher(req_to_dim=req_to_dim).enrich(
+        {"t": "violation", "req": "S-CON-1", "d": "maintainability",
+         "severity": "critical", "file": "a.py", "line": 1}
+    )
+    assert result["d"] == "security"
+
+
+def test_does_not_reroute_correctly_filed_finding() -> None:
+    req_to_dim = {"M-MOD-1": "maintainability"}
+    result = _enricher(req_to_dim=req_to_dim).enrich(
+        {"t": "violation", "req": "M-MOD-1", "d": "maintainability",
+         "file": "a.py", "line": 1}
+    )
+    assert result["d"] == "maintainability"
+
+
+def test_keeps_declared_dimension_when_requirement_unresolvable() -> None:
+    """Single-dimension scans leave req_to_dim empty; an unresolvable req
+    cannot be rerouted, so the declared dimension is preserved (the unmapped
+    finding is quarantined downstream at principle grouping, not here)."""
+    result = _enricher(dimension="maintainability").enrich(
+        {"t": "violation", "req": "N/A", "d": "maintainability",
+         "severity": "critical", "file": "a.py", "line": 1}
+    )
+    assert result["d"] == "maintainability"
+
+
+def test_reroute_is_logged(caplog) -> None:
+    import logging
+    req_to_dim = {"S-CON-1": "security"}
+    with caplog.at_level(logging.WARNING):
+        _enricher(req_to_dim=req_to_dim).enrich(
+            {"t": "violation", "req": "S-CON-1", "d": "maintainability",
+             "severity": "critical", "file": "a.py", "line": 1}
+        )
+    assert any(
+        "security" in r.getMessage() and "maintainability" in r.getMessage()
+        for r in caplog.records
+    )

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -5,9 +5,9 @@ src/quodeq/analysis/_api_runner.py:36:context
 src/quodeq/analysis/_api_runner.py:37:context
 src/quodeq/analysis/api_prompt_assembly.py:14:context
 src/quodeq/analysis/api_prompt_assembly.py:15:context
-src/quodeq/analysis/mcp/enricher.py:16:context
 src/quodeq/analysis/mcp/enricher.py:17:context
 src/quodeq/analysis/mcp/enricher.py:18:context
+src/quodeq/analysis/mcp/enricher.py:19:context
 src/quodeq/analysis/mcp/findings_server.py:20:context
 src/quodeq/analysis/mcp/findings_server.py:21:context
 src/quodeq/analysis/subprocess.py:232:llm_bridge


### PR DESCRIPTION
Closes #661. Follow-up to #659 (the phantom "N/A" maintainability principle fix).

## Problem

PR #659 *contained* the phantom-principle symptom (drops non-standard principles, quarantines unmapped findings). This PR addresses the *generator*: nothing made a finding's requirement authoritative for its dimension, so a finding the model declared under the wrong dimension stayed there.

The enricher only set the dimension from the requirement when the model left dimension **unset** (`if not declared_dimension`). When the model declared `d="maintainability"` for what was really a security issue, the requirement-based correction never ran.

## Fix

The **requirement is now authoritative for dimension**. When a requirement maps to a dimension (multi-dimension scans populate `req_to_dim` across all standards), the finding is routed there even if the model declared a different dimension, with a WARNING log on override. This reroutes a misfiled finding to where it is actually scored, instead of letting it land in — and be quarantined from — the wrong dimension.

**No regression path:** if the model supplied a valid principle (common in multi-dimension mode, where it has every standard in context), the finding is now correctly scored in the right dimension; if it didn't, it lands in the target dimension and #659 quarantines it there (same outcome, different bucket). Never worse than before.

## Scope

- **Reroute** (multi-dimension scans, `req_to_dim` non-empty): the new behavior here.
- **Quarantine + log** of an unresolvable requirement (single-dimension scans, `req_to_dim` empty — the original bug's mode): already handled downstream at principle grouping by #659. Behavior preserved.
- Behavior unchanged for correctly-filed findings.

## Verification

- 4 new enricher tests (2 red-first: reroute + WARNING log; 2 behavior-preservation: correctly-filed unchanged, unresolvable-req keeps declared dimension).
- `tests/analysis/mcp` + `tests/engine` green (473), `tests/tools` + `tests/ci` green (118), ruff clean.

## Incidental

- `tools/import_baseline.txt` regenerated: adding `import logging` shifted enricher.py's pre-existing grandfathered `quodeq.context` imports by one line (line-number shift only, no new layer violation).
- Removed a dead `import pytest` in the enricher test module.

## Out of scope

- Resolving a foreign requirement's *principle* in the target dimension when the model omitted it (relies on model-provided principle, common in multi-dim; otherwise quarantined downstream).
- Reconciling cross-dimension severity when the same issue is emitted under two dimensions.