### PR TITLE
refactor(io): make read_json enforce its dict contract (kill the non-dict .get() crash class)

### DIFF
--- a/src/quodeq/shared/_io.py
+++ b/src/quodeq/shared/_io.py
@@ -27,11 +27,25 @@ def open_text(path: str | Path, mode: str = "r") -> IO[str]:
 
 
 def read_json(path: Path) -> dict[str, Any]:
-    """Read and parse a JSON file, returning the parsed dict."""
+    """Read and parse a JSON object file, returning the parsed dict.
+
+    Enforces the ``-> dict`` contract: a valid-JSON-but-non-object payload (a
+    top-level list, string, number, or null) raises ``ValueError`` — the same
+    failure mode as a read/parse error. This shuts down the recurring crash
+    class where a caller does ``read_json(p).get(...)`` and a hand-edited or
+    malformed file that is valid JSON but not an object raises an unhandled
+    ``AttributeError`` deep in the caller. Callers that load top-level arrays
+    must use a plain ``json.loads`` (or ``default_read_json``), not this helper.
+    """
     try:
-        return json.loads(path.read_text(encoding=TEXT_ENCODING))
+        data = json.loads(path.read_text(encoding=TEXT_ENCODING))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"Cannot read JSON file {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Expected a JSON object in {path}, got {type(data).__name__}"
+        )
+    return data
 
 
 def configure_stdio_utf8() -> None:

--- a/tests/shared/test_utils.py
+++ b/tests/shared/test_utils.py
@@ -48,6 +48,16 @@ class TestReadJson:
         with pytest.raises((FileNotFoundError, ValueError)):
             utils.read_json(tmp_path / "missing.json")
 
+    @pytest.mark.parametrize("payload", ["[1, 2, 3]", "null", '"hello"', "42"])
+    def test_raises_on_non_object_json(self, tmp_path, payload):
+        """read_json is annotated -> dict; a valid-JSON-but-non-object payload
+        must raise ValueError (the same failure mode as a read/parse error) so
+        callers never receive a non-dict and crash later on .get()."""
+        f = tmp_path / "data.json"
+        f.write_text(payload)
+        with pytest.raises(ValueError):
+            utils.read_json(f)
+
 
 class TestConfigure:
     def test_overrides_defaults(self):


### PR DESCRIPTION
## Summary

Addresses the recurring crash class behind most of the real findings in #672 and #674 at its **source**, instead of patching call sites one at a time.

Every one of those fixes was the same shape: code loads JSON, calls `.get()` on the result, and a valid-JSON-but-non-object file (a top-level list or `null`, hand-edited or malformed) raises an unhandled `AttributeError` deep in the caller.

`shared/_io.read_json` is annotated `-> dict` but never enforced it. This PR makes it raise `ValueError` on a non-object payload — the **same** failure mode it already raises on read/parse errors — so the existing error handling at all **34 call sites** catches it and degrades gracefully rather than crashing later. One single-point change hardens every `read_json` caller and sets the canonical pattern going forward.

## Why it's safe

- The only top-level-array data file (`cwe/audit.json`, 368 entries) is loaded via `default_read_json`, **not** this helper.
- `StandardsService` is constructed without a `read_json` override, so the CWE path never touches the hardened helper.
- No `read_json` caller iterates its result as a list (verified by scan).
- Full non-integration suite green: **3674 tests** across shared/core/analysis/config/services/data/api/ci/engine/tools.

## Tests

Parametrized `read_json` over non-object payloads (list / null / string / number) — each now raises `ValueError`.

Follow-up (not in this PR): raw `json.loads(...).get(...)` sites could migrate to `read_json` over time; this PR makes the helper the safe default they should adopt.
