### PR TITLE
feat(settings): adaptive lane layout via CSS grid-lanes with multicol fallback

### DIFF
--- a/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
+++ b/src/quodeq/ui/src/features/settings/components/SettingsPage.jsx
@@ -36,29 +36,26 @@ export default function SettingsPage({ theme, onOpenGradeFormula }) {
       />
       <div className="settings-grid">
         <ProviderTabs providerConfigs={providerConfigs} />
-
-        <div className="settings-grid-col">
-          <ServerSection />
-          <AppearanceSection themeMode={themeMode} themeFamily={themeFamily} onApplyMode={onApplyMode} onApplyFamily={onApplyFamily} />
-          <UpdatesSection />
-          <section className="panel settings-section">
-            <div className="panel-header">
-              <SectionLabel marker="▶">Grade formula</SectionLabel>
+        <ServerSection />
+        <section className="panel settings-section">
+          <div className="panel-header">
+            <SectionLabel marker="▶">Grade formula</SectionLabel>
+          </div>
+          <div className="settings-row">
+            <div className="settings-row-label">
+              <span className="settings-label">Grade formula</span>
+              <span className="settings-description">
+                Tune how violations and compliance turn into grades. Changes rescore all runs.
+              </span>
             </div>
-            <div className="settings-row">
-              <div className="settings-row-label">
-                <span className="settings-label">Grade formula</span>
-                <span className="settings-description">
-                  Tune how violations and compliance turn into grades. Changes rescore all runs.
-                </span>
-              </div>
-              <button type="button" className="settings-pill" onClick={onOpenGradeFormula}>
-                open editor
-              </button>
-            </div>
-          </section>
-          <AboutSection appVersion={appVersion} settingsPhrase={settingsPhrase} />
-        </div>
+            <button type="button" className="settings-pill" onClick={onOpenGradeFormula}>
+              open editor
+            </button>
+          </div>
+        </section>
+        <AppearanceSection themeMode={themeMode} themeFamily={themeFamily} onApplyMode={onApplyMode} onApplyFamily={onApplyFamily} />
+        <UpdatesSection />
+        <AboutSection appVersion={appVersion} settingsPhrase={settingsPhrase} />
       </div>
     </div>
   );

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -1117,22 +1117,48 @@ textarea:focus {
   gap: var(--space-4);
 }
 
+/* Adaptive lanes: at least 360px wide, count adapts to the screen, lanes
+   stretch edge to edge (no width cap). Multicol auto-balances lane heights
+   in browsers without grid-lanes; the count cap of 3 matches how many
+   balanced lanes the current sections can fill — without it the balancer
+   leaves trailing empty lanes and squeezes content left on wide screens. */
 .settings-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--space-5);
-  align-items: start;
+  columns: 360px 3;
+  column-gap: var(--space-5);
   width: 100%;
 }
 
-.settings-grid-col {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-5);
+.settings-grid > .panel {
+  break-inside: avoid;
+  margin-bottom: var(--space-5);
+}
+
+/* Lane gaps/margins carry the rhythm; without this the .panel + .panel
+   margin (see Panels section) would double the vertical spacing. */
+.settings-grid .panel + .panel {
+  margin-top: 0;
+}
+
+/* CSS Grid Lanes (masonry) where supported: same adaptive lane count, but
+   blocks pack top-aligned in source order and never reshuffle across lanes
+   when one changes height. Chrome/Firefox fall back to multicol above
+   until they ship it. */
+@supports (display: grid-lanes) {
+  .settings-grid {
+    display: grid-lanes;
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: var(--space-5);
+    align-items: start;
+  }
+
+  .settings-grid > .panel {
+    margin-bottom: 0;
+  }
 }
 
 @container settings (max-width: 900px) {
   .settings-grid {
+    columns: 1;
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Problem

The settings page used a fixed 2-column grid with the provider panel alone in the first column:

- a large dead zone below the first block (worse with the Advanced `<details>` collapsed),
- sparse, stretched panels on wide/ultrawide screens with unused space on the right.

## Change

Blocks now flow into **adaptive lanes**: at least 360px wide, the count grows with the screen, and lanes stretch edge to edge — no width cap.

- **CSS Grid Lanes** (Safari 26.4+ and the macOS webview today; Chrome/Firefox have it behind a flag and pick it up automatically once shipped): `display: grid-lanes` + `repeat(auto-fill, minmax(360px, 1fr))` — true masonry packing in source order, no reshuffling when a block changes height.
- **Fallback — CSS multicol** (`columns: 360px 3`): auto-balances lane heights everywhere else. The count cap of 3 matches how many balanced lanes the current sections can fill; without it the column balancer strands empty lanes and squeezes content left on ultrawide screens.
- The `<900px` container query still collapses to a single column in both modes.
- Zeroed the inherited `.panel + .panel` margin inside the grid, which was doubling the vertical rhythm against the lane gap.
- `SettingsPage.jsx` sections are now flat children of `.settings-grid` (no lane wrapper divs), so both layout modes place each panel independently.

## Verification

- 586/586 vitest UI tests pass.
- Drove the real app (Flask API + Vite) with headless Chrome; screenshots at 900/1440/2560px in fallback mode and with `--enable-experimental-web-platform-features` for the grid-lanes path. No console errors; lanes fill the full width at every size, single column under 900px container width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)