### PR TITLE
feat(ui): group score history by day/week/month on the Overview

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -544,6 +544,7 @@ export default function App() {
       dashboard: state.dashboard, accumulated: state.accumulated, latestAccumulated: state.latestAccumulated, loading: state.loading, isFetching: state.isFetching, error: state.error,
       availableRuns: state.availableRuns, dailyRuns: state.dailyRuns, overviewRunIndex: state.overviewRunIndex,
       selectedDisplayName: state.selectedDisplayName,
+      granularity: state.granularity, onGranularityChange: state.onGranularityChange,
     },
     navigation: {
       selectedProject: state.selectedProject, selectedRun: state.selectedRun, projects: state.projects,

--- a/src/quodeq/ui/src/components/terminal/PeriodSelect.jsx
+++ b/src/quodeq/ui/src/components/terminal/PeriodSelect.jsx
@@ -1,0 +1,26 @@
+/**
+ * PeriodSelect — terminal-styled granularity selector for the score-history
+ * chart. A native <select> (keyboard + a11y for free) re-skinned to the mono
+ * terminal idiom, with a static caret. Options: Day / Week / Month.
+ *
+ * @param {object} props
+ * @param {'day'|'week'|'month'} props.value
+ * @param {(next: 'day'|'week'|'month') => void} props.onChange
+ */
+export default function PeriodSelect({ value, onChange }) {
+  return (
+    <span className="term-period-select-wrap">
+      <select
+        className="term-period-select"
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
+        aria-label="Group score history by"
+      >
+        <option value="day">Day</option>
+        <option value="week">Week</option>
+        <option value="month">Month</option>
+      </select>
+      <span className="term-period-select__caret" aria-hidden="true">▾</span>
+    </span>
+  );
+}

--- a/src/quodeq/ui/src/components/terminal/PeriodSelect.test.jsx
+++ b/src/quodeq/ui/src/components/terminal/PeriodSelect.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import PeriodSelect from './PeriodSelect.jsx';
+
+describe('PeriodSelect', () => {
+  it('renders the three options and reflects the current value', () => {
+    render(<PeriodSelect value="week" onChange={() => {}} />);
+    const select = screen.getByLabelText('Group score history by');
+    expect(select).toHaveValue('week');
+    expect(screen.getByRole('option', { name: 'Day' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Week' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Month' })).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected value', () => {
+    const onChange = vi.fn();
+    render(<PeriodSelect value="day" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Group score history by'), { target: { value: 'month' } });
+    expect(onChange).toHaveBeenCalledWith('month');
+  });
+});

--- a/src/quodeq/ui/src/components/terminal/index.js
+++ b/src/quodeq/ui/src/components/terminal/index.js
@@ -11,3 +11,4 @@ export { default as SectionLabel } from './SectionLabel.jsx';
 export { GridTable, GridRow, GridCell } from './GridTable.jsx';
 export { default as CodeGutter } from './CodeGutter.jsx';
 export { default as KeyHint } from './KeyHint.jsx';
+export { default as PeriodSelect } from './PeriodSelect.jsx';

--- a/src/quodeq/ui/src/constants.js
+++ b/src/quodeq/ui/src/constants.js
@@ -23,3 +23,7 @@ export const VISIBLE_STANDARDS_STORAGE_KEY = 'quodeq-visible-standards';
 export const DEFAULT_VISIBLE_STANDARDS = [
   'security', 'reliability', 'maintainability', 'performance', 'usability', 'flexibility',
 ];
+
+export const SCORE_HISTORY_GRANULARITY_STORAGE_KEY = 'quodeq-score-history-granularity';
+export const SCORE_HISTORY_GRANULARITIES = ['day', 'week', 'month'];
+export const DEFAULT_SCORE_HISTORY_GRANULARITY = 'day';

--- a/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/AccumulatedOverviewPanel.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, lazy, Suspense } from 'react';
 import TrendBadge from '../../../components/TrendBadge.jsx';
 import DimensionCardsGrid from './DimensionCardsGrid.jsx';
 import { formatRunId, gradeLetter, complianceRatio, extDisplayName } from '../../../utils/formatters.js';
-import { collapseByDay, collectDayDimensions } from '../../../utils/dailyGrouping.js';
+import { collapseByPeriod, collectPeriodDimensions, bucketKey } from '../../../utils/dailyGrouping.js';
 const RunHistoryPanel = lazy(() => import('./RunHistoryPanel.jsx'));
 import DimensionScorePanel from './DimensionScorePanel.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
@@ -153,46 +153,51 @@ function AccumulatedDimensionsSection({ sortedDimensions, onDimensionClick, sele
 // ---------------------------------------------------------------------------
 
 function useAccumulatedComputations(data) {
-  const { accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, trend, selectedRunId } = data;
+  const { accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, trend, selectedRunId, granularity = 'day' } = data;
   const dayRuns = dailyRuns || availableRuns;
-  const dailyTrend = useMemo(() => collapseByDay(trend), [trend]);
+  const dayTrend = useMemo(() => collapseByPeriod(trend, 'day'), [trend]);
+  const periodTrend = useMemo(() => collapseByPeriod(trend, granularity), [trend, granularity]);
 
   const effectiveSelectedId = useMemo(() => {
-    if (!selectedRunId || !trend.length) return dailyTrend[0]?.runId || null;
-    const direct = dailyTrend.find((t) => t.runId === selectedRunId);
+    if (!selectedRunId || !trend.length) return periodTrend[0]?.runId || null;
+    const direct = periodTrend.find((t) => t.runId === selectedRunId);
     if (direct) return direct.runId;
     const rawEntry = trend.find((t) => t.runId === selectedRunId);
     if (rawEntry) {
-      const datePart = (rawEntry.dateISO || '').slice(0, 10);
-      const dayEntry = dailyTrend.find((t) => (t.dateISO || '').slice(0, 10) === datePart);
-      if (dayEntry) return dayEntry.runId;
+      const key = bucketKey(rawEntry.dateISO, granularity);
+      const bucketEntry = periodTrend.find((t) => bucketKey(t.dateISO, granularity) === key);
+      if (bucketEntry) return bucketEntry.runId;
     }
-    return dailyTrend[0]?.runId || null;
-  }, [selectedRunId, trend, dailyTrend]);
+    return periodTrend[0]?.runId || null;
+  }, [selectedRunId, trend, periodTrend, granularity]);
 
   const currentOverviewRun = effectiveSelectedId || dayRuns[overviewRunIndex]?.runId || 'latest';
   const selectedDayDimNames = useMemo(
-    () => collectDayDimensions(trend, currentOverviewRun) || collectDayDimensions(trend, selectedRunId),
-    [trend, currentOverviewRun, selectedRunId]
+    () => collectPeriodDimensions(trend, currentOverviewRun, granularity) || collectPeriodDimensions(trend, selectedRunId, granularity),
+    [trend, currentOverviewRun, selectedRunId, granularity]
   );
 
   const visibleIds = useMemo(() => readVisibleStandardIds(), [accumulatedDimensions]);
   const visibleSet = useMemo(() => new Set(visibleIds), [visibleIds]);
-  const filteredDailyTrend = useMemo(() => filterTrendByVisibleStandardsDaily(trend, dailyTrend, visibleSet), [trend, dailyTrend, visibleSet]);
-  // Raw (per-run) filtered trend — needed by the dimension sparklines so they
-  // can show every evaluation where the standard was measured, not only the
-  // daily-collapsed representatives.
+  const filteredDayTrend = useMemo(() => filterTrendByVisibleStandardsDaily(trend, dayTrend, visibleSet, 'day'), [trend, dayTrend, visibleSet]);
+  const filteredPeriodTrend = useMemo(() => filterTrendByVisibleStandardsDaily(trend, periodTrend, visibleSet, granularity), [trend, periodTrend, visibleSet, granularity]);
+  // Raw (per-run) filtered trend — sparklines show every evaluation, not the
+  // period-collapsed representatives.
   const filteredTrend = useMemo(() => filterTrendByVisibleStandards(trend, visibleSet), [trend, visibleSet]);
   const filteredDimensions = useMemo(() => accumulatedDimensions.filter((d) => visibleSet.has((d.dimension || '').toLowerCase())), [accumulatedDimensions, visibleIds]);
-  const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredDailyTrend, currentOverviewRun), [accumulated, visibleSet, filteredDailyTrend, currentOverviewRun]);
-  const filteredStats = useMemo(() => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun), [filteredAccumulated, filteredDimensions, filteredDailyTrend, currentOverviewRun]);
+  const filteredAccumulated = useMemo(() => filterAccumulatedByVisibleStandards(accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun), [accumulated, visibleSet, filteredPeriodTrend, currentOverviewRun]);
+  const filteredStats = useMemo(() => computeAccumulatedStats(filteredAccumulated, filteredDimensions, filteredPeriodTrend, currentOverviewRun), [filteredAccumulated, filteredDimensions, filteredPeriodTrend, currentOverviewRun]);
 
-  return { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats };
+  // Preserve today's "panel appears iff ≥2 days of data" behavior, regardless
+  // of the chosen grouping — so the selector never disappears on collapse.
+  const chartMountable = filteredDayTrend.length >= 2;
+
+  return { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable };
 }
 
 export default function AccumulatedOverviewPanel({ data, callbacks }) {
   const { onRunClick, onDimensionClick, onNavigate } = callbacks;
-  const { currentOverviewRun, selectedDayDimNames, filteredDailyTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats } = useAccumulatedComputations(data);
+  const { currentOverviewRun, selectedDayDimNames, filteredPeriodTrend, filteredTrend, filteredDimensions, filteredAccumulated, filteredStats, chartMountable } = useAccumulatedComputations(data);
 
   const topFiles = useMemo(
     () => withDimensionsStr(buildTopOffendingFiles(filteredDimensions || [])),
@@ -247,7 +252,15 @@ export default function AccumulatedOverviewPanel({ data, callbacks }) {
 
       <div className="history-panels-row">
         <Suspense fallback={null}>
-          <RunHistoryPanel trend={filteredDailyTrend} selectedRunId={currentOverviewRun} onBarClick={onRunClick} />
+          {chartMountable && (
+            <RunHistoryPanel
+              trend={filteredPeriodTrend}
+              selectedRunId={currentOverviewRun}
+              onBarClick={onRunClick}
+              granularity={data.granularity || 'day'}
+              onGranularityChange={callbacks.onGranularityChange}
+            />
+          )}
         </Suspense>
         <DimensionScorePanel dimensions={filteredDimensions} onBarClick={onDimensionClick} runDate={filteredStats.lastRun.date} runId={filteredStats.lastRun.runId} trend={filteredTrend} />
       </div>

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -32,9 +32,9 @@ function NoCompletedEvalPanel({ availableRuns = [], onNavigate }) {
 }
 
 function DashboardContent({ runMode, data, focus, callbacks }) {
-  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo } = data;
+  const { dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity } = data;
   const { dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData } = focus;
-  const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate } = callbacks;
+  const { onRunSelect, onDimensionCardClick, onAccumulatedDimensionClick, onFileClick, onNavigate, onGranularityChange } = callbacks;
   if (runMode) {
     return (
       <RunOverviewPanel
@@ -77,10 +77,10 @@ function DashboardContent({ runMode, data, focus, callbacks }) {
       data={{
         accumulated: accumulated ? { ...accumulated, dimensions: accumulatedDimensions } : accumulated,
         accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex,
-        trend: dashboard?.trend || [], selectedRunId, selectedProject, projectInfo,
+        trend: dashboard?.trend || [], selectedRunId, selectedProject, projectInfo, granularity,
       }}
       callbacks={{
-        onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick, onNavigate,
+        onRunClick: onRunSelect, onDimensionClick: onAccumulatedDimensionClick, onNavigate, onGranularityChange,
       }}
     />
   );
@@ -107,9 +107,9 @@ function useDashboardHandlers(onNavigate, dashboard) {
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0 } = data;
+  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day' } = data;
   const projectInfo = projects.find((p) => (p.id || p.name) === selectedProject) || null;
-  const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
+  const { onNavigate, onRunSelect, onProjectsReload, onGranularityChange } = callbacks;
   // After a successful clone-on-add migration the project's repository_info.json
   // has been rewritten with location: "local". Refetch the projects list so the
   // sidebar/header reflect the new state. Fall back to a full reload if no
@@ -185,9 +185,9 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
       {dashboard && (
         <DashboardContent
           runMode={runMode}
-          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo }}
+          data={{ dashboard, selectedRunId, accumulated, accumulatedDimensions, availableRuns, dailyRuns, overviewRunIndex, selectedProject, projectInfo, granularity }}
           focus={{ dimension: focusedDimension, setDimension: setFocusedDimension, dimensionData: focusedDimensionData }}
-          callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate }}
+          callbacks={{ onRunSelect, onDimensionCardClick: handlers.handleDimensionCardClick, onAccumulatedDimensionClick: handlers.handleAccumulatedDimensionClick, onFileClick: handlers.handleFileClick, onNavigate, onGranularityChange }}
         />
       )}
     </div>

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -107,9 +107,9 @@ function useDashboardHandlers(onNavigate, dashboard) {
 }
 
 export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
-  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day' } = data;
+  const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange } = data;
   const projectInfo = projects.find((p) => (p.id || p.name) === selectedProject) || null;
-  const { onNavigate, onRunSelect, onProjectsReload, onGranularityChange } = callbacks;
+  const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
   // After a successful clone-on-add migration the project's repository_info.json
   // has been rewritten with location: "local". Refetch the projects list so the
   // sidebar/header reflect the new state. Fall back to a full reload if no

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { gradeLetter } from '../../../utils/formatters.js';
-import { SectionLabel } from '../../../components/terminal/index.js';
+import { SectionLabel, PeriodSelect } from '../../../components/terminal/index.js';
 import {
   ComposedChart,
   Area,
@@ -26,6 +26,7 @@ import {
 
 const MAX_CHART_RUNS = 20;
 const CHART_HEIGHT = 160;
+const GRANULARITY_SUFFIX = { day: 'd', week: 'w', month: 'mo' };
 
 
 function buildTrendData(trend, selectedRunId) {
@@ -137,29 +138,44 @@ function ScoreHistoryChart({ data, interaction }) {
   );
 }
 
-export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBarClick }) {
+export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBarClick, granularity = 'day', onGranularityChange }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
   // Hooks must run in the same order every render, so compute before any early return.
   const data = useMemo(() => buildTrendData(trend, selectedRunId), [trend, selectedRunId]);
 
-  if (!trend || trend.length < 2) return null;
+  // The parent only mounts this panel when there are ≥2 days of data, so an
+  // empty trend shouldn't happen — but guard the truly-empty case. A single
+  // bucket (e.g. all runs fall in one month) still renders the header so the
+  // selector stays reachable; only the chart body + MIN/MAX/AVG are hidden.
+  if (!trend || trend.length < 1) return null;
 
-  const min = Math.min(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
-  const max = Math.max(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
-  const avg = data.reduce((s, d) => s + (Number.isNaN(d.numericAverage) ? 0 : d.numericAverage), 0) / data.length;
+  const hasChart = data.length >= 2;
+  const suffix = GRANULARITY_SUFFIX[granularity] || 'd';
+  let stats = null;
+  if (hasChart) {
+    const min = Math.min(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
+    const max = Math.max(...data.map((d) => d.numericAverage).filter((n) => !Number.isNaN(n)));
+    const avg = data.reduce((s, d) => s + (Number.isNaN(d.numericAverage) ? 0 : d.numericAverage), 0) / data.length;
+    stats = `MIN ${min.toFixed(1)} / MAX ${max.toFixed(1)} / AVG ${avg.toFixed(1)}`;
+  }
 
   return (
     <section className="run-history-panel run-history-panel--terminal panel" aria-label="Score history chart">
       <div className="run-history-panel__header">
-        <SectionLabel>score_history · {data.length}d</SectionLabel>
-        <span className="run-history-panel__stats">
-          MIN {min.toFixed(1)} / MAX {max.toFixed(1)} / AVG {avg.toFixed(1)}
+        <SectionLabel>score_history · {data.length}{suffix}</SectionLabel>
+        <span className="run-history-panel__controls">
+          {onGranularityChange && <PeriodSelect value={granularity} onChange={onGranularityChange} />}
+          {stats && <span className="run-history-panel__stats">{stats}</span>}
         </span>
       </div>
-      <ScoreHistoryChart
-        data={data}
-        interaction={{ hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }}
-      />
+      {hasChart ? (
+        <ScoreHistoryChart
+          data={data}
+          interaction={{ hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }}
+        />
+      ) : (
+        <p className="run-history-panel__sparse">Only one {granularity} of data — choose a finer grouping to see a trend.</p>
+      )}
     </section>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { gradeLetter } from '../../../utils/formatters.js';
+import { gradeLetter, formatPeriodLabel } from '../../../utils/formatters.js';
 import { SectionLabel, PeriodSelect } from '../../../components/terminal/index.js';
 import {
   ComposedChart,
@@ -29,12 +29,13 @@ const CHART_HEIGHT = 160;
 const GRANULARITY_SUFFIX = { day: 'd', week: 'w', month: 'mo' };
 
 
-function buildTrendData(trend, selectedRunId) {
+function buildTrendData(trend, selectedRunId, granularity = 'day') {
   return [...trend].slice(0, MAX_CHART_RUNS).reverse().map((row, i, arr) => {
     const numericAverage = parseFloat(row.numericAverage);
     return {
       ...row,
       numericAverage,
+      periodLabel: formatPeriodLabel(row, granularity),
       delta: i > 0 ? numericAverage - parseFloat(arr[i - 1].numericAverage) : null,
     };
   });
@@ -49,7 +50,7 @@ function RunHistoryTooltip({ active, payload }) {
   const grade = gradeLetter(entry.overallGrade);
   return (
     <div className="run-history-tooltip">
-      <span className="rht-date">{entry.dateLabel}</span>
+      <span className="rht-date">{entry.periodLabel || entry.dateLabel}</span>
       <span className="rht-score">{score} - {grade}</span>
     </div>
   );
@@ -141,7 +142,7 @@ function ScoreHistoryChart({ data, interaction }) {
 export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBarClick, granularity = 'day', onGranularityChange }) {
   const [hoveredIndex, setHoveredIndex] = useState(null);
   // Hooks must run in the same order every render, so compute before any early return.
-  const data = useMemo(() => buildTrendData(trend, selectedRunId), [trend, selectedRunId]);
+  const data = useMemo(() => buildTrendData(trend, selectedRunId, granularity), [trend, selectedRunId, granularity]);
 
   // The parent only mounts this panel when there are ≥2 days of data, so an
   // empty trend shouldn't happen — but guard the truly-empty case. A single

--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import RunHistoryPanel from './RunHistoryPanel.jsx';
+
+const TREND = [
+  { runId: 'r1', dateISO: '2026-03-25T14:00:00', dateLabel: '25 Mar 2026', numericAverage: 9.5, overallGrade: 'Exemplary' },
+  { runId: 'r2', dateISO: '2026-03-24T10:00:00', dateLabel: '24 Mar 2026', numericAverage: 9.0, overallGrade: 'Good' },
+  { runId: 'r3', dateISO: '2026-03-23T10:00:00', dateLabel: '23 Mar 2026', numericAverage: 8.5, overallGrade: 'Good' },
+];
+
+describe('RunHistoryPanel', () => {
+  it('renders the granularity selector reflecting the current value', () => {
+    render(<RunHistoryPanel trend={TREND} selectedRunId="r1" granularity="week" onGranularityChange={() => {}} />);
+    expect(screen.getByLabelText('Group score history by')).toHaveValue('week');
+  });
+
+  it('shows a granularity-aware label suffix (w for week)', () => {
+    render(<RunHistoryPanel trend={TREND} selectedRunId="r1" granularity="week" onGranularityChange={() => {}} />);
+    expect(screen.getByText(/score_history · 3w/i)).toBeInTheDocument();
+  });
+
+  it('calls onGranularityChange when the selector changes', () => {
+    const onGranularityChange = vi.fn();
+    render(<RunHistoryPanel trend={TREND} selectedRunId="r1" granularity="day" onGranularityChange={onGranularityChange} />);
+    fireEvent.change(screen.getByLabelText('Group score history by'), { target: { value: 'month' } });
+    expect(onGranularityChange).toHaveBeenCalledWith('month');
+  });
+
+  it('keeps the selector but hides MIN/MAX/AVG when collapsed to a single bucket', () => {
+    render(<RunHistoryPanel trend={[TREND[0]]} selectedRunId="r1" granularity="month" onGranularityChange={() => {}} />);
+    expect(screen.getByLabelText('Group score history by')).toBeInTheDocument();
+    expect(screen.queryByText(/MIN /)).not.toBeInTheDocument();
+  });
+});

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -1,7 +1,8 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { useDashboard } from '../features/dashboard/hooks/useDashboard.js';
 import { usePrefetchAdjacentRuns } from '../features/dashboard/hooks/usePrefetchAdjacentRuns.js';
-import { buildDailyRuns } from '../utils/dailyGrouping.js';
+import { buildPeriodRuns } from '../utils/dailyGrouping.js';
+import { readScoreHistoryGranularity, writeScoreHistoryGranularity } from '../utils/scoreHistoryPrefs.js';
 import { useServerHealth } from './useServerHealth.js';
 import { useNavStack } from './useNavStack.js';
 import { useRunNavigator } from './useRunNavigator.js';
@@ -97,6 +98,11 @@ export function useAppState() {
     selectProjectAndRun, handleDeleteProject, handleExportProject, handleRelocateProject, handleImportProject,
   } = projectBundle;
   const settings = useAppSettings();
+  const [granularity, setGranularity] = useState(() => readScoreHistoryGranularity());
+  const handleGranularityChange = useCallback((next) => {
+    setGranularity(next);
+    writeScoreHistoryGranularity(next);
+  }, []);
   const isHistoryRun = activePage.page === 'history-run';
   const isHistoryTab = activePage.page === 'history';
   const effectiveRun = isHistoryRun ? historySelectedRun : selectedRun;
@@ -113,9 +119,9 @@ export function useAppState() {
     keepPlaceholder: !isHistoryRun && !isHistoryTab,
   });
   const { dailyRuns: rawDailyRuns, headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId } = useMemo(() => ({
-    dailyRuns: buildDailyRuns(availableRuns, dashboard?.trend || []),
+    dailyRuns: buildPeriodRuns(availableRuns, dashboard?.trend || [], granularity),
     ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
-  }), [availableRuns, dashboard, accumulated, selectedProject, projects]);
+  }), [availableRuns, dashboard, accumulated, selectedProject, projects, granularity]);
   const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const prefetchHandlers = usePrefetchAdjacentRuns({ selectedProject, availableRuns: visibleDailyRuns, overviewRunIndex });
@@ -154,5 +160,6 @@ export function useAppState() {
     headerMeta, selectedDisplayName, selectedProjectParent, selectedProjectParentId,
     historySelectedRun, setHistorySelectedRun,
     evalLifecycle, settings, activeTab, showProjectHeader, showRunNav, refreshDashboard,
+    granularity, onGranularityChange: handleGranularityChange,
   };
 }

--- a/src/quodeq/ui/src/hooks/useAppState.js
+++ b/src/quodeq/ui/src/hooks/useAppState.js
@@ -122,7 +122,7 @@ export function useAppState() {
     dailyRuns: buildPeriodRuns(availableRuns, dashboard?.trend || [], granularity),
     ...computeDerivedState(accumulated, dashboard, selectedProject, projects),
   }), [availableRuns, dashboard, accumulated, selectedProject, projects, granularity]);
-  const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun);
+  const visibleDailyRuns = useVisibleRuns(rawDailyRuns, dashboard, activePage.page, setSelectedRun, granularity);
   const { overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest, handleRunView, handleRunSelect } = useRunNavigator({ selectedRun, availableRuns: visibleDailyRuns, onRunChange: handleRunChange, onNavigate: handleNavigate });
   const prefetchHandlers = usePrefetchAdjacentRuns({ selectedProject, availableRuns: visibleDailyRuns, overviewRunIndex });
   const evalLifecycle = useEvaluationLifecycle({ settings, navigation: { navTab, navReset }, projects: { loadProjects, setProjects, selectProjectAndRun } });

--- a/src/quodeq/ui/src/hooks/useVisibleRuns.js
+++ b/src/quodeq/ui/src/hooks/useVisibleRuns.js
@@ -1,28 +1,32 @@
 import { useMemo, useEffect, useRef } from 'react';
 import { readVisibleStandardIds } from '../utils/visibleStandards.js';
+import { bucketKey } from '../utils/dailyGrouping.js';
 
 /**
  * Filters dailyRuns to those where at least one visible standard dimension
  * was evaluated. Resets selectedRun to 'latest' whenever the visible set
  * changes to a non-empty result.
+ *
+ * @param granularity - period granularity ('day' | 'week' | 'month'); determines
+ *   which period buckets are considered visible, matching the chart's bucketing.
  */
-export function useVisibleRuns(dailyRuns, dashboard, activePage, setSelectedRun) {
+export function useVisibleRuns(dailyRuns, dashboard, activePage, setSelectedRun, granularity = 'day') {
   const visibleDailyRuns = useMemo(() => {
     const visibleSet = new Set(readVisibleStandardIds());
     const trendEntries = dashboard?.trend || [];
-    // Build set of dates where at least one visible dimension was evaluated
+    // Build set of period buckets where at least one visible dimension was evaluated
     const visibleDates = new Set();
     for (const entry of trendEntries) {
       if ((entry.dimensions || []).some((d) => visibleSet.has(d.toLowerCase()))) {
-        visibleDates.add((entry.dateISO || '').slice(0, 10));
+        visibleDates.add(bucketKey(entry.dateISO, granularity));
       }
     }
     const trendByRunId = new Map(trendEntries.map((t) => [t.runId, t]));
     return dailyRuns.filter((run) => {
-      const datePart = (trendByRunId.get(run.runId)?.dateISO || '').slice(0, 10);
-      return visibleDates.has(datePart);
+      const bucket = bucketKey(trendByRunId.get(run.runId)?.dateISO, granularity);
+      return visibleDates.has(bucket);
     });
-  }, [dailyRuns, dashboard, activePage]);
+  }, [dailyRuns, dashboard, activePage, granularity]);
 
   const visibleRunIdsKey = visibleDailyRuns.map((r) => r.runId).join(',');
   const prevRunIdsKeyRef = useRef(visibleRunIdsKey);

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2384,3 +2384,41 @@ button.term-sev-badge--clickable:focus-visible {
 .eval-job-stat-strip .term-stat__value {
   font-size: 18px;
 }
+
+/* ------------------------------------------------------------
+   PeriodSelect: Day / Week / Month grouping selector
+   ------------------------------------------------------------ */
+.term-period-select-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+.term-period-select {
+  appearance: none;
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  line-height: 1;
+  padding: var(--term-space-1) calc(var(--term-space-3) + 6px) var(--term-space-1) var(--term-space-2);
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--term-radius);
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.term-period-select:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+.term-period-select:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+  border-color: var(--color-accent);
+}
+.term-period-select__caret {
+  position: absolute;
+  right: var(--term-space-2);
+  font-size: 9px;
+  color: var(--color-text-muted);
+  pointer-events: none;
+}

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2410,9 +2410,12 @@ button.term-sev-badge--clickable:focus-visible {
   color: var(--color-text);
   border-color: var(--color-text-muted);
 }
+.term-period-select:focus {
+  outline: none;
+}
 .term-period-select:focus-visible {
-  outline: 1px solid var(--color-border);
-  outline-offset: 1px;
+  outline: none;
+  border-color: var(--color-text-muted);
 }
 .term-period-select__caret {
   position: absolute;

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2422,3 +2422,18 @@ button.term-sev-badge--clickable:focus-visible {
   color: var(--color-text-muted);
   pointer-events: none;
 }
+
+/* ------------------------------------------------------------
+   RunHistoryPanel: score-history chart with grouping selector
+   ------------------------------------------------------------ */
+.run-history-panel--terminal .run-history-panel__controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--term-space-3);
+}
+.run-history-panel--terminal .run-history-panel__sparse {
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  margin: 0;
+}

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -2411,9 +2411,8 @@ button.term-sev-badge--clickable:focus-visible {
   border-color: var(--color-text-muted);
 }
 .term-period-select:focus-visible {
-  outline: 2px solid var(--color-accent);
+  outline: 1px solid var(--color-border);
   outline-offset: 1px;
-  border-color: var(--color-accent);
 }
 .term-period-select__caret {
   position: absolute;

--- a/src/quodeq/ui/src/utils/dailyGrouping.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.js
@@ -1,4 +1,110 @@
 /**
+ * ISO-8601 week key (Monday start; week 1 contains the first Thursday).
+ * Operates timezone-naively on the YYYY-MM-DD prefix via Date.UTC, matching
+ * how the day grouping slices the date string.
+ *
+ * @param {string} dateISO
+ * @returns {string} e.g. "2026-W13", or "" when the date is missing/invalid
+ */
+export function isoWeekKey(dateISO) {
+  const datePart = (dateISO || '').slice(0, 10);
+  const [y, m, d] = datePart.split('-').map(Number);
+  if (!y || !m || !d) return '';
+  const date = new Date(Date.UTC(y, m - 1, d));
+  const dayNum = date.getUTCDay() || 7;           // Mon=1 .. Sun=7
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum); // shift to this week's Thursday
+  const isoYear = date.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(isoYear, 0, 1));
+  const weekNo = Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
+  return `${isoYear}-W${String(weekNo).padStart(2, '0')}`;
+}
+
+/**
+ * Bucket key for a trend/run entry's date at the given granularity.
+ * Empty dates produce "" (their own group), matching legacy day behavior.
+ *
+ * @param {string} dateISO
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @returns {string}
+ */
+export function bucketKey(dateISO, granularity = 'day') {
+  if (granularity === 'month') return (dateISO || '').slice(0, 7);
+  if (granularity === 'week') return isoWeekKey(dateISO);
+  return (dateISO || '').slice(0, 10);
+}
+
+/**
+ * Collapse trend entries (newest-first) into one entry per period bucket,
+ * keeping the first (newest) entry of each bucket — the most up-to-date
+ * accumulated state for that period.
+ *
+ * @param {Array} trend - Trend entries, newest first
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @returns {Array} Collapsed entries, one per bucket
+ */
+export function collapseByPeriod(trend, granularity = 'day') {
+  if (!trend || trend.length === 0) return trend;
+  const collapsed = [];
+  let currentKey = null;
+  for (const entry of trend) {
+    const key = bucketKey(entry.dateISO, granularity);
+    if (key !== currentKey) {
+      currentKey = key;
+      collapsed.push({ ...entry });
+    }
+  }
+  return collapsed;
+}
+
+/**
+ * Build a Set of dimension names evaluated in the selected run's period.
+ *
+ * @param {Array} trend - Raw trend entries (all runs)
+ * @param {string} selectedRunId
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @returns {Set<string>} Lowercase dimension names evaluated that period
+ */
+export function collectPeriodDimensions(trend, selectedRunId, granularity = 'day') {
+  if (!trend || !trend.length || !selectedRunId) return new Set();
+  const entry = trend.find((t) => t.runId === selectedRunId);
+  if (!entry) return new Set();
+  const selectedKey = bucketKey(entry.dateISO, granularity);
+  if (!selectedKey) return new Set();
+  const names = new Set();
+  for (const t of trend) {
+    if (bucketKey(t.dateISO, granularity) === selectedKey) {
+      for (const dim of t.dimensions || []) names.add(dim.toLowerCase());
+    }
+  }
+  return names;
+}
+
+/**
+ * Build period-level available runs, keeping the first (newest) run per bucket.
+ *
+ * @param {Array} availableRuns - Raw available runs (newest first)
+ * @param {Array} trend - Trend entries with dateISO
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @returns {Array} One run per bucket
+ */
+export function buildPeriodRuns(availableRuns, trend, granularity = 'day') {
+  if (!availableRuns || !availableRuns.length) return [];
+  const trendMap = new Map(trend.map((r) => [r.runId, r]));
+  const byBucket = [];
+  let lastKey = null;
+  for (const run of availableRuns) {
+    const t = trendMap.get(run.runId);
+    const key = bucketKey(t?.dateISO, granularity);
+    if (key !== lastKey) {
+      byBucket.push(run);
+      lastKey = key;
+    }
+  }
+  return byBucket;
+}
+
+// ── Day-named wrappers (preserve existing call sites and tests) ─────────────
+/**
  * Collapse trend entries (newest-first) into one entry per calendar day.
  * Keeps the first (newest) entry of each day, which has the most
  * up-to-date accumulated state.
@@ -7,17 +113,7 @@
  * @returns {Array} Collapsed entries, one per day
  */
 export function collapseByDay(trend) {
-  if (!trend || trend.length === 0) return trend;
-  const collapsed = [];
-  let currentDay = null;
-  for (const entry of trend) {
-    const datePart = (entry.dateISO || '').slice(0, 10);
-    if (datePart !== currentDay) {
-      currentDay = datePart;
-      collapsed.push({ ...entry });
-    }
-  }
-  return collapsed;
+  return collapseByPeriod(trend, 'day');
 }
 
 /**
@@ -29,18 +125,7 @@ export function collapseByDay(trend) {
  * @returns {Set<string>} Lowercase dimension names evaluated that day
  */
 export function collectDayDimensions(trend, selectedRunId) {
-  if (!trend || !trend.length || !selectedRunId) return new Set();
-  const entry = trend.find((t) => t.runId === selectedRunId);
-  if (!entry) return new Set();
-  const selectedDate = (entry.dateISO || '').slice(0, 10);
-  if (!selectedDate) return new Set();
-  const names = new Set();
-  for (const t of trend) {
-    if ((t.dateISO || '').slice(0, 10) === selectedDate) {
-      for (const d of t.dimensions || []) names.add(d.toLowerCase());
-    }
-  }
-  return names;
+  return collectPeriodDimensions(trend, selectedRunId, 'day');
 }
 
 /**
@@ -52,17 +137,5 @@ export function collectDayDimensions(trend, selectedRunId) {
  * @returns {Array} One entry per day
  */
 export function buildDailyRuns(availableRuns, trend) {
-  if (!availableRuns || !availableRuns.length) return [];
-  const trendMap = new Map(trend.map((r) => [r.runId, r]));
-  const byDay = [];
-  let lastDate = null;
-  for (const run of availableRuns) {
-    const t = trendMap.get(run.runId);
-    const datePart = (t?.dateISO || '').slice(0, 10);
-    if (datePart !== lastDate) {
-      byDay.push(run);
-      lastDate = datePart;
-    }
-  }
-  return byDay;
+  return buildPeriodRuns(availableRuns, trend, 'day');
 }

--- a/src/quodeq/ui/src/utils/dailyGrouping.test.js
+++ b/src/quodeq/ui/src/utils/dailyGrouping.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { collapseByDay, collectDayDimensions, buildDailyRuns } from './dailyGrouping.js';
+import {
+  collapseByDay, collectDayDimensions, buildDailyRuns,
+  bucketKey, isoWeekKey, collapseByPeriod, collectPeriodDimensions, buildPeriodRuns,
+} from './dailyGrouping.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -139,4 +142,115 @@ test('buildDailyRuns: all runs on same day returns one entry', () => {
   const result = buildDailyRuns(runs, trend);
   assert.equal(result.length, 1);
   assert.equal(result[0].runId, 'r1');
+});
+
+// ---------------------------------------------------------------------------
+// New test fixtures for day/week/month grouping
+// ---------------------------------------------------------------------------
+
+// Runs spanning 3 days / 3 ISO-weeks / 3 months (newest-first).
+const MULTI = [
+  { runId: 'm1', dateISO: '2026-05-02T12:00:00', dimensions: ['security'] },        // Sat W18, 2026-05
+  { runId: 'm2', dateISO: '2026-04-14T18:00:00', dimensions: ['maintainability'] }, // Tue W16, 2026-04
+  { runId: 'm3', dateISO: '2026-04-14T09:00:00', dimensions: ['reliability'] },     // Tue W16 (older same day)
+  { runId: 'm4', dateISO: '2026-03-25T14:00:00', dimensions: ['security'] },        // Wed W13, 2026-03
+  { runId: 'm5', dateISO: '2026-03-23T10:00:00', dimensions: ['performance'] },     // Mon W13, 2026-03
+];
+
+const MULTI_RUNS = [
+  { runId: 'm1', dateLabel: '2 May 2026' },
+  { runId: 'm2', dateLabel: '14 Apr 2026' },
+  { runId: 'm3', dateLabel: '14 Apr 2026' },
+  { runId: 'm4', dateLabel: '25 Mar 2026' },
+  { runId: 'm5', dateLabel: '23 Mar 2026' },
+];
+
+// ---------------------------------------------------------------------------
+// isoWeekKey
+// ---------------------------------------------------------------------------
+
+test('isoWeekKey: ISO week with Monday start', () => {
+  assert.equal(isoWeekKey('2026-03-23T10:00:00'), '2026-W13'); // Monday
+  assert.equal(isoWeekKey('2026-03-25T14:00:00'), '2026-W13'); // Wednesday same week
+  assert.equal(isoWeekKey('2026-04-14T18:00:00'), '2026-W16');
+  assert.equal(isoWeekKey('2026-01-05T00:00:00'), '2026-W02');
+});
+
+test('isoWeekKey: year-boundary week belongs to the ISO year of its Thursday', () => {
+  assert.equal(isoWeekKey('2025-12-29T00:00:00'), '2026-W01'); // Mon whose Thu is 2026-01-01
+  assert.equal(isoWeekKey('2026-01-01T00:00:00'), '2026-W01'); // Thursday
+  assert.equal(isoWeekKey('2026-01-04T00:00:00'), '2026-W01'); // Sunday, still W01
+});
+
+test('isoWeekKey: missing/empty date returns empty string', () => {
+  assert.equal(isoWeekKey(''), '');
+  assert.equal(isoWeekKey(null), '');
+});
+
+// ---------------------------------------------------------------------------
+// bucketKey
+// ---------------------------------------------------------------------------
+
+test('bucketKey: day/week/month keys', () => {
+  assert.equal(bucketKey('2026-03-25T14:00:00', 'day'), '2026-03-25');
+  assert.equal(bucketKey('2026-03-25T14:00:00', 'month'), '2026-03');
+  assert.equal(bucketKey('2026-03-25T14:00:00', 'week'), '2026-W13');
+  assert.equal(bucketKey('2026-03-25T14:00:00'), '2026-03-25'); // default day
+  assert.equal(bucketKey('', 'week'), '');
+});
+
+// ---------------------------------------------------------------------------
+// collapseByPeriod
+// ---------------------------------------------------------------------------
+
+test('collapseByPeriod: day matches collapseByDay (no-op parity)', () => {
+  assert.deepEqual(collapseByPeriod(TREND, 'day'), collapseByDay(TREND));
+});
+
+test('collapseByPeriod: week keeps newest run per ISO week', () => {
+  const result = collapseByPeriod(MULTI, 'week');
+  assert.deepEqual(result.map((r) => r.runId), ['m1', 'm2', 'm4']);
+});
+
+test('collapseByPeriod: month keeps newest run per month', () => {
+  const result = collapseByPeriod(MULTI, 'month');
+  assert.deepEqual(result.map((r) => r.runId), ['m1', 'm2', 'm4']);
+});
+
+// ---------------------------------------------------------------------------
+// collectPeriodDimensions
+// ---------------------------------------------------------------------------
+
+test('collectPeriodDimensions: month gathers all dims in the run\'s month', () => {
+  const dims = collectPeriodDimensions(MULTI, 'm4', 'month'); // 2026-03: m4 + m5
+  assert.equal(dims.size, 2);
+  assert.ok(dims.has('security'));
+  assert.ok(dims.has('performance'));
+});
+
+test('collectPeriodDimensions: week gathers all dims in the run\'s ISO week', () => {
+  const dims = collectPeriodDimensions(MULTI, 'm2', 'week'); // W16: m2 + m3
+  assert.equal(dims.size, 2);
+  assert.ok(dims.has('maintainability'));
+  assert.ok(dims.has('reliability'));
+});
+
+test('collectPeriodDimensions: day matches collectDayDimensions', () => {
+  assert.deepEqual(
+    [...collectPeriodDimensions(TREND, 'r3', 'day')].sort(),
+    [...collectDayDimensions(TREND, 'r3')].sort(),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// buildPeriodRuns
+// ---------------------------------------------------------------------------
+
+test('buildPeriodRuns: month keeps newest run per month', () => {
+  const result = buildPeriodRuns(MULTI_RUNS, MULTI, 'month');
+  assert.deepEqual(result.map((r) => r.runId), ['m1', 'm2', 'm4']);
+});
+
+test('buildPeriodRuns: day matches buildDailyRuns', () => {
+  assert.deepEqual(buildPeriodRuns(AVAILABLE_RUNS, TREND, 'day'), buildDailyRuns(AVAILABLE_RUNS, TREND));
 });

--- a/src/quodeq/ui/src/utils/formatters.js
+++ b/src/quodeq/ui/src/utils/formatters.js
@@ -1,4 +1,5 @@
 import { getGradeThresholds } from './gradeThresholds.js';
+import { isoWeekKey } from './dailyGrouping.js';
 
 /**
  * Grade-to-CSS-class mapping.
@@ -261,4 +262,36 @@ export function mostFrequentGrade(grades) {
     }
   });
   return capitalizeGrade(maxGrade);
+}
+
+const PERIOD_MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/**
+ * Human label for a score-history bucket at the given grouping granularity.
+ * - day   -> the entry's specific date label (e.g. "25 Mar 2026")
+ * - month -> "March 2026" (from the YYYY-MM prefix; timezone-naive)
+ * - week  -> "Week 13, 2026" (from the ISO week key)
+ * Falls back to the entry's dateLabel (then dateISO) when unparseable.
+ *
+ * @param {{ dateISO?: string, dateLabel?: string }} entry
+ * @param {'day'|'week'|'month'} [granularity='day']
+ * @returns {string}
+ */
+export function formatPeriodLabel(entry, granularity = 'day') {
+  const iso = entry?.dateISO || '';
+  const fallback = entry?.dateLabel || iso;
+  if (granularity === 'month') {
+    const [y, m] = iso.slice(0, 7).split('-');
+    const idx = Number(m) - 1;
+    return (y && PERIOD_MONTH_NAMES[idx]) ? `${PERIOD_MONTH_NAMES[idx]} ${y}` : fallback;
+  }
+  if (granularity === 'week') {
+    const key = isoWeekKey(iso); // 'YYYY-Www' or ''
+    const [y, w] = key.split('-W');
+    return (y && w) ? `Week ${Number(w)}, ${y}` : fallback;
+  }
+  return fallback;
 }

--- a/src/quodeq/ui/src/utils/formatters.period.test.js
+++ b/src/quodeq/ui/src/utils/formatters.period.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatPeriodLabel } from './formatters.js';
+
+const E = { dateISO: '2026-03-25T14:00:00', dateLabel: '25 Mar 2026' };
+
+test('day granularity shows the specific date label', () => {
+  assert.equal(formatPeriodLabel(E, 'day'), '25 Mar 2026');
+  assert.equal(formatPeriodLabel(E), '25 Mar 2026'); // default day
+});
+
+test('month granularity shows month name + year', () => {
+  assert.equal(formatPeriodLabel(E, 'month'), 'March 2026');
+});
+
+test('week granularity shows ISO week number + year', () => {
+  assert.equal(formatPeriodLabel(E, 'week'), 'Week 13, 2026');
+});
+
+test('week granularity respects the ISO year-boundary', () => {
+  assert.equal(formatPeriodLabel({ dateISO: '2025-12-29T00:00:00' }, 'week'), 'Week 1, 2026');
+});
+
+test('falls back to dateLabel when dateISO is missing', () => {
+  assert.equal(formatPeriodLabel({ dateLabel: 'Latest' }, 'month'), 'Latest');
+  assert.equal(formatPeriodLabel({ dateLabel: 'Latest' }, 'week'), 'Latest');
+});

--- a/src/quodeq/ui/src/utils/scoreFiltering.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.js
@@ -5,6 +5,8 @@
  * returned by the unified /scores endpoint.
  */
 
+import { bucketKey } from './dailyGrouping.js';
+
 const roundOneDecimal = (n) => Math.round(n * 10) / 10;
 
 /**
@@ -45,21 +47,22 @@ export function filterTrendByVisibleStandards(trend, visibleSet) {
 }
 
 /**
- * Filter trend and collapse to daily entries (one per calendar day).
+ * Filter trend and collapse to period entries (one per calendar day, week, or month).
  *
  * Walks the raw trend oldest-first to build accumulated averages,
- * then maps onto dailyTrend entries (collapsed by day) for display.
- * Used by the Overview panel where bars represent days, not individual runs.
+ * then maps onto periodTrend entries (collapsed by the specified granularity) for display.
+ * Used by the Overview panel where bars represent periods, not individual runs.
  *
  * @param {Array} trend - Raw trend entries (newest-first)
- * @param {Array} dailyTrend - Daily-collapsed trend entries (from collapseByDay)
+ * @param {Array} periodTrend - Period-collapsed trend entries (from collapseByPeriod)
  * @param {Set<string>} visibleSet - Lowercase dimension IDs to include
- * @returns {Array} Filtered daily trend entries (newest-first)
+ * @param {'day'|'week'|'month'} [granularity='day'] - Bucket granularity
+ * @returns {Array} Filtered period trend entries (newest-first)
  */
-export function filterTrendByVisibleStandardsDaily(trend, dailyTrend, visibleSet) {
+export function filterTrendByVisibleStandardsDaily(trend, periodTrend, visibleSet, granularity = 'day') {
   const accByDim = {};
-  const accByDate = new Map(); // date string -> accAvg
-  const visibleDates = new Set();
+  const accByKey = new Map(); // bucket key -> accAvg
+  const visibleKeys = new Set();
   const rawReversed = [...trend].reverse(); // oldest first
   for (const entry of rawReversed) {
     let hasVisible = false;
@@ -73,17 +76,17 @@ export function filterTrendByVisibleStandardsDaily(trend, dailyTrend, visibleSet
     if (hasVisible) {
       const accScores = Object.values(accByDim).filter((s) => s != null);
       const accAvg = accScores.length > 0 ? roundOneDecimal(accScores.reduce((a, b) => a + b, 0) / accScores.length) : null;
-      const datePart = (entry.dateISO || '').slice(0, 10);
-      accByDate.set(datePart, accAvg);
-      visibleDates.add(datePart);
+      const key = bucketKey(entry.dateISO, granularity);
+      accByKey.set(key, accAvg);
+      visibleKeys.add(key);
     }
   }
-  // Match daily entries by date, only include days with visible evaluations
-  return dailyTrend
-    .filter((entry) => visibleDates.has((entry.dateISO || '').slice(0, 10)))
+  // Match period entries by bucket key, only include periods with visible evaluations
+  return periodTrend
+    .filter((entry) => visibleKeys.has(bucketKey(entry.dateISO, granularity)))
     .map((entry) => {
-      const datePart = (entry.dateISO || '').slice(0, 10);
-      const accAvg = accByDate.get(datePart) ?? null;
+      const key = bucketKey(entry.dateISO, granularity);
+      const accAvg = accByKey.get(key) ?? null;
       const details = (entry.dimensionDetails || []).filter((d) => visibleSet.has((d.dimension || '').toLowerCase()));
       const runScores = details.map((d) => d.score).filter((s) => s != null);
       const runAvg = runScores.length > 0 ? roundOneDecimal(runScores.reduce((a, b) => a + b, 0) / runScores.length) : null;

--- a/src/quodeq/ui/src/utils/scoreFiltering.period.test.js
+++ b/src/quodeq/ui/src/utils/scoreFiltering.period.test.js
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { filterTrendByVisibleStandardsDaily } from './scoreFiltering.js';
+import { collapseByPeriod } from './dailyGrouping.js';
+
+// Newest-first. The March bucket's NEWEST run (a3, Mar 28) measured only a
+// HIDDEN standard (performance); an earlier March run (a2, Mar 25) measured
+// the visible one (security). This is where day-keying and period-keying
+// diverge: keying the accumulated-average map by day drops the March bucket
+// (a3's day has no visible eval), while keying by month keeps it with a2's
+// accumulated average. When every run measures a visible standard the two
+// behave identically — so this hidden-standard run is what makes the red
+// step real.
+const TREND = [
+  { runId: 'a4', dateISO: '2026-04-14T18:00:00', dimensions: ['security'],
+    dimensionDetails: [{ dimension: 'security', score: 8 }] },
+  { runId: 'a3', dateISO: '2026-03-28T09:00:00', dimensions: ['performance'],
+    dimensionDetails: [{ dimension: 'performance', score: 2 }] }, // hidden standard
+  { runId: 'a2', dateISO: '2026-03-25T14:00:00', dimensions: ['security'],
+    dimensionDetails: [{ dimension: 'security', score: 6 }] },
+  { runId: 'a1', dateISO: '2026-03-23T10:00:00', dimensions: ['security'],
+    dimensionDetails: [{ dimension: 'security', score: 4 }] },
+];
+const VISIBLE = new Set(['security']);
+
+test('month granularity: keeps a bucket whose newest run measured only hidden standards', () => {
+  const periodTrend = collapseByPeriod(TREND, 'month'); // [a4 (Apr), a3 (Mar, newest)]
+  const result = filterTrendByVisibleStandardsDaily(TREND, periodTrend, VISIBLE, 'month');
+  assert.equal(result.length, 2); // both April and March kept
+  assert.equal(result[0].runId, 'a4');
+  assert.equal(result[0].numericAverage, 8);
+  assert.equal(result[1].runId, 'a3'); // March bucket survives (day-keying would drop it)
+  assert.equal(result[1].numericAverage, 6); // accumulated avg as of the last VISIBLE March run (a2)
+});
+
+test('day granularity (3-arg legacy call) is unchanged: one entry per visible day', () => {
+  const dayTrend = collapseByPeriod(TREND, 'day');
+  const result = filterTrendByVisibleStandardsDaily(TREND, dayTrend, VISIBLE); // no granularity arg
+  // a3's day (Mar 28) has no visible eval, so it's dropped at day granularity — unchanged behavior.
+  assert.deepEqual(result.map((r) => r.runId), ['a4', 'a2', 'a1']);
+});

--- a/src/quodeq/ui/src/utils/scoreHistoryPrefs.js
+++ b/src/quodeq/ui/src/utils/scoreHistoryPrefs.js
@@ -1,0 +1,28 @@
+import {
+  SCORE_HISTORY_GRANULARITY_STORAGE_KEY,
+  SCORE_HISTORY_GRANULARITIES,
+  DEFAULT_SCORE_HISTORY_GRANULARITY,
+} from '../constants.js';
+
+/**
+ * Read the persisted score-history grouping granularity.
+ * Returns 'day' when unset or invalid. Mirrors visibleStandards.js.
+ */
+export function readScoreHistoryGranularity(storage = localStorage) {
+  try {
+    const raw = storage.getItem(SCORE_HISTORY_GRANULARITY_STORAGE_KEY);
+    return SCORE_HISTORY_GRANULARITIES.includes(raw) ? raw : DEFAULT_SCORE_HISTORY_GRANULARITY;
+  } catch {
+    return DEFAULT_SCORE_HISTORY_GRANULARITY;
+  }
+}
+
+/** Persist the granularity. Silently ignores invalid values and storage errors. */
+export function writeScoreHistoryGranularity(value, storage = localStorage) {
+  if (!SCORE_HISTORY_GRANULARITIES.includes(value)) return;
+  try {
+    storage.setItem(SCORE_HISTORY_GRANULARITY_STORAGE_KEY, value);
+  } catch {
+    /* storage unavailable (private mode, quota) — non-fatal */
+  }
+}

--- a/src/quodeq/ui/src/utils/scoreHistoryPrefs.test.js
+++ b/src/quodeq/ui/src/utils/scoreHistoryPrefs.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readScoreHistoryGranularity, writeScoreHistoryGranularity } from './scoreHistoryPrefs.js';
+
+function fakeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => { map.set(k, String(v)); },
+    removeItem: (k) => { map.delete(k); },
+  };
+}
+
+test('read: returns "day" when nothing stored', () => {
+  assert.equal(readScoreHistoryGranularity(fakeStorage()), 'day');
+});
+
+test('read: returns a valid stored value', () => {
+  assert.equal(readScoreHistoryGranularity(fakeStorage({ 'quodeq-score-history-granularity': 'month' })), 'month');
+});
+
+test('read: falls back to "day" on an invalid stored value', () => {
+  assert.equal(readScoreHistoryGranularity(fakeStorage({ 'quodeq-score-history-granularity': 'decade' })), 'day');
+});
+
+test('write then read round-trips a valid value', () => {
+  const s = fakeStorage();
+  writeScoreHistoryGranularity('week', s);
+  assert.equal(readScoreHistoryGranularity(s), 'week');
+});
+
+test('write: ignores an invalid value (does not persist garbage)', () => {
+  const s = fakeStorage({ 'quodeq-score-history-granularity': 'week' });
+  writeScoreHistoryGranularity('decade', s);
+  assert.equal(readScoreHistoryGranularity(s), 'week');
+});


### PR DESCRIPTION
## Summary

Adds a compact **Day / Week / Month** selector inside the Overview score-history chart. **Day is the default and is a no-op vs. today**, and the choice is persisted (localStorage). Switching granularity re-buckets the chart, the run navigator, and the dimension-card highlighting. Each week/month bucket is represented by its **most recent run** — whose value is already the cumulative cross-run state — so the dimension cards and stats follow via the existing select-run → refetch path. **No backend changes.**

## Behavior

- Selector sits in the `score_history` header, left of MIN / MAX / AVG (which stays and recomputes over the visible buckets).
- Bars thin to one per period; the header suffix shows `d` / `w` / `mo`.
- Tooltip shows the period: e.g. `March 2026` (month), `Week 13, 2026` (week); Day keeps the specific date.
- Selector matches the terminal idiom (monospace, neutral focus — no accent glow).
- Single-bucket collapse keeps the selector visible (with a "choose a finer grouping" note) so you can switch back.
- Overview only; the History tab is unchanged.

## Implementation

- `dailyGrouping.js`: generalized the day-key into `bucketKey(dateISO, granularity)` (month = `YYYY-MM`; week = a hand-rolled ISO-8601 week key, no date library), keeping the newest run per bucket. The day-named helpers (`collapseByDay` / `collectDayDimensions` / `buildDailyRuns`) remain as thin wrappers, so Day stays a provable no-op.
- `scoreFiltering.js` + `useVisibleRuns.js`: made period-aware so the trend filter and the run navigator bucket consistently with the chart (avoids a navigator/chart desync when a standard is hidden).
- `PeriodSelect`: new terminal-design component wrapping a native `<select>` (keyboard-accessible).
- `granularity` is owned in `useAppState` (persisted via a new `scoreHistoryPrefs` util) and threaded down to the chart.

## Testing

- `npm run test:all` green: node:test util suites + vitest **553/553 across 103 files**; `npm run build` clean.
- New tests: prefs round-trip + invalid fallback; grouping engine incl. ISO-week year boundaries (`2025-12-29 → 2026-W01`); period trend filter (hidden-standard-only bucket edge case); `PeriodSelect`; `RunHistoryPanel` header (selector, dynamic label, single-bucket collapse); and the period tooltip label.
