### PR TITLE
feat(ui): move server status to a toolbar dot, slim the sidebar footer

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -630,22 +630,8 @@ export default function App() {
               violationsCount={filteredAccumulated?.summary?.totalViolations ?? state.accumulated?.summary?.totalViolations ?? null}
               historyCount={filteredTrend.length || state.dashboard?.trend?.length || null}
               lastEvalAt={state.accumulated?.summary?.lastEvaluatedAt || state.accumulated?.summary?.createdAt || null}
-              serverConnected={state.serverConnected}
               isPinned={sidebarPinned}
               onPinChange={setSidebarPinned}
-              mobileExtras={(
-                <div className="sidebar-mobile-extras__grid">
-                  {(sidebarProvider || sidebarModel) && (
-                    <div className="sidebar-status-row">
-                      <span className="sidebar-status-label">Provider</span>
-                      <span className="sidebar-status-value">
-                        {sidebarProvider || '\u2014'}
-                        {sidebarModel && <>&nbsp;·&nbsp;<span style={{ opacity: 0.7 }}>{sidebarModel}</span></>}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
             />
           }
           header={
@@ -653,7 +639,7 @@ export default function App() {
               projectName={resolvedDisplayName}
               activeTab={activeTab}
               serverConnected={state.serverConnected}
-              serverUrl={state.serverHealth?.url || null}
+              serverUrl={typeof window !== 'undefined' ? window.location.origin : null}
               provider={sidebarProvider}
               model={sidebarModel}
               onEvaluate={state.projects?.length > 0 ? (() => navTab('evaluate')) : null}

--- a/src/quodeq/ui/src/components/ServerStatusDot.jsx
+++ b/src/quodeq/ui/src/components/ServerStatusDot.jsx
@@ -1,0 +1,26 @@
+/**
+ * ServerStatusDot — a minimal status light for the local server, shown in
+ * the TopBar. A filled green dot when the server is reachable, a hollow red
+ * ring when the connection is lost (the fill/ring shape carries the state so
+ * it stays readable without relying on the red/green hue). The exact state
+ * and address live in the hover tooltip / aria-label so the bar stays
+ * uncluttered. Display-only: no click behavior.
+ *
+ * Renders nothing until the status is known (`connected == null`) rather than
+ * flashing a misleading dot during the first health check.
+ */
+export default function ServerStatusDot({ connected, url }) {
+  if (connected == null) return null;
+  const host = url ? url.replace(/^https?:\/\//, '') : null;
+  const label = connected
+    ? (host ? `Server running · ${host}` : 'Server running')
+    : 'Server offline';
+  return (
+    <span className="topbar-status-dot" role="img" aria-label={label} title={label}>
+      <span
+        className={`topbar-dot ${connected ? 'topbar-dot--ok' : 'topbar-dot--err'}`}
+        aria-hidden="true"
+      />
+    </span>
+  );
+}

--- a/src/quodeq/ui/src/components/ServerStatusDot.test.jsx
+++ b/src/quodeq/ui/src/components/ServerStatusDot.test.jsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import ServerStatusDot from './ServerStatusDot.jsx';
+
+describe('ServerStatusDot', () => {
+  it('renders a green dot with the address in the tooltip when connected', () => {
+    render(<ServerStatusDot connected url="http://127.0.0.1:7863" />);
+    const el = screen.getByRole('img', { name: 'Server running · 127.0.0.1:7863' });
+    expect(el).toHaveAttribute('title', 'Server running · 127.0.0.1:7863');
+    expect(el.querySelector('.topbar-dot--ok')).not.toBeNull();
+  });
+
+  it('strips the scheme from https urls too', () => {
+    render(<ServerStatusDot connected url="https://localhost:7863" />);
+    expect(screen.getByRole('img', { name: 'Server running · localhost:7863' })).toBeInTheDocument();
+  });
+
+  it('omits the address when no url is provided', () => {
+    render(<ServerStatusDot connected url={null} />);
+    expect(screen.getByRole('img', { name: 'Server running' })).toBeInTheDocument();
+  });
+
+  it('renders a red dot labelled offline when not connected', () => {
+    render(<ServerStatusDot connected={false} url="http://127.0.0.1:7863" />);
+    const el = screen.getByRole('img', { name: 'Server offline' });
+    expect(el.querySelector('.topbar-dot--err')).not.toBeNull();
+  });
+
+  it('renders nothing until the status is known', () => {
+    const { container } = render(<ServerStatusDot connected={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/components/Sidebar.jsx
+++ b/src/quodeq/ui/src/components/Sidebar.jsx
@@ -89,15 +89,10 @@ export default function Sidebar({
   historyCount = null,
   standardsCount = null,
   lastEvalAt = null,
-  serverConnected = null,
   /* Controlled pin state — when provided, the parent owns the toggle.
      Falls back to internal state when the parent doesn't care. */
   isPinned: controlledPinned,
   onPinChange,
-  /* Optional mobile-only extras rendered inside the drawer. Desktop still
-     shows these in the TopBar; on mobile the TopBar strips them so the bar
-     stays tidy, and the drawer surfaces them here instead. */
-  mobileExtras = null,
 }) {
   const [internalPinned, setInternalPinned] = useState(false);
   const isPinned = controlledPinned != null ? controlledPinned : internalPinned;
@@ -178,18 +173,6 @@ export default function Sidebar({
                 <span className="sidebar-status-label">Last eval</span>
                 <span className="sidebar-status-value">{lastEvalStr}</span>
               </div>
-            )}
-            {serverConnected != null && (
-              <div className="sidebar-status-row">
-                <span className="sidebar-status-label">Server</span>
-                <span className="sidebar-status-value">
-                  <span className={`sidebar-dot ${serverConnected ? 'sidebar-dot--ok' : 'sidebar-dot--err'}`} aria-hidden="true" />
-                  {serverConnected ? 'running' : 'offline'}
-                </span>
-              </div>
-            )}
-            {mobileExtras && (
-              <div className="sidebar-mobile-extras">{mobileExtras}</div>
             )}
           </div>
           <div className="sidebar-nav sidebar-block sidebar-block--flush">

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -11,6 +11,7 @@
  */
 import { useSidePane } from '../features/side-pane/index.js';
 import { FileTextIcon, SparkleIcon } from './CopyButton.jsx';
+import ServerStatusDot from './ServerStatusDot.jsx';
 
 function SidePaneSpecButton({ type, label, icon, modifier }) {
   const ctx = useSidePane();
@@ -43,10 +44,6 @@ function ReportToolbarButton() {
 
 function FixPlanToolbarButton() {
   return <SidePaneSpecButton type="fixplan" label="Fix plan" icon={<SparkleIcon />} modifier="fixplan" />;
-}
-
-function Dot({ ok }) {
-  return <span className={`topbar-dot ${ok ? 'topbar-dot--ok' : 'topbar-dot--err'}`} aria-hidden="true" />;
 }
 
 function BurgerIcon() {
@@ -128,6 +125,7 @@ export default function TopBar({
       <div className="topbar-spacer" />
 
       <div className="topbar-actions">
+        <ServerStatusDot connected={serverConnected} url={serverUrl} />
         <FixPlanToolbarButton />
         <ReportToolbarButton />
 

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1861,17 +1861,6 @@ button.term-sev-badge--clickable:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-.sidebar-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-text-muted);
-}
-.sidebar-dot--ok   { background: var(--color-success); }
-.sidebar-dot--warn { background: var(--color-warning); }
-.sidebar-dot--err  { background: var(--color-danger); }
-
 /* ============================================================
    TopBar — replaces ProjectHeader
    ============================================================ */
@@ -1991,13 +1980,24 @@ button.term-sev-badge--clickable:focus-visible {
 
 .topbar-dot {
   display: inline-block;
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
+  box-sizing: border-box;
   background: var(--color-text-muted);
 }
 .topbar-dot--ok  { background: var(--color-success); }
-.topbar-dot--err { background: var(--color-danger); }
+/* Offline reads as a hollow ring so it stays distinguishable from "running"
+   without relying on the red/green hue alone (WCAG 1.4.1, use of color). */
+.topbar-dot--err { background: transparent; border: 2px solid var(--color-danger); }
+
+/* Wrapper makes the 8px dot a comfortable hover/tooltip target and keeps it
+   vertically centered as the leading item in the actions row. */
+.topbar-status-dot {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 2px;
+}
 
 .topbar-btn {
   display: inline-flex;
@@ -2130,21 +2130,6 @@ button.term-sev-badge--clickable:focus-visible {
   border-color: var(--color-text-muted);
 }
 
-/* Mobile-extras slot inside the sidebar footer (server status, provider). */
-.sidebar-mobile-extras {
-  padding-top: var(--term-space-2);
-  margin-top: var(--term-space-2);
-  border-top: 1px dotted color-mix(in srgb, var(--color-border) 60%, transparent);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  font-size: 11px;
-}
-.sidebar-mobile-extras__grid {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
 .dim-score-panel--terminal .dim-score-rows {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

The sidebar footer carried two rows: a `Server running/offline` status line and a `Provider · model` line (the latter shown in the mobile drawer via `mobileExtras`). This moves server status to a small dot in the toolbar and drops both rows.

| Before (sidebar footer) | After |
|---|---|
| `Server  ● running` | gone — now a dot in the toolbar |
| `Provider  omlx · gemma4:26b` | gone — already shown by the toolbar provider pill and in Settings |
| `Last eval  …` | kept |

The dot is rendered by a new, independently-tested `ServerStatusDot` component, fed by the `serverConnected`/`serverUrl` props the `TopBar` already received (the old unused `Dot` is removed). A **filled green dot** means running; a **hollow red ring** means offline. The state and localhost address live in the hover tooltip / `aria-label` so the bar stays uncluttered. Display-only, no click behavior.

## Why

The provider/model was duplicated (toolbar pill + Settings), and the server row spent a whole text line on one bit of state. A dot is what was asked for.

## Review fixes folded in

A multi-lens review of the diff surfaced two real issues, both fixed here:

1. **`serverUrl` was always null.** It was wired from `state.serverHealth?.url`, but `useAppState` never exposes a `serverHealth` key, so the tooltip would never have shown the address. Nothing rendered `serverUrl` before this PR, so it was harmless dead wiring; the dot is the first consumer. Fixed by feeding `window.location.origin` (the UI is served by the server, so it is the true host:port). Tooltip now reads e.g. `Server running · 127.0.0.1:7863`.
2. **Color-only state (WCAG 1.4.1).** Running vs offline differed only by green/red hue. The offline state is now a hollow ring, distinguishable by shape — the old text row it replaced satisfied this with the literal `running`/`offline` words.

## Verification

- New `ServerStatusDot.test.jsx` (5 cases: green+host tooltip, https scheme strip, no-url, red offline, hidden when status unknown) — pass. Full component suite (37 tests) green.
- Production build compiles.
- Ran the app against live data (dev server + real backend):
  - Toolbar dot renders green/filled with `role=img` + tooltip `Server running · <host>`; no console errors.
  - Sidebar footer no longer has `Server` or `Provider` rows.
  - Offline state computes to a transparent fill + 2px red ring (shape-distinct).
  - Mobile (375px): the dot stays visible next to the burger, giving mobile parity after the drawer rows were dropped.

## Notes

- Removes now-unused `mobileExtras` plumbing, the `serverConnected` Sidebar prop, and the orphaned `.sidebar-dot` / `.sidebar-mobile-extras` CSS.
- `static/` is an untracked release-time build artifact, so no rebuild is included.