### PR TITLE
feat(scoring): align default grade formula with the tuned dev preset

### DIFF
--- a/src/quodeq/core/scoring/_constants.py
+++ b/src/quodeq/core/scoring/_constants.py
@@ -18,8 +18,8 @@ _CEIL_SCALE: float = 0.5
 # Severity grade floor: minimum score by worst severity present
 _SEVERITY_GRADE_FLOOR: dict[str, float] = {
     "critical": 0.0,
-    "major": 3.0,
-    "minor": 5.0,
+    "major": 5.0,
+    "minor": 8.0,
 }
 
 # Legacy dampening constants

--- a/src/quodeq/core/scoring/params.py
+++ b/src/quodeq/core/scoring/params.py
@@ -22,14 +22,16 @@ from quodeq.core.scoring._constants import (
 # Canonical grade labels: positions are fixed, only the numeric boundaries move.
 GRADE_LABELS: tuple[str, ...] = ("Exemplary", "Good", "Adequate", "Poor")
 
-# Mirrors data/config/dimensions.json (pinned by a sync test).
+# Mirrors data/config/dimensions.json (pinned by a sync test). Defaults are
+# equal (1.0) so the overall score is a plain mean; users can retune per
+# dimension in Settings > Grade formula.
 _DEFAULT_DIMENSION_WEIGHTS: dict[str, float] = {
-    "security": 1.2,
+    "security": 1.0,
     "reliability": 1.0,
     "maintainability": 1.0,
-    "performance": 0.8,
-    "usability": 0.6,
-    "flexibility": 0.6,
+    "performance": 1.0,
+    "usability": 1.0,
+    "flexibility": 1.0,
     "clean-architecture": 1.0,
     "domain-driven-design": 1.0,
 }
@@ -60,7 +62,7 @@ class ScoringParams:
     floor_minor: float
     floor_major: float
     grade_thresholds: tuple[tuple[float, str], ...]
-    dimension_weights_enabled: bool = False
+    dimension_weights_enabled: bool = True
     dimension_weights: Mapping[str, float] = field(
         default_factory=lambda: dict(_DEFAULT_DIMENSION_WEIGHTS),
     )

--- a/src/quodeq/data/config/dimensions.json
+++ b/src/quodeq/data/config/dimensions.json
@@ -1,9 +1,9 @@
 {
-  "_note": "The per-dimension 'weight' field seeds the grade formula's default dimension weights (ScoringParams.dimension_weights). Weights affect scoring only when the user enables them in Settings > Grade formula; by default every aggregation path takes a plain unweighted mean of dimension scores.",
+  "_note": "The per-dimension 'weight' field seeds the grade formula's default dimension weights (ScoringParams.dimension_weights). The defaults are all 1.0, so the overall score is a plain unweighted mean of dimension scores; users can retune the per-dimension weights in Settings > Grade formula.",
   "applies": [
     {
       "id": "security",
-      "weight": 1.2,
+      "weight": 1.0,
       "iso_25010": "Security",
       "source": "ISO/IEC 25010:2023"
     },
@@ -21,19 +21,19 @@
     },
     {
       "id": "performance",
-      "weight": 0.8,
+      "weight": 1.0,
       "iso_25010": "Performance Efficiency",
       "source": "ISO/IEC 25010:2023"
     },
     {
       "id": "usability",
-      "weight": 0.6,
+      "weight": 1.0,
       "iso_25010": "Usability",
       "source": "ISO/IEC 25010:2023"
     },
     {
       "id": "flexibility",
-      "weight": 0.6,
+      "weight": 1.0,
       "iso_25010": "Flexibility",
       "source": "ISO/IEC 25010:2023"
     },

--- a/tests/engine/test_scoring_internals.py
+++ b/tests/engine/test_scoring_internals.py
@@ -89,10 +89,10 @@ class TestSeverityGradeFloor:
         assert severity_grade_floor({"critical": 1}) == 0.0
 
     def test_major_floor(self):
-        assert severity_grade_floor({"major": 1}) == 3.0
+        assert severity_grade_floor({"major": 1}) == 5.0
 
     def test_minor_floor(self):
-        assert severity_grade_floor({"minor": 1}) == 5.0
+        assert severity_grade_floor({"minor": 1}) == 8.0
 
     def test_critical_takes_priority(self):
         assert severity_grade_floor({"critical": 1, "major": 5, "minor": 10}) == 0.0

--- a/tests/engine/test_scoring_params.py
+++ b/tests/engine/test_scoring_params.py
@@ -21,12 +21,12 @@ def test_defaults_match_q2_constants():
     assert DEFAULT_PARAMS.base_k == 0.12
     assert DEFAULT_PARAMS.lift_compress == 1.8
     assert DEFAULT_PARAMS.ceil_scale == 0.5
-    assert DEFAULT_PARAMS.floor_minor == 5.0
-    assert DEFAULT_PARAMS.floor_major == 3.0
+    assert DEFAULT_PARAMS.floor_minor == 8.0
+    assert DEFAULT_PARAMS.floor_major == 5.0
     assert DEFAULT_PARAMS.grade_thresholds == (
         (9.0, "Exemplary"), (7.0, "Good"), (5.0, "Adequate"), (3.0, "Poor"),
     )
-    assert DEFAULT_PARAMS.dimension_weights_enabled is False
+    assert DEFAULT_PARAMS.dimension_weights_enabled is True
 
 
 def test_default_dimension_weights_stay_in_sync_with_dimensions_json():
@@ -103,13 +103,21 @@ def test_validate_rejects_nonpositive_severity_weight():
 
 
 def test_dimension_weighted_average_disabled_is_plain_mean():
+    import dataclasses
+    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=False)
     pairs = [("security", 8.0), ("performance", 6.0)]
-    assert dimension_weighted_average(pairs, DEFAULT_PARAMS) == 7.0
+    assert dimension_weighted_average(pairs, params) == 7.0
 
 
 def test_dimension_weighted_average_enabled_weights_by_dimension():
     import dataclasses
-    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=True)
+    # Default weights are all 1.0; set explicit per-dimension weights to
+    # exercise the weighting math.
+    params = dataclasses.replace(
+        DEFAULT_PARAMS,
+        dimension_weights_enabled=True,
+        dimension_weights={"security": 1.2, "performance": 0.8},
+    )
     # security weight 1.2, performance 0.8 → (8*1.2 + 6*0.8) / 2.0 = 7.2
     pairs = [("security", 8.0), ("performance", 6.0)]
     assert dimension_weighted_average(pairs, params) == 7.2
@@ -117,7 +125,11 @@ def test_dimension_weighted_average_enabled_weights_by_dimension():
 
 def test_dimension_weighted_average_unknown_dimension_defaults_to_1():
     import dataclasses
-    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=True)
+    params = dataclasses.replace(
+        DEFAULT_PARAMS,
+        dimension_weights_enabled=True,
+        dimension_weights={"security": 1.2},
+    )
     pairs = [("not-a-dim", 8.0), ("security", 6.0)]
     # (8*1.0 + 6*1.2) / 2.2 = 15.2/2.2 = 6.909... → 6.9
     assert dimension_weighted_average(pairs, params) == 6.9

--- a/tests/services/scoring/test_projector_scoring.py
+++ b/tests/services/scoring/test_projector_scoring.py
@@ -238,7 +238,11 @@ def test_compute_dimension_score_with_custom_thresholds_changes_grade():
 
 
 def test_compute_run_score_applies_dimension_weights_when_enabled():
-    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=True)
+    params = dataclasses.replace(
+        DEFAULT_PARAMS,
+        dimension_weights_enabled=True,
+        dimension_weights={"security": 1.2, "performance": 0.8},
+    )
     from quodeq.services.scoring.projector_scoring import compute_run_score
     dims = [
         {"dimension": "security", "score": 8.0},
@@ -264,7 +268,11 @@ def test_summary_builders_agree_under_dimension_weights():
     from quodeq.data.fs.report_parser._summary import summarize_dimensions
     from quodeq.services.scoring import _build_summary_from_dim_dicts
 
-    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=True)
+    params = dataclasses.replace(
+        DEFAULT_PARAMS,
+        dimension_weights_enabled=True,
+        dimension_weights={"security": 1.2, "performance": 0.8},
+    )
 
     dims = [
         DimensionResult(dimension="security", overall_grade="Good", overall_score="8.0/10"),
@@ -322,7 +330,11 @@ def test_recompute_summary_applies_dimension_weights_when_enabled():
     performance 0.8) → 7.2, not the plain mean 7.0."""
     from quodeq.services.scoring._summary import recompute_summary
 
-    params = dataclasses.replace(DEFAULT_PARAMS, dimension_weights_enabled=True)
+    params = dataclasses.replace(
+        DEFAULT_PARAMS,
+        dimension_weights_enabled=True,
+        dimension_weights={"security": 1.2, "performance": 0.8},
+    )
     dims = [
         {"dimension": "security", "overallScore": "8.0/10", "overallGrade": "Good"},
         {"dimension": "performance", "overallScore": "6.0/10", "overallGrade": "Adequate"},


### PR DESCRIPTION
## What

Makes the shipped Q² default grade formula match the formula actually in use on dev (`~/.quodeq/grade_formula.json`).

I compared the saved preset to the shipped `DEFAULT_PARAMS`. Everything already matched (severity weights, baseK, liftCompress, ceilScale, grade thresholds) except:

| Param | Old default | New default |
|---|---|---|
| `floorMinor` | 5.0 | **8.0** |
| `floorMajor` | 3.0 | **5.0** |
| `dimensionWeightsEnabled` | false | **true** |
| `dimensionWeights` | security 1.2, perf 0.8, usability/flex 0.6, rest 1.0 | **all 1.0** |

## Changes

- **`_constants.py`** — `_SEVERITY_GRADE_FLOOR`: major `3.0→5.0`, minor `5.0→8.0` (critical stays `0.0`). This constant feeds `DEFAULT_PARAMS` only.
- **`params.py`** — `dimension_weights_enabled` defaults to `True`; `_DEFAULT_DIMENSION_WEIGHTS` set to all `1.0`.
- **`dimensions.json`** — weights set to `1.0` (kept in sync with `_DEFAULT_DIMENSION_WEIGHTS` per the existing sync test) and note updated. ISO-25010 classification fields are untouched.

## Behavior impact

- **Floors (real score change):** a project whose worst severity is major-with-no-critical now floors at 5.0 (was 3.0); a minor-only project floors at 8.0 (was 5.0). Users **without** a custom `grade_formula.json` get the higher floors by default; anyone with the matching preset (e.g. dev) sees no change.
- **Dimension weights (score-neutral):** enabling weights with all values `1.0` is mathematically identical to the previous disabled plain-mean, so this part changes no scores. It only makes the serialized default byte-match the dev preset and flips the editor's default state to "enabled". Note this resets the previously-**inert** ISO-suggested weights (security 1.2, etc.) to 1.0; trivially reversible if we'd rather keep them as the starting point.

## Tests

- `tests/engine/test_scoring_params.py`: updated floor defaults, the `dimension_weights_enabled` default, and made the weighting tests set explicit weights rather than relying on the old differentiated defaults.
- `tests/engine/test_scoring_internals.py`: `severity_grade_floor` major/minor expectations → 5.0 / 8.0.
- `tests/services/scoring/test_projector_scoring.py`: weighting tests set explicit per-dimension weights.
- Full Python suite green: **3652 passed**.

## Notes

- The frontend reads the default from the API (`getGradeFormula().defaults`), so there's no hardcoded JS default to change.
- `static/` is an untracked release-time build artifact, so no rebuild is included.