### PR TITLE
feat(ui): total project coverage on incremental scan progress + model chip on its own line

### DIFF
--- a/src/quodeq/analysis/_dim_estimates.py
+++ b/src/quodeq/analysis/_dim_estimates.py
@@ -92,7 +92,7 @@ def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
     path = run_dir / DIM_ESTIMATES_FILENAME
     try:
         raw = path.read_text(encoding="utf-8")
-    except (OSError, FileNotFoundError):
+    except (OSError, UnicodeDecodeError):
         return {}
     try:
         data = json.loads(raw)

--- a/src/quodeq/analysis/_dim_estimates.py
+++ b/src/quodeq/analysis/_dim_estimates.py
@@ -18,18 +18,31 @@ Each estimate also carries ``total`` (all source files for the dim) and
 ``cached`` (files already analyzed in previous runs) so the dashboard can
 render total project coverage, not just this run's queue. Non-incremental
 modes set ``total = count`` and ``cached = 0``.
+
+The on-disk format, IO, and normalisation live in
+``quodeq.shared.dim_estimates_io`` (re-exported below), since the reader is
+also used by ``quodeq.services.scan_progress``, which may not import
+analysis.
 """
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import Any
 
 from quodeq.analysis._types import RunConfig
 from quodeq.analysis.cache import LocalFileBackend, classify_files_via_cache
 from quodeq.analysis.subagents._source_files import _list_source_files
+from quodeq.shared.dim_estimates_io import (
+    DIM_ESTIMATES_FILENAME,
+    read_dim_estimates,
+    write_dim_estimates,
+)
 
-DIM_ESTIMATES_FILENAME = "dim_estimates.json"
+__all__ = [
+    "DIM_ESTIMATES_FILENAME",
+    "compute_dim_estimates",
+    "read_dim_estimates",
+    "write_dim_estimates",
+]
 
 
 def compute_dim_estimates(
@@ -68,50 +81,3 @@ def compute_dim_estimates(
         else:
             estimates[dim_id] = {"count": len(files), "reason": "full", "total": len(files), "cached": 0}
     return estimates
-
-
-def write_dim_estimates(
-    run_dir: Path, estimates: dict[str, dict[str, Any]],
-) -> None:
-    """Persist per-dim estimates next to status.json. Best-effort."""
-    try:
-        run_dir.mkdir(parents=True, exist_ok=True)
-        (run_dir / DIM_ESTIMATES_FILENAME).write_text(
-            json.dumps(estimates, indent=2), encoding="utf-8",
-        )
-    except OSError:
-        pass
-
-
-def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
-    """Return per-dim estimates from disk, or {} if missing/corrupt.
-
-    Each value is normalised to
-    ``{"count": int, "reason": str, "total": int, "cached": int}``.
-    """
-    path = run_dir / DIM_ESTIMATES_FILENAME
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return {}
-    try:
-        data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    out: dict[str, dict[str, Any]] = {}
-    for k, v in data.items():
-        # Current format: {"count": int, "reason": str, "total": int, "cached": int}.
-        if isinstance(v, dict) and isinstance(v.get("count"), int):
-            count = v["count"]
-            out[k] = {
-                "count": count,
-                "reason": str(v.get("reason", "")),
-                "total": v["total"] if isinstance(v.get("total"), int) else count,
-                "cached": v["cached"] if isinstance(v.get("cached"), int) else 0,
-            }
-        # Legacy format: a bare int. Older runs predate the reason tag.
-        elif isinstance(v, int):
-            out[k] = {"count": v, "reason": "", "total": v, "cached": 0}
-    return out

--- a/src/quodeq/analysis/_dim_estimates.py
+++ b/src/quodeq/analysis/_dim_estimates.py
@@ -13,6 +13,11 @@ counts that aren't really "this much code" but the cache being cold:
   - "diff"        — diff filter active; estimate = filter intersection
   - "incremental" — incremental run; estimate = cache-miss count
   - "first-run"   — cold cache for this dim; everything is a miss
+
+Each estimate also carries ``total`` (all source files for the dim) and
+``cached`` (files already analyzed in previous runs) so the dashboard can
+render total project coverage, not just this run's queue. Non-incremental
+modes set ``total = count`` and ``cached = 0``.
 """
 from __future__ import annotations
 
@@ -32,9 +37,10 @@ def compute_dim_estimates(
 ) -> dict[str, dict[str, Any]]:
     """Estimate per-dim file count + reason, before any dim runs.
 
-    Returns ``{dim_id: {"count": int, "reason": str}}``. The estimate is
-    the number of cache misses per dimension — exactly what V2 will
-    dispatch on this run.
+    Returns ``{dim_id: {"count": int, "reason": str, "total": int, "cached": int}}``.
+    ``count`` is the number of cache misses per dimension — exactly what V2
+    will dispatch on this run. ``total`` and ``cached`` describe overall
+    project coverage (see module docstring).
     """
     estimates: dict[str, dict[str, Any]] = {}
     file_filter = config.options.incremental_file_filter
@@ -42,7 +48,7 @@ def compute_dim_estimates(
     for dim_id in dimensions:
         files, _ext = _list_source_files(config, dim_id, ignore_file_filter=True)
         if not files:
-            estimates[dim_id] = {"count": 0, "reason": "empty"}
+            estimates[dim_id] = {"count": 0, "reason": "empty", "total": 0, "cached": 0}
             continue
         if config.options.incremental:
             classify = classify_files_via_cache(config, dim_id, files, cache)
@@ -52,12 +58,15 @@ def compute_dim_estimates(
                 reason = "first-run"
             else:
                 reason = "incremental"
-            estimates[dim_id] = {"count": miss_count, "reason": reason}
+            estimates[dim_id] = {
+                "count": miss_count, "reason": reason,
+                "total": len(files), "cached": len(files) - miss_count,
+            }
         elif file_filter is not None:
             count = sum(1 for f in files if f in file_filter)
-            estimates[dim_id] = {"count": count, "reason": "diff"}
+            estimates[dim_id] = {"count": count, "reason": "diff", "total": count, "cached": 0}
         else:
-            estimates[dim_id] = {"count": len(files), "reason": "full"}
+            estimates[dim_id] = {"count": len(files), "reason": "full", "total": len(files), "cached": 0}
     return estimates
 
 
@@ -77,7 +86,8 @@ def write_dim_estimates(
 def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
     """Return per-dim estimates from disk, or {} if missing/corrupt.
 
-    Each value is normalised to ``{"count": int, "reason": str}``.
+    Each value is normalised to
+    ``{"count": int, "reason": str, "total": int, "cached": int}``.
     """
     path = run_dir / DIM_ESTIMATES_FILENAME
     try:
@@ -92,10 +102,16 @@ def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
         return {}
     out: dict[str, dict[str, Any]] = {}
     for k, v in data.items():
-        # Current format: {"count": int, "reason": str}.
+        # Current format: {"count": int, "reason": str, "total": int, "cached": int}.
         if isinstance(v, dict) and isinstance(v.get("count"), int):
-            out[k] = {"count": v["count"], "reason": str(v.get("reason", ""))}
+            count = v["count"]
+            out[k] = {
+                "count": count,
+                "reason": str(v.get("reason", "")),
+                "total": v["total"] if isinstance(v.get("total"), int) else count,
+                "cached": v["cached"] if isinstance(v.get("cached"), int) else 0,
+            }
         # Legacy format: a bare int. Older runs predate the reason tag.
         elif isinstance(v, int):
-            out[k] = {"count": v, "reason": ""}
+            out[k] = {"count": v, "reason": "", "total": v, "cached": 0}
     return out

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -20,8 +20,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
-from quodeq.analysis._dim_estimates import read_dim_estimates
 from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
+from quodeq.shared.dim_estimates_io import read_dim_estimates
 from quodeq.shared.dimensions_state import read_dimensions
 
 _AGENT_ACTIVE_WINDOW_S = 30

--- a/src/quodeq/services/scan_progress.py
+++ b/src/quodeq/services/scan_progress.py
@@ -6,7 +6,7 @@ the in-memory JobManager state.
 
 Sources:
 - ``status.json``                 — phase, current_dimension, started_at, dimensions
-- ``dim_estimates.json``          — per-dim file count predicted before any dim runs
+- ``dim_estimates.json``          — per-dim file count predicted before any dim runs, plus total/cached coverage
 - ``scan.json``                   — total_files (project-wide fallback for pending dims)
 - ``<dim>_queue.json``            — taken / pending counts (precise once dim has started)
 - ``<dim>_evidence.jsonl``        — unique violation / compliance / duplicate counts (in-memory dedup)
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from quodeq.analysis._dim_estimates import read_dim_estimates
 from quodeq.analysis.subagents.jsonl_utils import tally_unique_findings
 from quodeq.shared.dimensions_state import read_dimensions
 
@@ -39,6 +40,8 @@ class _DimProgress:
     active_agents: int = 0
     estimate_reason: str | None = None  # see _dim_estimates module docstring
     exit_reason: str | None = None
+    files_cached: int | None = None        # files already analyzed in previous runs
+    files_project_total: int | None = None  # all source files for this dim
 
 
 @dataclass
@@ -67,23 +70,6 @@ def _project_total_files(run_dir: Path) -> int:
         return 0
     raw = scan.get("total_files")
     return int(raw) if isinstance(raw, int) else 0
-
-
-def _read_dim_estimates(run_dir: Path) -> dict[str, dict]:
-    """Per-dim file estimates written before any dim ran. Returns {} when absent.
-
-    Each value is ``{"count": int, "reason": str}`` (see _dim_estimates module).
-    """
-    raw = _read_json(run_dir / "dim_estimates.json") or {}
-    if not isinstance(raw, dict):
-        return {}
-    out: dict[str, dict] = {}
-    for k, v in raw.items():
-        if isinstance(v, dict) and isinstance(v.get("count"), int):
-            out[k] = {"count": v["count"], "reason": str(v.get("reason", ""))}
-        elif isinstance(v, int):
-            out[k] = {"count": v, "reason": ""}
-    return out
 
 
 def _active_agents(evidence_dir: Path, dim_id: str) -> int:
@@ -214,7 +200,7 @@ def build_scan_progress(
         total_elapsed_s = None
 
     project_files = _project_total_files(run_dir)
-    dim_estimates = _read_dim_estimates(run_dir)
+    dim_estimates = read_dim_estimates(run_dir)
     dim_records = read_dimensions(run_dir).get("dimensions") or {}
     dim_ids = list(status.get("dimensions") or [])
     if not dim_ids:
@@ -270,6 +256,8 @@ def build_scan_progress(
 
         estimate_meta = dim_estimates.get(dim_id)
         estimate_reason = estimate_meta["reason"] if estimate_meta else None
+        files_cached = estimate_meta["cached"] if estimate_meta else None
+        files_project_total = estimate_meta["total"] if estimate_meta else None
 
         tally = tally_unique_findings(evidence_dir / f"{dim_id}_evidence.jsonl")
         elapsed = _dim_elapsed_s(dim_id, run_dir, d_state)
@@ -288,6 +276,8 @@ def build_scan_progress(
             active_agents=active,
             estimate_reason=estimate_reason,
             exit_reason=exit_reason,
+            files_cached=files_cached,
+            files_project_total=files_project_total,
         ))
 
     return _ScanProgress(

--- a/src/quodeq/shared/dim_estimates_io.py
+++ b/src/quodeq/shared/dim_estimates_io.py
@@ -1,0 +1,82 @@
+"""On-disk IO + normalisation for the per-dim estimates sidecar.
+
+``dim_estimates.json`` sits next to ``status.json`` in a run directory and
+records, per dimension, how many files this run will process and how that
+compares to the dimension's full project coverage. It is written once by the
+analysis pipeline before any dim runs (see
+``quodeq.analysis._dim_estimates.compute_dim_estimates``) and read by the
+dashboard's progress reporting in ``quodeq.services.scan_progress``. Because
+both the writer (analysis) and the reader (services) need this format, and
+services must not import analysis, the IO lives here in the cross-cutting
+shared package.
+
+Each value is normalised to::
+
+    {"count": int, "reason": str, "total": int, "cached": int}
+
+- ``count``  — cache misses this run will dispatch for the dim.
+- ``reason`` — short tag explaining the estimate (see
+  ``compute_dim_estimates`` for the tag vocabulary).
+- ``total``  — all source files for the dim (overall project size).
+- ``cached`` — files already analyzed in previous runs.
+
+Legacy fallbacks for older/partial payloads:
+
+- Missing ``total`` falls back to ``count``.
+- Missing ``cached`` falls back to ``0``.
+- A bare int value (pre-dates the reason tag) becomes
+  ``{"count": v, "reason": "", "total": v, "cached": 0}``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+DIM_ESTIMATES_FILENAME = "dim_estimates.json"
+
+
+def write_dim_estimates(
+    run_dir: Path, estimates: dict[str, dict[str, Any]],
+) -> None:
+    """Persist per-dim estimates next to status.json. Best-effort."""
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(estimates, indent=2)
+        (run_dir / DIM_ESTIMATES_FILENAME).write_text(payload, encoding="utf-8")
+    except OSError:
+        pass
+
+
+def read_dim_estimates(run_dir: Path) -> dict[str, dict[str, Any]]:
+    """Return per-dim estimates from disk, or {} if missing/corrupt.
+
+    Each value is normalised to
+    ``{"count": int, "reason": str, "total": int, "cached": int}``.
+    """
+    path = run_dir / DIM_ESTIMATES_FILENAME
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for k, v in data.items():
+        # Current format: {"count": int, "reason": str, "total": int, "cached": int}.
+        if isinstance(v, dict) and isinstance(v.get("count"), int):
+            count = v["count"]
+            out[k] = {
+                "count": count,
+                "reason": str(v.get("reason", "")),
+                "total": v["total"] if isinstance(v.get("total"), int) else count,
+                "cached": v["cached"] if isinstance(v.get("cached"), int) else 0,
+            }
+        # Legacy format: a bare int. Older runs predate the reason tag.
+        elif isinstance(v, int):
+            out[k] = {"count": v, "reason": "", "total": v, "cached": 0}
+    return out

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.jsx
@@ -42,14 +42,20 @@ function JobIdLine({ jobId, aiProvider, aiModel }) {
   return (
     <div className="evaluate-job-id-line">
       <span className="evaluate-job-id-line__label">job</span>
-      <code>{jobId}</code>
-      <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(jobId)} />
+      <span className="evaluate-job-id-line__value">
+        <code>{jobId}</code>
+        <CopyButton aria-label="Copy job ID" onClick={() => copyToClipboard(jobId)} />
+      </span>
       {aiProvider && aiModel && (
-        <span data-testid="job-runtime-chip">
-          {aiProvider}
-          <span className="eval-provider-sep" aria-hidden="true"> · </span>
-          {aiModel}
-        </span>
+        <>
+          {/* empty first-column cell so the chip lands under the id */}
+          <span aria-hidden="true" />
+          <span data-testid="job-runtime-chip" className="evaluate-job-id-line__model">
+            {aiProvider}
+            <span className="eval-provider-sep" aria-hidden="true"> · </span>
+            {aiModel}
+          </span>
+        </>
       )}
     </div>
   );

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluationStatus.test.jsx
@@ -49,6 +49,18 @@ describe('JobIdLine', () => {
     );
     expect(screen.queryByTestId('job-runtime-chip')).toBeNull();
   });
+
+  it('renders the model chip on its own grid row below the job id', () => {
+    renderWithClient(
+      <EvaluationStatus
+        job={{ ...baseJob, aiProvider: 'llamacpp', aiModel: 'qwen3.6-27b' }}
+      />,
+    );
+    const chip = screen.getByTestId('job-runtime-chip');
+    expect(chip).toHaveClass('evaluate-job-id-line__model');
+    // The chip is a direct grid child, not nested inside the id row.
+    expect(chip.parentElement).toHaveClass('evaluate-job-id-line');
+  });
 });
 
 describe('project label', () => {

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -168,6 +168,8 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   const showCoverage = projectTotal > 0 && cachedFiles > 0;
   // coveredFiles is clamped to projectTotal upstream, so these widths can
   // never sum past 100 even when live queue counts drift from the estimate.
+  // cachedPctWidth alone also can't exceed 100: the producer (_dim_estimates.py)
+  // guarantees per-dim cached <= total, so summed cachedFiles <= projectTotal.
   const cachedPctWidth = showCoverage ? (cachedFiles / projectTotal) * 100 : 0;
   const runPctWidth = showCoverage ? ((coveredFiles - cachedFiles) / projectTotal) * 100 : 0;
   const inlineLabel = progress?.currentDimension
@@ -218,7 +220,7 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
           <div className="scan-progress__meta">
             <span>
               {showCoverage ? (
-                <><strong>{coveredFiles} / {projectTotal}</strong> files · {coveredPct}% total · this run {takenFiles} / {totalFiles}</>
+                <><strong>{coveredFiles} / {projectTotal}</strong> files · {coveredPct}% total{totalFiles > 0 ? <> · this run {takenFiles} / {totalFiles}</> : <> · nothing new this run</>}</>
               ) : totalFiles > 0 ? (
                 <><strong>{takenFiles} / {totalFiles}</strong> checks · {overallPct}%</>
               ) : <strong>preparing…</strong>}

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.jsx
@@ -161,7 +161,15 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
   if (!jobId) return null;
 
   const dims = progress?.dimensions || [];
-  const { totalFiles, takenFiles, overallPct } = computeOverallProgress(progress);
+  const { totalFiles, takenFiles, overallPct, projectTotal, cachedFiles, coveredFiles, coveredPct } =
+    computeOverallProgress(progress);
+  // Segmented coverage view only when there is actually a cached portion to
+  // show — full scans and legacy runs keep the familiar run-only display.
+  const showCoverage = projectTotal > 0 && cachedFiles > 0;
+  // coveredFiles is clamped to projectTotal upstream, so these widths can
+  // never sum past 100 even when live queue counts drift from the estimate.
+  const cachedPctWidth = showCoverage ? (cachedFiles / projectTotal) * 100 : 0;
+  const runPctWidth = showCoverage ? ((coveredFiles - cachedFiles) / projectTotal) * 100 : 0;
   const inlineLabel = progress?.currentDimension
     ? <>running <span className="scan-progress__dim-active">{progress.currentDimension}</span></>
     : progress?.phase
@@ -192,12 +200,28 @@ export default function ScanProgress({ job, hasEvaluations = false }) {
       {errorBanner}
       <div className="scan-progress__row">
         <div className="scan-progress__bar-wrap">
-          <div className="scan-progress__bar">
-            <div className="scan-progress__bar-fill" style={{ width: `${overallPct}%` }} />
+          <div
+            className="scan-progress__bar"
+            title={showCoverage ? `${cachedFiles} files analyzed in previous runs` : undefined}
+          >
+            {showCoverage && (
+              <div
+                className="scan-progress__bar-fill scan-progress__bar-fill--cached"
+                style={{ width: `${cachedPctWidth}%` }}
+              />
+            )}
+            <div
+              className="scan-progress__bar-fill"
+              style={{ width: showCoverage ? `${runPctWidth}%` : `${overallPct}%` }}
+            />
           </div>
           <div className="scan-progress__meta">
             <span>
-              {totalFiles > 0 ? <><strong>{takenFiles} / {totalFiles}</strong> checks · {overallPct}%</> : <strong>preparing…</strong>}
+              {showCoverage ? (
+                <><strong>{coveredFiles} / {projectTotal}</strong> files · {coveredPct}% total · this run {takenFiles} / {totalFiles}</>
+              ) : totalFiles > 0 ? (
+                <><strong>{takenFiles} / {totalFiles}</strong> checks · {overallPct}%</>
+              ) : <strong>preparing…</strong>}
               {isRunning && inlineLabel && <> · {inlineLabel}</>}
             </span>
             {progress?.totalElapsedS != null && (

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -142,6 +142,8 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     expect(cached.style.width).toBe('80%');
     const fills = container.querySelectorAll('.scan-progress__bar-wrap .scan-progress__bar-fill:not(.scan-progress__bar-fill--cached)');
     expect(fills[0].style.width).toBe('8%');
+    expect(container.querySelector('.scan-progress__bar-wrap .scan-progress__bar'))
+      .toHaveAttribute('title', '80 files analyzed in previous runs');
   });
 
   it('collapses to the run-only display when there is no cached portion', async () => {
@@ -158,6 +160,8 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     expect(screen.getByText(/checks · 20%/)).toBeInTheDocument();
     expect(screen.queryByText(/this run/)).toBeNull();
     expect(container.querySelector('.scan-progress__bar-fill--cached')).toBeNull();
+    expect(container.querySelector('.scan-progress__bar-wrap .scan-progress__bar'))
+      .not.toHaveAttribute('title');
   });
 
   it('collapses to the run-only display on legacy payloads without coverage fields', async () => {
@@ -186,6 +190,8 @@ describe('ScanProgress total coverage (incremental runs)', () => {
     withEvalLog(<ScanProgress job={baseJob} />, ctx);
     expect(await screen.findByText('100 / 100')).toBeInTheDocument();
     expect(screen.getByText(/100% total/)).toBeInTheDocument();
+    expect(screen.getByText(/nothing new this run/)).toBeInTheDocument();
+    expect(screen.queryByText(/this run 0 \/ 0/)).toBeNull();
     expect(screen.queryByText('preparing…')).toBeNull();
   });
 });

--- a/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ScanProgress.test.jsx
@@ -109,3 +109,83 @@ describe('ScanProgress partial coverage signal', () => {
     expect(container.querySelector('.scan-progress__coverage--partial')).toBeNull();
   });
 });
+
+describe('ScanProgress total coverage (incremental runs)', () => {
+  const ctx = { activeJobId: null, status: 'idle', openLog: vi.fn(), closeLog: vi.fn(), updateJobStatus: vi.fn() };
+
+  function coveragePayload() {
+    return {
+      runId: 'r1', phase: 'analyzing', currentDimension: 'security',
+      totalElapsedS: 60, projectFiles: 100, state: 'running',
+      dimensions: [
+        { id: 'security', state: 'running', files: { taken: 8, total: 20 },
+          filesCached: 80, filesProjectTotal: 100 },
+      ],
+    };
+  }
+
+  it('shows total coverage plus this-run detail when a cached portion exists', async () => {
+    getEvaluationProgress.mockResolvedValue(coveragePayload());
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    // 80 cached + 8 taken = 88 of 100 → 88% total; this run 8 / 20.
+    expect(await screen.findByText('88 / 100')).toBeInTheDocument();
+    expect(screen.getByText(/88% total/)).toBeInTheDocument();
+    expect(screen.getByText(/this run 8 \/ 20/)).toBeInTheDocument();
+  });
+
+  it('renders a dim cached segment and a bright run segment', async () => {
+    getEvaluationProgress.mockResolvedValue(coveragePayload());
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    await screen.findByText('88 / 100');
+    const cached = container.querySelector('.scan-progress__bar-fill--cached');
+    expect(cached).not.toBeNull();
+    expect(cached.style.width).toBe('80%');
+    const fills = container.querySelectorAll('.scan-progress__bar-wrap .scan-progress__bar-fill:not(.scan-progress__bar-fill--cached)');
+    expect(fills[0].style.width).toBe('8%');
+  });
+
+  it('collapses to the run-only display when there is no cached portion', async () => {
+    getEvaluationProgress.mockResolvedValue({
+      runId: 'r1', phase: 'analyzing', currentDimension: 'security',
+      totalElapsedS: 60, projectFiles: 60, state: 'running',
+      dimensions: [
+        { id: 'security', state: 'running', files: { taken: 12, total: 60 },
+          filesCached: 0, filesProjectTotal: 60 },
+      ],
+    });
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('12 / 60')).toBeInTheDocument();
+    expect(screen.getByText(/checks · 20%/)).toBeInTheDocument();
+    expect(screen.queryByText(/this run/)).toBeNull();
+    expect(container.querySelector('.scan-progress__bar-fill--cached')).toBeNull();
+  });
+
+  it('collapses to the run-only display on legacy payloads without coverage fields', async () => {
+    getEvaluationProgress.mockResolvedValue({
+      runId: 'r1', phase: 'analyzing', currentDimension: 'security',
+      totalElapsedS: 60, projectFiles: 60, state: 'running',
+      dimensions: [
+        { id: 'security', state: 'running', files: { taken: 12, total: 60 } },
+      ],
+    });
+    const { container } = withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('12 / 60')).toBeInTheDocument();
+    expect(container.querySelector('.scan-progress__bar-fill--cached')).toBeNull();
+  });
+
+  it('fully-cached re-scan shows coverage, not preparing', async () => {
+    // Nothing new to analyze this run: totalFiles 0 but full coverage data.
+    getEvaluationProgress.mockResolvedValue({
+      runId: 'r1', phase: 'analyzing', currentDimension: null,
+      totalElapsedS: 5, projectFiles: 100, state: 'running',
+      dimensions: [
+        { id: 'security', state: 'done', files: { taken: 0, total: 0 },
+          filesCached: 100, filesProjectTotal: 100 },
+      ],
+    });
+    withEvalLog(<ScanProgress job={baseJob} />, ctx);
+    expect(await screen.findByText('100 / 100')).toBeInTheDocument();
+    expect(screen.getByText(/100% total/)).toBeInTheDocument();
+    expect(screen.queryByText('preparing…')).toBeNull();
+  });
+});

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -11,6 +11,10 @@
  * rather than printing a misleading partial sum. This covers the brief
  * window between status.json (state=running) and dim_estimates.json
  * landing on disk.
+ *
+ * The header additionally sums whole-project coverage (`filesCached` /
+ * `filesProjectTotal` per dim) when every dim carries it; otherwise the
+ * coverage fields are null and the UI falls back to the run-only display.
  */
 
 export function pct(taken, total) {
@@ -33,10 +37,12 @@ export function dimFileEstimate(progress) {
   return progress?.projectFiles ?? 0;
 }
 
+const NO_COVERAGE = { projectTotal: null, cachedFiles: null, coveredFiles: null, coveredPct: null };
+
 export function computeOverallProgress(progress) {
   const dims = progress?.dimensions || [];
   if (dims.length === 0) {
-    return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE };
   }
 
   // "preparing…" only when *nothing* is known yet — i.e. no dim has
@@ -46,7 +52,7 @@ export function computeOverallProgress(progress) {
   const anyDimStarted = dims.some((d) => d?.state === 'running' || d?.state === 'done');
   const anyTotalKnown = dims.some((d) => (d?.files?.total ?? 0) > 0);
   if (!anyDimStarted && !anyTotalKnown) {
-    return { totalFiles: 0, takenFiles: 0, overallPct: 0 };
+    return { totalFiles: 0, takenFiles: 0, overallPct: 0, ...NO_COVERAGE };
   }
 
   // Sum across dims using whatever total each one carries. Pending dims
@@ -54,10 +60,30 @@ export function computeOverallProgress(progress) {
   // header sum once their estimate or queue lands.
   let takenFiles = 0;
   let totalFiles = 0;
+  // Whole-project coverage (incremental runs): every dim must carry the
+  // fields — a single legacy dim would make the sum lie, so it nulls out.
+  let hasCoverage = true;
+  let cachedFiles = 0;
+  let projectTotal = 0;
   for (const d of dims) {
     takenFiles += d?.files?.taken ?? 0;
     totalFiles += d?.files?.total ?? 0;
+    if (Number.isFinite(d?.filesCached) && Number.isFinite(d?.filesProjectTotal)) {
+      cachedFiles += d.filesCached;
+      projectTotal += d.filesProjectTotal;
+    } else {
+      hasCoverage = false;
+    }
   }
 
-  return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles) };
+  const coverage = hasCoverage
+    ? {
+        projectTotal,
+        cachedFiles,
+        coveredFiles: cachedFiles + takenFiles,
+        coveredPct: pct(cachedFiles + takenFiles, projectTotal),
+      }
+    : NO_COVERAGE;
+
+  return { totalFiles, takenFiles, overallPct: pct(takenFiles, totalFiles), ...coverage };
 }

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.js
@@ -80,7 +80,9 @@ export function computeOverallProgress(progress) {
     ? {
         projectTotal,
         cachedFiles,
-        coveredFiles: cachedFiles + takenFiles,
+        // Estimate-time totals vs live queue counts can drift when files
+        // change on disk mid-run; clamp so we never render "105 / 100".
+        coveredFiles: Math.min(cachedFiles + takenFiles, projectTotal),
         coveredPct: pct(cachedFiles + takenFiles, projectTotal),
       }
     : NO_COVERAGE;

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -325,3 +325,52 @@ test('computeOverallProgress: full scan aggregates with zero cached', () => {
   assert.equal(r.coveredFiles, 12);
   assert.equal(r.coveredPct, 20);
 });
+
+test('computeOverallProgress: covered files clamp to project total on overshoot', () => {
+  // filesCached/filesProjectTotal are frozen at estimate time while
+  // files.taken comes from the live queue — files changing on disk in
+  // between can push cached+taken past the frozen total. Never render
+  // "105 / 100".
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security', state: 'running', files: { taken: 30, total: 30 },
+        filesCached: 80, filesProjectTotal: 100 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.coveredFiles, 100);
+  assert.equal(r.coveredPct, 100);
+});
+
+test('computeOverallProgress: completed incremental run reads full coverage', () => {
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security', state: 'done', files: { taken: 20, total: 20 },
+        filesCached: 80, filesProjectTotal: 100 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.coveredFiles, 100);
+  assert.equal(r.coveredPct, 100);
+});
+
+test('computeOverallProgress: fully-cached re-scan keeps coverage despite empty queues', () => {
+  // Nothing changed since the last run: every dim is done with a zero
+  // queue. The run-relative sum is empty, but coverage data is still
+  // present — the whole project is covered by cache.
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security', state: 'done', files: { taken: 0, total: 0 },
+        filesCached: 100, filesProjectTotal: 100 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 0);
+  assert.equal(r.projectTotal, 100);
+  assert.equal(r.cachedFiles, 100);
+  assert.equal(r.coveredFiles, 100);
+  assert.equal(r.coveredPct, 100);
+});

--- a/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
+++ b/src/quodeq/ui/src/features/evaluation/components/scanProgressTotals.test.js
@@ -65,7 +65,10 @@ test('dimFileEstimate: returns 0 when nothing is known', () => {
 
 test('computeOverallProgress: returns zeros when progress is null', () => {
   const r = computeOverallProgress(null);
-  assert.deepEqual(r, { totalFiles: 0, takenFiles: 0, overallPct: 0 });
+  assert.deepEqual(r, {
+    totalFiles: 0, takenFiles: 0, overallPct: 0,
+    projectTotal: null, cachedFiles: null, coveredFiles: null, coveredPct: null,
+  });
 });
 
 test('computeOverallProgress: returns zeros when dimensions array is empty', () => {
@@ -263,4 +266,62 @@ test('computeOverallProgress: completed run with no pending dims still sums', ()
   assert.equal(r.totalFiles, 50);
   assert.equal(r.takenFiles, 50);
   assert.equal(r.overallPct, 100);
+});
+
+// ---------------------------------------------------------------------------
+// computeOverallProgress — total project coverage (incremental runs)
+// ---------------------------------------------------------------------------
+
+test('computeOverallProgress: aggregates coverage when all dims carry the fields', () => {
+  // 100-file project per dim, 80 cached, this run 20; 8 taken so far.
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security',    state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100 },
+      { id: 'reliability', state: 'pending', files: { taken: 0, total: 10 },
+        filesCached: 90, filesProjectTotal: 100 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.totalFiles, 30);
+  assert.equal(r.takenFiles, 8);
+  assert.equal(r.projectTotal, 200);
+  assert.equal(r.cachedFiles, 170);
+  assert.equal(r.coveredFiles, 178);
+  assert.equal(r.coveredPct, pct(178, 200));
+});
+
+test('computeOverallProgress: coverage is null when any dim lacks the fields (legacy run)', () => {
+  const progress = {
+    projectFiles: 100,
+    dimensions: [
+      { id: 'security',    state: 'running', files: { taken: 8, total: 20 },
+        filesCached: 80, filesProjectTotal: 100 },
+      { id: 'reliability', state: 'pending', files: { taken: 0, total: 10 } },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.projectTotal, null);
+  assert.equal(r.cachedFiles, null);
+  assert.equal(r.coveredFiles, null);
+  assert.equal(r.coveredPct, null);
+  // Run-relative aggregation untouched.
+  assert.equal(r.totalFiles, 30);
+  assert.equal(r.takenFiles, 8);
+});
+
+test('computeOverallProgress: full scan aggregates with zero cached', () => {
+  const progress = {
+    projectFiles: 60,
+    dimensions: [
+      { id: 'security', state: 'running', files: { taken: 12, total: 60 },
+        filesCached: 0, filesProjectTotal: 60 },
+    ],
+  };
+  const r = computeOverallProgress(progress);
+  assert.equal(r.projectTotal, 60);
+  assert.equal(r.cachedFiles, 0);
+  assert.equal(r.coveredFiles, 12);
+  assert.equal(r.coveredPct, 20);
 });

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -3055,20 +3055,23 @@ button.eval-provider-badge--clickable:focus-visible {
 }
 
 /* ------------------------------------------------------------
-   evaluate-job-id-line — minimal mono row showing just the job
-   ID with a copy button. Replaces the old `term-meta-grid`
-   block that surfaced project / provider / repo redundantly.
+   evaluate-job-id-line — minimal mono grid showing the job ID
+   with a copy button on the first row, and the provider · model
+   chip beneath the id on a second row. Replaces the old
+   `term-meta-grid` block that surfaced project / provider / repo
+   redundantly.
    ------------------------------------------------------------ */
 .evaluate-job-id-line {
-  display: flex;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: var(--term-space-2);
+  row-gap: 2px;
   align-items: center;
-  gap: var(--term-space-2);
   padding: var(--term-space-1) 0;
   margin-bottom: var(--term-space-2);
   font-family: var(--term-font-mono);
   font-size: 11px;
   color: var(--color-text-muted);
-  flex-wrap: wrap;
 }
 .evaluate-job-id-line__label {
   text-transform: uppercase;
@@ -3080,4 +3083,14 @@ button.eval-provider-badge--clickable:focus-visible {
   background: transparent;
   padding: 0;
   font-family: var(--term-font-mono);
+}
+.evaluate-job-id-line__value {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--term-space-2);
+  min-width: 0;
+}
+.evaluate-job-id-line__model {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -2797,6 +2797,7 @@ button.eval-provider-badge--clickable:focus-visible {
 }
 
 .scan-progress__bar {
+  display: flex;
   height: 6px;
   background: var(--color-surface-alt);
   border-radius: 3px;
@@ -2809,6 +2810,7 @@ button.eval-provider-badge--clickable:focus-visible {
 }
 .scan-progress__bar-fill--done    { background: var(--color-success, #56d364); }
 .scan-progress__bar-fill--partial { background: var(--color-warn, #d29922); }
+.scan-progress__bar-fill--cached  { background: var(--color-accent); opacity: 0.35; }
 
 .scan-progress__meta {
   display: flex;

--- a/tests/analysis/test_dim_estimates.py
+++ b/tests/analysis/test_dim_estimates.py
@@ -64,7 +64,7 @@ class TestComputeDimEstimates:
         config = _make_config(src, ["a.py", "b.py", "c.py"], incremental=False)
 
         result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 3, "reason": "full"}
+        assert result["security"] == {"count": 3, "reason": "full", "total": 3, "cached": 0}
 
     def test_diff_mode_intersects_filter(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -75,7 +75,7 @@ class TestComputeDimEstimates:
         )
 
         result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 2, "reason": "diff"}
+        assert result["security"] == {"count": 2, "reason": "diff", "total": 2, "cached": 0}
 
     def test_empty_dim_returns_zero_with_empty_reason(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -85,6 +85,8 @@ class TestComputeDimEstimates:
         result = compute_dim_estimates(config, ["security"])
         assert result["security"]["count"] == 0
         assert result["security"]["reason"] == "empty"
+        assert result["security"]["total"] == 0
+        assert result["security"]["cached"] == 0
 
     def test_incremental_first_run_all_misses(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -96,7 +98,7 @@ class TestComputeDimEstimates:
             return_value=LocalFileBackend(root=tmp_path / "fresh-cache"),
         ):
             result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 2, "reason": "first-run"}
+        assert result["security"] == {"count": 2, "reason": "first-run", "total": 2, "cached": 0}
 
     def test_incremental_partial_cache_marks_incremental(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -110,7 +112,7 @@ class TestComputeDimEstimates:
             return_value=cache,
         ):
             result = compute_dim_estimates(config, ["security"])
-        assert result["security"] == {"count": 1, "reason": "incremental"}
+        assert result["security"] == {"count": 1, "reason": "incremental", "total": 3, "cached": 2}
 
     def test_incremental_full_cache_returns_zero(self, tmp_path: Path):
         src = tmp_path / "src"
@@ -126,14 +128,16 @@ class TestComputeDimEstimates:
             result = compute_dim_estimates(config, ["security"])
         assert result["security"]["count"] == 0
         assert result["security"]["reason"] == "incremental"
+        assert result["security"]["total"] == 1
+        assert result["security"]["cached"] == 1
 
 
 class TestPersistence:
     def test_write_and_read_round_trip(self, tmp_path: Path):
         run_dir = tmp_path / "run"
         estimates = {
-            "security": {"count": 3, "reason": "incremental"},
-            "reliability": {"count": 0, "reason": "empty"},
+            "security": {"count": 3, "reason": "incremental", "total": 10, "cached": 7},
+            "reliability": {"count": 0, "reason": "empty", "total": 0, "cached": 0},
         }
         write_dim_estimates(run_dir, estimates)
         loaded = read_dim_estimates(run_dir)
@@ -153,7 +157,18 @@ class TestPersistence:
         run_dir.mkdir()
         (run_dir / DIM_ESTIMATES_FILENAME).write_text(json.dumps({"security": 5}))
         loaded = read_dim_estimates(run_dir)
-        assert loaded == {"security": {"count": 5, "reason": ""}}
+        assert loaded == {"security": {"count": 5, "reason": "", "total": 5, "cached": 0}}
+
+    def test_read_legacy_dict_without_coverage_fields_normalises(self, tmp_path: Path):
+        # Runs from before the total/cached fields: total falls back to count,
+        # cached to 0 — the UI then has no cached segment to draw.
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / DIM_ESTIMATES_FILENAME).write_text(
+            json.dumps({"security": {"count": 5, "reason": "incremental"}})
+        )
+        loaded = read_dim_estimates(run_dir)
+        assert loaded == {"security": {"count": 5, "reason": "incremental", "total": 5, "cached": 0}}
 
 
 class TestFreshRunSafety:

--- a/tests/analysis/test_dim_estimates.py
+++ b/tests/analysis/test_dim_estimates.py
@@ -152,6 +152,14 @@ class TestPersistence:
         (run_dir / DIM_ESTIMATES_FILENAME).write_text("{not json")
         assert read_dim_estimates(run_dir) == {}
 
+    def test_read_non_utf8_returns_empty(self, tmp_path: Path):
+        # A sidecar with invalid UTF-8 must not raise out of the reader —
+        # it feeds the polled progress endpoint, which would 500 otherwise.
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        (run_dir / DIM_ESTIMATES_FILENAME).write_bytes(b"\xff\xfe\x00garbage")
+        assert read_dim_estimates(run_dir) == {}
+
     def test_read_legacy_int_format_normalises(self, tmp_path: Path):
         run_dir = tmp_path / "run"
         run_dir.mkdir()

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -132,7 +132,24 @@ class TestPendingDimTotals:
         progress = build_scan_progress("j1", run_dir)
         assert progress is not None
         # Corrupt estimates → empty dict → pending dim reports 0 (preparing…).
-        assert progress.dimensions[0].files["total"] == 0
+        dim = progress.dimensions[0]
+        assert dim.files["total"] == 0
+        assert dim.files_cached is None
+        assert dim.files_project_total is None
+
+    def test_non_utf8_dim_estimates_does_not_break_reader(self, tmp_path: Path) -> None:
+        # Invalid UTF-8 in the sidecar must not raise out of the reader — the
+        # polled progress endpoint would 500 on every request otherwise.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_bytes(b"\xff\xfe\x00garbage")
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.files["total"] == 0
+        assert dim.files_cached is None
+        assert dim.files_project_total is None
 
 
 def _write_dimensions_json(run_dir: Path, states: dict[str, str]) -> None:

--- a/tests/services/test_scan_progress.py
+++ b/tests/services/test_scan_progress.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from quodeq.services.scan_progress import build_scan_progress
+from quodeq.services.scan_progress import build_scan_progress, progress_to_dict
 
 
 def _write_status(run_dir: Path, *, dimensions: list[str], state: str = "running",
@@ -226,3 +226,86 @@ class TestEmptyStatusDimensionsRecovery:
         progress = build_scan_progress("j1", run_dir)
         assert progress is not None
         assert progress.dimensions == []
+
+
+class TestCoverageFields:
+    def test_dims_carry_cached_and_project_total_from_estimates(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 20, "reason": "incremental",
+                                     "total": 100, "cached": 80}}),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.files_cached == 80
+        assert dim.files_project_total == 100
+        # Run-relative totals unchanged: pending dim still reports the estimate count.
+        assert dim.files == {"taken": 0, "total": 20}
+
+    def test_running_dim_keeps_coverage_fields_alongside_queue_totals(self, tmp_path: Path) -> None:
+        # Queue totals stay run-relative; coverage fields ride the estimate.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"], current_dimension="security")
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 20, "reason": "incremental",
+                                     "total": 100, "cached": 80}}),
+            encoding="utf-8",
+        )
+        queue_payload = {
+            "taken": [{"files": ["a.py", "b.py"], "agent": "a1", "ts": 1}],
+            "pending": [f"f{i}.py" for i in range(18)],
+        }
+        (run_dir / "evidence" / "security_queue.json").write_text(
+            json.dumps(queue_payload), encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.files == {"taken": 2, "total": 20}
+        assert dim.files_cached == 80
+        assert dim.files_project_total == 100
+
+    def test_legacy_estimates_normalise_coverage_fields(self, tmp_path: Path) -> None:
+        # Old sidecars lack total/cached → total falls back to count, cached 0.
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 20, "reason": "incremental"}}),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.files_cached == 0
+        assert dim.files_project_total == 20
+
+    def test_no_estimates_file_leaves_coverage_fields_none(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+
+        progress = build_scan_progress("j1", run_dir)
+        assert progress is not None
+        dim = progress.dimensions[0]
+        assert dim.files_cached is None
+        assert dim.files_project_total is None
+
+    def test_progress_to_dict_camel_cases_coverage_fields(self, tmp_path: Path) -> None:
+        run_dir = _make_run(tmp_path)
+        _write_status(run_dir, dimensions=["security"])
+        (run_dir / "dim_estimates.json").write_text(
+            json.dumps({"security": {"count": 20, "reason": "incremental",
+                                     "total": 100, "cached": 80}}),
+            encoding="utf-8",
+        )
+
+        progress = build_scan_progress("j1", run_dir)
+        payload = progress_to_dict(progress)
+        dim = payload["dimensions"][0]
+        assert dim["filesCached"] == 80
+        assert dim["filesProjectTotal"] == 100

--- a/tests/test_no_bare_text_io.py
+++ b/tests/test_no_bare_text_io.py
@@ -39,12 +39,7 @@ _NON_TEXT_OPEN = (
 
 # Sites that legitimately cannot pin encoding (document the reason).
 # Format: "src-relative/path.py:LINE"
-_ALLOWLIST: set[str] = {
-    # write_text() opener on its own line; encoding="utf-8" is passed on the
-    # following continuation line. The call IS UTF-8-safe; the line-based
-    # scanner just can't see a kwarg that lives on a different physical line.
-    "analysis/_dim_estimates.py:70",
-}
+_ALLOWLIST: set[str] = set()
 
 
 def _offenders() -> list[str]:


### PR DESCRIPTION
## Summary
- Incremental scans now show **total project coverage**, not just this run's queue. The overall progress bar is segmented: a dim segment for files analyzed in previous runs, a bright segment growing with this run. Meta line reads e.g. `178 / 200 files · 89% total · this run 8 / 30 · running security`. Full scans, diff scans, and legacy runs render exactly as before (test-pinned).
- The provider · model chip moves to its own line directly under the job id (2-column grid, aligned with the id).
- Data plumbing: `dim_estimates.json` now carries per-dim `total`/`cached` (the cache-hit count was previously computed and discarded); the progress API exposes them as `filesCached`/`filesProjectTotal`; `computeOverallProgress` aggregates all-or-nothing (a single legacy dim nulls coverage rather than rendering a lie) and clamps `coveredFiles` against estimate-vs-live-queue drift.
- Refactor: sidecar IO + legacy normalisation moved to cross-cutting `quodeq/shared/dim_estimates_io.py` so `services/scan_progress.py` reads it without a new layer-rule violation; `analysis._dim_estimates` re-exports. Also hardened `read_dim_estimates` against non-UTF8 sidecars (would previously 500 the polled progress endpoint).
- Edge cases covered: fully-cached re-scan shows `nothing new this run` (not `preparing…` or `0 / 0`); tooltip on the bar explains the dim segment.

## Test Plan
- [x] `uv run pytest -q -m "not integration"`: 4025 passed (includes the import-layers baseline gate and bare-text-IO gate, no baseline bumps)
- [x] `npm run test:all`: 704 tests / 126 files passed (new: coverage aggregation, segment widths, collapse behavior, fully-cached copy, job-id grid)
- [x] Visual verification against a fabricated mid-flight incremental run served through the real stack (run index → API → dev UI): segmented bar 85% dim + 4% bright, meta line and tooltip exact, model chip under the job id, no console errors
- [ ] Optional pre-release smoke: eyeball the 0.35-opacity cached segment across themes in the native WKWebView

Spec + plan brainstormed and reviewed per-task (spec compliance + code quality, all approved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)