### PR TITLE
feat(ui): consistent dashboard titles + persistent project indicator

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -646,11 +646,13 @@ export default function App() {
               evaluating={state.evalLifecycle?.job?.status === 'running'}
               onProviderClick={() => navTab('settings')}
               onMenuToggle={() => setSidebarPinned((v) => !v)}
+              onSelectProject={() => navTab('projects')}
               breadcrumb={
                 <NavBreadcrumb
                   stack={navStack}
-                  onBack={navPop}
                   onGoTo={navGoTo}
+                  projectName={resolvedDisplayName}
+                  onSelectProject={() => navTab('projects')}
                 />
               }
               mobileTitle={navStack.length ? navLabelFor(navStack[navStack.length - 1]) : (activeTab || '')}

--- a/src/quodeq/ui/src/components/TopBar.jsx
+++ b/src/quodeq/ui/src/components/TopBar.jsx
@@ -91,6 +91,7 @@ export default function TopBar({
   evaluating = false,
   onProviderClick,
   onMenuToggle,
+  onSelectProject,
   breadcrumb = null,
   mobileTitle = '',
   canGoBack = false,
@@ -118,9 +119,27 @@ export default function TopBar({
         </button>
       )}
 
-      {/* Desktop: full breadcrumb chain. Mobile: just the current page title. */}
+      {/* Desktop: full breadcrumb chain. Mobile: tappable project + current
+          page title. The breadcrumb slot is display:none on mobile and this
+          row is display:none on desktop, so only one project control is ever
+          live per viewport. */}
       {breadcrumb && <div className="topbar-breadcrumb-slot">{breadcrumb}</div>}
-      <div className="topbar-mobile-title" aria-hidden={!mobileTitle}>{mobileTitle}</div>
+      <div className="topbar-mobile-title" aria-hidden={!mobileTitle && !projectName}>
+        {projectName && onSelectProject && (
+          <button
+            type="button"
+            className="topbar-mobile-project"
+            onClick={onSelectProject}
+            title="Open projects"
+          >
+            {projectName}
+          </button>
+        )}
+        {projectName && onSelectProject && mobileTitle && (
+          <span className="topbar-mobile-sep" aria-hidden="true">/</span>
+        )}
+        {mobileTitle && <span className="topbar-mobile-page">{mobileTitle}</span>}
+      </div>
 
       <div className="topbar-spacer" />
 

--- a/src/quodeq/ui/src/components/TopBar.test.jsx
+++ b/src/quodeq/ui/src/components/TopBar.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import TopBar from './TopBar.jsx';
+import { SidePaneContext } from '../features/side-pane/SidePaneContext.jsx';
+
+const sidePaneStub = {
+  getRegisteredSpec: () => null,
+  hasWindow: () => false,
+  addWindow: () => {},
+  removeWindow: () => {},
+};
+
+function renderTopBar(props) {
+  return render(
+    <SidePaneContext.Provider value={sidePaneStub}>
+      <TopBar {...props} />
+    </SidePaneContext.Provider>
+  );
+}
+
+describe('TopBar mobile project label', () => {
+  it('renders a tappable project label that calls onSelectProject', () => {
+    const onSelectProject = vi.fn();
+    renderTopBar({ projectName: 'my-project', mobileTitle: 'violations', onSelectProject });
+    const btn = screen.getByRole('button', { name: 'my-project' });
+    fireEvent.click(btn);
+    expect(onSelectProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('still shows the current page label alongside the project', () => {
+    renderTopBar({ projectName: 'my-project', mobileTitle: 'violations', onSelectProject: () => {} });
+    expect(screen.getByText('violations')).toBeInTheDocument();
+  });
+
+  it('omits the project label when no projectName is given', () => {
+    renderTopBar({ mobileTitle: 'violations', onSelectProject: () => {} });
+    expect(screen.queryByRole('button', { name: 'my-project' })).toBeNull();
+    expect(screen.getByText('violations')).toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -95,7 +95,7 @@ function AccumulatedHeroSection({ accumulated, scoreDelta, lastDate, accumulated
     <section className="acc-eval-panel acc-eval-panel--terminal">
       <div className="acc-eval-panel__top">
         <TermHeader
-          name={projectInfo?.displayName || projectInfo?.name || projectName || 'overview'}
+          name="overview"
           sub={buildLanguageSub(projectInfo) || (lastDate ? `last_evaluated · ${lastDate}` : null)}
         />
         <LastFetchedLine lastFetchedAt={projectInfo?.lastFetchedAt} />

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.jsx
@@ -42,9 +42,9 @@ export function labelFor(entry) {
  * segments are clickable to pop the nav stack; the current segment is
  * accent-colored and non-interactive.
  */
-export default function NavBreadcrumb({ stack = [], onGoTo, projectName }) {
+export default function NavBreadcrumb({ stack = [], onGoTo, projectName, onSelectProject }) {
   const crumbs = [];
-  if (projectName) crumbs.push({ label: projectName, index: -1 });
+  if (projectName) crumbs.push({ label: projectName, index: -1, isProject: true });
   stack.forEach((entry, i) => crumbs.push({ label: labelFor(entry), index: i }));
 
   if (crumbs.length === 0) return null;
@@ -54,13 +54,25 @@ export default function NavBreadcrumb({ stack = [], onGoTo, projectName }) {
       <ol className="nav-breadcrumb__crumbs">
         {crumbs.map((seg, i) => {
           const isLast = i === crumbs.length - 1;
-          const isClickable = !isLast && seg.index >= 0;
+          // The project root is the persistent indicator: clickable whenever a
+          // handler is wired, regardless of position. Other crumbs only pop the
+          // nav stack and only when they aren't the current page.
+          const isProjectButton = seg.isProject && typeof onSelectProject === 'function';
+          const isClickable = isProjectButton || (!isLast && seg.index >= 0);
+          const crumbClass = `nav-breadcrumb__crumb${isLast ? ' is-current' : ''}${
+            seg.isProject ? ' nav-breadcrumb__crumb--project' : ''
+          }`;
           return (
             <Fragment key={`${seg.label}-${i}`}>
               {i > 0 && <li className="nav-breadcrumb__sep" aria-hidden="true">/</li>}
-              <li className={`nav-breadcrumb__crumb${isLast ? ' is-current' : ''}`}>
+              <li className={crumbClass}>
                 {isClickable ? (
-                  <button type="button" onClick={() => onGoTo(seg.index)}>{seg.label}</button>
+                  <button
+                    type="button"
+                    onClick={() => (seg.isProject ? onSelectProject() : onGoTo(seg.index))}
+                  >
+                    {seg.label}
+                  </button>
                 ) : (
                   <span>{seg.label}</span>
                 )}

--- a/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/NavBreadcrumb.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import NavBreadcrumb from './NavBreadcrumb.jsx';
+
+describe('NavBreadcrumb project crumb', () => {
+  const stack = [{ page: 'violations' }];
+
+  it('renders the project root as a clickable button when projectName and onSelectProject are given', () => {
+    render(
+      <NavBreadcrumb
+        stack={stack}
+        onGoTo={() => {}}
+        projectName="my-project"
+        onSelectProject={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'my-project' })).toBeInTheDocument();
+  });
+
+  it('calls onSelectProject when the project crumb is clicked', () => {
+    const onSelectProject = vi.fn();
+    render(
+      <NavBreadcrumb
+        stack={stack}
+        onGoTo={() => {}}
+        projectName="my-project"
+        onSelectProject={onSelectProject}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'my-project' }));
+    expect(onSelectProject).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the project crumb with the --project class and keeps it clickable even as the only stack tab', () => {
+    const { container } = render(
+      <NavBreadcrumb
+        stack={[{ page: 'projects' }]}
+        onGoTo={() => {}}
+        projectName="my-project"
+        onSelectProject={() => {}}
+      />
+    );
+    const projectCrumb = container.querySelector('.nav-breadcrumb__crumb--project');
+    expect(projectCrumb).not.toBeNull();
+    expect(projectCrumb.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders the project crumb as non-clickable text when onSelectProject is absent (backward compatible)', () => {
+    render(<NavBreadcrumb stack={stack} onGoTo={() => {}} projectName="my-project" />);
+    expect(screen.getByText('my-project').tagName).toBe('SPAN');
+    expect(screen.queryByRole('button', { name: 'my-project' })).toBeNull();
+  });
+
+  it('renders no project crumb when projectName is falsy', () => {
+    const { container } = render(
+      <NavBreadcrumb stack={stack} onGoTo={() => {}} onSelectProject={() => {}} />
+    );
+    expect(container.querySelector('.nav-breadcrumb__crumb--project')).toBeNull();
+    expect(screen.queryByText('my-project')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -314,8 +314,8 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
     <div className="history-page history-page--terminal">
       <div className="history-page__top">
         <TermHeader
-          name={`history · ${trend.length} eval${trend.length !== 1 ? 's' : ''}`}
-          sub={languageSub}
+          name="history"
+          sub={`${trend.length} eval${trend.length !== 1 ? 's' : ''}${languageSub ? ` · ${languageSub}` : ''}`}
         />
         {availableRuns && availableRuns.length > 0 && (
           <div className="history-run-nav">

--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -223,6 +223,25 @@
   font-weight: 500;
 }
 
+/* Project root — the persistent "which project" indicator. Accent-colored
+   and clickable (opens the Projects tab), with a leading ▸ marker. Kept as
+   plain text per this breadcrumb's no-chips convention. */
+.nav-breadcrumb__crumb--project > button,
+.nav-breadcrumb__crumb--project > span {
+  color: var(--color-accent);
+  font-weight: 500;
+}
+.nav-breadcrumb__crumb--project > button::before,
+.nav-breadcrumb__crumb--project > span::before {
+  content: '\25B8'; /* ▸ */
+  margin-right: 5px;
+  opacity: 0.85;
+}
+.nav-breadcrumb__crumb--project > button:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+
 /* Legacy chip-trail classes — kept inert in case a stray consumer
    imports them; the new breadcrumb does not use them. */
 .nav-back-btn,

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1926,6 +1926,43 @@ button.term-sev-badge--clickable:focus-visible {
   text-overflow: ellipsis;
 }
 
+/* Mobile project indicator: the tappable accent label that mirrors the
+   desktop breadcrumb root. The surrounding title sets pointer-events:none on
+   mobile, so the button re-enables them for itself. */
+.topbar-mobile-project {
+  flex: 0 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  font-weight: 500;
+  cursor: pointer;
+  pointer-events: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.topbar-mobile-project::before {
+  content: '\25B8'; /* ▸ */
+  margin-right: 4px;
+  opacity: 0.85;
+}
+.topbar-mobile-sep {
+  flex: 0 0 auto;
+  margin: 0 5px;
+  color: var(--color-text-subtle);
+  opacity: 0.55;
+}
+.topbar-mobile-page {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 
 .topbar-actions {
   display: inline-flex;


### PR DESCRIPTION
## What & why

Dashboard page titles were inconsistent: the **overview** tab's header showed the selected *project name*, while every other tab (**violations**, **history**, **map**) showed the *tab name*. There was also no persistent place indicating which project you're viewing — the breadcrumb component supported a project root, but `App.jsx` never passed `projectName` to it.

This makes the page headers consistent and gives the selected project one clear, clickable home.

## Changes

- **Headers → tab name everywhere.** `overview` no longer renders the project name; `history`'s eval count moves into the sub-line. `violations`/`map` were already correct.
- **Desktop.** The breadcrumb root is now the project — accent-styled with a `▸` marker and clickable, opening the Projects tab.
- **Mobile.** The compact title gains a tappable accent project label (TopBar already received `projectName` but ignored it).
- Kept as **accent text**, not a boxed chip, to respect the breadcrumb's documented "slash-separated plain text, no chips" convention.

## Verification

- New unit tests: `NavBreadcrumb` (clickable project crumb + fallback/backward-compat cases) and `TopBar` (mobile project label).
- Full UI suite green (538 tests, 100 files); `vite build` clean.
- Rendered the real CSS at desktop + mobile widths to confirm the accent indicator, the `▸` glyph, and the four now-consistent headers.

## Notes

- No behavior change to project-switching logic; the indicator only navigates to the Projects tab.
- Mobile keeps its compact title; the breadcrumb remains desktop-only, so only one project control is live per viewport.
