### PR TITLE
chore(build): ship help screenshots once in the wheel, via static/ only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,13 @@ build-backend = "uv_build"
 # Note: src/quodeq/static is intentionally INCLUDED so the wheel ships a
 # pre-built UI. End users no longer need Node/npm at runtime. Build it
 # with `tools/build-dist.sh` (runs npm ci + vite build before uv build).
-wheel-exclude = ["src/quodeq/ui/node_modules"]
+# Help screenshots ship via static/ (Vite copies them there); excluding the
+# source copies keeps the wheel from carrying each image twice. They stay in
+# the source tarball because rebuilding the UI needs them.
+wheel-exclude = [
+    "src/quodeq/ui/node_modules",
+    "src/quodeq/ui/src/assets/help",
+]
 # Keep the installed JS dependency tree (~28MB / 11k files, reproducible from
 # package-lock.json) and local build cruft out of the published source tarball.
 source-exclude = [


### PR DESCRIPTION
## What

Adds `src/quodeq/ui/src/assets/help` to `wheel-exclude` in `[tool.uv.build-backend]`.

## Why

`feat/help-refresh` (not yet merged) adds the repo's first binary assets under the UI source tree: `grade-formula.dark.webp` (78,948 B) and `grade-formula.light.webp` (67,984 B). Vite copies them, content-hashed, into `src/quodeq/static/assets/` at build time. Since `wheel-exclude` only listed `node_modules`, the wheel would ship both the source copies and the built copies, roughly 294 KB instead of 147 KB, and the duplication grows with every screenshot pair added per `CAPTURE.md`.

The source copies stay in the sdist (not added to `source-exclude`) because rebuilding the UI needs them. This also matters because `uv build` builds the wheel from the sdist.

## Merge order

Safe to merge before or after `feat/help-refresh`: that branch does not touch `pyproject.toml`, and until its assets land this exclude simply matches nothing.

## Verification

Full `tools/build-dist.sh` (npm ci + vite build + uv build) in a scratch worktree at `feat/help-refresh`'s head (f6af1272) with this fix applied:

- **Wheel before fix:** help images present under both `quodeq/ui/src/assets/help/` and `quodeq/static/assets/`
- **Wheel after fix:** images only under `quodeq/static/assets/` (hashed: `grade-formula.dark-C6mbbghZ.webp`, `grade-formula.light-CVOTBI7_.webp`); `CAPTURE.md` and the source webps gone; `node_modules` still excluded; the rest of `ui/src` unchanged (461 files)
- **Sdist after fix:** `src/quodeq/ui/src/assets/help/` fully present, so the UI is rebuildable from the tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)