### PR TITLE
feat(dashboard): document llama.cpp provider in help

### DIFF
--- a/src/quodeq/ui/src/features/help/components/HelpPage.test.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.test.jsx
@@ -38,6 +38,12 @@ describe('HelpPage providers section', () => {
     fireEvent.click(screen.getByRole('button', { name: 'AI Providers' }));
     expect(screen.getByRole('heading', { level: 3, name: /omlx \(Apple Silicon only\)/ })).toBeInTheDocument();
   });
+
+  it('documents the llama.cpp provider', () => {
+    render(<HelpPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'AI Providers' }));
+    expect(screen.getByRole('heading', { level: 3, name: /llama\.cpp \(local, GGUF models\)/ })).toBeInTheDocument();
+  });
 });
 
 describe('HelpPage settings section', () => {

--- a/src/quodeq/ui/src/features/help/components/HelpSections.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpSections.jsx
@@ -177,6 +177,14 @@ export function Providers() {
         <li>Under <em>Advanced</em> you can set a custom server address, an API key, and run the parallel-agent auto-detect, which recommends a sub-agent count based on your unified memory.</li>
       </ol>
 
+      <h3>llama.cpp (local, GGUF models)</h3>
+      <p>Points Quodeq at a llama-server instance you run yourself. It serves one GGUF model at a time, fixed at launch.</p>
+      <ol>
+        <li>Start the server with <code>llama-server -m model.gguf --port 8080</code>.</li>
+        <li>In <strong>Settings → llama.cpp</strong>, the loaded model appears automatically. To switch models, restart llama-server with a different GGUF.</li>
+        <li>Under <em>Advanced</em>, run the parallel-agent auto-detect, which tests the server and recommends a sub-agent count.</li>
+      </ol>
+
       <h3>Power tiers</h3>
       <p>Each provider exposes three power levels that map to model size:</p>
       <KeyTable rows={[


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on the local `feat/help-refresh` branch** (not yet pushed / no PR). Only the last commit (57d85112) is new; the rest is the help-refresh work this builds on. Kept as draft until `feat/help-refresh` lands on develop, then this diff shrinks to the single commit and can be marked ready. Merging this as-is would pull the whole help refresh in through the side door.

## What

The Settings help section lists a llama.cpp provider tab, but the dedicated AI Providers help section never mentioned llama.cpp, so a user reading the providers help never learns it exists. This adds a short llama.cpp subsection to `Providers()` in `HelpSections.jsx`, following the existing h3-with-qualifier pattern, placed between the omlx block and Power tiers.

Facts cross-checked against `LlamaCppTab.jsx` and the `llamacpp` entry in `ai_providers.json`:
- start command `llama-server -m model.gguf --port 8080` (matches the tab's offline hint and the `http://localhost:8080/v1` api_base)
- one GGUF at a time, fixed at launch; loaded model appears automatically in Settings and switching requires a relaunch
- Advanced has the parallel-agent auto-detect (concurrency test)

## Test

Added an assertion to `HelpPage.test.jsx` mirroring the existing provider-section pattern (render, click the AI Providers nav button, assert the new h3). All 7 tests in the file pass. Also verified in the vite dev preview: the section renders between omlx and Power tiers with consistent styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)