### PR TITLE
style(ui): drawer model tag next to the tabs, squared corners

### DIFF
--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -74,12 +74,12 @@ export function BottomDrawer({ uiState }) {
               onClick={() => selectTab(t)}>{TAB_LABELS[t]}</button>
           ))}
         </div>
+        {active === 'assistant' && modelLabel && (
+          <span className="drawer-model-chip" title={modelLabel}>
+            {modelLabel}
+          </span>
+        )}
         <div className="assistant-drawer-controls">
-          {active === 'assistant' && modelLabel && (
-            <span className="drawer-model-chip" title={modelLabel}>
-              {modelLabel}
-            </span>
-          )}
           {active === 'assistant' && WEB_PROVIDERS.has(provider) && (
             <button type="button" className="assistant-drawer-btn assistant-drawer-web"
               onClick={toggleWebEnabled}

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -52,6 +52,13 @@ it('the close (×) button closes only the active tab, not the whole drawer', () 
   expect(drawer.close).not.toHaveBeenCalled();
 });
 
+it('the model chip sits with the tabs on the left, not in the right controls', () => {
+  render(<BottomDrawer uiState={{}} />);
+  const chip = screen.getByTitle('Ollama · m');
+  expect(chip.closest('.assistant-drawer-controls')).toBeNull();
+  expect(chip.previousElementSibling).toHaveClass('drawer-tabs');
+});
+
 it('shows the web toggle for web-capable providers and toggles it', () => {
   render(<BottomDrawer uiState={{}} />);
   const globe = screen.getByRole('button', { name: /web access/i });

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -143,7 +143,6 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 0.5rem;
   padding: 0.375rem 1rem;
   border-bottom: 1px solid var(--color-border);
@@ -160,6 +159,7 @@
 .assistant-drawer-controls {
   display: flex;
   gap: 0.25rem;
+  margin-left: auto;  /* chip sits left with the tabs; controls stay right */
 }
 
 .assistant-drawer-btn {
@@ -421,20 +421,20 @@
   background: color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 .drawer-panel { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; }
-/* Model pill in the drawer header (Assistant tab): a compact accent chip that
-   integrates the provider/model without a separate subtitle line. */
+/* Model tag in the drawer header (Assistant tab): a compact squared accent
+   tag next to the tabs, integrating the provider/model without a subtitle. */
 .drawer-model-chip {
   align-self: center;
   max-width: 14rem;   /* px-based cap so short model names show in full (a %
-                         here resolves against the tiny content-sized controls
-                         box and ellipsizes even short names) */
+                         would resolve against a content-sized flex box and
+                         ellipsize even short names) */
   font-family: var(--font-mono);
   font-size: 0.6875rem;
   line-height: 1.4;
   color: var(--color-accent);
   background: color-mix(in srgb, var(--color-accent) 12%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent);
-  border-radius: 999px;
+  border-radius: 4px;
   padding: 1px 8px;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Two drawer-header tweaks requested by Victor:

- The provider/model chip moves out of the right-side controls to sit immediately right of the Assistant tab (header drops space-between; controls get margin-left auto).
- The chip is a squared tag now (border-radius 999px to 4px), matching the drawer buttons.

Verified live against the running dashboard in light and dark themes (chip outside controls, 8px from the tabs, radius 4px); placement pinned by a new BottomDrawer test. UI suite: 693 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)