### PR TITLE
feat(scoring): cache the accumulated view (score cache Phase 2, sub-second launch)

### DIFF
--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -179,6 +179,49 @@ def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def accumulated_cache_version(
+    project_dir: Path, params: ScoringParams,
+    run_fingerprint: list[tuple[str, str]], as_of: str | None,
+) -> str:
+    """Version for the accumulated cache: the base dismissals/deletions/params
+    hash plus the run-set (run_id, status) and *as_of*, so a new scan, a status
+    change, or a historical view all invalidate. Run-set is sorted for order
+    independence.
+    """
+    payload = json.dumps({
+        "base": score_cache_version(project_dir, params),
+        "runs": sorted(list(t) for t in run_fingerprint),
+        "as_of": as_of or "",
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def cached_accumulated(
+    project: str, version: str, compute: Callable[[], dict],
+) -> dict:
+    """Read-through cache for the accumulated payload.
+
+    Hit -> return the deserialized cached payload. Miss (or kill switch / cache
+    error) -> call *compute*, cache the result best-effort, return it.
+    """
+    if score_cache_disabled():
+        return compute()
+    try:
+        with open_score_cache() as conn:
+            cached = read_cached_accumulated(conn, project, version)
+        if cached is not None:
+            return cached
+    except sqlite3.Error:
+        return compute()
+    result = compute()
+    try:
+        with open_score_cache() as conn:
+            write_cached_accumulated(conn, project, version, result)
+    except sqlite3.Error:
+        pass
+    return result
+
+
 def make_cache_backed_fetcher(
     project: str, version: str,
     base_fetcher: Callable[[str], list[DimensionResult]],

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -132,6 +132,11 @@ def write_cached_accumulated(
 ) -> None:
     """Replace the cached accumulated payload for *project* at *version*.
 
+    Single-slot per project: the DELETE clears any prior version first, so the
+    table holds at most one accumulated payload per project. The default
+    dashboard uses ``as_of=None`` (one version), so this is stable; rapidly
+    alternating distinct ``as_of`` historical views would each miss + overwrite.
+
     Best-effort: logs and returns on any SQLite/serialization error.
     """
     try:

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -29,6 +29,10 @@ _SCHEMA = (
     " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
     " PRIMARY KEY (project, run_id, dimension, version));"
     "CREATE INDEX IF NOT EXISTS idx_run_scalars_lookup ON run_scalars(project, version);"
+    "CREATE TABLE IF NOT EXISTS accumulated_cache ("
+    " project TEXT NOT NULL, version TEXT NOT NULL, payload TEXT NOT NULL,"
+    " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
+    " PRIMARY KEY (project, version));"
 )
 
 
@@ -102,6 +106,48 @@ def write_cached_rows(
         conn.commit()
     except sqlite3.Error:
         _logger.warning("score cache write failed for %s/%s", project, run_id, exc_info=True)
+
+
+def read_cached_accumulated(
+    conn: sqlite3.Connection, project: str, version: str,
+) -> dict | None:
+    """Return the cached accumulated payload for (project, version), or None."""
+    try:
+        row = conn.execute(
+            "SELECT payload FROM accumulated_cache WHERE project=? AND version=?",
+            (project, version),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        return json.loads(row[0])
+    except (ValueError, TypeError):
+        return None
+
+
+def write_cached_accumulated(
+    conn: sqlite3.Connection, project: str, version: str, payload: dict,
+) -> None:
+    """Replace the cached accumulated payload for *project* at *version*.
+
+    Best-effort: logs and returns on any SQLite/serialization error.
+    """
+    try:
+        blob = json.dumps(payload)
+    except (TypeError, ValueError):
+        _logger.warning("accumulated payload for %s not serializable; skipping cache", project)
+        return
+    try:
+        conn.execute("DELETE FROM accumulated_cache WHERE project=?", (project,))
+        conn.execute(
+            "INSERT OR REPLACE INTO accumulated_cache (project, version, payload) VALUES (?, ?, ?)",
+            (project, version, blob),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("accumulated cache write failed for %s", project, exc_info=True)
 
 
 def _params_fingerprint(params: ScoringParams) -> str:

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -43,7 +43,13 @@ from quodeq.services.dashboard import (
 from quodeq.services.grade_formula import load_params
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
-from quodeq.services.score_cache import make_cache_backed_fetcher, score_cache_version
+from quodeq.services._fs_projects import find_children
+from quodeq.services.score_cache import (
+    accumulated_cache_version,
+    cached_accumulated,
+    make_cache_backed_fetcher,
+    score_cache_version,
+)
 from quodeq.services.ports import RunInfo, list_runs, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
 from quodeq.services.scoring._summary import recompute_summary
@@ -482,14 +488,23 @@ def get_project_scores(
         }
 
     # Build accumulated using the existing service (returns full data with violations)
-    accumulated = compute_accumulated(
-        str(reports_root), project, as_of, params=params,
-    )
-    if accumulated is None:
-        accumulated = {"dimensions": [], "summary": {}}
+    def _compute_accumulated_payload() -> dict:
+        acc = compute_accumulated(str(reports_root), project, as_of, params=params)
+        if acc is None:
+            acc = {"dimensions": [], "summary": {}}
+        return _rescore_accumulated_response(acc, reports_root, project, params=params)
 
-    # Apply rescore to accumulated dimensions
-    accumulated = _rescore_accumulated_response(accumulated, reports_root, project, params=params)
+    if find_children(reports_root, project):
+        # Parent aggregation pulls child projects' dismissals/runs into the
+        # payload, which the project-scoped cache version can't see -- bypass
+        # the cache for parents to avoid serving stale data.
+        accumulated = _compute_accumulated_payload()
+    else:
+        acc_version = accumulated_cache_version(
+            reports_root / project, params,
+            [(r.run_id, r.status) for r in all_runs], as_of,
+        )
+        accumulated = cached_accumulated(project, acc_version, _compute_accumulated_payload)
 
     # Build trend using the appropriate fetcher: scalar fast path when there
     # are no active dismissals/deletions, rescoring (findings) path otherwise.

--- a/tests/services/test_score_cache_accumulated_helper.py
+++ b/tests/services/test_score_cache_accumulated_helper.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from quodeq.core.scoring.params import DEFAULT_PARAMS
+from quodeq.services.score_cache import accumulated_cache_version, cached_accumulated
+
+
+def _patch_keys(monkeypatch, dismissed=frozenset(), deleted=frozenset()):
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: set(dismissed))
+    monkeypatch.setattr("quodeq.services.score_cache.deleted_keys", lambda _p: set(deleted))
+
+
+def test_version_changes_with_run_set(tmp_path, monkeypatch):
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+    v1 = accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "complete")], None)
+    v2 = accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "complete"), ("r2", "complete")], None)
+    assert v1 != v2 and len(v1) == 64
+
+
+def test_version_changes_with_status_and_as_of(tmp_path, monkeypatch):
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+    base = accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "complete")], None)
+    assert accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "in_progress")], None) != base
+    assert accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "complete")], "r1") != base
+
+
+def test_version_stable_regardless_of_run_order(tmp_path, monkeypatch):
+    _patch_keys(monkeypatch)
+    pd = tmp_path / "proj"; pd.mkdir()
+    a = accumulated_cache_version(pd, DEFAULT_PARAMS, [("r1", "complete"), ("r2", "complete")], None)
+    b = accumulated_cache_version(pd, DEFAULT_PARAMS, [("r2", "complete"), ("r1", "complete")], None)
+    assert a == b  # run-set is order-independent (sorted)
+
+
+def test_cached_accumulated_miss_then_hit(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    calls = []
+    def compute():
+        calls.append(1)
+        return {"dimensions": [], "summary": {"x": 1}}
+    r1 = cached_accumulated("proj", "v1", compute)     # miss -> compute + cache
+    r2 = cached_accumulated("proj", "v1", lambda: (_ for _ in ()).throw(AssertionError("recomputed on hit")))
+    assert r1 == r2 == {"dimensions": [], "summary": {"x": 1}}
+    assert calls == [1]
+
+
+def test_cached_accumulated_kill_switch(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    calls = []
+    def compute():
+        calls.append(1); return {"y": 2}
+    assert cached_accumulated("proj", "v1", compute) == {"y": 2}
+    assert cached_accumulated("proj", "v1", compute) == {"y": 2}
+    assert calls == [1, 1]  # never cached

--- a/tests/services/test_score_cache_accumulated_parity.py
+++ b/tests/services/test_score_cache_accumulated_parity.py
@@ -1,0 +1,63 @@
+"""Differential + correctness for the accumulated cache: identical to direct,
+run-set invalidation, and parent-project cache bypass."""
+from pathlib import Path
+
+import pytest
+
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.dismissed import dismiss_finding
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def test_accumulated_identical_cached_vs_direct(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+
+    cold = get_project_scores(reports, "proj")   # miss -> compute + cache
+    warm = get_project_scores(reports, "proj")   # hit
+
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    direct = get_project_scores(reports, "proj")
+
+    assert cold["accumulated"] == direct["accumulated"]
+    assert warm["accumulated"] == direct["accumulated"]
+
+
+def test_new_run_invalidates_accumulated(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    get_project_scores(reports, "proj")                    # cache under version A
+    build_projected_run(reports, "proj", "20260102T000000", {"security": (9.0, "Good")})
+    second = get_project_scores(reports, "proj")           # run-set changed -> version B
+    assert len(second["availableRuns"]) == 2               # not the stale 1-run payload
+    monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+    assert second["accumulated"] == get_project_scores(reports, "proj")["accumulated"]
+
+
+def test_parent_project_bypasses_cache(tmp_path, monkeypatch):
+    """A project WITH children must NOT use the accumulated cache (child dismissals
+    escape the version). Verified by making the cache helper raise if consulted."""
+    reports = tmp_path / "evaluations"
+    build_projected_run(reports, "parent", "20260101T000000", {"security": (7.0, "Fair")})
+    child = reports / "child"
+    child.mkdir(parents=True)
+    (child / "repository_info.json").write_text('{"parent": "parent"}', encoding="utf-8")
+
+    import quodeq.services.scoring as scoring
+    def boom(*a, **k):
+        raise AssertionError("accumulated cache used for a parent project")
+    monkeypatch.setattr(scoring, "cached_accumulated", boom)
+
+    result = get_project_scores(reports, "parent")   # must NOT raise (bypasses cache)
+    assert result is not None

--- a/tests/services/test_score_cache_accumulated_store.py
+++ b/tests/services/test_score_cache_accumulated_store.py
@@ -1,0 +1,28 @@
+from quodeq.services.score_cache import (
+    open_score_cache, read_cached_accumulated, write_cached_accumulated,
+)
+
+
+def test_accumulated_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    payload = {"dimensions": [{"dimension": "security", "overallScore": "8/10"}],
+               "summary": {"critical": 2, "totalViolations": 5}}
+    with open_score_cache() as conn:
+        write_cached_accumulated(conn, "proj", "v1", payload)
+    with open_score_cache() as conn:
+        assert read_cached_accumulated(conn, "proj", "v1") == payload
+
+
+def test_accumulated_miss_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    with open_score_cache() as conn:
+        assert read_cached_accumulated(conn, "proj", "v1") is None
+
+
+def test_accumulated_write_replaces_prior_version(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    with open_score_cache() as conn:
+        write_cached_accumulated(conn, "proj", "v1", {"a": 1})
+        write_cached_accumulated(conn, "proj", "v2", {"a": 2})   # replaces (only 1 version per project)
+        assert read_cached_accumulated(conn, "proj", "v1") is None
+        assert read_cached_accumulated(conn, "proj", "v2") == {"a": 2}


### PR DESCRIPTION
## Summary

Phase 2 of the score cache: caches the computed **accumulated (cross-run overview)** payload in `score_cache.db`, completing the dismissal-heavy launch speedup. With Phase 1 (trend) + Phase 2 (accumulated), a dismissal-heavy project's warm launch is now **sub-second**.

> **Stacked on #690** (score cache Phase 1, which is stacked on the merged #689). Diff shown is the Phase 2 increment.

### How it works
- New `accumulated_cache` table in the same `score_cache.db`. `get_project_scores` computes an **accumulated version** = the Phase 1 dismissals/deletions/params hash **plus a fingerprint of the run-set** (`(run_id, status)` for all runs) **plus `as_of`** — so a new scan, a status change, or a historical view all auto-invalidate. Read-through: hit deserializes the cached payload (~10ms), miss computes (`compute_accumulated` + rescore) and writes back.
- **Parent-project bypass:** projects that aggregate child projects skip the cache (child dismissals/runs escape the project-scoped version). Standalone projects (the common case) cache normally. `find_children` is empty for all current projects.
- Disposable, best-effort, kill switch `QUODEQ_DISABLE_SCORE_CACHE`, single-slot-per-project (documented).

### Correctness (byte-identical + mutation-verified)
- **Differential test:** accumulated through the cache == direct (cache-disabled) compute, cold (miss) + warm (hit), on a project with dismissals.
- **New-run invalidation** and **parent-bypass** tests, all three mutation-verified to have teeth (corrupt cache → parity fails; remove bypass → parent test fails; drop run-set from the version → invalidation test fails).
- Full suite: 3758 passed; the 1 failure is the known-flaky live-Gemma `external_header_deref` provenance-gate test (unrelated — this change touches no analysis code).

### Measured (real quodeq project, 1819 dismissed + 937 deleted)
| Launch | Time |
|---|---|
| Baseline (pre-cache) | ~4.5-5.3s |
| COLD (empty cache) | 5.21s |
| **WARM (trend + accumulated cached)** | **0.45s** (~10x) |

Warm launch is byte-identical to direct (trend + accumulated both verified `cold==warm`). The residual ~0.45s is mostly `list_runs` (a ~0.34s filesystem walk) — a separate future target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
