### PR TITLE
feat(assistant): command layer + CLI system-prompt parity

### DIFF
--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -19,6 +19,8 @@ from quodeq.api._assistant_helpers import (
 from quodeq.api._sse_log_helpers import sse_line
 from quodeq.assistant import get_provider_configs
 from quodeq.assistant.orchestrator import TurnRequest, run_turn
+from quodeq.assistant.skills import RESERVED_COMMANDS, load_skills
+from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES
 from quodeq.services.standards import StandardsService
 
 _running_turns: set[str] = set()
@@ -72,6 +74,23 @@ def register_assistant_routes(app: Flask) -> None:
             project_id=str(project_id) if project_id else None,
         )
         return jsonify({"sessionId": session_id}), 201
+
+    @app.get("/api/assistant/skills")
+    def get_assistant_catalog():
+        # Static catalog for the drawer's welcome panel, autocomplete, and
+        # /help /skills /actions meta-commands. Read-only, no session needed.
+        return jsonify({
+            "commands": [{"name": n, "description": d} for n, d in RESERVED_COMMANDS],
+            "skills": [
+                {"name": s.name, "description": s.description,
+                 "argumentHint": s.argument_hint, "views": list(s.views)}
+                for s in load_skills().values()
+            ],
+            "actions": [
+                {"type": t, "description": ACTION_DESCRIPTIONS.get(t, "")}
+                for t in sorted(ACTION_TYPES)
+            ],
+        })
 
     @app.post("/api/assistant/sessions/<sid>/messages")
     def post_assistant_message(sid: str):

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -110,7 +110,10 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
                     return text
                 name, arguments = prompted
                 result = registry.dispatch(name, arguments)
-                emit({"type": "tool_call", "name": name, "ok": result["ok"]})
+                frame = {"type": "tool_call", "name": name, "ok": result["ok"]}
+                if _args_summary(arguments):
+                    frame["argsSummary"] = _args_summary(arguments)
+                emit(frame)
                 fenced, warnings = guard_tool_result(result, name)
                 _emit_warnings(emit, warnings)
                 convo.append({"role": "assistant", "content": text})
@@ -127,12 +130,19 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
             for call in tool_calls:
                 arguments = _parse_args(call["arguments"])
                 result = registry.dispatch(call["name"], arguments)
-                emit({"type": "tool_call", "name": call["name"], "ok": result["ok"]})
+                frame = {"type": "tool_call", "name": call["name"], "ok": result["ok"]}
+                if _args_summary(arguments):
+                    frame["argsSummary"] = _args_summary(arguments)
+                emit(frame)
                 fenced, warnings = guard_tool_result(result, call["name"])
                 _emit_warnings(emit, warnings)
                 convo.append({"role": "tool", "tool_call_id": call["id"],
                               "content": fenced})
     return text + _CAP_NOTE
+
+
+def _args_summary(arguments: dict) -> str:
+    return json.dumps(arguments, ensure_ascii=False)[:80] if arguments else ""
 
 
 def _parse_args(raw: str) -> dict:

--- a/src/quodeq/assistant/adapters/_cli.py
+++ b/src/quodeq/assistant/adapters/_cli.py
@@ -33,6 +33,8 @@ class CliTurnConfig:
     mcp_server_args: list[str]
     db_path: Path
     web_enabled: bool = False
+    system_prompt: str = ""
+    skill_block: str = ""
 
 
 def _latest_user(messages: list[dict]) -> str:
@@ -64,10 +66,14 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
     timer = None
     cwd = None
     try:
+        # argv-append providers get the system prompt every run; on the
+        # rebuild-replay path the transcript also carries a [system] block,
+        # a rare accepted duplication.
         spec = build_turn_argv(cli_cfg, prompt=prompt, model=cfg.model,
                                mcp_config_path=mcp_config_path,
                                prior_session_id=prior_session_id, new_session_id=new_session_id,
-                               web_enabled=cfg.web_enabled)
+                               web_enabled=cfg.web_enabled,
+                               system_prompt=cfg.system_prompt)
         cwd = scratch_cwd(cfg.scratch_base)
         proc = spawn_fn(spec.argv, cwd=cwd, env=build_chat_env())
         # wall-clock guard: a hung/silent CLI can't wedge the turn slot forever
@@ -123,8 +129,14 @@ def run_cli_turn(*, messages: list[dict], config: CliTurnConfig, session_id: str
                  emit: Callable[[dict], None], spawn_fn=None) -> str:
     spawn_fn = spawn_fn or spawn_turn
     cli_cfg = load_cli_chat_config(config.provider)
+    prompt = _latest_user(messages)
+    if config.skill_block and cli_cfg.system_prompt_style == "message-prefix":
+        # argv-append providers carry the skill inside --append-system-prompt;
+        # message-prefix providers get it inline because normal turns send
+        # only the latest user message.
+        prompt = f"{config.skill_block}\n\n{prompt}"
     final, _sid, _rc = _run_once(
-        config, cli_cfg, prompt=_latest_user(messages), session_id=session_id,
+        config, cli_cfg, prompt=prompt, session_id=session_id,
         prior_session_id=prior_session_id, new_session_id=str(uuid.uuid4()),
         repository=repository, emit=emit, spawn_fn=spawn_fn)
     # replay only on a genuinely empty result; a non-empty answer is success

--- a/src/quodeq/assistant/adapters/_cli.py
+++ b/src/quodeq/assistant/adapters/_cli.py
@@ -97,8 +97,11 @@ def _run_once(cfg: CliTurnConfig, cli_cfg, *, prompt: str, session_id: str,
                     continue
                 emit({"type": "token", "text": t})
                 last_emitted = t
-            for name in _stream.tool_uses(event):
-                emit({"type": "tool_call", "name": name})
+            for tu in _stream.tool_use_details(event):
+                frame = {"type": "tool_call", "name": tu["name"]}
+                if tu["args_summary"]:
+                    frame["argsSummary"] = tu["args_summary"]
+                emit(frame)
             sid = _stream.session_id(event)
             if sid:
                 parsed_sid = sid

--- a/src/quodeq/assistant/adapters/_cli_command.py
+++ b/src/quodeq/assistant/adapters/_cli_command.py
@@ -53,7 +53,8 @@ def _resume_args(cfg: CliChatConfig, prior: str | None, new_id: str) -> tuple[li
 
 def build_turn_argv(cfg: CliChatConfig, *, prompt: str, model: str | None,
                     mcp_config_path: str | None, prior_session_id: str | None,
-                    new_session_id: str, web_enabled: bool = False) -> CliTurnSpec:
+                    new_session_id: str, web_enabled: bool = False,
+                    system_prompt: str = "") -> CliTurnSpec:
     argv: list[str] = [cfg.cmd]
     if cfg.cmd_subcommand:
         argv.append(cfg.cmd_subcommand)
@@ -71,6 +72,8 @@ def build_turn_argv(cfg: CliChatConfig, *, prompt: str, model: str | None,
         argv.extend(["--mcp-config", mcp_config_path])
     if model:
         argv.extend(["--model", model])
+    if system_prompt and cfg.system_prompt_style == "argv-append":
+        argv.extend(["--append-system-prompt", system_prompt])
 
     if cfg.prompt_style == "positional":
         argv.append(prompt)

--- a/src/quodeq/assistant/adapters/_cli_config.py
+++ b/src/quodeq/assistant/adapters/_cli_config.py
@@ -19,6 +19,7 @@ class CliChatConfig:
     resume_style: str
     session_id_source: str
     supports_tools: bool
+    system_prompt_style: str
 
 
 def load_cli_chat_config(provider_id: str) -> CliChatConfig:
@@ -39,4 +40,5 @@ def load_cli_chat_config(provider_id: str) -> CliChatConfig:
         resume_style=assistant.get("resume_style", "flag-resume"),
         session_id_source=assistant.get("session_id_source", "preassign"),
         supports_tools=cfg.get("supports_tools", True),
+        system_prompt_style=assistant.get("system_prompt_style", "message-prefix"),
     )

--- a/src/quodeq/assistant/adapters/_stream.py
+++ b/src/quodeq/assistant/adapters/_stream.py
@@ -45,7 +45,8 @@ def assistant_text(event: dict) -> list[str]:
     return []
 
 
-def tool_uses(event: dict) -> list[str]:
+def tool_use_details(event: dict) -> list[dict]:
+    """tool_use blocks as {name, args_summary}; args JSON truncated for display."""
     if event.get("type") == "assistant":
         msg = event.get("message")
         blocks = msg.get("content") if isinstance(msg, dict) else None
@@ -54,12 +55,19 @@ def tool_uses(event: dict) -> list[str]:
         blocks = item.get("content") if isinstance(item, dict) else None
     else:
         blocks = None
-    names = []
+    details = []
     if isinstance(blocks, list):
         for b in blocks:
             if isinstance(b, dict) and b.get("type") == "tool_use" and isinstance(b.get("name"), str):
-                names.append(b["name"])
-    return names
+                args = b.get("input")
+                summary = (json.dumps(args, ensure_ascii=False)[:80]
+                           if isinstance(args, dict) and args else "")
+                details.append({"name": b["name"], "args_summary": summary})
+    return details
+
+
+def tool_uses(event: dict) -> list[str]:
+    return [d["name"] for d in tool_use_details(event)]
 
 
 def session_id(event: dict) -> str | None:

--- a/src/quodeq/assistant/orchestrator.py
+++ b/src/quodeq/assistant/orchestrator.py
@@ -84,6 +84,8 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
                      "content": build_system_prompt(skill=skill, web_enabled=web_tools_on)},
                     *({"role": m["role"], "content": m["content"]} for m in history)]
         if _provider_type(request.provider) == "cli":
+            skill_block = (f"[skill:{skill.name}]\n{skill.instructions}"
+                           if skill is not None else "")
             final = cli_turn_fn(
                 messages=messages,
                 config=CliTurnConfig(
@@ -92,6 +94,8 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
                     mcp_server_args=_mcp_server_args(request, tool_ctx),
                     db_path=tool_ctx.repository.db_path,
                     web_enabled=request.web_enabled,
+                    system_prompt=messages[0]["content"],
+                    skill_block=skill_block,
                 ),
                 session_id=request.session_id,
                 prior_session_id=(repository.get_session(request.session_id) or {}).get("cli_session_id"),

--- a/src/quodeq/assistant/skills.py
+++ b/src/quodeq/assistant/skills.py
@@ -15,12 +15,23 @@ _SKILLS_DIR = Path(
     )
 )
 
+# Names the client answers locally; a skill file may never shadow them.
+RESERVED_COMMANDS: tuple[tuple[str, str], ...] = (
+    ("help", "Show what the assistant can do here"),
+    ("skills", "List available skill commands"),
+    ("actions", "List actions the assistant can draft"),
+    ("clear", "Start a new conversation"),
+)
+_RESERVED_NAMES = frozenset(name for name, _ in RESERVED_COMMANDS)
+
 
 @dataclass(frozen=True)
 class Skill:
     name: str
     description: str
     instructions: str
+    argument_hint: str = ""
+    views: tuple[str, ...] = ()
 
 
 def _parse(text: str) -> Skill | None:
@@ -36,7 +47,9 @@ def _parse(text: str) -> Skill | None:
         meta[key.strip()] = value.strip()
     if not meta.get("name") or not meta.get("description"):
         return None
-    return Skill(meta["name"], meta["description"], body.strip())
+    views = tuple(v.strip() for v in meta.get("views", "").split(",") if v.strip())
+    return Skill(meta["name"], meta["description"], body.strip(),
+                 argument_hint=meta.get("argument_hint", ""), views=views)
 
 
 def load_skills(skills_dir: Path | None = None) -> dict[str, Skill]:
@@ -48,6 +61,10 @@ def load_skills(skills_dir: Path | None = None) -> dict[str, Skill]:
         skill = _parse(path.read_text(encoding="utf-8"))
         if skill is None:
             _logger.warning("skipping malformed skill file: %s", path)
+            continue
+        if skill.name in _RESERVED_NAMES:
+            _logger.warning("skill name %r is a reserved command; skipping %s",
+                            skill.name, path)
             continue
         skills[skill.name] = skill
     return skills

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -11,6 +11,10 @@ from quodeq.services.import_validator import validate_import
 
 ACTION_TYPES = frozenset({"create_standard"})
 
+ACTION_DESCRIPTIONS = {
+    "create_standard": "Draft a new custom standard. Applied only after you approve the preview card.",
+}
+
 
 def _draft_action(ctx: ToolContext, action_type: str, payload: dict) -> dict:
     if action_type not in ACTION_TYPES:

--- a/src/quodeq/data/assistant/skills/create-standard.md
+++ b/src/quodeq/data/assistant/skills/create-standard.md
@@ -1,6 +1,8 @@
 ---
 name: create-standard
 description: Draft a new custom standard from a plain-language description
+argument_hint: [what the standard should enforce]
+views: standards
 ---
 The user wants a new standard. Work in this order:
 1. Ask (or infer from the conversation) the standard's goal, and check

--- a/src/quodeq/data/assistant/skills/explain-finding.md
+++ b/src/quodeq/data/assistant/skills/explain-finding.md
@@ -1,6 +1,8 @@
 ---
 name: explain-finding
 description: Explain a finding in depth, with code context
+argument_hint: [file:line or search terms]
+views: violations
 ---
 The user wants to understand one finding (usually the one selected in
 `[ui-state]`). Use `search_findings` to fetch it, then `read_repo_file` on the

--- a/src/quodeq/data/assistant/skills/explain-score.md
+++ b/src/quodeq/data/assistant/skills/explain-score.md
@@ -1,6 +1,8 @@
 ---
 name: explain-score
 description: Explain why a dimension scored the way it did
+argument_hint: [dimension]
+views: overview, violations
 ---
 The user wants to understand a dimension's score/grade (usually the one in
 `[ui-state]`). Call `get_report` for that dimension. Explain the grade from

--- a/src/quodeq/data/config/ai_providers.json
+++ b/src/quodeq/data/config/ai_providers.json
@@ -39,7 +39,8 @@
                          "--disallowedTools", "Bash Edit Write NotebookEdit WebFetch WebSearch",
                          "--allowedTools", "mcp__quodeq-assistant", "--strict-mcp-config"],
       "resume_style": "flag-resume",
-      "session_id_source": "preassign"
+      "session_id_source": "preassign",
+      "system_prompt_style": "argv-append"
     }
   },
   "codex": {
@@ -59,7 +60,8 @@
     "assistant": {
       "assistant_args": ["--json", "-s", "read-only", "-a", "never"],
       "resume_style": "exec-resume",
-      "session_id_source": "parse-jsonl"
+      "session_id_source": "parse-jsonl",
+      "system_prompt_style": "message-prefix"
     }
   },
   "gemini": {
@@ -82,7 +84,8 @@
       "assistant_args": ["--output-format", "stream-json", "--approval-mode", "plan",
                          "--allowed-mcp-server-names", "quodeq-assistant"],
       "resume_style": "gemini-resume",
-      "session_id_source": "preassign"
+      "session_id_source": "preassign",
+      "system_prompt_style": "message-prefix"
     }
   },
   "openrouter": {

--- a/src/quodeq/ui/src/api/assistant.js
+++ b/src/quodeq/ui/src/api/assistant.js
@@ -20,3 +20,7 @@ export function rejectAssistantAction(actionId) {
 export function assistantEventsUrl(sessionId, afterSeq = 0) {
   return `${BASE}/assistant/sessions/${encodeURIComponent(sessionId)}/events?after=${afterSeq}`;
 }
+
+export function fetchAssistantCatalog() {
+  return request('/assistant/skills');
+}

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.jsx
@@ -1,44 +1,85 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useAssistantDrawer } from './AssistantDrawerProvider.jsx';
 import { MessageList } from './MessageList.jsx';
+import { CommandMenu } from './CommandMenu.jsx';
+import { AssistantWelcome } from './AssistantWelcome.jsx';
+import { buildMetaResponse, matchCommands, parseMetaCommand } from './commands.js';
 
 /**
  * Residual assistant content rendered inside the shared BottomDrawer host.
  * The shell (aside, drag-resize, header controls, isOpen gating) lives in
- * `features/drawer/BottomDrawer.jsx`; this component owns only the title
- * label, the scrollable conversation (MessageList), the error banner, and
- * the monospace prompt input.
+ * `features/drawer/BottomDrawer.jsx`; this component owns the conversation
+ * area (welcome panel or MessageList), the error banner, the slash-command
+ * menu, and the prompt input.
  *
  * `uiState` is passed in as a prop (current app view context, e.g. active
  * tab) and forwarded verbatim to `sendMessage` on every send.
  */
 export function AssistantPane({ uiState }) {
-  // provider/model are shown as a pill in the drawer header (BottomDrawer),
-  // not here — keeps the pane's content area clean.
-  const { messages, streaming, error, sendMessage } = useAssistantDrawer();
+  const {
+    messages, streaming, error, sendMessage,
+    catalog, addLocalExchange, resetConversation,
+  } = useAssistantDrawer();
   const [draft, setDraft] = useState('');
+  const [menuIndex, setMenuIndex] = useState(0);
+  const [menuDismissed, setMenuDismissed] = useState(false);
+
+  const suggestions = useMemo(
+    () => (streaming ? [] : matchCommands(catalog, draft)),
+    [catalog, draft, streaming],
+  );
+  const menuVisible = suggestions.length > 0 && !menuDismissed;
+
+  const acceptSuggestion = useCallback((cmd) => {
+    setDraft(`/${cmd.name} `);
+    setMenuIndex(0);
+  }, []);
 
   const handleSend = useCallback(() => {
     const text = draft.trim();
     if (!text || streaming) return;
+    const meta = parseMetaCommand(text);
+    if (meta === 'clear') { resetConversation(); setDraft(''); return; }
+    if (meta) { addLocalExchange(text, buildMetaResponse(meta, catalog)); setDraft(''); return; }
     sendMessage(text, uiState);
     setDraft('');
-  }, [draft, streaming, sendMessage, uiState]);
+  }, [draft, streaming, sendMessage, uiState, catalog, addLocalExchange, resetConversation]);
 
   const handleKeyDown = useCallback((event) => {
+    if (menuVisible) {
+      if (event.key === 'ArrowDown') { event.preventDefault(); setMenuIndex((i) => (i + 1) % suggestions.length); return; }
+      if (event.key === 'ArrowUp') { event.preventDefault(); setMenuIndex((i) => (i - 1 + suggestions.length) % suggestions.length); return; }
+      if (event.key === 'Escape') { event.preventDefault(); setMenuDismissed(true); return; }
+      if (event.key === 'Tab') { event.preventDefault(); acceptSuggestion(suggestions[menuIndex]); return; }
+      // Enter completes a partial prefix; once the draft IS the command it sends.
+      if (event.key === 'Enter' && !event.shiftKey && draft.trim() !== `/${suggestions[menuIndex].name}`) {
+        event.preventDefault(); acceptSuggestion(suggestions[menuIndex]); return;
+      }
+    }
     if (event.key === 'Enter' && !event.shiftKey) { event.preventDefault(); handleSend(); }
-  }, [handleSend]);
+  }, [menuVisible, suggestions, menuIndex, draft, acceptSuggestion, handleSend]);
+
+  const handleChange = useCallback((event) => {
+    setDraft(event.target.value);
+    setMenuDismissed(false);
+    setMenuIndex(0);
+  }, []);
 
   return (
     <>
-      <MessageList messages={messages} streaming={streaming} />
+      {messages.length === 0
+        ? <AssistantWelcome catalog={catalog} view={uiState?.view} onPick={setDraft} />
+        : <MessageList messages={messages} streaming={streaming} />}
       {error && <div className="assistant-drawer-error" role="alert">{error}</div>}
       <div className="assistant-drawer-input-row">
+        {menuVisible && (
+          <CommandMenu suggestions={suggestions} selectedIndex={menuIndex} onPick={acceptSuggestion} />
+        )}
         <textarea
           className="assistant-drawer-input"
           placeholder="Ask the assistant…"
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onChange={handleChange}
           onKeyDown={handleKeyDown}
           disabled={streaming}
           rows={1}

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -9,8 +9,11 @@ const state = {
     { role: 'tool', name: 'get_scores' },
     { role: 'assistant', text: '**Security** is graded C.' },
     { role: 'action', actionId: 'a1', actionType: 'create_standard', summary: { id: 'x', name: 'X', principleCount: 1 } },
+    { role: 'local', text: '**Commands** listed' },
+    { role: 'tool', name: 'get_report', argsSummary: '{"dimension":"security"}' },
   ],
   streaming: false, error: null, sendMessage: vi.fn(),
+  catalog: null, addLocalExchange: vi.fn(), resetConversation: vi.fn(),
 };
 vi.mock('./AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => state }));
 vi.mock('./ActionPreviewCard.jsx', () => ({ ActionPreviewCard: ({ action }) => <div>card:{action.actionId}</div> }));
@@ -22,6 +25,8 @@ it('renders messages, markdown, tool marker, and action card', () => {
   expect(screen.getByText(/used get_scores/i)).toBeInTheDocument();
   expect(screen.getByText('Security').tagName).toBe('STRONG'); // markdown rendered
   expect(screen.getByText('card:a1')).toBeInTheDocument();
+  expect(screen.getByText('Commands').tagName).toBe('STRONG'); // local renders markdown
+  expect(screen.getByText(/get_report · \{"dimension":"security"\}/)).toBeInTheDocument();
 });
 
 it('renders the prompt input', () => {

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -19,6 +19,12 @@ vi.mock('./AssistantDrawerProvider.jsx', () => ({ useAssistantDrawer: () => stat
 vi.mock('./ActionPreviewCard.jsx', () => ({ ActionPreviewCard: ({ action }) => <div>card:{action.actionId}</div> }));
 import { AssistantPane } from './AssistantDrawer.jsx';
 
+beforeEach(() => {
+  state.sendMessage.mockClear();
+  state.addLocalExchange.mockClear();
+  state.resetConversation.mockClear();
+});
+
 it('renders messages, markdown, tool marker, and action card', () => {
   render(<AssistantPane uiState={{ activeTab: 'overview' }} />);
   expect(screen.getByText('why grade C?')).toBeInTheDocument();
@@ -40,4 +46,40 @@ it('Enter sends the message with uiState', () => {
   fireEvent.change(input, { target: { value: 'make a standard' } });
   fireEvent.keyDown(input, { key: 'Enter' });
   expect(state.sendMessage).toHaveBeenCalledWith('make a standard', { activeTab: 'standards' });
+});
+
+it('answers /help locally and never posts it', () => {
+  render(<AssistantPane uiState={{}} />);
+  const input = screen.getByPlaceholderText(/ask/i);
+  fireEvent.change(input, { target: { value: '/help' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(state.addLocalExchange).toHaveBeenCalledWith('/help', expect.stringContaining('/skills'));
+  expect(state.sendMessage).not.toHaveBeenCalled();
+});
+
+it('/clear resets the conversation', () => {
+  render(<AssistantPane uiState={{}} />);
+  const input = screen.getByPlaceholderText(/ask/i);
+  fireEvent.change(input, { target: { value: '/clear' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(state.resetConversation).toHaveBeenCalled();
+  expect(state.sendMessage).not.toHaveBeenCalled();
+});
+
+it('shows the command menu while typing a slash prefix and fills on Tab', () => {
+  render(<AssistantPane uiState={{}} />);
+  const input = screen.getByPlaceholderText(/ask/i);
+  fireEvent.change(input, { target: { value: '/he' } });
+  expect(screen.getByRole('listbox')).toBeInTheDocument();
+  fireEvent.keyDown(input, { key: 'Tab' });
+  expect(input.value).toBe('/help ');
+  expect(state.sendMessage).not.toHaveBeenCalled();
+});
+
+it('slash-prefixed skill names still go to the server', () => {
+  render(<AssistantPane uiState={{ view: 'overview' }} />);
+  const input = screen.getByPlaceholderText(/ask/i);
+  fireEvent.change(input, { target: { value: '/explain-score security' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(state.sendMessage).toHaveBeenCalledWith('/explain-score security', { view: 'overview' });
 });

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawer.test.jsx
@@ -83,3 +83,11 @@ it('slash-prefixed skill names still go to the server', () => {
   fireEvent.keyDown(input, { key: 'Enter' });
   expect(state.sendMessage).toHaveBeenCalledWith('/explain-score security', { view: 'overview' });
 });
+
+it('shows the welcome panel when the transcript is empty', () => {
+  const prev = state.messages;
+  state.messages = [];
+  render(<AssistantPane uiState={{ view: 'overview' }} />);
+  expect(screen.getByText(/explain scores/i)).toBeInTheDocument();
+  state.messages = prev;
+});

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { createAssistantSession, postAssistantMessage } from '../../api/assistant.js';
+import { createAssistantSession, fetchAssistantCatalog, postAssistantMessage } from '../../api/assistant.js';
 import useAssistantProvider from '../settings/hooks/useAssistantProvider.js';
 import useTerminalSettings from '../settings/hooks/useTerminalSettings.js';
 import { useAssistantStream } from './useAssistantStream.js';
@@ -81,6 +81,19 @@ export function AssistantDrawerProvider({ children }) {
   // session-start or message POST. Rendered by the drawer alongside (and
   // taking precedence over) the stream's own error frames.
   const [localError, setLocalError] = useState(null);
+  // Command/skill catalog for the welcome panel, autocomplete, and
+  // meta-commands. Fetched once per app session on first drawer open;
+  // failures leave it null and the UI degrades to the built-in commands.
+  const [catalog, setCatalog] = useState(null);
+  useEffect(() => {
+    if (!isOpen || catalog !== null) return undefined;
+    let cancelled = false;
+    fetchAssistantCatalog()
+      .then((c) => { if (!cancelled) setCatalog(c); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [isOpen, catalog]);
+
   // Per-conversation web access. Default OFF and reset on every context
   // switch: web access is opt-in per conversation, never sticky.
   const [webEnabled, setWebEnabled] = useState(false);
@@ -245,6 +258,15 @@ export function AssistantDrawerProvider({ children }) {
     }
   }, [sessionId, stream.messages.length, webEnabled]);
 
+  // Client-answered meta-commands (/help, /skills, /actions): show the user
+  // turn and the local response in the transcript without any server call.
+  const addLocalExchange = useCallback((userText, responseText) => {
+    setUserTurns((prev) => [...prev,
+      { role: 'user', text: userText, atIndex: stream.messages.length },
+      { role: 'local', text: responseText, atIndex: stream.messages.length },
+    ]);
+  }, [stream.messages.length]);
+
   const messages = useMemo(
     () => mergeMessages(userTurns, stream.messages),
     [userTurns, stream.messages],
@@ -258,8 +280,9 @@ export function AssistantDrawerProvider({ children }) {
     sessionReady: sessionId != null,
     provider: sessionMeta.provider, model: sessionMeta.model,
     webEnabled, toggleWebEnabled,
+    catalog, addLocalExchange,
     startSession, sendMessage, resetConversation,
-  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, startSession, sendMessage, resetConversation]);
+  }), [isOpen, open, close, toggle, closeActiveTab, openPanels, activeTab, openTab, selectTab, toggleTopbar, terminalEnabled, height, setHeight, maximized, toggleMaximized, messages, turnActive, stream.error, localError, sessionId, sessionMeta, webEnabled, toggleWebEnabled, catalog, addLocalExchange, startSession, sendMessage, resetConversation]);
 
   return (
     <AssistantDrawerContext.Provider value={value}>

--- a/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantDrawerProvider.test.jsx
@@ -6,6 +6,7 @@ vi.mock('../../api/assistant.js', () => ({
   createAssistantSession: vi.fn(async () => ({ sessionId: 's1' })),
   postAssistantMessage: vi.fn(async () => ({ accepted: true })),
   assistantEventsUrl: (id, a) => `/api/assistant/sessions/${id}/events?after=${a}`,
+  fetchAssistantCatalog: vi.fn(async () => ({ commands: [], skills: [], actions: [] })),
 }));
 const _streamHooks = { onDone: null };
 vi.mock('./useAssistantStream.js', () => ({
@@ -14,7 +15,7 @@ vi.mock('./useAssistantStream.js', () => ({
     return { messages: [], streaming: false, error: null, reset: vi.fn() };
   },
 }));
-import { createAssistantSession, postAssistantMessage } from '../../api/assistant.js';
+import { createAssistantSession, postAssistantMessage, fetchAssistantCatalog } from '../../api/assistant.js';
 
 function Probe() {
   const d = useAssistantDrawer();
@@ -26,13 +27,17 @@ function Probe() {
       <span data-testid="model">{String(d.model)}</span>
       <span data-testid="error">{String(d.error)}</span>
       <span data-testid="web">{String(d.webEnabled)}</span>
+      <span data-testid="catalog">{JSON.stringify(d.catalog)}</span>
+      <span data-testid="messages">{JSON.stringify(d.messages)}</span>
       <button onClick={d.toggleWebEnabled}>web</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'p', runId: 'r' })}>start</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pA', runId: 'r' })}>startA</button>
       <button onClick={() => d.startSession({ provider: 'claude', model: 'sonnet', projectId: 'pB', runId: 'r' })}>startB</button>
       <button onClick={d.toggle}>toggle</button>
+      <button onClick={() => d.openTab('assistant')}>openAssistant</button>
       <button onClick={() => d.sendMessage('hi', { activeTab: 'overview' })}>send</button>
       <button onClick={d.resetConversation}>reset</button>
+      <button onClick={() => d.addLocalExchange?.('/help', 'HELP TEXT')}>localExchange</button>
     </div>
   );
 }
@@ -176,4 +181,42 @@ it('resetConversation is a no-op while a turn is in flight or before any session
   await act(async () => { screen.getByText('send').click(); });   // turn in flight
   await act(async () => { screen.getByText('reset').click(); });
   expect(createAssistantSession).toHaveBeenCalledTimes(1);
+});
+
+it('fetches the catalog once when the drawer opens, cached across open/close/open', async () => {
+  fetchAssistantCatalog.mockResolvedValue({ commands: [], skills: [], actions: [] });
+  render(<AssistantDrawerProvider><Probe /></AssistantDrawerProvider>);
+
+  // Drawer is closed; catalog should be null and fetch should not have been called.
+  expect(screen.getByTestId('catalog').textContent).toBe('null');
+  expect(fetchAssistantCatalog).not.toHaveBeenCalled();
+
+  // Open the assistant panel.
+  await act(async () => { screen.getByText('openAssistant').click(); });
+  expect(fetchAssistantCatalog).toHaveBeenCalledTimes(1);
+  expect(screen.getByTestId('catalog').textContent).toBe(
+    JSON.stringify({ commands: [], skills: [], actions: [] }),
+  );
+
+  // Close and reopen: still only 1 call (catalog is cached).
+  act(() => screen.getByText('toggle').click()); // close
+  await act(async () => { screen.getByText('openAssistant').click(); }); // reopen
+  expect(fetchAssistantCatalog).toHaveBeenCalledTimes(1);
+});
+
+it('addLocalExchange appends a user and a local message', async () => {
+  let hookRef;
+  const Grab = () => { hookRef = useAssistantDrawer(); return null; };
+  render(<AssistantDrawerProvider><Probe /><Grab /></AssistantDrawerProvider>);
+
+  // Capture initial messages count (should be empty).
+  expect(hookRef.messages).toHaveLength(0);
+
+  // Invoke addLocalExchange.
+  act(() => { hookRef.addLocalExchange('/help', 'HELP TEXT'); });
+
+  // Two messages appended: user turn then local response.
+  expect(hookRef.messages).toHaveLength(2);
+  expect(hookRef.messages[0]).toMatchObject({ role: 'user', text: '/help', atIndex: 0 });
+  expect(hookRef.messages[1]).toMatchObject({ role: 'local', text: 'HELP TEXT', atIndex: 0 });
 });

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export function AssistantWelcome() { return null; }

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,3 +1,42 @@
 import React from 'react';
+import { META_COMMANDS, pillsForView } from './commands.js';
 
-export function AssistantWelcome() { return null; }
+/**
+ * Empty-transcript state of the assistant pane: a one-line intro, the
+ * command/skill catalog, and context-aware suggestion pills. Pure UI, never
+ * persisted, never sent to the model; reappears on every fresh session.
+ */
+export function AssistantWelcome({ catalog, view, onPick }) {
+  const pills = pillsForView(catalog, view);
+  const skills = catalog?.skills ?? [];
+  return (
+    <div className="assistant-welcome">
+      <p className="assistant-welcome-intro">
+        I can explain scores, dig into findings, and draft standards for this project.
+      </p>
+      <ul className="assistant-welcome-commands">
+        {META_COMMANDS.map((c) => (
+          <li key={c.name}><code>/{c.name}</code> {c.description}</li>
+        ))}
+        {skills.map((s) => (
+          <li key={s.name}><code>/{s.name}</code> {s.description}</li>
+        ))}
+      </ul>
+      {pills.length > 0 && (
+        <div className="assistant-welcome-pills">
+          {pills.map((p) => (
+            <button
+              key={p.fill}
+              type="button"
+              className="assistant-pill"
+              title={p.description}
+              onClick={() => onPick(p.fill)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.jsx
@@ -1,25 +1,22 @@
 import React from 'react';
-import { META_COMMANDS, pillsForView } from './commands.js';
+import { VISIBLE_META_COMMANDS, pillsForView } from './commands.js';
 
 /**
  * Empty-transcript state of the assistant pane: a one-line intro, the
- * command/skill catalog, and context-aware suggestion pills. Pure UI, never
- * persisted, never sent to the model; reappears on every fresh session.
+ * meta-command list, and skill pills (view-relevant first). Skills appear
+ * only as pills, never as text lines. Pure UI, never persisted, never sent
+ * to the model; reappears on every fresh session.
  */
 export function AssistantWelcome({ catalog, view, onPick }) {
   const pills = pillsForView(catalog, view);
-  const skills = catalog?.skills ?? [];
   return (
     <div className="assistant-welcome">
       <p className="assistant-welcome-intro">
         I can explain scores, dig into findings, and draft standards for this project.
       </p>
       <ul className="assistant-welcome-commands">
-        {META_COMMANDS.map((c) => (
+        {VISIBLE_META_COMMANDS.map((c) => (
           <li key={c.name}><code>/{c.name}</code> {c.description}</li>
-        ))}
-        {skills.map((s) => (
-          <li key={s.name}><code>/{s.name}</code> {s.description}</li>
         ))}
       </ul>
       {pills.length > 0 && (

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -7,15 +7,19 @@ import { AssistantWelcome } from './AssistantWelcome.jsx';
 const catalog = {
   skills: [
     { name: 'explain-score', description: 'Explain a dimension score', argumentHint: '[dimension]', views: ['overview'] },
+    { name: 'create-standard', description: 'Draft a custom standard', argumentHint: '', views: ['standards'] },
   ],
   actions: [],
 };
 
-it('lists meta commands and skills', () => {
+it('lists meta commands as text, skills as pills only', () => {
   render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
   expect(screen.getByText('/help')).toBeInTheDocument();
   expect(screen.getByText('/clear')).toBeInTheDocument();
-  expect(screen.getByText('/explain-score')).toBeInTheDocument();
+  expect(screen.queryByText('/actions')).toBeNull(); // hidden meta stays out
+  expect(screen.queryByText('/explain-score')).toBeNull(); // skills are pills, not text
+  expect(screen.getByRole('button', { name: 'Explain score' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Create standard' })).toBeInTheDocument();
 });
 
 it('pill click pre-fills, does not send', () => {

--- a/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/AssistantWelcome.test.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { AssistantWelcome } from './AssistantWelcome.jsx';
+
+const catalog = {
+  skills: [
+    { name: 'explain-score', description: 'Explain a dimension score', argumentHint: '[dimension]', views: ['overview'] },
+  ],
+  actions: [],
+};
+
+it('lists meta commands and skills', () => {
+  render(<AssistantWelcome catalog={catalog} view="overview" onPick={() => {}} />);
+  expect(screen.getByText('/help')).toBeInTheDocument();
+  expect(screen.getByText('/clear')).toBeInTheDocument();
+  expect(screen.getByText('/explain-score')).toBeInTheDocument();
+});
+
+it('pill click pre-fills, does not send', () => {
+  const onPick = vi.fn();
+  render(<AssistantWelcome catalog={catalog} view="overview" onPick={onPick} />);
+  fireEvent.click(screen.getByRole('button', { name: 'Explain score' }));
+  expect(onPick).toHaveBeenCalledWith('/explain-score ');
+});
+
+it('renders without a catalog (fetch failed)', () => {
+  render(<AssistantWelcome catalog={null} view="overview" onPick={() => {}} />);
+  expect(screen.getByText('/help')).toBeInTheDocument();
+  expect(screen.queryByRole('button')).toBeNull(); // no pills without catalog
+});

--- a/src/quodeq/ui/src/features/assistant/CommandMenu.jsx
+++ b/src/quodeq/ui/src/features/assistant/CommandMenu.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+/**
+ * Autocomplete popup for slash commands, anchored above the composer.
+ * Pure presentation: selection/keyboard state lives in AssistantPane.
+ */
+export function CommandMenu({ suggestions, selectedIndex, onPick }) {
+  if (!suggestions.length) return null;
+  return (
+    <div className="assistant-command-menu" role="listbox">
+      {suggestions.map((cmd, i) => (
+        <button
+          type="button"
+          key={cmd.name}
+          role="option"
+          aria-selected={i === selectedIndex}
+          className={`assistant-command-item${i === selectedIndex ? ' selected' : ''}`}
+          // mousedown (not click) so the textarea keeps focus
+          onMouseDown={(event) => { event.preventDefault(); onPick(cmd); }}
+        >
+          <span className="assistant-command-name">/{cmd.name}</span>
+          {cmd.argumentHint ? <span className="assistant-command-hint">{cmd.argumentHint}</span> : null}
+          <span className="assistant-command-desc">{cmd.description}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/assistant/MessageList.jsx
+++ b/src/quodeq/ui/src/features/assistant/MessageList.jsx
@@ -25,7 +25,19 @@ function MessageItem({ message }) {
         </div>
       );
     case 'tool':
-      return <div className="assistant-msg assistant-msg-tool">↳ used {message.name}</div>;
+      return (
+        <div className="assistant-msg assistant-msg-tool">
+          ↳ used {message.name}{message.argsSummary ? ` · ${message.argsSummary}` : ''}
+        </div>
+      );
+    case 'local':
+      return (
+        <div className="assistant-msg assistant-msg-local assistant-md">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>
+            {message.text}
+          </ReactMarkdown>
+        </div>
+      );
     case 'action':
       return (
         <div className="assistant-msg assistant-msg-action">

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -1,0 +1,62 @@
+// Pure helpers for the assistant command layer: meta-command parsing,
+// autocomplete matching, and welcome/pill derivation. No React, no network.
+// META_COMMANDS mirrors RESERVED_COMMANDS in src/quodeq/assistant/skills.py
+// and doubles as the offline fallback when the catalog fetch fails.
+
+export const META_COMMANDS = [
+  { name: 'help', description: 'Show what the assistant can do here' },
+  { name: 'skills', description: 'List available skill commands' },
+  { name: 'actions', description: 'List actions the assistant can draft' },
+  { name: 'clear', description: 'Start a new conversation' },
+];
+
+export function parseMetaCommand(text) {
+  const first = text.trim().split(/\s+/)[0];
+  if (!first.startsWith('/')) return null;
+  const name = first.slice(1);
+  return META_COMMANDS.some((c) => c.name === name) ? name : null;
+}
+
+export function matchCommands(catalog, draft) {
+  if (!draft.startsWith('/') || /\s/.test(draft)) return [];
+  const prefix = draft.slice(1).toLowerCase();
+  const skills = (catalog?.skills ?? []).map((s) => ({
+    name: s.name, description: s.description, argumentHint: s.argumentHint || '',
+  }));
+  return [...META_COMMANDS.map((c) => ({ ...c, argumentHint: '' })), ...skills]
+    .filter((c) => c.name.startsWith(prefix));
+}
+
+function commandLines(catalog) {
+  const skills = catalog?.skills ?? [];
+  return [
+    ...META_COMMANDS.map((c) => `- \`/${c.name}\` ${c.description}`),
+    ...skills.map((s) => `- \`/${s.name}${s.argumentHint ? ` ${s.argumentHint}` : ''}\` ${s.description}`),
+  ].join('\n');
+}
+
+export function buildMetaResponse(kind, catalog) {
+  if (kind === 'skills') {
+    const skills = catalog?.skills ?? [];
+    if (!skills.length) return 'No skill packs are installed.';
+    return `**Skills**\n${skills.map((s) => `- \`/${s.name}${s.argumentHint ? ` ${s.argumentHint}` : ''}\` ${s.description}`).join('\n')}`;
+  }
+  if (kind === 'actions') {
+    const actions = catalog?.actions ?? [];
+    if (!actions.length) return 'No draftable actions are available.';
+    return `**Actions** (drafted as preview cards, applied only after you approve)\n${actions.map((a) => `- \`${a.type}\` ${a.description}`).join('\n')}`;
+  }
+  return `I can explain scores, dig into findings, and draft standards for this project.\n\n**Commands**\n${commandLines(catalog)}`;
+}
+
+export function pillsForView(catalog, view) {
+  if (!view) return [];
+  return (catalog?.skills ?? [])
+    .filter((s) => (s.views ?? []).includes(view))
+    .slice(0, 4)
+    .map((s) => ({
+      label: s.name.replace(/-/g, ' ').replace(/^./, (ch) => ch.toUpperCase()),
+      fill: `/${s.name} `,
+      description: s.description,
+    }));
+}

--- a/src/quodeq/ui/src/features/assistant/commands.js
+++ b/src/quodeq/ui/src/features/assistant/commands.js
@@ -6,9 +6,14 @@
 export const META_COMMANDS = [
   { name: 'help', description: 'Show what the assistant can do here' },
   { name: 'skills', description: 'List available skill commands' },
-  { name: 'actions', description: 'List actions the assistant can draft' },
+  // Still answered locally if typed, but hidden from the welcome list,
+  // /help, and autocomplete until the Phase 2 action registry gives it
+  // more than one entry. The name stays reserved server-side.
+  { name: 'actions', description: 'List actions the assistant can draft', hidden: true },
   { name: 'clear', description: 'Start a new conversation' },
 ];
+
+export const VISIBLE_META_COMMANDS = META_COMMANDS.filter((c) => !c.hidden);
 
 export function parseMetaCommand(text) {
   const first = text.trim().split(/\s+/)[0];
@@ -23,14 +28,14 @@ export function matchCommands(catalog, draft) {
   const skills = (catalog?.skills ?? []).map((s) => ({
     name: s.name, description: s.description, argumentHint: s.argumentHint || '',
   }));
-  return [...META_COMMANDS.map((c) => ({ ...c, argumentHint: '' })), ...skills]
+  return [...VISIBLE_META_COMMANDS.map((c) => ({ ...c, argumentHint: '' })), ...skills]
     .filter((c) => c.name.startsWith(prefix));
 }
 
 function commandLines(catalog) {
   const skills = catalog?.skills ?? [];
   return [
-    ...META_COMMANDS.map((c) => `- \`/${c.name}\` ${c.description}`),
+    ...VISIBLE_META_COMMANDS.map((c) => `- \`/${c.name}\` ${c.description}`),
     ...skills.map((s) => `- \`/${s.name}${s.argumentHint ? ` ${s.argumentHint}` : ''}\` ${s.description}`),
   ].join('\n');
 }
@@ -51,8 +56,12 @@ export function buildMetaResponse(kind, catalog) {
 
 export function pillsForView(catalog, view) {
   if (!view) return [];
-  return (catalog?.skills ?? [])
-    .filter((s) => (s.views ?? []).includes(view))
+  const skills = catalog?.skills ?? [];
+  // View-relevant skills lead; the rest follow so any view with context
+  // offers every skill as a pill (skills appear only here, not as text).
+  const matching = skills.filter((s) => (s.views ?? []).includes(view));
+  const rest = skills.filter((s) => !(s.views ?? []).includes(view));
+  return [...matching, ...rest]
     .slice(0, 4)
     .map((s) => ({
       label: s.name.replace(/-/g, ' ').replace(/^./, (ch) => ch.toUpperCase()),

--- a/src/quodeq/ui/src/features/assistant/commands.test.js
+++ b/src/quodeq/ui/src/features/assistant/commands.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  META_COMMANDS, parseMetaCommand, matchCommands, buildMetaResponse, pillsForView,
+} from './commands.js';
+
+const catalog = {
+  commands: META_COMMANDS,
+  skills: [
+    { name: 'explain-score', description: 'Explain a dimension score', argumentHint: '[dimension]', views: ['overview', 'violations'] },
+    { name: 'create-standard', description: 'Draft a custom standard', argumentHint: '', views: ['standards'] },
+  ],
+  actions: [{ type: 'create_standard', description: 'Draft a new custom standard.' }],
+};
+
+test('parseMetaCommand recognizes reserved names only', () => {
+  assert.equal(parseMetaCommand('/help'), 'help');
+  assert.equal(parseMetaCommand('  /clear  '), 'clear');
+  assert.equal(parseMetaCommand('/help me please'), 'help');
+  assert.equal(parseMetaCommand('/explain-score'), null);
+  assert.equal(parseMetaCommand('hello'), null);
+});
+
+test('matchCommands filters by prefix, empty after a space', () => {
+  assert.deepEqual(matchCommands(catalog, '/ex').map((c) => c.name), ['explain-score']);
+  const all = matchCommands(catalog, '/');
+  assert.equal(all.length, META_COMMANDS.length + 2);
+  assert.deepEqual(matchCommands(catalog, '/explain-score sec'), []);
+  assert.deepEqual(matchCommands(null, '/he').map((c) => c.name), ['help']);
+});
+
+test('buildMetaResponse renders markdown catalogs', () => {
+  assert.match(buildMetaResponse('skills', catalog), /\/explain-score/);
+  assert.match(buildMetaResponse('actions', catalog), /create_standard/);
+  assert.match(buildMetaResponse('help', catalog), /\/help/);
+  assert.match(buildMetaResponse('help', null), /\/help/); // catalog fetch failed: still useful
+});
+
+test('pillsForView picks skills matching the view, max 4', () => {
+  const pills = pillsForView(catalog, 'overview');
+  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ']);
+  assert.equal(pills[0].label, 'Explain score');
+  assert.deepEqual(pillsForView(catalog, 'map'), []);
+  assert.deepEqual(pillsForView(null, 'overview'), []);
+});

--- a/src/quodeq/ui/src/features/assistant/commands.test.js
+++ b/src/quodeq/ui/src/features/assistant/commands.test.js
@@ -1,7 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  META_COMMANDS, parseMetaCommand, matchCommands, buildMetaResponse, pillsForView,
+  META_COMMANDS, VISIBLE_META_COMMANDS, parseMetaCommand, matchCommands,
+  buildMetaResponse, pillsForView,
 } from './commands.js';
 
 const catalog = {
@@ -17,14 +18,16 @@ test('parseMetaCommand recognizes reserved names only', () => {
   assert.equal(parseMetaCommand('/help'), 'help');
   assert.equal(parseMetaCommand('  /clear  '), 'clear');
   assert.equal(parseMetaCommand('/help me please'), 'help');
+  assert.equal(parseMetaCommand('/actions'), 'actions'); // hidden but still answered locally
   assert.equal(parseMetaCommand('/explain-score'), null);
   assert.equal(parseMetaCommand('hello'), null);
 });
 
-test('matchCommands filters by prefix, empty after a space', () => {
+test('matchCommands filters by prefix, empty after a space, hides hidden metas', () => {
   assert.deepEqual(matchCommands(catalog, '/ex').map((c) => c.name), ['explain-score']);
   const all = matchCommands(catalog, '/');
-  assert.equal(all.length, META_COMMANDS.length + 2);
+  assert.equal(all.length, VISIBLE_META_COMMANDS.length + 2);
+  assert.deepEqual(matchCommands(catalog, '/ac'), []); // /actions never suggested
   assert.deepEqual(matchCommands(catalog, '/explain-score sec'), []);
   assert.deepEqual(matchCommands(null, '/he').map((c) => c.name), ['help']);
 });
@@ -33,13 +36,19 @@ test('buildMetaResponse renders markdown catalogs', () => {
   assert.match(buildMetaResponse('skills', catalog), /\/explain-score/);
   assert.match(buildMetaResponse('actions', catalog), /create_standard/);
   assert.match(buildMetaResponse('help', catalog), /\/help/);
+  assert.doesNotMatch(buildMetaResponse('help', catalog), /\/actions/); // hidden metas stay out of /help
   assert.match(buildMetaResponse('help', null), /\/help/); // catalog fetch failed: still useful
 });
 
-test('pillsForView picks skills matching the view, max 4', () => {
+test('pillsForView leads with view-matching skills, then the rest, max 4', () => {
   const pills = pillsForView(catalog, 'overview');
-  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ']);
+  assert.deepEqual(pills.map((p) => p.fill), ['/explain-score ', '/create-standard ']);
   assert.equal(pills[0].label, 'Explain score');
-  assert.deepEqual(pillsForView(catalog, 'map'), []);
+  // standards view reorders: create-standard first, remaining skills after
+  assert.deepEqual(pillsForView(catalog, 'standards').map((p) => p.fill),
+    ['/create-standard ', '/explain-score ']);
+  // no view match: every skill still offered, catalog order
+  assert.deepEqual(pillsForView(catalog, 'map').map((p) => p.fill),
+    ['/explain-score ', '/create-standard ']);
   assert.deepEqual(pillsForView(null, 'overview'), []);
 });

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.js
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.js
@@ -72,7 +72,7 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
       resetInactivity();
       let frame; try { frame = JSON.parse(e.data); } catch { return; }
       if (frame.type === 'token') { beginContent(); pending.current += frame.text || ''; scheduleFlush(); }
-      else if (frame.type === 'tool_call') { beginContent(); flushTokens(); append({ role: 'tool', name: frame.name }); }
+      else if (frame.type === 'tool_call') { beginContent(); flushTokens(); append({ role: 'tool', name: frame.name, argsSummary: frame.argsSummary }); }
       else if (frame.type === 'action_draft') { beginContent(); flushTokens();
         append({ role: 'action', actionId: frame.actionId, actionType: frame.actionType, summary: frame.summary }); }
       else if (frame.type === 'warning') { beginContent(); flushTokens(); append({ role: 'warning', message: frame.message }); }

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -440,3 +440,24 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* --- Command layer: welcome panel, pills, autocomplete, local messages --- */
+.assistant-drawer-input-row { position: relative; }
+
+.assistant-welcome { flex: 1; overflow-y: auto; padding: 12px 16px; color: var(--color-text); }
+.assistant-welcome-intro { margin: 0 0 8px; color: var(--color-text-muted); font-size: 13px; }
+.assistant-welcome-commands { list-style: none; margin: 0 0 12px; padding: 0; font-size: 12px; }
+.assistant-welcome-commands li { margin: 3px 0; color: var(--color-text-muted); }
+.assistant-welcome-commands code { font-family: var(--font-mono); color: var(--color-text); margin-right: 6px; }
+.assistant-welcome-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+.assistant-pill { border: 1px solid var(--color-border); background: var(--color-surface-alt); color: var(--color-text); border-radius: 999px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+.assistant-pill:hover { border-color: var(--color-accent); }
+
+.assistant-command-menu { position: absolute; bottom: 100%; left: 0; right: 0; margin-bottom: 4px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; z-index: 10; }
+.assistant-command-item { display: flex; align-items: baseline; gap: 8px; width: 100%; text-align: left; padding: 6px 10px; background: none; border: none; color: var(--color-text); cursor: pointer; font-size: 12px; }
+.assistant-command-item.selected, .assistant-command-item:hover { background: var(--color-surface-alt); }
+.assistant-command-name { font-family: var(--font-mono); }
+.assistant-command-hint { color: var(--color-text-subtle); }
+.assistant-command-desc { color: var(--color-text-muted); margin-left: auto; }
+
+.assistant-msg-local { border-left: 2px solid var(--color-border); padding-left: 8px; }

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -449,7 +449,7 @@
 .assistant-welcome-commands { list-style: none; margin: 0 0 12px; padding: 0; font-size: 12px; }
 .assistant-welcome-commands li { margin: 3px 0; color: var(--color-text-muted); }
 .assistant-welcome-commands code { font-family: var(--font-mono); color: var(--color-text); margin-right: 6px; }
-.assistant-welcome-pills { display: flex; flex-wrap: wrap; gap: 6px; }
+.assistant-welcome-pills { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
 .assistant-pill { border: 1px solid var(--color-border); background: var(--color-surface-alt); color: var(--color-text); border-radius: 6px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
 .assistant-pill:hover { border-color: var(--color-accent); }
 

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -450,7 +450,7 @@
 .assistant-welcome-commands li { margin: 3px 0; color: var(--color-text-muted); }
 .assistant-welcome-commands code { font-family: var(--font-mono); color: var(--color-text); margin-right: 6px; }
 .assistant-welcome-pills { display: flex; flex-wrap: wrap; gap: 6px; }
-.assistant-pill { border: 1px solid var(--color-border); background: var(--color-surface-alt); color: var(--color-text); border-radius: 999px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
+.assistant-pill { border: 1px solid var(--color-border); background: var(--color-surface-alt); color: var(--color-text); border-radius: 6px; padding: 4px 10px; font-size: 12px; cursor: pointer; }
 .assistant-pill:hover { border-color: var(--color-accent); }
 
 .assistant-command-menu { position: absolute; bottom: 100%; left: 0; right: 0; margin-bottom: 4px; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: 6px; overflow: hidden; z-index: 10; }

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -416,3 +416,17 @@ def test_apply_invalid_payload_400(client, app):
     assert resp.status_code == 400
     assert resp.get_json()["error"]
     assert repo.get_action("a-bad")["status"] == "drafted"
+
+
+def test_assistant_catalog(client):
+    resp = client.get("/api/assistant/skills")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [c["name"] for c in body["commands"]] == ["help", "skills", "actions", "clear"]
+    names = {s["name"] for s in body["skills"]}
+    assert {"create-standard", "explain-finding", "explain-score"} <= names
+    one = next(s for s in body["skills"] if s["name"] == "explain-score")
+    assert one["argumentHint"] and isinstance(one["views"], list)
+    assert body["actions"] == [
+        {"type": "create_standard",
+         "description": "Draft a new custom standard. Applied only after you approve the preview card."}]

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -96,6 +96,19 @@ def test_fallback_mode_uses_prompted_json_and_no_tools_param():
     assert "tool_call" in client.calls[0]["messages"][0]["content"]  # contract in system
 
 
+def test_tool_call_frame_carries_args_summary():
+    turn1 = [_delta('{"tool_call": {"name": "get_scores", "arguments": {"dimension": "security"}}}'),
+             _delta(finish="stop")]
+    turn2 = [_delta("C grade"), _delta(finish="stop")]
+    client = FakeClient([turn1, turn2])
+    frames = []
+    run_api_turn(messages=[{"role": "user", "content": "score?"}],
+                 config=_config(native=False), registry=_registry(),
+                 emit=frames.append, client_factory=lambda c: client)
+    tool_frames = [f for f in frames if f["type"] == "tool_call"]
+    assert tool_frames and tool_frames[0]["argsSummary"].startswith('{"')
+
+
 def test_iteration_cap_ends_turn():
     looping = [
         _delta(tool_calls=[_tool_call_delta(0, "c1", "get_scores", "{}")]),

--- a/tests/assistant/test_cli_adapter.py
+++ b/tests/assistant/test_cli_adapter.py
@@ -1,8 +1,10 @@
+import dataclasses
 import io
 from pathlib import Path
 
 import pytest
 
+from quodeq.assistant.adapters import _cli as _cli_mod
 from quodeq.assistant.adapters._cli import CliTurnConfig, run_cli_turn
 from quodeq.data.sqlite.assistant_repository import AssistantRepository
 
@@ -204,11 +206,6 @@ def test_web_disabled_by_default_in_spawned_argv(tmp_path):
                  session_id="s1", prior_session_id=None, repository=repo,
                  emit=lambda f: None, spawn_fn=spawn)
     assert captured["argv"][captured["argv"].index("--allowedTools") + 1] == "mcp__quodeq-assistant"
-
-
-import dataclasses
-
-from quodeq.assistant.adapters import _cli as _cli_mod
 
 
 def _capture_spawn(captured, lines):

--- a/tests/assistant/test_cli_adapter.py
+++ b/tests/assistant/test_cli_adapter.py
@@ -204,3 +204,48 @@ def test_web_disabled_by_default_in_spawned_argv(tmp_path):
                  session_id="s1", prior_session_id=None, repository=repo,
                  emit=lambda f: None, spawn_fn=spawn)
     assert captured["argv"][captured["argv"].index("--allowedTools") + 1] == "mcp__quodeq-assistant"
+
+
+import dataclasses
+
+from quodeq.assistant.adapters import _cli as _cli_mod
+
+
+def _capture_spawn(captured, lines):
+    def spawn(argv, cwd=None, env=None):
+        captured["argv"] = argv
+        return FakeProc(lines)
+    return spawn
+
+
+def test_claude_system_prompt_reaches_argv(tmp_path):
+    repo = _repo(tmp_path)
+    captured = {}
+    cfg = dataclasses.replace(_config(tmp_path), system_prompt="CTX", skill_block="")
+    run_cli_turn(
+        messages=[{"role": "system", "content": "CTX"},
+                  {"role": "user", "content": "hi"}],
+        config=cfg, session_id="s1", prior_session_id=None, repository=repo,
+        emit=lambda f: None,
+        spawn_fn=_capture_spawn(captured, ['{"type": "result", "result": "ok"}']))
+    i = captured["argv"].index("--append-system-prompt")
+    assert captured["argv"][i + 1] == "CTX"
+    assert captured["argv"][-1] == "hi"  # skill never prefixes argv-append prompts
+
+
+def test_message_prefix_provider_gets_skill_block(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    captured = {}
+    base = _cli_mod.load_cli_chat_config("claude")
+    monkeypatch.setattr(_cli_mod, "load_cli_chat_config",
+                        lambda p: dataclasses.replace(base, system_prompt_style="message-prefix"))
+    cfg = dataclasses.replace(_config(tmp_path), system_prompt="CTX",
+                              skill_block="[skill:x]\nDo X")
+    run_cli_turn(
+        messages=[{"role": "system", "content": "CTX"},
+                  {"role": "user", "content": "hi"}],
+        config=cfg, session_id="s1", prior_session_id=None, repository=repo,
+        emit=lambda f: None,
+        spawn_fn=_capture_spawn(captured, ['{"type": "result", "result": "ok"}']))
+    assert captured["argv"][-1] == "[skill:x]\nDo X\n\nhi"
+    assert "--append-system-prompt" not in captured["argv"]

--- a/tests/assistant/test_cli_command.py
+++ b/tests/assistant/test_cli_command.py
@@ -117,3 +117,19 @@ def test_with_web_access_pure_and_idempotent():
     once = _with_web_access(args)
     assert args == original  # input not mutated
     assert _with_web_access(once) == once  # applying twice equals applying once
+
+
+def test_claude_appends_system_prompt():
+    spec = _spec("claude", system_prompt="CTX RULES")
+    i = spec.argv.index("--append-system-prompt")
+    assert spec.argv[i + 1] == "CTX RULES"
+    assert spec.argv[-2:] == ["-p", "hi"]  # prompt stays last
+
+
+def test_claude_no_append_flag_without_system_prompt():
+    assert "--append-system-prompt" not in _spec("claude").argv
+
+
+def test_message_prefix_providers_never_get_append_flag():
+    assert "--append-system-prompt" not in _spec("codex", system_prompt="CTX").argv
+    assert "--append-system-prompt" not in _spec("gemini", system_prompt="CTX").argv

--- a/tests/assistant/test_cli_config.py
+++ b/tests/assistant/test_cli_config.py
@@ -40,3 +40,12 @@ def test_unknown_provider_raises():
     import pytest
     with pytest.raises(KeyError):
         load_cli_chat_config("nope")
+
+
+def test_claude_system_prompt_style_is_argv_append():
+    assert load_cli_chat_config("claude").system_prompt_style == "argv-append"
+
+
+def test_codex_and_gemini_use_message_prefix():
+    assert load_cli_chat_config("codex").system_prompt_style == "message-prefix"
+    assert load_cli_chat_config("gemini").system_prompt_style == "message-prefix"

--- a/tests/assistant/test_cli_stream.py
+++ b/tests/assistant/test_cli_stream.py
@@ -1,3 +1,4 @@
+from quodeq.assistant.adapters import _stream
 from quodeq.assistant.adapters._stream import (
     assistant_text, parse_line, session_id, tool_uses,
 )
@@ -50,3 +51,18 @@ def test_session_id_from_system_and_result():
     assert session_id({"type": "result", "session_id": "uuid-2"}) == "uuid-2"
     assert session_id({"type": "assistant", "message": {"content": []}}) is None
     assert session_id({"type": "session.created", "thread_id": "th-9"}) == "th-9"
+
+
+def test_tool_use_details_includes_args_summary():
+    event = {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "get_report",
+         "input": {"dimension": "security"}}]}}
+    assert _stream.tool_use_details(event) == [
+        {"name": "get_report", "args_summary": '{"dimension": "security"}'}]
+
+
+def test_tool_use_details_empty_input_gives_empty_summary():
+    event = {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "name": "get_scores", "input": {}}]}}
+    assert _stream.tool_use_details(event) == [
+        {"name": "get_scores", "args_summary": ""}]

--- a/tests/assistant/test_orchestrator.py
+++ b/tests/assistant/test_orchestrator.py
@@ -249,3 +249,36 @@ def test_web_enabled_threads_to_cli_config(setup, monkeypatch):
                       web_enabled=True)
     run_turn(req, repository=repo, tool_ctx=ctx)
     assert seen["config"].web_enabled is True
+
+
+def test_cli_config_carries_system_prompt_and_skill_block(setup):
+    repo, ctx = setup
+    captured = {}
+
+    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit):
+        captured["config"] = config
+        return "answer"
+
+    request = TurnRequest(session_id="s1", text="/explain-score security",
+                          ui_state=None, api_base="", api_key=None,
+                          provider="claude", model="sonnet")
+    run_turn(request, repository=repo, tool_ctx=ctx, cli_turn_fn=fake_cli)
+    cfg = captured["config"]
+    assert "# Active skill: explain-score" in cfg.system_prompt
+    assert cfg.skill_block.startswith("[skill:explain-score]\n")
+
+
+def test_cli_config_skill_block_empty_without_skill(setup):
+    repo, ctx = setup
+    captured = {}
+
+    def fake_cli(*, messages, config, session_id, prior_session_id, repository, emit):
+        captured["config"] = config
+        return "answer"
+
+    request = TurnRequest(session_id="s1", text="hello",
+                          ui_state=None, api_base="", api_key=None,
+                          provider="claude", model="sonnet")
+    run_turn(request, repository=repo, tool_ctx=ctx, cli_turn_fn=fake_cli)
+    assert captured["config"].skill_block == ""
+    assert captured["config"].system_prompt  # context always present

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -42,3 +42,12 @@ def test_extras_default_empty(tmp_path):
 def test_reserved_command_name_skipped(tmp_path):
     (tmp_path / "help.md").write_text("---\nname: help\ndescription: D\n---\nBody.\n")
     assert load_skills(skills_dir=tmp_path) == {}
+
+
+def test_builtin_skills_have_views_and_hints():
+    skills = load_skills()
+    for name in ("create-standard", "explain-finding", "explain-score"):
+        assert skills[name].views, f"{name} missing views frontmatter"
+    assert "overview" in skills["explain-score"].views
+    assert "violations" in skills["explain-finding"].views
+    assert "standards" in skills["create-standard"].views

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -20,3 +20,25 @@ def test_custom_skills_dir(tmp_path):
 def test_malformed_skill_skipped(tmp_path):
     (tmp_path / "bad.md").write_text("no frontmatter here")
     assert load_skills(skills_dir=tmp_path) == {}
+
+
+def test_frontmatter_extras_parsed(tmp_path):
+    (tmp_path / "s.md").write_text(
+        "---\nname: s\ndescription: D\nargument_hint: [dim]\n"
+        "views: overview, violations\n---\nBody.\n"
+    )
+    skill = load_skills(skills_dir=tmp_path)["s"]
+    assert skill.argument_hint == "[dim]"
+    assert skill.views == ("overview", "violations")
+
+
+def test_extras_default_empty(tmp_path):
+    (tmp_path / "s.md").write_text("---\nname: s\ndescription: D\n---\nBody.\n")
+    skill = load_skills(skills_dir=tmp_path)["s"]
+    assert skill.argument_hint == ""
+    assert skill.views == ()
+
+
+def test_reserved_command_name_skipped(tmp_path):
+    (tmp_path / "help.md").write_text("---\nname: help\ndescription: D\n---\nBody.\n")
+    assert load_skills(skills_dir=tmp_path) == {}


### PR DESCRIPTION
## Summary

Phase 1 of the assistant harness design: command layer + CLI system-prompt parity.

**The parity fix (the headline):** CLI providers never received the system prompt on normal turns, so `quodeq_context.md` and active skills were effectively local-API-only. Now:
- **claude** gets the full built system prompt (context + web section + active skill) via `--append-system-prompt` on every turn, driven by a new per-provider `system_prompt_style: "argv-append"` knob in `ai_providers.json`. Stateless, survives `--resume` and rebuilds.
- **codex / gemini** (`"message-prefix"`) get active-skill instructions prepended to the user message as a `[skill:<name>]` block; base context still arrives via the rebuild-replay path, per the spec.

**New surface:**
- `GET /api/assistant/skills`: read-only catalog of reserved commands, skills (with new optional `argument_hint` / `views` frontmatter), and draftable actions. Reserved names (`help`, `skills`, `actions`, `clear`) can no longer be shadowed by skill files (skipped with a warning).
- Client-side meta-commands: `/help`, `/skills`, `/actions` render local transcript responses (new `local` message role, zero server round-trip); `/clear` reuses the new-conversation handler.
- Composer autocomplete: slash-prefix popup with keyboard navigation (arrows / Tab / Enter / Escape), fed by the cached catalog and degrading to built-in commands if the fetch fails.
- Empty-transcript welcome panel with context-aware suggestion pills chosen by matching `uiState.view` against each skill's `views` (pills pre-fill, never auto-send).
- Tool-call frames now carry a truncated `argsSummary`, shown as `used <tool> . {json}` in the transcript.

**Spec deviations (intentional, noted in the plan):**
- Skill frontmatter `views` / `argument_hint` moved from spec Phase 3 to Phase 1 (the welcome pills need them).
- On the rare rebuild-replay path, argv-append providers see the context twice (transcript `[system]` block + argv). Accepted; commented at the call site.

## Verification

- Backend: 584 passed (`pytest tests/assistant tests/api -m "not integration"`).
- UI: 708 passed across 127 files (node:test + vitest); production build clean.
- Invariants re-checked: web tools never in `build_registry`, orchestrator gating pins (48 passed).
- Live smoke on the built app: catalog endpoint, welcome panel + pills (overview view), autocomplete menu, `/help` local exchange, both themes.
- Not exercised live: an end-to-end claude CLI turn (needs a configured provider + spends tokens). The argv construction is test-pinned; recommend one manual "what is quodeq?" + `/explain-score <dim>` check with the claude provider before or after merge.

## Follow-up (non-blocking, from final review)

- CommandMenu a11y: `button role="option"` inside `role="listbox"` can double-announce in screen readers; proper combobox wiring would be cleaner.
- `/clear` with no committed session clears the draft but not locally added `/help` exchanges (same semantics as the header button today).
- Catalog fetch triggers when any drawer tab opens, not just the assistant tab.
- `_api.py` computes `_args_summary` twice per emit site (plan-mandated pattern, behavior identical).
