### PR TITLE
feat(scoring): scalar fast-path for dashboard trend

### DIFF
--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -122,6 +122,10 @@ def read_run_scalars(reports_root: Path, project: str, run_id: str) -> list[Dime
     if on_disk and len(dim_rows) != on_disk:
         return read_run_data(reports_root, project, run_id)
 
+    # No eval-time grade fallback here (unlike overlay_sql_grades): the fast
+    # path doesn't read the JSON, and a projected dim past the NULL-score
+    # guard always carries a real grade label ("Insufficient" or better),
+    # never "".
     principles_by_dim: dict[str, list[PrincipleGrade]] = {}
     for r in principle_rows:
         principles_by_dim.setdefault(r["dimension"], []).append(PrincipleGrade(

--- a/src/quodeq/data/fs/report_parser/runs.py
+++ b/src/quodeq/data/fs/report_parser/runs.py
@@ -68,6 +68,81 @@ def read_run_data(reports_root: Path, project: str, run_id: str) -> list[Dimensi
     return overlay_sql_grades(run_dir, dimensions)
 
 
+def read_run_scalars(reports_root: Path, project: str, run_id: str) -> list[DimensionResult]:
+    """Load a run's per-dimension SCALARS (score/grade/principles) only.
+
+    Fast path for the dashboard trend and accumulated carry-forward, which need
+    only ``overall_score`` / ``overall_grade`` per dimension — not the full
+    findings.  Reads the authoritative SQL grade tables directly instead of
+    parsing the evaluation JSON, then falls back to :func:`read_run_data`
+    whenever the SQL tables can't faithfully reproduce the overlaid result:
+    legacy run (no ``events.jsonl``) or no ``evaluation.db``; SQLite disabled or
+    db unreadable; empty grade tables; a NULL SQL score (overlay would keep the
+    eval-time score); or the SQL dim count != the on-disk ``evaluation/*.json``
+    count (partial projection).  Returned dimensions carry empty findings.
+    """
+    validate_path_segment(project, run_id)
+    run_dir = reports_root / project / run_id
+
+    from quodeq.data.fs.report_parser._evidence_sqlite import has_evaluation_db  # noqa: PLC0415
+    from quodeq.shared._env import sqlite_disabled  # noqa: PLC0415
+
+    if (
+        sqlite_disabled()
+        or not has_evaluation_db(run_dir)
+        or not (run_dir / "events.jsonl").is_file()
+    ):
+        return read_run_data(reports_root, project, run_id)
+
+    import sqlite3  # noqa: PLC0415
+
+    from quodeq.core.types.report import PrincipleGrade  # noqa: PLC0415
+    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+    from quodeq.data.sqlite.state_store import SQLiteStateStore  # noqa: PLC0415
+
+    try:
+        SqliteFindingsRepository(run_dir).ensure_projected()
+        store = SQLiteStateStore(run_dir)
+        dim_rows = store.read_dimension_scores()
+        principle_rows = store.read_principle_grades()
+    except sqlite3.DatabaseError:
+        return read_run_data(reports_root, project, run_id)
+
+    if not dim_rows:
+        return read_run_data(reports_root, project, run_id)
+
+    if any(r.get("score") is None for r in dim_rows):
+        return read_run_data(reports_root, project, run_id)
+
+    eval_dir = run_dir / "evaluation"
+    on_disk = (
+        sum(1 for p in eval_dir.iterdir() if p.suffix == ".json")
+        if eval_dir.is_dir() else 0
+    )
+    if on_disk and len(dim_rows) != on_disk:
+        return read_run_data(reports_root, project, run_id)
+
+    principles_by_dim: dict[str, list[PrincipleGrade]] = {}
+    for r in principle_rows:
+        principles_by_dim.setdefault(r["dimension"], []).append(PrincipleGrade(
+            principle=r["principle_id"],
+            score=f'{r["score"]}/10' if r.get("score") is not None else None,
+            grade=r.get("grade"),
+        ))
+
+    dimensions = [
+        DimensionResult(
+            dimension=r["dimension"],
+            overall_score=f'{r["score"]}/10',
+            overall_grade=r.get("grade"),
+            principles=principles_by_dim.get(r["dimension"], []),
+        )
+        for r in dim_rows
+    ]
+    dimensions.sort(key=lambda d: d.dimension)
+    return dimensions
+
+
 def _read_run_status(run_dir: Path) -> str | None:
     """Read state from status.json if present. Returns the state string or None."""
     import json as _json  # noqa: PLC0415

--- a/src/quodeq/services/_cache.py
+++ b/src/quodeq/services/_cache.py
@@ -19,6 +19,8 @@ _logger = logging.getLogger(__name__)
 
 _CACHE_WAIT_TIMEOUT_S = 30
 
+_Reader = Callable[[Path, str, str], list[DimensionResult]]
+
 
 @dataclass
 class _CacheContext:
@@ -26,11 +28,16 @@ class _CacheContext:
     cache: OrderedDict
     lock: threading.Lock
     max_size: int
+    reader: _Reader | None = None
     inflight: dict[tuple, threading.Event] = field(default_factory=dict)
+
+    def get_reader(self) -> _Reader:
+        """Return the configured reader, defaulting to read_run_data."""
+        return self.reader if self.reader is not None else read_run_data
 
 
 def _fetch_dimensions_from_disk(
-    reports_root: Path, project: str, run_id: str,
+    reports_root: Path, project: str, run_id: str, reader: _Reader | None = None,
 ) -> list[DimensionResult]:
     """Read dimension data from disk with error handling.
 
@@ -38,8 +45,9 @@ def _fetch_dimensions_from_disk(
     so that slow reads do not block other cache lookups.  Per-key mutual
     exclusion is guaranteed by the inflight-event mechanism in the caller.
     """
+    _reader = reader if reader is not None else read_run_data
     try:
-        return read_run_data(reports_root, project, run_id)
+        return _reader(reports_root, project, run_id)
     except (OSError, ValueError, KeyError) as exc:
         _logger.warning(
             "Failed to read run data for %s/%s: %s", project, run_id, exc,
@@ -83,7 +91,7 @@ def _fetch_and_store(
     ctx: _CacheContext,
 ) -> list[DimensionResult]:
     """Perform the disk fetch, store in cache, and notify waiters."""
-    data = _fetch_dimensions_from_disk(reports_root, project, run_id)
+    data = _fetch_dimensions_from_disk(reports_root, project, run_id, ctx.get_reader())
     if data:
         _cache_store(key, data, ctx)
     with ctx.lock:
@@ -99,6 +107,7 @@ def make_lru_dimension_fetcher(
     cache: OrderedDict[tuple, list[DimensionResult]],
     lock: threading.Lock,
     max_size: int,
+    reader: _Reader | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a callable that fetches dimension data for a run.
 
@@ -110,7 +119,7 @@ def make_lru_dimension_fetcher(
     threads that request the same key while I/O is in progress wait on the
     event and then read the result from the cache.
     """
-    ctx = _CacheContext(cache=cache, lock=lock, max_size=max_size)
+    ctx = _CacheContext(cache=cache, lock=lock, max_size=max_size, reader=reader)
 
     def get_run_dimensions(run_id: str) -> list[DimensionResult]:
         key = (reports_root, project, run_id)

--- a/src/quodeq/services/ports.py
+++ b/src/quodeq/services/ports.py
@@ -27,6 +27,7 @@ from quodeq.data.fs.report_parser.runs import (
     RunInfo as RunInfo,
     list_runs,
     read_run_data,
+    read_run_scalars,
     safe_read_dir,
 )
 from quodeq.data.ports.findings import FindingsRepository
@@ -65,6 +66,7 @@ __all__ = [
     "most_frequent_grade",
     "parse_numeric_score",
     "read_run_data",
+    "read_run_scalars",
     "safe_read_dir",
     "summarize_dimensions",
 ]

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 import logging
 import os
-import threading
-from collections import OrderedDict
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
@@ -34,14 +32,15 @@ from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams, dimension_weighted_average
 from quodeq.core.types.report import PrincipleGrade
 from quodeq.core.types.dimension import DimensionResult, DimensionSummary, GradeBreakdown
+from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services.accumulated import compute_accumulated
 from quodeq.services.dashboard import (
     DashboardCacheConfig,
     _make_run_dimension_fetcher,
+    create_dimension_cache,
 )
 from quodeq.services.grade_formula import load_params
-from quodeq.services._cache import make_lru_dimension_fetcher
-from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
 from quodeq.services.ports import RunInfo, list_runs, read_run_scalars
@@ -358,9 +357,12 @@ def _make_trend_fetcher(
     """
     project_dir = reports_root / project
     if dismissed_keys(project_dir) or deleted_keys(project_dir):
+        # _make_rescoring_fetcher re-reads dismissed/deleted internally; the
+        # extra read is cheap and keeps this branch a thin delegate.
         return _make_rescoring_fetcher(reports_root, project, params=params)
+    cache, lock = create_dimension_cache()
     return make_lru_dimension_fetcher(
-        reports_root, project, OrderedDict(), threading.Lock(),
+        reports_root, project, cache, lock,
         _max_history_runs(), reader=read_run_scalars,
     )
 
@@ -481,7 +483,8 @@ def get_project_scores(
     # Apply rescore to accumulated dimensions
     accumulated = _rescore_accumulated_response(accumulated, reports_root, project, params=params)
 
-    # Build trend using a rescoring fetcher (applies dismissals to each run).
+    # Build trend using the appropriate fetcher: scalar fast path when there
+    # are no active dismissals/deletions, rescoring (findings) path otherwise.
     # Exclude cancelled/failed runs — their partial scores are misleading on
     # the history chart. They remain in availableRuns so the UI can show them
     # when the user asks for them explicitly.

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
+from collections import OrderedDict
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Callable
@@ -38,10 +40,11 @@ from quodeq.services.dashboard import (
     _make_run_dimension_fetcher,
 )
 from quodeq.services.grade_formula import load_params
+from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_trend import build_accumulated_trend
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-from quodeq.services.ports import RunInfo, list_runs
+from quodeq.services.ports import RunInfo, list_runs, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
 from quodeq.services.scoring._summary import recompute_summary
 
@@ -339,6 +342,29 @@ def _make_rescoring_fetcher(
     return rescoring_fetcher
 
 
+def _make_trend_fetcher(
+    reports_root: Path, project: str,
+    params: ScoringParams = DEFAULT_PARAMS,
+) -> Callable[[str], list[DimensionResult]]:
+    """Return the dimension fetcher for the trend chart.
+
+    Fast path: when the project has no active dismissals/deletions, read only
+    the per-run scalar grades (``read_run_scalars``) -- the trend needs nothing
+    else. Uses a fresh per-call LRU cache so scalar (findings-less) results
+    never collide with the shared full-data cache used elsewhere.
+
+    Slow path: when dismissals/deletions are active, fall back to the existing
+    findings-based rescoring fetcher, which recomputes grades from findings.
+    """
+    project_dir = reports_root / project
+    if dismissed_keys(project_dir) or deleted_keys(project_dir):
+        return _make_rescoring_fetcher(reports_root, project, params=params)
+    return make_lru_dimension_fetcher(
+        reports_root, project, OrderedDict(), threading.Lock(),
+        _max_history_runs(), reader=read_run_scalars,
+    )
+
+
 def _rescore_runs_by_dimension(
     dims: list[dict], reports_root: Path, project: str,
     dismissed: set[tuple], deleted: set[tuple] | None = None,
@@ -461,8 +487,8 @@ def get_project_scores(
     # when the user asks for them explicitly.
     scoreable_runs = [r for r in all_runs if r.status not in ("cancelled", "failed")]
     history_runs = scoreable_runs[:_max_history_runs()]
-    rescoring_fetcher = _make_rescoring_fetcher(reports_root, project, params=params)
-    trend = build_accumulated_trend(history_runs, rescoring_fetcher, params=params)
+    trend_fetcher = _make_trend_fetcher(reports_root, project, params=params)
+    trend = build_accumulated_trend(history_runs, trend_fetcher, params=params)
 
     # Build available runs list
     available_runs = [

--- a/tests/data/fs/report_parser/test_run_scalars.py
+++ b/tests/data/fs/report_parser/test_run_scalars.py
@@ -1,0 +1,75 @@
+"""Tests for read_run_scalars: the lightweight per-run grade reader."""
+from pathlib import Path
+
+import pytest
+
+from quodeq.data.fs.report_parser.runs import read_run_data, read_run_scalars
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from tests.services._scalar_fixtures import build_legacy_run, build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def test_reads_scalars_from_db_without_findings(tmp_path: Path) -> None:
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "r1", [
+        {"dimension": "security", "severity": "major"},
+        {"dimension": "reliability", "severity": "minor"},
+    ])
+
+    by_name = {d.dimension: d for d in read_run_scalars(reports, "proj", "r1")}
+
+    assert set(by_name) == {"security", "reliability"}
+    assert by_name["security"].overall_score is not None
+    assert by_name["security"].overall_grade is not None
+    assert by_name["security"].violations == []
+
+
+def test_scalars_match_read_run_data_scores(tmp_path: Path) -> None:
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "r1", [
+        {"dimension": "security", "severity": "major"},
+        {"dimension": "reliability", "severity": "minor"},
+    ])
+
+    scalar = {d.dimension: (d.overall_score, d.overall_grade) for d in read_run_scalars(reports, "proj", "r1")}
+    heavy = {d.dimension: (d.overall_score, d.overall_grade) for d in read_run_data(reports, "proj", "r1")}
+    assert scalar == heavy
+    assert all(v[0] is not None for v in scalar.values())
+
+
+def test_legacy_run_falls_back_to_read_run_data(tmp_path: Path) -> None:
+    reports = tmp_path / "evaluations"
+    build_legacy_run(reports, "proj", "legacy", {"security": ("7.0/10", "Fair")})
+
+    scalar = read_run_scalars(reports, "proj", "legacy")
+    heavy = read_run_data(reports, "proj", "legacy")
+    assert [(d.dimension, d.overall_score, d.overall_grade) for d in scalar] == \
+           [(d.dimension, d.overall_score, d.overall_grade) for d in heavy]
+
+
+def test_null_sql_score_falls_back(tmp_path: Path) -> None:
+    reports = tmp_path / "evaluations"
+    run_dir = build_projected_run(reports, "proj", "r1",
+                                  [{"dimension": "security", "severity": "major"}])
+    SQLiteStateStore(run_dir).record_dimension_score(
+        dimension="reliability", score=None, grade="Insufficient")
+    import json
+    (run_dir / "evaluation" / "reliability.json").write_text(json.dumps({
+        "dimension": "reliability", "overallScore": "no score", "overallGrade": "Insufficient",
+        "principles": [], "violations": [], "compliance": [],
+        "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
+    }))
+    dims = {d.dimension for d in read_run_scalars(reports, "proj", "r1")}
+    assert "reliability" in dims
+
+
+def test_path_traversal_rejected(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        read_run_scalars(tmp_path, "proj", "../escape")

--- a/tests/data/fs/report_parser/test_run_scalars.py
+++ b/tests/data/fs/report_parser/test_run_scalars.py
@@ -1,4 +1,5 @@
 """Tests for read_run_scalars: the lightweight per-run grade reader."""
+import json
 from pathlib import Path
 
 import pytest
@@ -55,19 +56,44 @@ def test_legacy_run_falls_back_to_read_run_data(tmp_path: Path) -> None:
            [(d.dimension, d.overall_score, d.overall_grade) for d in heavy]
 
 
-def test_null_sql_score_falls_back(tmp_path: Path) -> None:
+def test_null_sql_score_falls_back(tmp_path: Path, monkeypatch) -> None:
     reports = tmp_path / "evaluations"
     run_dir = build_projected_run(reports, "proj", "r1", {"security": (8.5, "Good")})
     SQLiteStateStore(run_dir).record_dimension_score(
         dimension="reliability", score=None, grade="Insufficient")
-    import json
     (run_dir / "evaluation" / "reliability.json").write_text(json.dumps({
         "dimension": "reliability", "overallScore": "no score", "overallGrade": "Insufficient",
         "principles": [], "violations": [], "compliance": [],
         "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
     }))
+
+    import quodeq.data.fs.report_parser.runs as runs_mod
+    fell_back = []
+    orig = runs_mod.read_run_data
+    monkeypatch.setattr(runs_mod, "read_run_data",
+                        lambda *a, **k: (fell_back.append(True), orig(*a, **k))[1])
+
     dims = {d.dimension for d in read_run_scalars(reports, "proj", "r1")}
+    assert fell_back, "expected fallback to read_run_data on NULL SQL score"
     assert "reliability" in dims
+
+
+def test_partial_projection_falls_back(tmp_path: Path, monkeypatch) -> None:
+    reports = tmp_path / "evaluations"
+    run_dir = build_projected_run(reports, "proj", "r1", {"security": (8.5, "Good")})
+    # A second eval JSON with no matching SQL dimension row → count mismatch.
+    (run_dir / "evaluation" / "reliability.json").write_text(json.dumps({
+        "dimension": "reliability", "overallScore": "7.0/10", "overallGrade": "Fair",
+        "principles": [], "violations": [], "compliance": [],
+        "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
+    }))
+    import quodeq.data.fs.report_parser.runs as runs_mod
+    fell_back = []
+    orig = runs_mod.read_run_data
+    monkeypatch.setattr(runs_mod, "read_run_data",
+                        lambda *a, **k: (fell_back.append(True), orig(*a, **k))[1])
+    read_run_scalars(reports, "proj", "r1")
+    assert fell_back, "expected fallback when SQL dim count != on-disk JSON count"
 
 
 def test_path_traversal_rejected(tmp_path: Path) -> None:

--- a/tests/data/fs/report_parser/test_run_scalars.py
+++ b/tests/data/fs/report_parser/test_run_scalars.py
@@ -18,10 +18,8 @@ def _clear_cache():
 
 def test_reads_scalars_from_db_without_findings(tmp_path: Path) -> None:
     reports = tmp_path / "evaluations"
-    build_projected_run(reports, "proj", "r1", [
-        {"dimension": "security", "severity": "major"},
-        {"dimension": "reliability", "severity": "minor"},
-    ])
+    build_projected_run(reports, "proj", "r1",
+                        {"security": (8.5, "Good"), "reliability": (6.0, "Fair")})
 
     by_name = {d.dimension: d for d in read_run_scalars(reports, "proj", "r1")}
 
@@ -33,15 +31,18 @@ def test_reads_scalars_from_db_without_findings(tmp_path: Path) -> None:
 
 def test_scalars_match_read_run_data_scores(tmp_path: Path) -> None:
     reports = tmp_path / "evaluations"
-    build_projected_run(reports, "proj", "r1", [
-        {"dimension": "security", "severity": "major"},
-        {"dimension": "reliability", "severity": "minor"},
-    ])
+    build_projected_run(reports, "proj", "r1",
+                        {"security": (8.5, "Good"), "reliability": (6.0, "Fair")})
 
     scalar = {d.dimension: (d.overall_score, d.overall_grade) for d in read_run_scalars(reports, "proj", "r1")}
     heavy = {d.dimension: (d.overall_score, d.overall_grade) for d in read_run_data(reports, "proj", "r1")}
+    # Equal to each other AND to the concrete non-NULL values: proves the fast
+    # path returns real scores, not "None/10" from a silent fallback.
     assert scalar == heavy
-    assert all(v[0] is not None for v in scalar.values())
+    assert scalar == {
+        "security": ("8.5/10", "Good"),
+        "reliability": ("6.0/10", "Fair"),
+    }
 
 
 def test_legacy_run_falls_back_to_read_run_data(tmp_path: Path) -> None:
@@ -56,8 +57,7 @@ def test_legacy_run_falls_back_to_read_run_data(tmp_path: Path) -> None:
 
 def test_null_sql_score_falls_back(tmp_path: Path) -> None:
     reports = tmp_path / "evaluations"
-    run_dir = build_projected_run(reports, "proj", "r1",
-                                  [{"dimension": "security", "severity": "major"}])
+    run_dir = build_projected_run(reports, "proj", "r1", {"security": (8.5, "Good")})
     SQLiteStateStore(run_dir).record_dimension_score(
         dimension="reliability", score=None, grade="Insufficient")
     import json
@@ -73,3 +73,18 @@ def test_null_sql_score_falls_back(tmp_path: Path) -> None:
 def test_path_traversal_rejected(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         read_run_scalars(tmp_path, "proj", "../escape")
+
+
+def test_fast_path_does_not_fall_back(tmp_path: Path, monkeypatch) -> None:
+    """With non-NULL SQL scores, read_run_scalars must NOT call read_run_data."""
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "r1", {"security": (8.5, "Good")})
+
+    import quodeq.data.fs.report_parser.runs as runs_mod
+
+    def boom(*_a, **_k):
+        raise AssertionError("read_run_scalars fell back to read_run_data")
+    monkeypatch.setattr(runs_mod, "read_run_data", boom)
+
+    dims = {d.dimension: d.overall_score for d in read_run_scalars(reports, "proj", "r1")}
+    assert dims == {"security": "8.5/10"}

--- a/tests/services/_scalar_fixtures.py
+++ b/tests/services/_scalar_fixtures.py
@@ -5,44 +5,41 @@ Mirrors tests/services/test_scoring_sql_overlay.py::_build_event_log_run.
 import json
 from pathlib import Path
 
-from quodeq.core.events.models import Judgment
-from quodeq.core.scoring.params import DEFAULT_PARAMS
-from quodeq.data.projection.grade_projector import recompute_grades
 from quodeq.data.sqlite.state_store import SQLiteStateStore
 
 
 def build_projected_run(
     reports: Path, project: str, run_id: str,
-    findings: list[dict],
+    dims: dict[str, tuple[float, str]],
     totals_by_dim: dict[str, dict] | None = None,
 ) -> Path:
-    """A complete event-log run: DB findings, baked SQL grades, eval JSON, manifest.
+    """A projected run with real (non-NULL) SQL grades baked directly.
 
-    *findings*: each ``{"dimension": str, "severity": str, "verdict": str}``.
+    *dims*: ``{dimension: (score_float, grade_str)}``.
     *totals_by_dim*: optional eval-JSON ``"totals"`` per dimension so full reads
     carry non-zero severity.
+
+    Scores are written straight into ``dimension_scores`` via
+    ``record_dimension_score`` (NOT via ``recompute_grades``, which hits the
+    confidence gate and yields NULL scores for low-evidence findings). The empty
+    event log is frozen as fully projected so ``ensure_projected()`` is a no-op
+    and won't wipe them.
     """
     run_dir = reports / project / run_id
     run_dir.mkdir(parents=True)
     (run_dir / "events.jsonl").write_text("")
     store = SQLiteStateStore(run_dir)
-    for i, f in enumerate(findings):
-        store.record_finding(Judgment(
-            practice_id="p1", dimension=f["dimension"], req=f"req{i}",
-            verdict=f.get("verdict", "violation"), severity=f.get("severity", "major"),
-            file=f"f{i}.py", line=1, title=f"t{i}", reason=f"r{i}",
-        ))
     store.save_projected_size((run_dir / "events.jsonl").stat().st_size)
-    recompute_grades(run_dir, params=DEFAULT_PARAMS)
+    for dim, (score, grade) in dims.items():
+        store.record_dimension_score(dimension=dim, score=score, grade=grade)
 
     eval_dir = run_dir / "evaluation"
     eval_dir.mkdir(parents=True, exist_ok=True)
-    for row in store.read_dimension_scores():
-        dim = row["dimension"]
+    for dim, (score, grade) in dims.items():
         (eval_dir / f"{dim}.json").write_text(json.dumps({
             "schema_version": 1, "dimension": dim, "discipline": "Python",
             "date": "2026-05-23", "sourceFileCount": 100,
-            "overallScore": f"{row['score']}/10", "overallGrade": row["grade"],
+            "overallScore": f"{score}/10", "overallGrade": grade,
             "principles": [], "violations": [], "compliance": [],
             "totals": (totals_by_dim or {}).get(
                 dim, {"violationCount": 0, "complianceCount": 0, "severity": {}}),

--- a/tests/services/_scalar_fixtures.py
+++ b/tests/services/_scalar_fixtures.py
@@ -67,8 +67,9 @@ def build_legacy_run(
             "dimension": dim, "overallScore": score, "overallGrade": grade,
             "principles": [], "violations": [], "compliance": [],
             "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
-        }))
+        }), encoding="utf-8")
     evidence_dir = run_dir / "evidence"
     evidence_dir.mkdir(parents=True)
-    (evidence_dir / "manifest.json").write_text(json.dumps({"language_stats": {}}))
+    (evidence_dir / "manifest.json").write_text(
+        json.dumps({"language_stats": {}}), encoding="utf-8")
     return run_dir

--- a/tests/services/_scalar_fixtures.py
+++ b/tests/services/_scalar_fixtures.py
@@ -1,0 +1,77 @@
+"""Shared fixtures for scalar-fast-path tests: runs with baked SQL grades.
+
+Mirrors tests/services/test_scoring_sql_overlay.py::_build_event_log_run.
+"""
+import json
+from pathlib import Path
+
+from quodeq.core.events.models import Judgment
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.data.projection.grade_projector import recompute_grades
+from quodeq.data.sqlite.state_store import SQLiteStateStore
+
+
+def build_projected_run(
+    reports: Path, project: str, run_id: str,
+    findings: list[dict],
+    totals_by_dim: dict[str, dict] | None = None,
+) -> Path:
+    """A complete event-log run: DB findings, baked SQL grades, eval JSON, manifest.
+
+    *findings*: each ``{"dimension": str, "severity": str, "verdict": str}``.
+    *totals_by_dim*: optional eval-JSON ``"totals"`` per dimension so full reads
+    carry non-zero severity.
+    """
+    run_dir = reports / project / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "events.jsonl").write_text("")
+    store = SQLiteStateStore(run_dir)
+    for i, f in enumerate(findings):
+        store.record_finding(Judgment(
+            practice_id="p1", dimension=f["dimension"], req=f"req{i}",
+            verdict=f.get("verdict", "violation"), severity=f.get("severity", "major"),
+            file=f"f{i}.py", line=1, title=f"t{i}", reason=f"r{i}",
+        ))
+    store.save_projected_size((run_dir / "events.jsonl").stat().st_size)
+    recompute_grades(run_dir, params=DEFAULT_PARAMS)
+
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    for row in store.read_dimension_scores():
+        dim = row["dimension"]
+        (eval_dir / f"{dim}.json").write_text(json.dumps({
+            "schema_version": 1, "dimension": dim, "discipline": "Python",
+            "date": "2026-05-23", "sourceFileCount": 100,
+            "overallScore": f"{row['score']}/10", "overallGrade": row["grade"],
+            "principles": [], "violations": [], "compliance": [],
+            "totals": (totals_by_dim or {}).get(
+                dim, {"violationCount": 0, "complianceCount": 0, "severity": {}}),
+        }), encoding="utf-8")
+
+    evidence_dir = run_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    (evidence_dir / "manifest.json").write_text(
+        json.dumps({"language_stats": {}}), encoding="utf-8")
+    return run_dir
+
+
+def build_legacy_run(
+    reports: Path, project: str, run_id: str, dims: dict[str, tuple[str, str]],
+) -> Path:
+    """A legacy run: eval JSON only, no events.jsonl, no evaluation.db.
+
+    *dims*: ``{dimension: (overallScore, overallGrade)}``.
+    """
+    run_dir = reports / project / run_id
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(parents=True)
+    for dim, (score, grade) in dims.items():
+        (eval_dir / f"{dim}.json").write_text(json.dumps({
+            "dimension": dim, "overallScore": score, "overallGrade": grade,
+            "principles": [], "violations": [], "compliance": [],
+            "totals": {"violationCount": 0, "complianceCount": 0, "severity": {}},
+        }))
+    evidence_dir = run_dir / "evidence"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "manifest.json").write_text(json.dumps({"language_stats": {}}))
+    return run_dir

--- a/tests/services/test_cache.py
+++ b/tests/services/test_cache.py
@@ -213,3 +213,28 @@ class TestMakeLruDimensionFetcher:
         assert results[1] is not None
         # Only one disk read should have occurred
         assert call_count["n"] == 1
+
+
+def test_make_lru_dimension_fetcher_uses_custom_reader():
+    """A custom reader is invoked instead of read_run_data, and results cache."""
+    import threading
+    from collections import OrderedDict
+
+    from quodeq.core.types import DimensionResult
+    from quodeq.services._cache import make_lru_dimension_fetcher
+
+    calls: list[str] = []
+
+    def fake_reader(reports_root, project, run_id):
+        calls.append(run_id)
+        return [DimensionResult(dimension="security", overall_score="9.0/10", overall_grade="Good")]
+
+    fetcher = make_lru_dimension_fetcher(
+        Path("/reports"), "proj", OrderedDict(), threading.Lock(), 8, reader=fake_reader,
+    )
+    result = fetcher("r1")
+    result_again = fetcher("r1")  # served from cache, reader not called twice
+
+    assert [d.overall_score for d in result] == ["9.0/10"]
+    assert result_again == result
+    assert calls == ["r1"]  # cached: reader ran exactly once

--- a/tests/services/test_scoring_scalar_parity.py
+++ b/tests/services/test_scoring_scalar_parity.py
@@ -1,0 +1,40 @@
+"""Differential test: scalar-fast-path trend == heavy-path trend (no dismissals)."""
+from pathlib import Path
+
+import pytest
+
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def test_trend_identical_between_fast_and_heavy_paths(tmp_path: Path, monkeypatch) -> None:
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "20260101T000000",
+                        {"security": (7.0, "Fair"), "reliability": (6.0, "Fair")})
+    build_projected_run(reports, "proj", "20260102T000000",
+                        {"security": (8.5, "Good"), "reliability": (6.5, "Fair")})
+
+    # Fast path (default: no dismissals -> scalar reader).
+    fast = get_project_scores(reports, "proj")
+
+    # Force the heavy path for the SAME data by making _make_trend_fetcher
+    # return the rescoring fetcher regardless of dismissals.
+    import quodeq.services.scoring as scoring
+    monkeypatch.setattr(
+        scoring, "_make_trend_fetcher",
+        lambda rr, p, params=scoring.DEFAULT_PARAMS: scoring._make_rescoring_fetcher(rr, p, params=params),
+    )
+    heavy = get_project_scores(reports, "proj")
+
+    assert fast["trend"] == heavy["trend"]
+    # And the trend actually has content (guard against both being empty).
+    assert len(fast["trend"]) == 2
+    assert fast["trend"][0]["numericAverage"] is not None

--- a/tests/services/test_scoring_trend_fetcher.py
+++ b/tests/services/test_scoring_trend_fetcher.py
@@ -1,0 +1,51 @@
+"""Tests for the trend fetcher selection (scalar fast-path vs heavy rescoring)."""
+from pathlib import Path
+
+from quodeq.core.types import DimensionResult
+from quodeq.services.scoring import _make_trend_fetcher
+
+
+def _make_project(tmp_path: Path) -> tuple[Path, str]:
+    reports = tmp_path / "evaluations"
+    (reports / "proj").mkdir(parents=True)
+    return reports, "proj"
+
+
+def test_no_dismissals_uses_scalar_reader(tmp_path: Path, monkeypatch) -> None:
+    reports, project = _make_project(tmp_path)  # fresh project -> no dismissals
+
+    calls: list[str] = []
+
+    def fake_scalar(rr, p, rid):
+        calls.append(rid)
+        return [DimensionResult(dimension="security", overall_score="8.0/10", overall_grade="Good")]
+
+    # _make_trend_fetcher passes the module-global read_run_scalars as the
+    # reader (an explicit arg, so patching the module global takes effect).
+    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", fake_scalar)
+
+    fetcher = _make_trend_fetcher(reports, project)
+    result = fetcher("r1")
+
+    assert [d.overall_score for d in result] == ["8.0/10"]
+    assert calls == ["r1"]  # scalar reader was used
+
+
+def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
+    reports, project = _make_project(tmp_path)
+    # Force a non-empty dismissed set so the scalar fast path is bypassed.
+    monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: {("R1", "a.py", 1)})
+    monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: set())
+
+    sentinel = object()
+    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher",
+                        lambda rr, p, params=None: sentinel)
+
+    def boom(*_a):
+        raise AssertionError("scalar reader used despite active dismissals")
+    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", boom)
+
+    fetcher = _make_trend_fetcher(reports, project)
+
+    # Heavy path: _make_trend_fetcher returns the rescoring fetcher unchanged.
+    assert fetcher is sentinel

--- a/tests/services/test_scoring_trend_fetcher.py
+++ b/tests/services/test_scoring_trend_fetcher.py
@@ -49,3 +49,19 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     # Heavy path: _make_trend_fetcher returns the rescoring fetcher unchanged.
     assert fetcher is sentinel
+
+
+def test_active_deletion_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
+    reports, project = _make_project(tmp_path)
+    monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: set())
+    monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: {("sec", "prin", "a.py")})
+
+    sentinel = object()
+    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher",
+                        lambda rr, p, params=None: sentinel)
+
+    def boom(*_a):
+        raise AssertionError("scalar reader used despite active deletions")
+    monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", boom)
+
+    assert _make_trend_fetcher(reports, project) is sentinel

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -19,7 +19,7 @@ src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
 src/quodeq/api/routes_findings.py:107:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
-src/quodeq/data/fs/report_parser/runs.py:111:services
+src/quodeq/data/fs/report_parser/runs.py:190:services
 src/quodeq/data/projection/grade_projector.py:132:services
 src/quodeq/data/projection/grade_projector.py:20:services
 src/quodeq/data/sqlite/state_store.py:246:services


### PR DESCRIPTION
## Summary

Speeds up the dashboard **trend** by reading per-run scalar grades directly from each run's `evaluation.db` SQL grade tables (`dimension_scores`/`principle_grades`) instead of re-parsing the multi-MB findings JSON per run. Slice 1 of the scalar-fast-path plan; Slice 2 (accumulated view) will follow.

### What changed
- **`read_run_scalars(reports_root, project, run_id)`** (`data/fs/report_parser/runs.py`) — returns per-dimension `DimensionResult`s with `overall_score`/`overall_grade`/`principles` populated from SQL and findings left empty. Falls back to the full `read_run_data` for legacy runs (no `events.jsonl`/`evaluation.db`), SQLite-disabled, unreadable/empty grade tables, any NULL score, or a SQL-dim-vs-eval-file count mismatch.
- **Pluggable `reader`** on `make_lru_dimension_fetcher` (`services/_cache.py`) — default resolves to `read_run_data` lazily (keeps existing `@patch` tests working).
- **`_make_trend_fetcher`** (`services/scoring/__init__.py`) — the dashboard trend uses the scalar fast-path **when a project has no active dismissals/deletions**, else falls back to the existing findings-based rescoring fetcher. Uses a fresh per-call cache so scalar (findings-less) results never pollute the shared full-data cache.

### Correctness
- **Differential parity test** proves the fast-path trend is **byte-identical** to the heavy path on projected runs, verified to have teeth (a real score mutation makes it fail).
- In the no-dismissal case both paths provably end at the same SQL grades (`read_run_data` overlays the same tables via `overlay_sql_grades`); float-format parity is safe (SQLite `REAL` always returns `float`).
- Full suite green (3733 passed); import-layer baseline rebased for the pure line-shift of the pre-existing grandfathered import in `runs.py`.

### Performance
Trend build over the real quodeq project's 73 scoreable runs: **~0.92s (scalar) vs ~2.05s (findings)** — a ~2x win, and flat regardless of findings volume.

## ⚠️ Known limitation (deliberate)
The fast-path only engages for projects with **no active dismissals/deletions**. Projects with dismissals correctly fall back to the rescoring path (verified necessary: the per-run SQL grade tables don't reflect *project-wide* dismissals for all historical runs, so the scalar trend diverges by ~0.1). Notably, the heavily-triaged **quodeq self-scan project (1819 dismissed + 937 deleted) gets no speedup** from this PR — it stays on the heavy path.

## Follow-up (planned)
To make dismissal-heavy projects fast, a separate change will **eagerly re-project all affected runs' SQL grade tables when dismissals/deletions change** (as grade-formula "Apply" already does), after which the scalar fast-path becomes correct with dismissals active and the fallback can be dropped. `read_run_scalars` is the foundation for that work. (Alternative under consideration: read the rescoring path's findings from the per-run SQLite `findings` table instead of the JSON.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
