### PR TITLE
fix(dashboard): stop the close button freezing the app during a running scan

### DIFF
--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -741,13 +741,46 @@ def _create_window(url: str, api: "_WindowApi") -> "webview.Window":
     )
 
 
+_CLOSE_CONFIRM_TITLE = "Quit quodeq?"
+_CLOSE_CONFIRM_BODY = (
+    "A scan is running. Click OK to quit — the scan keeps running "
+    "in the background. Click Cancel to stay."
+)
+
+
 def _make_on_closing(api: "_WindowApi", window: object) -> "Callable[[], bool]":
     """Native close handler: confirm via a native dialog if a scan is running.
 
-    Returns True to allow the close, False to keep the window open. The scan
-    is a separate process, so 'Quit' just closes the window and the scan
-    keeps running.
+    The scan is a separate process, so 'Quit' just closes the window and the
+    scan keeps running.
+
+    pywebview's ``closing`` event is a *locking* event: its handler runs
+    synchronously on the GUI thread (on macOS, inside ``windowShouldClose:``).
+    How the confirmation dialog can be shown from there depends on the backend:
+
+    * macOS / GTK / Qt — ``create_confirmation_dialog`` marshals the native
+      alert back onto the GUI thread and then blocks its caller on a semaphore.
+      Called from the GUI-thread closing handler it self-deadlocks (the alert
+      can never run — the GUI thread is parked in the handler), which froze the
+      window whenever a scan was in flight. So we don't answer inline: veto the
+      close (return False), show the dialog on a worker thread (off the GUI
+      thread the semaphore is safe), and re-issue the close via
+      ``window.destroy`` once the user confirms.
+
+    * Windows — winforms' ``create_confirmation_dialog`` is a *direct* modal
+      ``MessageBox.Show`` with no GUI-thread marshaling. Showing it from a
+      worker thread would make it ownerless and non-modal, so on Windows we show
+      it inline on the (already UI-thread) closing handler and answer
+      synchronously. winforms doesn't self-block, so there is no deadlock.
     """
+    if sys.platform == "win32":
+        return _make_on_closing_inline(api, window)
+    return _make_on_closing_async(api, window)
+
+
+def _make_on_closing_inline(api: "_WindowApi", window: object) -> "Callable[[], bool]":
+    """Windows path: the closing handler runs on the UI thread and the dialog is
+    a direct modal MessageBox, so show it inline and answer synchronously."""
     def _on_closing() -> bool:
         try:
             job = api._get_running_evaluation()
@@ -757,13 +790,67 @@ def _make_on_closing(api: "_WindowApi", window: object) -> "Callable[[], bool]":
             return True
         try:
             return bool(window.create_confirmation_dialog(
-                "Quit quodeq?",
-                "A scan is running. Click OK to quit — the scan keeps running "
-                "in the background. Click Cancel to stay.",
+                _CLOSE_CONFIRM_TITLE, _CLOSE_CONFIRM_BODY,
             ))
         except Exception:
             # If the native dialog can't render, don't trap the user.
             return True
+    _on_closing._worker = None  # type: ignore[attr-defined]  # parity with the async path
+    return _on_closing
+
+
+def _make_on_closing_async(api: "_WindowApi", window: object) -> "Callable[[], bool]":
+    """macOS / GTK / Qt path: run the (GUI-thread-marshaling, caller-blocking)
+    dialog on a worker thread so it can't self-deadlock the closing handler.
+
+    ``state`` is shared between the GUI thread (``_on_closing``) and the worker
+    (``_prompt_and_close``). Dict-item writes are atomic under the GIL and only
+    one prompt is ever in flight — the ``prompting`` guard plus the modal (which
+    parks the GUI thread until it is answered) serialise access — so no lock is
+    needed.
+    """
+    state = {"prompting": False, "confirmed": False}
+
+    def _prompt_and_close() -> None:
+        try:
+            ok = bool(window.create_confirmation_dialog(
+                _CLOSE_CONFIRM_TITLE, _CLOSE_CONFIRM_BODY,
+            ))
+        except Exception:
+            # If the native dialog can't render, don't trap the user.
+            ok = True
+        state["prompting"] = False
+        if not ok:
+            return
+        # Set `confirmed` BEFORE destroy(): on GTK/Qt/winforms window.destroy()
+        # re-fires the closing event, and the guard in _on_closing is what lets
+        # that re-issued close through instead of looping into another prompt.
+        # (On macOS destroy() bypasses windowShouldClose:, so the guard is inert
+        # there — but do not reorder this to "after destroy succeeds", it would
+        # reintroduce the re-entry loop on the other backends.)
+        state["confirmed"] = True
+        try:
+            window.destroy()  # type: ignore[union-attr]
+        except Exception:
+            _logger.debug("window.destroy after close-confirm failed", exc_info=True)
+
+    def _on_closing() -> bool:
+        if state["confirmed"]:
+            return True  # user already confirmed; let the re-issued close through
+        try:
+            job = api._get_running_evaluation()
+        except Exception:
+            job = None
+        if not job:
+            return True
+        if not state["prompting"]:
+            state["prompting"] = True
+            worker = threading.Thread(target=_prompt_and_close, daemon=True)
+            _on_closing._worker = worker  # type: ignore[attr-defined]
+            worker.start()
+        return False  # veto now; the worker re-closes the window if confirmed
+
+    _on_closing._worker = None  # type: ignore[attr-defined]
     return _on_closing
 
 

--- a/tests/dashboard/test_native_chrome.py
+++ b/tests/dashboard/test_native_chrome.py
@@ -109,26 +109,184 @@ class TestSetTitlebarTheme:
 
 
 class TestOnClosing:
-    def _wire(self, job, confirm=True):
+    """The close handler behaves differently by backend (see _make_on_closing):
+
+    macOS/GTK/Qt marshal the dialog onto the GUI thread and block the caller, so
+    it must run OFF the GUI thread (worker + veto + destroy). Windows/winforms
+    shows a direct modal MessageBox and runs its closing handler on the UI
+    thread, so it shows the dialog inline. Tests pin the platform explicitly so
+    they are deterministic regardless of the host OS.
+    """
+
+    def _wire(self, job, confirm=True, platform="darwin"):
         api = MagicMock()
         api._get_running_evaluation.return_value = job
         window = MagicMock()
         window.create_confirmation_dialog.return_value = confirm
-        return ww._make_on_closing(api, window), window
+        with patch.object(ww.sys, "platform", platform):
+            on_closing = ww._make_on_closing(api, window)
+        return on_closing, window
+
+    @staticmethod
+    def _join(on_closing):
+        worker = getattr(on_closing, "_worker", None)
+        if worker is not None:
+            worker.join(timeout=2)
+            # A hung worker is the exact failure class this fix targets — surface
+            # it as itself, not as a downstream mock-call-count mismatch.
+            assert not worker.is_alive(), "close-confirm worker did not finish (possible re-deadlock)"
+
+    # --- macOS / GTK / Qt: dialog runs off the GUI thread -------------------
 
     def test_no_job_closes_without_dialog(self):
         on_closing, window = self._wire(job=None)
         assert on_closing() is True
         window.create_confirmation_dialog.assert_not_called()
 
-    def test_running_job_confirm_allows_close(self):
+    def test_running_job_vetoes_the_close_and_prompts_async(self):
+        # A running scan must NOT be answered synchronously: pywebview's
+        # create_confirmation_dialog marshals the alert onto the GUI thread and
+        # blocks the caller, so calling it from the closing handler (which runs
+        # ON the GUI thread) self-deadlocks. The handler vetoes this close and
+        # shows the dialog on a worker thread instead.
         on_closing, window = self._wire(job={"jobId": "x"}, confirm=True)
-        assert on_closing() is True
+        assert on_closing() is False
+        self._join(on_closing)
         window.create_confirmation_dialog.assert_called_once()
 
-    def test_running_job_cancel_blocks_close(self):
+    def test_dialog_runs_off_the_calling_thread(self):
+        # The dialog blocks its caller until the GUI thread renders it; if the
+        # caller IS the GUI thread it deadlocks. So it must be invoked from a
+        # different thread than the one that runs _on_closing.
+        import threading
+        caller = threading.get_ident()
+        seen = {}
+        api = MagicMock()
+        api._get_running_evaluation.return_value = {"jobId": "x"}
+        window = MagicMock()
+        window.create_confirmation_dialog.side_effect = (
+            lambda *a, **k: seen.__setitem__("tid", threading.get_ident()) or False
+        )
+        with patch.object(ww.sys, "platform", "darwin"):
+            on_closing = ww._make_on_closing(api, window)
+        assert on_closing() is False
+        self._join(on_closing)
+        assert seen["tid"] != caller
+
+    def test_on_closing_returns_without_waiting_on_the_dialog(self):
+        # The core invariant of the whole fix: _on_closing must return promptly,
+        # never blocking on the dialog/worker. Simulate the real semaphore (only
+        # the GUI thread can release it) with an Event the caller never gets to
+        # set until AFTER _on_closing has returned. A regression that joins the
+        # worker (or shows the dialog inline) would park here and re-deadlock.
+        import threading
+        release = threading.Event()
+        api = MagicMock()
+        api._get_running_evaluation.return_value = {"jobId": "x"}
+        window = MagicMock()
+        window.create_confirmation_dialog.side_effect = lambda *a, **k: release.wait() or True
+        with patch.object(ww.sys, "platform", "darwin"):
+            on_closing = ww._make_on_closing(api, window)
+        result = []
+        caller = threading.Thread(target=lambda: result.append(on_closing()))
+        caller.start()
+        caller.join(timeout=2)
+        try:
+            assert not caller.is_alive(), "_on_closing blocked on the dialog — re-deadlock regression"
+            assert result == [False]
+        finally:
+            release.set()
+            self._join(on_closing)
+
+    def test_confirm_destroys_window_then_allows_close(self):
+        on_closing, window = self._wire(job={"jobId": "x"}, confirm=True)
+        on_closing()
+        self._join(on_closing)
+        window.destroy.assert_called_once()
+        # The re-issued close (from destroy) is allowed straight through.
+        assert on_closing() is True
+
+    def test_cancel_keeps_window_open_and_can_reprompt(self):
         on_closing, window = self._wire(job={"jobId": "x"}, confirm=False)
         assert on_closing() is False
+        self._join(on_closing)
+        window.destroy.assert_not_called()
+        # Cancelling leaves the window open; a later close prompts again.
+        assert on_closing() is False
+        self._join(on_closing)
+        assert window.create_confirmation_dialog.call_count == 2
+
+    def test_double_close_while_prompting_spawns_one_worker(self):
+        # Clicking close again while the dialog is already up must not spawn a
+        # second worker / second alert — the `prompting` guard covers this.
+        import threading
+        import time
+        release = threading.Event()
+        api = MagicMock()
+        api._get_running_evaluation.return_value = {"jobId": "x"}
+        window = MagicMock()
+        window.create_confirmation_dialog.side_effect = lambda *a, **k: release.wait() or True
+        with patch.object(ww.sys, "platform", "darwin"):
+            on_closing = ww._make_on_closing(api, window)
+        assert on_closing() is False
+        first_worker = on_closing._worker
+        for _ in range(200):  # wait until the worker is actually showing the dialog
+            if window.create_confirmation_dialog.call_count == 1:
+                break
+            time.sleep(0.01)
+        assert window.create_confirmation_dialog.call_count == 1
+        # Second close while still prompting: vetoed, no new worker, no new dialog.
+        assert on_closing() is False
+        assert on_closing._worker is first_worker
+        assert window.create_confirmation_dialog.call_count == 1
+        release.set()
+        self._join(on_closing)
+
+    def test_dialog_failure_does_not_trap_the_user(self):
+        # If the native dialog can't render, fall through to closing the window
+        # rather than leaving it un-closeable.
+        on_closing, window = self._wire(job={"jobId": "x"})
+        window.create_confirmation_dialog.side_effect = RuntimeError("no GUI")
+        assert on_closing() is False
+        self._join(on_closing)
+        window.destroy.assert_called_once()
+
+    # --- Windows / winforms: dialog runs inline on the UI thread ------------
+
+    def test_windows_no_job_closes_without_dialog(self):
+        on_closing, window = self._wire(job=None, platform="win32")
+        assert on_closing() is True
+        window.create_confirmation_dialog.assert_not_called()
+
+    def test_windows_shows_dialog_inline_on_the_calling_thread(self):
+        # winforms' create_confirmation_dialog is a direct modal MessageBox with
+        # no GUI-thread marshaling; showing it on a worker thread would make it
+        # ownerless/non-modal. The winforms closing handler already runs on the
+        # UI thread, so it must be shown inline and answered synchronously.
+        import threading
+        caller = threading.get_ident()
+        seen = {}
+        api = MagicMock()
+        api._get_running_evaluation.return_value = {"jobId": "x"}
+        window = MagicMock()
+        window.create_confirmation_dialog.side_effect = (
+            lambda *a, **k: seen.__setitem__("tid", threading.get_ident()) or True
+        )
+        with patch.object(ww.sys, "platform", "win32"):
+            on_closing = ww._make_on_closing(api, window)
+        assert on_closing() is True  # returns the dialog's answer directly
+        assert seen["tid"] == caller  # shown on the UI thread, not a worker
+        window.create_confirmation_dialog.assert_called_once()
+        window.destroy.assert_not_called()  # inline path lets the native close proceed
+
+    def test_windows_cancel_blocks_close(self):
+        on_closing, window = self._wire(job={"jobId": "x"}, confirm=False, platform="win32")
+        assert on_closing() is False
+
+    def test_windows_dialog_failure_does_not_trap_the_user(self):
+        on_closing, window = self._wire(job={"jobId": "x"}, platform="win32")
+        window.create_confirmation_dialog.side_effect = RuntimeError("no GUI")
+        assert on_closing() is True
 
 
 @_MACOS_ONLY


### PR DESCRIPTION
## Symptom

The native window **close button** froze the desktop app ("stays loading" / beachball) when clicked **while an evaluation scan was running**. Regression from **v1.5.0** (commit `f6cc337e`, "replace the in-page close dialog with a native confirmation dialog").

## Root cause

pywebview's `closing` event is a **locking** event (`Event(self, True)`) — its handler runs **synchronously on the GUI thread** (macOS: inside `windowShouldClose:` → `should_close` → `events.closing.set()`).

On macOS/GTK/Qt, `create_confirmation_dialog` marshals the alert **back onto the GUI thread** (`AppHelper.callAfter` / `glib.idle_add` / queued signal) and then **blocks its caller on a semaphore**. Called from the closing handler, the caller *is* the GUI thread, so it parks on the semaphore and never spins the run loop → the alert can never render → **permanent deadlock**. It only triggers with a scan running, since otherwise the handler returns `True` before touching the dialog — exactly the reported condition.

## Fix (per backend)

- **macOS / GTK / Qt** — veto the close (`return False`), show the dialog on a **worker thread** (off the GUI thread the semaphore is safe), and re-issue the close via `window.destroy()` once confirmed. A `confirmed` guard lets the re-issued close through and prevents a re-entry loop on GTK/Qt/winforms (whose `destroy()` re-fires the `closing` event). `confirmed` is deliberately set **before** `destroy()` for that reason.
- **Windows** — winforms' `create_confirmation_dialog` is a **direct modal `MessageBox`** with no GUI-thread marshaling, and its closing handler already runs on the UI thread. Showing it on a worker thread (as the mac path does) would make it ownerless/non-modal, so on Windows it is shown **inline** and answered synchronously. No deadlock (winforms doesn't self-block).

## Tests

`TestOnClosing` in `tests/dashboard/test_native_chrome.py` now pins:
- **No-block invariant** — `_on_closing` must return without waiting on the dialog. (Verified this bites: injecting a `worker.join()` regression re-deadlocks and the guard catches it; the old off-thread-only assertion stayed green.)
- Off-GUI-thread dialog (mac/linux) and **inline on the UI thread** (Windows).
- Double-click-while-prompting spawns only one worker/dialog.
- Dialog-render failure falls through to closing (never traps the user).
- `_join` now asserts the worker actually finished.

154 dashboard tests pass; ruff clean.

## Scope / known items (from an adversarial review, out of scope here)

- **Cmd+Q via the in-webview key handler** bypasses the `closing` event entirely (pywebview's `keyDown_` calls `app.stop_` directly), so it never prompts. This **predates** the regression (same behavior before/after `f6cc337e`); the scan runs in a separate process and keeps running, so no freeze/data loss. Left as a known gap.
- **Dropped "Cancel evaluation and close" option** — the pre-v1.5.0 in-page dialog had a third button that cancelled the scan. Native two-button dialogs can't reintroduce it via this path; the in-app "Cancel evaluation" affordance is unchanged. Behavior change dates to `f6cc337e`, noted for release notes.
- `_get_running_evaluation()` still runs on the GUI thread inside the handler (up to two 0.5s-timeout HTTP calls). Bounded sub-second, only on close-during-scan; left as-is.