### PR TITLE
fix(ui): remove em-dashes from user-facing strings

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunHistoryPanel.jsx
@@ -177,7 +177,7 @@ export default function RunHistoryPanel({ trend = [], selectedRunId = null, onBa
           interaction={{ hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }}
         />
       ) : (
-        <p className="run-history-panel__sparse">Only one {granularity} of data — choose a finer grouping to see a trend.</p>
+        <p className="run-history-panel__sparse">Only one {granularity} of data. Choose a finer grouping to see a trend.</p>
       )}
     </section>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ConsoleLogViewer.jsx
@@ -123,7 +123,7 @@ function FollowToggle({ active, onToggle }) {
     <button
       type="button"
       className={`console-follow-btn${active ? ' console-follow-btn--active' : ''}`}
-      title={active ? 'Following — click to stop' : 'Click to follow new output'}
+      title={active ? 'Following, click to stop' : 'Click to follow new output'}
       aria-pressed={active}
       onClick={onToggle}
     >

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -183,7 +183,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   const errorBanner = isFailed
     ? <div className="scan-progress__error">{lastRelevantLog(job.logs) || 'Analysis failed'}</div>
     : isLost
-      ? <div className="scan-progress__error">Server restarted — job tracking lost</div>
+      ? <div className="scan-progress__error">Server restarted, job tracking lost</div>
       : null;
 
   return (

--- a/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/DimensionScoreHistoryPanel.jsx
@@ -167,7 +167,7 @@ export default function DimensionScoreHistoryPanel({ trend = [], dimension, sele
             onBarClick={onBarClick}
           />
           <ChartKeyboardControls
-            label={`${dimension} score history — Tab to a run, Enter to open it`}
+            label={`${dimension} score history. Tab to a run, Enter to open it`}
             items={onBarClick ? data.map((d, i) => ({
               key: d.runId ?? i,
               text: `${d.dateLabel}: ${Number.isFinite(d.numericAverage) ? d.numericAverage.toFixed(1) : '?'}, grade ${gradeLetter(d.overallGrade)}${d.runId === selectedRunId ? ' (selected)' : ''}`,

--- a/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryChartPanel.jsx
@@ -178,7 +178,7 @@ export default function HistoryChartPanel({ trend = [], selectedRunId = null, on
           data={data}
           interaction={{ hoveredIndex, setHoveredIndex, selectedRunId, onBarClick }}
         />
-        <ChartKeyboardControls label="Score history runs — Tab to a run, Enter to open it" items={kbdItems} />
+        <ChartKeyboardControls label="Score history runs. Tab to a run, Enter to open it" items={kbdItems} />
       </div>
     </section>
   );

--- a/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryDimensionPanel.jsx
@@ -212,7 +212,7 @@ export default function DimensionScorePanel({ dimensions = [], onBarClick, runDa
       <div className="chart-with-kbd">
         <DimensionBarChart data={data} onBarClick={onBarClick} />
         <ChartKeyboardControls
-          label="Dimension scores — Tab to a dimension, Enter to open it"
+          label="Dimension scores. Tab to a dimension, Enter to open it"
           items={onBarClick ? data.map((d, i) => ({
             key: d.dimension ?? i,
             text: `${d.dimension}: ${Number.isFinite(d.numericScore) ? d.numericScore.toFixed(1) : '?'} / 10, grade ${gradeLetter(d.overallGrade)}`,

--- a/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/EmptyStateWithTour.jsx
@@ -11,7 +11,7 @@ export default function EmptyStateWithTour({ onAdd, onTour, isEvaluating = false
   return (
     <section className="empty-state empty-state--with-tour">
       <TermHeader name="projects" sub="no projects yet" />
-      <p>set up your first repository — quodeq scans it locally and runs an evaluation against the standards you pick.</p>
+      <p>set up your first repository. quodeq scans it locally and runs an evaluation against the standards you pick.</p>
       <div className="empty-state__actions">
         <button
           type="button"

--- a/src/quodeq/ui/src/features/onboarding/components/steps/ProviderStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/ProviderStep.jsx
@@ -99,7 +99,7 @@ export default function ProviderStep({ state, actions, onContinue, onBack, stepI
     <div className="onboarding-step onboarding-step--provider">
       <TermHeader name="provider" sub={`step ${stepIndex} of ${stepTotal} · pick an ai provider`} />
       <p className="onboarding-step__pitch">
-        quodeq sends source files to an AI model for review. Pick the provider you want to use — uninstalled providers are shown disabled with install hints.
+        quodeq sends source files to an AI model for review. Pick the provider you want to use. Uninstalled providers are shown disabled with install hints.
       </p>
 
       {summary}

--- a/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/RepoScanStep.jsx
@@ -125,7 +125,7 @@ export default function RepoScanStep({ state, actions, createProject, getProject
     <div className="onboarding-step onboarding-step--repo-scan">
       <TermHeader name="repo" sub={`step ${stepIndex} of ${stepTotal} · paste a url or local folder`} />
       <p className="onboarding-step__pitch">
-        Paste a Git URL or pick a local folder. quodeq will scan it locally — no AI tokens used yet.
+        Paste a Git URL or pick a local folder. quodeq will scan it locally. No AI tokens used yet.
       </p>
 
       <div className={sub === 'idle' ? 'onboarding-repo-row' : 'onboarding-repo-row onboarding-form-locked'}>

--- a/src/quodeq/ui/src/features/onboarding/components/steps/WelcomeStep.jsx
+++ b/src/quodeq/ui/src/features/onboarding/components/steps/WelcomeStep.jsx
@@ -3,7 +3,7 @@ import { TermHeader } from '../../../../components/terminal/index.js';
 const PREVIEW_ITEMS = [
   { label: 'connect a repository', sub: 'git url or local folder' },
   { label: 'pick an ai provider', sub: 'local cli, ollama, or cloud' },
-  { label: 'pick a standard', sub: 'start with one — run more later' },
+  { label: 'pick a standard', sub: 'start with one, run more later' },
 ];
 
 export default function WelcomeStep({ onStart, onSkip }) {

--- a/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
+++ b/src/quodeq/ui/src/features/standards/components/StandardsTable.jsx
@@ -80,7 +80,7 @@ function StarToggle({ isVisible, standardId, onToggleVisibility }) {
     <button
       type="button"
       className={`standards-star-btn${isVisible ? ' standards-star-btn--on' : ''}`}
-      title={isVisible ? 'Enabled — click to disable' : 'Disabled — click to enable'}
+      title={isVisible ? 'Enabled, click to disable' : 'Disabled, click to enable'}
       onClick={(e) => { e.stopPropagation(); onToggleVisibility(standardId); }}
     >
       {isVisible ? ICON_STAR_FILLED : ICON_STAR_OUTLINE}

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
@@ -24,7 +24,7 @@ export default function UpdateBanner() {
   return (
     <div className={`update-banner${status.is_security ? ' update-banner--security' : ''}`} role="status">
       <span className="update-banner-text">
-        {status.is_security ? 'Security update — ' : ''}
+        {status.is_security ? 'Security update: ' : ''}
         Quodeq {status.current} → {status.latest} is available.
         {status.action_command ? ` Run: ${status.action_command}` : ''}
       </span>

--- a/src/quodeq/ui/src/utils/reportBuilder.js
+++ b/src/quodeq/ui/src/utils/reportBuilder.js
@@ -128,7 +128,7 @@ export function buildDimensionReport({ evalData, principleGrades, allViolations,
   lines.push(...buildComplianceSection(compliance));
 
   if (evalData?.partial) {
-    lines.push('> **Note:** Evaluation in progress — results may be incomplete.');
+    lines.push('> **Note:** Evaluation in progress. Results may be incomplete.');
     lines.push('');
   }
 


### PR DESCRIPTION
## Summary
Removes em-dashes from user-facing UI strings per project convention (they read as AI-generated); replaced with periods, commas, or a colon.

Starting point was the dashboard sparse-data hint in `RunHistoryPanel.jsx`, then a sweep of `src/quodeq/ui/src/` for other em-dashes in user-facing strings:

- **RunHistoryPanel**: "Only one {granularity} of data. Choose a finer grouping to see a trend."
- **UpdateBanner**: "Security update: " prefix
- **ScanProgress**: "Server restarted, job tracking lost"
- **ConsoleLogViewer**: tooltip "Following, click to stop"
- **StandardsTable**: tooltips "Enabled, click to disable" / "Disabled, click to enable"
- **Onboarding** (EmptyStateWithTour, WelcomeStep, ProviderStep, RepoScanStep): step copy split into sentences
- **Chart keyboard-control labels** (DimensionScoreHistoryPanel, HistoryChartPanel, HistoryDimensionPanel): screen-reader labels
- **reportBuilder**: exported report note "Evaluation in progress. Results may be incomplete."

Intentionally left alone: standalone `'—'` placeholder glyphs for missing values, code comments, test names, and `planBuilder`/`planConstants` prompt text addressed to AI coding agents (not UI copy).

No test pinned any of the old strings (checked via grep).

## Test plan
- `npm run test` (node): 230 passed
- `npx vitest run`: 586 passed (105 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)