### PR TITLE
perf(analysis): lower subagent scout timeout to 30s

### DIFF
--- a/src/quodeq/analysis/subagents/_pool_models.py
+++ b/src/quodeq/analysis/subagents/_pool_models.py
@@ -7,7 +7,7 @@ from pathlib import Path
 _AGENT_ID_PREFIX = "agent"
 _FUTURE_POLL_INTERVAL_S = 0.5
 _HEARTBEAT_JOIN_TIMEOUT_S = 2
-_SCOUT_TIMEOUT_S = 180             # 3 min before forcing scale-up
+_SCOUT_TIMEOUT_S = 30              # 30s before forcing scale-up
 _DEFAULT_MAX_DURATION_S = 600      # 10 min per-agent ceiling; clamped lower by remaining run budget when set
 _DEFAULT_FILES_PER_AGENT = 30
 


### PR DESCRIPTION
## What

Lowers `_SCOUT_TIMEOUT_S` from **180s → 30s** in `src/quodeq/analysis/subagents/_pool_models.py`.

## Why

The subagent pool runs in **scout-first mode** for per-token providers (e.g. Claude/Sonnet — any provider not in `QUODEQ_NON_SCOUT_PROVIDERS`, default `codex,gemini`). It launches a single "scout" agent and only fans out to the full pool once the scout either finishes the queue *or* hits the scout timeout.

On large queues the scout can never finish in scout time, so scale-up is **always** gated by the timeout. With the previous 180s ceiling, big runs sat at 1 agent for a full 3 minutes before fanning out. 30s reaches the full agent count ~2.5 min sooner.

The value is still a ceiling inside the existing clamp — `min(_SCOUT_TIMEOUT_S, max_duration / n_agents * 0.5)` (`_pool_loops.py:50`) — so small per-agent budgets continue to shorten it further. No behavioral change for subscription providers, which skip the scout entirely.

## Testing

`pytest` for the scout/scaling suites — 32 passed:
- `tests/engine/test_subagent_pool.py`
- `tests/engine/test_subagent_pool_advanced.py`
- `tests/engine/test_adaptive_scaling_integration.py`
- `tests/analysis/test_pool_exit_reason.py`
- `tests/analysis/test_loops_safety.py`

No test asserted the literal `180`; the suites exercise scout behavior (scout-first ordering, overflow on large queues), which is unaffected.