### PR TITLE
fix(grade-formula): mention arrow-key path in boundaries hint

### DIFF
--- a/src/quodeq/ui/src/features/grade-formula/tabs.jsx
+++ b/src/quodeq/ui/src/features/grade-formula/tabs.jsx
@@ -42,7 +42,7 @@ export function BoundariesTab({ draft, update }) {
   return (
     <div>
       <span className="settings-label">GRADE LABELS</span>
-      <span className="settings-description"> drag the dividers. These labels drive every gauge and badge in the app.</span>
+      <span className="settings-description"> drag the dividers, or focus one and use the arrow keys. These labels drive every gauge and badge in the app.</span>
       <GradeBoundaryBar
         thresholds={draft.gradeThresholds}
         onChange={(t) => update({ gradeThresholds: t })}


### PR DESCRIPTION
## Summary
- The BOUNDARIES tab hint in the Grade Formula editor only mentioned dragging the dividers, but `GradeBoundaryBar` dividers are keyboard-operable (`role="slider"`, `tabIndex=0`, ArrowRight/Up = +0.5 and ArrowLeft/Down = -0.5).
- Update the hint to also mention the keyboard path: "drag the dividers, or focus one and use the arrow keys. These labels drive every gauge and badge in the app."

## Notes
- One-string change in `src/quodeq/ui/src/features/grade-formula/tabs.jsx`; no test pins this hint text (verified via grep for "drag the dividers").
- Keeps the lowercase terminal voice and avoids em-dashes in user-facing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)