### PR TITLE
fix: malformed-JSON robustness + openExternal scheme guard (nightly 3c302305 triage)

### DIFF
--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -46,7 +46,11 @@ def _build_req_to_principle_map(dimension: str, evaluators_dir: Path | None = No
                 if rid and pname:
                     mapping[rid] = pname
         return mapping
-    except (OSError, ValueError):
+    except (OSError, ValueError, AttributeError, TypeError):
+        # AttributeError/TypeError: a valid-JSON-but-non-dict payload (a list
+        # or null at the top level, or non-dict principle/requirement items)
+        # makes .get() raise. The contract is an empty map on any malformed
+        # input so callers stay permissive, never a crash.
         return {}
 
 

--- a/src/quodeq/data/projection/grade_projector.py
+++ b/src/quodeq/data/projection/grade_projector.py
@@ -44,6 +44,8 @@ def _read_source_file_count(run_dir: Path) -> int:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if not isinstance(data, dict):
+            continue  # a valid-JSON-but-non-dict file: skip, don't crash the loop
         count = data.get("sourceFileCount")
         if isinstance(count, int) and count > 0:
             return count

--- a/src/quodeq/services/_standards_io.py
+++ b/src/quodeq/services/_standards_io.py
@@ -44,7 +44,11 @@ def count_principles_and_requirements(data: dict) -> tuple[int, int]:
     if not isinstance(principles, list):
         principles = []
     valid = [p for p in principles if isinstance(p, dict)]
-    return len(valid), sum(len(p.get("requirements", [])) for p in valid)
+    # A present-but-null or non-list 'requirements' contributes zero rather
+    # than crashing: .get(..., []) returns the null value, not the default.
+    return len(valid), sum(
+        len(reqs) for p in valid if isinstance(reqs := p.get("requirements"), list)
+    )
 
 
 def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDetail:
@@ -61,7 +65,8 @@ def build_detail(data: dict, *, type_default: str = _TYPE_CUSTOM) -> StandardDet
 
 
 def build_builtin_detail(data: dict, standard_id: str, weight: float) -> StandardDetail:
-    source = data.get("source", "") or ", ".join(data.get("sources", []))
+    sources = data.get("sources")
+    source = data.get("source") or (", ".join(sources) if isinstance(sources, list) else "")
     description = data.get("description") or f"{data.get('name', standard_id)} standard"
     return StandardDetail(
         id=standard_id, name=data.get("name", standard_id),

--- a/src/quodeq/ui/src/features/updates/openExternal.js
+++ b/src/quodeq/ui/src/features/updates/openExternal.js
@@ -1,5 +1,16 @@
 export function openExternal(url) {
   if (!url) return;
+  // The URL originates from the remote update API (latest_url / download_url),
+  // so it crosses a trust boundary. Only follow web schemes — refuse
+  // unparseable input and javascript:/data:/file: smuggled by a hostile or
+  // MITM'd response.
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
   const api = typeof window !== 'undefined' && window.pywebview && window.pywebview.api;
   if (api && typeof api.open_browser === 'function') {
     try { api.open_browser(url); return; } catch { /* fall through to window.open */ }

--- a/src/quodeq/ui/src/features/updates/openExternal.test.jsx
+++ b/src/quodeq/ui/src/features/updates/openExternal.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { openExternal } from './openExternal.js';
+
+// The URL handed to openExternal originates from the remote update API
+// (status.latest_url / status.download_url), so it crosses a trust boundary.
+// A malicious or MITM'd response must not be able to smuggle a javascript:,
+// data:, or file: URL into window.open / pywebview.open_browser.
+describe('openExternal', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('opens https URLs', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('https://github.com/quodeq/quodeq/releases/tag/v1.5.0');
+    expect(open).toHaveBeenCalledWith(
+      'https://github.com/quodeq/quodeq/releases/tag/v1.5.0', '_blank', 'noopener',
+    );
+  });
+
+  it('opens http URLs', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('http://example.com/download');
+    expect(open).toHaveBeenCalled();
+  });
+
+  it('blocks javascript: URLs', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('javascript:alert(document.cookie)');
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('blocks file: URLs', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('file:///etc/passwd');
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('blocks data: URLs', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('data:text/html,<script>alert(1)</script>');
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('ignores empty or unparseable input', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    openExternal('');
+    openExternal(null);
+    openExternal('not a url');
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/tests/core/test_req_mapping_robustness.py
+++ b/tests/core/test_req_mapping_robustness.py
@@ -1,0 +1,40 @@
+"""Robustness of _build_req_to_principle_map against malformed evaluator JSON.
+
+The function contract is to degrade to an empty mapping on any unreadable or
+malformed evaluator file (so callers stay permissive), but its except clause
+only caught OSError/ValueError. A top-level JSON value that is valid but not a
+dict (a list, or null) made data.get(...) raise AttributeError and crash.
+"""
+from __future__ import annotations
+
+import json
+
+from quodeq.core.evidence._req_mapping import _build_req_to_principle_map
+
+
+def test_list_top_level_json_returns_empty(tmp_path):
+    (tmp_path / "security.json").write_text(json.dumps(["not", "a", "dict"]))
+    assert _build_req_to_principle_map("security", tmp_path) == {}
+
+
+def test_null_top_level_json_returns_empty(tmp_path):
+    (tmp_path / "reliability.json").write_text("null")
+    assert _build_req_to_principle_map("reliability", tmp_path) == {}
+
+
+def test_non_dict_principle_items_do_not_crash(tmp_path):
+    (tmp_path / "performance.json").write_text(
+        json.dumps({"principles": ["garbage", 42, None]})
+    )
+    assert _build_req_to_principle_map("performance", tmp_path) == {}
+
+
+def test_well_formed_file_still_maps(tmp_path):
+    (tmp_path / "usability.json").write_text(
+        json.dumps({
+            "principles": [
+                {"name": "Learnability", "requirements": [{"id": "U-LRN-1"}]},
+            ]
+        })
+    )
+    assert _build_req_to_principle_map("usability", tmp_path) == {"U-LRN-1": "Learnability"}

--- a/tests/data/projection/test_grade_projector.py
+++ b/tests/data/projection/test_grade_projector.py
@@ -3,8 +3,29 @@ from __future__ import annotations
 from pathlib import Path
 
 from quodeq.core.events.models import Judgment
-from quodeq.data.projection.grade_projector import recompute_grades
+from quodeq.data.projection.grade_projector import (
+    _read_source_file_count,
+    recompute_grades,
+)
 from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def test_read_source_file_count_skips_non_dict_json(tmp_path: Path) -> None:
+    """A valid-JSON-but-non-dict dim file (a top-level list or null) must be
+    skipped, not crash the loop with AttributeError on data.get(...)."""
+    eval_dir = tmp_path / "evaluation"
+    eval_dir.mkdir()
+    (eval_dir / "security.json").write_text("[1, 2, 3]")  # list, not a dict
+    assert _read_source_file_count(tmp_path) == 0
+
+
+def test_read_source_file_count_skips_non_dict_then_finds_valid(tmp_path: Path) -> None:
+    """A malformed dim file does not abort the scan of the remaining files."""
+    eval_dir = tmp_path / "evaluation"
+    eval_dir.mkdir()
+    (eval_dir / "a_security.json").write_text("null")
+    (eval_dir / "b_reliability.json").write_text('{"sourceFileCount": 7}')
+    assert _read_source_file_count(tmp_path) == 7
 
 
 def _seed(store: SQLiteStateStore, *, req: str, principle: str, dimension: str, severity: str = "medium") -> None:

--- a/tests/services/test_standards_io_coverage.py
+++ b/tests/services/test_standards_io_coverage.py
@@ -101,6 +101,20 @@ class TestCountPrinciplesAndRequirements:
         }
         assert count_principles_and_requirements(data) == (2, 2)
 
+    def test_requirements_null_treated_as_empty(self):
+        """A principle whose 'requirements' is explicitly null must not raise.
+
+        .get('requirements', []) returns None (not the default) when the key
+        is present with a null value, so len() would crash without a guard.
+        """
+        data = {"principles": [{"name": "P1", "requirements": None}]}
+        assert count_principles_and_requirements(data) == (1, 0)
+
+    def test_requirements_non_list_treated_as_empty(self):
+        """A non-list 'requirements' value contributes zero, never a bad count."""
+        data = {"principles": [{"name": "P1", "requirements": {"R1": {}}}]}
+        assert count_principles_and_requirements(data) == (1, 0)
+
 
 class TestBuildDetail:
     def test_minimal(self):
@@ -154,6 +168,16 @@ class TestBuildBuiltinDetail:
 
     def test_no_source(self):
         data = {"name": "Test", "principles": []}
+        detail = build_builtin_detail(data, "test", 1.0)
+        assert detail.source == ""
+
+    def test_sources_null_treated_as_empty(self):
+        """'sources' explicitly null must not raise.
+
+        ', '.join(data.get('sources', [])) crashes on None because .get
+        returns the null value, not the default, when the key is present.
+        """
+        data = {"name": "Test", "sources": None, "principles": []}
         detail = build_builtin_detail(data, "test", 1.0)
         assert detail.source == ""
 

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -20,7 +20,7 @@ src/quodeq/api/routes_findings.py:107:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:111:services
-src/quodeq/data/projection/grade_projector.py:130:services
+src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:240:services
 src/quodeq/engine/scoring_pipeline.py:10:services


### PR DESCRIPTION
## Summary

Triage and fix of the **critical** and **major** findings from nightly self-scan run `3c302305`. As usual for the quantized local-model nightly, the large majority were false positives (3/8 criticals and ~8% of majors were real); this PR fixes the genuinely-real bugs only, each **test-first**.

## Real bugs fixed

**Criticals (3) — all the "tolerate malformed JSON config" class:**
- `_standards_io.count_principles_and_requirements`: `requirements: null` crashed `len(None)` (TypeError), 500-ing the standards-list endpoint. It already tolerated non-list principles; now it tolerates bad `requirements` too.
- `_standards_io.build_builtin_detail`: `sources: null` crashed `", ".join(None)`, 500-ing the standard-detail endpoint.
- `_req_mapping._build_req_to_principle_map`: a valid-JSON-but-non-dict evaluator file (top-level list/null, or non-dict items) raised `AttributeError` that escaped the function's own `except`, crashing scoring. The contract is an empty map on any malformed input.

**Majors (2):**
- `grade_projector._read_source_file_count`: `data.get("sourceFileCount")` sat outside the `json.loads` try/except, so a non-dict dim file aborted the loop that is meant to *skip* bad files. Same class as the criticals.
- `openExternal`: the URL comes from the remote update API (`latest_url`/`download_url`), crossing a trust boundary. Now refuses unparseable input and any non-`http(s)` scheme, blocking `javascript:`/`data:`/`file:` smuggled by a hostile or MITM'd update response. Both call sites pass `https` GitHub URLs, so legitimate use is unaffected.

## False positives (left untouched, with reasons)

The other 5 criticals and the bulk of the 214 majors triaged out as:
- **Trust-domain**: "command exec / path traversal / arbitrary file / SSRF" via operator-controlled config/env/provider settings, internal-enum `dimension`, or DB-keyed `job_id`, on a localhost single-user tool with no privilege boundary.
- **Already-guarded**: e.g. `params_from_dict`'s "crash" is caught by both callers; the galaxy tooltip already `escapeHtml`s the only user-controlled value.
- **By-design**: localhost no-auth dashboard, SSRF blacklist (allowlist impractical for user-configured URLs), atomic-write "races", an `httpx` timeout the scanner missed.
- **Hallucinated**: a JSX template-literal "syntax error" that does not exist.

## Tests

13 new regression tests (Python: standards-io, req-mapping, grade-projector; JS/vitest: openExternal scheme allowlist). Regional suites green: 1283 services/core/engine + 248 data + 10 updates JS.