### PR TITLE
feat(ui): new-conversation button clears the assistant context

### DIFF
--- a/src/quodeq/ui/src/components/CopyButton.jsx
+++ b/src/quodeq/ui/src/components/CopyButton.jsx
@@ -61,6 +61,16 @@ export function ChevronDownIcon() {
   );
 }
 
+// Counter-clockwise restart arrow: "new conversation" in the drawer header.
+export function RotateCcwIcon() {
+  return (
+    <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="1 4 1 10 7 10" />
+      <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+    </svg>
+  );
+}
+
 export function GlobeIcon() {
   return (
     <svg width={ICON_SIZE} height={ICON_SIZE} viewBox={ICON_VIEWBOX} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -181,9 +181,11 @@ export function AssistantDrawerProvider({ children }) {
     writeStoredHeight(next);
   }, []);
 
-  const startSession = useCallback(async (ctx) => {
-    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}`;
-    if (key === sessionCtxKey && sessionId) return;
+  // The last committed session context, kept so resetConversation can mint a
+  // fresh session for the SAME project/run/provider.
+  const lastCtxRef = useRef(null);
+
+  const commitSession = useCallback(async (ctx, key) => {
     // Record this as the latest requested context synchronously, before the
     // await, so a later call can invalidate this one's resolution.
     latestKeyRef.current = key;
@@ -198,8 +200,8 @@ export function AssistantDrawerProvider({ children }) {
       }
       return;
     }
-    // Ignore a stale resolution: a newer startSession for a different context
-    // has since been requested, so committing this (older) one would let the
+    // Ignore a stale resolution: a newer request for a different context has
+    // since been made, so committing this (older) one would let the
     // last-resolving response win regardless of request order.
     if (latestKeyRef.current !== key) return;
     setLocalError(null);
@@ -208,7 +210,25 @@ export function AssistantDrawerProvider({ children }) {
     setSessionCtxKey(key);
     setSessionId(created.sessionId);
     setSessionMeta({ provider: ctx?.provider ?? null, model: ctx?.model ?? null });
-  }, [sessionCtxKey, sessionId]);
+    lastCtxRef.current = ctx;
+  }, []);
+
+  const startSession = useCallback(async (ctx) => {
+    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}`;
+    if (key === sessionCtxKey && sessionId) return;
+    await commitSession(ctx, key);
+  }, [sessionCtxKey, sessionId, commitSession]);
+
+  // Fresh session for the SAME context: each turn replays only its own
+  // session's messages server-side, so a new session id gives the model a
+  // clean history and the stream hook an empty transcript. No-op while a
+  // turn is in flight or before any session exists.
+  const resetConversation = useCallback(async () => {
+    const ctx = lastCtxRef.current;
+    if (!ctx || turnActive) return;
+    const key = `${ctx?.provider}:${ctx?.model}:${ctx?.projectId}:${ctx?.runId}`;
+    await commitSession(ctx, key);
+  }, [turnActive, commitSession]);
 
   const sendMessage = useCallback(async (text, uiState) => {
     if (!sessionId) return;
@@ -238,8 +258,8 @@ export function AssistantDrawerProvider({ children }) {
     sessionReady: sessionId != null,
     provider: sessionMeta.provider, model: sessionMeta.model,
     webEnabled, toggleWebEnabled,
-    startSession, sendMessage,
-  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, startSession, sendMessage]);
+    startSession, sendMessage, resetConversation,
+  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, startSession, sendMessage, resetConversation]);
 
   return (
     <AssistantDrawerContext.Provider value={value}>

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -32,6 +32,7 @@ function Probe() {
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pB', runId: 'r' })}>startB</button>
       <button onClick={d.toggle}>toggle</button>
       <button onClick={() => d.sendMessage('hi', { activeTab: 'overview' })}>send</button>
+      <button onClick={d.resetConversation}>reset</button>
     </div>
   );
 }
@@ -148,4 +149,31 @@ it('webEnabled toggles, rides the POST body, and resets on a new session', async
   // switching context (new session) resets the toggle to off
   await act(async () => { screen.getByText('startA').click(); });
   expect(screen.getByTestId('web').textContent).toBe('false');
+});
+
+it('resetConversation mints a fresh session for the same context and clears state', async () => {
+  let n = 0;
+  createAssistantSession.mockImplementation(async () => ({ sessionId: `s-${++n}` }));
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('start').click(); });
+  act(() => { screen.getByText('web').click(); });  // dirty the toggle
+  await act(async () => { screen.getByText('reset').click(); });
+  expect(createAssistantSession).toHaveBeenCalledTimes(2);
+  expect(createAssistantSession).toHaveBeenLastCalledWith(
+    { provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r' });
+  expect(screen.getByTestId('web').textContent).toBe('false');       // toggle reset
+  expect(screen.getByTestId('provider').textContent).toBe('claude'); // meta kept
+  await act(async () => { screen.getByText('send').click(); });
+  expect(postAssistantMessage).toHaveBeenCalledWith('s-2', expect.objectContaining({ text: 'hi' }));
+});
+
+it('resetConversation is a no-op while a turn is in flight or before any session', async () => {
+  createAssistantSession.mockImplementation(async () => ({ sessionId: 's1' }));
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+  await act(async () => { screen.getByText('reset').click(); });  // no session yet
+  expect(createAssistantSession).not.toHaveBeenCalled();
+  await act(async () => { screen.getByText('start').click(); });
+  await act(async () => { screen.getByText('send').click(); });   // turn in flight
+  await act(async () => { screen.getByText('reset').click(); });
+  expect(createAssistantSession).toHaveBeenCalledTimes(1);
 });

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useRef, lazy, Suspense } from 'react';
 import { useAssistantDrawer } from '../assistant/AssistantDrawerProvider.jsx';
 import { AssistantPane } from '../assistant/AssistantDrawer.jsx';
-import { ChevronUpIcon, ChevronDownIcon, GlobeIcon } from '../../components/CopyButton.jsx';
+import { ChevronUpIcon, ChevronDownIcon, GlobeIcon, RotateCcwIcon } from '../../components/CopyButton.jsx';
 
 const TerminalPane = lazy(() => import('../terminal/TerminalPane.jsx'));
 
@@ -24,7 +24,8 @@ const WEB_PROVIDERS = new Set(['claude', 'ollama', 'omlx', 'llamacpp']);
 export function BottomDrawer({ uiState }) {
   const { isOpen, height, setHeight, closeActiveTab, openPanels, activeTab, selectTab,
           maximized, toggleMaximized, setMaximized, provider, model,
-          streaming, webEnabled, toggleWebEnabled } = useAssistantDrawer();
+          streaming, webEnabled, toggleWebEnabled,
+          sessionReady, resetConversation } = useAssistantDrawer();
   const dragRef = useRef(null);
 
   const handleDragMove = useCallback((event) => {
@@ -80,6 +81,15 @@ export function BottomDrawer({ uiState }) {
           </span>
         )}
         <div className="assistant-drawer-controls">
+          {active === 'assistant' && (
+            <button type="button" className="assistant-drawer-btn"
+              onClick={resetConversation}
+              aria-label="New conversation"
+              title="New conversation (clears the model context)"
+              disabled={streaming || !sessionReady}>
+              <RotateCcwIcon />
+            </button>
+          )}
           {active === 'assistant' && WEB_PROVIDERS.has(provider) && (
             <button type="button" className="assistant-drawer-btn assistant-drawer-web"
               onClick={toggleWebEnabled}

--- a/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/drawer/BottomDrawer.test.jsx
@@ -8,6 +8,7 @@ const drawer = {
   maximized: false, toggleMaximized: vi.fn(), setMaximized: vi.fn(),
   provider: 'ollama', model: 'm', messages: [], streaming: false, error: null, sendMessage: vi.fn(),
   webEnabled: false, toggleWebEnabled: vi.fn(),
+  sessionReady: true, resetConversation: vi.fn(),
 };
 vi.mock('../assistant/AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => drawer }));
 vi.mock('../terminal/TerminalPane.jsx', () => ({ default: () => <div data-testid="tty" /> }));
@@ -86,4 +87,29 @@ it('disables the web toggle while a turn is streaming', () => {
   render(<BottomDrawer uiState={{}} />);
   expect(screen.getByRole('button', { name: /web access/i })).toBeDisabled();
   drawer.streaming = false;
+});
+
+it('the new-conversation control resets the conversation', () => {
+  render(<BottomDrawer uiState={{}} />);
+  fireEvent.click(screen.getByRole('button', { name: /new conversation/i }));
+  expect(drawer.resetConversation).toHaveBeenCalled();
+});
+
+it('disables the new-conversation control while streaming and before a session exists', () => {
+  drawer.streaming = true;
+  const { unmount } = render(<BottomDrawer uiState={{}} />);
+  expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled();
+  drawer.streaming = false;
+  unmount();
+  drawer.sessionReady = false;
+  render(<BottomDrawer uiState={{}} />);
+  expect(screen.getByRole('button', { name: /new conversation/i })).toBeDisabled();
+  drawer.sessionReady = true;
+});
+
+it('hides the new-conversation control while the terminal tab is active', () => {
+  drawer.activeTab = 'terminal';
+  render(<BottomDrawer uiState={{}} />);
+  expect(screen.queryByRole('button', { name: /new conversation/i })).toBeNull();
+  drawer.activeTab = 'assistant';
 });


### PR DESCRIPTION
Stacked on #715 (merge that first; GitHub retargets this to develop automatically).

A restart-arrow button in the drawer header (assistant tab only) that starts a fresh conversation: it mints a new assistant session for the SAME project/run/provider, so the model's replayed history is empty, the transcript clears (the stream hook already resets on session-id change), the web toggle returns to off, and the claude resume chain breaks naturally. No backend changes needed since each turn replays only its own session's messages.

- Disabled while a turn is streaming and before any session exists; hidden on the terminal tab.
- Provider refactor: session-create/commit logic extracted into one `commitSession` used by both `startSession` (guarded) and `resetConversation` (same-context), preserving the stale-race protection.
- Verified live against the running dashboard: clicking it produced a second `POST /api/assistant/sessions` (201, new id), closed the old SSE stream and attached a fresh one.
- UI suite: 698 passed (5 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)