### PR TITLE
fix(robustness): malformed-JSON/config tolerance + Windows portability (nightly 3c302305 minors)

### DIFF
--- a/src/quodeq/analysis/stream/validation.py
+++ b/src/quodeq/analysis/stream/validation.py
@@ -24,6 +24,8 @@ def get_mcp_status(stream_file: Path) -> str | None:
             if not isinstance(d, dict):
                 return None
             for srv in d.get("mcp_servers", []):
+                if not isinstance(srv, dict):
+                    continue  # skip a non-dict element, keep scanning the rest
                 if srv.get("name") == _MCP_SERVER_NAME:
                     return srv.get("status")
     except (json.JSONDecodeError, OSError) as exc:
@@ -38,6 +40,8 @@ def _is_error_event(line: str, stream_file: Path) -> bool | None:
     except json.JSONDecodeError as exc:
         log_debug(f"Skipping malformed stream line in {stream_file}: {exc}")
         return None
+    if not isinstance(d, dict):
+        return False  # a valid-JSON non-object line is not an error event
     if d.get("type") == "result" and d.get("is_error"):
         return True
     return False

--- a/src/quodeq/api/_rate_limit_file_store.py
+++ b/src/quodeq/api/_rate_limit_file_store.py
@@ -18,9 +18,14 @@ _DEFAULT_PATH = str(default_rate_limit_path())
 class FileRateLimitStore:
     """Rate-limit store backed by a JSON file.
 
-    Suitable for single-machine multi-worker deployments where processes
-    need to share rate-limit state without Redis.  Not recommended for
-    high-throughput production use.
+    Lets the workers of a single-machine deployment share rate-limit state
+    through a common file without Redis. NOTE: the ``threading.Lock`` below
+    only serializes access within a SINGLE process; under multiple worker
+    processes the file read-modify-write can still interleave, so the counts
+    are best-effort (a concurrent burst may slip a few requests past the
+    limit) rather than strictly exact across processes. Not recommended for
+    high-throughput production use; add OS-level file locking
+    (``fcntl.flock``) if exact cross-process enforcement is required.
     """
 
     def __init__(

--- a/src/quodeq/config/ai_provider.py
+++ b/src/quodeq/config/ai_provider.py
@@ -81,7 +81,12 @@ def _write_env(paths: ConfigPaths, provider: str, api_key_var: str, api_key_valu
     fd, tmp_path = tempfile.mkstemp(dir=str(paths.env_file.parent), suffix=".tmp")
     closed = False
     try:
-        os.fchmod(fd, _OWNER_RW_PERMS)
+        # os.fchmod is POSIX-only; on Windows it is absent. The
+        # post-replace os.chmod below carries the 0600 guarantee on POSIX,
+        # and mkstemp already creates the temp file 0600, so skipping
+        # fchmod on Windows loses no hardening.
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, _OWNER_RW_PERMS)
         os.write(fd, ("\n".join(lines) + "\n").encode())
         os.close(fd)
         closed = True

--- a/src/quodeq/llm_bridge/_providers.py
+++ b/src/quodeq/llm_bridge/_providers.py
@@ -32,7 +32,9 @@ def _is_local_api(provider_id: str) -> bool:
     """Check if an API provider is local (e.g. Ollama)."""
     configs = get_provider_configs()
     cfg = configs.get(provider_id, {})
-    api_base = cfg.get("api_base", "")
+    # `or ""`: a present-but-null api_base returns None from .get(default),
+    # which would crash the .lower() below.
+    api_base = cfg.get("api_base") or ""
     return any(marker in api_base.lower() for marker in _LOCAL_API_MARKERS)
 
 

--- a/src/quodeq/services/_violations_jsonl.py
+++ b/src/quodeq/services/_violations_jsonl.py
@@ -90,6 +90,8 @@ def _load_req_to_principle(dimension: str, evaluators_dir: "Path | None" = None)
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return {}  # valid JSON but not an object: degrade, don't crash
         mapping: dict[str, str] = {}
         for p in data.get("principles", []):
             pname = p.get("name", "")

--- a/tests/analysis/test_stream_validation_nondict.py
+++ b/tests/analysis/test_stream_validation_nondict.py
@@ -36,3 +36,31 @@ class TestGetMcpStatusNonDict:
         p = self._write_stream(tmp_path, json.dumps(payload) + "\n")
         result = get_mcp_status(p)
         assert result == "ok"
+
+    def test_non_dict_server_element_skipped(self, tmp_path: Path) -> None:
+        """A non-dict element in mcp_servers must be skipped, not crash."""
+        from quodeq.analysis.stream.validation import get_mcp_status
+        payload = {"mcp_servers": ["garbage", 42, {"name": "findings", "status": "ok"}]}
+        p = self._write_stream(tmp_path, json.dumps(payload) + "\n")
+        assert get_mcp_status(p) == "ok"
+
+    def test_non_list_mcp_servers_returns_none(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import get_mcp_status
+        p = self._write_stream(tmp_path, json.dumps({"mcp_servers": "x"}) + "\n")
+        assert get_mcp_status(p) is None
+
+
+class TestIsStreamValidNonDictLine:
+    def test_non_dict_line_is_not_an_error_event(self, tmp_path: Path) -> None:
+        """A valid-JSON line that is a list/scalar must not crash
+        _is_error_event; the stream is treated as valid (no error event)."""
+        from quodeq.analysis.stream.validation import is_stream_valid
+        p = tmp_path / "stream.json"
+        p.write_text(json.dumps([1, 2, 3]) + "\n", encoding="utf-8")
+        assert is_stream_valid(p) is True
+
+    def test_error_event_still_detected(self, tmp_path: Path) -> None:
+        from quodeq.analysis.stream.validation import is_stream_valid
+        p = tmp_path / "stream.json"
+        p.write_text(json.dumps({"type": "result", "is_error": True}) + "\n", encoding="utf-8")
+        assert is_stream_valid(p) is False

--- a/tests/config/test_config_ai_provider.py
+++ b/tests/config/test_config_ai_provider.py
@@ -13,6 +13,18 @@ def test_configure_provider_writes_env(tmp_path):
     assert "AI_PROVIDER=claude" in paths.env_file.read_text()
 
 
+def test_configure_provider_works_without_fchmod(tmp_path, monkeypatch):
+    """os.fchmod is absent on Windows; saving provider config must still
+    succeed there (the post-replace os.chmod carries the 0600 guarantee)."""
+    import os
+    monkeypatch.delattr(os, "fchmod", raising=False)
+    paths = ConfigPaths.from_root(tmp_path)
+    exit_code = configure_provider_noninteractive("claude", paths)
+    assert exit_code == 0
+    assert paths.env_file.exists()
+    assert "AI_PROVIDER=claude" in paths.env_file.read_text()
+
+
 def test_get_current_provider_prefers_env_file(tmp_path):
     env_file = tmp_path / ".quodeq.env"
     env_file.write_text("export AI_PROVIDER=codex\n")

--- a/tests/llm_bridge/test_providers.py
+++ b/tests/llm_bridge/test_providers.py
@@ -21,6 +21,16 @@ class TestGetProviderConfigs:
         assert "claude" in configs or "ollama" in configs
 
 
+class TestIsLocalApiNullApiBase:
+    def test_null_api_base_does_not_crash(self):
+        """A provider config whose api_base is null (operator-edited
+        ai_providers.json) must not crash on .lower()."""
+        from quodeq.llm_bridge import _providers
+        cfgs = {"weird": {"type": "api", "api_base": None}}
+        with patch.object(_providers, "get_provider_configs", return_value=cfgs):
+            assert _providers._is_local_api("weird") is False
+
+
 class TestGetProviderType:
     def test_cli_provider(self):
         assert get_provider_type("claude") == "cli"

--- a/tests/services/test_violations_jsonl_coverage.py
+++ b/tests/services/test_violations_jsonl_coverage.py
@@ -127,6 +127,14 @@ class TestLoadReqToPrinciple:
         result = _load_req_to_principle("security", tmp_path)
         assert result == {}
 
+    @pytest.mark.parametrize("payload", ['[{"name": "x"}]', "null", '"hello"', "42"])
+    def test_non_dict_top_level_returns_empty(self, tmp_path, payload):
+        """A valid-JSON-but-non-dict evaluator file must not crash with
+        AttributeError on data.get(); it degrades to an empty mapping."""
+        from quodeq.services._violations_jsonl import _load_req_to_principle
+        (tmp_path / "security.json").write_text(payload)
+        assert _load_req_to_principle("security", tmp_path) == {}
+
 
 class TestParseViolationsFromJsonl:
     def test_missing_file(self, tmp_path):

--- a/tests/tools/test_migrate_reason_title.py
+++ b/tests/tools/test_migrate_reason_title.py
@@ -27,3 +27,22 @@ class TestMigrateEntryNonDict:
         # The function should handle a valid dict without raising
         result = migrate_entry(entry)
         assert isinstance(result, bool)
+
+
+class TestMigrateFileNonDict:
+    def test_non_dict_top_level_returns_zero(self, tmp_path) -> None:
+        """A valid-JSON-but-non-dict evaluation file must not crash the
+        migration with AttributeError on data.get('violations')."""
+        import json
+        from migrate_reason_title import migrate_file
+        p = tmp_path / "eval.json"
+        p.write_text(json.dumps([{"reason": "x"}]))
+        assert migrate_file(p, apply=False) == (0, 0)
+
+    def test_valid_dict_file_still_migrates(self, tmp_path) -> None:
+        import json
+        from migrate_reason_title import migrate_file
+        p = tmp_path / "eval.json"
+        p.write_text(json.dumps({"violations": [{"reason": "Modularity -- x"}], "compliance": []}))
+        v, c = migrate_file(p, apply=False)
+        assert (v, c) == (1, 0)

--- a/tools/migrate_reason_title.py
+++ b/tools/migrate_reason_title.py
@@ -80,6 +80,9 @@ def migrate_file(path: Path, apply: bool) -> tuple[int, int]:
     except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
         print(f"  SKIP  cannot read {path}: {exc}")
         return 0, 0
+    if not isinstance(data, dict):
+        print(f"  SKIP  unexpected payload type in {path}: {type(data).__name__}")
+        return 0, 0
     v_count = sum(1 for entry in data.get("violations", []) if migrate_entry(entry))
     c_count = sum(1 for entry in data.get("compliance", []) if migrate_entry(entry))
 


### PR DESCRIPTION
## Summary

Follow-up to #672. After clearing the 200 open **major** findings from nightly run `3c302305` (186 dismissed as false positives via a verified re-triage), this PR fixes the **6 verified-real, severity-minor robustness bugs** in the residue, plus one docstring correction. Every fix is test-first and was adversarially re-verified against source before implementation.

## Fixes (6) + docstring (1)

| Finding | File | Bug → fix |
|---|---|---|
| 147 | `services/_violations_jsonl.py` | non-dict evaluator JSON crashed `data.get()` → `isinstance` guard degrades to `{}` |
| 165 | `analysis/stream/validation.py` | a valid-JSON non-object stream line crashed `_is_error_event` and escaped the dimension run → guard returns "not an error event" |
| 166 | `analysis/stream/validation.py` | a non-dict element in `mcp_servers` crashed `srv.get()` → skip non-dict elements, keep scanning |
| 441 | `llm_bridge/_providers.py` | `cfg.get("api_base", "")` returns `None` on a null value → `.lower()` crash; coerce with `or ""` |
| 622 | `tools/migrate_reason_title.py` | non-dict JSON crashed the migration → skip with a message |
| 2474 | `config/ai_provider.py` | **`os.fchmod` is POSIX-only → `AttributeError` on Windows** (CI runs `windows-latest`), blocking config save; guard with `hasattr` (post-replace `os.chmod` keeps the 0600 guarantee) |
| 286 | `api/_rate_limit_file_store.py` | docstring overclaimed exact cross-process safety while using a per-process `threading.Lock`; corrected to state the best-effort limitation |

Five of the six are the same "tolerate malformed JSON / null config" class as #672; #2474 is a genuine cross-platform bug.

## Adversarial verification dropped 2 candidates as false positives

- **#60** (unbounded `resp.read()`): the cited `HttpClient` has no production caller (dead infra), and the live remote path is gated on an unset `STANDARDS_LIBRARY_URL` with operator-supplied trusted URLs — no untrusted input can trigger it.
- **#2205** (external-header null-deref): lives in `tests/.../fixtures/provenance_gate/...` — a deliberately-vulnerable test fixture, not production code.

## Deferred

The 4 chart/canvas keyboard-accessibility findings (1800, 1888, 2096, 2021) are real but need design work, so they are tracked separately rather than bundled here. #1459 (an N+1 over runs) is bounded by runs-per-project on a local tool — won't-fix.

## Tests

11 new regression tests (parametrized non-dict payloads, non-dict stream lines/elements, null `api_base`, non-dict migration input, Windows `fchmod`-absent path). Regional suites green: 1160 passing across services/analysis/llm_bridge/config/tools; import-layer baseline unchanged.
