### PR TITLE
fix(minors): clear the 13 verified-real minor findings from nightly 3c302305

### DIFF
--- a/src/quodeq/api/llm_bridge_routes.py
+++ b/src/quodeq/api/llm_bridge_routes.py
@@ -128,6 +128,7 @@ def register_llm_bridge_routes(app: Flask) -> None:
         if not api_key and api_key_env:
             return jsonify({
                 "success": False,
+                "code": "MISSING_API_KEY",
                 "error": f"{api_key_env} is not set in the dashboard's environment. "
                          f"Export it in your shell (e.g. ~/.zshrc) and relaunch the dashboard from that terminal.",
             })

--- a/src/quodeq/data/fs/repo_clone.py
+++ b/src/quodeq/data/fs/repo_clone.py
@@ -91,6 +91,8 @@ def cleanup_cloned_repo(repo_path: str) -> None:
         return
     parent = str(Path(repo_path).resolve().parent)
     try:
-        shutil.rmtree(parent, ignore_errors=True)
+        # No ignore_errors=True: it would swallow the OSError and make the
+        # warning below unreachable. Let rmtree raise so the failure is logged.
+        shutil.rmtree(parent)
     except OSError as exc:
         _logger.warning("Failed to clean up temp repo dir %s: %s", parent, exc)

--- a/src/quodeq/shared/prereqs.py
+++ b/src/quodeq/shared/prereqs.py
@@ -140,7 +140,8 @@ def _check_api_provider(provider: str, *, env: dict[str, str] | None = None) -> 
     if provider == "ollama":
         try:
             _ollama_base = _env.get("OLLAMA_BASE_URL", "http://localhost:11434")
-            urllib.request.urlopen(f"{_ollama_base}/api/tags", timeout=_API_CHECK_TIMEOUT_S)
+            with urllib.request.urlopen(f"{_ollama_base}/api/tags", timeout=_API_CHECK_TIMEOUT_S):
+                pass
         except (urllib.error.URLError, OSError) as exc:
             raise RuntimeError(
                 "Ollama is configured as your AI provider but the server is not running.\n\n"
@@ -151,7 +152,8 @@ def _check_api_provider(provider: str, *, env: dict[str, str] | None = None) -> 
     elif provider == "llamacpp":
         try:
             _base = _env.get("LLAMACPP_BASE_URL", "http://localhost:8080")
-            urllib.request.urlopen(f"{_base}/health", timeout=_API_CHECK_TIMEOUT_S)
+            with urllib.request.urlopen(f"{_base}/health", timeout=_API_CHECK_TIMEOUT_S):
+                pass
         except (urllib.error.URLError, OSError) as exc:
             raise RuntimeError(
                 "llama.cpp is configured as your AI provider but llama-server is not running.\n\n"

--- a/src/quodeq/shared/ssrf.py
+++ b/src/quodeq/shared/ssrf.py
@@ -59,5 +59,5 @@ def is_loopback_address(hostname: str) -> bool:
                 return False
         return True
     except (socket.gaierror, OSError) as exc:
-        _logger.warning("DNS resolution failed for %r - treating as private (fail-closed): %s", hostname, exc)
+        _logger.warning("DNS resolution failed for %r - treating as non-loopback: %s", hostname, exc)
         return False

--- a/src/quodeq/ui/src/components/HeatGridCells.jsx
+++ b/src/quodeq/ui/src/components/HeatGridCells.jsx
@@ -32,7 +32,11 @@ export default function HeatGridCells({ row, onCellClick, variant = 'heat' }) {
               className={`heat-grid-cell${hasValue ? ' clickable' : ' empty'}`}
               style={style}
               onClick={() => hasValue && onCellClick?.({ row, severity: sev })}
+              onKeyDown={hasValue ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCellClick?.({ row, severity: sev }); }
+              } : undefined}
               role={hasValue ? 'button' : undefined}
+              tabIndex={hasValue ? 0 : undefined}
               aria-label={`${sev}: ${count} violation${count !== 1 ? 's' : ''} in ${row.name || 'row'}`}
             >
               {count || '—'}
@@ -44,7 +48,11 @@ export default function HeatGridCells({ row, onCellClick, variant = 'heat' }) {
         <div
           className={`heat-grid-num${row.violations > 0 ? ' clickable' : ''}`}
           onClick={() => row.violations > 0 && onCellClick?.({ row, severity: null })}
+          onKeyDown={row.violations > 0 ? (e) => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onCellClick?.({ row, severity: null }); }
+          } : undefined}
           role={row.violations > 0 ? 'button' : undefined}
+          tabIndex={row.violations > 0 ? 0 : undefined}
         >
           {row.violations}
         </div>

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
@@ -68,7 +68,14 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
         <thead>
           <tr>
             {COLUMNS.map((col) => (
-              <th key={col.id} className={`heat-grid-th-sort${col.align === 'left' ? ' left' : ''}`} onClick={() => handleSort(col.id)}>
+              <th
+                key={col.id}
+                className={`heat-grid-th-sort${col.align === 'left' ? ' left' : ''}`}
+                onClick={() => handleSort(col.id)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort(col.id); } }}
+                tabIndex={0}
+                aria-sort={sortCol === col.id ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+              >
                 {col.label}{sortCol === col.id ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
               </th>
             ))}

--- a/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
+++ b/src/quodeq/ui/src/features/settings/components/LlamaCppTab.jsx
@@ -118,7 +118,7 @@ export default function LlamaCppTab({ state, update }) {
               <span className="settings-description">Estimated from your VRAM. Run a quick test for a more accurate number.</span>
             </div>
             <div className="settings-budget-control">
-              <input type="number" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
+              <input type="number" aria-label="Max parallel agents" className="settings-model-input" min={MIN_SUBAGENTS} max={MAX_SUBAGENTS} value={state.subagents} onChange={(e) => update('subagents', e.target.value)} />
               <button type="button" className="settings-action-btn" onClick={runTest} disabled={testing || !models.length}>
                 {testing ? 'Testing...' : 'Auto-detect'}
               </button>

--- a/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.js
+++ b/src/quodeq/ui/src/features/settings/server-log/useServerLogPoll.js
@@ -23,15 +23,11 @@ export function useServerLogPoll(active) {
   const [logs, setLogs] = useState([]);
   const sinceRef = useRef(-1);
 
-  // Reset when toggling off; on toggle-on the next queryFn picks up since=-1.
+  // Reset whenever `active` toggles; on toggle-on the next queryFn picks up
+  // since=-1. Both branches were identical, so the reset is unconditional.
   useEffect(() => {
-    if (!active) {
-      setLogs([]);
-      sinceRef.current = -1;
-    } else {
-      setLogs([]);
-      sinceRef.current = -1;
-    }
+    setLogs([]);
+    sinceRef.current = -1;
   }, [active]);
 
   useQuery({

--- a/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
+++ b/src/quodeq/ui/src/features/standards/components/ReferenceEditor.jsx
@@ -31,7 +31,14 @@ function CweList({ filtered, onSelect, onClose }) {
   return (
     <div className="cwe-browser-list">
       {filtered.map((c) => (
-        <div key={c.id} className="cwe-browser-item" onClick={() => { onSelect(c); onClose(); }}>
+        <div
+          key={c.id}
+          className="cwe-browser-item"
+          onClick={() => { onSelect(c); onClose(); }}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(c); onClose(); } }}
+          role="button"
+          tabIndex={0}
+        >
           <div className="cwe-browser-item-header">
             <span className="cwe-browser-item-id">CWE-{c.id}</span>
             <span className="cwe-browser-item-abstraction">{c.abstraction}</span>

--- a/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardTree.jsx
@@ -12,7 +12,13 @@ function TreeNodeRow({ node, actions, titles, expand }) {
       onClick={() => { onClick(); if (showExpand) setExpanded((v) => !v); }}
       role="button"
       tabIndex={0}
-      onKeyDown={(e) => e.key === 'Enter' && onClick()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+          if (showExpand) setExpanded((v) => !v);
+        }
+      }}
     >
       {showExpand ? (
         <span className="tree-expand-btn" aria-hidden="true">

--- a/src/quodeq/ui/src/hooks/useVisibleRuns.js
+++ b/src/quodeq/ui/src/hooks/useVisibleRuns.js
@@ -22,7 +22,7 @@ export function useVisibleRuns(dailyRuns, dashboard, activePage, setSelectedRun)
       const datePart = (trendByRunId.get(run.runId)?.dateISO || '').slice(0, 10);
       return visibleDates.has(datePart);
     });
-  }, [dailyRuns, dashboard, activePage]);
+  }, [dailyRuns, dashboard]);
 
   const visibleRunIdsKey = visibleDailyRuns.map((r) => r.runId).join(',');
   const prevRunIdsKeyRef = useRef(visibleRunIdsKey);


### PR DESCRIPTION
## Summary

Final cleanup of nightly run `3c302305`: after a verified re-triage of the 1135 **minor** findings (1121 dismissed as false positives — ~99%), this fixes the **13 genuine** ones. They're small but real.

| Theme | Findings |
|-------|----------|
| **Resource leaks** | `prereqs.py` Ollama + llama.cpp probes called `urlopen()` with no context manager (socket leaked until GC) — wrapped in `with` |
| **Dead code / correctness** | `repo_clone.py` `ignore_errors=True` made the warning `except` unreachable; `ssrf.py` DNS-failure log claimed "fail-closed/private" but returns non-loopback; `useServerLogPoll.js` identical if/else; `useVisibleRuns.js` unused `activePage` dep; `llm_bridge_routes` missing-API-key error lacked the `code` field |
| **Keyboard a11y** | `HeatGridCells` (severity + count cells), `HeatGridView` (sortable headers, with `aria-sort`), `ReferenceEditor` (CWE items), `StandardTree` (Space key + expand parity), `LlamaCppTab` (input `aria-label`) — all were `onClick`-only |

## Not a bug

One re-triage candidate, `_MAX_LEGACY_SCAN` ("unused constant"), is a **false positive** — it's imported and used in `_resolution.py:67`; the agent only checked the defining module. Left in place.

## Verification

Python suites (shared/data/api/import-layers) **223 passing**; full UI vitest **547 passing**; production build clean. The a11y additions follow the same `role=button` + `tabIndex` + Enter/Space pattern established in #677.

With this, nightly run `3c302305` is fully cleared: **0 open findings at every severity** (8 criticals + 214 majors + 1135 minors all triaged → fixed or dismissed).
