### PR TITLE
fix(a11y): gate focus ring behind :focus-visible app-wide (WebKit stray border)

### DIFF
--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -17,6 +17,19 @@ body,
   min-height: 100%;
 }
 
+/* ── Focus ────────────────────────────────────────────── */
+
+/* The dashboard runs in a native WKWebView (pywebview), and WebKit draws the
+   default focus ring on :focus for plain mouse clicks, not just keyboard focus
+   like Chromium does. On custom focusable elements (div/span/svg with a
+   tabindex) that reads as a stray border after a click. Gate the ring behind
+   :focus-visible for every tabbable element: pointer focus shows nothing,
+   keyboard focus keeps its indicator. Zero specificity via :where() so any
+   component's own :focus / :focus-visible styling always wins. */
+:where([tabindex]):focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* ── Base ─────────────────────────────────────────────── */
 
 body {


### PR DESCRIPTION
## Context

Follow-up to #685 (which fixed the map viz). That PR raised the question: is the same stray-focus-ring bug present elsewhere? The dashboard runs in a native **pywebview / WKWebView** window, and WebKit draws the default focus ring on `:focus` for **plain mouse clicks** (Chromium gates it behind `:focus-visible`). So any custom `tabindex` element without a `:focus` reset shows a stray border after a click.

## Audit

I ran an exhaustive multi-agent audit of **every focusable element in the UI** (36 across 31 files), classifying each by tag, native-vs-custom, and focus-CSS handling, with adversarial verification.

**Result: 23 confirmed stray-border elements**, all custom `<div>/<span>/<li>/<circle>/<g>` with **no focus CSS at all**:

- side-pane dividers (×2), explorer radial (`circle`, `g`), file-picker items (×2), folder-browser rows (×2), heat-grid cells (`components/HeatGridCells` ×2, `DimensionHeatGridView`), standards row / tree-node / editor divider / cwe-browser item, history rows, grade-formula divider, live-violations row, project card, principle accordion row, dimension-score row, project-header parent link, context-block scope bar.

The 9 map-viz elements all came back clean (`has-focus-reset`) — confirming #685 and validating the audit logic. The audit found **zero** elements relying on an intentional mouse-`:focus` outline, so nothing gets clobbered.

## Fix

One zero-specificity global rule in `base.css`:

```css
:where([tabindex]):focus:not(:focus-visible) { outline: none; }
```

- **Pointer focus** → no ring (fixes the stray border everywhere at once).
- **Keyboard focus** → `:focus-visible` matches, rule doesn't apply, indicator preserved.
- `:where()` keeps specificity **0**, so any component's own `:focus` / `:focus-visible` styling always wins.

This supersedes the need to sprinkle `.viz-focusable`-style resets across 15 files, and covers the viz redundantly (harmless).

## Verification

- Live-checked in the running app: the rule loads as a **valid** selector, `[tabindex]` matches focusable elements, `:focus-visible` is supported.
- `vite build` compiles cleanly; no console errors.
- No unit-test seam (jsdom doesn't render `:focus-visible`); the #685 component class-assertion tests still pass and are unaffected.
- **Caveat (same as #685):** the actual mouse-vs-keyboard pixel can't be captured here — preview is Chromium, runtime is WebKit, and headless windows can't hold OS focus to trigger `:focus`. The cascade is spec-defined and engine-consistent; a glance in the real dashboard confirms it.

## Notes / follow-ups (not in this PR)
- `components/HeatGridCells.jsx` appears to be a **duplicate** of `features/map/viz/components/HeatGridCells.jsx` — possible dead code worth a separate cleanup.
- Per-node SVG keyboard *indicators* (pack/risk circles, file shapes) rely on `outline`, which is historically flaky on SVG in WebKit; suppression is unaffected, but the keyboard ring on those specific nodes should be spot-checked in the real dashboard.