### PR TITLE
fix(nightly): N_SUBAGENTS=1 to stop Ollama queue-timeout circuit-breaker trips

### DIFF
--- a/quodeq.env
+++ b/quodeq.env
@@ -7,7 +7,12 @@
 
 AI_PROVIDER=ollama
 AI_MODEL=gemma4:26b-mlx
-N_SUBAGENTS=8
+# Local Ollama serves one request at a time (MLX engine, OLLAMA_NUM_PARALLEL
+# unset). n-subagents > 1 only queues requests until they exceed the 500s read
+# timeout, which trips the failure-streak circuit breaker on whichever dimension
+# runs last (flexibility was left unanalyzed in run ext-3c302305). Match the
+# concurrency to the single runner; no throughput loss since it serializes anyway.
+N_SUBAGENTS=1
 # Where the runner writes evaluation output. `~` expands to the runner user's home.
 # Default `~/.quodeq/evaluations` unifies CI runs with the local dashboard on
 # self-hosted runners. Change to a repo-local path (e.g. `.quodeq-ci/output`) for


### PR DESCRIPTION
## Problem
The nightly self-scan (`gemma4:26b-mlx` via local Ollama) left the **flexibility** dimension unanalyzed in run `ext-3c302305`. Root cause: `quodeq.env` set `N_SUBAGENTS=8`, but the Ollama MLX engine serves one request at a time (`OLLAMA_NUM_PARALLEL` unset, single `mlx runner` subprocess). The 7 queued subagent requests exceed the 500s read timeout; each timeout writes a `file_done` error marker, and 5 consecutive errors trip the `FailureStreakWatcher`, which aborts whichever dimension runs last.

## Fix
Set `N_SUBAGENTS=1` to match the single-threaded local runner. No throughput loss: the model serializes regardless, so >1 subagent only adds queue latency and timeouts.

## Scope
One-line config change (plus an explanatory comment). A follow-up PR hardens the runtime so a breaker trip salvages the dimension's collected findings instead of discarding them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)