### PR TITLE
feat: salvage circuit-breaker-interrupted dimensions, exclude from grade

### DIFF
--- a/src/quodeq/analysis/_loops.py
+++ b/src/quodeq/analysis/_loops.py
@@ -248,6 +248,9 @@ def run_incremental_loop(
         if deadline is not None and time.monotonic() >= deadline:
             log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
             break
+        if cancellation.is_cancelled():
+            log_info(f"[loop] cancellation requested -- skipping {dimension} and remaining dims")
+            break
         run_dir = _run_dir_for(config)
         _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)
         emit_marker("analyzing", dimension=dimension)
@@ -372,6 +375,10 @@ def run_per_dimension_loop(
         if deadline is not None and time.monotonic() >= deadline:
             log_info(f"[loop] deadline reached -- skipping {dimension} and remaining dims")
             # Remaining dims stay in PENDING (they were never RUNNING). No write needed.
+            break
+        if cancellation.is_cancelled():
+            log_info(f"[loop] cancellation requested -- skipping {dimension} and remaining dims")
+            # Remaining dims stay in PENDING. No write needed.
             break
         run_dir = _run_dir_for(config)
         _safe_write_dim_state(run_dir, dimension, DimState.RUNNING)

--- a/src/quodeq/analysis/cache/dimension_runner.py
+++ b/src/quodeq/analysis/cache/dimension_runner.py
@@ -397,9 +397,22 @@ def process_dimension_with_cache(
         breaker.stop_and_join(timeout=5.0)
 
     if breaker.trip_event is not None:
-        # The breaker tripped. Surface a typed exception so the pipeline
-        # layer can mark this dim's state with reason=circuit_breaker and
-        # the lifecycle layer can record exit_reason=failure_streak.
+        # The breaker tripped, but the finally block above already persisted
+        # every completed file to the JSONL. Salvage that work instead of
+        # discarding the whole dimension: parse the collected findings into
+        # Evidence and flag it failure_streak so the loop scores it (DONE +
+        # exit_reason) and the grade layer can exclude it. The breaker already
+        # requested run-wide cancellation, so the run still ends after this dim.
+        if jsonl.exists():
+            salvaged = parse_evidence_from_jsonl(
+                config, dim_id, ctx, jsonl,
+                files_read=_compute_files_read(classify, jsonl, files),
+            )
+            if salvaged is not None and salvaged.principles:
+                salvaged.exit_reason = "failure_streak"
+                return salvaged
+        # Nothing collected -- no score to fabricate. Surface the typed
+        # exception so the dim is marked INCOMPLETE/unscored as before.
         raise CircuitBreakerError("circuit_breaker")
 
     if miss_evidence is None:

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -131,5 +131,18 @@ def recompute_grades(run_dir: Path, params: ScoringParams | None = None) -> None
         params = grade_formula.load_params()
     principle_rows, dimension_rows = compute_run_grades(run_dir, params)
 
+    # Carry the per-dim exit_reason (failure_streak, time_limit, ...) from the
+    # authoritative dim-state file so the grade layer can flag/exclude
+    # interrupted dimensions. Match case-insensitively: findings carry the
+    # dimension label, dimensions.json carries the dimension id.
+    from quodeq.shared.dimensions_state import read_dimensions  # noqa: PLC0415
+    dim_states = read_dimensions(run_dir).get("dimensions", {})
+    exit_by_dim = {
+        str(name).lower(): entry.get("exit_reason")
+        for name, entry in dim_states.items()
+    }
+    for row in dimension_rows:
+        row["exit_reason"] = exit_by_dim.get(str(row["dimension"]).lower())
+
     store = SQLiteStateStore(run_dir)
     store.batch_rewrite_grades(principle_rows, dimension_rows)

--- a/src/quodeq/data/sqlite/state_store.py
+++ b/src/quodeq/data/sqlite/state_store.py
@@ -202,9 +202,11 @@ class SQLiteStateStore:
                 )
             for d_score in dimension_rows:
                 conn.execute(
-                    "INSERT INTO dimension_scores (dimension, score, grade, completed_at) "
-                    "VALUES (?, ?, ?, datetime('now'))",
-                    (d_score["dimension"], d_score["score"], d_score["grade"]),
+                    "INSERT INTO dimension_scores "
+                    "(dimension, score, grade, exit_reason, completed_at) "
+                    "VALUES (?, ?, ?, ?, datetime('now'))",
+                    (d_score["dimension"], d_score["score"], d_score["grade"],
+                     d_score.get("exit_reason")),
                 )
             conn.commit()
 
@@ -217,9 +219,13 @@ class SQLiteStateStore:
     def read_dimension_scores(self) -> list[dict]:
         with open_evaluation_db(self._run_dir) as conn:
             rows = conn.execute(
-                "SELECT dimension, score, grade FROM dimension_scores ORDER BY dimension"
+                "SELECT dimension, score, grade, exit_reason "
+                "FROM dimension_scores ORDER BY dimension"
             ).fetchall()
-        return [{"dimension": r[0], "score": r[1], "grade": r[2]} for r in rows]
+        return [
+            {"dimension": r[0], "score": r[1], "grade": r[2], "exit_reason": r[3]}
+            for r in rows
+        ]
 
     def read_principle_grades(self) -> list[dict]:
         with open_evaluation_db(self._run_dir) as conn:

--- a/src/quodeq/services/scoring/_summary.py
+++ b/src/quodeq/services/scoring/_summary.py
@@ -26,7 +26,11 @@ def recompute_summary(
 
     for d in dimensions:
         score_str = d.get("overallScore")
-        if score_str:
+        # A failure_streak dimension carries a provisional, optimistic score
+        # (its errored files contribute no findings). Tally its violations
+        # below, but keep it out of the overall numeric average. Other
+        # exit_reasons (time_limit, etc.) still count.
+        if score_str and d.get("exitReason") != "failure_streak":
             val = parse_numeric_score(score_str)
             if val is not None:
                 score_pairs.append((d.get("dimension"), val))

--- a/src/quodeq/services/scoring/projector_scoring.py
+++ b/src/quodeq/services/scoring/projector_scoring.py
@@ -145,9 +145,14 @@ def compute_run_score(
 
     Applies per-dimension weights when params enable them.
     """
+    # Dimensions aborted by the failure-streak circuit breaker carry a
+    # provisional, structurally-optimistic score (the errored files are the
+    # ones with no findings). Show the per-dim score but keep it OUT of the
+    # overall grade. time_limit and other partial reasons still count.
     pairs = [
         (d.get("dimension"), d["score"])
-        for d in dimension_scores if d.get("score") is not None
+        for d in dimension_scores
+        if d.get("score") is not None and d.get("exit_reason") != "failure_streak"
     ]
     avg = dimension_weighted_average(pairs, params)
     if avg is None:

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.jsx
@@ -45,6 +45,11 @@ function buildPartialTooltip({ filesRead, sourceFileCount, exitReason }) {
   }
   if (typeof exitReason === 'string') {
     parts.push(`stopped: ${exitReason}`);
+    // A failure-streak (circuit-breaker) dimension is salvaged and shown with a
+    // provisional score, but kept out of the overall grade. Say so explicitly.
+    if (exitReason === 'failure_streak') {
+      parts.push('excluded from grade');
+    }
   }
   return parts.join(' · ');
 }

--- a/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DimensionGaugeCard.test.jsx
@@ -80,6 +80,25 @@ describe('DimensionGaugeCard', () => {
       );
     });
 
+    it('appends "excluded from grade" for a failure_streak (circuit breaker) dimension', () => {
+      render(
+        <DimensionGaugeCard
+          item={{
+            ...baseItem,
+            filesRead: 90,
+            sourceFileCount: 100,
+            exitReason: 'failure_streak',
+          }}
+          dateLabel={dateLabel}
+          onDimensionClick={() => {}}
+        />,
+      );
+      const line = screen.getByText(coverageLineMatcher(`${dateLabel} · 90%`));
+      expect(line.getAttribute('title')).toBe(
+        'Partial run · 90 of 100 files · stopped: failure_streak · excluded from grade',
+      );
+    });
+
     it('flags partial when exitReason is "deadline" even if file counts match', () => {
       render(
         <DimensionGaugeCard

--- a/tests/analysis/cache/test_dimension_runner.py
+++ b/tests/analysis/cache/test_dimension_runner.py
@@ -35,6 +35,7 @@ from quodeq.analysis.cache import (
     build_cache_key_for_file,
 )
 from quodeq.analysis.cache.dimension_runner import process_dimension_with_cache
+from quodeq.analysis.cache._failure_streak import CircuitBreakerError
 from quodeq.analysis.manifest_models import AnalysisTarget, SourceManifest
 from quodeq.analysis.subagents.runner import DimensionCallbacks
 from quodeq.core.evidence.model import Evidence
@@ -1242,3 +1243,93 @@ class TestFilesReadReflectsAnalyzedCount:
         assert ev.files_read == 1, (
             f"expected files_read=1 (just the cache hit), got {ev.files_read}"
         )
+
+
+def _finding_line(file: str) -> str:
+    """A realistic violation finding (the producer's compact schema) that the
+    evidence parser groups under principle ``Adaptability``."""
+    return json.dumps({
+        "schema_version": 1, "req": "F-ADP-1", "t": "violation",
+        "file": file, "line": 1, "severity": "minor",
+        "w": "hardcoded value", "snippet": "x = 1",
+        "reason": "hardcoded environment-specific value",
+        "p": "Adaptability", "d": "flexibility",
+    })
+
+
+class _SalvageDispatcher:
+    """Writes one real finding + N consecutive error markers to trip the breaker.
+
+    Models a dimension whose model calls start failing after some real work
+    has already been persisted to the JSONL.
+    """
+
+    def __init__(self, n_errors: int) -> None:
+        self.n_errors = n_errors
+
+    def __call__(self, config, dim_id, idx, ctx, callbacks):
+        jsonl = (config.work_dir or config.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            out.write(_finding_line("a.py") + "\n")
+            out.write(json.dumps(
+                {"_marker": "file_done", "file": "a.py", "status": "ok"}) + "\n")
+            for i in range(self.n_errors):
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": f"e{i}.py",
+                    "status": "error", "reason": "model call failed",
+                }) + "\n")
+        return None
+
+
+class _AllErrorsDispatcher:
+    """Writes only error markers — nothing to salvage."""
+
+    def __init__(self, n_errors: int) -> None:
+        self.n_errors = n_errors
+
+    def __call__(self, config, dim_id, idx, ctx, callbacks):
+        jsonl = (config.work_dir or config.src) / f"{dim_id}_evidence.jsonl"
+        jsonl.parent.mkdir(parents=True, exist_ok=True)
+        with jsonl.open("a") as out:
+            for i in range(self.n_errors):
+                out.write(json.dumps({
+                    "_marker": "file_done", "file": f"e{i}.py",
+                    "status": "error", "reason": "model call failed",
+                }) + "\n")
+        return None
+
+
+class TestBreakerSalvage:
+    @pytest.fixture(autouse=True)
+    def _reset_cancel(self):
+        from quodeq.shared import cancellation
+        cancellation.reset()
+        yield
+        cancellation.reset()
+
+    def test_breaker_trip_salvages_partial_evidence(self, tmp_path, cache):
+        config, _src = _setup(tmp_path, {"a.py": "x"})
+        config = replace(
+            config, options=replace(config.options, failure_streak_threshold=3))
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=_SalvageDispatcher(n_errors=3),
+        ):
+            ev = process_dimension_with_cache(
+                config, "flexibility", 1, _make_ctx(), _make_callbacks(), cache=cache)
+        assert ev is not None, "breaker trip should salvage collected findings, not discard"
+        assert ev.exit_reason == "failure_streak"
+        assert ev.principles, "salvaged Evidence should carry the collected findings"
+
+    def test_breaker_trip_with_no_findings_raises(self, tmp_path, cache):
+        config, _src = _setup(tmp_path, {"a.py": "x"})
+        config = replace(
+            config, options=replace(config.options, failure_streak_threshold=3))
+        with patch(
+            "quodeq.analysis.cache.dimension_runner.process_dimension_with_subagents",
+            new=_AllErrorsDispatcher(n_errors=3),
+        ):
+            with pytest.raises(CircuitBreakerError):
+                process_dimension_with_cache(
+                    config, "flexibility", 1, _make_ctx(), _make_callbacks(), cache=cache)

--- a/tests/analysis/test_loop_stops_on_cancel.py
+++ b/tests/analysis/test_loop_stops_on_cancel.py
@@ -1,0 +1,79 @@
+"""Both dimension loops stop processing once run-wide cancellation is set.
+
+After the failure-streak breaker trips (now salvaging the in-flight dimension
+rather than raising), the run-wide cancellation flag is set. The loop must not
+spin up the remaining dimensions only to have them short-circuit.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from quodeq.analysis._loops import run_incremental_loop, run_per_dimension_loop
+from quodeq.core.evidence.model import Evidence
+from quodeq.shared import cancellation
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancellation.reset()
+    yield
+    cancellation.reset()
+
+
+def _mk_config(tmp_path):
+    config = MagicMock()
+    config.run_dir = tmp_path
+    config.work_dir = tmp_path
+    config.src = tmp_path
+    config.source_file_count = 1
+    config.options.deadline_at = None
+    config.options.incremental_file_filter = None
+    config.options.skip_scoring = True
+    return config
+
+
+def _mk_ctx():
+    ctx = MagicMock()
+    ctx.total = 3
+    return ctx
+
+
+def _ev() -> Evidence:
+    return Evidence(
+        repository="", language="python", date="2026-01-01",
+        source_file_count=1, files_read=1, coverage_pct=100.0,
+        principles={}, exit_reason="failure_streak",
+    )
+
+
+def _trip_on_first(calls):
+    def fake_run(cfg, dim, idx, ctx, emit_log=False):
+        calls.append(dim)
+        cancellation.request_cancel()  # simulate a breaker trip during the first dim
+        return _ev()
+    return fake_run
+
+
+@patch("quodeq.analysis._loops.emit_marker", lambda *a, **k: None)
+def test_incremental_loop_breaks_after_cancellation(tmp_path):
+    calls: list[str] = []
+    runner = MagicMock()
+    runner.run.side_effect = _trip_on_first(calls)
+    run_incremental_loop(
+        _mk_config(tmp_path), ["security", "flexibility", "usability"],
+        _mk_ctx(), runner=runner,
+    )
+    assert calls == ["security"], "loop must stop after run-wide cancellation"
+
+
+def test_per_dimension_loop_breaks_after_cancellation(tmp_path):
+    calls: list[str] = []
+    runner = MagicMock()
+    runner.run.side_effect = _trip_on_first(calls)
+    run_per_dimension_loop(
+        _mk_config(tmp_path), ["security", "flexibility", "usability"],
+        _mk_ctx(), runner=runner,
+    )
+    assert calls == ["security"], "loop must stop after run-wide cancellation"

--- a/tests/data/projection/test_grade_projector.py
+++ b/tests/data/projection/test_grade_projector.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from quodeq.core.events.models import Judgment
 from quodeq.data.projection.grade_projector import recompute_grades
 from quodeq.data.sqlite.state_store import SQLiteStateStore
+from quodeq.shared.dimensions_state import DimState, write_dim_state
 
 
 def _seed(store: SQLiteStateStore, *, req: str, principle: str, dimension: str, severity: str = "medium") -> None:
@@ -118,3 +119,35 @@ def test_recompute_grades_no_findings_clears_tables(tmp_path: Path) -> None:
     recompute_grades(tmp_path)
     assert store.read_dimension_scores() == []
     assert store.read_principle_grades() == []
+
+
+def test_recompute_grades_carries_exit_reason_from_dim_state(tmp_path: Path) -> None:
+    """A dimension marked DONE with exit_reason=failure_streak in dimensions.json
+    carries that reason onto its dimension_scores row (so the grade layer can
+    flag/exclude it)."""
+    store = SQLiteStateStore(tmp_path)
+    for i in range(5):
+        _seed(store, req=f"P1-{i}", principle="P1", dimension="flexibility", severity="high")
+    write_dim_state(tmp_path, "flexibility", DimState.RUNNING)
+    write_dim_state(tmp_path, "flexibility", DimState.DONE, exit_reason="failure_streak")
+
+    recompute_grades(tmp_path)
+
+    rows = store.read_dimension_scores()
+    flex = next(r for r in rows if r["dimension"] == "flexibility")
+    assert flex["score"] is not None
+    assert flex["exit_reason"] == "failure_streak"
+
+
+def test_recompute_grades_exit_reason_none_when_done_clean(tmp_path: Path) -> None:
+    store = SQLiteStateStore(tmp_path)
+    for i in range(5):
+        _seed(store, req=f"P1-{i}", principle="P1", dimension="security", severity="high")
+    write_dim_state(tmp_path, "security", DimState.RUNNING)
+    write_dim_state(tmp_path, "security", DimState.DONE)
+
+    recompute_grades(tmp_path)
+
+    rows = store.read_dimension_scores()
+    sec = next(r for r in rows if r["dimension"] == "security")
+    assert sec["exit_reason"] is None

--- a/tests/data/test_state_store.py
+++ b/tests/data/test_state_store.py
@@ -189,7 +189,7 @@ def test_record_dimension_score_round_trip(tmp_path: Path) -> None:
     store.record_dimension_score(dimension="Security", score=7.4, grade="B")
 
     rows = store.read_dimension_scores()
-    assert rows == [{"dimension": "Security", "score": 7.4, "grade": "B"}]
+    assert rows == [{"dimension": "Security", "score": 7.4, "grade": "B", "exit_reason": None}]
 
 
 def test_record_dimension_score_upserts(tmp_path: Path) -> None:
@@ -198,7 +198,7 @@ def test_record_dimension_score_upserts(tmp_path: Path) -> None:
     store.record_dimension_score(dimension="Security", score=8.2, grade="B+")
 
     rows = store.read_dimension_scores()
-    assert rows == [{"dimension": "Security", "score": 8.2, "grade": "B+"}]
+    assert rows == [{"dimension": "Security", "score": 8.2, "grade": "B+", "exit_reason": None}]
 
 
 def test_record_principle_grade_round_trip(tmp_path: Path) -> None:

--- a/tests/services/scoring/test_compute_run_score_exclusion.py
+++ b/tests/services/scoring/test_compute_run_score_exclusion.py
@@ -1,0 +1,25 @@
+"""compute_run_score excludes circuit-breaker-interrupted dimensions from the
+overall grade, but leaves other partial reasons (time_limit, ...) counting."""
+from __future__ import annotations
+
+from quodeq.services.scoring.projector_scoring import compute_run_score
+
+
+def test_excludes_failure_streak_dim_from_overall():
+    rows = [
+        {"dimension": "security", "score": 6.0, "grade": "Adequate", "exit_reason": None},
+        {"dimension": "flexibility", "score": 9.5, "grade": "Exemplary",
+         "exit_reason": "failure_streak"},
+    ]
+    result = compute_run_score(rows)
+    assert result["score"] == 6.0  # flexibility (9.5) excluded from the mean
+
+
+def test_time_limit_dim_still_counts():
+    rows = [
+        {"dimension": "security", "score": 6.0, "grade": "Adequate", "exit_reason": None},
+        {"dimension": "usability", "score": 8.0, "grade": "Good",
+         "exit_reason": "time_limit"},
+    ]
+    result = compute_run_score(rows)
+    assert result["score"] == 7.0  # (6.0 + 8.0) / 2 -- time_limit is NOT excluded

--- a/tests/services/scoring/test_recompute_summary_exclusion.py
+++ b/tests/services/scoring/test_recompute_summary_exclusion.py
@@ -1,0 +1,38 @@
+"""recompute_summary keeps a failure_streak dimension out of the overall numeric
+average, while still tallying its findings. time_limit dims keep counting."""
+from __future__ import annotations
+
+from quodeq.services.scoring._summary import recompute_summary
+
+
+def _dim(name, score, grade, exit_reason=None, violations=0):
+    return {
+        "dimension": name,
+        "overallScore": f"{score}/10",
+        "overallGrade": grade,
+        "exitReason": exit_reason,
+        "totals": {
+            "violationCount": violations, "complianceCount": 0,
+            "severity": {"critical": 0, "major": 0, "minor": violations},
+        },
+    }
+
+
+def test_failure_streak_dim_excluded_from_average_but_counted_in_totals():
+    dims = [
+        _dim("security", 6.0, "Adequate", violations=2),
+        _dim("flexibility", 9.5, "Exemplary", exit_reason="failure_streak", violations=3),
+    ]
+    summary = recompute_summary(dims, {})
+    assert summary["numericAverage"] == 6.0  # flexibility excluded from the mean
+    assert summary["totalViolations"] == 5  # but its findings still tallied
+    assert summary["dimensionCount"] == 2
+
+
+def test_time_limit_dim_still_in_average():
+    dims = [
+        _dim("security", 6.0, "Adequate"),
+        _dim("usability", 8.0, "Good", exit_reason="time_limit"),
+    ]
+    summary = recompute_summary(dims, {})
+    assert summary["numericAverage"] == 7.0

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -22,7 +22,7 @@ src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
 src/quodeq/data/projection/grade_projector.py:130:services
 src/quodeq/data/projection/grade_projector.py:20:services
-src/quodeq/data/sqlite/state_store.py:240:services
+src/quodeq/data/sqlite/state_store.py:246:services
 src/quodeq/engine/scoring_pipeline.py:10:services
 src/quodeq/services/_external_jobs.py:22:analysis
 src/quodeq/services/_violations_jsonl.py:11:analysis


### PR DESCRIPTION
## Why
When the failure-streak circuit breaker trips mid-dimension, the runner used to `raise CircuitBreakerError` and **discard the whole dimension** — even though the `finally` block had already persisted every completed file to the JSONL. In nightly run `ext-3c302305`, flexibility had processed 117/122 files and collected 603 findings, all thrown away, leaving it unanalyzed. Separately, the event-log projection silently scored that partial data (a phantom 7.5/Good) while the report path scored nothing, so the two disagreed.

Follows the config fix in #670 (which stops the breaker tripping in the first place); this hardens the runtime against *any* transient failure.

## What
1. **Salvage (runner)** — on a breaker trip, parse the persisted JSONL into Evidence and return it tagged `exit_reason="failure_streak"`, instead of raising. Only when real findings were collected; an all-errors dimension still raises -> INCOMPLETE/unscored (no fabricated score).
2. **End the run (loop)** — both loops `break` once run-wide cancellation is set, so remaining dims aren't needlessly spun up. The salvaged dim is scored first.
3. **Flag + persist (projection)** — `dimension_scores.exit_reason` (column already existed, was unused) is now written, sourced from the authoritative `dimensions.json`, and read back.
4. **Exclude from grade (both paths)** — `compute_run_score` (dashboard grade, formula preview, report SQL overlay) and `recompute_summary` (accumulated average) drop `failure_streak` dims from the overall mean, while still showing the per-dim score and tallying its findings. This makes the projection and report agree, resolving the phantom-score divergence.
5. **UI** — the dashboard already badges `exitReason != 'done'` dims as partial-coverage; the tooltip now adds `excluded from grade` for `failure_streak`.

## Decisions (please sanity-check)
- **Narrow exclusion:** only `exit_reason == "failure_streak"` is excluded. `time_limit` and other partial reasons keep counting, exactly as today — excluding them would silently shift every time-bounded nightly's grade. (Tests assert this.)
- **Salvage, not retry:** a retry re-fails under the same conditions; with #670 the trigger is gone anyway.
- **Run-level `exit_reason=failure_streak` is unchanged:** `run_lifecycle` only sets it when a `CircuitBreakerError` propagates out, and both loops already swallow it — so it was never set in loop runs (run `ext-3c302305` recorded `exit_reason=null`). No regression; wiring it positively is out of scope.

## Tests (TDD throughout)
- New: runner salvage (+ no-salvage raises), loop cancellation-break (both loops), projection exit_reason round-trip, `compute_run_score` + `recompute_summary` exclusion (with `time_limit`-still-counts guards), UI tooltip.
- Full suite green: **3647 Python passed** (import baseline refreshed for the shifted `state_store` line), **541 UI passed**.

Spec + plan: `docs/superpowers/specs/2026-06-30-circuit-breaker-dimension-salvage-design.md` and `docs/superpowers/plans/2026-06-30-circuit-breaker-dimension-salvage.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)