### PR TITLE
fix(ui): refetch Overview dashboard when an evaluation finishes

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -69,6 +69,22 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
     });
   }, [queryClient, selectedProject]);
 
+  // Force-refresh variant for when fresh data is genuinely expected NOW and the
+  // user is parked on a mounted observer that won't otherwise refetch — namely
+  // when an evaluation finishes. Unlike ``refreshDashboard`` (refetchType:'none',
+  // used by the high-frequency dismiss path to avoid re-pulling the 10-20 MB
+  // payload), this uses the default refetchType:'active' so the always-mounted
+  // Overview observer actually refetches. Without it, a freshly-completed run
+  // leaves the Overview showing the stale pre-run payload (empty "No
+  // evaluations yet" state) until the user switches projects and back, which is
+  // the only other action that re-subscribes the observer to its query key.
+  const refreshDashboardActive = useCallback(() => {
+    if (!selectedProject) return;
+    queryClient.invalidateQueries({
+      queryKey: projectKeys.project(selectedProject),
+    });
+  }, [queryClient, selectedProject]);
+
   return {
     dashboard: dashboardWithTrend,
     accumulated: scores?.accumulated || null,
@@ -84,5 +100,6 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
       : (scoresError || null),
     availableRuns,
     refreshDashboard,
+    refreshDashboardActive,
   };
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { useDashboard } from "./useDashboard";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
@@ -72,6 +72,45 @@ describe("useDashboard", () => {
     );
     await waitFor(() => expect(result.current.dashboard).not.toBeNull());
     expect(typeof result.current.refreshDashboard).toBe("function");
+  });
+
+  // The dismiss path must stay lazy: invalidating with refetchType:'none'
+  // marks the cache stale but must NOT refetch the mounted observer (the
+  // dashboard payload is 10-20 MB; refetching on every dismiss froze the UI).
+  it("refreshDashboard does NOT refetch the mounted observer (lazy dismiss path)", async () => {
+    fakeApi.getDashboard.mockClear();
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refreshDashboard();
+    });
+    // Give any errant refetch a chance to fire, then assert it didn't.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  // The eval-completion path must actively refetch the always-mounted Overview
+  // observer — otherwise a freshly-finished run leaves the Overview showing the
+  // stale (often null) pre-run payload until the user switches projects.
+  it("refreshDashboardActive refetches the mounted observer (eval-completion path)", async () => {
+    fakeApi.getDashboard.mockClear();
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null }),
+      { wrapper: ({ children }) => wrap(children) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(fakeApi.getDashboard).toHaveBeenCalledTimes(1);
+    expect(typeof result.current.refreshDashboardActive).toBe("function");
+
+    await act(async () => {
+      await result.current.refreshDashboardActive();
+    });
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
   });
 });
 

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -107,7 +107,7 @@ export function useAppState() {
   // usually nearly identical. The dashboard-refreshing class dims the
   // page during the background refetch so the user sees that something
   // is happening without the jarring full-screen LoadingScreen.
-  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard } = useDashboard({
+  const { dashboard, accumulated, latestAccumulated, rescoreLookup, loading, isFetching, error, availableRuns, refreshDashboard, refreshDashboardActive } = useDashboard({
     selectedProject,
     selectedRun: effectiveRun,
     keepPlaceholder: !isHistoryRun && !isHistoryTab,
@@ -121,16 +121,22 @@ export function useAppState() {
   const prefetchHandlers = usePrefetchAdjacentRuns({ selectedProject, availableRuns: visibleDailyRuns, overviewRunIndex });
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });
 
-  // Refresh all dashboard data (including latestAccumulated) when an evaluation finishes
+  // Refresh all dashboard data (including latestAccumulated) when an evaluation
+  // finishes. This uses the *active* refetch (not the lazy refreshDashboard the
+  // dismiss path uses): the Overview's useDashboard observer is mounted here at
+  // the app root and never remounts on tab navigation, so a mark-stale-only
+  // invalidation would never actually refetch while the user stays on the same
+  // project — leaving the Overview on the stale pre-run payload until a project
+  // switch. A completed run is exactly when a real refetch is warranted.
   const evalRefreshedRef = useRef(null);
   useEffect(() => {
     const job = evalLifecycle.job;
     const finished = job && job.status !== 'running' && job.outputRunId;
     if (finished && evalRefreshedRef.current !== job.outputRunId) {
       evalRefreshedRef.current = job.outputRunId;
-      refreshDashboard();
+      refreshDashboardActive();
     }
-  }, [evalLifecycle.job, refreshDashboard]);
+  }, [evalLifecycle.job, refreshDashboardActive]);
 
   const activeTab = KNOWN_TABS.includes(activePage.page) ? activePage.page
     : activePage.sourceTab && KNOWN_TABS.includes(activePage.sourceTab) ? activePage.sourceTab


### PR DESCRIPTION
## Problem

When you run an evaluation and then open the **Overview** tab, it can show **"No evaluations yet / Run an evaluation"** even though the run finished. Switching to another project and back makes the Overview render correctly.

## Root cause

The Overview's `useDashboard()` query observer is mounted **once** at the app root (`useAppState`), above the tab router — switching tabs only swaps which page renders, it never remounts the observer. On eval-completion (with SSE off, the default), the only refresh was `refreshDashboard()` which uses **`refetchType:'none'`**: it marks the project queries stale but, by design, never refetches an already-mounted observer (the perf guard against re-pulling the 10–20 MB dashboard payload on every dismiss).

So a freshly-finished run left the Overview parked on its stale pre-run payload (often `null` → the empty state at `DashboardPage.jsx:158`). Switching projects changes the observer's query key and re-subscribes it — the only normal action that forces a real refetch, which is why the workaround "worked".

The SSE path already does an **active** `invalidateQueries(projectKeys.all())` on terminal state (`useRunEventStream.js`), which is exactly why the bug never reproduced with `VITE_USE_SSE_EVENTS=true`.

## Fix

- Add `refreshDashboardActive()` to `useDashboard` — same invalidation but with the default `refetchType:'active'`, so the mounted Overview observer actually refetches.
- The eval-completion effect in `useAppState` now calls `refreshDashboardActive()` instead of the lazy `refreshDashboard()`.
- The dismiss/restore path keeps `refreshDashboard()` (`refetchType:'none'`) untouched — no regression of the dismiss-freeze it was built to prevent.

## Blast radius

Small. The active refetch fires once per completed run (guarded by `evalRefreshedRef` on `outputRunId`, so it can't loop), exactly when fresh data is expected. No query keys, mounting, or SSE behavior change.

## Testing

- New unit tests in `useDashboard.test.jsx`: one asserts `refreshDashboardActive` refetches the mounted observer (the fix), one asserts `refreshDashboard` stays lazy (guards the dismiss perf path). Followed RED → GREEN.
- Full UI suite: **515 passed / 94 files**.