### PR TITLE
fix(a11y): suppress stray focus-ring border on focusable map viz

### DIFF
--- a/src/quodeq/ui/src/features/map/viz/components/FileShape.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/FileShape.jsx
@@ -29,6 +29,7 @@ export default function FileShape({ cx, cy, r, color, borderColor, glow, handler
       transform={`translate(${cx},${cy}) scale(${scale})`}
     >
       <path
+        className={handlers?.onClick ? 'viz-focusable' : undefined}
         d={BODY}
         fill={color} fillOpacity={FILE_FILL_OPACITY} stroke={stroke} strokeWidth={0.8 / totalScale}
         filter={glow ? 'url(#glow)' : undefined}

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyFolderView.jsx
@@ -269,6 +269,7 @@ export default function GalaxyFolderView({ node, currentPath = '', onPathChange,
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%', opacity: visible ? 1 : 0, transition: 'opacity 0.4s ease' }}>
       <canvas
+        className="viz-focusable"
         ref={canvasRef}
         width={size.w}
         height={size.h}

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
@@ -96,7 +96,6 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
   const frameRef = useRef(null);
   const prevNavRef = useRef(null);
   const [liveMsg, setLiveMsg] = useState('');
-  const [canvasFocused, setCanvasFocused] = useState(false);
   const announce = useCallback((msg) => setLiveMsg(msg), []);
 
   const saveNav = useCallback(() => {
@@ -141,18 +140,15 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%', opacity: visible ? 1 : 0, transition: 'opacity 0.4s ease' }}>
       <canvas ref={canvasRef} width={size.w} height={size.h}
-        style={{
-          width: '100%', height: '100%', display: 'block',
-          outline: canvasFocused ? '2px solid var(--color-accent)' : 'none',
-          outlineOffset: '-2px',
-        }}
+        className="viz-focusable"
+        style={{ width: '100%', height: '100%', display: 'block' }}
         onMouseMove={handleMouseMove} onMouseLeave={handleMouseLeave} onClick={handleClick}
         tabIndex={0}
         role="application"
         aria-label="Galaxy visualization of project compliance. Use arrow keys to move between nodes, Enter to open, Escape to go back."
         onKeyDown={handleKeyDown}
-        onFocus={() => { setCanvasFocused(true); handleFocus(); }}
-        onBlur={() => { setCanvasFocused(false); handleBlur(); }} />
+        onFocus={handleFocus}
+        onBlur={handleBlur} />
       <div aria-live="polite" aria-atomic="true" style={{
         position: 'absolute', width: 1, height: 1, padding: 0, margin: -1,
         overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0,

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridCells.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridCells.jsx
@@ -28,7 +28,7 @@ export default function HeatGridCells({ row, onCellClick, variant = 'heat' }) {
         return (
           <td key={sev}>
             <div
-              className={`heat-grid-cell${hasValue ? ' clickable' : ' empty'}`}
+              className={`heat-grid-cell${hasValue ? ' clickable viz-focusable' : ' empty'}`}
               style={style}
               onClick={() => hasValue && onCellClick?.({ row, severity: sev })}
               role={hasValue ? 'button' : undefined}

--- a/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/HeatGridView.jsx
@@ -70,7 +70,7 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
             {COLUMNS.map((col) => (
               <th
                 key={col.id}
-                className={`heat-grid-th-sort${col.align === 'left' ? ' left' : ''}`}
+                className={`heat-grid-th-sort viz-focusable${col.align === 'left' ? ' left' : ''}`}
                 onClick={() => handleSort(col.id)}
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleSort(col.id); } }}
                 tabIndex={0}
@@ -88,7 +88,7 @@ export default function HeatGridView({ node, onDrillDown, onFileClick, onCellCli
               <tr key={row.path}>
                 <td>
                   <div
-                    className={`heat-grid-file${canDrill || row.isFile ? ' clickable' : ''}`}
+                    className={`heat-grid-file${canDrill || row.isFile ? ' clickable viz-focusable' : ''}`}
                     role={canDrill || row.isFile ? 'button' : undefined}
                     tabIndex={canDrill || row.isFile ? 0 : undefined}
                     onClick={() => canDrill ? onDrillDown(row.path) : row.isFile && onFileClick?.(row)}

--- a/src/quodeq/ui/src/features/map/viz/components/PackCircles.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/PackCircles.jsx
@@ -14,7 +14,7 @@ export default function PackCircles({ circles, folderIndices, fileIndices, hover
         const isRoot = c.depth === 0;
         const isHovered = hover === i;
         return (
-          <circle key={d.path || i} cx={c.x} cy={c.y} r={c.r}
+          <circle key={d.path || i} className="viz-focusable" cx={c.x} cy={c.y} r={c.r}
             fill={isRoot ? 'var(--color-surface-alt)' : nodeColor(d, viewMode)}
             stroke={isRoot ? 'var(--color-border)' : nodeBorderColor(d, viewMode)}
             strokeWidth={FOLDER_STROKE_WIDTH} vectorEffect="non-scaling-stroke"

--- a/src/quodeq/ui/src/features/map/viz/components/PackCircles.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/PackCircles.test.jsx
@@ -39,6 +39,12 @@ describe('PackCircles keyboard accessibility (#2056)', () => {
     expect(circle).toHaveAttribute('tabindex', '0');
   });
 
+  it('folder circle carries the viz-focusable class (suppresses stray focus ring)', () => {
+    renderPackCircles();
+    const circle = document.querySelector('circle');
+    expect(circle).toHaveClass('viz-focusable');
+  });
+
   it('folder circle has role="button"', () => {
     renderPackCircles();
     const circle = document.querySelector('circle');

--- a/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.jsx
@@ -72,7 +72,7 @@ function BubbleGroup({ points, px, py, br, entered, showLabels, tip, setTip, onD
               <animate attributeName="opacity" values="0.3;0.1;0.3" dur="2s" repeatCount="indefinite" />
             </circle>}
             {canDrill ? (
-              <circle cx={cx} cy={cy} r={r} fill={color} fillOpacity={0.85}
+              <circle className="viz-focusable" cx={cx} cy={cy} r={r} fill={color} fillOpacity={0.85}
                 stroke={border} strokeWidth={1}
                 filter={tip?.name === child.name ? 'url(#glow)' : undefined}
                 style={{ cursor: 'pointer', transition: 'fill-opacity 0.2s ease' }}

--- a/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/RiskMatrixView.test.jsx
@@ -45,6 +45,12 @@ describe('RiskMatrixView drillable circle keyboard accessibility (#1936)', () =>
     expect(circle).toHaveAttribute('tabindex', '0');
   });
 
+  it('drillable circle carries the viz-focusable class (suppresses stray focus ring)', () => {
+    const { container } = render(<RiskMatrixView node={NODE} onDrillDown={vi.fn()} />);
+    const circle = getDrillableCircle(container);
+    expect(circle).toHaveClass('viz-focusable');
+  });
+
   it('drillable circle has role="button"', () => {
     const { container } = render(<RiskMatrixView node={NODE} onDrillDown={vi.fn()} />);
     const circle = getDrillableCircle(container);

--- a/src/quodeq/ui/src/features/map/viz/components/VizBreadcrumb.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/VizBreadcrumb.jsx
@@ -25,6 +25,7 @@ export default function VizBreadcrumb({ items }) {
           <span key={i} style={{ display: 'flex', alignItems: 'center', gap: BREADCRUMB_GAP }}>
             {i > 0 && <span style={{ color: 'var(--color-border)' }}>{'\u203A'}</span>}
             <span
+              className={clickable ? 'viz-focusable' : undefined}
               style={{ color: isLast ? 'var(--color-text)' : 'var(--color-text-muted)', cursor: clickable ? 'pointer' : 'default', padding: BREADCRUMB_ITEM_PADDING, borderRadius: BREADCRUMB_BORDER_RADIUS, transition: 'all 0.2s' }}
               onClick={clickable ? item.onClick : undefined}
               onMouseEnter={clickable ? (e) => { e.target.style.background = 'color-mix(in srgb, var(--color-accent) 15%, transparent)'; e.target.style.color = 'var(--color-text)'; } : undefined}

--- a/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.jsx
@@ -194,6 +194,7 @@ export default function ZoomablePackView({ node, viewMode, onDrillDown, onFileCl
   return (
     <div ref={containerRef} style={{ position: 'relative', width: '100%', height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }} onMouseMove={(e) => { const r = containerRef.current?.getBoundingClientRect(); if (r) { mousePos.current = { x: e.clientX - r.left, y: e.clientY - r.top }; } }}>
       <svg
+        className="viz-focusable"
         viewBox={`${-PAD} ${-PAD} ${BASE_SIZE + PAD * 2} ${BASE_SIZE + PAD * 2}`}
         style={{ width: '100%', height: '100%', overflow: 'hidden' }}
         tabIndex={0}

--- a/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/ZoomablePackView.test.jsx
@@ -38,4 +38,12 @@ describe('ZoomablePackView container Escape key (#1907)', () => {
     fireEvent.keyDown(svg, { key: 'Escape' });
     expect(onDrillDown).toHaveBeenCalled();
   });
+
+  it('svg container carries the viz-focusable class (suppresses stray focus ring)', () => {
+    const { container } = render(
+      <ZoomablePackView node={NODE} viewMode="violations" onDrillDown={vi.fn()} />
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('viz-focusable');
+  });
 });

--- a/src/quodeq/ui/src/styles/map.css
+++ b/src/quodeq/ui/src/styles/map.css
@@ -147,6 +147,20 @@
   opacity: 0.6;
 }
 
+/* Focusable map-viz elements (canvas / SVG / per-node shapes made keyboard-
+   navigable by the a11y work) suppress the browser's default focus ring on
+   pointer interaction: it reads as a stray border, and the native WKWebView
+   draws it on plain mouse clicks. A clean accent ring is kept for keyboard
+   users via :focus-visible, matching the app-wide focus convention. */
+.viz-focusable:focus {
+  outline: none;
+}
+
+.viz-focusable:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
 /* Active-state dot: floats in the top-right corner of the button
    when a subset of dimensions is active (standard notification dot
    pattern — does not affect the button's width). */


### PR DESCRIPTION
## What & why

You reported a "weird border" on the **Circle Pack** graph. It's the browser's **default focus ring** on the pack `<svg>`: the keyboard-nav a11y work (`9c4a741c`) made the viz canvases/SVGs/nodes focusable (`tabIndex={0}`), but only **GalaxyView** (#675) paired that with focus-outline styling. Every other focusable viz element fell back to the UA focus ring — and because the dashboard runs in a native **pywebview / WKWebView** window, WebKit draws that ring on plain **mouse clicks**, so it sticks as a stray border.

You asked to fix **all** focusable viz, so this is a complete sweep.

## Change

A shared `.viz-focusable` utility in `map.css` (matching the app-wide `:focus-visible` convention, e.g. `.sidebar-nav-item`):

```css
.viz-focusable:focus { outline: none; }                 /* no stray border on pointer focus */
.viz-focusable:focus-visible {                           /* clean keyboard a11y ring */
  outline: 2px solid var(--color-accent);
  outline-offset: -2px;
}
```

Applied to every focusable map-viz element:

| Component | Element | Before |
|---|---|---|
| ZoomablePackView | SVG container | UA ring |
| GalaxyFolderView | canvas | UA ring |
| PackCircles | folder circles | UA ring |
| RiskMatrixView | drillable circles | UA ring |
| FileShape | file path | UA ring |
| HeatGridCells / HeatGridView | cells, sort headers, file rows | UA ring |
| VizBreadcrumb | clickable crumbs | UA ring |
| GalaxyView | canvas | **harmonized** off its inline `canvasFocused` outline (which also showed on mouse) onto the shared class |

Net effect: no pointer-triggered border anywhere in the map viz; keyboard users still get a clean accent focus ring (a11y from the original PR preserved).

## Verification

- **60/60** viz unit tests pass, including 3 new regression tests asserting `viz-focusable` on the pack SVG, pack circles, and risk-matrix circles.
- Full `vite build` compiles (all components, incl. GalaxyView/GalaxyFolderView).
- Live-checked in the running app: `.viz-focusable` rules load, `:focus-visible` is authored last (wins on keyboard), accent resolves to a real color, no stale `pack-svg`.
- Note: a live *pixel* of the ring couldn't be captured — the preview is Chromium while the runtime is WebKit, and headless windows can't hold OS focus to trigger `:focus`. The cascade is spec-defined and identical across engines, but a glance in the actual dashboard is the final confirmation.