### PR TITLE
feat(dashboard): document llama.cpp provider in help

### DIFF
--- a/src/quodeq/ui/src/features/help/components/HelpPage.test.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpPage.test.jsx
@@ -38,6 +38,12 @@ describe('HelpPage providers section', () => {
     fireEvent.click(screen.getByRole('button', { name: 'AI Providers' }));
     expect(screen.getByRole('heading', { level: 3, name: /omlx \(Apple Silicon only\)/ })).toBeInTheDocument();
   });
+
+  it('documents the llama.cpp provider', () => {
+    render(<HelpPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'AI Providers' }));
+    expect(screen.getByRole('heading', { level: 3, name: /llama\.cpp \(local, GGUF models\)/ })).toBeInTheDocument();
+  });
 });
 
 describe('HelpPage settings section', () => {

--- a/src/quodeq/ui/src/features/help/components/HelpSections.jsx
+++ b/src/quodeq/ui/src/features/help/components/HelpSections.jsx
@@ -177,6 +177,14 @@ export function Providers() {
         <li>Under <em>Advanced</em> you can set a custom server address, an API key, and run the parallel-agent auto-detect, which recommends a sub-agent count based on your unified memory.</li>
       </ol>
 
+      <h3>llama.cpp (local, GGUF models)</h3>
+      <p>Points Quodeq at a llama-server instance you run yourself. It serves one GGUF model at a time, fixed at launch.</p>
+      <ol>
+        <li>Start the server with <code>llama-server -m model.gguf --port 8080</code>.</li>
+        <li>In <strong>Settings → llama.cpp</strong>, the loaded model appears automatically. To switch models, restart llama-server with a different GGUF.</li>
+        <li>Under <em>Advanced</em>, run the parallel-agent auto-detect, which tests the server and recommends a sub-agent count.</li>
+      </ol>
+
       <h3>Power tiers</h3>
       <p>Each provider exposes three power levels that map to model size:</p>
       <KeyTable rows={[


### PR DESCRIPTION
Re-lands #704, whose commit never reached develop: #706 (feat/help-refresh -> develop) merged at 07:04, then #704 merged into the feat/help-refresh branch at 07:06, two minutes after that branch's tip had already been merged. Both PRs show as merged, but the llama.cpp commit was stranded on the orphaned branch tip. This is a clean cherry-pick of 57d85112 onto develop.

## What

Adds a llama.cpp subsection to the AI Providers help section (between omlx and Power tiers), following the existing h3-with-qualifier pattern. Facts cross-checked against LlamaCppTab.jsx and the llamacpp entry in ai_providers.json: start command `llama-server -m model.gguf --port 8080`, one GGUF at a time fixed at launch, loaded model auto-appears in Settings, parallel-agent auto-detect under Advanced.

## Test

HelpPage.test.jsx assertion mirroring the omlx pattern (render, click AI Providers nav, assert the new h3). All 7 tests in the file pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)