### PR TITLE
feat: SARIF 2.1.0 export (quodeq export sarif + evaluate --sarif)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ quodeq evaluate /path/to/project --scope src/api    # Scoped to a subdirectory
 quodeq evaluate /path/to/project -d security        # Single dimension
 ```
 
+### SARIF / GitHub code scanning
+
+Quodeq can emit findings as [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+for GitHub code scanning (the Security tab), GitLab SAST, or any SARIF
+consumer. Generate it during a scan, or export it from a past run:
+
+```bash
+quodeq evaluate . --sarif quodeq.sarif            # during a scan
+quodeq export sarif --evaluation-dir <dir> -o quodeq.sarif   # from existing reports
+```
+
+Code snippets are omitted by default (so source never leaves your machine on
+upload); pass `--with-snippets` to include them. Use `--min-severity` to drop
+low-severity findings.
+
+Upload to GitHub code scanning:
+
+```yaml
+- run: quodeq evaluate . --sarif quodeq.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: quodeq.sarif
+```
+
 ---
 
 ## Updates

--- a/src/quodeq/_cli_evaluation.py
+++ b/src/quodeq/_cli_evaluation.py
@@ -104,6 +104,41 @@ def _no_verify(args: argparse.Namespace, env: dict[str, str] | None = None) -> b
 
 
 # ---------------------------------------------------------------------------
+# SARIF export helper
+# ---------------------------------------------------------------------------
+
+def _write_sarif_if_requested(args: argparse.Namespace, evaluation_dir: Path) -> None:
+    """Write a SARIF file if --sarif was passed. Fail-soft: never raises.
+
+    Called from run_evaluate AFTER the run lifecycle has fully closed, so a
+    failure here can never flip a successful run to failed. The scored reports
+    are already on disk in evaluation_dir.
+    """
+    sarif_path = getattr(args, "sarif", None)
+    if not sarif_path:
+        return
+    try:
+        from quodeq import __version__
+        from quodeq.ci.reporter import load_evaluation_reports
+        from quodeq.ci.sarif import build_sarif
+
+        reports = load_evaluation_reports(evaluation_dir)
+        doc = build_sarif(
+            reports,
+            tool_version=__version__ or "0.0.0+dev",
+            min_severity=getattr(args, "min_severity", None),
+            include_snippets=getattr(args, "with_snippets", False),
+        )
+        out = Path(sarif_path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+        count = sum(len(r["results"]) for r in doc["runs"])
+        log_info(f"Wrote {count} finding(s) to SARIF: {out}")
+    except Exception as exc:  # noqa: BLE001 — fail-soft: SARIF must never sink a scan
+        log_warning(f"SARIF export failed (evaluation results are safe): {exc}")
+
+
+# ---------------------------------------------------------------------------
 # Run directory setup
 # ---------------------------------------------------------------------------
 
@@ -416,4 +451,17 @@ def run_evaluate(args: argparse.Namespace) -> int:
         if worktree_dir and worktree_origin:
             _cleanup_worktree(worktree_origin, worktree_dir)
         raise
-    return _run_pipeline_with_cleanup(args, inputs, paths)
+    result = _run_pipeline_with_cleanup(args, inputs, paths)
+    # Fail-soft SARIF export, OUTSIDE the run lifecycle (it has fully closed by
+    # now), only on success and only when scored reports exist. A SARIF error
+    # here can never flip the run state. --diff-from / --evidence-only produce
+    # no scored reports, so skip them.
+    if (
+        result == 0
+        and getattr(args, "sarif", None)
+        and not getattr(args, "diff_from", None)
+        and not getattr(args, "evidence_only", False)
+    ):
+        _, _evidence_dir, evaluation_dir = paths
+        _write_sarif_if_requested(args, evaluation_dir)
+    return result

--- a/src/quodeq/ci/export_cli.py
+++ b/src/quodeq/ci/export_cli.py
@@ -1,0 +1,50 @@
+# src/quodeq/ci/export_cli.py
+"""CLI handler for the `quodeq export` subcommand."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _tool_version() -> str:
+    from quodeq import __version__
+    return __version__ or "0.0.0+dev"
+
+
+def handle_export(args) -> int:
+    """Handle `quodeq export <format>`. Returns an exit code."""
+    if getattr(args, "export_format", None) != "sarif":
+        print("Usage: quodeq export sarif --evaluation-dir DIR -o FILE", file=sys.stderr)
+        return 1
+    return _handle_sarif(args)
+
+
+def _handle_sarif(args) -> int:
+    from quodeq.ci.reporter import load_evaluation_reports
+    from quodeq.ci.sarif import build_sarif
+
+    evaluation_dir = Path(args.evaluation_dir)
+    if not evaluation_dir.is_dir():
+        print(f"Error: evaluation directory not found: {evaluation_dir}", file=sys.stderr)
+        return 1
+
+    reports = load_evaluation_reports(evaluation_dir)
+    doc = build_sarif(
+        reports,
+        tool_version=_tool_version(),
+        min_severity=getattr(args, "min_severity", None),
+        include_snippets=getattr(args, "with_snippets", False),
+    )
+
+    out_path = Path(args.output)
+    try:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    except OSError as exc:
+        print(f"Error: could not write SARIF to {out_path}: {exc}", file=sys.stderr)
+        return 1
+
+    count = sum(len(r["results"]) for r in doc["runs"])
+    print(f"Wrote {count} finding(s) to {out_path}")
+    return 0

--- a/src/quodeq/ci/export_cli.py
+++ b/src/quodeq/ci/export_cli.py
@@ -2,6 +2,7 @@
 """CLI handler for the `quodeq export` subcommand."""
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -12,7 +13,7 @@ def _tool_version() -> str:
     return __version__ or "0.0.0+dev"
 
 
-def handle_export(args) -> int:
+def handle_export(args: argparse.Namespace) -> int:
     """Handle `quodeq export <format>`. Returns an exit code."""
     if getattr(args, "export_format", None) != "sarif":
         print("Usage: quodeq export sarif --evaluation-dir DIR -o FILE", file=sys.stderr)
@@ -20,7 +21,7 @@ def handle_export(args) -> int:
     return _handle_sarif(args)
 
 
-def _handle_sarif(args) -> int:
+def _handle_sarif(args: argparse.Namespace) -> int:
     from quodeq.ci.reporter import load_evaluation_reports
     from quodeq.ci.sarif import build_sarif
 

--- a/src/quodeq/ci/sarif.py
+++ b/src/quodeq/ci/sarif.py
@@ -1,0 +1,48 @@
+"""Build a SARIF 2.1.0 document from Quodeq evaluation reports.
+
+Pure: report dicts in, a SARIF dict out. No I/O. The CLI glue
+(`export_cli.py`, `_cli_evaluation.py`) handles loading and writing.
+"""
+from __future__ import annotations
+
+import re
+
+from quodeq.context.precedent import fingerprint
+
+# quodeq severity -> (SARIF result level, GitHub security-severity string).
+# GitHub buckets security-severity: >=9.0 Critical, 7.0-8.9 High,
+# 4.0-6.9 Medium, 0.1-3.9 Low. `level` is the separate SARIF axis.
+_SEVERITY_MAP: dict[str, tuple[str, str]] = {
+    "critical": ("error", "9.0"),
+    "major": ("error", "7.0"),
+    "high": ("error", "7.0"),
+    "minor": ("warning", "4.0"),
+}
+_DEFAULT_LEVEL_SEVERITY = ("note", "2.0")  # unknown/low/blank
+
+# Ranking used for --min-severity filtering and worst-of rollup.
+# Unknown/low/garbage all fall to the default (1).
+_RANK = {"critical": 4, "major": 3, "high": 3, "minor": 2}
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _severity_level(severity: str | None) -> str:
+    return _SEVERITY_MAP.get((severity or "").lower(), _DEFAULT_LEVEL_SEVERITY)[0]
+
+
+def _security_severity(severity: str | None) -> str:
+    return _SEVERITY_MAP.get((severity or "").lower(), _DEFAULT_LEVEL_SEVERITY)[1]
+
+
+def _severity_rank(severity: str | None) -> int:
+    """Higher = more severe. Unknown/blank/garbage all rank lowest (1)."""
+    return _RANK.get((severity or "").lower(), 1)
+
+
+def _slug(text: str | None) -> str:
+    return _SLUG_RE.sub("-", (text or "").lower()).strip("-")
+
+
+def _rule_id(dimension: str | None, principle: str | None) -> str:
+    return f"{(dimension or 'unknown').lower()}/{_slug(principle) or 'unknown'}"

--- a/src/quodeq/ci/sarif.py
+++ b/src/quodeq/ci/sarif.py
@@ -6,6 +6,7 @@ Pure: report dicts in, a SARIF dict out. No I/O. The CLI glue
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from quodeq.context.precedent import fingerprint
 
@@ -48,7 +49,7 @@ def _rule_id(dimension: str | None, principle: str | None) -> str:
     return f"{(dimension or 'unknown').lower()}/{_slug(principle) or 'unknown'}"
 
 
-def _cwe_tags(req_refs: list[dict] | None) -> list[str]:
+def _cwe_tags(req_refs: list[dict[str, Any]] | None) -> list[str]:
     """GitHub-form CWE tags (``external/cwe/cwe-NNN``) from a violation's req_refs.
 
     GitHub's Security-tab CWE filter reads these from rule.properties.tags.
@@ -89,18 +90,18 @@ _SCHEMA_URI = "https://json.schemastore.org/sarif-2.1.0.json"
 _INFO_URI = "https://github.com/quodeq/quodeq"
 
 
-def _message_text(violation: dict) -> str:
+def _message_text(violation: dict[str, Any]) -> str:
     title = str(violation.get("title") or "").strip()
     reason = str(violation.get("reason") or "").strip()
     text = ". ".join(p for p in (title, reason) if p)
     return text or str(violation.get("principle") or "Quodeq finding")
 
 
-def _location(violation: dict, *, include_snippets: bool) -> dict | None:
+def _location(violation: dict[str, Any], *, include_snippets: bool) -> dict[str, Any] | None:
     uri = _safe_uri(violation.get("file"))
     if uri is None:
         return None
-    region: dict = {}
+    region: dict[str, Any] = {}
     line = violation.get("line")
     if isinstance(line, int) and line >= 1:
         region["startLine"] = line
@@ -109,15 +110,15 @@ def _location(violation: dict, *, include_snippets: bool) -> dict | None:
             region["endLine"] = end
     if include_snippets and violation.get("snippet"):
         region["snippet"] = {"text": str(violation["snippet"])}
-    physical: dict = {"artifactLocation": {"uri": uri, "uriBaseId": "SRCROOT"}}
+    physical: dict[str, Any] = {"artifactLocation": {"uri": uri, "uriBaseId": "SRCROOT"}}
     if region:
         physical["region"] = region
     return {"physicalLocation": physical}
 
 
-def _result(violation: dict, dimension: str, *, include_snippets: bool) -> dict:
+def _result(violation: dict[str, Any], dimension: str, *, include_snippets: bool) -> dict[str, Any]:
     severity = violation.get("severity") or "unknown"
-    result: dict = {
+    result: dict[str, Any] = {
         "ruleId": _rule_id(dimension, violation.get("principle")),
         "level": _severity_level(severity),
         "message": {"text": _message_text(violation)},
@@ -144,7 +145,7 @@ def _result(violation: dict, dimension: str, *, include_snippets: bool) -> dict:
     return result
 
 
-def _rule(rule_id: str, principle: str, dimension: str, *, severity: str, cwe_tags: list[str]) -> dict:
+def _rule(rule_id: str, principle: str, dimension: str, *, severity: str, cwe_tags: list[str]) -> dict[str, Any]:
     tags = ["quodeq", dimension.lower()]
     if cwe_tags and "security" not in tags:
         tags.append("security")
@@ -162,12 +163,12 @@ def _rule(rule_id: str, principle: str, dimension: str, *, severity: str, cwe_ta
 
 
 def build_sarif(
-    reports: list[dict],
+    reports: list[dict[str, Any]],
     *,
     tool_version: str,
     min_severity: str | None = None,
     include_snippets: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """Build a SARIF 2.1.0 document from Quodeq evaluation reports.
 
     Violations only (compliance/dismissed excluded). Single run, all
@@ -175,9 +176,9 @@ def build_sarif(
     carries the union of its CWEs and a worst-of security-severity. Never
     emits absolute paths or the host `project` field. Deterministic output.
     """
-    results: list[dict] = []
+    results: list[dict[str, Any]] = []
     # rule_id -> {"principle", "dimension", "worst_rank", "worst_sev", "cwe_tags"(ordered set)}
-    rule_acc: dict[str, dict] = {}
+    rule_acc: dict[str, dict[str, Any]] = {}
 
     for report in reports:
         dimension = str(report.get("dimension") or "unknown")

--- a/src/quodeq/ci/sarif.py
+++ b/src/quodeq/ci/sarif.py
@@ -46,3 +46,40 @@ def _slug(text: str | None) -> str:
 
 def _rule_id(dimension: str | None, principle: str | None) -> str:
     return f"{(dimension or 'unknown').lower()}/{_slug(principle) or 'unknown'}"
+
+
+def _cwe_tags(req_refs: list[dict] | None) -> list[str]:
+    """GitHub-form CWE tags (``external/cwe/cwe-NNN``) from a violation's req_refs.
+
+    GitHub's Security-tab CWE filter reads these from rule.properties.tags.
+    Preserves order, de-duplicates, ignores non-CWE labels.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    for ref in req_refs or []:
+        label = str(ref.get("label", "")).strip().lower()
+        if not label.startswith("cwe-"):
+            continue
+        tag = f"external/cwe/{label}"
+        if tag not in seen:
+            seen.add(tag)
+            out.append(tag)
+    return out
+
+
+def _safe_uri(file: str | None) -> str | None:
+    """Repo-root-relative POSIX URI, or None if unusable.
+
+    Violation `file` is already repo-root-relative; this only hardens it:
+    backslashes -> '/', strip a leading '/', reject blanks and paths that
+    escape the root via '..'. Never emits an absolute path.
+    """
+    if not file:
+        return None
+    uri = file.replace("\\", "/").lstrip("/")
+    if not uri:
+        return None
+    parts = uri.split("/")
+    if ".." in parts:
+        return None
+    return uri

--- a/src/quodeq/ci/sarif.py
+++ b/src/quodeq/ci/sarif.py
@@ -83,3 +83,157 @@ def _safe_uri(file: str | None) -> str | None:
     if ".." in parts:
         return None
     return uri
+
+
+_SCHEMA_URI = "https://json.schemastore.org/sarif-2.1.0.json"
+_INFO_URI = "https://github.com/quodeq/quodeq"
+
+
+def _message_text(violation: dict) -> str:
+    title = str(violation.get("title") or "").strip()
+    reason = str(violation.get("reason") or "").strip()
+    text = ". ".join(p for p in (title, reason) if p)
+    return text or str(violation.get("principle") or "Quodeq finding")
+
+
+def _location(violation: dict, *, include_snippets: bool) -> dict | None:
+    uri = _safe_uri(violation.get("file"))
+    if uri is None:
+        return None
+    region: dict = {}
+    line = violation.get("line")
+    if isinstance(line, int) and line >= 1:
+        region["startLine"] = line
+        end = violation.get("end_line")
+        if isinstance(end, int) and end >= line:
+            region["endLine"] = end
+    if include_snippets and violation.get("snippet"):
+        region["snippet"] = {"text": str(violation["snippet"])}
+    physical: dict = {"artifactLocation": {"uri": uri, "uriBaseId": "SRCROOT"}}
+    if region:
+        physical["region"] = region
+    return {"physicalLocation": physical}
+
+
+def _result(violation: dict, dimension: str, *, include_snippets: bool) -> dict:
+    severity = violation.get("severity") or "unknown"
+    result: dict = {
+        "ruleId": _rule_id(dimension, violation.get("principle")),
+        "level": _severity_level(severity),
+        "message": {"text": _message_text(violation)},
+        "properties": {
+            "quodeq": {
+                "dimension": dimension,
+                "principle": violation.get("principle"),
+                "req": violation.get("req"),
+                "severity": severity,
+                "cwe": [
+                    str(r.get("label"))
+                    for r in (violation.get("req_refs") or [])
+                    if str(r.get("label", "")).lower().startswith("cwe-")
+                ],
+            }
+        },
+    }
+    location = _location(violation, include_snippets=include_snippets)
+    if location is not None:
+        result["locations"] = [location]
+    fp = fingerprint(violation.get("req"), violation.get("snippet"))
+    if fp:
+        result["partialFingerprints"] = {"quodeqReqSnippet/v1": fp}
+    return result
+
+
+def _rule(rule_id: str, principle: str, dimension: str, *, severity: str, cwe_tags: list[str]) -> dict:
+    tags = ["quodeq", dimension.lower()]
+    if cwe_tags:
+        tags.append("security")
+        tags.extend(cwe_tags)
+    # GitHub soft-caps tags at 10; keep order, trim defensively.
+    tags = tags[:10]
+    return {
+        "id": rule_id,
+        "name": principle or rule_id,
+        "shortDescription": {"text": principle or rule_id},
+        "fullDescription": {"text": f"{dimension.capitalize()} principle: {principle or rule_id}"},
+        "helpUri": _INFO_URI,
+        "properties": {"tags": tags, "security-severity": _security_severity(severity)},
+    }
+
+
+def build_sarif(
+    reports: list[dict],
+    *,
+    tool_version: str,
+    min_severity: str | None = None,
+    include_snippets: bool = False,
+) -> dict:
+    """Build a SARIF 2.1.0 document from Quodeq evaluation reports.
+
+    Violations only (compliance/dismissed excluded). Single run, all
+    dimensions merged. Rules are one per (dimension, principle); each rule
+    carries the union of its CWEs and a worst-of security-severity. Never
+    emits absolute paths or the host `project` field. Deterministic output.
+    """
+    results: list[dict] = []
+    # rule_id -> {"principle", "dimension", "worst_rank", "worst_sev", "cwe_tags"(ordered set)}
+    rule_acc: dict[str, dict] = {}
+
+    for report in reports:
+        dimension = str(report.get("dimension") or "unknown")
+        for violation in report.get("violations") or []:
+            if min_severity is not None and _severity_rank(violation.get("severity")) < _severity_rank(min_severity):
+                continue
+            results.append(_result(violation, dimension, include_snippets=include_snippets))
+            rid = _rule_id(dimension, violation.get("principle"))
+            acc = rule_acc.setdefault(
+                rid,
+                {
+                    "principle": violation.get("principle") or rid,
+                    "dimension": dimension,
+                    "worst_rank": -1,
+                    "worst_sev": "unknown",
+                    "cwe_tags": [],
+                },
+            )
+            rank = _severity_rank(violation.get("severity"))
+            if rank > acc["worst_rank"]:
+                acc["worst_rank"] = rank
+                acc["worst_sev"] = violation.get("severity") or "unknown"
+            for tag in _cwe_tags(violation.get("req_refs")):
+                if tag not in acc["cwe_tags"]:
+                    acc["cwe_tags"].append(tag)
+
+    rules = [
+        _rule(rid, acc["principle"], acc["dimension"], severity=acc["worst_sev"], cwe_tags=acc["cwe_tags"])
+        for rid, acc in rule_acc.items()
+    ]
+    rules.sort(key=lambda r: r["id"])
+    results.sort(
+        key=lambda r: (
+            (r.get("locations", [{}])[0].get("physicalLocation", {}).get("artifactLocation", {}).get("uri", "")),
+            (r.get("locations", [{}])[0].get("physicalLocation", {}).get("region", {}).get("startLine", 0)),
+            r["ruleId"],
+        )
+    )
+
+    return {
+        "$schema": _SCHEMA_URI,
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "Quodeq",
+                        "informationUri": _INFO_URI,
+                        "version": tool_version,
+                        "semanticVersion": tool_version,
+                        "rules": rules,
+                    }
+                },
+                "automationDetails": {"id": "quodeq/scan"},
+                "results": results,
+                "columnKind": "utf16CodeUnits",
+            }
+        ],
+    }

--- a/src/quodeq/ci/sarif.py
+++ b/src/quodeq/ci/sarif.py
@@ -146,9 +146,9 @@ def _result(violation: dict, dimension: str, *, include_snippets: bool) -> dict:
 
 def _rule(rule_id: str, principle: str, dimension: str, *, severity: str, cwe_tags: list[str]) -> dict:
     tags = ["quodeq", dimension.lower()]
-    if cwe_tags:
+    if cwe_tags and "security" not in tags:
         tags.append("security")
-        tags.extend(cwe_tags)
+    tags.extend(t for t in cwe_tags if t not in tags)
     # GitHub soft-caps tags at 10; keep order, trim defensively.
     tags = tags[:10]
     return {

--- a/src/quodeq/cli.py
+++ b/src/quodeq/cli.py
@@ -140,6 +140,9 @@ def main(argv: list[str] | None = None) -> int:
     elif command == "review":
         from quodeq.ci.review import handle_review
         code = handle_review(args)
+    elif command == "export":
+        from quodeq.ci.export_cli import handle_export
+        code = handle_export(args)
     else:
         handler = _COMMAND_HANDLERS.get(command)
         code = handler(argv) if handler else 1

--- a/src/quodeq/cli_parser.py
+++ b/src/quodeq/cli_parser.py
@@ -98,6 +98,24 @@ def _add_evaluate_args(parser: argparse.ArgumentParser) -> None:
             "Produces evidence only — no scored evaluation reports."
         ),
     )
+    parser.add_argument(
+        "--sarif",
+        default=None,
+        metavar="PATH",
+        help="Also write findings as a SARIF 2.1.0 file at PATH (for GitHub code scanning / GitLab).",
+    )
+    parser.add_argument(
+        "--min-severity",
+        default=None,
+        choices=["critical", "major", "minor"],
+        help="When writing SARIF, drop findings below this severity.",
+    )
+    parser.add_argument(
+        "--with-snippets",
+        action="store_true",
+        dest="with_snippets",
+        help="Include code snippets in SARIF output (off by default; snippets leave the machine when uploaded).",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -140,6 +158,21 @@ def build_parser() -> argparse.ArgumentParser:
             "instead of scored evaluation/<dim>.json reports. Use for PR diff "
             "mode runs that skip the scoring phase."
         ),
+    )
+
+    export_parser = subparsers.add_parser("export", help="Export findings in machine-readable formats")
+    export_parser.set_defaults(handler_command="export")
+    export_sub = export_parser.add_subparsers(dest="export_format")
+    sarif_parser = export_sub.add_parser("sarif", help="Export findings as a SARIF 2.1.0 file")
+    sarif_parser.add_argument("--evaluation-dir", required=True, help="Directory containing evaluation/<dim>.json reports")
+    sarif_parser.add_argument("-o", "--output", required=True, help="Path to write the .sarif file")
+    sarif_parser.add_argument(
+        "--min-severity", default=None, choices=["critical", "major", "minor"],
+        help="Drop findings below this severity.",
+    )
+    sarif_parser.add_argument(
+        "--with-snippets", action="store_true", dest="with_snippets",
+        help="Include code snippets (off by default; snippets leave the machine when uploaded).",
     )
 
     review_parser = subparsers.add_parser(

--- a/tests/ci/fixtures/sarif-schema-2.1.0.json
+++ b/tests/ci/fixtures/sarif-schema-2.1.0.json
@@ -1,0 +1,3389 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "$id": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+
+    "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
+      "type": "string",
+      "format": "uri"
+    },
+
+    "version": {
+      "description": "The SARIF format version of this log file.",
+      "enum": [ "2.1.0" ],
+      "type": "string"
+    },
+
+    "runs": {
+      "description": "The set of runs contained in this log file.",
+      "type": [ "array", "null" ],
+      "minItems": 0,
+      "uniqueItems": false,
+      "items": {
+        "$ref": "#/definitions/run"
+      }
+    },
+
+    "inlineExternalProperties": {
+      "description": "References to external property files that share data between runs.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/externalProperties"
+      }
+    },
+
+    "properties": {
+      "description": "Key/value pairs that provide additional information about the log file.",
+      "$ref": "#/definitions/propertyBag"
+    }
+  },
+
+  "required": [ "version", "runs" ],
+
+  "definitions": {
+
+    "address": {
+      "description": "A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "absoluteAddress": {
+          "description": "The address expressed as a byte offset from the start of the addressable region.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+
+        },
+
+        "relativeAddress": {
+          "description": "The address expressed as a byte offset from the absolute address of the top-most parent object.",
+          "type": "integer"
+
+        },
+
+        "length": {
+          "description": "The number of bytes in this range of addresses.",
+          "type": "integer"
+        },
+
+        "kind": {
+          "description": "An open-ended string that identifies the address kind. 'data', 'function', 'header','instruction', 'module', 'page', 'section', 'segment', 'stack', 'stackFrame', 'table' are well-known values.",
+          "type": "string"
+        },
+
+        "name": {
+          "description": "A name that is associated with the address, e.g., '.text'.",
+          "type": "string"
+        },
+
+        "fullyQualifiedName": {
+          "description": "A human-readable fully qualified name that is associated with the address.",
+          "type": "string"
+        },
+
+        "offsetFromParent": {
+          "description": "The byte offset of this address from the absolute or relative address of the parent object.",
+          "type": "integer"
+        },
+
+        "index": {
+          "description": "The index within run.addresses of the cached object for this address.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "parentIndex": {
+          "description": "The index within run.addresses of the parent object.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the address.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifact": {
+      "description": "A single artifact. In some cases, this artifact might be nested within another artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A short description of the artifact.",
+          "$ref": "#/definitions/message"
+        },
+
+        "location": {
+          "description": "The location of the artifact.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the artifact, if this artifact is nested.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "offset": {
+          "description": "The offset in bytes of the artifact within its containing artifact.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "length": {
+          "description": "The length of the artifact in bytes.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "roles": {
+          "description": "The role or roles played by the artifact in the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "enum": [
+              "analysisTarget",
+              "attachment",
+              "responseFile",
+              "resultFile",
+              "standardStream",
+              "tracedFile",
+              "unmodified",
+              "modified",
+              "added",
+              "deleted",
+              "renamed",
+              "uncontrolled",
+              "driver",
+              "extension",
+              "translation",
+              "taxonomy",
+              "policy",
+              "referencedOnCommandLine",
+              "memoryContents",
+              "directory",
+              "userSpecifiedConfiguration",
+              "toolSpecifiedConfiguration",
+              "debugOutputFile"
+            ],
+            "type": "string"
+          }
+        },
+
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the artifact.",
+          "type": "string",
+          "pattern": "[^/]+/.+"
+        },
+
+        "contents": {
+          "description": "The contents of the artifact.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "encoding": {
+          "description": "Specifies the encoding for an artifact object that refers to a text file.",
+          "type": "string"
+        },
+
+        "sourceLanguage": {
+          "description": "Specifies the source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+
+        "hashes": {
+          "description": "A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "lastModifiedTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifactChange": {
+      "description": "A change to a single artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "artifactLocation": {
+          "description": "The location of the artifact to change.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "replacements": {
+          "description": "An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/replacement"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the change.",
+          "$ref": "#/definitions/propertyBag"
+        }
+
+      },
+
+      "required": [ "artifactLocation", "replacements" ]
+    },
+
+    "artifactContent": {
+      "description": "Represents the contents of an artifact.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "text": {
+          "description": "UTF-8-encoded content from a text artifact.",
+          "type": "string"
+        },
+
+        "binary": {
+          "description": "MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.",
+          "type": "string"
+        },
+
+        "rendered": {
+          "description": "An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region).",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact content.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "artifactLocation": {
+      "description": "Specifies the location of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "uri": {
+          "description": "A string containing a valid relative or absolute URI.",
+          "type": "string",
+          "format": "uri-reference"
+        },
+
+        "uriBaseId": {
+          "description": "A string which indirectly specifies the absolute URI with respect to which a relative URI in the \"uri\" property is interpreted.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index within the run artifacts array of the artifact object associated with the artifact location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "description": {
+          "description": "A short description of the artifact location.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the artifact location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "attachment": {
+      "description": "An artifact relevant to a result.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "description": {
+          "description": "A message describing the role played by the attachment.",
+          "$ref": "#/definitions/message"
+        },
+
+        "artifactLocation": {
+          "description": "The location of the attachment.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "regions": {
+          "description": "An array of regions of interest within the attachment.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+
+        "rectangles": {
+          "description": "An array of rectangles specifying areas of interest within the image.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/rectangle"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the attachment.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "artifactLocation" ]
+    },
+
+    "codeFlow": {
+      "description": "A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "message": {
+          "description": "A message relevant to the code flow.",
+          "$ref": "#/definitions/message"
+        },
+
+        "threadFlows": {
+          "description": "An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlow"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the code flow.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "threadFlows" ]
+    },
+
+    "configurationOverride": {
+      "description": "Information about how a specific rule or notification was reconfigured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "configuration": {
+          "description": "Specifies how the rule or notification was configured during the scan.",
+          "$ref": "#/definitions/reportingConfiguration"
+        },
+
+        "descriptor": {
+          "description": "A reference used to locate the descriptor whose configuration was overridden.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the configuration override.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "configuration", "descriptor" ]
+    },
+
+    "conversion": {
+      "description": "Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "tool": {
+          "description": "A tool object that describes the converter.",
+          "$ref": "#/definitions/tool"
+        },
+
+        "invocation": {
+          "description": "An invocation object that describes the invocation of the converter.",
+          "$ref": "#/definitions/invocation"
+        },
+
+        "analysisToolLogFiles": {
+          "description": "The locations of the analysis tool's per-run log files.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the conversion.",
+          "$ref": "#/definitions/propertyBag"
+        }
+
+      },
+
+      "required": [ "tool" ]
+    },
+
+    "edge": {
+      "description": "Represents a directed edge in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "A string that uniquely identifies the edge within its graph.",
+          "type": "string"
+        },
+
+        "label": {
+          "description": "A short description of the edge.",
+          "$ref": "#/definitions/message"
+        },
+
+        "sourceNodeId": {
+          "description": "Identifies the source node (the node at which the edge starts).",
+          "type": "string"
+        },
+
+        "targetNodeId": {
+          "description": "Identifies the target node (the node at which the edge ends).",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the edge.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "id", "sourceNodeId", "targetNodeId" ]
+    },
+
+    "edgeTraversal": {
+      "description": "Represents the traversal of a single edge during a graph traversal.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "edgeId": {
+          "description": "Identifies the edge being traversed.",
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message to display to the user as the edge is traversed.",
+          "$ref": "#/definitions/message"
+        },
+
+        "finalState": {
+          "description": "The values of relevant expressions after the edge has been traversed.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "stepOverEdgeCount": {
+          "description": "The number of edge traversals necessary to return from a nested graph.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the edge traversal.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "edgeId" ]
+    },
+
+    "exception": {
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "kind": {
+          "type": "string",
+          "description": "A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal."
+        },
+
+        "message": {
+          "description": "A message that describes the exception.",
+          "type": "string"
+        },
+
+        "stack": {
+          "description": "The sequence of function calls leading to the exception.",
+          "$ref": "#/definitions/stack"
+        },
+
+        "innerExceptions": {
+          "description": "An array of exception objects each of which is considered a cause of this exception.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/exception"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the exception.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "externalProperties": {
+      "description": "The top-level element of an external property file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "schema": {
+          "description": "The URI of the JSON schema corresponding to the version of the external property file format.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "version": {
+          "description": "The SARIF format version of this external properties object.",
+          "enum": [ "2.1.0" ],
+          "type": "string"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "runGuid": {
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "conversion": {
+          "description": "A conversion object that will be merged with a separate run.",
+          "$ref": "#/definitions/conversion"
+        },
+
+        "graphs": {
+          "description": "An array of graph objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "externalizedProperties": {
+          "description": "Key/value pairs that provide additional information that will be merged with a separate run.",
+          "$ref": "#/definitions/propertyBag"
+        },
+
+        "artifacts": {
+          "description": "An array of artifact objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "results": {
+          "description": "An array of result objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+
+        "taxonomies": {
+          "description": "Tool taxonomies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "driver": {
+          "description": "The analysis tool object that will be merged with a separate run.",
+          "$ref": "#/definitions/toolComponent"
+        },
+
+        "extensions": {
+          "description": "Tool extensions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "policies": {
+          "description": "Tool policies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "translations": {
+          "description": "Tool translations that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "addresses": {
+          "description": "Addresses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+
+        "webRequests": {
+          "description": "Requests that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+
+        "webResponses": {
+          "description": "Responses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external properties.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "externalPropertyFileReference": {
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "location": {
+          "description": "The location of the external property file.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "itemCount": {
+          "description": "A non-negative integer specifying the number of items contained in the external property file.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external property file.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "location" ] },
+        { "required": [ "guid" ] }
+      ]
+    },
+
+    "externalPropertyFileReferences": {
+      "description": "References to external property files that should be inlined with the content of a root log file.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "conversion": {
+          "description": "An external property file containing a run.conversion object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "graphs": {
+          "description": "An array of external property files containing a run.graphs object to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "externalizedProperties": {
+          "description": "An external property file containing a run.properties object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "artifacts": {
+          "description": "An array of external property files containing run.artifacts arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "invocations": {
+          "description": "An array of external property files containing run.invocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of external property files containing run.logicalLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "results": {
+          "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "taxonomies": {
+          "description": "An array of external property files containing run.taxonomies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "addresses": {
+          "description": "An array of external property files containing run.addresses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "driver": {
+          "description": "An external property file containing a run.driver object to be merged with the root log file.",
+          "$ref": "#/definitions/externalPropertyFileReference"
+        },
+
+        "extensions": {
+          "description": "An array of external property files containing run.extensions arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "policies": {
+          "description": "An array of external property files containing run.policies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "translations": {
+          "description": "An array of external property files containing run.translations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "webRequests": {
+          "description": "An array of external property files containing run.requests arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "webResponses": {
+          "description": "An array of external property files containing run.responses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the external property files.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "fix": {
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A message that describes the proposed fix, enabling viewers to present the proposed change to an end user.",
+          "$ref": "#/definitions/message"
+        },
+
+        "artifactChanges": {
+          "description": "One or more artifact changes that comprise a fix for a result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactChange"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the fix.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "artifactChanges" ]
+    },
+
+    "graph": {
+      "description": "A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "description": {
+          "description": "A description of the graph.",
+          "$ref": "#/definitions/message"
+        },
+
+        "nodes": {
+          "description": "An array of node objects representing the nodes of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+
+        "edges": {
+          "description": "An array of edge objects representing the edges of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edge"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the graph.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "graphTraversal": {
+      "description": "Represents a path through a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "runGraphIndex": {
+          "description": "The index within the run.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "resultGraphIndex": {
+          "description": "The index within the result.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "description": {
+          "description": "A description of this graph traversal.",
+          "$ref": "#/definitions/message"
+        },
+
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that may change during graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "edgeTraversals": {
+          "description": "The sequences of edges traversed by this graph traversal.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edgeTraversal"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the graph traversal.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "oneOf": [
+        { "required": [ "runGraphIndex" ] },
+        { "required": [ "resultGraphIndex" ] }
+      ]
+    },
+
+    "invocation": {
+      "description": "The runtime environment of the analysis tool run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "commandLine": {
+          "description": "The command line used to invoke the tool.",
+          "type": "string"
+        },
+
+        "arguments": {
+          "description": "An array of strings, containing in order the command line arguments passed to the tool from the operating system.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "responseFiles": {
+          "description": "The locations of any response files specified on the tool's command line.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "startTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "endTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "exitCode": {
+          "description": "The process exit code.",
+          "type": "integer"
+        },
+
+        "ruleConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe rules related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+
+        "notificationConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe notifications related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+
+        "toolExecutionNotifications": {
+          "description": "A list of runtime conditions detected by the tool during the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+
+        "toolConfigurationNotifications": {
+          "description": "A list of conditions detected by the tool that are relevant to the tool's configuration.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+
+        "exitCodeDescription": {
+          "description": "The reason for the process exit.",
+          "type": "string"
+        },
+
+        "exitSignalName": {
+          "description": "The name of the signal that caused the process to exit.",
+          "type": "string"
+        },
+
+        "exitSignalNumber": {
+          "description": "The numeric value of the signal that caused the process to exit.",
+          "type": "integer"
+        },
+
+        "processStartFailureMessage": {
+          "description": "The reason given by the operating system that the process failed to start.",
+          "type": "string"
+        },
+
+        "executionSuccessful": {
+          "description": "Specifies whether the tool's execution completed successfully.",
+          "type": "boolean"
+        },
+
+        "machine": {
+          "description": "The machine on which the invocation occurred.",
+          "type": "string"
+        },
+
+        "account": {
+          "description": "The account under which the invocation occurred.",
+          "type": "string"
+        },
+
+        "processId": {
+          "description": "The id of the process in which the invocation occurred.",
+          "type": "integer"
+        },
+
+        "executableLocation": {
+          "description": "An absolute URI specifying the location of the executable that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "workingDirectory": {
+          "description": "The working directory for the invocation.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "environmentVariables": {
+          "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "stdin": {
+          "description": "A file containing the standard input stream to the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stdout": {
+          "description": "A file containing the standard output stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stderr": {
+          "description": "A file containing the standard error stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "stdoutStderr": {
+          "description": "A file containing the interleaved standard output and standard error stream from the process that was invoked.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the invocation.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "executionSuccessful" ]
+    },
+
+    "location": {
+      "description": "A location within a programming artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "id": {
+          "description": "Value that distinguishes this location from all other locations within a single result object.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+
+        "physicalLocation": {
+          "description": "Identifies the artifact and region.",
+          "$ref": "#/definitions/physicalLocation"
+        },
+
+        "logicalLocations": {
+          "description": "The logical locations associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "message": {
+          "description": "A message relevant to the location.",
+          "$ref": "#/definitions/message"
+        },
+
+        "annotations": {
+          "description": "A set of regions relevant to the location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+
+        "relationships": {
+          "description": "An array of objects that describe relationships between this location and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/locationRelationship"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "locationRelationship": {
+      "description": "Information about the relation of one location to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "target": {
+          "description": "A reference to the related location.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.",
+          "type": "array",
+          "default": [ "relevant" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "description": {
+          "description": "A description of the location relationship.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the location relationship.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "target" ]
+    },
+
+    "logicalLocation": {
+      "description": "A logical location of a construct that produced a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "name": {
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index within the logical locations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "fullyQualifiedName": {
+          "description": "The human-readable fully qualified name of the logical location.",
+          "type": "string"
+        },
+
+        "decoratedName": {
+          "description": "The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
+          "type": "string"
+        },
+
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "kind": {
+          "description": "The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the logical location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "message": {
+      "description": "Encapsulates a message intended to be read by the end user.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "text": {
+          "description": "A plain text message string.",
+          "type": "string"
+        },
+
+        "markdown": {
+          "description": "A Markdown message string.",
+          "type": "string"
+        },
+
+        "id": {
+          "description": "The identifier for this message.",
+          "type": "string"
+        },
+
+        "arguments": {
+          "description": "An array of strings to substitute into the message string.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the message.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "text" ] },
+        { "required": [ "id" ] }
+      ]
+    },
+
+    "multiformatMessageString": {
+      "description": "A message string or message format string rendered in multiple formats.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "text": {
+          "description": "A plain text message string or format string.",
+          "type": "string"
+        },
+
+        "markdown": {
+          "description": "A Markdown message string or format string.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the message.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "text" ]
+    },
+
+    "node": {
+      "description": "Represents a node in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+
+        "id": {
+          "description": "A string that uniquely identifies the node within its graph.",
+          "type": "string"
+        },
+
+        "label": {
+          "description": "A short description of the node.",
+          "$ref": "#/definitions/message"
+        },
+
+        "location": {
+          "description": "A code location associated with the node.",
+          "$ref": "#/definitions/location"
+        },
+
+        "children": {
+          "description": "Array of child nodes.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the node.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "id" ]
+    },
+
+    "notification": {
+      "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "locations": {
+          "description": "The locations relevant to this notification.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "message": {
+          "description": "A message that describes the condition that was encountered.",
+          "$ref": "#/definitions/message"
+        },
+
+        "level": {
+          "description": "A value specifying the severity level of the notification.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+
+        "timeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "exception": {
+          "description": "The runtime exception, if any, relevant to this notification.",
+          "$ref": "#/definitions/exception"
+        },
+
+        "descriptor": {
+          "description": "A reference used to locate the descriptor relevant to this notification.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "associatedRule": {
+          "description": "A reference used to locate the rule descriptor associated with this notification.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the notification.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "message" ]
+    },
+
+    "physicalLocation": {
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "address": {
+          "description": "The address of the location.",
+          "$ref": "#/definitions/address"
+        },
+
+        "artifactLocation": {
+          "description": "The location of the artifact.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "region": {
+          "description": "Specifies a portion of the artifact.",
+          "$ref": "#/definitions/region"
+        },
+
+        "contextRegion": {
+          "description": "Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region.",
+          "$ref": "#/definitions/region"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the physical location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "anyOf": [
+        {
+          "required": [ "address" ]
+        },
+        {
+          "required": [ "artifactLocation" ]
+        }
+      ]
+    },
+
+    "propertyBag": {
+      "description": "Key/value pairs that provide additional information about the object.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tags": {
+
+          "description": "A set of distinct strings that provide additional information.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+
+    "rectangle": {
+      "description": "An area within an image.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "top": {
+          "description": "The Y coordinate of the top edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "left": {
+          "description": "The X coordinate of the left edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "bottom": {
+          "description": "The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "right": {
+          "description": "The X coordinate of the right edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+
+        "message": {
+          "description": "A message relevant to the rectangle.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the rectangle.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "region": {
+      "description": "A region within an artifact where a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "startLine": {
+          "description": "The line number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "startColumn": {
+          "description": "The column number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "endLine": {
+          "description": "The line number of the last character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "endColumn": {
+          "description": "The column number of the character following the end of the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "charOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first character in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "charLength": {
+          "description": "The length of the region in characters.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "byteOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first byte in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "byteLength": {
+          "description": "The length of the region in bytes.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "snippet": {
+          "description": "The portion of the artifact contents within the specified region.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "message": {
+          "description": "A message relevant to the region.",
+          "$ref": "#/definitions/message"
+        },
+
+        "sourceLanguage": {
+          "description": "Specifies the source language, if any, of the portion of the artifact specified by the region object.",
+          "type": "string"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the region.",
+          "$ref": "#/definitions/propertyBag"
+        },
+
+        "anyOf": [
+          { "required": [ "startLine" ] },
+          { "required": [ "charOffset" ] },
+          { "required": [ "byteOffset" ] }
+        ]
+      }
+    },
+
+    "replacement": {
+      "description": "The replacement of a single region of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "deletedRegion": {
+          "description": "The region of the artifact to delete.",
+          "$ref": "#/definitions/region"
+        },
+
+        "insertedContent": {
+          "description": "The content to insert at the location specified by the 'deletedRegion' property.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the replacement.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "deletedRegion" ]
+    },
+
+    "reportingDescriptor": {
+      "description": "Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "id": {
+          "description": "A stable, opaque identifier for the report.",
+          "type": "string"
+        },
+
+        "deprecatedIds": {
+          "description": "An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "guid": {
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "deprecatedGuids": {
+          "description": "An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          }
+        },
+
+        "name": {
+          "description": "A report identifier that is understandable to an end user.",
+          "type": "string"
+        },
+
+        "deprecatedNames": {
+          "description": "An array of readable identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "shortDescription": {
+          "description": "A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "messageStrings": {
+          "description": "A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "defaultConfiguration": {
+          "description": "Default reporting configuration information.",
+          "$ref": "#/definitions/reportingConfiguration"
+        },
+
+        "helpUri": {
+          "description": "A URI where the primary documentation for the report can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "help": {
+          "description": "Provides the primary documentation for the report, useful when there is no online documentation.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "relationships": {
+          "description": "An array of objects that describe relationships between this reporting descriptor and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorRelationship"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the report.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "id" ]
+    },
+
+    "reportingConfiguration": {
+      "description": "Information about a rule or notification that can be configured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "enabled": {
+          "description": "Specifies whether the report may be produced during the scan.",
+          "type": "boolean",
+          "default": true
+        },
+
+        "level": {
+          "description": "Specifies the failure level for the report.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "rank": {
+          "description": "Specifies the relative priority of the report. Used for analysis output only.",
+          "type": "number",
+          "default": -1.0,
+          "minimum": -1.0,
+          "maximum": 100.0
+        },
+
+        "parameters": {
+          "description": "Contains configuration information specific to a report.",
+          "$ref": "#/definitions/propertyBag"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting configuration.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "reportingDescriptorReference": {
+      "description": "Information about how to locate a relevant reporting descriptor.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "The id of the descriptor.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "guid": {
+          "description": "A guid that uniquely identifies the descriptor.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "toolComponent": {
+          "description": "A reference used to locate the toolComponent associated with the descriptor.",
+          "$ref": "#/definitions/toolComponentReference"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "anyOf": [
+        { "required": [ "index" ] },
+        { "required": [ "guid" ] },
+        { "required": [ "id" ] }
+      ]
+    },
+
+    "reportingDescriptorRelationship": {
+      "description": "Information about the relation of one reporting descriptor to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "target": {
+          "description": "A reference to the related reporting descriptor.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.",
+          "type": "array",
+          "default": [ "relevant" ],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "description": {
+          "description": "A description of the reporting descriptor relationship.",
+          "$ref": "#/definitions/message"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "target" ]
+    },
+
+    "result": {
+      "description": "A result produced by an analysis tool.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "ruleId": {
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
+          "type": "string"
+        },
+
+        "ruleIndex": {
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "rule": {
+          "description": "A reference used to locate the rule descriptor relevant to this result.",
+          "$ref": "#/definitions/reportingDescriptorReference"
+        },
+
+        "kind": {
+          "description": "A value that categorizes results by evaluation state.",
+          "default": "fail",
+          "enum": [ "notApplicable", "pass", "fail", "review", "open", "informational" ],
+          "type": "string"
+        },
+
+        "level": {
+          "description": "A value specifying the severity level of the result.",
+          "default": "warning",
+          "enum": [ "none", "note", "warning", "error" ],
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message that describes the result. The first sentence of the message only will be displayed when visible space is limited.",
+          "$ref": "#/definitions/message"
+        },
+
+        "analysisTarget": {
+          "description": "Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "locations": {
+          "description": "The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "occurrenceCount": {
+          "description": "A positive integer specifying the number of times this logically unique result was observed in this run.",
+          "type": "integer",
+          "minimum": 1
+        },
+
+        "partialFingerprints": {
+          "description": "A set of strings that contribute to the stable, unique identity of the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "fingerprints": {
+          "description": "A set of strings each of which individually defines a stable, unique identity for the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "stacks": {
+          "description": "An array of 'stack' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/stack"
+          }
+        },
+
+        "codeFlows": {
+          "description": "An array of 'codeFlow' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/codeFlow"
+          }
+        },
+
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "graphTraversals": {
+          "description": "An array of one or more unique 'graphTraversal' objects.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graphTraversal"
+          }
+        },
+
+        "relatedLocations": {
+          "description": "A set of locations relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+
+        "suppressions": {
+          "description": "A set of suppressions relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/suppression"
+          }
+        },
+
+        "baselineState": {
+          "description": "The state of a result relative to a baseline of a previous run.",
+          "enum": [
+            "new",
+            "unchanged",
+            "updated",
+            "absent"
+          ],
+          "type": "string"
+        },
+
+        "rank": {
+          "description": "A number representing the priority or importance of the result.",
+          "type": "number",
+          "default": -1.0,
+          "minimum": -1.0,
+          "maximum": 100.0
+        },
+
+        "attachments": {
+          "description": "A set of artifacts relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/attachment"
+          }
+        },
+
+        "hostedViewerUri": {
+          "description": "An absolute URI at which the result can be viewed.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "workItemUris": {
+          "description": "The URIs of the work items associated with this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+
+        "provenance": {
+          "description": "Information about how and when the result was detected.",
+          "$ref": "#/definitions/resultProvenance"
+        },
+
+        "fixes": {
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/fix"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of references to taxonomy reporting descriptors that are applicable to the result.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+
+        "webRequest": {
+          "description": "A web request associated with this result.",
+          "$ref": "#/definitions/webRequest"
+        },
+
+        "webResponse": {
+          "description": "A web response associated with this result.",
+          "$ref": "#/definitions/webResponse"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the result.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "message" ]
+    },
+
+    "resultProvenance": {
+      "description": "Contains information about how and when a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "firstDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "lastDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "firstDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "lastDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "invocationIndex": {
+          "description": "The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "conversionSources": {
+          "description": "An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/physicalLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the result.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "run": {
+      "description": "Describes a single run of an analysis tool, and contains the reported output of that run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "tool": {
+          "description": "Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.",
+          "$ref": "#/definitions/tool"
+        },
+
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+
+        "conversion": {
+          "description": "A conversion object that describes how a converter transformed an analysis tool's native reporting format into the SARIF format.",
+          "$ref": "#/definitions/conversion"
+        },
+
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^(?i)[a-zA]{2}(-[a-z]{2})?$"
+        },
+
+        "versionControlProvenance": {
+          "description": "Specifies the revision in version control of the artifacts that were scanned.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/versionControlDetails"
+          }
+        },
+
+        "originalUriBaseIds": {
+          "description": "The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "artifacts": {
+          "description": "An array of artifact objects relevant to the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+
+        "automationDetails": {
+          "description": "Automation details that describe this run.",
+          "$ref": "#/definitions/runAutomationDetails"
+        },
+
+        "runAggregates": {
+          "description": "Automation details that describe the aggregate of runs to which this run belongs.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/runAutomationDetails"
+          }
+        },
+
+        "baselineGuid": {
+          "description": "The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "redactionTokens": {
+          "description": "An array of strings used to replace sensitive information in a redaction-aware property.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "defaultEncoding": {
+          "description": "Specifies the default encoding for any artifact object that refers to a text file.",
+          "type": "string"
+        },
+
+        "defaultSourceLanguage": {
+          "description": "Specifies the default source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+
+        "newlineSequences": {
+          "description": "An ordered list of character sequences that were treated as line breaks when computing region information for the run.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "default": [ "\r\n", "\n" ],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "columnKind": {
+          "description": "Specifies the unit in which the tool measures columns.",
+          "enum": [ "utf16CodeUnits", "unicodeCodePoints" ],
+          "type": "string"
+        },
+
+        "externalPropertyFileReferences": {
+          "description": "References to external property files that should be inlined with the content of a root log file.",
+          "$ref": "#/definitions/externalPropertyFileReferences"
+        },
+
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "taxonomies": {
+          "description": "An array of toolComponent objects relevant to a taxonomy in which results are categorized.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "addresses": {
+          "description": "Addresses associated with this run instance, if any.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+
+        "translations": {
+          "description": "The set of available translations of the localized data provided by the tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "policies": {
+          "description": "Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "webRequests": {
+          "description": "An array of request objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+
+        "webResponses": {
+          "description": "An array of response objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+
+        "specialLocations": {
+          "description": "A specialLocations object that defines locations of special significance to SARIF consumers.",
+          "$ref": "#/definitions/specialLocations"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the run.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "tool" ]
+    },
+
+    "runAutomationDetails": {
+      "description": "Information that describes a run's identity and role within an engineering system process.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "description": {
+          "description": "A description of the identity and role played within the engineering system by this object's containing run object.",
+          "$ref": "#/definitions/message"
+        },
+
+        "id": {
+          "description": "A hierarchical string that uniquely identifies this object's containing run object.",
+          "type": "string"
+        },
+
+        "guid": {
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the run automation details.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "specialLocations": {
+      "description": "Defines locations of special significance to SARIF consumers.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "displayBase": {
+          "description": "Provides a suggestion to SARIF consumers to display file paths relative to the specified location.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the special locations.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "stack": {
+      "description": "A call stack that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "message": {
+          "description": "A message relevant to this call stack.",
+          "$ref": "#/definitions/message"
+        },
+
+        "frames": {
+          "description": "An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/stackFrame"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the stack.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "frames" ]
+    },
+
+    "stackFrame": {
+      "description": "A function call within a stack trace.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "location": {
+          "description": "The location to which this stack frame refers.",
+          "$ref": "#/definitions/location"
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code of this stack frame.",
+          "type": "string"
+        },
+
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
+        },
+
+        "parameters": {
+          "description": "The parameters of the call that is executing.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string",
+            "default": []
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the stack frame.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "suppression": {
+      "description": "A suppression that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "guid": {
+          "description": "A stable, unique identifier for the suprression in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "kind": {
+          "description": "A string that indicates where the suppression is persisted.",
+          "enum": [
+            "inSource",
+            "external"
+          ],
+          "type": "string"
+        },
+
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
+          "enum": [
+            "accepted",
+            "underReview",
+            "rejected"
+          ],
+          "type": "string"
+        },
+
+        "justification": {
+          "description": "A string representing the justification for the suppression.",
+          "type": "string"
+        },
+
+        "location": {
+          "description": "Identifies the location associated with the suppression.",
+          "$ref": "#/definitions/location"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the suppression.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "kind" ]
+    },
+
+    "threadFlow": {
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "id": {
+          "description": "An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.",
+          "type": "string"
+        },
+
+        "message": {
+          "description": "A message relevant to the thread flow.",
+          "$ref": "#/definitions/message"
+        },
+
+
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the thread flow that may change during thread flow execution.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the thread flow that remain constant.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "locations": {
+          "description": "A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the thread flow.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "locations" ]
+    },
+
+    "threadFlowLocation": {
+      "description": "A location visited by an analysis tool while simulating or monitoring the execution of a program.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "index": {
+          "description": "The index within the run threadFlowLocations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "location": {
+          "description": "The code location.",
+          "$ref": "#/definitions/location"
+        },
+
+        "stack": {
+          "description": "The call stack leading to this location.",
+          "$ref": "#/definitions/stack"
+        },
+
+        "kinds": {
+          "description": "A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+
+        "state": {
+          "description": "A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "nestingLevel": {
+          "description": "An integer representing a containment hierarchy within the thread flow.",
+          "type": "integer",
+          "minimum": 0
+        },
+
+        "executionOrder": {
+          "description": "An integer representing the temporal order in which execution reached this location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "executionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which this location was executed.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "importance": {
+          "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
+          "enum": [ "important", "essential", "unimportant" ],
+          "default": "important",
+          "type": "string"
+        },
+
+        "webRequest": {
+          "description": "A web request associated with this thread flow location.",
+          "$ref": "#/definitions/webRequest"
+        },
+
+        "webResponse": {
+          "description": "A web response associated with this thread flow location.",
+          "$ref": "#/definitions/webResponse"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the threadflow location.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "tool": {
+      "description": "The analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "driver": {
+          "description": "The analysis tool that was run.",
+          "$ref": "#/definitions/toolComponent"
+        },
+
+        "extensions": {
+          "description": "Tool extensions that contributed to or reconfigured the analysis tool that was run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the tool.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "driver" ]
+    },
+
+    "toolComponent": {
+      "description": "A component, such as a plug-in or the driver, of the analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+
+        "guid": {
+          "description": "A unique identifier for the tool component in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "name": {
+          "description": "The name of the tool component.",
+          "type": "string"
+        },
+
+        "organization": {
+          "description": "The organization or company that produced the tool component.",
+          "type": "string"
+        },
+
+        "product": {
+          "description": "A product suite to which the tool component belongs.",
+          "type": "string"
+        },
+
+        "productSuite": {
+          "description": "A localizable string containing the name of the suite of products to which the tool component belongs.",
+          "type": "string"
+        },
+
+        "shortDescription": {
+          "description": "A brief description of the tool component.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A comprehensive description of the tool component.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullName": {
+          "description": "The name of the tool component along with its version and any other useful identifying information, such as its locale.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The tool component version, in whatever format the component natively provides.",
+          "type": "string"
+        },
+
+        "semanticVersion": {
+          "description": "The tool component version in the format specified by Semantic Versioning 2.0.",
+          "type": "string"
+        },
+
+        "dottedQuadFileVersion": {
+          "description": "The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).",
+          "type": "string",
+          "pattern": "[0-9]+(\\.[0-9]+){3}"
+        },
+
+        "releaseDateUtc": {
+          "description": "A string specifying the UTC date (and optionally, the time) of the component's release.",
+          "type": "string"
+        },
+
+        "downloadUri": {
+          "description": "The absolute URI from which the tool component can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "informationUri": {
+          "description": "The absolute URI at which information about this version of the tool component can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "globalMessageStrings": {
+          "description": "A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+
+        "notifications": {
+          "description": "An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "rules": {
+          "description": "An array of reportingDescriptor objects relevant to the analysis performed by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "taxa": {
+          "description": "An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+
+        "locations": {
+          "description": "An array of the artifactLocation objects associated with the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^(?i)[a-zA]{2}(-[a-z]{2})?$"
+        },
+
+        "contents": {
+          "description": "The kinds of data contained in this object.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": [ "localizedData", "nonLocalizedData" ],
+          "items": {
+            "enum": [
+              "localizedData",
+              "nonLocalizedData"
+            ],
+            "type": "string"
+          }
+        },
+
+        "isComprehensive": {
+          "description": "Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "localizedDataSemanticVersion": {
+          "description": "The semantic version of the localized strings defined in this component; maintained by components that provide translations.",
+          "type": "string"
+        },
+
+        "minimumRequiredLocalizedDataSemanticVersion": {
+          "description": "The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.",
+          "type": "string"
+        },
+
+        "associatedComponent": {
+          "description": "The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model.",
+          "$ref": "#/definitions/toolComponentReference"
+        },
+
+        "translationMetadata": {
+          "description": "Translation metadata, required for a translation, not populated by other component types.",
+          "$ref": "#/definitions/translationMetadata"
+        },
+
+        "supportedTaxonomies": {
+          "description": "An array of toolComponentReference objects to declare the taxonomies supported by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponentReference"
+          }
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the tool component.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "name" ]
+    },
+
+    "toolComponentReference": {
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "name": {
+          "description": "The 'name' property of the referenced toolComponent.",
+          "type": "string"
+        },
+
+        "index": {
+          "description": "An index into the referenced toolComponent in tool.extensions.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "guid": {
+          "description": "The 'guid' property of the referenced toolComponent.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the toolComponentReference.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "translationMetadata": {
+      "description": "Provides additional metadata related to translation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "name": {
+          "description": "The name associated with the translation metadata.",
+          "type": "string"
+        },
+
+        "fullName": {
+          "description": "The full name associated with the translation metadata.",
+          "type": "string"
+        },
+
+        "shortDescription": {
+          "description": "A brief description of the translation metadata.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "fullDescription": {
+          "description": "A comprehensive description of the translation metadata.",
+          "$ref": "#/definitions/multiformatMessageString"
+        },
+
+        "downloadUri": {
+          "description": "The absolute URI from which the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "informationUri": {
+          "description": "The absolute URI from which information related to the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the translation metadata.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+      "required": [ "name" ]
+    },
+
+    "versionControlDetails": {
+      "description": "Specifies the information necessary to retrieve a desired revision from a version control system.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "repositoryUri": {
+          "description": "The absolute URI of the repository.",
+          "type": "string",
+          "format": "uri"
+        },
+
+        "revisionId": {
+          "description": "A string that uniquely and permanently identifies the revision within the repository.",
+          "type": "string"
+        },
+
+        "branch": {
+          "description": "The name of a branch containing the revision.",
+          "type": "string"
+        },
+
+        "revisionTag": {
+          "description": "A tag that has been applied to the revision.",
+          "type": "string"
+        },
+
+        "asOfTimeUtc": {
+          "description": "A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "mappedTo": {
+          "description": "The location in the local file system to which the root of the repository was mapped at the time of the analysis.",
+          "$ref": "#/definitions/artifactLocation"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the version control details.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      },
+
+      "required": [ "repositoryUri" ]
+    },
+
+    "webRequest": {
+      "description": "Describes an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "index": {
+          "description": "The index within the run.webRequests array of the request object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+
+        },
+
+        "protocol": {
+          "description": "The request protocol. Example: 'http'.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The request version. Example: '1.1'.",
+          "type": "string"
+        },
+
+        "target": {
+          "description": "The target of the request.",
+          "type": "string"
+        },
+
+        "method": {
+          "description": "The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.",
+          "type": "string"
+        },
+
+        "headers": {
+          "description": "The request headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "parameters": {
+          "description": "The request parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "body": {
+          "description": "The body of the request.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the request.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    },
+
+    "webResponse": {
+      "description": "Describes the response to an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        "index": {
+          "description": "The index within the run.webResponses array of the response object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+
+        "protocol": {
+          "description": "The response protocol. Example: 'http'.",
+          "type": "string"
+        },
+
+        "version": {
+          "description": "The response version. Example: '1.1'.",
+          "type": "string"
+        },
+
+        "statusCode": {
+          "description": "The response status code. Example: 451.",
+          "type": "integer"
+        },
+
+        "reasonPhrase": {
+          "description": "The response reason. Example: 'Not found'.",
+          "type": "string"
+        },
+
+        "headers": {
+          "description": "The response headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+
+        "body": {
+          "description": "The body of the response.",
+          "$ref": "#/definitions/artifactContent"
+        },
+
+        "noResponseReceived": {
+          "description": "Specifies whether a response was received from the server.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "properties": {
+          "description": "Key/value pairs that provide additional information about the response.",
+          "$ref": "#/definitions/propertyBag"
+        }
+      }
+    }
+  }
+}

--- a/tests/ci/test_export_cli.py
+++ b/tests/ci/test_export_cli.py
@@ -52,3 +52,39 @@ def test_handle_export_missing_dir_returns_error(tmp_path, capsys):
 def test_handle_export_unknown_format_returns_error(tmp_path):
     code = handle_export(_args(export_format="xml", evaluation_dir=str(tmp_path), output="x"))
     assert code == 1
+
+
+from quodeq.cli_parser import build_parser
+
+
+def test_parser_export_sarif_args():
+    parser = build_parser()
+    args = parser.parse_args([
+        "export", "sarif",
+        "--evaluation-dir", "/tmp/e",
+        "-o", "/tmp/out.sarif",
+        "--min-severity", "major",
+        "--with-snippets",
+    ])
+    assert args.command == "export"
+    assert args.export_format == "sarif"
+    assert args.evaluation_dir == "/tmp/e"
+    assert args.output == "/tmp/out.sarif"
+    assert args.min_severity == "major"
+    assert args.with_snippets is True
+
+
+def test_parser_evaluate_sarif_flags_default_off():
+    parser = build_parser()
+    args = parser.parse_args(["evaluate", "."])
+    assert args.sarif is None
+    assert args.min_severity is None
+    assert args.with_snippets is False
+
+
+def test_parser_evaluate_sarif_flags_set():
+    parser = build_parser()
+    args = parser.parse_args(["evaluate", ".", "--sarif", "q.sarif", "--min-severity", "critical", "--with-snippets"])
+    assert args.sarif == "q.sarif"
+    assert args.min_severity == "critical"
+    assert args.with_snippets is True

--- a/tests/ci/test_export_cli.py
+++ b/tests/ci/test_export_cli.py
@@ -1,0 +1,54 @@
+# tests/ci/test_export_cli.py
+import argparse
+import json
+from pathlib import Path
+
+from quodeq.ci.export_cli import handle_export
+
+
+def _write_report(eval_dir: Path, dimension: str, violations: list[dict]) -> None:
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / f"{dimension}.json").write_text(
+        json.dumps({"dimension": dimension, "violations": violations, "compliance": []}),
+        encoding="utf-8",
+    )
+
+
+def _args(**kw) -> argparse.Namespace:
+    base = {
+        "export_format": "sarif",
+        "evaluation_dir": None,
+        "output": None,
+        "min_severity": None,
+        "with_snippets": False,
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_handle_export_writes_valid_sarif(tmp_path):
+    eval_dir = tmp_path / "evaluation"
+    _write_report(eval_dir, "reliability", [
+        {"principle": "Fault Tolerance", "file": "app.py", "line": 1, "severity": "major",
+         "title": "t", "reason": "r", "req": "R-FT-1", "req_refs": []},
+    ])
+    out = tmp_path / "out.sarif"
+
+    code = handle_export(_args(evaluation_dir=str(eval_dir), output=str(out)))
+
+    assert code == 0
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    assert doc["version"] == "2.1.0"
+    assert len(doc["runs"][0]["results"]) == 1
+
+
+def test_handle_export_missing_dir_returns_error(tmp_path, capsys):
+    out = tmp_path / "out.sarif"
+    code = handle_export(_args(evaluation_dir=str(tmp_path / "nope"), output=str(out)))
+    assert code == 1
+    assert not out.exists()
+
+
+def test_handle_export_unknown_format_returns_error(tmp_path):
+    code = handle_export(_args(export_format="xml", evaluation_dir=str(tmp_path), output="x"))
+    assert code == 1

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -253,3 +253,41 @@ def test_windows_style_path_is_relativized():
     )
     uri = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
     assert uri == "src/api/x.py"
+
+
+from pathlib import Path
+import pytest
+
+_SCHEMA_PATH = Path(__file__).parent / "fixtures" / "sarif-schema-2.1.0.json"
+
+
+@pytest.mark.skipif(not _SCHEMA_PATH.exists(), reason="SARIF schema fixture not vendored")
+def test_build_sarif_validates_against_official_schema():
+    import json
+    import jsonschema
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    doc = build_sarif(
+        [
+            _report("reliability", [_violation()]),
+            _report("security", [_violation(principle="Authentication", req="S-AUT-1", severity="critical")]),
+        ],
+        tool_version="1.4.0",
+        include_snippets=True,
+    )
+    # Use Draft202012Validator directly to match the schema's declared $schema
+    # and avoid jsonschema.validate calling check_schema(), which rejects a
+    # regex in the SARIF schema itself on Python 3.14+.
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(doc))
+    assert errors == [], "\n".join(str(e) for e in errors)
+
+
+@pytest.mark.skipif(not _SCHEMA_PATH.exists(), reason="SARIF schema fixture not vendored")
+def test_empty_sarif_validates_against_official_schema():
+    import json
+    import jsonschema
+
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    doc = build_sarif([_report("reliability", [])], tool_version="1.4.0")
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(doc))
+    assert errors == [], "\n".join(str(e) for e in errors)

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -220,3 +220,36 @@ def test_with_snippets_toggles_snippet_text():
     on = build_sarif(reports, tool_version="1.4.0", include_snippets=True)
     region_on = on["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
     assert region_on["snippet"]["text"] == "secret = 'x'"
+
+
+import json as _json
+
+
+def test_no_absolute_paths_or_project_field_anywhere():
+    report = _report(
+        "reliability",
+        [_violation(file="src/api/x.py")],
+        project="/Users/victor/GitHub/secret-project",
+        runId="abc123",
+    )
+    doc = build_sarif([report], tool_version="1.4.0", include_snippets=True)
+    blob = _json.dumps(doc)
+    assert "/Users/" not in blob
+    assert "secret-project" not in blob
+    assert "abc123" not in blob
+    # Every uri is relative POSIX.
+    for run in doc["runs"]:
+        for result in run["results"]:
+            for loc in result.get("locations", []):
+                uri = loc["physicalLocation"]["artifactLocation"]["uri"]
+                assert not uri.startswith("/")
+                assert "\\" not in uri
+
+
+def test_windows_style_path_is_relativized():
+    doc = build_sarif(
+        [_report("reliability", [_violation(file="src\\api\\x.py")])],
+        tool_version="1.4.0",
+    )
+    uri = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+    assert uri == "src/api/x.py"

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -188,3 +188,35 @@ def test_build_sarif_clamps_startline_and_tolerates_missing_fields():
     assert result.get("locations", []) == []
     assert result["message"]["text"]
     assert "partialFingerprints" not in result  # req and snippet both blank
+
+
+def test_min_severity_filters_below_threshold():
+    violations = [
+        _violation(severity="critical", title="c", snippet="c"),
+        _violation(severity="major", title="m", snippet="m"),
+        _violation(severity="minor", title="n", snippet="n"),
+        _violation(severity="unknown", title="u", snippet="u"),
+    ]
+    reports = [_report("reliability", violations)]
+
+    all_doc = build_sarif(reports, tool_version="1.4.0")
+    assert len(all_doc["runs"][0]["results"]) == 4
+
+    major_doc = build_sarif(reports, tool_version="1.4.0", min_severity="major")
+    levels = [r["properties"]["quodeq"]["severity"] for r in major_doc["runs"][0]["results"]]
+    assert sorted(levels) == ["critical", "major"]
+
+    minor_doc = build_sarif(reports, tool_version="1.4.0", min_severity="minor")
+    assert len(minor_doc["runs"][0]["results"]) == 3  # drops unknown
+
+
+def test_with_snippets_toggles_snippet_text():
+    reports = [_report("reliability", [_violation(snippet="secret = 'x'")])]
+
+    off = build_sarif(reports, tool_version="1.4.0", include_snippets=False)
+    region_off = off["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+    assert "snippet" not in region_off
+
+    on = build_sarif(reports, tool_version="1.4.0", include_snippets=True)
+    region_on = on["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]
+    assert region_on["snippet"]["text"] == "secret = 'x'"

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -39,3 +39,35 @@ def test_slug_lowercases_and_hyphenates():
 
 def test_rule_id_joins_dimension_and_principle_slug():
     assert _rule_id("reliability", "Fault Tolerance") == "reliability/fault-tolerance"
+
+
+from quodeq.ci.sarif import _cwe_tags, _safe_uri
+
+
+def test_cwe_tags_extracts_github_form_from_req_refs():
+    refs = [
+        {"label": "CWE-390", "url": "https://cwe.mitre.org/data/definitions/390.html"},
+        {"label": "CISQ", "url": "https://www.it-cisq.org/"},
+        {"label": "cwe-79", "url": ""},
+    ]
+    assert _cwe_tags(refs) == ["external/cwe/cwe-390", "external/cwe/cwe-79"]
+
+
+def test_cwe_tags_handles_missing_or_empty():
+    assert _cwe_tags(None) == []
+    assert _cwe_tags([]) == []
+    assert _cwe_tags([{"label": "CISQ"}]) == []
+
+
+def test_safe_uri_normalizes_to_relative_posix():
+    assert _safe_uri("app.py") == "app.py"
+    assert _safe_uri("src/api/x.py") == "src/api/x.py"
+    assert _safe_uri("src\\api\\x.py") == "src/api/x.py"
+    assert _safe_uri("/abs/leak.py") == "abs/leak.py"  # leading slash stripped
+
+
+def test_safe_uri_rejects_blank_and_escaping():
+    assert _safe_uri("") is None
+    assert _safe_uri(None) is None
+    assert _safe_uri("../outside.py") is None
+    assert _safe_uri("a/../../b.py") is None

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -291,3 +291,40 @@ def test_empty_sarif_validates_against_official_schema():
     doc = build_sarif([_report("reliability", [])], tool_version="1.4.0")
     errors = list(jsonschema.Draft202012Validator(schema).iter_errors(doc))
     assert errors == [], "\n".join(str(e) for e in errors)
+
+
+def test_golden_two_findings():
+    reports = [
+        _report("reliability", [
+            _violation(file="app.py", line=58, end_line=59, severity="major",
+                       title="Empty except", reason="Bare except hides failures.", req="R-FT-1",
+                       req_refs=[{"label": "CWE-390", "url": "https://cwe.mitre.org/data/definitions/390.html"}],
+                       snippet="except:\n    pass"),
+        ]),
+        _report("security", [
+            _violation(principle="Authentication", file="auth.py", line=5, end_line=5, severity="critical",
+                       title="Hardcoded creds", reason="Credentials in source.", req="S-AUT-1",
+                       req_refs=[{"label": "CWE-798", "url": "https://cwe.mitre.org/data/definitions/798.html"}],
+                       snippet="PASS = 'admin'"),
+        ]),
+    ]
+    doc = build_sarif(reports, tool_version="1.4.0")
+
+    run = doc["runs"][0]
+    # Rules sorted by id; two distinct (dimension, principle).
+    assert [r["id"] for r in run["tool"]["driver"]["rules"]] == [
+        "reliability/fault-tolerance",
+        "security/authentication",
+    ]
+    # Results sorted by (uri, startLine, ruleId).
+    assert [r["locations"][0]["physicalLocation"]["artifactLocation"]["uri"] for r in run["results"]] == [
+        "app.py",
+        "auth.py",
+    ]
+    # Security rule has worst-of critical security-severity and the CWE tag.
+    sec_rule = next(r for r in run["tool"]["driver"]["rules"] if r["id"] == "security/authentication")
+    assert sec_rule["properties"]["security-severity"] == "9.0"
+    assert "external/cwe/cwe-798" in sec_rule["properties"]["tags"]
+    # Snippets omitted by default.
+    region = run["results"][0]["locations"][0]["physicalLocation"]["region"]
+    assert "snippet" not in region

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -71,3 +71,120 @@ def test_safe_uri_rejects_blank_and_escaping():
     assert _safe_uri(None) is None
     assert _safe_uri("../outside.py") is None
     assert _safe_uri("a/../../b.py") is None
+
+
+from quodeq.ci.sarif import build_sarif
+
+
+def _report(dimension, violations, **extra):
+    return {"dimension": dimension, "violations": violations, "compliance": [], **extra}
+
+
+def _violation(**kw):
+    base = {
+        "principle": "Fault Tolerance",
+        "file": "app.py",
+        "line": 58,
+        "end_line": 59,
+        "title": "Empty except swallows errors",
+        "reason": "The bare except hides failures.",
+        "snippet": "except:\n    pass",
+        "severity": "major",
+        "req": "R-FT-1",
+        "req_refs": [{"label": "CWE-390", "url": "https://cwe.mitre.org/data/definitions/390.html"}],
+    }
+    base.update(kw)
+    return base
+
+
+def test_build_sarif_top_level_shape():
+    doc = build_sarif([_report("reliability", [_violation()])], tool_version="1.4.0")
+    assert doc["version"] == "2.1.0"
+    assert doc["$schema"].endswith("sarif-2.1.0.json")
+    assert len(doc["runs"]) == 1
+    run = doc["runs"][0]
+    assert run["tool"]["driver"]["name"] == "Quodeq"
+    assert run["tool"]["driver"]["version"] == "1.4.0"
+    assert run["automationDetails"]["id"] == "quodeq/scan"
+
+
+def test_build_sarif_result_fields():
+    doc = build_sarif([_report("reliability", [_violation()])], tool_version="1.4.0")
+    result = doc["runs"][0]["results"][0]
+    assert result["ruleId"] == "reliability/fault-tolerance"
+    assert result["level"] == "error"
+    assert result["message"]["text"]
+    loc = result["locations"][0]["physicalLocation"]
+    assert loc["artifactLocation"]["uri"] == "app.py"
+    assert loc["region"]["startLine"] == 58
+    assert loc["region"]["endLine"] == 59
+    assert result["partialFingerprints"]["quodeqReqSnippet/v1"]
+    assert result["properties"]["quodeq"]["req"] == "R-FT-1"
+
+
+def test_build_sarif_rule_carries_cwe_and_security_severity():
+    doc = build_sarif([_report("reliability", [_violation()])], tool_version="1.4.0")
+    rules = doc["runs"][0]["tool"]["driver"]["rules"]
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["id"] == "reliability/fault-tolerance"
+    assert rule["properties"]["security-severity"] == "7.0"
+    assert "security" in rule["properties"]["tags"]
+    assert "external/cwe/cwe-390" in rule["properties"]["tags"]
+
+
+def test_build_sarif_worst_severity_drives_rule_security_severity():
+    violations = [
+        _violation(severity="minor", title="minor one", snippet="a"),
+        _violation(severity="critical", title="crit one", snippet="b"),
+    ]
+    doc = build_sarif([_report("reliability", violations)], tool_version="1.4.0")
+    rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+    assert rule["properties"]["security-severity"] == "9.0"  # worst = critical
+
+
+def test_build_sarif_merges_dimensions_into_one_run():
+    doc = build_sarif(
+        [
+            _report("reliability", [_violation()]),
+            _report("security", [_violation(principle="Authentication", req="S-AUT-1")]),
+        ],
+        tool_version="1.4.0",
+    )
+    assert len(doc["runs"]) == 1
+    rule_ids = {r["id"] for r in doc["runs"][0]["tool"]["driver"]["rules"]}
+    assert rule_ids == {"reliability/fault-tolerance", "security/authentication"}
+
+
+def test_build_sarif_excludes_compliance_and_dismissed():
+    rep = _report("reliability", [_violation(verdict="violation")])
+    rep["compliance"] = [{"principle": "X", "file": "y.py"}]
+    doc = build_sarif([rep], tool_version="1.4.0")
+    assert len(doc["runs"][0]["results"]) == 1
+
+
+def test_build_sarif_empty_when_no_violations():
+    doc = build_sarif([_report("reliability", [])], tool_version="1.4.0")
+    assert doc["runs"][0]["results"] == []
+    assert doc["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+def test_build_sarif_is_deterministic():
+    reports = [
+        _report("security", [_violation(principle="Authentication", req="S-AUT-1", file="b.py")]),
+        _report("reliability", [_violation(file="a.py")]),
+    ]
+    import json
+    assert json.dumps(build_sarif(reports, tool_version="1.4.0")) == json.dumps(
+        build_sarif(reports, tool_version="1.4.0")
+    )
+
+
+def test_build_sarif_clamps_startline_and_tolerates_missing_fields():
+    v = _violation(line=0, end_line=None, file=None, req=None, req_refs=None, snippet=None)
+    doc = build_sarif([_report("reliability", [v])], tool_version="1.4.0")
+    result = doc["runs"][0]["results"][0]
+    # No usable file -> no locations, but the result still exists with a message.
+    assert result.get("locations", []) == []
+    assert result["message"]["text"]
+    assert "partialFingerprints" not in result  # req and snippet both blank

--- a/tests/ci/test_sarif.py
+++ b/tests/ci/test_sarif.py
@@ -1,0 +1,41 @@
+from quodeq.ci.sarif import (
+    _severity_level,
+    _security_severity,
+    _severity_rank,
+    _slug,
+    _rule_id,
+)
+
+
+def test_severity_level_maps_canonical_severities():
+    assert _severity_level("critical") == "error"
+    assert _severity_level("major") == "error"
+    assert _severity_level("high") == "error"
+    assert _severity_level("minor") == "warning"
+    assert _severity_level("unknown") == "note"
+    assert _severity_level("") == "note"
+    assert _severity_level("weird") == "note"
+
+
+def test_security_severity_is_string_decimal():
+    assert _security_severity("critical") == "9.0"
+    assert _security_severity("major") == "7.0"
+    assert _security_severity("minor") == "4.0"
+    assert _security_severity("unknown") == "2.0"
+
+
+def test_severity_rank_orders_high_to_low():
+    assert _severity_rank("critical") > _severity_rank("major")
+    assert _severity_rank("major") > _severity_rank("minor")
+    assert _severity_rank("minor") > _severity_rank("unknown")
+    assert _severity_rank("nonsense") == _severity_rank("unknown")
+
+
+def test_slug_lowercases_and_hyphenates():
+    assert _slug("Fault Tolerance") == "fault-tolerance"
+    assert _slug("  Spaced  Out  ") == "spaced-out"
+    assert _slug("Mixed/Case & Symbols!") == "mixed-case-symbols"
+
+
+def test_rule_id_joins_dimension_and_principle_slug():
+    assert _rule_id("reliability", "Fault Tolerance") == "reliability/fault-tolerance"

--- a/tests/ci/test_sarif_evaluate_emission.py
+++ b/tests/ci/test_sarif_evaluate_emission.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+from quodeq._cli_evaluation import _write_sarif_if_requested
+
+
+def _seed_reports(eval_dir: Path) -> None:
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    (eval_dir / "reliability.json").write_text(
+        json.dumps({
+            "dimension": "reliability",
+            "violations": [{"principle": "Fault Tolerance", "file": "app.py", "line": 1,
+                            "severity": "major", "title": "t", "reason": "r", "req": "R-FT-1", "req_refs": []}],
+            "compliance": [],
+        }),
+        encoding="utf-8",
+    )
+
+
+class _Args:
+    def __init__(self, **kw):
+        self.sarif = kw.get("sarif")
+        self.min_severity = kw.get("min_severity")
+        self.with_snippets = kw.get("with_snippets", False)
+
+
+def test_write_sarif_emits_file_on_success(tmp_path):
+    eval_dir = tmp_path / "evaluation"
+    _seed_reports(eval_dir)
+    out = tmp_path / "q.sarif"
+
+    _write_sarif_if_requested(_Args(sarif=str(out)), eval_dir)
+
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    assert doc["version"] == "2.1.0"
+    assert len(doc["runs"][0]["results"]) == 1
+
+
+def test_write_sarif_is_fail_soft(tmp_path):
+    eval_dir = tmp_path / "evaluation"
+    _seed_reports(eval_dir)
+    # Output path under a *file* (not a dir) -> write raises; must be swallowed.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("x", encoding="utf-8")
+    bad_out = blocker / "nested" / "q.sarif"
+
+    # Must NOT raise.
+    _write_sarif_if_requested(_Args(sarif=str(bad_out)), eval_dir)
+    assert not bad_out.exists()
+
+
+def test_write_sarif_noop_when_flag_absent(tmp_path):
+    eval_dir = tmp_path / "evaluation"
+    _seed_reports(eval_dir)
+    # sarif=None -> nothing written, no error.
+    _write_sarif_if_requested(_Args(sarif=None), eval_dir)


### PR DESCRIPTION
## Summary

Adds SARIF 2.1.0 export so Quodeq findings can be uploaded to GitHub code scanning (Security tab), GitLab SAST, or any SARIF consumer. This was the cheapest table-stakes interop gap (every incumbent ships SARIF; Quodeq had none).

- **Pure builder** `build_sarif(reports, *, tool_version, min_severity, include_snippets) -> dict` in `src/quodeq/ci/sarif.py` (no I/O). Reuses `ci.reporter.load_evaluation_reports` and `context.precedent.fingerprint`.
- **Two surfaces**, both calling the same builder:
  - `quodeq export sarif --evaluation-dir <dir> -o out.sarif` (new `ci/export_cli.py`)
  - `quodeq evaluate <path> --sarif out.sarif`
- **Rules** = one per `dimension/principle`; each rule carries the union of its CWEs as `external/cwe/cwe-NNN` tags plus a worst-of `security-severity` (string), so GitHub's Security-tab severity buckets and CWE filter work. Per-finding `level` (error/warning/note) preserved on each result.
- `--min-severity {critical,major,minor}` filter; `--with-snippets` opt-in.

## Safety / design decisions

- **Output-only and opt-in** — no change to scoring, findings, the JSONL log, the SQLite projection, or the dashboard. Cannot regress existing users.
- **Fail-soft** — `evaluate --sarif` runs *outside* `RunLifecycleContext` (after `_run_pipeline_with_cleanup` returns, on success only) wrapped in try/except, so a SARIF error can never flip a successful run to `failed`. Skipped for `--diff-from`/`--evidence-only`.
- **No host-info leak** — the absolute `project` path and `runId` are never emitted; `_safe_uri` strips absolute paths and rejects `..`; `partialFingerprints` is a hash, not snippet text.
- **Privacy default** — code snippets omitted unless `--with-snippets` (keeps Quodeq's local-first promise on upload).
- **Deterministic output** (sorted rules/results) so re-uploads don't churn GitHub alerts; `automationDetails.id` set so re-uploads replace rather than stack; valid empty-results doc when the repo is clean.

## Test Plan

- [x] 34 new unit tests (`tests/ci/test_sarif.py`, `test_export_cli.py`, `test_sarif_evaluate_emission.py`) pass
- [x] Output validated against the official SARIF 2.1.0 JSON schema (vendored fixture)
- [x] Full unit suite green (3708 passed) rebased on latest `develop`
- [x] `mypy --strict` clean on new modules; import-layer gate clean
- [x] End-to-end on real evaluation data: 78 findings exported, 0 schema errors, no absolute-path leak, relative URIs, snippets omitted by default, CWE tags + security-severity present
- [ ] Reviewer: upload an emitted `.sarif` to a test repo's code scanning to confirm GitHub ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)