### PR TITLE
fix(ui): overview stat cards are clickable across the whole card

### DIFF
--- a/src/quodeq/ui/src/components/terminal/StatStrip.jsx
+++ b/src/quodeq/ui/src/components/terminal/StatStrip.jsx
@@ -45,8 +45,9 @@ export function Stat({ label, value, hint, trailing, tone = 'default', onClick, 
     // The card itself stays a plain <div> so the hint — which may hold its own
     // interactive elements (e.g. clickable SevBadges) — sits beside the button
     // rather than inside it. Nesting a <button> in a <button> is invalid HTML,
-    // breaks hydration, and is an accessibility trap. The label+value act as the
-    // primary click target; severity badges remain independent siblings.
+    // breaks hydration, and is an accessibility trap. The button's ::after is
+    // stretched over the whole card in CSS so the full square is the click
+    // target; severity badges remain independent siblings raised above it.
     return (
       <div className={className}>
         <button type="button" className="term-stat__hitbox" onClick={onClick} aria-label={ariaLabel || label}>

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -139,8 +139,12 @@
 /* Clickable variant — a Stat doubles as a navigation affordance. The card stays
    a <div>; an inner `.term-stat__hitbox` button is the actual click target so
    the hint (which may hold its own interactive badges) is a sibling of the
-   button, never nested inside it. Nesting <button> in <button> is invalid HTML. */
+   button, never nested inside it. Nesting <button> in <button> is invalid HTML.
+   The button's `::after` stretches over the whole card so hover, highlight and
+   click cover the full square; interactive hint children (severity badges) are
+   raised above the overlay and stay independent click targets. */
 .term-stat--clickable {
+  position: relative;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .term-stat__hitbox {
@@ -158,12 +162,30 @@
   gap: var(--term-space-1);
   width: 100%;
 }
-.term-stat__hitbox:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+.term-stat__hitbox::after {
+  content: '';
+  position: absolute;
+  inset: 0;
   border-radius: var(--term-radius);
 }
-/* Whole-card hover highlight, driven by the inner hitbox — not the sibling
+.term-stat__hitbox:focus-visible {
+  outline: none;
+}
+.term-stat--clickable:has(.term-stat__hitbox:focus-visible) {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+/* Non-interactive hint text lets hover/click fall through to the stretched
+   hitbox; buttons inside the hint (severity badges) opt back in. */
+.term-stat--clickable .term-stat__hint {
+  position: relative;
+  z-index: 1;
+  pointer-events: none;
+}
+.term-stat--clickable .term-stat__hint :is(button, a) {
+  pointer-events: auto;
+}
+/* Whole-card hover highlight, driven by the stretched hitbox — not the sibling
    severity badges, which are their own independent click targets. */
 .term-stat--clickable:has(.term-stat__hitbox:hover) {
   border-color: var(--color-accent);


### PR DESCRIPTION
## Problem

On the overview, the VIOLATIONS and COMPLIANCE cards are selectable, but only the label+value area reacted to hover/highlight/click. The hint row (severity badges, "passing / N checks") and the surrounding card space were dead, which made the affordance feel broken.

## Root cause

A clickable `Stat` wraps only label+value in the `term-stat__hitbox` button. That structure is intentional: the hint can hold its own clickable severity badges, and nesting a button inside a button is invalid HTML. But the hover rule and the click target were limited to that inner button's box.

## Fix

Pure CSS, no DOM change (so the valid-HTML/a11y constraint is untouched):

- Stretch the hitbox button over the whole card with an absolutely positioned `::after` overlay (the standard stretched-link pattern), with `position: relative` on the card.
- Severity badges inside the hint are raised above the overlay (`z-index` + `pointer-events`), so they remain independent click targets that filter by severity.
- Non-interactive hint text is `pointer-events: none`, so clicking it falls through to the card navigation.
- The keyboard focus ring now outlines the full card instead of just the label+value block.

## Verification

Verified in the dev dashboard against the quodeq project:
- `elementFromPoint` at the center and all four corners of both cards resolves to the hitbox button.
- Clicking the "passing / 1794 checks" hint area (previously dead) navigates to the compliance listing.
- Clicking the "4 crit" badge still navigates to the critical-filtered view, not the all-violations view.
- Full UI suite: 698 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)