### PR TITLE
fix(ui): compact 'k' nav count badge instead of hard 999+ cap

### DIFF
--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -30,11 +30,11 @@ function Logo() {
 }
 
 // Cap the count badge text so the absolutely-positioned chip can't grow
-// past the rail edge. Anything four digits or more reads as "999+", and
-// the title carries the exact number.
+// past the rail edge. Thousands collapse to a compact "k" form (1200 -> "1k",
+// 12500 -> "13k"), and the title carries the exact number.
 function formatNavCount(count) {
   if (count == null) return null;
-  if (count >= 1000) return '999+';
+  if (count >= 1000) return `${Math.round(count / 1000)}k`;
   return String(count);
 }
 

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1820,8 +1820,8 @@ button.term-sev-badge--clickable:focus-visible {
   border-radius: var(--term-radius);
   font-variant-numeric: tabular-nums;
   /* Constant min-width so single-digit counts don't render as a tiny dot,
-     plus a max-width as a final safety net (the JSX caps display at
-     "999+", so this should never actually ellipsize in practice). */
+     plus a max-width as a final safety net (the JSX collapses thousands to a
+     compact "k" form, so this should never actually ellipsize in practice). */
   min-width: 22px;
   max-width: 48px;
   text-align: center;


### PR DESCRIPTION
## What

The sidebar nav count badge (violations, history) capped at the literal `999+` for any count of 1000 or more. This swaps that for a compact `k` form.

| count | before | after |
|-------|--------|-------|
| 71    | `71`   | `71`  |
| 999   | `999`  | `999` |
| 1000  | `999+` | `1k`  |
| 1200  | `999+` | `1k`  |
| 1500  | `999+` | `2k`  |
| 12500 | `999+` | `13k` |

Thousands round to the nearest whole `k`. The exact number stays available via the badge `title` on hover (unchanged). Counts under 1000 are untouched.

## Why

`999+` reads as a dead-end cap and gives no sense of scale. `1k`/`13k` is shorter and conveys magnitude, which is what the user asked for.

## Notes

- Pure formatting change in `formatNavCount` ([Sidebar.jsx](../blob/fix/nav-count-badge-compact/src/quodeq/ui/src/components/Sidebar.jsx)); also updated two stale comments referencing `999+`.
- The narrow-rail `max-width` CSS safety net still covers the degenerate `1000k`-style case (which can't occur for real finding counts).
- No tests pinned the old text, so none needed updating. `static/` is a release-time build artifact (not tracked), so no rebuild is included.