### PR TITLE
fix(ui): confine elastic overscroll to content, freeze sidebar/topbar

### DIFF
--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -15,6 +15,12 @@ body,
 #root {
   margin: 0;
   min-height: 100%;
+  /* The dashboard runs in a native WKWebView. When the content scroller
+     (.dashboard) hits its edge, WebKit chains the overscroll to the main
+     frame and rubber-bands the WHOLE web view — sidebar and topbar included.
+     Refuse the viewport-level bounce so the app chrome stays put; the
+     content keeps its own elastic overscroll (see .dashboard below). */
+  overscroll-behavior: none;
 }
 
 /* ── Focus ────────────────────────────────────────────── */
@@ -750,6 +756,10 @@ textarea:focus {
   min-width: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  /* Keep this scroller's own elastic overscroll, but `contain` stops it from
+     chaining to the main frame so the bounce never spreads to the sidebar or
+     topbar. Pairs with `overscroll-behavior: none` on the viewport above. */
+  overscroll-behavior-y: contain;
 }
 
 /* ── Content header ───────────────────────────────────── */


### PR DESCRIPTION
## What

Scrolling the dashboard produced an elastic rubber-band bounce that dragged the **sidebar and topbar** along with it. This confines the bounce to the content.

## Why

The only scroll container is `main.dashboard`. When it hits its top/bottom edge, WebKit chains the overscroll up to the WKWebView main frame, which rubber-bands the entire web view as one unit, chrome included.

## Change (`base.css`)

| Element | Property | Effect |
|---|---|---|
| `.dashboard` (content) | `overscroll-behavior-y: contain` | keeps its own elastic bounce, blocks the chain |
| `html, body, #root` (viewport) | `overscroll-behavior: none` | app chrome never rubber-bands |

Net: content still bounces, sidebar and topbar stay still.

## Notes

- CSS-only, additive. `src/quodeq/static/` is gitignored, so no build artifacts in this diff.
- The rubber-band is native WebKit behavior and does not reproduce in the Chromium preview, so this was verified by running the packaged app. A contained scroller's bounce is momentum-driven (a flick shows it, a slow crawl eases to a stop), which is expected native behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)