### PR TITLE
fix(assistant): repo access for run-unscoped sessions

### DIFF
--- a/src/quodeq/api/_assistant_helpers.py
+++ b/src/quodeq/api/_assistant_helpers.py
@@ -55,9 +55,26 @@ def resolve_run_location(project_id: str, run_id: str) -> tuple[str | None, str 
         return None, None
     if not run_dir.is_dir():
         return None, None
-    info = get_project_info(str(evaluations_root), project_id)
-    repo_root = info.get("path") if info else None
-    return str(run_dir), repo_root
+    return str(run_dir), resolve_repo_root(project_id)
+
+
+def resolve_repo_root(project_id: str) -> str | None:
+    """Resolve the project's local working copy from ``project_id`` alone.
+
+    The repo root is a PROJECT-level fact (``repository_info.json``'s
+    ``path``), independent of any run: overview/accumulated sessions carry no
+    ``runId`` yet still need repo access for the code-reading tools. Returns
+    the path only when it is an existing local directory, so online projects
+    (whose ``path`` is a URL) and moved/deleted working copies stay detached
+    instead of carrying a bogus root. ``get_project_info`` jails the lookup
+    to the evaluations root; the stored ``path`` itself is server-side data
+    written at analysis time, never client input.
+    """
+    info = get_project_info(get_evaluations_dir(), project_id)
+    path = (info or {}).get("path")
+    if not path or not isinstance(path, str) or not Path(path).is_dir():
+        return None
+    return path
 
 
 def get_repository(app: Flask) -> AssistantRepository:

--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -66,6 +66,10 @@ def register_assistant_routes(app: Flask) -> None:
             run_dir, repo_root = _assistant_helpers.resolve_run_location(
                 str(body["projectId"]), str(body["runId"]),
             )
+        elif body.get("projectId"):
+            # The repo root is a project-level fact; without it, run-unscoped
+            # sessions (the app's default state) cannot read code at all.
+            repo_root = _assistant_helpers.resolve_repo_root(str(body["projectId"]))
         project_id = body.get("projectId")
         get_repository(app).create_session(
             session_id=session_id, provider=body["provider"],

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -331,6 +331,79 @@ def test_resolve_run_location_rejects_path_traversal(monkeypatch, tmp_path):
     assert run_dir == str((evals / "proj" / "run-1").resolve())
 
 
+def test_resolve_repo_root_returns_local_working_copy(monkeypatch, tmp_path):
+    evals = tmp_path / "evaluations"
+    (evals / "proj").mkdir(parents=True)
+    repo_dir = tmp_path / "src" / "client-app"
+    repo_dir.mkdir(parents=True)
+    (evals / "proj" / "repository_info.json").write_text(
+        json.dumps({"path": str(repo_dir)}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.get_evaluations_dir", lambda: str(evals)
+    )
+    from quodeq.api._assistant_helpers import resolve_repo_root
+    assert resolve_repo_root("proj") == str(repo_dir)
+
+
+def test_resolve_repo_root_rejects_urls_and_missing_dirs(monkeypatch, tmp_path):
+    # Online projects record a URL as their path; moved repos record a dir
+    # that no longer exists. Neither is a readable working copy, so the
+    # session must stay detached rather than carry a bogus repo root.
+    evals = tmp_path / "evaluations"
+    for name, path in (
+        ("online", "https://github.com/acme/app"),
+        ("ssh", "git@github.com:acme/app.git"),
+        ("moved", str(tmp_path / "gone")),
+    ):
+        (evals / name).mkdir(parents=True)
+        (evals / name / "repository_info.json").write_text(
+            json.dumps({"path": path}), encoding="utf-8"
+        )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.get_evaluations_dir", lambda: str(evals)
+    )
+    from quodeq.api._assistant_helpers import resolve_repo_root
+    assert resolve_repo_root("online") is None
+    assert resolve_repo_root("ssh") is None
+    assert resolve_repo_root("moved") is None
+    assert resolve_repo_root("nonexistent") is None
+
+
+def test_resolve_run_location_detaches_unreadable_repo_root(monkeypatch, tmp_path):
+    # Run-scoped resolution applies the same working-copy guard: an online
+    # project's URL path must not ride along as a bogus repo root.
+    evals = tmp_path / "evaluations"
+    (evals / "proj" / "run-1").mkdir(parents=True)
+    (evals / "proj" / "repository_info.json").write_text(
+        json.dumps({"path": "https://github.com/acme/app"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.get_evaluations_dir", lambda: str(evals)
+    )
+    from quodeq.api._assistant_helpers import resolve_run_location
+    run_dir, repo_root = resolve_run_location("proj", "run-1")
+    assert run_dir == str((evals / "proj" / "run-1").resolve())
+    assert repo_root is None
+
+
+def test_create_session_attaches_repo_root_without_run(client, app, monkeypatch):
+    # Overview/accumulated views send projectId with no runId. The repo root
+    # is a project-level fact, so it must attach anyway; otherwise repo tools
+    # fail with "no analyzed repository attached" in the app's default state.
+    monkeypatch.setattr(
+        "quodeq.api._assistant_helpers.resolve_repo_root",
+        lambda project_id: "/src/selectives-android",
+    )
+    resp = client.post("/api/assistant/sessions",
+                       json={"provider": "ollama", "projectId": "selectives"})
+    assert resp.status_code == 201
+    sid = resp.get_json()["sessionId"]
+    sess = AssistantRepository(app.config["ASSISTANT_DB_PATH"]).get_session(sid)
+    assert sess["project_uuid"] == "/src/selectives-android"
+    assert sess["run_id"] is None  # run scope untouched: still accumulated
+
+
 def test_apply_action_creates_standard(client, app):
     repo = _repo(app)
     repo.create_session(session_id="s1", provider="ollama")


### PR DESCRIPTION
## Problem

Reported from a client session (claude/sonnet CLI provider): the assistant answered with "tool call just failed with 'no analyzed repository attached'" when asked to verify a finding against the source.

Root cause: `POST /api/assistant/sessions` only resolved `repo_root` when the request carried BOTH `projectId` and `runId`. The UI deliberately sends no `runId` from the overview and accumulated views (so data tools read the per-dimension-latest composition), which meant sessions in the app's default navigation state had no repo access at all: `read_repo_file` / `list_repo_dir` refused every call, degrading `explain-finding` and any code-level verification.

## Fix

- New `resolve_repo_root(project_id)` helper: the repo root is a project-level fact (`repository_info.json`'s `path` via the jailed `get_project_info` lookup), so resolve it from `projectId` alone. It returns the path only when it is an existing local directory: online projects (URL paths) and moved/deleted working copies stay detached instead of carrying a bogus root.
- The create-session route attaches it for project-only sessions; `run_dir` stays gated on `runId`, so accumulated-view data behavior is unchanged.
- `resolve_run_location` now applies the same working-copy guard (previously a URL/stale path rode along raw into the MCP `--repo-root`).

Security posture unchanged: client-supplied `runDir`/`repoRoot` are still ignored (test-pinned); the resolved path is server-side data written at analysis time, jailed to the evaluations root.

## Verification

- TDD: 4 new tests (project-only session attaches root; URL/missing-dir/absent project detach; run-scoped resolution detaches unreadable roots), each seen failing first.
- Full backend suite: 588 passed (`pytest tests/assistant tests/api -m "not integration"`).

## Risk audit

- Behavior delta for run-scoped sessions with unreadable paths: repo tools now report "no analyzed repository attached" instead of path-not-found errors on a phantom root. No score or data-path impact; session creation does one extra project-info read.
