### PR TITLE
feat(a11y): keyboard navigation for galaxy canvas (#675)

### DIFF
--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
@@ -2,13 +2,13 @@ import { useRef, useEffect, useMemo, useCallback, useState } from 'react';
 import { invalidateThemeColors, LEGEND_ITEMS } from '../core/galaxyCore.js';
 import VizBreadcrumb from './VizBreadcrumb.jsx';
 import { buildScene, updateSceneLiveData } from './galaxyViewScene.js';
-import { updateTooltip, handleCanvasClick } from './galaxyViewEvents.js';
+import { updateTooltip, handleCanvasClick, createKeyboardHandlers } from './galaxyViewEvents.js';
 import { computeLevelInfo, buildBreadcrumb, LevelInfoPanel } from './galaxyViewInfo.jsx';
 import { useGalaxyCamera } from './useGalaxyCamera.js';
 
 /* ── Custom hook: mouse/click handler setup ── */
 
-function useGalaxyHandlers({ canvasRef, navRef, animRef, camRef, hoveredRef, mouseRef, tooltipRef, prevNavRef, scene, size, startTransition, saveNav, w2s }) {
+function useGalaxyHandlers({ canvasRef, navRef, animRef, camRef, hoveredRef, mouseRef, tooltipRef, prevNavRef, focusedIdxRef, announce, scene, size, startTransition, saveNav, w2s }) {
   const navigateTo = useCallback((depth, dim, prin) => {
     if (animRef.current) return;
     const wasDepth = navRef.current.depth;
@@ -44,7 +44,15 @@ function useGalaxyHandlers({ canvasRef, navRef, animRef, camRef, hoveredRef, mou
     else if (d === 1) navigateTo(1, nav.dim);
   }, [navRef, navigateTo]);
 
-  return { handleMouseMove, handleMouseLeave, navigateTo, handleClick, goToDepth };
+  const { handleKeyDown, handleFocus, handleBlur } = useMemo(
+    () => createKeyboardHandlers(
+      { navRef, animRef, focusedIdxRef },
+      { scene, navigateTo, startTransition, saveNav, announce },
+    ),
+    [navRef, animRef, focusedIdxRef, scene, navigateTo, startTransition, saveNav, announce],
+  );
+
+  return { handleMouseMove, handleMouseLeave, navigateTo, handleClick, goToDepth, handleKeyDown, handleFocus, handleBlur };
 }
 
 export default function GalaxyView({ dimensions, onNavigate, showLabels = true, setShowLabels, darkMode, resetKey = 0, projectName = '', standardTypes = {} }) {
@@ -83,9 +91,13 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
   const [navVersion, setNavVersion] = useState(0);
   const mouseRef = useRef({ x: -1, y: -1 });
   const hoveredRef = useRef(null);
+  const focusedIdxRef = useRef(null);
   const tooltipRef = useRef(null);
   const frameRef = useRef(null);
   const prevNavRef = useRef(null);
+  const [liveMsg, setLiveMsg] = useState('');
+  const [canvasFocused, setCanvasFocused] = useState(false);
+  const announce = useCallback((msg) => setLiveMsg(msg), []);
 
   const saveNav = useCallback(() => {
     savedNavRef.current = { ...navRef.current };
@@ -95,7 +107,7 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
 
   const { camRef, w2s, startTransition } = useGalaxyCamera({
     canvasRef, scene, size, showLabels, savedNavRef, savedCamRef,
-    navRef, prevNavRef, animRef, mouseRef, hoveredRef, frameRef,
+    navRef, prevNavRef, animRef, mouseRef, hoveredRef, focusedIdxRef, frameRef,
   });
 
   // Reset on resetKey change
@@ -112,8 +124,8 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
     }
   }, [resetKey, saveNav, startTransition]);
 
-  const { handleMouseMove, handleMouseLeave, handleClick, goToDepth } = useGalaxyHandlers({
-    canvasRef, navRef, animRef, camRef, hoveredRef, mouseRef, tooltipRef, prevNavRef,
+  const { handleMouseMove, handleMouseLeave, handleClick, goToDepth, handleKeyDown, handleFocus, handleBlur } = useGalaxyHandlers({
+    canvasRef, navRef, animRef, camRef, hoveredRef, mouseRef, tooltipRef, prevNavRef, focusedIdxRef, announce,
     scene, size, startTransition, saveNav, w2s,
   });
 
@@ -129,9 +141,22 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%', opacity: visible ? 1 : 0, transition: 'opacity 0.4s ease' }}>
       <canvas ref={canvasRef} width={size.w} height={size.h}
-        style={{ width: '100%', height: '100%', display: 'block' }}
+        style={{
+          width: '100%', height: '100%', display: 'block',
+          outline: canvasFocused ? '2px solid var(--color-accent)' : 'none',
+          outlineOffset: '-2px',
+        }}
         onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave} onClick={handleClick}
-        role="img" aria-label="Galaxy visualization of project compliance" />
+        tabIndex={0}
+        role="application"
+        aria-label="Galaxy visualization of project compliance. Use arrow keys to move between nodes, Enter to open, Escape to go back."
+        onKeyDown={handleKeyDown}
+        onFocus={() => { setCanvasFocused(true); handleFocus(); }}
+        onBlur={() => { setCanvasFocused(false); handleBlur(); }} />
+      <div aria-live="polite" aria-atomic="true" style={{
+        position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
+        overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0,
+      }}>{liveMsg}</div>
       <VizBreadcrumb items={breadcrumb.map((bc, i) => ({
         label: bc.label,
         onClick: i < breadcrumb.length - 1 ? () => {

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewDraw.js
@@ -137,6 +137,11 @@ function drawDimStars(ctx, scene, cam, nav, opts, tc, mr, mg, mb) {
       ctx.fillStyle = rgba(tc.textMuted, 0.8 * labelAlpha);
       ctx.fillText(s.score.toFixed(1), sc.x, sc.y + sr + 24 * fs);
     }
+    // Keyboard focus ring (a11y, #675) — drawn at the dim's hit radius so it
+    // lines up with where Enter activates.
+    if (nav.depth === 0 && opts.focusedIdx === i) {
+      drawFocusRing(ctx, sc.x, sc.y, Math.max(sr * 2, 20) + 4, tc);
+    }
     if (!animating && nav.depth === 0 && mx >= 0) {
       const dx = mx - sc.x, dy = my - sc.y;
       const hitR = Math.max(sr * 2, 20);
@@ -144,6 +149,19 @@ function drawDimStars(ctx, scene, cam, nav, opts, tc, mr, mg, mb) {
     }
   });
   return newHovered;
+}
+
+/** Dashed ring marking the keyboard-focused node (a11y, #675). */
+function drawFocusRing(ctx, cx, cy, r, tc) {
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, TAU);
+  ctx.strokeStyle = rgba(tc.text, 0.9);
+  ctx.lineWidth = 2;
+  ctx.setLineDash([5, 4]);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  ctx.restore();
 }
 
 /**
@@ -186,6 +204,9 @@ function drawPrinciples(ctx, scene, cam, nav, opts, tc, rDim) {
       ctx.font = `12px -apple-system,BlinkMacSystemFont,sans-serif`;
       ctx.fillStyle = rgba(tc.textMuted, 0.7 * la);
       ctx.fillText(p.score.toFixed(1), sc.x, sc.y + sr + 16);
+    }
+    if (nav.depth === 1 && opts.focusedIdx === pi) {
+      drawFocusRing(ctx, sc.x, sc.y, sr + 10 + 4, tc);
     }
     if (!animating && nav.depth === 1 && pAlpha > 0.4 && mx >= 0) {
       const dx = mx - sc.x, dy = my - sc.y;

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.js
@@ -110,3 +110,115 @@ export function handleCanvasClick(e, refs, scene, size, navigateTo, startTransit
     saveNav();
   }
 }
+
+/**
+ * The nodes a keyboard user can move focus across at the current depth.
+ * Depth 0 → dimension stars; depth 1 → the active dimension's principles;
+ * depth 2 (zoomed into a single principle) has no siblings to traverse.
+ *
+ * @param {object|null} scene - The scene data
+ * @param {object} nav - Navigation state { depth, dim, prin }
+ * @returns {Array} focusable node objects (may be empty)
+ */
+export function focusableNodes(scene, nav) {
+  if (!scene) return [];
+  if (nav.depth === 0) return scene.stars ?? [];
+  if (nav.depth === 1 && nav.dim !== null && nav.dim !== undefined) {
+    return scene.principles?.[nav.dim] ?? [];
+  }
+  return [];
+}
+
+function announceNode(announce, node, idx, total) {
+  if (!announce || !node) return;
+  const score = typeof node.score === 'number' ? `, score ${node.score.toFixed(1)}` : '';
+  announce(`${node.name}${score}, ${idx + 1} of ${total}`);
+}
+
+/**
+ * Build keyboard handlers for the galaxy canvas (a11y, #675).
+ *
+ * The canvas has no per-node DOM, so focus is tracked as an index into the
+ * current depth's node list (`focusedIdxRef`) and the renderer draws a ring
+ * on it. Arrow keys move focus across siblings; Enter/Space drills in via the
+ * same `navigateTo` the mouse click uses; Escape steps back up. Movements are
+ * announced through an aria-live region so screen-reader users get feedback.
+ *
+ * @param {object} refs - { navRef, animRef, focusedIdxRef }
+ * @param {object} params - { scene, navigateTo, startTransition, saveNav, announce }
+ * @returns {{ handleKeyDown: Function, handleFocus: Function, handleBlur: Function }}
+ */
+export function createKeyboardHandlers(refs, params) {
+  const { navRef, animRef, focusedIdxRef } = refs;
+  const { scene, navigateTo, startTransition, saveNav, announce } = params;
+
+  function focusAt(idx) {
+    const nodes = focusableNodes(scene, navRef.current);
+    if (!nodes.length) return;
+    const clamped = ((idx % nodes.length) + nodes.length) % nodes.length;
+    focusedIdxRef.current = clamped;
+    announceNode(announce, nodes[clamped], clamped, nodes.length);
+  }
+
+  function move(delta) {
+    const nodes = focusableNodes(scene, navRef.current);
+    if (!nodes.length) return;
+    const cur = focusedIdxRef.current;
+    focusAt(cur === null ? (delta > 0 ? 0 : nodes.length - 1) : cur + delta);
+  }
+
+  function activate() {
+    const nav = navRef.current;
+    const nodes = focusableNodes(scene, nav);
+    const idx = focusedIdxRef.current;
+    if (idx === null || !nodes[idx]) return;
+    const node = nodes[idx];
+    if (nav.depth === 0) navigateTo(1, idx);
+    else if (nav.depth === 1) navigateTo(2, nav.dim, idx);
+    else return;
+    focusedIdxRef.current = null;
+    if (announce) announce(`Opened ${node.name}`);
+  }
+
+  function goUp() {
+    const nav = navRef.current;
+    if (nav.depth === 2) { navigateTo(1, nav.dim); announce?.('Returned to principles'); }
+    else if (nav.depth === 1) { navigateTo(0); announce?.('Returned to galaxy overview'); }
+    else if (nav.clusterCx != null) {
+      nav.clusterCx = null; nav.clusterCy = null;
+      startTransition(true); saveNav();
+      announce?.('Returned to galaxy overview');
+    } else return false;
+    focusedIdxRef.current = null;
+    return true;
+  }
+
+  function handleKeyDown(e) {
+    if (animRef.current) return; // mid-transition: let the camera settle first
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        e.preventDefault(); move(1); break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        e.preventDefault(); move(-1); break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault(); activate(); break;
+      case 'Escape':
+        if (goUp() !== false) e.preventDefault();
+        break;
+      default: break;
+    }
+  }
+
+  function handleFocus() {
+    if (focusedIdxRef.current === null) focusAt(0);
+  }
+
+  function handleBlur() {
+    focusedIdxRef.current = null;
+  }
+
+  return { handleKeyDown, handleFocus, handleBlur };
+}

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewEvents.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { handleCanvasClick } from './galaxyViewEvents.js';
+import { handleCanvasClick, focusableNodes, createKeyboardHandlers } from './galaxyViewEvents.js';
 
 describe('handleCanvasClick', () => {
   it('does not throw when camRef.current is null during a cluster-click hit-test', () => {
@@ -30,5 +30,149 @@ describe('handleCanvasClick', () => {
     expect(() =>
       handleCanvasClick(e, refs, scene, size, navigateTo, startTransition, saveNav, w2s)
     ).not.toThrow();
+  });
+});
+
+function makeScene() {
+  return {
+    stars: [
+      { name: 'Reliability', score: 8.2 },
+      { name: 'Performance', score: 7.1 },
+      { name: 'Security', score: 6.5 },
+    ],
+    principles: {
+      0: [{ name: 'Error Handling', score: 9 }, { name: 'Retries', score: 5 }],
+    },
+  };
+}
+
+function makeRefs(nav) {
+  return {
+    navRef: { current: nav },
+    animRef: { current: null },
+    focusedIdxRef: { current: null },
+  };
+}
+
+function makeParams(scene, overrides = {}) {
+  return {
+    scene,
+    navigateTo: vi.fn(),
+    startTransition: vi.fn(),
+    saveNav: vi.fn(),
+    announce: vi.fn(),
+    ...overrides,
+  };
+}
+
+const key = (k) => ({ key: k, preventDefault: vi.fn() });
+
+describe('focusableNodes (#675)', () => {
+  it('returns dimension stars at depth 0', () => {
+    expect(focusableNodes(makeScene(), { depth: 0 })).toHaveLength(3);
+  });
+
+  it('returns the active dimension principles at depth 1', () => {
+    expect(focusableNodes(makeScene(), { depth: 1, dim: 0 })).toHaveLength(2);
+  });
+
+  it('returns an empty list at depth 2 (no siblings to traverse)', () => {
+    expect(focusableNodes(makeScene(), { depth: 2, dim: 0, prin: 0 })).toEqual([]);
+  });
+
+  it('returns an empty list for a null scene', () => {
+    expect(focusableNodes(null, { depth: 0 })).toEqual([]);
+  });
+});
+
+describe('createKeyboardHandlers (#675)', () => {
+  it('ArrowRight from no focus selects the first node and announces it', () => {
+    const refs = makeRefs({ depth: 0 });
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('ArrowRight'));
+    expect(refs.focusedIdxRef.current).toBe(0);
+    expect(params.announce).toHaveBeenCalledWith('Reliability, score 8.2, 1 of 3');
+  });
+
+  it('ArrowLeft from no focus selects the last node', () => {
+    const refs = makeRefs({ depth: 0 });
+    createKeyboardHandlers(refs, makeParams(makeScene())).handleKeyDown(key('ArrowLeft'));
+    expect(refs.focusedIdxRef.current).toBe(2);
+  });
+
+  it('ArrowRight wraps from the last node back to the first', () => {
+    const refs = makeRefs({ depth: 0 });
+    refs.focusedIdxRef.current = 2;
+    createKeyboardHandlers(refs, makeParams(makeScene())).handleKeyDown(key('ArrowRight'));
+    expect(refs.focusedIdxRef.current).toBe(0);
+  });
+
+  it('Enter at depth 0 drills into the focused dimension', () => {
+    const refs = makeRefs({ depth: 0 });
+    refs.focusedIdxRef.current = 1;
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Enter'));
+    expect(params.navigateTo).toHaveBeenCalledWith(1, 1);
+    expect(refs.focusedIdxRef.current).toBeNull();
+  });
+
+  it('Enter at depth 1 drills into the focused principle', () => {
+    const refs = makeRefs({ depth: 1, dim: 0 });
+    refs.focusedIdxRef.current = 1;
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Enter'));
+    expect(params.navigateTo).toHaveBeenCalledWith(2, 0, 1);
+  });
+
+  it('Enter with nothing focused does nothing', () => {
+    const refs = makeRefs({ depth: 0 });
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Enter'));
+    expect(params.navigateTo).not.toHaveBeenCalled();
+  });
+
+  it('Escape at depth 2 returns to the principle list', () => {
+    const refs = makeRefs({ depth: 2, dim: 0, prin: 1 });
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Escape'));
+    expect(params.navigateTo).toHaveBeenCalledWith(1, 0);
+  });
+
+  it('Escape at depth 1 returns to the galaxy overview', () => {
+    const refs = makeRefs({ depth: 1, dim: 0 });
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Escape'));
+    expect(params.navigateTo).toHaveBeenCalledWith(0);
+  });
+
+  it('Escape inside a cluster at depth 0 resets the cluster', () => {
+    const nav = { depth: 0, clusterCx: 10, clusterCy: 20 };
+    const refs = makeRefs(nav);
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('Escape'));
+    expect(nav.clusterCx).toBeNull();
+    expect(params.startTransition).toHaveBeenCalledWith(true);
+  });
+
+  it('ignores key input while a camera transition is animating', () => {
+    const refs = makeRefs({ depth: 0 });
+    refs.animRef.current = { t: 0.3 };
+    const params = makeParams(makeScene());
+    createKeyboardHandlers(refs, params).handleKeyDown(key('ArrowRight'));
+    expect(refs.focusedIdxRef.current).toBeNull();
+    expect(params.announce).not.toHaveBeenCalled();
+  });
+
+  it('handleFocus auto-focuses the first node', () => {
+    const refs = makeRefs({ depth: 0 });
+    createKeyboardHandlers(refs, makeParams(makeScene())).handleFocus();
+    expect(refs.focusedIdxRef.current).toBe(0);
+  });
+
+  it('handleBlur clears focus', () => {
+    const refs = makeRefs({ depth: 0 });
+    refs.focusedIdxRef.current = 1;
+    createKeyboardHandlers(refs, makeParams(makeScene())).handleBlur();
+    expect(refs.focusedIdxRef.current).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
+++ b/src/quodeq/ui/src/features/map/viz/components/useGalaxyCamera.js
@@ -52,7 +52,7 @@ function interpolateCamera(cam, tg, anim, frameCount) {
 /**
  * Manages camera state, target computation, and the animation loop for GalaxyView.
  */
-export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRef, savedCamRef, navRef, prevNavRef, animRef, mouseRef, hoveredRef, frameRef }) {
+export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRef, savedCamRef, navRef, prevNavRef, animRef, mouseRef, hoveredRef, focusedIdxRef, frameRef }) {
   const camRef = useRef(savedCamRef.current ? { ...savedCamRef.current } : null);
   const frameCount = useRef(0);
   const timeRef = useRef(0);
@@ -135,6 +135,7 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
         mx: mouseRef.current.x, my: mouseRef.current.y,
         showLabels, animating: !!anim,
         rDim, rPrin, w2s,
+        focusedIdx: focusedIdxRef?.current ?? null,
         parentEl: canvasRef.current?.parentElement,
       });
       hoveredRef.current = hovered;
@@ -144,7 +145,7 @@ export function useGalaxyCamera({ canvasRef, scene, size, showLabels, savedNavRe
 
     frameRef.current = requestAnimationFrame(frame);
     return () => { running = false; cancelAnimationFrame(frameRef.current); };
-  }, [scene, size, showLabels, w2s, getTarget, canvasRef, navRef, prevNavRef, animRef, mouseRef, hoveredRef, frameRef, getFitZoom]);
+  }, [scene, size, showLabels, w2s, getTarget, canvasRef, navRef, prevNavRef, animRef, mouseRef, hoveredRef, focusedIdxRef, frameRef, getFitZoom]);
 
   return { camRef, w2s, startTransition, getTarget };
 }


### PR DESCRIPTION
Closes the remaining piece of #675 — the **galaxy canvas** (`GalaxyView`). The three Recharts panels were already handled in #677.

## Problem

The canvas was mouse-only: `role="img"` + `aria-label` but no focusable element or key handlers (`GalaxyView.jsx:131`). Keyboard-only and assistive-tech users could not reach or activate it.

## Why not mirror `GalaxyFolderView` (camera-pan)?

They *look* alike but their cameras differ. `GalaxyFolderView` is free-pan (its keydown mutates `cam.x/cam.y` and they stick). **`GalaxyView`'s camera is target-locked** — every frame it eases toward a nav-derived point (`useGalaxyCamera.js` → `getTarget()`), even at rest. A panned camera is pulled straight back, so camera-pan can't work here without rewriting the core camera loop. Discrete node focus fits the target-locked model and is the better a11y outcome (real focus + screen-reader feedback).

## What this adds

- Canvas is focusable: `tabIndex={0}`, `role="application"`, descriptive `aria-label`, and a visible focus outline.
- **Arrow keys** move focus across sibling nodes at the current depth (dimensions at depth 0, principles at depth 1). The renderer draws a dashed focus ring on the focused node, aligned to its hit radius.
- **Enter/Space** drills into the focused node via the *same* `navigateTo` the mouse click uses; **Escape** steps back up a level.
- An **`aria-live` region** announces the focused node (name + score + position) and level changes, so screen-reader users get feedback.

Focus is tracked as an index into the current depth's node list (`focusedIdxRef`) since the canvas has no per-node DOM. Mouse behavior is unchanged.

## Files

- `galaxyViewEvents.js` — `focusableNodes()` + `createKeyboardHandlers()` (arrow/Enter/Escape/focus/blur)
- `galaxyViewDraw.js` — `drawFocusRing()`, drawn for the focused dim/principle
- `useGalaxyCamera.js` — threads `focusedIdxRef` into the render loop
- `GalaxyView.jsx` — wires focus ref, aria-live region, canvas attrs/handlers

## Testing

`vitest` — 27 tests pass in the galaxy viz suite (18 new for `focusableNodes`/`createKeyboardHandlers`: arrow movement + wrap, Enter drill-in at each depth, Escape up-navigation, cluster reset, transition-guard, focus/blur), and the full `src/features/map` suite is green (57 tests). Logic is unit-tested at the handler level; mouse paths and the camera loop are unchanged.

## Follow-up / known limitations

- Keyboard `Enter` is gated while a camera transition animates (~0.8s) — intentional, so focus lands after the camera settles.
- When zoomed into a cluster, arrow focus still traverses all dimensions (not just the cluster's). Acceptable for v1; can scope later if desired.