### PR TITLE
refactor(map): migrate dark-theme detection to shared useThemeIsDark hook

### DIFF
--- a/src/quodeq/ui/src/features/map/components/MapPage.jsx
+++ b/src/quodeq/ui/src/features/map/components/MapPage.jsx
@@ -8,21 +8,14 @@ import useMapPageState from './useMapPageState.js';
 import { TermHeader } from '../../../components/terminal/index.js';
 import EmptyState from '../../../components/EmptyState.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
+import { useThemeIsDark } from '../../../hooks/useThemeIsDark.js';
 
-function getAppThemeInfo() {
-  const attr = document.documentElement.getAttribute('data-theme') || '';
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const isDark = attr.includes('dark') || (!attr.includes('light') && prefersDark);
-  const family = attr.replace(/-?(dark|light)$/, '') || 'daruma';
-  return { isDark, family, attr };
-}
-
-function isAppDark() {
-  return getAppThemeInfo().isDark;
-}
-
+// data-theme attr for forcing the viz dark while the app is light: keep the
+// active theme family, swap the mode suffix. Attribute values: absent =
+// daruma family in system mode; otherwise 'light' | 'dark' | '<family>-<mode>'.
 function getDarkThemeAttr() {
-  const { family } = getAppThemeInfo();
+  const attr = document.documentElement.getAttribute('data-theme') || '';
+  const family = attr.replace(/-?(dark|light)$/, '') || 'daruma';
   return family === 'daruma' ? 'dark' : `${family}-dark`;
 }
 
@@ -132,19 +125,20 @@ function MapBreadcrumb({ path, onNavigate, projectName }) {
 }
 
 function MapVizContainer({ vizState, treeState, dimensions, callbacks, display }) {
+  const appIsDark = useThemeIsDark();
   const { vizStyle, viewMode, galaxyMode, setGalaxyMode } = vizState;
   const { node, fullTree, currentPath, onPathChange } = treeState;
   const { onDrillDown, onFileClick, onNavigate, onBreadcrumbNav } = callbacks;
   const { showLabels, setShowLabels, darkMode, setDarkMode, breadcrumb, resetKey, projectName, standardTypes } = display;
   return (
-    <div className="map-viz-container" {...(darkMode && !isAppDark() ? { 'data-theme': getDarkThemeAttr() } : {})}>
+    <div className="map-viz-container" {...(darkMode && !appIsDark ? { 'data-theme': getDarkThemeAttr() } : {})}>
       {vizStyle !== 'galaxy' && <MapBreadcrumb path={breadcrumb} onNavigate={onBreadcrumbNav} projectName={projectName} />}
       <div className="map-viz-toggles">
         <label className="map-label-toggle">
           <input type="checkbox" checked={showLabels} onChange={(e) => setShowLabels(e.target.checked)} />
           Labels
         </label>
-        {!isAppDark() && (
+        {!appIsDark && (
           <label className="map-label-toggle">
             <input type="checkbox" checked={!darkMode} onChange={(e) => setDarkMode(!e.target.checked)} />
             Light

--- a/src/quodeq/ui/src/features/map/components/useMapPageState.js
+++ b/src/quodeq/ui/src/features/map/components/useMapPageState.js
@@ -3,16 +3,11 @@ import { buildFileTree, treeNodeToFileObj } from '../viz/index.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { listStandards } from '../../../api/standards.js';
 import { readCachedState, writeCachedState, resetCachedScope } from '../../../utils/pageStateCache.js';
+import { useThemeIsDark } from '../../../hooks/useThemeIsDark.js';
 
 const MAP_LABELS_KEY = 'quodeq-map-labels';
 const MAP_DARK_KEY = 'quodeq-map-dark';
 const MAX_TREE_DEPTH = 64;
-
-function isAppDark() {
-  const attr = document.documentElement.getAttribute('data-theme') || '';
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  return attr.includes('dark') || (!attr.includes('light') && prefersDark);
-}
 
 function findSubtree(root, path) {
   if (!path) return root;
@@ -99,19 +94,18 @@ export default function useMapPageState({ data, callbacks, tabKey = 0 }) {
   const setGalaxyMode = (v) => { writeCachedState('map', selectedProject, { galaxyMode: v }); _setGalaxyMode(v); };
   const [showLabels, _setShowLabels] = useState(() => { try { const v = localStorage.getItem(MAP_LABELS_KEY); return v === null ? true : v === '1'; } catch { return true; } });
   const setShowLabels = (v) => { _setShowLabels(v); try { localStorage.setItem(MAP_LABELS_KEY, v ? '1' : '0'); } catch {} };
+  const appIsDark = useThemeIsDark();
   const [darkMode, _setDarkMode] = useState(() => {
-    if (isAppDark()) return true;
+    if (appIsDark) return true;
     try { const v = localStorage.getItem(MAP_DARK_KEY); return v === null ? true : v === '1'; } catch { return true; }
   });
   const setDarkMode = (v) => { _setDarkMode(v); try { localStorage.setItem(MAP_DARK_KEY, v ? '1' : '0'); } catch {} };
+  // A dark app theme always forces dark viz; back on light, restore the
+  // user's stored viz preference.
   useEffect(() => {
-    const obs = new MutationObserver(() => {
-      if (isAppDark()) { _setDarkMode(true); }
-      else { try { const v = localStorage.getItem(MAP_DARK_KEY); _setDarkMode(v === null ? true : v === '1'); } catch { _setDarkMode(true); } }
-    });
-    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
-    return () => obs.disconnect();
-  }, []);
+    if (appIsDark) { _setDarkMode(true); }
+    else { try { const v = localStorage.getItem(MAP_DARK_KEY); _setDarkMode(v === null ? true : v === '1'); } catch { _setDarkMode(true); } }
+  }, [appIsDark]);
   const [currentPath, _setCurrentPath] = useState(cached.currentPath);
   const setCurrentPath = (p) => { writeCachedState('map', selectedProject, { currentPath: p }); _setCurrentPath(p); };
 

--- a/src/quodeq/ui/src/hooks/useThemeIsDark.js
+++ b/src/quodeq/ui/src/hooks/useThemeIsDark.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+// Resolves whether the ACTIVE theme is dark by observing the applied
+// `data-theme` attribute on <html> rather than re-reading settings state.
+// useAppSettings owns the attribute; observing it keeps every consumer in
+// sync no matter which code path applied the theme (TopBar toggle, Settings,
+// initial paint). Attribute values: absent = daruma family in system mode
+// (the OS preference decides); otherwise 'light' | 'dark' | '<family>-<mode>'.
+function computeIsDark() {
+  const attr = document.documentElement.getAttribute('data-theme');
+  if (attr) return attr === 'dark' || attr.endsWith('-dark');
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+export function useThemeIsDark() {
+  const [isDark, setIsDark] = useState(computeIsDark);
+
+  useEffect(() => {
+    const update = () => setIsDark(computeIsDark());
+    update(); // re-sync: covers any change between render and subscription
+    const observer = new MutationObserver(update);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    mql.addEventListener('change', update);
+    return () => {
+      observer.disconnect();
+      mql.removeEventListener('change', update);
+    };
+  }, []);
+
+  return isDark;
+}

--- a/src/quodeq/ui/src/hooks/useThemeIsDark.test.jsx
+++ b/src/quodeq/ui/src/hooks/useThemeIsDark.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useThemeIsDark } from './useThemeIsDark.js';
+
+// The hook resolves dark/light from the APPLIED html[data-theme] attribute
+// (set by useAppSettings / initial paint), not from settings state, so it
+// stays correct no matter which code path changed the theme.
+
+afterEach(() => {
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('useThemeIsDark', () => {
+  it('is dark when data-theme is dark', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(true);
+  });
+
+  it('is dark for family dark variants like ifrit-dark', () => {
+    document.documentElement.setAttribute('data-theme', 'ifrit-dark');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(true);
+  });
+
+  it('is light when data-theme is light', () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(false);
+  });
+
+  it('is light for family light variants like galadriel-light', () => {
+    document.documentElement.setAttribute('data-theme', 'galadriel-light');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to the OS preference when no data-theme is set', () => {
+    // vitest.setup.js stubs matchMedia with matches: false
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(false);
+  });
+
+  it('reacts when the applied theme changes', async () => {
+    document.documentElement.setAttribute('data-theme', 'light');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(false);
+    document.documentElement.setAttribute('data-theme', 'dark');
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('falls back to the OS preference when the attribute is removed', async () => {
+    document.documentElement.setAttribute('data-theme', 'ifrit-dark');
+    const { result } = renderHook(() => useThemeIsDark());
+    expect(result.current).toBe(true);
+    document.documentElement.removeAttribute('data-theme');
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});


### PR DESCRIPTION
## What

Replaces the two duplicated, non-reactive `isAppDark()` helpers in the Map feature with the canonical reactive `useThemeIsDark` hook:

- **`MapPage.jsx`**: `getAppThemeInfo()` / `isAppDark()` removed. `MapVizContainer` now consumes `useThemeIsDark()` for the forced-dark attr condition and the Light toggle visibility. The theme-family derivation stays behind as a slimmed `getDarkThemeAttr()`, since only that call site needs it.
- **`useMapPageState.js`**: the duplicate `isAppDark()` and hand-rolled MutationObserver are gone. `darkMode` initializes from the hook and re-syncs via an effect keyed on it.

## Why

- The old check used `attr.includes('dark')`, which would misclassify any theme family whose name contains "dark". The hook uses `attr === 'dark' || attr.endsWith('-dark')`.
- The logic was duplicated in two files.
- The old MutationObserver only watched attribute changes, so OS-level `prefers-color-scheme` flips in system mode were missed. The hook's media-query listener covers that now.

## Relationship to feat/help-refresh

The first commit adds `useThemeIsDark.js` + its test, extracted **verbatim** from `feat/help-refresh`, so this can land independently. When help-refresh lands, both sides add identical files and merge cleanly.

## Verification

- `npm run test:all`: 230 node + 593 vitest tests green, including the hook's own test file. `vite build` passes (nothing else imports the two migrated files, so the build is the compile check).
- Manually driven in the real dashboard against a project with 100 runs: theme toggle light/dark reactively hides/shows the Light toggle and adds/removes the forced `data-theme` on the viz container; the Light checkbox round-trips through localStorage; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)