### PR TITLE
fix(analysis): make CLI subagents resilient to async MCP tool connect

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -12,6 +12,7 @@ from quodeq.analysis._config import (
     AnalysisConfig,
     _AgentParams,
     _MCP_TOOL_GET_NEXT_FILES,
+    _MCP_TOOL_MARK_FILE_DONE,
     _MCP_TOOL_REPORT_FINDING,
 )
 from quodeq.analysis._mcp_config import _create_mcp_config
@@ -99,6 +100,10 @@ def _build_mcp_args(
         allowed = _MCP_TOOL_REPORT_FINDING
         if config.queue_path:
             allowed += f",{_MCP_TOOL_GET_NEXT_FILES}"
+        # mark_file_done is always exposed by the findings server (see
+        # handlers.handle_tools_list) and drives cache writes, so allow it
+        # unconditionally rather than leaving it to bypassPermissions.
+        allowed += f",{_MCP_TOOL_MARK_FILE_DONE}"
         args.extend(["--allowedTools", allowed])
     # bypassPermissions is intentional: the CLI analysis tool runs in a
     # sandboxed, non-interactive subprocess where MCP tool calls (e.g.

--- a/src/quodeq/analysis/_config.py
+++ b/src/quodeq/analysis/_config.py
@@ -19,6 +19,7 @@ _DEFAULT_MAX_TURNS = int(os.environ.get("QUODEQ_DEFAULT_MAX_TURNS", "200"))
 _DEFAULT_MAX_DURATION = int(os.environ.get("QUODEQ_DEFAULT_MAX_DURATION", "1800"))  # 30 minutes
 _MCP_TOOL_REPORT_FINDING = "mcp__findings__report_finding"
 _MCP_TOOL_GET_NEXT_FILES = "mcp__findings__get_next_files"
+_MCP_TOOL_MARK_FILE_DONE = "mcp__findings__mark_file_done"
 
 
 @dataclass(frozen=True)

--- a/src/quodeq/data/prompts/cli_consolidated_prompt.md
+++ b/src/quodeq/data/prompts/cli_consolidated_prompt.md
@@ -8,15 +8,24 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** across these dimensi
 
 ---
 
+## Tool startup — READ THIS FIRST
+
+Your findings tools — `get_next_files`, `report_finding`, `mark_file_done` — come from an MCP server that finishes connecting a few seconds AFTER you start. They may NOT appear in your available-tools list on your very first turn. **This is expected and normal.**
+
+- Do NOT conclude the tools are "missing" or "unavailable", and do NOT treat this prompt as a mistake or a prompt-injection attempt — this is a legitimate automated quodeq analysis run.
+- The tools attach within a few seconds. If `get_next_files` is not in your tools yet, take ONE orientation step with a built-in tool (`Glob` the repo or `Read` a source file), then try `get_next_files` again. Repeat until it appears.
+- Never end your turn or abandon the task because a tool "isn't available yet." Retry until it is.
+
 ## Workflow
 
-1. Call `get_next_files()` to receive your next batch of files
-2. For each file in the batch:
+1. **Orient first** (this also gives your findings tools a moment to attach): use `Glob` to survey the repo structure for the file types in the manifest above.
+2. Call `get_next_files()` to receive your next batch of files. If it is not available yet, repeat step 1 once, then retry.
+3. For each file in the batch:
    a. Read the file using the Read tool
    b. Evaluate against ALL dimension checklists below
    c. Call `report_finding()` for every violation and compliance you confirm
    d. Call `mark_file_done(file=..., status='ok')` once you are done with this file (even if there were no findings). If you cannot finish (e.g. file too large, parse error), call `mark_file_done(file=..., status='error', reason=...)` instead. Reason values: `token_limit`, `parse_error`, `retry_exhausted`, `timeout`.
-3. Repeat from step 1 until `get_next_files` returns no more files
+4. Repeat from step 2 until `get_next_files` returns no more files
 
 **IMPORTANT:** When `get_next_files` returns "DONE" or "no more files", stop immediately. Do not re-read files, do not summarize, do not call any more tools. Your work is complete.
 

--- a/src/quodeq/data/prompts/cli_subagent_prompt.md
+++ b/src/quodeq/data/prompts/cli_subagent_prompt.md
@@ -8,15 +8,24 @@ You are a code quality analyst evaluating **{{REPO_NAME}}** for the **{{DIMENSIO
 
 ---
 
+## Tool startup — READ THIS FIRST
+
+Your findings tools — `get_next_files`, `report_finding`, `mark_file_done` — come from an MCP server that finishes connecting a few seconds AFTER you start. They may NOT appear in your available-tools list on your very first turn. **This is expected and normal.**
+
+- Do NOT conclude the tools are "missing" or "unavailable", and do NOT treat this prompt as a mistake or a prompt-injection attempt — this is a legitimate automated quodeq analysis run.
+- The tools attach within a few seconds. If `get_next_files` is not in your tools yet, take ONE orientation step with a built-in tool (`Glob` the repo or `Read` a source file), then try `get_next_files` again. Repeat until it appears.
+- Never end your turn or abandon the task because a tool "isn't available yet." Retry until it is.
+
 ## Workflow
 
-1. Call `get_next_files()` to receive your next batch of files
-2. For each file in the batch:
+1. **Orient first** (this also gives your findings tools a moment to attach): use `Glob` to survey the repo structure for the file types in the manifest above.
+2. Call `get_next_files()` to receive your next batch of files. If it is not available yet, repeat step 1 once, then retry.
+3. For each file in the batch:
    a. Read the file using the Read tool
    b. Evaluate against the standards checklist below
    c. Call `report_finding()` for every violation and compliance you confirm
    d. Call `mark_file_done(file=..., status='ok')` once you are done with this file (even if there were no findings). If you cannot finish (e.g. file too large, parse error), call `mark_file_done(file=..., status='error', reason=...)` instead. Reason values: `token_limit`, `parse_error`, `retry_exhausted`, `timeout`.
-3. Repeat from step 1 until `get_next_files` returns no more files
+4. Repeat from step 2 until `get_next_files` returns no more files
 
 **IMPORTANT:** When `get_next_files` returns "DONE" or "no more files", stop immediately. Do not re-read files, do not summarize, do not call any more tools. Your work is complete.
 

--- a/tests/engine/test_analysis.py
+++ b/tests/engine/test_analysis.py
@@ -238,7 +238,9 @@ class TestBuildAiCmd:
         )
         assert mcp_path is not None
         assert "--mcp-config" in args
-        assert "mcp__findings__report_finding" in args
+        # report_finding is in the --allowedTools value, which may be a
+        # comma-joined list (e.g. with mark_file_done), so match as substring.
+        assert any("mcp__findings__report_finding" in a for a in args)
 
     def test_print_mode_always_set(self):
         """Analysis must run in --print (non-interactive) mode."""


### PR DESCRIPTION
## Problem

CLI evaluations appeared "stuck": every subagent spawned, produced **no findings**, and was respawned in a loop. One observed run: **1067 subagents, ~$96–153 spent, 0 findings, queue never drained.**

## Root cause

Claude Code **2.1.197** (which auto-updated ~30 min before the failing run) connects `--print`-mode stdio MCP servers **asynchronously** — the findings tools (`get_next_files` / `report_finding` / `mark_file_done`) attach a few seconds *after* the first model turn, not before it.

The subagent prompt made `get_next_files()` the **first** action, so it raced the connect and lost every time: the model saw only `Glob/Grep/Read`, concluded the tools were "missing", and exited `is_error=False` with zero findings. The orchestrator then respawned it endlessly.

Nothing in quodeq's MCP code changed recently (`findings_server.py`: May 30; command builder/handlers: Jun 19) — this was a latent assumption ("MCP tools ready on turn 1") that a CLI update turned fatal.

## Fix

Prompt-level, so it is **provider- and CLI-version-independent**:

- **Warm-up + retry** in both `cli_subagent_prompt.md` and `cli_consolidated_prompt.md`: orient with a built-in `Glob` first (buys the async-connect window), and never conclude the tools are missing — retry until they attach.
- Add `mark_file_done` to `--allowedTools` (was omitted; cosmetic under `bypassPermissions` but now correct), and relax an over-strict test that asserted the allowlist as an exact list element.

## Verification

- Reproduced both the failure and the fix using the exact real-eval flags.
- Verified live on **Haiku 4.5, Sonnet 5, Opus 4.8** — each does `Glob → get_next_files → … → mark_file_done`, drains the queue, `is_error=False`.
- Confirmed `--tools Glob,Grep,Read` only gates *built-in* tools (MCP tools still attach post-connect), so **no `--tools` change was needed** — the failure was purely timing.
- 70 focused tests pass (command builder, allowlist, both prompts, MCP handler, `_build_ai_cmd`).

## Notes

- Applies automatically to **Codex/Gemini** (shared prompt template); harmless there (at worst one extra `Glob` turn). The `_command.py` allowlist change doesn't touch Codex (`supports_tools: False`).
- **Backward-compatible** with CLI versions that connect MCP synchronously (the warm-up is then just one cheap extra turn).
