### PR TITLE
feat(scoring): score cache for dismissal-heavy dashboard trend (Phase 1)

### DIFF
--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -12,13 +12,13 @@ import logging
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
 from quodeq.core.scoring.params import ScoringParams
 from quodeq.core.types import DimensionResult
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-from quodeq.shared._env import get_score_cache_path
+from quodeq.shared._env import get_score_cache_path, score_cache_disabled
 
 _logger = logging.getLogger(__name__)
 _BUSY_TIMEOUT_MS = 5000
@@ -131,3 +131,50 @@ def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
         "params": _params_fingerprint(params),
     }, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def make_cache_backed_fetcher(
+    project: str, version: str,
+    base_fetcher: Callable[[str], list[DimensionResult]],
+) -> Callable[[str], list[DimensionResult]]:
+    """Wrap *base_fetcher* (returns rescored dims) with the read-through cache.
+
+    Bulk-loads all cached runs for (project, version) once, serves hits from
+    memory, and on a miss computes via *base_fetcher*, extracts scalars, writes
+    them back, and returns the scalars. Returns scalar-only DimensionResults
+    (dimension/overall_score/overall_grade). If the kill switch is set, returns
+    *base_fetcher* unchanged.
+    """
+    if score_cache_disabled():
+        return base_fetcher
+
+    by_run: dict[str, list[DimensionResult]] = {}
+    try:
+        with open_score_cache() as conn:
+            for rid, dim, score, grade in conn.execute(
+                "SELECT run_id, dimension, overall_score, overall_grade FROM run_scalars "
+                "WHERE project=? AND version=? ORDER BY run_id, dimension",
+                (project, version),
+            ):
+                by_run.setdefault(rid, []).append(
+                    DimensionResult(dimension=dim, overall_score=score, overall_grade=grade))
+    except sqlite3.Error:
+        by_run = {}
+
+    def fetch(run_id: str) -> list[DimensionResult]:
+        hit = by_run.get(run_id)
+        if hit is not None:
+            return hit
+        dims = base_fetcher(run_id)
+        scalars = [DimensionResult(dimension=d.dimension, overall_score=d.overall_score,
+                                   overall_grade=d.overall_grade)
+                   for d in dims if d.dimension]
+        by_run[run_id] = scalars
+        try:
+            with open_score_cache() as conn:
+                write_cached_rows(conn, project, run_id, version, scalars)
+        except sqlite3.Error:
+            pass
+        return scalars
+
+    return fetch

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -6,13 +6,18 @@ older-schema db is rebuilt, and any cache error falls through to recompute.
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
+from quodeq.core.scoring.params import ScoringParams
 from quodeq.core.types import DimensionResult
+from quodeq.services.deleted import deleted_keys
+from quodeq.services.dismissed import dismissed_keys
 from quodeq.shared._env import get_score_cache_path
 
 _logger = logging.getLogger(__name__)
@@ -97,3 +102,32 @@ def write_cached_rows(
         conn.commit()
     except sqlite3.Error:
         _logger.warning("score cache write failed for %s/%s", project, run_id, exc_info=True)
+
+
+def _params_fingerprint(params: ScoringParams) -> str:
+    """Deterministic serialization of the grade-formula params (sorted maps)."""
+    return json.dumps({
+        "severity_weight": dict(sorted(params.severity_weight.items())),
+        "base_k": params.base_k,
+        "lift_compress": params.lift_compress,
+        "ceil_scale": params.ceil_scale,
+        "floor_minor": params.floor_minor,
+        "floor_major": params.floor_major,
+        "grade_thresholds": [list(t) for t in params.grade_thresholds],
+        "dimension_weights_enabled": params.dimension_weights_enabled,
+        "dimension_weights": dict(sorted(params.dimension_weights.items())),
+    }, sort_keys=True)
+
+
+def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
+    """Content-hash of the project's dismissals + deletions + grade params.
+
+    Any change to any of these produces a new version, auto-invalidating cached
+    rows without a write-path hook.
+    """
+    payload = json.dumps({
+        "dismissed": sorted(str(k) for k in dismissed_keys(project_dir)),
+        "deleted": sorted(str(k) for k in deleted_keys(project_dir)),
+        "params": _params_fingerprint(params),
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -1,0 +1,99 @@
+"""Read-through cache of rescored per-run dimension scalars.
+
+Keyed by a content-hash version of the project's dismissals/deletions + grade
+params, so any change auto-invalidates. Disposable/best-effort: a corrupt or
+older-schema db is rebuilt, and any cache error falls through to recompute.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from quodeq.core.types import DimensionResult
+from quodeq.shared._env import get_score_cache_path
+
+_logger = logging.getLogger(__name__)
+_BUSY_TIMEOUT_MS = 5000
+_SCHEMA = (
+    "CREATE TABLE IF NOT EXISTS run_scalars ("
+    " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
+    " dimension TEXT NOT NULL, overall_score TEXT, overall_grade TEXT,"
+    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
+    " PRIMARY KEY (project, run_id, dimension, version));"
+    "CREATE INDEX IF NOT EXISTS idx_run_scalars_lookup ON run_scalars(project, version);"
+)
+
+
+def _init(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        conn.executescript(_SCHEMA)
+        conn.commit()
+    except sqlite3.DatabaseError:
+        # Close before re-raising so the caller's rebuild path can unlink the
+        # file with no open handle (Windows raises PermissionError otherwise).
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def open_score_cache() -> Iterator[sqlite3.Connection]:
+    """Open the score cache DB (WAL). Rebuilds from scratch if corrupt/older-schema."""
+    path = Path(get_score_cache_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        conn = _init(path)
+    except sqlite3.DatabaseError:
+        _logger.warning("score cache at %s unreadable; rebuilding", path)
+        path.unlink(missing_ok=True)
+        conn = _init(path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def read_cached_rows(
+    conn: sqlite3.Connection, project: str, run_id: str, version: str,
+) -> list[DimensionResult] | None:
+    """Return cached scalar dims for (project, run_id, version), or None on miss/error."""
+    try:
+        rows = conn.execute(
+            "SELECT dimension, overall_score, overall_grade FROM run_scalars "
+            "WHERE project=? AND run_id=? AND version=? ORDER BY dimension",
+            (project, run_id, version),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    if not rows:
+        return None
+    return [DimensionResult(dimension=r[0], overall_score=r[1], overall_grade=r[2]) for r in rows]
+
+
+def write_cached_rows(
+    conn: sqlite3.Connection, project: str, run_id: str, version: str,
+    dims: list[DimensionResult],
+) -> None:
+    """Replace all cached rows for (project, run_id) with *dims* at *version*.
+
+    Best-effort: logs and returns on any SQLite error (the caller still has the
+    computed result).
+    """
+    try:
+        conn.execute("DELETE FROM run_scalars WHERE project=? AND run_id=?", (project, run_id))
+        conn.executemany(
+            "INSERT OR REPLACE INTO run_scalars "
+            "(project, run_id, version, dimension, overall_score, overall_grade) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [(project, run_id, version, d.dimension, d.overall_score, d.overall_grade)
+             for d in dims if d.dimension],
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("score cache write failed for %s/%s", project, run_id, exc_info=True)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -353,14 +353,18 @@ def _make_trend_fetcher(
     else. Uses a fresh per-call LRU cache so scalar (findings-less) results
     never collide with the shared full-data cache used elsewhere.
 
-    Slow path: when dismissals/deletions are active, fall back to the existing
-    findings-based rescoring fetcher, which recomputes grades from findings.
+    Heavy path: when dismissals/deletions are active, wrap the findings-based
+    rescoring fetcher with the read-through score cache. The cache version is a
+    content-hash of the project's dismissals/deletions/params, so any change
+    auto-invalidates without a write-path hook.
     """
     project_dir = reports_root / project
     if dismissed_keys(project_dir) or deleted_keys(project_dir):
         # Heavy path: wrap the findings-based rescoring fetcher with the
         # read-through score cache. Version is a content hash of the project's
         # dismissals/deletions/params, so any change auto-invalidates.
+        # dismissed/deleted are read here (branch test), in _make_rescoring_fetcher,
+        # and in score_cache_version -- three reads total, each ~0.01s, acceptable.
         base = _make_rescoring_fetcher(reports_root, project, params=params)
         version = score_cache_version(project_dir, params)
         return make_cache_backed_fetcher(project, version, base)

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -43,6 +43,7 @@ from quodeq.services.dashboard import (
 from quodeq.services.grade_formula import load_params
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
+from quodeq.services.score_cache import make_cache_backed_fetcher, score_cache_version
 from quodeq.services.ports import RunInfo, list_runs, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
 from quodeq.services.scoring._summary import recompute_summary
@@ -357,9 +358,12 @@ def _make_trend_fetcher(
     """
     project_dir = reports_root / project
     if dismissed_keys(project_dir) or deleted_keys(project_dir):
-        # _make_rescoring_fetcher re-reads dismissed/deleted internally; the
-        # extra read is cheap and keeps this branch a thin delegate.
-        return _make_rescoring_fetcher(reports_root, project, params=params)
+        # Heavy path: wrap the findings-based rescoring fetcher with the
+        # read-through score cache. Version is a content hash of the project's
+        # dismissals/deletions/params, so any change auto-invalidates.
+        base = _make_rescoring_fetcher(reports_root, project, params=params)
+        version = score_cache_version(project_dir, params)
+        return make_cache_backed_fetcher(project, version, base)
     cache, lock = create_dimension_cache()
     return make_lru_dimension_fetcher(
         reports_root, project, cache, lock,

--- a/src/quodeq/shared/_env.py
+++ b/src/quodeq/shared/_env.py
@@ -127,6 +127,31 @@ def get_index_db_path(default: str | None = None, env: dict[str, str] | None = N
     return default or str(_DEFAULT_INDEX_DB_PATH)
 
 
+_DEFAULT_SCORE_CACHE_PATH = Path.home() / ".quodeq" / "score_cache.db"
+
+
+def get_score_cache_path(env: dict[str, str] | None = None) -> str:
+    """Return the absolute path to the rescored-score cache DB.
+
+    Resolution: QUODEQ_SCORE_CACHE_PATH env var, else next to the index DB
+    (so the test suite's QUODEQ_INDEX_DB_PATH override auto-isolates it), else
+    ~/.quodeq/score_cache.db. This cache is disposable -- deleting it is safe.
+    """
+    environ = env if env is not None else os.environ
+    if "QUODEQ_SCORE_CACHE_PATH" in environ:
+        return environ["QUODEQ_SCORE_CACHE_PATH"]
+    index_parent = Path(get_index_db_path(env=environ)).parent
+    if str(index_parent) not in ("", "."):
+        return str(index_parent / "score_cache.db")
+    return str(_DEFAULT_SCORE_CACHE_PATH)
+
+
+def score_cache_disabled(env: dict[str, str] | None = None) -> bool:
+    """Return True when QUODEQ_DISABLE_SCORE_CACHE is truthy (operator kill switch)."""
+    environ = env if env is not None else os.environ
+    return environ.get("QUODEQ_DISABLE_SCORE_CACHE", "").strip().lower() in _SQLITE_DISABLE_TRUTHY
+
+
 _DEFAULT_CLONES_DIR = Path.home() / ".quodeq" / "clones"
 
 

--- a/tests/services/test_score_cache_fetcher.py
+++ b/tests/services/test_score_cache_fetcher.py
@@ -1,0 +1,45 @@
+from quodeq.core.types import DimensionResult
+from quodeq.services.score_cache import make_cache_backed_fetcher
+
+
+def _rescored(rid):
+    # A "rescored" full dim (findings omitted for the test).
+    return [DimensionResult(dimension="security", overall_score="8.0/10", overall_grade="Good")]
+
+
+def test_miss_computes_and_caches_then_hit_skips_base(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def base(rid):
+        calls.append(rid)
+        return _rescored(rid)
+
+    f1 = make_cache_backed_fetcher("proj", "v1", base)
+    out1 = f1("r1")                    # miss -> base called, cached
+    assert [d.overall_score for d in out1] == ["8.0/10"]
+    assert calls == ["r1"]
+
+    # New fetcher instance (fresh bulk-load) sees the cached row -> base NOT called.
+    def boom(rid):
+        raise AssertionError("base fetcher called on a cache hit")
+    f2 = make_cache_backed_fetcher("proj", "v1", boom)
+    out2 = f2("r1")
+    assert [(d.dimension, d.overall_score, d.overall_grade) for d in out2] == [("security", "8.0/10", "Good")]
+
+
+def test_version_change_is_a_miss(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    make_cache_backed_fetcher("proj", "v1", _rescored)("r1")  # cache under v1
+    calls = []
+    def base(rid):
+        calls.append(rid)
+        return _rescored(rid)
+    make_cache_backed_fetcher("proj", "v2", base)("r1")       # different version -> miss
+    assert calls == ["r1"]
+
+
+def test_kill_switch_returns_base_fetcher(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    base = _rescored
+    assert make_cache_backed_fetcher("proj", "v1", base) is base

--- a/tests/services/test_score_cache_parity.py
+++ b/tests/services/test_score_cache_parity.py
@@ -51,7 +51,8 @@ def test_trend_identical_cached_vs_direct(tmp_path, monkeypatch):
     warm = get_project_scores(reports, "proj")   # warm cache: hits
 
     monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
-    direct = get_project_scores(reports, "proj")  # cache off: direct rescoring
+    # cache off (kill switch -> make_cache_backed_fetcher returns base unchanged): direct rescoring
+    direct = get_project_scores(reports, "proj")
 
     assert cold["trend"] == direct["trend"]
     assert warm["trend"] == direct["trend"]

--- a/tests/services/test_score_cache_parity.py
+++ b/tests/services/test_score_cache_parity.py
@@ -1,0 +1,58 @@
+"""Differential: trend through the score cache == direct rescoring, with dismissals."""
+from pathlib import Path
+
+import pytest
+
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.dismissed import dismiss_finding, dismissed_keys
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def _dismiss(project_dir: Path, req: str, file: str, line: int) -> None:
+    """Record a dismissal so dismissed_keys(project_dir) is non-empty (heavy path).
+
+    Uses dismiss_finding() from quodeq.services.dismissed, which appends a
+    FindingDismissedEvent to project_dir/actions.jsonl.  The finding dict only
+    needs req/file/line; the rest are optional metadata fields.
+    """
+    dismiss_finding(project_dir, {"req": req, "file": file, "line": line})
+
+
+def test_dismiss_activates_heavy_path(tmp_path):
+    """Sanity check: _dismiss makes dismissed_keys non-empty."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    assert dismissed_keys(project_dir) == set()
+    _dismiss(project_dir, "R1", "a.py", 1)
+    assert dismissed_keys(project_dir) == {("R1", "a.py", 1)}
+
+
+def test_trend_identical_cached_vs_direct(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    build_projected_run(reports, "proj", "20260102T000000", {"security": (8.0, "Good")})
+    _dismiss(reports / "proj", "R1", "a.py", 1)  # activate the heavy (rescoring) path
+
+    # Verify the heavy path is actually taken (dismissed_keys must be non-empty).
+    assert dismissed_keys(reports / "proj"), (
+        "_dismiss did not produce a non-empty dismissed_keys; heavy path not exercised"
+    )
+
+    cold = get_project_scores(reports, "proj")   # cold cache: misses -> compute + populate
+    warm = get_project_scores(reports, "proj")   # warm cache: hits
+
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    direct = get_project_scores(reports, "proj")  # cache off: direct rescoring
+
+    assert cold["trend"] == direct["trend"]
+    assert warm["trend"] == direct["trend"]
+    assert len(cold["trend"]) == 2

--- a/tests/services/test_score_cache_store.py
+++ b/tests/services/test_score_cache_store.py
@@ -1,0 +1,38 @@
+from quodeq.core.types import DimensionResult
+from quodeq.services.score_cache import open_score_cache, read_cached_rows, write_cached_rows
+
+
+def test_write_then_read_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    dims = [DimensionResult(dimension="security", overall_score="8.5/10", overall_grade="Good"),
+            DimensionResult(dimension="reliability", overall_score="6.0/10", overall_grade="Fair")]
+    with open_score_cache() as conn:
+        write_cached_rows(conn, "proj", "r1", "v1", dims)
+    with open_score_cache() as conn:
+        got = read_cached_rows(conn, "proj", "r1", "v1")
+    assert [(d.dimension, d.overall_score, d.overall_grade) for d in got] == \
+           [("reliability", "6.0/10", "Fair"), ("security", "8.5/10", "Good")]  # ordered by dimension
+
+
+def test_read_miss_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    with open_score_cache() as conn:
+        assert read_cached_rows(conn, "proj", "nope", "v1") is None
+
+
+def test_write_replaces_prior_version_for_run(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    d = [DimensionResult(dimension="security", overall_score="9/10", overall_grade="A")]
+    with open_score_cache() as conn:
+        write_cached_rows(conn, "proj", "r1", "v1", d)
+        write_cached_rows(conn, "proj", "r1", "v2", d)  # new version replaces
+        assert read_cached_rows(conn, "proj", "r1", "v1") is None
+        assert read_cached_rows(conn, "proj", "r1", "v2") is not None
+
+
+def test_corrupt_db_is_rebuilt(tmp_path, monkeypatch):
+    p = tmp_path / "sc.db"
+    p.write_text("not a database")  # garbage
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(p))
+    with open_score_cache() as conn:  # must not raise; rebuilds
+        assert read_cached_rows(conn, "proj", "r1", "v1") is None

--- a/tests/services/test_score_cache_version.py
+++ b/tests/services/test_score_cache_version.py
@@ -1,0 +1,35 @@
+import dataclasses
+from pathlib import Path
+
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.services.score_cache import score_cache_version
+
+
+def test_stable_for_same_inputs(tmp_path, monkeypatch):
+    pd = tmp_path / "proj"
+    pd.mkdir()
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: {("R1", "a.py", 1)})
+    monkeypatch.setattr("quodeq.services.score_cache.deleted_keys", lambda _p: set())
+    v1 = score_cache_version(pd, DEFAULT_PARAMS)
+    v2 = score_cache_version(pd, DEFAULT_PARAMS)
+    assert v1 == v2 and len(v1) == 64  # sha256 hex
+
+
+def test_changes_when_dismissals_change(tmp_path, monkeypatch):
+    pd = tmp_path / "proj"; pd.mkdir()
+    monkeypatch.setattr("quodeq.services.score_cache.deleted_keys", lambda _p: set())
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: {("R1", "a.py", 1)})
+    v1 = score_cache_version(pd, DEFAULT_PARAMS)
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: {("R1", "a.py", 1), ("R2", "b.py", 2)})
+    v2 = score_cache_version(pd, DEFAULT_PARAMS)
+    assert v1 != v2
+
+
+def test_changes_when_params_change(tmp_path, monkeypatch):
+    pd = tmp_path / "proj"; pd.mkdir()
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: set())
+    monkeypatch.setattr("quodeq.services.score_cache.deleted_keys", lambda _p: set())
+    v1 = score_cache_version(pd, DEFAULT_PARAMS)
+    strict = dataclasses.replace(DEFAULT_PARAMS, base_k=DEFAULT_PARAMS.base_k + 1.0)
+    v2 = score_cache_version(pd, strict)
+    assert v1 != v2

--- a/tests/services/test_scoring_trend_fetcher.py
+++ b/tests/services/test_scoring_trend_fetcher.py
@@ -36,10 +36,18 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
     # Force a non-empty dismissed set so the scalar fast path is bypassed.
     monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: {("R1", "a.py", 1)})
     monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: set())
+    # Use a tmp score cache so the test stays isolated.
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
 
-    sentinel = object()
-    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher",
-                        lambda rr, p, params=None: sentinel)
+    rescoring_calls: list[str] = []
+
+    def fake_rescoring_fetcher(rr, p, params=None):
+        def fetch(run_id: str) -> list[DimensionResult]:
+            rescoring_calls.append(run_id)
+            return [DimensionResult(dimension="security", overall_score="7.0/10", overall_grade="Fair")]
+        return fetch
+
+    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher", fake_rescoring_fetcher)
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active dismissals")
@@ -47,21 +55,36 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     fetcher = _make_trend_fetcher(reports, project)
 
-    # Heavy path: _make_trend_fetcher returns the rescoring fetcher unchanged.
-    assert fetcher is sentinel
+    # Heavy path: the cache-wrapper is returned (not the raw rescoring fetcher).
+    # Calling it must invoke the rescoring fetcher (not the scalar reader).
+    result = fetcher("r1")
+    assert [d.overall_score for d in result] == ["7.0/10"]
+    assert rescoring_calls == ["r1"]  # rescoring fetcher was used, not the scalar reader
 
 
 def test_active_deletion_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
     reports, project = _make_project(tmp_path)
     monkeypatch.setattr("quodeq.services.scoring.dismissed_keys", lambda _pd: set())
     monkeypatch.setattr("quodeq.services.scoring.deleted_keys", lambda _pd: {("sec", "prin", "a.py")})
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
 
-    sentinel = object()
-    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher",
-                        lambda rr, p, params=None: sentinel)
+    rescoring_calls: list[str] = []
+
+    def fake_rescoring_fetcher(rr, p, params=None):
+        def fetch(run_id: str) -> list[DimensionResult]:
+            rescoring_calls.append(run_id)
+            return [DimensionResult(dimension="security", overall_score="6.0/10", overall_grade="Fair")]
+        return fetch
+
+    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher", fake_rescoring_fetcher)
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active deletions")
     monkeypatch.setattr("quodeq.services.scoring.read_run_scalars", boom)
 
-    assert _make_trend_fetcher(reports, project) is sentinel
+    fetcher = _make_trend_fetcher(reports, project)
+
+    # Heavy path: rescoring fetcher is wrapped in the cache; scalar reader must NOT be called.
+    result = fetcher("r2")
+    assert [d.overall_score for d in result] == ["6.0/10"]
+    assert rescoring_calls == ["r2"]

--- a/tests/shared/test_env_score_cache.py
+++ b/tests/shared/test_env_score_cache.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from quodeq.shared._env import get_score_cache_path, score_cache_disabled
+
+
+def test_explicit_env_path_wins():
+    env = {"QUODEQ_SCORE_CACHE_PATH": "/tmp/x/score.db"}
+    assert get_score_cache_path(env=env) == "/tmp/x/score.db"
+
+
+def test_derives_from_index_db_dir():
+    env = {"QUODEQ_INDEX_DB_PATH": "/tmp/quodeqtest/index.db"}
+    assert get_score_cache_path(env=env) == str(Path("/tmp/quodeqtest") / "score_cache.db")
+
+
+def test_kill_switch():
+    assert score_cache_disabled(env={"QUODEQ_DISABLE_SCORE_CACHE": "1"}) is True
+    assert score_cache_disabled(env={"QUODEQ_DISABLE_SCORE_CACHE": "true"}) is True
+    assert score_cache_disabled(env={}) is False


### PR DESCRIPTION
## Summary

Caches the rescored per-run dimension scalars in a dedicated `~/.quodeq/score_cache.db`, so the **dismissal-heavy dashboard trend** stops re-parsing + re-rescoring ~73 runs of findings JSON on every launch. Phase 1 of the score-cache work (trend only; the accumulated view is Phase 2).

> **Stacked on #689** (scalar fast-path). This PR wires into `_make_trend_fetcher`, which #689 adds — review/merge #689 first. Diff shown is the score-cache increment only.

### How it works
- **`services/score_cache.py`** — a dedicated, disposable SQLite cache. Read-through: bulk-load all cached runs for the current version once, serve hits from memory, compute misses via the existing rescoring path and write them back.
- **Version = content hash** of the project's `dismissed_keys` + `deleted_keys` + grade-formula params. Any change (a dismiss, a deletion, an "Apply") produces a new version, so cached rows auto-invalidate — **no write-path hook, no stale-invalidation logic**. Liveness preserved: the first load after any dismiss is a cache miss and recomputes.
- **Integration:** only `_make_trend_fetcher`'s heavy (dismissal-active) branch is wrapped. The no-dismissal fast path (#689) is untouched.
- **Disposable + safe:** rebuild-on-corrupt, best-effort writes (a cache failure never breaks scoring), kill switch `QUODEQ_DISABLE_SCORE_CACHE`.

### Correctness
- **Differential test** proves the trend through the cache is **byte-identical** to the direct (cache-disabled) rescoring path, both cold (all misses) and warm (all hits), on a project with dismissals — verified to have teeth (a corrupted cached score fails the assertion).
- Full suite green (3746 passed; the 2 failures are the known-flaky live-Gemma provenance-gate behavioral tests, unrelated — this change touches no analysis code).

### Measured (real quodeq project, 1819 dismissed + 937 deleted)
| Launch | Time |
|---|---|
| COLD (empty cache / first load after a dismissal change) | 5.34s |
| **WARM (cache hit)** | **2.99s** |

## ⚠️ Scope: Phase 1 is a partial win
This caches the **trend** (~2.3s saved on warm loads). The remaining ~3.0s is the **accumulated view** (`compute_accumulated`), which Phase 1 deliberately does not cache. So steady-state launch drops ~5.3s → ~3.0s — a real, correct, incremental improvement and the foundation, but **not yet sub-second**. **Phase 2** (supply the accumulated carry-forward scalars from this cache + full-read only the ~6 displayed dims) finishes the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
