### PR TITLE
fix: update banner readability, external link, and dev-proxy CSRF

### DIFF
--- a/src/quodeq/dashboard/_webview_window.py
+++ b/src/quodeq/dashboard/_webview_window.py
@@ -140,7 +140,15 @@ class _WindowApi:
             _logger.warning("cancel-on-quit for job %s failed", job_id, exc_info=True)
 
     def open_browser(self, path: str = '/') -> None:
-        """Open a URL in the system default browser."""
+        """Open a dashboard path or an absolute web URL in the default browser.
+
+        Absolute http(s) URLs (e.g. the update banner's GitHub release link)
+        pass through untouched; anything else is treated as a path on the
+        local dashboard origin, which also neutralizes non-web schemes.
+        """
+        if path.startswith(('http://', 'https://')):
+            webbrowser.open(path)
+            return
         url = self._base_url + path if self._base_url else path
         webbrowser.open(url)
 

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
@@ -25,7 +25,7 @@ export default function UpdateBanner() {
     <div className={`update-banner${status.is_security ? ' update-banner--security' : ''}`} role="status">
       <span className="update-banner-text">
         {status.is_security ? <strong>Security update: </strong> : null}
-        Quodeq {status.current} → {status.latest} is available.
+        Quodeq v{status.latest} is available.
         {status.action_command ? (
           <> Run <code className="update-banner-cmd">{status.action_command}</code></>
         ) : null}

--- a/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
+++ b/src/quodeq/ui/src/features/updates/UpdateBanner.jsx
@@ -24,9 +24,11 @@ export default function UpdateBanner() {
   return (
     <div className={`update-banner${status.is_security ? ' update-banner--security' : ''}`} role="status">
       <span className="update-banner-text">
-        {status.is_security ? 'Security update: ' : ''}
+        {status.is_security ? <strong>Security update: </strong> : null}
         Quodeq {status.current} → {status.latest} is available.
-        {status.action_command ? ` Run: ${status.action_command}` : ''}
+        {status.action_command ? (
+          <> Run <code className="update-banner-cmd">{status.action_command}</code></>
+        ) : null}
       </span>
       <span className="update-banner-actions">
         <button type="button" className="settings-pill" onClick={() => openExternal(status.latest_url || status.download_url)}>

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -2096,17 +2096,33 @@ fieldset.gf-tab-body:disabled .gf-boundary-divider { pointer-events: none; curso
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
-  background: var(--panel, #1c1c1c);
-  border-bottom: 1px solid var(--border, #333);
-  font-size: 0.85rem;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-surface-alt);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-size: var(--text-sm);
 }
-.update-banner--security { border-bottom-color: #c0392b; }
-.update-banner-actions { display: flex; align-items: center; gap: 0.5rem; }
+.update-banner-text { min-width: 0; }
+.update-banner-cmd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  padding: 1px 6px;
+  background: color-mix(in srgb, var(--color-text) 8%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  user-select: all; /* one click selects the whole command for copy */
+}
+.update-banner--security {
+  background: color-mix(in srgb, var(--color-danger) 10%, var(--color-bg));
+  border-bottom-color: color-mix(in srgb, var(--color-danger) 40%, transparent);
+}
+.update-banner-actions { display: flex; align-items: center; gap: var(--space-2); flex-shrink: 0; }
 .update-banner-dismiss {
   background: none; border: none; cursor: pointer;
   font-size: 1.1rem; line-height: 1; color: inherit; opacity: 0.7;
+  padding: 2px 6px;
 }
 .update-banner-dismiss:hover { opacity: 1; }
 

--- a/src/quodeq/ui/src/styles/base.css
+++ b/src/quodeq/ui/src/styles/base.css
@@ -2104,13 +2104,16 @@ fieldset.gf-tab-body:disabled .gf-boundary-divider { pointer-events: none; curso
   font-size: var(--text-sm);
 }
 .update-banner-text { min-width: 0; }
+/* Matches the inline-code idiom from .help-section code; the banner bg is
+   already surface-alt, so the chip drops to the page bg to stand out. */
 .update-banner-cmd {
   font-family: var(--font-mono);
-  font-size: 0.85em;
-  padding: 1px 6px;
-  background: color-mix(in srgb, var(--color-text) 8%, transparent);
+  font-size: 0.82em;
+  padding: 2px 7px;
+  background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
+  color: var(--color-accent);
   white-space: nowrap;
   user-select: all; /* one click selects the whole command for copy */
 }

--- a/src/quodeq/ui/vite.config.js
+++ b/src/quodeq/ui/vite.config.js
@@ -32,7 +32,11 @@ export default defineConfig({
     proxy: {
       '/api': {
         target: process.env.VITE_API_TARGET || DEFAULT_API_TARGET,
-        changeOrigin: true
+        changeOrigin: true,
+        // changeOrigin rewrites Host but not the browser's Origin header,
+        // so the API's CSRF origin check 403s every state-changing request
+        // in dev. Send an Origin that matches the proxy target instead.
+        headers: { origin: process.env.VITE_API_TARGET || DEFAULT_API_TARGET }
       }
     }
   }

--- a/tests/dashboard/test_open_browser_external_url.py
+++ b/tests/dashboard/test_open_browser_external_url.py
@@ -1,0 +1,49 @@
+"""_WindowApi.open_browser: absolute web URLs must open as-is.
+
+The update banner's "what's new" button passes the GitHub release URL
+through this API. Prefixing it with the local dashboard base URL sends
+the user to http://127.0.0.1:PORT/https://github.com/... — a 404.
+"""
+from unittest.mock import MagicMock, patch
+
+from quodeq.dashboard import _webview_window as ww
+
+
+def _bound_api(base_url: str = "http://127.0.0.1:7863") -> ww._WindowApi:
+    api = ww._WindowApi()
+    api.bind(MagicMock(), base_url=base_url)
+    return api
+
+
+class TestOpenBrowser:
+    def test_absolute_https_url_opens_unprefixed(self):
+        api = _bound_api()
+        with patch.object(ww.webbrowser, "open") as opened:
+            api.open_browser("https://github.com/quodeq/quodeq/releases/tag/v1.5.2")
+        opened.assert_called_once_with("https://github.com/quodeq/quodeq/releases/tag/v1.5.2")
+
+    def test_absolute_http_url_opens_unprefixed(self):
+        api = _bound_api()
+        with patch.object(ww.webbrowser, "open") as opened:
+            api.open_browser("http://example.com/page")
+        opened.assert_called_once_with("http://example.com/page")
+
+    def test_relative_path_still_gets_base_url(self):
+        api = _bound_api()
+        with patch.object(ww.webbrowser, "open") as opened:
+            api.open_browser("/help")
+        opened.assert_called_once_with("http://127.0.0.1:7863/help")
+
+    def test_default_path_opens_dashboard_root(self):
+        api = _bound_api()
+        with patch.object(ww.webbrowser, "open") as opened:
+            api.open_browser()
+        opened.assert_called_once_with("http://127.0.0.1:7863/")
+
+    def test_non_web_scheme_is_not_treated_as_absolute(self):
+        # javascript:/file: etc. keep the old prefixing behavior, which
+        # renders them harmless relative paths on the local origin.
+        api = _bound_api()
+        with patch.object(ww.webbrowser, "open") as opened:
+            api.open_browser("javascript:alert(1)")
+        opened.assert_called_once_with("http://127.0.0.1:7863javascript:alert(1)")


### PR DESCRIPTION
## Summary

Three fixes around the update-available banner, found while verifying it end to end with a faked update state in both themes.

- **Unreadable banner in light mode.** `.update-banner` referenced `--panel` / `--border`, variables that exist nowhere in `tokens.css`, so the bar always rendered the dark `#1c1c1c` fallback while the text color followed the theme: near-black text on a near-black bar in light mode, and the dismiss × was invisible. Restyled with real theme tokens, the upgrade command as a one-click-selectable monospace chip, and a danger-tinted background for the security variant.
- **"what's new" opened a 404 in the native app.** `_WindowApi.open_browser` prefixes every path with the local dashboard base URL, so the GitHub release URL became `http://127.0.0.1:PORT/https://github.com/...`. Absolute http(s) URLs now pass through untouched (relative paths keep the prefix, which also neutralizes non-web schemes). TDD'd in `tests/dashboard/test_open_browser_external_url.py`.
- **Every POST 403'd in the dev browser.** The vite proxy's `changeOrigin` rewrites Host but not the browser's Origin header, so the API's CSRF origin check rejected all state-changing requests in dev (banner dismiss included, silently). The proxy now sends an Origin matching the API target. Dev-only; the packaged app and native webview are unaffected.

## Verification

- Banner verified in the dev preview: light + dark themes, normal + security variants, dismiss hides the banner and persists `dismissed_version`, button opens the release URL.
- `pytest -m "not integration"`: 3775 passed.
- UI `npm run test:all`: 611 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)