### PR TITLE
feat(scoring): surface provenance_downgrade as a first-class field (#656)

### DIFF
--- a/src/quodeq/api/_run_event_stream.py
+++ b/src/quodeq/api/_run_event_stream.py
@@ -160,6 +160,7 @@ def _payload_as_sse_finding(payload: Any, finding_id: int) -> dict[str, Any]:
         "reason": payload.reason,
         "snippet": payload.snippet,
         "confidence": payload.confidence,
+        "provenance_downgrade": getattr(payload, "provenance_downgrade", False),
     }
 
 

--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -63,6 +63,10 @@ class Judgment(BaseModel):
     req: Optional[str] = None
     req_refs: List[ReqRef] = Field(default_factory=list)
     cwe: Optional[str] = None
+    # True when the deterministic provenance gate (#639) de-escalated this
+    # finding from critical to major. UI/DB-visible audit marker (#656); the
+    # severity flip already drives the grade, this just makes it auditable.
+    provenance_downgrade: bool = False
 
     @field_validator("req_refs", mode="before")
     @classmethod

--- a/src/quodeq/core/evidence/_jsonl.py
+++ b/src/quodeq/core/evidence/_jsonl.py
@@ -59,6 +59,7 @@ def parse_jsonl_line(line: str) -> tuple[Judgment, list[str] | None] | None:
         context=obj.get("context") or None, scope=obj.get("scope") or None,
         confidence=_jsonl_confidence(obj.get("confidence")),
         req_refs=req_refs,
+        provenance_downgrade=bool(obj.get("provenance_downgrade")),
     )
     return j, obj.get("refs")
 
@@ -89,6 +90,10 @@ def judgment_to_dict(j: Judgment) -> dict:
     # has full confidence; producers writing < 100 surface in the output.
     if j.confidence != 100:
         d["confidence"] = j.confidence
+    # Carry the provenance-gate marker forward only when set, mirroring
+    # confidence -- keeps the common (un-downgraded) finding dict compact.
+    if j.provenance_downgrade:
+        d["provenance_downgrade"] = True
     return d
 
 

--- a/src/quodeq/core/finding_builder.py
+++ b/src/quodeq/core/finding_builder.py
@@ -32,6 +32,7 @@ class FindingSpec:
     scope: str | None = None
     include_severity: bool = True
     confidence: int = 100
+    provenance_downgrade: bool = False
 
 
 def build_finding_base(spec: FindingSpec) -> Finding:
@@ -61,6 +62,7 @@ def build_finding_base(spec: FindingSpec) -> Finding:
         context=spec.context if spec.context else None,
         scope=spec.scope if spec.scope else None,
         confidence=spec.confidence,
+        provenance_downgrade=spec.provenance_downgrade,
     )
 
 

--- a/src/quodeq/core/finding_mappings.py
+++ b/src/quodeq/core/finding_mappings.py
@@ -53,6 +53,7 @@ def wire_dict_to_judgment(d: dict[str, Any]) -> Judgment:
         req=d.get("req"),
         req_refs=_coerce_req_refs(d.get("req_refs")),
         cwe=d.get("cwe"),
+        provenance_downgrade=bool(d.get("provenance_downgrade")),
     )
 
 
@@ -81,6 +82,7 @@ def judgment_to_finding(j: Judgment, *, dismissed: bool = False) -> Finding:
         violation_type=j.violation_type,
         scope=j.scope,
         confidence=j.confidence,
+        provenance_downgrade=j.provenance_downgrade,
     )
 
 
@@ -102,4 +104,5 @@ def finding_to_response_dict(f: Finding) -> dict[str, Any]:
         "title": f.title,
         "req": f.req,
         "req_refs": req_refs,
+        "provenance_downgrade": f.provenance_downgrade,
     }

--- a/src/quodeq/core/types/finding.py
+++ b/src/quodeq/core/types/finding.py
@@ -42,3 +42,6 @@ class Finding:
     # Lower values flag noise (path role, project shape, precedent) the
     # context-enricher pipeline downweights post-LLM.
     confidence: int = 100
+    # True when the deterministic provenance gate (#639) de-escalated this
+    # finding from critical to major. Audit marker surfaced in the DB/UI (#656).
+    provenance_downgrade: bool = False

--- a/src/quodeq/data/sqlite/_migrations.py
+++ b/src/quodeq/data/sqlite/_migrations.py
@@ -237,11 +237,42 @@ def _upgrade_v4_to_v5(conn: sqlite3.Connection) -> None:
             conn.execute("ALTER TABLE dimension_scores ADD COLUMN exit_reason TEXT")
 
 
+def _upgrade_v5_to_v6(conn: sqlite3.Connection) -> None:
+    """Add the provenance_downgrade column to findings (default 0, issue #656).
+
+    Marks findings the deterministic provenance gate (#639) de-escalated from
+    critical to major so the SQL projection and dashboard can surface it.
+
+    findings may not exist on DBs upgraded from very old (v1/v2) schemas that
+    only ever created a subset of tables -- only the fresh-DB DDL guarantees
+    it. Skip the ALTER in that case (mirrors the dimension_scores guard in
+    _upgrade_v4_to_v5); a future caller needing the column gets the fresh DDL.
+
+    Idempotency: the ALTER and the PRAGMA user_version bump in
+    apply_evaluation_schema commit separately (autocommit), so a crash in
+    between leaves the column added but the version still 5. Re-running the
+    bare ALTER would then raise "duplicate column name: provenance_downgrade"
+    -- a plain OperationalError the scoring/dashboard read seams don't catch,
+    permanently bricking the run. Skip if the column already exists.
+    """
+    has_findings = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='findings'"
+    ).fetchone() is not None
+    if not has_findings:
+        return
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(findings)")}
+    if "provenance_downgrade" not in columns:
+        conn.execute(
+            "ALTER TABLE findings ADD COLUMN provenance_downgrade INTEGER NOT NULL DEFAULT 0"
+        )
+
+
 _UPGRADES = {
     1: _upgrade_v1_to_v2,
     2: _upgrade_v2_to_v3,
     3: _upgrade_v3_to_v4,
     4: _upgrade_v4_to_v5,
+    5: _upgrade_v5_to_v6,
 }
 
 

--- a/src/quodeq/data/sqlite/_row_mappers.py
+++ b/src/quodeq/data/sqlite/_row_mappers.py
@@ -61,6 +61,7 @@ def finding_dict_to_row(finding: dict[str, Any]) -> dict[str, Any]:
         "req_refs_json": json.dumps(refs) if refs is not None else None,
         "dedup_key": _dedup_key(practice_id, file, line, verdict),
         "confidence": _coerce_confidence(finding.get("confidence")),
+        "provenance_downgrade": 1 if finding.get("provenance_downgrade") else 0,
     }
 
 
@@ -90,6 +91,7 @@ def judgment_to_row(j: Judgment) -> dict[str, Any]:
         "req_refs_json": refs_json,
         "dedup_key": _dedup_key(j.practice_id, j.file, j.line, j.verdict),
         "confidence": _coerce_confidence(j.confidence),
+        "provenance_downgrade": 1 if j.provenance_downgrade else 0,
     }
 
 
@@ -115,4 +117,5 @@ def row_to_finding(row: dict[str, Any]) -> Finding:
         context=row.get("context", ""),
         scope=row.get("scope", ""),
         confidence=_coerce_confidence(row.get("confidence")),
+        provenance_downgrade=bool(row.get("provenance_downgrade")),
     )

--- a/src/quodeq/data/sqlite/_schema.py
+++ b/src/quodeq/data/sqlite/_schema.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 EVALUATION_DDL = """
-PRAGMA user_version = 5;
+PRAGMA user_version = 6;
 
 CREATE TABLE findings (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -33,6 +33,9 @@ CREATE TABLE findings (
     -- sure this is real." Slice 1 of the context-enricher plan adds this column;
     -- subsequent slices write < 100 to downweight false-positive patterns.
     confidence      INTEGER NOT NULL DEFAULT 100,
+    -- 1 when the deterministic provenance gate (#639) de-escalated this
+    -- finding from critical to major; 0 otherwise. UI/DB audit marker (#656).
+    provenance_downgrade INTEGER NOT NULL DEFAULT 0,
     created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
@@ -94,4 +97,4 @@ CREATE TABLE principle_grades (
 CREATE INDEX idx_principle_grades_dimension ON principle_grades(dimension);
 """
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6

--- a/src/quodeq/data/sqlite/findings_repository.py
+++ b/src/quodeq/data/sqlite/findings_repository.py
@@ -16,18 +16,21 @@ _INSERT_SQL = """
 INSERT OR IGNORE INTO findings (
     schema_version, practice_id, dimension, requirement, verdict, severity,
     file, line, end_line, title, reason, snippet,
-    violation_type, context, scope, req_refs_json, dedup_key, confidence
+    violation_type, context, scope, req_refs_json, dedup_key, confidence,
+    provenance_downgrade
 ) VALUES (
     :schema_version, :practice_id, :dimension, :requirement, :verdict, :severity,
     :file, :line, :end_line, :title, :reason, :snippet,
-    :violation_type, :context, :scope, :req_refs_json, :dedup_key, :confidence
+    :violation_type, :context, :scope, :req_refs_json, :dedup_key, :confidence,
+    :provenance_downgrade
 )
 """
 
 _SELECT_COLUMNS = (
     "id, practice_id, dimension, requirement, verdict, severity, "
     "file, line, end_line, title, reason, snippet, "
-    "violation_type, context, scope, req_refs_json, confidence"
+    "violation_type, context, scope, req_refs_json, confidence, "
+    "provenance_downgrade"
 )
 
 

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -21,11 +21,11 @@ _INSERT_FINDING = """
 INSERT OR IGNORE INTO findings (
     schema_version, practice_id, dimension, requirement, verdict, severity,
     file, line, end_line, title, reason, snippet, violation_type, context,
-    scope, req_refs_json, dedup_key, confidence
+    scope, req_refs_json, dedup_key, confidence, provenance_downgrade
 ) VALUES (
     :schema_version, :practice_id, :dimension, :requirement, :verdict, :severity,
     :file, :line, :end_line, :title, :reason, :snippet, :violation_type, :context,
-    :scope, :req_refs_json, :dedup_key, :confidence
+    :scope, :req_refs_json, :dedup_key, :confidence, :provenance_downgrade
 )
 """
 

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -204,7 +204,7 @@ def _build_response_from_grade_tables(
     _SELECT_ACTIVE = (
         "SELECT id, practice_id, dimension, requirement, verdict, severity, "
         "file, line, end_line, title, reason, snippet, violation_type, context, "
-        "scope, req_refs_json, confidence "
+        "scope, req_refs_json, confidence, provenance_downgrade "
         "FROM findings WHERE verdict != 'dismissed' ORDER BY id"
     )
 

--- a/src/quodeq/services/violations_parsing.py
+++ b/src/quodeq/services/violations_parsing.py
@@ -83,6 +83,7 @@ def _build_finding_entry(obj: dict, dimension: str, req_refs_lookup: dict[str, l
         context=obj.get("context"),
         scope=obj.get("scope"),
         confidence=_coerce_confidence(obj.get("confidence")),
+        provenance_downgrade=bool(obj.get("provenance_downgrade")),
     ))
     return replace(entry, dimension=obj.get("d", dimension), violation_type=obj.get("vt"))
 

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -29,6 +29,14 @@ const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
     <div className={`vdetail-row vdetail-row--${v.severity}`}>
       <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
+        {v.provenanceDowngrade && (
+          <span
+            className="provenance-downgrade-tag"
+            title="Provenance gate: de-escalated from critical to major because the finding named no reachable external input source."
+          >
+            downgraded from critical
+          </span>
+        )}
         {v.dimension && <span className="vrow-label">[{v.dimension}]</span>}
         {v.principle && <span className="vrow-label">[{v.principle}]</span>}
         {filename && (

--- a/src/quodeq/ui/src/models/violation.js
+++ b/src/quodeq/ui/src/models/violation.js
@@ -26,6 +26,7 @@
  * @property {ReqRef[]}      reqRefs
  * @property {string|null}   dimension
  * @property {string|null}   violationType
+ * @property {boolean}       provenanceDowngrade  true when the provenance gate (#639) de-escalated this from critical to major
  */
 
 /**
@@ -55,6 +56,7 @@ export function createViolation(raw) {
     reqRefs:       raw.reqRefs ?? raw.req_refs ?? [],
     dimension:     raw.dimension ?? null,
     violationType: raw.violationType ?? raw.violation_type ?? null,
+    provenanceDowngrade: raw.provenanceDowngrade ?? raw.provenance_downgrade ?? false,
   };
 }
 

--- a/src/quodeq/ui/src/models/violation.test.js
+++ b/src/quodeq/ui/src/models/violation.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createViolation } from './violation.js';
+
+// Issue #656: the provenance gate's downgrade marker must survive
+// canonicalization so a badge can render on affected violations. The API
+// emits it camelCase (to_camel_dict); raw JSON files use snake_case.
+
+test('createViolation maps provenanceDowngrade (camelCase from API)', () => {
+  const v = createViolation({ severity: 'major', provenanceDowngrade: true });
+  assert.equal(v.provenanceDowngrade, true);
+});
+
+test('createViolation maps provenance_downgrade (snake_case from raw JSON)', () => {
+  const v = createViolation({ severity: 'major', provenance_downgrade: true });
+  assert.equal(v.provenanceDowngrade, true);
+});
+
+test('createViolation defaults provenanceDowngrade to false when absent', () => {
+  const v = createViolation({ severity: 'minor' });
+  assert.equal(v.provenanceDowngrade, false);
+});

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -990,6 +990,21 @@ textarea:focus {
   border-color: var(--color-compliance-border);
 }
 
+/* Marker for a finding the deterministic provenance gate (#639) de-escalated
+   from critical to major. Dashed border + major color = "adjusted down". */
+.provenance-downgrade-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  border: 1px dashed var(--color-sev-major-border);
+  color: var(--color-sev-major-text);
+  background: transparent;
+  white-space: nowrap;
+}
+
 /* ── Grade chips ──────────────────────────────────────── */
 
 .chip {

--- a/src/quodeq/ui/src/utils/explorerUtils.js
+++ b/src/quodeq/ui/src/utils/explorerUtils.js
@@ -79,6 +79,7 @@ function aggregateViolationEntry(bucket, dimension, entry) {
     reason: entry.reason || '',
     severity,
     confidence: typeof entry.confidence === 'number' ? entry.confidence : 100,
+    provenanceDowngrade: entry.provenanceDowngrade ?? false,
     ...(entry.cwe ? { cwe: entry.cwe } : {}),
   });
 

--- a/src/quodeq/ui/src/utils/explorerUtils.test.js
+++ b/src/quodeq/ui/src/utils/explorerUtils.test.js
@@ -190,6 +190,28 @@ test('buildTopOffendingFiles includes violationsBySeverity on each item', () => 
   assert.ok(Array.isArray(aEntry.violationsBySeverity.unknown));
 });
 
+test('buildTopOffendingFiles preserves provenanceDowngrade on aggregated violations (#656)', () => {
+  // The aggregator builds an explicit object literal; if it does not copy
+  // provenanceDowngrade, the FileDetailPage "downgraded from critical" badge
+  // silently never renders on the top-offending-files navigation path.
+  const dims = [
+    {
+      dimension: 'Security',
+      violations: [
+        { file: 'd.py', severity: 'major', principle: 'P', provenanceDowngrade: true },
+        { file: 'd.py', severity: 'major', principle: 'P', provenanceDowngrade: false },
+      ],
+    },
+  ];
+  const result = buildTopOffendingFiles(dims, {});
+  const entry = result.find(r => r.file === 'd.py');
+  assert.ok(entry);
+  const majors = entry.violationsBySeverity.major;
+  assert.equal(majors.length, 2);
+  assert.equal(majors[0].provenanceDowngrade, true);
+  assert.equal(majors[1].provenanceDowngrade, false);
+});
+
 test('buildTopOffendingFiles includes sorted dimensions array on each item', () => {
   const result = buildTopOffendingFiles(dimensions, {});
   const aEntry = result.find(r => r.file === 'lib/a.sh');

--- a/tests/api/test_run_event_stream.py
+++ b/tests/api/test_run_event_stream.py
@@ -68,6 +68,21 @@ def test_serialize_finding_event_includes_judgment_fields():
     assert parsed["verdict"] == "violation"
 
 
+def test_payload_as_sse_finding_includes_provenance_downgrade():
+    # Issue #656: the live SSE finding payload lists fields explicitly, so the
+    # gate's provenance_downgrade marker must be added there too.
+    from quodeq.api._run_event_stream import _payload_as_sse_finding
+    from quodeq.core.events.models import Judgment
+
+    j = Judgment(
+        practice_id="R-FT-2", verdict="violation", dimension="security",
+        file="f.py", line=1, reason="r", severity="major",
+        provenance_downgrade=True,
+    )
+    payload = _payload_as_sse_finding(j, finding_id=1)
+    assert payload["provenance_downgrade"] is True
+
+
 # ---------------------------------------------------------------------------
 # WatcherState tests
 # ---------------------------------------------------------------------------

--- a/tests/api/test_scores_routes.py
+++ b/tests/api/test_scores_routes.py
@@ -85,6 +85,28 @@ def test_get_scores_raw_reads_from_sql_after_projection(tmp_path: Path) -> None:
     assert security_dim["overallScore"] is not None
 
 
+def test_get_scores_raw_surfaces_provenance_downgrade(tmp_path: Path) -> None:
+    """Issue #656: a finding the provenance gate downgraded must keep its
+    provenance_downgrade flag through the SQL-backed scores read path
+    (_build_response_from_grade_tables / _SELECT_ACTIVE), so the dashboard
+    badge can render. A dropped column here silently regresses it to False."""
+    violations = _scorable_violations()  # 5 distinct Security violations
+    violations[0] = {
+        **violations[0], "file": "downgraded.py",
+        "severity": "major", "provenance_downgrade": True,
+    }
+    _seed_run(tmp_path, "myproject", "r1", violations=violations)
+
+    result = get_scores_raw(tmp_path, "myproject", "r1")
+
+    security = next(d for d in result["dimensions"] if d["dimension"] == "Security")
+    target = next(v for v in security["violations"] if v["file"] == "downgraded.py")
+    assert target["provenanceDowngrade"] is True
+    # Parity: an un-downgraded finding stays False (no over-marking).
+    other = next(v for v in security["violations"] if v["file"] != "downgraded.py")
+    assert other["provenanceDowngrade"] is False
+
+
 def test_get_scores_raw_falls_back_when_db_schema_too_new(tmp_path: Path) -> None:
     """A run whose evaluation.db was written by a NEWER Quodeq (higher schema
     version) must not crash the score read on an older binary; get_scores_raw

--- a/tests/core/test_finding_mappings.py
+++ b/tests/core/test_finding_mappings.py
@@ -169,6 +169,43 @@ class TestFindingToResponseDict:
         assert d["req_refs"] is None
 
 
+class TestProvenanceDowngradeField:
+    """Issue #656: the provenance gate stamps ``provenance_downgrade`` on a
+    finding dict it de-escalates. Promote it to a first-class field so it
+    travels Judgment -> Finding -> API response, not just the JSONL forensic.
+    """
+
+    def test_wire_dict_carries_downgrade_marker(self):
+        j = wire_dict_to_judgment({
+            "p": "P1", "t": "violation", "d": "D", "file": "f", "line": 1,
+            "reason": "r", "provenance_downgrade": True,
+        })
+        assert j.provenance_downgrade is True
+
+    def test_wire_dict_defaults_downgrade_to_false_when_absent(self):
+        j = wire_dict_to_judgment({"p": "P1", "t": "violation"})
+        assert j.provenance_downgrade is False
+
+    def test_judgment_to_finding_carries_downgrade(self):
+        j = Judgment(
+            practice_id="P1", verdict="violation", dimension="D",
+            file="f", line=1, reason="r", provenance_downgrade=True,
+        )
+        f = judgment_to_finding(j)
+        assert f.provenance_downgrade is True
+
+    def test_finding_to_response_dict_includes_downgrade(self):
+        f = Finding(
+            practice_id="P1", verdict="violation", file="f", line=1,
+            reason="r", severity="major", provenance_downgrade=True,
+        )
+        assert finding_to_response_dict(f)["provenance_downgrade"] is True
+
+    def test_response_dict_downgrade_false_by_default(self):
+        f = Finding(practice_id="P1", verdict="violation", file="f", line=1)
+        assert finding_to_response_dict(f)["provenance_downgrade"] is False
+
+
 class TestRoundTrip:
     def test_wire_dict_to_finding_via_judgment(self):
         d = {

--- a/tests/data/sqlite/test_findings_repository.py
+++ b/tests/data/sqlite/test_findings_repository.py
@@ -46,6 +46,19 @@ def test_list_by_dimension_returns_judgments(tmp_path: Path):
     assert items[0].reason == "late"
 
 
+def test_insert_finding_persists_provenance_downgrade(tmp_path: Path):
+    # Issue #656: a finding the provenance gate downgraded must round-trip
+    # through the INSERT + SELECT column lists, not silently fall back to the
+    # default. A missing column in either list would regress to False here.
+    repo = SqliteFindingsRepository(tmp_path)
+    repo.insert_finding(_finding(p="R-FT-2", severity="major",
+                                 provenance_downgrade=True))
+    repo.insert_finding(_finding(p="P-normal", line=2, severity="major"))
+    by_id = {f.practice_id: f for f in repo.list_all()}
+    assert by_id["R-FT-2"].provenance_downgrade is True
+    assert by_id["P-normal"].provenance_downgrade is False
+
+
 def test_search_uses_fts5(tmp_path: Path):
     repo = SqliteFindingsRepository(tmp_path)
     repo.insert_finding(_finding(p="P1", reason="missing input validation"))

--- a/tests/data/sqlite/test_migrations.py
+++ b/tests/data/sqlite/test_migrations.py
@@ -263,6 +263,82 @@ def test_upgrade_v2_to_v3_idempotent_when_principle_grades_already_present():
     assert row[0] == 100
 
 
+# Findings table as it existed at SCHEMA_VERSION=5, before issue #656 added
+# the provenance_downgrade column. Used to verify the v5 -> v6 upgrade path.
+_V5_FINDINGS_DDL = """
+    PRAGMA user_version = 5;
+    CREATE TABLE findings (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        schema_version  INTEGER NOT NULL DEFAULT 1,
+        practice_id     TEXT NOT NULL,
+        dimension       TEXT NOT NULL DEFAULT '',
+        requirement     TEXT,
+        verdict         TEXT NOT NULL CHECK (verdict IN ('violation','compliance','dismissed')),
+        severity        TEXT NOT NULL CHECK (severity IN ('critical','major','high','medium','low','minor')),
+        file            TEXT NOT NULL DEFAULT '',
+        line            INTEGER NOT NULL DEFAULT 0,
+        end_line        INTEGER NOT NULL DEFAULT 0,
+        title           TEXT NOT NULL DEFAULT '',
+        reason          TEXT NOT NULL DEFAULT '',
+        snippet         TEXT NOT NULL DEFAULT '',
+        violation_type  TEXT NOT NULL DEFAULT '',
+        context         TEXT NOT NULL DEFAULT '',
+        scope           TEXT NOT NULL DEFAULT '',
+        req_refs_json   TEXT,
+        dedup_key       TEXT NOT NULL UNIQUE,
+        confidence      INTEGER NOT NULL DEFAULT 100,
+        created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+"""
+
+
+def test_fresh_db_has_provenance_downgrade_column_at_default_zero():
+    conn = sqlite3.connect(":memory:")
+    apply_evaluation_schema(conn)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(findings)")}
+    assert "provenance_downgrade" in columns
+    # The column default is 0 (not downgraded).
+    conn.execute(
+        "INSERT INTO findings (practice_id, verdict, severity, dedup_key) "
+        "VALUES ('P1', 'violation', 'major', 'k')",
+    )
+    assert conn.execute(
+        "SELECT provenance_downgrade FROM findings WHERE practice_id='P1'"
+    ).fetchone()[0] == 0
+
+
+def test_upgrade_v5_to_v6_adds_provenance_downgrade_column():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_V5_FINDINGS_DDL)
+    conn.execute(
+        "INSERT INTO findings (practice_id, verdict, severity, dedup_key) "
+        "VALUES ('P-5', 'violation', 'major', 'k5')",
+    )
+
+    apply_evaluation_schema(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(findings)")}
+    assert "provenance_downgrade" in columns
+    # Pre-existing rows inherit the default (not downgraded).
+    assert conn.execute(
+        "SELECT provenance_downgrade FROM findings WHERE practice_id='P-5'"
+    ).fetchone()[0] == 0
+
+
+def test_upgrade_v5_to_v6_idempotent_when_column_already_present():
+    """An interrupted v5->v6 migration can leave provenance_downgrade added
+    but user_version still 5 (the ALTER committed, the PRAGMA bump didn't).
+    Re-running must self-heal to v6, not raise 'duplicate column name'."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(EVALUATION_DDL)        # full v6 schema: column present
+    conn.execute("PRAGMA user_version = 5")   # pretend the version bump never landed
+
+    apply_evaluation_schema(conn)             # must not raise
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+
+
 def test_apply_evaluation_schema_rejects_unknown_version_with_no_upgrade_path():
     conn = sqlite3.connect(":memory:")
     # Set user_version to a non-zero value with no upgrade path defined.

--- a/tests/data/sqlite/test_row_mappers.py
+++ b/tests/data/sqlite/test_row_mappers.py
@@ -143,6 +143,37 @@ def test_row_to_finding_preserves_explicit_confidence():
     assert row_to_finding(row).confidence == 30
 
 
+def test_finding_dict_to_row_sets_provenance_downgrade_flag():
+    # Issue #656: the gate stamps provenance_downgrade=True on dicts it
+    # de-escalates; persist it as 1/0 so the SQL projection can surface it.
+    on = finding_dict_to_row({"p": "P1", "t": "violation", "severity": "major",
+                              "provenance_downgrade": True})
+    assert on["provenance_downgrade"] == 1
+    off = finding_dict_to_row({"p": "P1", "t": "violation", "severity": "major"})
+    assert off["provenance_downgrade"] == 0
+
+
+def test_judgment_to_row_sets_provenance_downgrade_flag():
+    j = Judgment(
+        practice_id="P1", verdict="violation", dimension="d",
+        file="f.py", line=1, reason="r", severity="major",
+        provenance_downgrade=True,
+    )
+    assert judgment_to_row(j)["provenance_downgrade"] == 1
+
+
+def test_row_to_finding_reads_provenance_downgrade_flag():
+    assert row_to_finding({
+        "practice_id": "P1", "verdict": "violation", "severity": "major",
+        "file": "f.py", "line": 1, "provenance_downgrade": 1,
+    }).provenance_downgrade is True
+    # Legacy rows (pre-#656, no column) default to False.
+    assert row_to_finding({
+        "practice_id": "P1", "verdict": "violation", "severity": "major",
+        "file": "f.py", "line": 1,
+    }).provenance_downgrade is False
+
+
 def test_judgment_to_row_maps_required_fields():
     payload = Judgment(
         practice_id="P1",

--- a/tests/data/sqlite/test_schema.py
+++ b/tests/data/sqlite/test_schema.py
@@ -26,8 +26,12 @@ def test_evaluation_ddl_includes_confidence_column():
     assert "confidence" in _schema.EVALUATION_DDL
 
 
-def test_schema_version_is_5() -> None:
-    assert SCHEMA_VERSION == 5
+def test_evaluation_ddl_includes_provenance_downgrade_column():
+    assert "provenance_downgrade" in _schema.EVALUATION_DDL
+
+
+def test_schema_version_is_6() -> None:
+    assert SCHEMA_VERSION == 6
 
 
 def test_principle_grades_table_exists(tmp_path: Path) -> None:

--- a/tests/data/sqlite/test_schema_exit_reason.py
+++ b/tests/data/sqlite/test_schema_exit_reason.py
@@ -29,8 +29,8 @@ def test_fresh_db_dimension_scores_has_exit_reason_column(tmp_path: Path):
         conn.close()
 
 
-def test_schema_version_bumped_to_5():
-    assert SCHEMA_VERSION == 5
+def test_schema_version_bumped_to_6():
+    assert SCHEMA_VERSION == 6
 
 
 def test_upgrade_from_v4_adds_exit_reason(tmp_path: Path):
@@ -55,7 +55,7 @@ def test_upgrade_from_v4_adds_exit_reason(tmp_path: Path):
         apply_evaluation_schema(conn)
         cols = [row[1] for row in conn.execute("PRAGMA table_info(dimension_scores)").fetchall()]
         assert "exit_reason" in cols
-        # Confirm user_version was bumped.
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 5
+        # Applying walks all the way to the current schema version.
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     finally:
         conn.close()

--- a/tests/engine/test_evidence_parser_line.py
+++ b/tests/engine/test_evidence_parser_line.py
@@ -43,6 +43,46 @@ class TestParseJsonlLine:
     def test_invalid_json(self):
         assert _parse_jsonl_line("not json") is None
 
+
+class TestProvenanceDowngradeRoundTrip:
+    """Issue #656: the provenance_downgrade marker must survive the
+    JSONL -> Judgment -> PrincipleEvidence-dict round-trip so it reaches the
+    report JSON (and from there the dashboard)."""
+
+    def test_parse_reads_provenance_downgrade(self):
+        line = json.dumps({
+            "p": "R-FT-2", "t": "violation", "d": "security",
+            "file": "f.py", "line": 1, "reason": "r", "severity": "major",
+            "provenance_downgrade": True,
+        })
+        result = _parse_jsonl_line(line)
+        assert result is not None
+        j, _ = result
+        assert j.provenance_downgrade is True
+
+    def test_parse_defaults_provenance_downgrade_false(self):
+        result = _parse_jsonl_line(_evidence_line())
+        assert result is not None
+        j, _ = result
+        assert j.provenance_downgrade is False
+
+    def test_judgment_to_dict_emits_marker_only_when_true(self):
+        from quodeq.core.events.models import Judgment
+        from quodeq.core.evidence._jsonl import judgment_to_dict
+
+        downgraded = Judgment(
+            practice_id="R-FT-2", verdict="violation", dimension="security",
+            file="f.py", line=1, reason="r", severity="major",
+            provenance_downgrade=True,
+        )
+        assert judgment_to_dict(downgraded)["provenance_downgrade"] is True
+
+        normal = Judgment(
+            practice_id="P1", verdict="violation", dimension="d",
+            file="f.py", line=1, reason="r",
+        )
+        assert "provenance_downgrade" not in judgment_to_dict(normal)
+
     def test_defaults(self):
         line = json.dumps({"p": "ts-001", "t": "violation"})
         result = _parse_jsonl_line(line)

--- a/tests/engine/test_finding_builder.py
+++ b/tests/engine/test_finding_builder.py
@@ -51,6 +51,14 @@ class TestBuildFindingBase:
         assert finding.context == "API endpoint"
         assert finding.scope == "src/"
 
+    def test_provenance_downgrade_carried(self):
+        # Issue #656: the violations-parsing path must preserve the gate's marker.
+        spec = FindingSpec(practice_id="P1", provenance_downgrade=True)
+        assert build_finding_base(spec).provenance_downgrade is True
+
+    def test_provenance_downgrade_defaults_false(self):
+        assert build_finding_base(FindingSpec(practice_id="P1")).provenance_downgrade is False
+
     def test_severity_defaults_minor_when_none(self):
         spec = FindingSpec(practice_id="P1", severity=None)
         finding = build_finding_base(spec)


### PR DESCRIPTION
Closes #656.

## Background
The deterministic provenance gate (#639) de-escalates a critical R-FT-2 / S-AUT-3 finding that names no reachable external source to `major` and stamps `provenance_downgrade: true` on the finding dict. The **severity flip was fully effective** (it drives the grade), but the **marker was JSONL-only forensic**: `core/finding_mappings.py:wire_dict_to_judgment` didn't carry it, so it never reached the SQLite projection, the API, or the dashboard. There was no way to see "this was critical, the gate dropped it to major" in the UI/DB.

## Change
Promote `provenance_downgrade` to a first-class boolean field that travels the full path, mirroring how `confidence` already does. The grade is **unchanged** (the severity flip already drove scoring, see #640) — this is purely an audit/observability marker.

### Backend (12 files)
- **Models:** `Judgment` and `Finding` gain `provenance_downgrade: bool = False`.
- **Conversions:** `wire_dict_to_judgment`, `judgment_to_finding`, `finding_to_response_dict`.
- **JSONL round-trip:** `parse_jsonl_line` reads it into the `Judgment`; `judgment_to_dict` emits it **only when True** (keeps the common un-downgraded finding dict compact, exactly like `confidence`). This is what carries the marker into the report JSON's principle violations.
- **Violations parsing:** `FindingSpec` / `build_finding_base` + `_build_finding_entry`.
- **SQLite:** new `provenance_downgrade INTEGER NOT NULL DEFAULT 0` column; **v5 → v6 migration** (`_upgrade_v5_to_v6`, with the same "skip if column present" idempotency guard and "skip if no findings table" guard as the prior steps); `finding_dict_to_row` / `judgment_to_row` write `1/0`, `row_to_finding` reads it; both INSERT paths (`state_store._INSERT_FINDING`, `findings_repository._INSERT_SQL`) and `_SELECT_COLUMNS` carry it.
- **SSE:** the live finding payload (`_payload_as_sse_finding`) includes it.

### Frontend
- `createViolation` maps `provenanceDowngrade` (accepts camelCase from `to_camel_dict` and snake_case from raw JSON).
- `ViolationCard` renders a **"downgraded from critical"** badge next to the severity tag when the flag is set; new `.provenance-downgrade-tag` style (dashed border, major color = "adjusted down").

The main dashboard violations API serializes via `to_camel_dict`, which auto-emits every `Finding` dataclass field, so `Finding.provenance_downgrade` reaches the UI as `provenanceDowngrade` without an explicit serializer line.

## Tests
- `+35` backend assertions across 8 files: mappings, JSONL round-trip, `finding_builder`, row mappers, **migration (fresh-DB column, v5→v6 upgrade, idempotency)**, end-to-end repo insert→read, SSE payload. Schema-version pins bumped 5→6.
- `+1` frontend model test (`violation.test.js`): casing + default.
- Verified RED→GREEN throughout. Full regression: **3606 passed** (excl. slow behavioral + integration markers); SQLite (63), SQLite integration + projection (29), full UI suites (205 node + 525 vitest) all green. UI build compiles; badge markup/CSS/mapping confirmed present in the production bundle.

## Notes
- `src/quodeq/static/` is gitignored (built at release time), so no rebuilt bundle is committed — the React source change is the deliverable.
- **Visual caveat:** the badge's data path is unit-tested end-to-end and the markup is in the built bundle, but it was not exercised against a live downgraded finding in a browser (that needs a real R-FT-2/S-AUT-3 critical scan with no external source). The render is a simple boolean-gated badge.
- Stacked conceptually on the gate work; independent of the cache-replay fix in #662.