### PR TITLE
fix(ui): remove decorative arrow before project name in topbar

### DIFF
--- a/src/quodeq/ui/src/styles/explorer.css
+++ b/src/quodeq/ui/src/styles/explorer.css
@@ -224,18 +224,12 @@
 }
 
 /* Project root — the persistent "which project" indicator. Accent-colored
-   and clickable (opens the Projects tab), with a leading ▸ marker. Kept as
-   plain text per this breadcrumb's no-chips convention. */
+   and clickable (opens the Projects tab). Kept as plain text per this
+   breadcrumb's no-chips convention. */
 .nav-breadcrumb__crumb--project > button,
 .nav-breadcrumb__crumb--project > span {
   color: var(--color-accent);
   font-weight: 500;
-}
-.nav-breadcrumb__crumb--project > button::before,
-.nav-breadcrumb__crumb--project > span::before {
-  content: '\25B8'; /* ▸ */
-  margin-right: 5px;
-  opacity: 0.85;
 }
 .nav-breadcrumb__crumb--project > button:hover {
   color: var(--color-accent-hover);

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -1944,11 +1944,6 @@ button.term-sev-badge--clickable:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.topbar-mobile-project::before {
-  content: '\25B8'; /* ▸ */
-  margin-right: 4px;
-  opacity: 0.85;
-}
 .topbar-mobile-sep {
   flex: 0 0 auto;
   margin: 0 5px;


### PR DESCRIPTION
## What

Removes the decorative `▸` arrow that was prepended to the project name in the topbar.

## Changes
- `explorer.css` — drop the leading `▸` `::before` marker on the desktop breadcrumb project root (`.nav-breadcrumb__crumb--project`)
- `terminal.css` — drop the same `▸` `::before` marker on the mobile topbar project button (`.topbar-mobile-project`)

Both were purely decorative pseudo-elements. Text, links, and the `/` breadcrumb separators are untouched.