### PR TITLE
fix(evidence): fall back to compiled standards in unmapped-principle quarantine

### DIFF
--- a/src/quodeq/core/evidence/_req_mapping.py
+++ b/src/quodeq/core/evidence/_req_mapping.py
@@ -54,25 +54,50 @@ def _build_req_to_principle_map(dimension: str, evaluators_dir: Path | None = No
         return {}
 
 
+def _resolve_req_to_principle_map(
+    dimension: str,
+    evaluators_dir: Path | None = None,
+    compiled_dir: Path | None = None,
+) -> dict[str, str]:
+    """Resolve the requirement-to-principle map for *dimension*.
+
+    A custom evaluator standard (evaluators_dir) is authoritative when it
+    defines the dimension; otherwise fall back to the compiled built-in
+    standard (compiled_dir). On real installs the evaluators dir exists but
+    is empty for built-in dimensions, so without the fallback the map is
+    empty and standard-validation callers silently go permissive.
+    """
+    mapping = _build_req_to_principle_map(dimension, evaluators_dir)
+    if not mapping:
+        mapping = _build_req_to_principle_map(dimension, compiled_dir)
+    return mapping
+
+
 def principle_names_for_dimension(
     dimension: str, evaluators_dir: Path | None = None,
+    compiled_dir: Path | None = None,
 ) -> set[str]:
     """Return the principle names defined by *dimension*'s standard.
 
-    Empty when the standard is unavailable, so callers stay permissive (no
-    standard to validate against) rather than dropping everything. The
-    *evaluators_dir* must be supplied by the caller; the core layer does not
-    resolve paths itself.
+    Empty when no standard is available from either source, so callers stay
+    permissive (no standard to validate against) rather than dropping
+    everything. The directories must be supplied by the caller; the core
+    layer does not resolve paths itself.
     """
-    return {p for p in _build_req_to_principle_map(dimension, evaluators_dir).values() if p}
+    mapping = _resolve_req_to_principle_map(dimension, evaluators_dir, compiled_dir)
+    return {p for p in mapping.values() if p}
 
 
 def _group_judgments(
     judgments: list[Judgment],
     dimension: str = "",
     evaluators_dir: Path | None = None,
+    compiled_dir: Path | None = None,
 ) -> _GroupedJudgments:
-    req_to_principle = _build_req_to_principle_map(dimension, evaluators_dir) if dimension else {}
+    req_to_principle = (
+        _resolve_req_to_principle_map(dimension, evaluators_dir, compiled_dir)
+        if dimension else {}
+    )
     canonical = {p for p in req_to_principle.values() if p}
     sc_violations: dict[str, list[Judgment]] = {}
     sc_compliance: dict[str, list[Judgment]] = {}

--- a/src/quodeq/core/evidence/parser.py
+++ b/src/quodeq/core/evidence/parser.py
@@ -85,7 +85,8 @@ def parse_jsonl_to_evidence_by_dimension(
         return {}
     return {
         dim: _build_evidence(context, _build_principles(
-            _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir),
+            _group_judgments(dj, dimension=dim, evaluators_dir=evaluators_dir,
+                             compiled_dir=compiled_dir),
             dim, context.source_file_count))
         for dim, dj in by_dim.items()
     }
@@ -102,5 +103,6 @@ def parse_jsonl_to_evidence(
     # parse_jsonl_to_evidence_by_dimension which groups incrementally.
     judgments = read_judgments(jsonl_file, compiled_dir)
     dim = judgments[0].dimension if judgments else ""
-    grouped = _group_judgments(judgments, dimension=dim, evaluators_dir=evaluators_dir)
+    grouped = _group_judgments(judgments, dimension=dim, evaluators_dir=evaluators_dir,
+                               compiled_dir=compiled_dir)
     return _build_evidence(context, _build_principles(grouped, dim, context.source_file_count))

--- a/src/quodeq/data/fs/report_parser/_eval_parsing.py
+++ b/src/quodeq/data/fs/report_parser/_eval_parsing.py
@@ -35,7 +35,7 @@ def parse_eval_from_json(
         _logger.warning("Failed to parse evaluation %s: %s", json_path.name, exc)
         return None
 
-    canonical = principle_names_for_dimension(dimension, compiled_dir)
+    canonical = principle_names_for_dimension(dimension, compiled_dir=compiled_dir)
 
     def _in_standard(name: Any) -> bool:
         # Permissive when no standard is available (canonical empty).

--- a/tests/engine/test_evidence_parser_unmapped_principle.py
+++ b/tests/engine/test_evidence_parser_unmapped_principle.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from quodeq.core.evidence.parser import (
     EvidenceContext,
+    parse_jsonl_to_evidence,
     parse_jsonl_to_evidence_by_dimension,
 )
 
@@ -84,6 +85,117 @@ def test_unmappable_finding_is_logged(tmp_path, caplog):
         "N/A" in r.getMessage() or "unmapped" in r.getMessage().lower()
         for r in caplog.records
     )
+
+
+def test_empty_evaluators_dir_falls_back_to_compiled_standard(tmp_path, caplog):
+    """Production config: ~/.quodeq/evaluators exists but is EMPTY and the
+    built-in standard lives only in standards/compiled/<dim>.json. The
+    quarantine must fall back to the compiled standard instead of silently
+    going permissive. Regression for run 03c99d26 (quodeq 1.5.2): a phantom
+    "N/A" principle plus a principle="N/A" critical were written into
+    evaluation/maintainability.json despite the write-time guard."""
+    compiled = tmp_path / "standards" / "compiled"
+    _write_compiled_standard(compiled, "maintainability", {
+        "Modularity": ["M-MOD-1"],
+        "Testability": ["M-TST-1"],
+    })
+    evaluators = tmp_path / "evaluators"
+    evaluators.mkdir()  # exists but holds no standards — the real-install shape
+    jsonl = tmp_path / "evidence.jsonl"
+    findings = [
+        {"schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+         "req": "M-MOD-1", "file": "b.py", "line": 10, "w": "high complexity",
+         "severity": "major", "snippet": "def big(): ..."},
+        {"schema_version": 1, "d": "maintainability", "t": "violation",
+         "req": "N/A", "file": "c.py", "line": 73, "w": "arbitrary file read",
+         "severity": "critical", "snippet": "open(os.environ['X'])"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(f) for f in findings) + "\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        result = parse_jsonl_to_evidence_by_dimension(
+            jsonl, _ctx(), compiled_dir=compiled, evaluators_dir=evaluators,
+        )
+
+    maint = result["maintainability"]
+    assert "N/A" not in maint.principles
+    assert set(maint.principles.keys()) == {"Modularity"}
+    all_violations = [v for pe in maint.principles.values() for v in pe.violations]
+    assert not any(v.get("req") == "N/A" for v in all_violations)
+    assert any("Quarantining" in r.getMessage() for r in caplog.records)
+
+
+def test_single_dimension_parse_falls_back_to_compiled_standard(tmp_path):
+    """parse_jsonl_to_evidence (the per-dimension analysis path) must apply the
+    same compiled-standard fallback as the by-dimension variant."""
+    compiled = tmp_path / "standards" / "compiled"
+    _write_compiled_standard(compiled, "maintainability", {"Modularity": ["M-MOD-1"]})
+    evaluators = tmp_path / "evaluators"
+    evaluators.mkdir()
+    jsonl = tmp_path / "evidence.jsonl"
+    findings = [
+        {"schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+         "req": "M-MOD-1", "file": "b.py", "line": 10, "w": "x",
+         "severity": "major", "snippet": "y"},
+        {"schema_version": 1, "d": "maintainability", "t": "violation",
+         "req": "N/A", "file": "c.py", "line": 1, "w": "z",
+         "severity": "critical", "snippet": "w"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(f) for f in findings) + "\n", encoding="utf-8")
+
+    evidence = parse_jsonl_to_evidence(
+        jsonl, _ctx(), compiled_dir=compiled, evaluators_dir=evaluators,
+    )
+
+    assert "N/A" not in evidence.principles
+    assert set(evidence.principles.keys()) == {"Modularity"}
+
+
+def test_custom_evaluator_standard_takes_precedence_over_compiled(tmp_path):
+    """When the evaluators dir HAS a standard for the dimension, it is
+    authoritative: the compiled built-in standard is not consulted."""
+    compiled = tmp_path / "standards" / "compiled"
+    _write_compiled_standard(compiled, "maintainability", {"Modularity": ["M-MOD-1"]})
+    evaluators = tmp_path / "evaluators"
+    _write_compiled_standard(evaluators, "maintainability", {"CustomP": ["C-1"]})
+    jsonl = tmp_path / "evidence.jsonl"
+    findings = [
+        {"schema_version": 1, "p": "CustomP", "d": "maintainability", "t": "violation",
+         "req": "C-1", "file": "a.py", "line": 1, "w": "x",
+         "severity": "minor", "snippet": "y"},
+        # In the compiled standard but not the custom one -> quarantined
+        {"schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+         "req": "M-MOD-1", "file": "b.py", "line": 2, "w": "x",
+         "severity": "minor", "snippet": "y"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(f) for f in findings) + "\n", encoding="utf-8")
+
+    result = parse_jsonl_to_evidence_by_dimension(
+        jsonl, _ctx(), compiled_dir=compiled, evaluators_dir=evaluators,
+    )
+
+    assert set(result["maintainability"].principles.keys()) == {"CustomP"}
+
+
+def test_permissive_when_neither_source_has_standard(tmp_path):
+    """Both dirs supplied but neither holds a standard for the dimension:
+    the guard must stay permissive and group by the raw principle."""
+    compiled = tmp_path / "standards" / "compiled"
+    compiled.mkdir(parents=True)
+    evaluators = tmp_path / "evaluators"
+    evaluators.mkdir()
+    jsonl = tmp_path / "evidence.jsonl"
+    jsonl.write_text(json.dumps({
+        "schema_version": 1, "p": "Modularity", "d": "maintainability", "t": "violation",
+        "req": "M-MOD-1", "file": "a.py", "line": 1, "w": "x", "severity": "minor",
+        "snippet": "y",
+    }) + "\n", encoding="utf-8")
+
+    result = parse_jsonl_to_evidence_by_dimension(
+        jsonl, _ctx(), compiled_dir=compiled, evaluators_dir=evaluators,
+    )
+
+    assert set(result["maintainability"].principles.keys()) == {"Modularity"}
 
 
 def test_no_standard_keeps_all_principles(tmp_path):


### PR DESCRIPTION
## Problem

The write-time quarantine for unmappable-principle findings (#659) is silently inert in production for built-in dimensions. `_group_judgments` builds its canonical principle set only from `evaluators_dir` (`~/.quodeq/evaluators`, which exists but is empty on real installs), never from the compiled standards dir. `canonical` is therefore always empty and the permissive no-standard branch runs unconditionally.

Result: run `03c99d26` (quodeq 1.5.2, 2026-07-04, maintainability-only) again wrote a phantom "N/A" principle row plus a `principle="N/A"/req="N/A"` critical into `evaluation/maintainability.json` (`src/quodeq/api/_llamacpp_log_routes.py:73`).

The #659 tests masked the gap by passing the compiled standards dir **as** `evaluators_dir`, a config that never occurs in production.

## Fix

- `_resolve_req_to_principle_map`: custom evaluator standard is authoritative when it defines the dimension; otherwise fall back to `standards_dir/compiled/<dim>.json`. Permissive only when **neither** source has a standard.
- `parser.py` threads its existing `compiled_dir` parameter through to `_group_judgments` (all four analysis-layer call sites already pass it, so no wiring changes needed there).
- `principle_names_for_dimension` gains the same fallback; the read-side guard in `_eval_parsing.py` now passes `compiled_dir` under its proper keyword instead of the positional pun.

## Tests

- New: production config (empty evaluators dir + populated compiled dir) asserts the N/A judgment is quarantined out of principles **and** violations with a WARNING log, through both `parse_jsonl_to_evidence` and `parse_jsonl_to_evidence_by_dimension`.
- New: custom-evaluator precedence over compiled, and permissive-when-neither-source pinned.
- Real-data verification: re-parsing run `03c99d26`'s actual `maintainability_evidence.jsonl` with the bundled compiled standards + the real empty `~/.quodeq/evaluators` yields exactly the 5 canonical principles (frozen JSON has 6 incl. "N/A") and logs the quarantine WARNING for the misfiled critical.
- Full suite: 4050 passed (non-integration), import gate clean (32 grandfathered, no new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)