### PR TITLE
feat(assistant): verify-finding skill + action registry + verified badges

### DIFF
--- a/src/quodeq/api/assistant_routes.py
+++ b/src/quodeq/api/assistant_routes.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import threading
 import uuid
-from pathlib import Path
 
 from flask import Flask, Response, current_app, jsonify, request
 
@@ -20,8 +19,7 @@ from quodeq.api._sse_log_helpers import sse_line
 from quodeq.assistant import get_provider_configs
 from quodeq.assistant.orchestrator import TurnRequest, run_turn
 from quodeq.assistant.skills import RESERVED_COMMANDS, load_skills
-from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES
-from quodeq.services.standards import StandardsService
+from quodeq.assistant.tools._actions import ACTION_DESCRIPTIONS, ACTION_TYPES, ACTIONS, ActionConflict
 
 _running_turns: set[str] = set()
 _running_lock = threading.Lock()
@@ -209,27 +207,27 @@ def register_assistant_routes(app: Flask) -> None:
             return jsonify({"error": "unknown action"}), 404
         if action["status"] != "drafted":
             return jsonify({"error": f"action already {action['status']}"}), 409
-        service = StandardsService(
-            Path(current_app.config["STANDARDS_EVALUATORS_DIR"]),
-            Path(current_app.config["STANDARDS_COMPILED_DIR"]),
-            Path(current_app.config["STANDARDS_DIMENSIONS_FILE"]),
-        )
-        # StandardsService.import_from_file returns {"status": "conflict"|"imported", ...}
-        # (see src/quodeq/services/_standards_crud.py:86-105) — not a boolean "conflict"
-        # key the original plan assumed.
+        spec = ACTIONS.get(action["action_type"])
+        if spec is None:
+            return jsonify({"error": "unsupported action type"}), 400
         try:
-            result = service.import_from_file(action["payload"], force=False)
+            result = spec.apply(action["payload"], current_app)
         except ValueError as exc:
             return jsonify({"error": str(exc)}), 400
-        if result.get("status") == "conflict":
-            return jsonify({"error": "standard id already exists"}), 409
+        except ActionConflict as exc:
+            return jsonify({"error": str(exc)}), 409
         repo.set_action_status(action_id, "applied")
         return jsonify({"applied": True, "result": result}), 200
 
     @app.post("/api/assistant/actions/<action_id>/reject")
     def reject_assistant_action(action_id: str):
         repo = get_repository(app)
-        if repo.get_action(action_id) is None:
+        action = repo.get_action(action_id)
+        if action is None:
             return jsonify({"error": "unknown action"}), 404
+        # Same replay guard as apply: an applied action must not flip to
+        # rejected on a stale card click or SSE replay.
+        if action["status"] != "drafted":
+            return jsonify({"error": f"action already {action['status']}"}), 409
         repo.set_action_status(action_id, "rejected")
         return jsonify({"status": "rejected"}), 200

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -156,6 +156,31 @@ def _rescore_run(
         return None
 
 
+def rescore_with_fallback(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any] | None:
+    """Rescore the requested run, falling back to a project-wide projection.
+
+    Shared by the findings mutation routes and the assistant's
+    dismiss_finding action apply. See _rescore_run for the slim payload.
+    """
+    scores = _rescore_run(evaluations_dir, project, run_id)
+    if scores is None:
+        proj_dir = _project_dir(evaluations_dir, project)
+        lock = _get_projection_lock(project)
+
+        def _bg_project() -> None:
+            if not lock.acquire(blocking=False):
+                return
+            try:
+                _project_all_runs(proj_dir)
+            finally:
+                lock.release()
+
+        threading.Thread(target=_bg_project, daemon=True).start()
+    return scores
+
+
 def register_findings_routes(app: Flask) -> None:
     """Register /api/findings/* routes."""
 
@@ -165,36 +190,7 @@ def register_findings_routes(app: Flask) -> None:
     def _scores_with_fallback(
         project: str, run_id: str | None,
     ) -> dict[str, Any] | None:
-        """Rescore the requested run, falling back to a project-wide projection.
-
-        When the caller can't supply a usable ``run_id`` (Violations / Map
-        nav paths don't carry one today), ``_rescore_run`` returns ``None`` —
-        but the action *must* still propagate to SQL or the dismissed-tab
-        list won't see it. Project every run in the background as the
-        fallback so the entry becomes visible without blocking the response.
-
-        A per-project non-blocking lock prevents duplicate concurrent
-        projections for the same project: if one projection is already
-        running, the second caller skips rather than queueing behind it
-        (the in-flight run will already cover the latest actions).
-        """
-        evaluations_dir = _eval_dir()
-        scores = _rescore_run(evaluations_dir, project, run_id)
-        if scores is None:
-            proj_dir = _project_dir(evaluations_dir, project)
-            lock = _get_projection_lock(project)
-
-            def _bg_project() -> None:
-                if not lock.acquire(blocking=False):
-                    # Another projection for this project is already running.
-                    return
-                try:
-                    _project_all_runs(proj_dir)
-                finally:
-                    lock.release()
-
-            threading.Thread(target=_bg_project, daemon=True).start()
-        return scores
+        return rescore_with_fallback(_eval_dir(), project, run_id)
 
     @app.get("/api/findings/dismissed")
     def list_dismissed() -> Response:

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -170,6 +170,8 @@ def rescore_with_fallback(
         lock = _get_projection_lock(project)
 
         def _bg_project() -> None:
+            # Non-blocking acquire on purpose: skip rather than queue.
+            # An in-flight projection already covers the latest actions.
             if not lock.acquire(blocking=False):
                 return
             try:

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -11,7 +11,6 @@ sessions that ended in PRs #525-#528.)
 from __future__ import annotations
 
 import logging
-import threading
 from pathlib import Path
 from typing import Any
 
@@ -19,34 +18,13 @@ from flask import Flask, Response, abort, jsonify, request
 
 from quodeq.services.deleted import delete_all_dismissed, delete_finding
 from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
+from quodeq.services.mutation_rescore import rescore_with_fallback
 from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
 _MAX_DISMISSED_LIMIT = 5000
-
-# Per-project locks for background projection.  A module-level guard lock
-# protects creation of per-project entries; after creation each project's Lock
-# is accessed without the guard.
-#
-# Intentionally unbounded: one tiny Lock object per distinct project name that
-# has ever triggered a background projection on this host.  In practice this
-# mirrors the number of projects on disk, which is small and naturally bounded
-# by real usage.  Contrast with _scored_jobs (bounded LRU) — scored jobs can
-# accumulate many run-ids per project, so a size cap there is meaningful;
-# here there is one entry per project, not per run.
-_projection_locks: dict[str, threading.Lock] = {}
-_projection_locks_guard = threading.Lock()
-
-
-def _get_projection_lock(project: str) -> threading.Lock:
-    """Return (and lazily create) the Lock for *project*."""
-    with _projection_locks_guard:
-        if project not in _projection_locks:
-            _projection_locks[project] = threading.Lock()
-        return _projection_locks[project]
-
 
 def _project_dir(evaluations_dir: str, project: str) -> Path:
     validate_path_segment(project)
@@ -55,132 +33,6 @@ def _project_dir(evaluations_dir: str, project: str) -> Path:
     if not resolved.is_relative_to(base):
         abort(400, description="Invalid project path")
     return resolved
-
-
-def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
-    """Drop violation/compliance arrays from the rescored payload.
-
-    The UI's dismiss handlers (PrincipleDetail, FileDetail, FindingDetail)
-    only need the per-dimension and per-principle ``score`` / ``grade``
-    fields to update local state. Returning the full payload meant 300+ KB
-    on large projects (quodeq: 322 KB → 543 B after slimming, a 600× cut),
-    which was the bulk of the perceived dismiss latency: parse + transfer +
-    re-render against violations the page already has from its initial fetch.
-    """
-    if not scores:
-        return scores
-    slim_dims = []
-    for dim in scores.get("dimensions", []) or []:
-        slim_principles = [
-            {
-                "principle": p.get("principle"),
-                "score": p.get("score"),
-                "grade": p.get("grade"),
-            }
-            for p in (dim.get("principles") or [])
-        ]
-        slim_dims.append({
-            "dimension": dim.get("dimension"),
-            "overallScore": dim.get("overallScore"),
-            "overallGrade": dim.get("overallGrade"),
-            "principles": slim_principles,
-        })
-    return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
-
-
-def _project_all_runs(project_dir: Path) -> None:
-    """Trigger projection across every run dir of the project.
-
-    Used as a safety net when the dismiss POST didn't carry a usable
-    ``run_id`` (callers from the Violations / Map pages don't always have
-    one in hand). Without this, the action lands in ``actions.jsonl`` but
-    no run's SQL ``findings`` table is updated, so the dismissed-tab list
-    — which reads ``WHERE verdict = 'dismissed'`` from each run's
-    evaluation.db — stays empty until the user navigates somewhere that
-    happens to trigger projection for the right run.
-
-    Projection is incremental (gated by checkpoint + log-size), so this is
-    cheap in steady state; the first call after a fresh dismiss replays only
-    the actions-log delta.
-    """
-    if not project_dir.is_dir():
-        return
-    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
-
-    for run_dir in project_dir.iterdir():
-        if not run_dir.is_dir():
-            continue
-        if not (run_dir / "events.jsonl").is_file():
-            continue
-        try:
-            SqliteFindingsRepository(run_dir)._ensure_fresh()  # noqa: SLF001
-        except Exception:
-            _logger.warning("Projection after mutation failed for %s", run_dir, exc_info=True)
-
-
-def _rescore_run(
-    evaluations_dir: str, project: str, run_id: str | None,
-) -> dict[str, Any] | None:
-    """Compute the slim rescored payload for the run referenced in a mutation body.
-
-    Returns ``None`` when ``run_id`` is missing or the run directory cannot
-    be resolved. When it returns ``None``, the caller also calls
-    ``_project_all_runs`` so the action still lands in SQL — otherwise the
-    dismissed-tab list (which reads ``WHERE verdict='dismissed'`` from each
-    run's evaluation.db) wouldn't see the entry until the user happened to
-    trigger projection some other way.
-
-    The payload omits per-finding arrays since dismiss handlers only need
-    score/grade fields — see ``_slim_scores`` for the rationale. Callers
-    fold the result into the response body so the UI can apply the new
-    scores without a follow-up GET.
-    """
-    if not run_id:
-        return None
-    try:
-        validate_path_segment(run_id)
-    except ValueError:
-        return None
-    from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
-
-    reports_root = Path(evaluations_dir).resolve()
-    try:
-        return _slim_scores(get_scores_raw(reports_root, project, run_id))
-    except FileNotFoundError:
-        return None
-    except Exception:
-        # Never let a rescore failure break the mutation — the dismiss is
-        # already persisted in actions.jsonl. Log and return None so the
-        # client falls back to a refetch.
-        _logger.warning("Rescore after mutation failed for %s/%s", project, run_id, exc_info=True)
-        return None
-
-
-def rescore_with_fallback(
-    evaluations_dir: str, project: str, run_id: str | None,
-) -> dict[str, Any] | None:
-    """Rescore the requested run, falling back to a project-wide projection.
-
-    Shared by the findings mutation routes and the assistant's
-    dismiss_finding action apply. See _rescore_run for the slim payload.
-    """
-    scores = _rescore_run(evaluations_dir, project, run_id)
-    if scores is None:
-        proj_dir = _project_dir(evaluations_dir, project)
-        lock = _get_projection_lock(project)
-
-        def _bg_project() -> None:
-            # Non-blocking acquire on purpose: skip rather than queue.
-            # An in-flight projection already covers the latest actions.
-            if not lock.acquire(blocking=False):
-                return
-            try:
-                _project_all_runs(proj_dir)
-            finally:
-                lock.release()
-
-        threading.Thread(target=_bg_project, daemon=True).start()
-    return scores
 
 
 def register_findings_routes(app: Flask) -> None:

--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -19,6 +19,7 @@ from flask import Flask, Response, abort, jsonify, request
 
 from quodeq.services.deleted import delete_all_dismissed, delete_finding
 from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
+from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
 
@@ -275,3 +276,22 @@ def register_findings_routes(app: Flask) -> None:
         count = delete_all_dismissed(_project_dir(_eval_dir(), project))
         scores = _scores_with_fallback(project, run_id)
         return jsonify({"ok": True, "deleted": count, "scores": scores}), 200
+
+    @app.get("/api/findings/verified")
+    def list_verified() -> Response:
+        project = request.args.get("project", "")
+        if not project:
+            return jsonify([])
+        return jsonify(verified_entries(_project_dir(_eval_dir(), project)))
+
+    @app.post("/api/findings/unverify")
+    def unverify() -> tuple[Response, int]:
+        body = request.get_json(silent=True) or {}
+        project = body.get("project", "")
+        req = body.get("req", "")
+        file = body.get("file", "")
+        line = body.get("line")
+        if not project or not req or not file or line is None:
+            return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
+        unverify_finding(_project_dir(_eval_dir(), project), body)
+        return jsonify({"ok": True}), 200

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -14,7 +14,7 @@ from quodeq.assistant.adapters._fallback import (
     FALLBACK_CONTRACT,
     extract_prompted_tool_call,
 )
-from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS, guard_tool_result
+from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, guard_tool_result
 from quodeq.assistant.tools._registry import ToolRegistry
 
 _logger = logging.getLogger(__name__)

--- a/src/quodeq/assistant/adapters/_api.py
+++ b/src/quodeq/assistant/adapters/_api.py
@@ -14,7 +14,7 @@ from quodeq.assistant.adapters._fallback import (
     FALLBACK_CONTRACT,
     extract_prompted_tool_call,
 )
-from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, guard_tool_result
+from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS, guard_tool_result
 from quodeq.assistant.tools._registry import ToolRegistry
 
 _logger = logging.getLogger(__name__)
@@ -51,6 +51,7 @@ class ApiTurnConfig:
     api_key: str | None
     model: str
     native_tools: bool
+    max_tool_iterations: int = MAX_TOOL_ITERATIONS
 
 
 def _default_client(config: ApiTurnConfig):
@@ -102,7 +103,7 @@ def run_api_turn(*, messages: list[dict], config: ApiTurnConfig,
     factory = client_factory or _default_client
     text = ""
     with factory(config) as client:
-        for _ in range(MAX_TOOL_ITERATIONS):
+        for _ in range(config.max_tool_iterations):
             text, tool_calls = _stream_once(client, config, convo, registry, emit)
             if not config.native_tools:
                 prompted = extract_prompted_tool_call(text)

--- a/src/quodeq/assistant/guard.py
+++ b/src/quodeq/assistant/guard.py
@@ -7,6 +7,9 @@ import secrets
 from quodeq.services.import_validator import scan_text
 
 MAX_TOOL_ITERATIONS = 6
+# Skill turns legitimately chain search -> standard -> code -> draft; give
+# them headroom without raising the default for free-form turns.
+SKILL_MAX_TOOL_ITERATIONS = 12
 MAX_TOOL_RESULT_CHARS = 16_000
 
 _PREAMBLE = (

--- a/src/quodeq/assistant/orchestrator.py
+++ b/src/quodeq/assistant/orchestrator.py
@@ -7,9 +7,9 @@ from dataclasses import dataclass
 from quodeq.assistant import get_provider_configs
 from quodeq.assistant._context import build_system_prompt, build_turn_message
 from quodeq.assistant.adapters._api import ApiTurnConfig, run_api_turn
-from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS
 from quodeq.assistant.adapters._capabilities import supports_native_tools
 from quodeq.assistant.adapters._cli import CliTurnConfig, run_cli_turn
+from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS
 from quodeq.assistant.skills import load_skills
 from quodeq.assistant.tools import ToolContext, build_registry, register_web_tools
 from quodeq.data.sqlite.assistant_repository import AssistantRepository

--- a/src/quodeq/assistant/orchestrator.py
+++ b/src/quodeq/assistant/orchestrator.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from quodeq.assistant import get_provider_configs
 from quodeq.assistant._context import build_system_prompt, build_turn_message
 from quodeq.assistant.adapters._api import ApiTurnConfig, run_api_turn
+from quodeq.assistant.guard import MAX_TOOL_ITERATIONS, SKILL_MAX_TOOL_ITERATIONS
 from quodeq.assistant.adapters._capabilities import supports_native_tools
 from quodeq.assistant.adapters._cli import CliTurnConfig, run_cli_turn
 from quodeq.assistant.skills import load_skills
@@ -107,6 +108,8 @@ def run_turn(request: TurnRequest, *, repository: AssistantRepository,
                 model=request.model,
                 native_tools=capability_fn(request.provider, request.api_base,
                                            request.model),
+                max_tool_iterations=(SKILL_MAX_TOOL_ITERATIONS if skill is not None
+                                     else MAX_TOOL_ITERATIONS),
             )
             registry = build_registry(tool_ctx)
             if web_tools_on:

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -13,6 +13,7 @@ from flask import Flask
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
 from quodeq.services.import_validator import validate_import
+from quodeq.shared.validation import validate_path_segment
 
 
 class ActionConflict(Exception):
@@ -60,10 +61,14 @@ def _canonical_finding_key(payload: dict, ctx: ToolContext) -> dict:
     req = str(payload.get("req") or "").strip()
     file = str(payload.get("file") or "").strip()
     line = payload.get("line")
-    if not req or not file or not isinstance(line, int) or line < 0:
+    if not req or not file or not isinstance(line, int) or isinstance(line, bool) or line < 0:
         raise ToolError("req, file, and a non-negative integer line are required")
     if not ctx.project_id:
         raise ToolError("no project attached to this session")
+    try:
+        validate_path_segment(ctx.project_id)
+    except ValueError:
+        raise ToolError("invalid project attached to this session")
     # The project always comes from the session, never from the model.
     canonical = {"project": ctx.project_id, "req": req, "file": file, "line": line}
     if ctx.run_dir is not None:
@@ -90,6 +95,7 @@ def _apply_dismiss_finding(payload: dict, app: Flask) -> dict:
     from quodeq.services.dismissed import dismiss_finding  # noqa: PLC0415
     from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
 
+    validate_path_segment(payload["project"])
     evaluations_dir = app.config.get("EVALUATIONS_DIR") or get_evaluations_dir()
     project_dir = Path(evaluations_dir) / payload["project"]
     dismiss_finding(project_dir, {
@@ -118,6 +124,7 @@ def _apply_verify_finding(payload: dict, app: Flask) -> dict:
     from quodeq.services.verified import verify_finding  # noqa: PLC0415
     from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
 
+    validate_path_segment(payload["project"])
     evaluations_dir = app.config.get("EVALUATIONS_DIR") or get_evaluations_dir()
     verify_finding(Path(evaluations_dir) / payload["project"], payload)
     return {"verified": True}

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -56,6 +56,73 @@ def _apply_create_standard(payload: dict, app: Flask) -> dict:
     return result
 
 
+def _canonical_finding_key(payload: dict, ctx: ToolContext) -> dict:
+    req = str(payload.get("req") or "").strip()
+    file = str(payload.get("file") or "").strip()
+    line = payload.get("line")
+    if not req or not file or not isinstance(line, int) or line < 0:
+        raise ToolError("req, file, and a non-negative integer line are required")
+    if not ctx.project_id:
+        raise ToolError("no project attached to this session")
+    # The project always comes from the session, never from the model.
+    canonical = {"project": ctx.project_id, "req": req, "file": file, "line": line}
+    if ctx.run_dir is not None:
+        canonical["runId"] = ctx.run_dir.name
+    return canonical
+
+
+def _validate_dismiss_finding(payload: dict, ctx: ToolContext) -> dict:
+    canonical = _canonical_finding_key(payload, ctx)
+    reason = str(payload.get("reason") or "").strip()
+    if not reason:
+        raise ToolError("a dismissal reason is required")
+    canonical["reason"] = reason
+    return canonical
+
+
+def _summarize_dismiss_finding(canonical: dict) -> dict:
+    return {"req": canonical["req"], "file": canonical["file"],
+            "line": canonical["line"], "reason": canonical["reason"]}
+
+
+def _apply_dismiss_finding(payload: dict, app: Flask) -> dict:
+    from quodeq.api.routes_findings import rescore_with_fallback  # noqa: PLC0415
+    from quodeq.services.dismissed import dismiss_finding  # noqa: PLC0415
+    from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
+
+    evaluations_dir = app.config.get("EVALUATIONS_DIR") or get_evaluations_dir()
+    project_dir = Path(evaluations_dir) / payload["project"]
+    dismiss_finding(project_dir, {
+        "req": payload["req"], "file": payload["file"], "line": payload["line"],
+        "dismissReason": payload["reason"],
+    })
+    scores = rescore_with_fallback(evaluations_dir, payload["project"], payload.get("runId"))
+    return {"dismissed": True, "scores": scores}
+
+
+def _validate_verify_finding(payload: dict, ctx: ToolContext) -> dict:
+    canonical = _canonical_finding_key(payload, ctx)
+    note = str(payload.get("note") or "").strip()
+    if not note:
+        raise ToolError("a one-line note explaining why the finding is real is required")
+    canonical["note"] = note
+    return canonical
+
+
+def _summarize_verify_finding(canonical: dict) -> dict:
+    return {"req": canonical["req"], "file": canonical["file"],
+            "line": canonical["line"], "note": canonical["note"]}
+
+
+def _apply_verify_finding(payload: dict, app: Flask) -> dict:
+    from quodeq.services.verified import verify_finding  # noqa: PLC0415
+    from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
+
+    evaluations_dir = app.config.get("EVALUATIONS_DIR") or get_evaluations_dir()
+    verify_finding(Path(evaluations_dir) / payload["project"], payload)
+    return {"verified": True}
+
+
 ACTIONS: dict[str, ActionSpec] = {
     "create_standard": ActionSpec(
         action_type="create_standard",
@@ -63,6 +130,20 @@ ACTIONS: dict[str, ActionSpec] = {
         validate=_validate_create_standard,
         summarize=_summarize_create_standard,
         apply=_apply_create_standard,
+    ),
+    "dismiss_finding": ActionSpec(
+        action_type="dismiss_finding",
+        description="Dismiss a finding as a false positive, with a reason. Applied only after you approve the preview card; scores are recomputed.",
+        validate=_validate_dismiss_finding,
+        summarize=_summarize_dismiss_finding,
+        apply=_apply_dismiss_finding,
+    ),
+    "verify_finding": ActionSpec(
+        action_type="verify_finding",
+        description="Mark a finding as human-verified real, with a short note. Adds a badge on the violations screen; scores are unchanged.",
+        validate=_validate_verify_finding,
+        summarize=_summarize_verify_finding,
+        apply=_apply_verify_finding,
     ),
 }
 
@@ -96,7 +177,9 @@ def register_action_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
         "draft_action",
         "Draft an action for the user to review and apply. The draft is shown "
         "to the user as a preview card; nothing is written until they approve. "
-        "Payloads by type: create_standard takes a full standard JSON.",
+        "Payloads by type: create_standard takes a full standard JSON; "
+        "dismiss_finding takes {req, file, line, reason}; "
+        "verify_finding takes {req, file, line, note}.",
         {"type": "object", "properties": {
             "action_type": {"type": "string", "enum": sorted(ACTION_TYPES)},
             "payload": {"type": "object"},

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -91,7 +91,7 @@ def _summarize_dismiss_finding(canonical: dict) -> dict:
 
 
 def _apply_dismiss_finding(payload: dict, app: Flask) -> dict:
-    from quodeq.api.routes_findings import rescore_with_fallback  # noqa: PLC0415
+    from quodeq.services.mutation_rescore import rescore_with_fallback  # noqa: PLC0415
     from quodeq.services.dismissed import dismiss_finding  # noqa: PLC0415
     from quodeq.shared._env import get_evaluations_dir  # noqa: PLC0415
 

--- a/src/quodeq/assistant/tools/_actions.py
+++ b/src/quodeq/assistant/tools/_actions.py
@@ -1,28 +1,81 @@
-"""draft_action: the model's only write primitive — server-canonical drafts."""
+"""draft_action: the model's only write primitive, server-canonical drafts."""
 from __future__ import annotations
 
 import hashlib
 import json
 import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from flask import Flask
 
 from quodeq.assistant.tools._context import ToolContext
 from quodeq.assistant.tools._registry import ToolError, ToolRegistry, ToolSpec
 from quodeq.services.import_validator import validate_import
 
-ACTION_TYPES = frozenset({"create_standard"})
 
-ACTION_DESCRIPTIONS = {
-    "create_standard": "Draft a new custom standard. Applied only after you approve the preview card.",
-}
+class ActionConflict(Exception):
+    """Apply-time domain conflict; the endpoint maps it to HTTP 409."""
 
 
-def _draft_action(ctx: ToolContext, action_type: str, payload: dict) -> dict:
-    if action_type not in ACTION_TYPES:
-        raise ToolError(f"unsupported action type: {action_type}")
+@dataclass(frozen=True)
+class ActionSpec:
+    action_type: str
+    description: str
+    validate: Callable[[dict, ToolContext], dict]  # raises ToolError / returns canonical payload
+    summarize: Callable[[dict], dict]              # server-canonical card summary fields
+    apply: Callable[[dict, Flask], dict]           # executes on user approval
+
+
+def _validate_create_standard(payload: dict, ctx: ToolContext) -> dict:
     verdict = validate_import(payload)
     if not verdict["valid"]:
         raise ToolError("invalid standard payload: " + "; ".join(verdict["errors"]))
-    canonical = verdict["data"]
+    return verdict["data"]
+
+
+def _summarize_create_standard(canonical: dict) -> dict:
+    return {
+        "id": canonical.get("id"), "name": canonical.get("name"),
+        "principleCount": len(canonical.get("principles", [])),
+    }
+
+
+def _apply_create_standard(payload: dict, app: Flask) -> dict:
+    from quodeq.services.standards import StandardsService  # noqa: PLC0415
+
+    service = StandardsService(
+        Path(app.config["STANDARDS_EVALUATORS_DIR"]),
+        Path(app.config["STANDARDS_COMPILED_DIR"]),
+        Path(app.config["STANDARDS_DIMENSIONS_FILE"]),
+    )
+    result = service.import_from_file(payload, force=False)
+    if result.get("status") == "conflict":
+        raise ActionConflict("standard id already exists")
+    return result
+
+
+ACTIONS: dict[str, ActionSpec] = {
+    "create_standard": ActionSpec(
+        action_type="create_standard",
+        description="Draft a new custom standard. Applied only after you approve the preview card.",
+        validate=_validate_create_standard,
+        summarize=_summarize_create_standard,
+        apply=_apply_create_standard,
+    ),
+}
+
+# Derived views kept for the catalog route and existing imports.
+ACTION_TYPES = frozenset(ACTIONS)
+ACTION_DESCRIPTIONS = {t: s.description for t, s in ACTIONS.items()}
+
+
+def _draft_action(ctx: ToolContext, action_type: str, payload: dict) -> dict:
+    spec = ACTIONS.get(action_type)
+    if spec is None:
+        raise ToolError(f"unsupported action type: {action_type}")
+    canonical = spec.validate(payload, ctx)
     action_id = uuid.uuid4().hex
     content_hash = hashlib.sha256(
         json.dumps(canonical, sort_keys=True).encode("utf-8")
@@ -33,10 +86,7 @@ def _draft_action(ctx: ToolContext, action_type: str, payload: dict) -> dict:
     )
     ctx.repository.append_event(ctx.session_id, {
         "type": "action_draft", "actionId": action_id, "actionType": action_type,
-        "summary": {
-            "id": canonical.get("id"), "name": canonical.get("name"),
-            "principleCount": len(canonical.get("principles", [])),
-        },
+        "summary": spec.summarize(canonical),
     })
     return {"action_id": action_id, "status": "drafted", "action_type": action_type}
 
@@ -45,7 +95,8 @@ def register_action_tools(registry: ToolRegistry, ctx: ToolContext) -> None:
     registry.register(ToolSpec(
         "draft_action",
         "Draft an action for the user to review and apply. The draft is shown "
-        "to the user as a preview card; nothing is written until they approve.",
+        "to the user as a preview card; nothing is written until they approve. "
+        "Payloads by type: create_standard takes a full standard JSON.",
         {"type": "object", "properties": {
             "action_type": {"type": "string", "enum": sorted(ACTION_TYPES)},
             "payload": {"type": "object"},

--- a/src/quodeq/core/events/models.py
+++ b/src/quodeq/core/events/models.py
@@ -22,6 +22,8 @@ class EventType(str, Enum):
     DIMENSION_FAILED = "DIMENSION_FAILED"
     FINDING_DISMISSED = "FINDING_DISMISSED"
     FINDING_UNDISMISSED = "FINDING_UNDISMISSED"
+    FINDING_VERIFIED = "FINDING_VERIFIED"
+    FINDING_UNVERIFIED = "FINDING_UNVERIFIED"
 
 
 class BaseEvent(BaseModel, Generic[T]):
@@ -137,10 +139,39 @@ class FindingUndismissedEvent(BaseEvent[FindingUndismissed]):
     event_type: EventType = EventType.FINDING_UNDISMISSED
 
 
+class FindingVerified(BaseModel):
+    """User confirmed a finding is a real defect, identified by (req, file, line)."""
+    model_config = ConfigDict(frozen=True)
+
+    req: str
+    file: str
+    line: int
+    note: Optional[str] = None
+
+
+class FindingUnverified(BaseModel):
+    """User cleared a previously verified badge."""
+    model_config = ConfigDict(frozen=True)
+
+    req: str
+    file: str
+    line: int
+
+
+class FindingVerifiedEvent(BaseEvent[FindingVerified]):
+    event_type: EventType = EventType.FINDING_VERIFIED
+
+
+class FindingUnverifiedEvent(BaseEvent[FindingUnverified]):
+    event_type: EventType = EventType.FINDING_UNVERIFIED
+
+
 # Mapping to allow the Reader to resolve the correct model for validation
 # This is crucial for correct payload parsing
 EVENT_MODEL_MAP: Dict[EventType, type[BaseEvent]] = {
     EventType.JUDGMENT_CREATED: JudgmentCreatedEvent,
     EventType.FINDING_DISMISSED: FindingDismissedEvent,
     EventType.FINDING_UNDISMISSED: FindingUndismissedEvent,
+    EventType.FINDING_VERIFIED: FindingVerifiedEvent,
+    EventType.FINDING_UNVERIFIED: FindingUnverifiedEvent,
 }

--- a/src/quodeq/data/assistant/skills/verify-finding.md
+++ b/src/quodeq/data/assistant/skills/verify-finding.md
@@ -1,0 +1,22 @@
+---
+name: verify-finding
+description: Adversarially verify a finding, then dismiss it or mark it verified
+argument_hint: [file:line or search terms]
+views: violations
+---
+The user wants to know whether one finding (usually the one selected in
+`[ui-state]`) is a real defect or a false positive. Work in this order:
+1. Locate the finding: `search_findings` when a run is selected, otherwise
+   `get_violations` for the dimension in `[ui-state]`.
+2. Read the requirement text with `get_standard` so you judge against what the
+   standard actually demands, not the finding's own summary.
+3. Read the cited code with `read_repo_file`, plus any related file (imports,
+   callers) when the verdict hinges on behavior elsewhere.
+4. Argue adversarially: try to refute the finding before accepting it. State
+   REAL or FALSE POSITIVE with a confidence (high, medium, low) and the
+   decisive evidence.
+5. Draft exactly one action with `draft_action`: FALSE POSITIVE ->
+   `dismiss_finding` with your reasoning as the reason; REAL ->
+   `verify_finding` with a one-line note. The user approves or rejects the
+   card; never claim the action was applied.
+Keep the reply under ~250 words and quote at most a few lines of code.

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -1,0 +1,180 @@
+"""Rescore-after-mutation helpers, shared by API routes and assistant actions.
+
+Moved out of ``api/routes_findings.py`` so the assistant's dismiss action can
+reuse ``rescore_with_fallback`` without an assistant -> api layer import.
+Behavior is unchanged: rescore the referenced run when possible, otherwise
+kick a background projection so the mutation still lands in SQL. Distinct
+from ``services/rescore.py``, which is the in-memory grade recompute engine.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from quodeq.shared.validation import validate_path_segment
+
+_logger = logging.getLogger(__name__)
+
+# Per-project locks for background projection.  A module-level guard lock
+# protects creation of per-project entries; after creation each project's Lock
+# is accessed without the guard.
+#
+# Intentionally unbounded: one tiny Lock object per distinct project name that
+# has ever triggered a background projection on this host.  In practice this
+# mirrors the number of projects on disk, which is small and naturally bounded
+# by real usage.  Contrast with _scored_jobs (bounded LRU) — scored jobs can
+# accumulate many run-ids per project, so a size cap there is meaningful;
+# here there is one entry per project, not per run.
+_projection_locks: dict[str, threading.Lock] = {}
+_projection_locks_guard = threading.Lock()
+
+
+def _get_projection_lock(project: str) -> threading.Lock:
+    """Return (and lazily create) the Lock for *project*."""
+    with _projection_locks_guard:
+        if project not in _projection_locks:
+            _projection_locks[project] = threading.Lock()
+        return _projection_locks[project]
+
+
+def _resolve_project_dir(evaluations_dir: str, project: str) -> Path:
+    """Jailed project-dir resolution; raises ValueError on escape attempts.
+
+    The api layer's ``_project_dir`` does the same with a Flask ``abort``;
+    this service-layer twin raises so non-HTTP callers can map the error
+    themselves.
+    """
+    validate_path_segment(project)
+    base = Path(evaluations_dir).resolve()
+    resolved = (base / project).resolve()
+    if not resolved.is_relative_to(base):
+        raise ValueError("Invalid project path")
+    return resolved
+
+
+def _slim_scores(scores: dict[str, Any]) -> dict[str, Any]:
+    """Drop violation/compliance arrays from the rescored payload.
+
+    The UI's dismiss handlers (PrincipleDetail, FileDetail, FindingDetail)
+    only need the per-dimension and per-principle ``score`` / ``grade``
+    fields to update local state. Returning the full payload meant 300+ KB
+    on large projects (quodeq: 322 KB → 543 B after slimming, a 600× cut),
+    which was the bulk of the perceived dismiss latency: parse + transfer +
+    re-render against violations the page already has from its initial fetch.
+    """
+    if not scores:
+        return scores
+    slim_dims = []
+    for dim in scores.get("dimensions", []) or []:
+        slim_principles = [
+            {
+                "principle": p.get("principle"),
+                "score": p.get("score"),
+                "grade": p.get("grade"),
+            }
+            for p in (dim.get("principles") or [])
+        ]
+        slim_dims.append({
+            "dimension": dim.get("dimension"),
+            "overallScore": dim.get("overallScore"),
+            "overallGrade": dim.get("overallGrade"),
+            "principles": slim_principles,
+        })
+    return {"dimensions": slim_dims, "summary": scores.get("summary", {})}
+
+
+def _project_all_runs(project_dir: Path) -> None:
+    """Trigger projection across every run dir of the project.
+
+    Used as a safety net when the dismiss POST didn't carry a usable
+    ``run_id`` (callers from the Violations / Map pages don't always have
+    one in hand). Without this, the action lands in ``actions.jsonl`` but
+    no run's SQL ``findings`` table is updated, so the dismissed-tab list
+    — which reads ``WHERE verdict = 'dismissed'`` from each run's
+    evaluation.db — stays empty until the user navigates somewhere that
+    happens to trigger projection for the right run.
+
+    Projection is incremental (gated by checkpoint + log-size), so this is
+    cheap in steady state; the first call after a fresh dismiss replays only
+    the actions-log delta.
+    """
+    if not project_dir.is_dir():
+        return
+    from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository  # noqa: PLC0415
+
+    for run_dir in project_dir.iterdir():
+        if not run_dir.is_dir():
+            continue
+        if not (run_dir / "events.jsonl").is_file():
+            continue
+        try:
+            SqliteFindingsRepository(run_dir)._ensure_fresh()  # noqa: SLF001
+        except Exception:
+            _logger.warning("Projection after mutation failed for %s", run_dir, exc_info=True)
+
+
+def _rescore_run(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any] | None:
+    """Compute the slim rescored payload for the run referenced in a mutation body.
+
+    Returns ``None`` when ``run_id`` is missing or the run directory cannot
+    be resolved. When it returns ``None``, the caller also calls
+    ``_project_all_runs`` so the action still lands in SQL — otherwise the
+    dismissed-tab list (which reads ``WHERE verdict='dismissed'`` from each
+    run's evaluation.db) wouldn't see the entry until the user happened to
+    trigger projection some other way.
+
+    The payload omits per-finding arrays since dismiss handlers only need
+    score/grade fields — see ``_slim_scores`` for the rationale. Callers
+    fold the result into the response body so the UI can apply the new
+    scores without a follow-up GET.
+    """
+    if not run_id:
+        return None
+    try:
+        validate_path_segment(run_id)
+    except ValueError:
+        return None
+    from quodeq.services.scoring import get_scores_raw  # noqa: PLC0415
+
+    reports_root = Path(evaluations_dir).resolve()
+    try:
+        return _slim_scores(get_scores_raw(reports_root, project, run_id))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        # Never let a rescore failure break the mutation — the dismiss is
+        # already persisted in actions.jsonl. Log and return None so the
+        # client falls back to a refetch.
+        _logger.warning("Rescore after mutation failed for %s/%s", project, run_id, exc_info=True)
+        return None
+
+
+def rescore_with_fallback(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any] | None:
+    """Rescore the requested run, falling back to a project-wide projection.
+
+    Shared by the findings mutation routes and the assistant's
+    dismiss_finding action apply. See _rescore_run for the slim payload.
+    """
+    scores = _rescore_run(evaluations_dir, project, run_id)
+    if scores is None:
+        proj_dir = _resolve_project_dir(evaluations_dir, project)
+        lock = _get_projection_lock(project)
+
+        def _bg_project() -> None:
+            # Non-blocking acquire on purpose: skip rather than queue.
+            # An in-flight projection already covers the latest actions.
+            if not lock.acquire(blocking=False):
+                return
+            try:
+                _project_all_runs(proj_dir)
+            finally:
+                lock.release()
+
+        threading.Thread(target=_bg_project, daemon=True).start()
+    return scores

--- a/src/quodeq/services/verified.py
+++ b/src/quodeq/services/verified.py
@@ -1,0 +1,60 @@
+"""Persistent 'verified' badges for findings, project-level actions.jsonl.
+
+Mirrors services/dismissed.py: verify_finding()/unverify_finding() append
+events; verified_entries() replays the log into the net set. Badges never
+affect scores; they record that a human approved the assistant's
+real-defect verdict for a finding keyed by (req, file, line).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from quodeq.core.events.models import (
+    EventType,
+    FindingUnverified,
+    FindingUnverifiedEvent,
+    FindingVerified,
+    FindingVerifiedEvent,
+)
+from quodeq.data.actions_log import ActionLogWriter, read_action_events
+
+
+def verify_finding(project_dir: Path, finding: dict) -> None:
+    """Append a FindingVerified event to project_dir/actions.jsonl."""
+    payload = FindingVerified(
+        req=str(finding.get("req", "")),
+        file=str(finding.get("file", "")),
+        line=int(finding.get("line", 0)),
+        note=finding.get("note"),
+    )
+    ActionLogWriter(project_dir).emit(FindingVerifiedEvent(payload=payload))
+
+
+def unverify_finding(project_dir: Path, finding: dict) -> None:
+    """Append a FindingUnverified event to project_dir/actions.jsonl."""
+    payload = FindingUnverified(
+        req=str(finding.get("req", "")),
+        file=str(finding.get("file", "")),
+        line=int(finding.get("line", 0)),
+    )
+    ActionLogWriter(project_dir).emit(FindingUnverifiedEvent(payload=payload))
+
+
+def verified_entries(project_dir: Path) -> list[dict]:
+    """Net verified badges: replay of VERIFIED/UNVERIFIED events in order."""
+    if not project_dir.is_dir():
+        return []
+    entries: dict[tuple, dict] = {}
+    for event in read_action_events(project_dir):
+        if event.event_type == EventType.FINDING_VERIFIED:
+            p = event.payload
+            key = (str(p.req or ""), str(p.file or ""), int(p.line or 0))
+            entries[key] = {
+                "req": key[0], "file": key[1], "line": key[2],
+                "note": p.note or "",
+                "verifiedAt": event.timestamp.isoformat(),
+            }
+        elif event.event_type == EventType.FINDING_UNVERIFIED:
+            p = event.payload
+            entries.pop((str(p.req or ""), str(p.file or ""), int(p.line or 0)), None)
+    return list(entries.values())

--- a/src/quodeq/services/verified.py
+++ b/src/quodeq/services/verified.py
@@ -51,6 +51,8 @@ def verified_entries(project_dir: Path) -> list[dict]:
             key = (str(p.req or ""), str(p.file or ""), int(p.line or 0))
             entries[key] = {
                 "req": key[0], "file": key[1], "line": key[2],
+                # note is always a string in entries; absent notes normalize
+                # to "" so JSON and UI consumers never see null.
                 "note": p.note or "",
                 "verifiedAt": event.timestamp.isoformat(),
             }

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -33,6 +33,7 @@ import { buildProjectRootFile } from './utils/explorerUtils.js';
 import { filterTrendByVisibleStandards, filterAccumulatedByVisibleStandards } from './utils/scoreFiltering.js';
 import { syncNativeTitlebar } from './utils/nativeTitlebar.js';
 import { SidePane, useSidePane } from './features/side-pane/index.js';
+import { VerifiedFindingsProvider } from './features/violations/components/verifiedFindingsContext.jsx';
 import { BottomDrawer } from './features/drawer/BottomDrawer.jsx';
 import { useAssistantDrawer } from './features/assistant/AssistantDrawerProvider.jsx';
 import { useAssistantProvider } from './features/settings/hooks/useAssistantProvider.js';
@@ -640,6 +641,7 @@ export default function App() {
         <ServerLogProvider>
           <OllamaLogProvider>
             <LlamaCppLogProvider>
+              <VerifiedFindingsProvider project={state.selectedProject}>
               <AppShell
           drawer={<BottomDrawer uiState={assistantCtx.uiState} />}
           sidebar={
@@ -721,6 +723,7 @@ export default function App() {
             </Suspense>
           }
             />
+              </VerifiedFindingsProvider>
             </LlamaCppLogProvider>
           </OllamaLogProvider>
         </ServerLogProvider>

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -444,6 +444,13 @@ export default function App() {
   // fetched once on mount.
   const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
+  useEffect(() => {
+    const handler = (event) => {
+      if (event.detail?.actionType === 'dismiss_finding') bumpDismissRefresh();
+    };
+    window.addEventListener('quodeq:assistant-action-applied', handler);
+    return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
+  }, []);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's

--- a/src/quodeq/ui/src/api/findings.js
+++ b/src/quodeq/ui/src/api/findings.js
@@ -97,3 +97,27 @@ export async function deleteAllFindings(projectId) {
     body: JSON.stringify({ project: projectId }),
   });
 }
+
+/**
+ * List verified-badge entries for a project.
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Array>} Entries: { req, file, line, note, verifiedAt }
+ */
+export async function listVerifiedFindings(projectId) {
+  return request(`/findings/verified?project=${encodeURIComponent(projectId)}`);
+}
+
+/**
+ * Clear a verified badge.
+ * @param {string} projectId - Project identifier
+ * @param {object} finding - Finding key: { req, file, line }
+ * @returns {Promise<object>} Server response
+ */
+export async function unverifyFinding(projectId, finding) {
+  return request('/findings/unverify', {
+    method: 'POST',
+    body: JSON.stringify({
+      project: projectId, req: finding.req, file: finding.file, line: finding.line,
+    }),
+  });
+}

--- a/src/quodeq/ui/src/api/index.js
+++ b/src/quodeq/ui/src/api/index.js
@@ -14,7 +14,7 @@ import { createJob } from '../models/job.js';
 import { createProject } from '../models/project.js';
 import { request, BASE } from './request.js';
 
-export { listDismissedFindings, dismissFinding, restoreFinding, restoreAllFindings, getRescore, deleteFinding, deleteAllFindings } from './findings.js';
+export { listDismissedFindings, dismissFinding, restoreFinding, restoreAllFindings, getRescore, deleteFinding, deleteAllFindings, listVerifiedFindings, unverifyFinding } from './findings.js';
 export { listStandards, getStandard, createStandard, updateStandard, deleteStandard, duplicateStandard, listLibrary, listCwes, importFromLibrary, importStandard, exportStandard } from './standards.js';
 export {
   createAssistantSession, postAssistantMessage,

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
@@ -43,6 +43,7 @@ export function ActionPreviewCard({ action }) {
     setStatus('pending');
     try {
       await applyAssistantAction(actionId);
+      window.dispatchEvent(new CustomEvent('quodeq:assistant-action-applied', { detail: { actionType } }));
       setStatus('applied');
     } catch {
       setStatus('error');

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.jsx
@@ -1,6 +1,31 @@
 import { useState } from 'react';
 import { applyAssistantAction, rejectAssistantAction } from '../../api/assistant.js';
 
+function CardSummary({ actionType, summary }) {
+  if (actionType === 'dismiss_finding' || actionType === 'verify_finding') {
+    const isDismiss = actionType === 'dismiss_finding';
+    return (
+      <div className="assistant-card-summary">
+        <div className="assistant-card-name">
+          {isDismiss ? 'Dismiss finding' : 'Mark finding as verified'}
+        </div>
+        <div className="assistant-card-meta">
+          {summary.req} &middot; {summary.file}:{summary.line}
+        </div>
+        <div className="assistant-card-note">{isDismiss ? summary.reason : summary.note}</div>
+      </div>
+    );
+  }
+  return (
+    <div className="assistant-card-summary">
+      <div className="assistant-card-name">{summary.name}</div>
+      <div className="assistant-card-meta">
+        {summary.principleCount} principles &middot; {actionType}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Renders the server-canonical summary of a proposed assistant action
  * (name, principle count, action type) with Apply / Reject controls.
@@ -36,12 +61,7 @@ export function ActionPreviewCard({ action }) {
 
   return (
     <div className="assistant-card">
-      <div className="assistant-card-summary">
-        <div className="assistant-card-name">{summary.name}</div>
-        <div className="assistant-card-meta">
-          {summary.principleCount} principles &middot; {actionType}
-        </div>
-      </div>
+      <CardSummary actionType={actionType} summary={summary} />
       <div className="assistant-card-actions">
         <button
           type="button"

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
@@ -33,3 +33,18 @@ it('reject calls the endpoint and shows rejected', async () => {
   await waitFor(() => expect(rejectAssistantAction).toHaveBeenCalledWith('a1'));
   expect(await screen.findByText(/rejected/i)).toBeInTheDocument();
 });
+
+it('renders a dismiss_finding summary', () => {
+  render(<ActionPreviewCard action={{ actionId: 'a1', actionType: 'dismiss_finding',
+    summary: { req: 'r1', file: 'a.py', line: 3, reason: 'guarded above' } }} />);
+  expect(screen.getByText('Dismiss finding')).toBeInTheDocument();
+  expect(screen.getByText(/r1 · a\.py:3/)).toBeInTheDocument();
+  expect(screen.getByText('guarded above')).toBeInTheDocument();
+});
+
+it('renders a verify_finding summary', () => {
+  render(<ActionPreviewCard action={{ actionId: 'a2', actionType: 'verify_finding',
+    summary: { req: 'r1', file: 'a.py', line: 3, note: 'real, unsanitized input' } }} />);
+  expect(screen.getByText('Mark finding as verified')).toBeInTheDocument();
+  expect(screen.getByText('real, unsanitized input')).toBeInTheDocument();
+});

--- a/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/ActionPreviewCard.test.jsx
@@ -48,3 +48,17 @@ it('renders a verify_finding summary', () => {
   expect(screen.getByText('Mark finding as verified')).toBeInTheDocument();
   expect(screen.getByText('real, unsanitized input')).toBeInTheDocument();
 });
+
+it('dispatches quodeq:assistant-action-applied on successful apply', async () => {
+  const events = [];
+  const handler = (e) => events.push(e);
+  window.addEventListener('quodeq:assistant-action-applied', handler);
+  const dismissAction = { actionId: 'a3', actionType: 'dismiss_finding',
+    summary: { req: 'r1', file: 'a.py', line: 3, reason: 'fp' } };
+  render(<ActionPreviewCard action={dismissAction} />);
+  fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+  await waitFor(() => expect(applyAssistantAction).toHaveBeenCalledWith('a3'));
+  await waitFor(() => expect(events.length).toBe(1));
+  expect(events[0].detail.actionType).toBe('dismiss_finding');
+  window.removeEventListener('quodeq:assistant-action-applied', handler);
+});

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -6,6 +6,7 @@ import ContextBlock from '../../../components/ContextBlock.jsx';
 import SevBadge from '../../../components/terminal/SevBadge.jsx';
 import usePretextHeight from '../../../hooks/usePretextHeight.js';
 import { useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
+import { useVerifiedFindings } from '../../violations/components/verifiedFindingsContext.jsx';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
@@ -82,6 +83,9 @@ function ViolationDetail({ item }) {
 export function EvalViolationCard({ v, principle, index, onDismiss }) {
   const { addWindow } = useSidePane();
   const { filename, ref, display } = useFileInfo(v.file, v.line, v.endLine);
+  const verifiedCtx = useVerifiedFindings();
+  const verifiedKey = `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
+  const isVerified = Boolean(verifiedCtx?.keys?.has(verifiedKey));
   return (
     <div
       className={`vdetail-row vdetail-row--terminal vdetail-row--${v.severity}`}
@@ -89,6 +93,16 @@ export function EvalViolationCard({ v, principle, index, onDismiss }) {
     >
       <div className="vdetail-row-main">
         <SevBadge level={v.severity} format="long" />
+        {isVerified && (
+          <button
+            type="button"
+            className="verified-chip"
+            title={`${verifiedCtx.noteFor(verifiedKey) || 'Verified by the assistant'}. Click to remove the badge.`}
+            onClick={(e) => { e.stopPropagation(); verifiedCtx.unverify(v); }}
+          >
+            verified
+          </button>
+        )}
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
         <button

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -6,7 +6,7 @@ import ContextBlock from '../../../components/ContextBlock.jsx';
 import SevBadge from '../../../components/terminal/SevBadge.jsx';
 import usePretextHeight from '../../../hooks/usePretextHeight.js';
 import { useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
-import { useVerifiedFindings } from '../../violations/components/verifiedFindingsContext.jsx';
+import { VerifiedChip } from '../../violations/components/VerifiedChip.jsx';
 
 const ANIM_DELAY_PER_ITEM_MS = 30;
 const ANIM_MAX_DELAY_MS = 300;
@@ -83,9 +83,6 @@ function ViolationDetail({ item }) {
 export function EvalViolationCard({ v, principle, index, onDismiss }) {
   const { addWindow } = useSidePane();
   const { filename, ref, display } = useFileInfo(v.file, v.line, v.endLine);
-  const verifiedCtx = useVerifiedFindings();
-  const verifiedKey = `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
-  const isVerified = Boolean(verifiedCtx?.keys?.has(verifiedKey));
   return (
     <div
       className={`vdetail-row vdetail-row--terminal vdetail-row--${v.severity}`}
@@ -93,16 +90,7 @@ export function EvalViolationCard({ v, principle, index, onDismiss }) {
     >
       <div className="vdetail-row-main">
         <SevBadge level={v.severity} format="long" />
-        {isVerified && (
-          <button
-            type="button"
-            className="verified-chip"
-            title={`${verifiedCtx.noteFor(verifiedKey) || 'Verified by the assistant'}. Click to remove the badge.`}
-            onClick={(e) => { e.stopPropagation(); verifiedCtx.unverify(v); }}
-          >
-            verified
-          </button>
-        )}
+        <VerifiedChip v={v} />
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
         <button

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -9,6 +9,7 @@ import ContextBlock from '../../../components/ContextBlock.jsx';
 import SeverityFilterPills from '../../../components/SeverityFilterPills.jsx';
 import { ComplianceCard } from './EvalCards.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge } from '../../../components/terminal/index.js';
+import { VerifiedChip } from '../../violations/components/VerifiedChip.jsx';
 import { useRegisterWindowSpec, ReportContent, useSidePane, violationFixPlanSpec } from '../../side-pane/index.js';
 import { isLowConfidence } from '../../violations/components/LowConfidenceGroup.jsx';
 
@@ -29,6 +30,7 @@ const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
     <div className={`vdetail-row vdetail-row--${v.severity}`}>
       <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
+        <VerifiedChip v={v} />
         {v.provenanceDowngrade && (
           <span
             className="provenance-downgrade-tag"

--- a/src/quodeq/ui/src/features/violations/components/VerifiedChip.jsx
+++ b/src/quodeq/ui/src/features/violations/components/VerifiedChip.jsx
@@ -1,0 +1,26 @@
+import { useVerifiedFindings } from './verifiedFindingsContext.jsx';
+
+/**
+ * Shared verified-badge chip for any violation row.
+ * Renders nothing when there is no VerifiedFindingsProvider in the tree
+ * or when the finding has no badge. A failed unverify POST is swallowed
+ * so it cannot produce an unhandled rejection.
+ */
+export function VerifiedChip({ v }) {
+  const verifiedCtx = useVerifiedFindings();
+  const key = `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
+  if (!verifiedCtx?.keys?.has(key)) return null;
+  return (
+    <button
+      type="button"
+      className="verified-chip"
+      title={`${verifiedCtx.noteFor(key) || 'Verified by the assistant'}. Click to remove the badge.`}
+      onClick={(e) => {
+        e.stopPropagation();
+        verifiedCtx.unverify(v).catch(() => {});
+      }}
+    >
+      verified
+    </button>
+  );
+}

--- a/src/quodeq/ui/src/features/violations/components/VerifiedChip.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/VerifiedChip.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+vi.mock('../../../api/findings.js', () => ({
+  listVerifiedFindings: vi.fn(async () => [
+    { req: 'r1', file: 'a.py', line: 3, note: 'confirmed real', verifiedAt: 't' },
+  ]),
+  unverifyFinding: vi.fn(async () => ({ ok: true })),
+}));
+import { listVerifiedFindings, unverifyFinding } from '../../../api/findings.js';
+import { VerifiedFindingsProvider } from './verifiedFindingsContext.jsx';
+import { VerifiedChip } from './VerifiedChip.jsx';
+
+beforeEach(() => vi.clearAllMocks());
+
+it('renders nothing without a provider', () => {
+  const { container } = render(<VerifiedChip v={{ req: 'r1', file: 'a.py', line: 3 }} />);
+  expect(container.firstChild).toBeNull();
+});
+
+it('renders the chip inside a provider when the key matches', async () => {
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <VerifiedChip v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  await waitFor(() => expect(screen.getByRole('button', { name: /verified/i })).toBeInTheDocument());
+});
+
+it('renders nothing for an unmatched key', async () => {
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <VerifiedChip v={{ req: 'r2', file: 'b.py', line: 99 }} />
+    </VerifiedFindingsProvider>,
+  );
+  await waitFor(() => expect(listVerifiedFindings).toHaveBeenCalled());
+  expect(screen.queryByRole('button', { name: /verified/i })).toBeNull();
+});
+
+it('click calls unverifyFinding and removes the chip', async () => {
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <VerifiedChip v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  const btn = await screen.findByRole('button', { name: /verified/i });
+  fireEvent.click(btn);
+  await waitFor(() => expect(unverifyFinding).toHaveBeenCalledWith('proj', { req: 'r1', file: 'a.py', line: 3 }));
+  await waitFor(() => expect(screen.queryByRole('button', { name: /verified/i })).toBeNull());
+});
+
+it('a rejected unverifyFinding does not throw (chip stays, no unhandled rejection)', async () => {
+  unverifyFinding.mockRejectedValueOnce(new Error('network error'));
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <VerifiedChip v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  const btn = await screen.findByRole('button', { name: /verified/i });
+  // Should not throw
+  fireEvent.click(btn);
+  await waitFor(() => expect(unverifyFinding).toHaveBeenCalled());
+  // chip stays because unverify failed; context unverify will have rejected but catch absorbed it
+  // Wait a tick to let any async error surface
+  await new Promise((r) => setTimeout(r, 20));
+  // If we get here without an unhandled rejection, the test passes
+});

--- a/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.jsx
+++ b/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.jsx
@@ -1,0 +1,46 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { listVerifiedFindings, unverifyFinding } from '../../../api/findings.js';
+
+/**
+ * Project-level verified-badge state. Findings are keyed by
+ * `${req}|${file}|${line}` (the same convention the dismissal paths use).
+ * Consumers get null when no provider is mounted, so cards render without
+ * badges in isolated tests and legacy mounts.
+ */
+const VerifiedFindingsContext = createContext(null);
+
+export function useVerifiedFindings() {
+  return useContext(VerifiedFindingsContext);
+}
+
+const keyOf = (v) => `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
+
+export function VerifiedFindingsProvider({ project, children }) {
+  const [entries, setEntries] = useState([]);
+
+  const refresh = useCallback(() => {
+    if (!project) { setEntries([]); return; }
+    listVerifiedFindings(project).then(setEntries).catch(() => setEntries([]));
+  }, [project]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const value = useMemo(() => {
+    const notes = new Map(entries.map((e) => [keyOf(e), e.note || '']));
+    return {
+      keys: new Set(notes.keys()),
+      noteFor: (key) => notes.get(key) || '',
+      unverify: async (v) => {
+        await unverifyFinding(project, { req: v.req, file: v.file, line: v.line });
+        setEntries((prev) => prev.filter((e) => keyOf(e) !== keyOf(v)));
+      },
+      refresh,
+    };
+  }, [entries, project, refresh]);
+
+  return (
+    <VerifiedFindingsContext.Provider value={value}>
+      {children}
+    </VerifiedFindingsContext.Provider>
+  );
+}

--- a/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.jsx
+++ b/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.jsx
@@ -25,6 +25,14 @@ export function VerifiedFindingsProvider({ project, children }) {
 
   useEffect(() => { refresh(); }, [refresh]);
 
+  useEffect(() => {
+    const handler = (event) => {
+      if (event.detail?.actionType === 'verify_finding') refresh();
+    };
+    window.addEventListener('quodeq:assistant-action-applied', handler);
+    return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
+  }, [refresh]);
+
   const value = useMemo(() => {
     const notes = new Map(entries.map((e) => [keyOf(e), e.note || '']));
     return {

--- a/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { it, expect, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
 vi.mock('../../../api/findings.js', () => ({
@@ -11,6 +11,8 @@ vi.mock('../../../api/findings.js', () => ({
 }));
 import { listVerifiedFindings, unverifyFinding } from '../../../api/findings.js';
 import { VerifiedFindingsProvider, useVerifiedFindings } from './verifiedFindingsContext.jsx';
+
+beforeEach(() => vi.clearAllMocks());
 
 function Probe({ v }) {
   const ctx = useVerifiedFindings();
@@ -46,4 +48,25 @@ it('unverify removes the key locally', async () => {
 it('returns null without a provider', () => {
   render(<Probe v={{ req: 'r1', file: 'a.py', line: 3 }} />);
   expect(screen.getByText('not verified')).toBeInTheDocument();
+});
+
+it('refetches when quodeq:assistant-action-applied fires with verify_finding', async () => {
+  listVerifiedFindings.mockResolvedValueOnce([])
+    .mockResolvedValueOnce([{ req: 'r1', file: 'a.py', line: 3, note: 'checked', verifiedAt: 't' }]);
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <Probe v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  // initial fetch returned empty list
+  await waitFor(() => expect(listVerifiedFindings).toHaveBeenCalledTimes(1));
+  expect(screen.getByText('not verified')).toBeInTheDocument();
+  // fire the window event
+  await act(async () => {
+    window.dispatchEvent(new CustomEvent('quodeq:assistant-action-applied', {
+      detail: { actionType: 'verify_finding' },
+    }));
+  });
+  await waitFor(() => expect(listVerifiedFindings).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(screen.getByText('checked')).toBeInTheDocument());
 });

--- a/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/verifiedFindingsContext.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+
+vi.mock('../../../api/findings.js', () => ({
+  listVerifiedFindings: vi.fn(async () => [
+    { req: 'r1', file: 'a.py', line: 3, note: 'checked', verifiedAt: 't' },
+  ]),
+  unverifyFinding: vi.fn(async () => ({ ok: true })),
+}));
+import { listVerifiedFindings, unverifyFinding } from '../../../api/findings.js';
+import { VerifiedFindingsProvider, useVerifiedFindings } from './verifiedFindingsContext.jsx';
+
+function Probe({ v }) {
+  const ctx = useVerifiedFindings();
+  const key = `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
+  if (!ctx?.keys?.has(key)) return <div>not verified</div>;
+  return (
+    <button type="button" onClick={() => ctx.unverify(v)}>{ctx.noteFor(key)}</button>
+  );
+}
+
+it('exposes fetched keys and notes', async () => {
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <Probe v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  await waitFor(() => expect(screen.getByText('checked')).toBeInTheDocument());
+  expect(listVerifiedFindings).toHaveBeenCalledWith('proj');
+});
+
+it('unverify removes the key locally', async () => {
+  render(
+    <VerifiedFindingsProvider project="proj">
+      <Probe v={{ req: 'r1', file: 'a.py', line: 3 }} />
+    </VerifiedFindingsProvider>,
+  );
+  await waitFor(() => screen.getByText('checked'));
+  fireEvent.click(screen.getByText('checked'));
+  await waitFor(() => expect(screen.getByText('not verified')).toBeInTheDocument());
+  expect(unverifyFinding).toHaveBeenCalledWith('proj', { req: 'r1', file: 'a.py', line: 3 });
+});
+
+it('returns null without a provider', () => {
+  render(<Probe v={{ req: 'r1', file: 'a.py', line: 3 }} />);
+  expect(screen.getByText('not verified')).toBeInTheDocument();
+});

--- a/src/quodeq/ui/src/styles/assistant.css
+++ b/src/quodeq/ui/src/styles/assistant.css
@@ -26,6 +26,8 @@
   color: var(--color-text-muted);
 }
 
+.assistant-card-note { color: var(--color-text-muted); font-size: 12px; margin-top: 2px; }
+
 .assistant-card-actions {
   display: flex;
   gap: 0.5rem;

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -3079,3 +3079,5 @@ button.eval-provider-badge--clickable:focus-visible {
   padding: 0;
   font-family: var(--term-font-mono);
 }
+
+.verified-chip { border: 1px solid var(--color-accent); color: var(--color-accent); background: transparent; border-radius: 6px; padding: 1px 7px; font-size: 11px; font-family: var(--font-mono); cursor: pointer; }

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -500,9 +500,8 @@ def test_assistant_catalog(client):
     assert {"create-standard", "explain-finding", "explain-score"} <= names
     one = next(s for s in body["skills"] if s["name"] == "explain-score")
     assert one["argumentHint"] and isinstance(one["views"], list)
-    assert body["actions"] == [
-        {"type": "create_standard",
-         "description": "Draft a new custom standard. Applied only after you approve the preview card."}]
+    assert [a["type"] for a in body["actions"]] == ["create_standard", "dismiss_finding", "verify_finding"]
+    assert all(a["description"] for a in body["actions"])
 
 
 def test_reject_after_apply_conflicts(client, app):
@@ -516,3 +515,36 @@ def test_reject_after_apply_conflicts(client, app):
     assert resp.status_code == 409
     sess = repo.get_action("a1")
     assert sess["status"] == "applied"  # apply outcome survives the replay
+
+
+def test_apply_dismiss_finding_writes_action_log(client, app, tmp_path, monkeypatch):
+    evals = tmp_path / "evals"
+    (evals / "proj").mkdir(parents=True)
+    monkeypatch.setitem(app.config, "EVALUATIONS_DIR", str(evals))
+    repo = _repo(app)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(action_id="a1", session_id="s1",
+                       action_type="dismiss_finding",
+                       payload={"project": "proj", "req": "r1", "file": "a.py",
+                                "line": 3, "reason": "false positive: guarded"},
+                       content_hash="h")
+    resp = client.post("/api/assistant/actions/a1/apply")
+    assert resp.status_code == 200
+    from quodeq.services.dismissed import dismissed_keys
+    assert dismissed_keys(evals / "proj") == {("r1", "a.py", 3)}
+
+
+def test_apply_verify_finding_writes_badge(client, app, tmp_path, monkeypatch):
+    evals = tmp_path / "evals"
+    (evals / "proj").mkdir(parents=True)
+    monkeypatch.setitem(app.config, "EVALUATIONS_DIR", str(evals))
+    repo = _repo(app)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(action_id="a1", session_id="s1",
+                       action_type="verify_finding",
+                       payload={"project": "proj", "req": "r1", "file": "a.py",
+                                "line": 3, "note": "real: unsanitized input"},
+                       content_hash="h")
+    assert client.post("/api/assistant/actions/a1/apply").status_code == 200
+    from quodeq.services.verified import verified_entries
+    assert [e["note"] for e in verified_entries(evals / "proj")] == ["real: unsanitized input"]

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -503,3 +503,16 @@ def test_assistant_catalog(client):
     assert body["actions"] == [
         {"type": "create_standard",
          "description": "Draft a new custom standard. Applied only after you approve the preview card."}]
+
+
+def test_reject_after_apply_conflicts(client, app):
+    repo = _repo(app)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(action_id="a1", session_id="s1",
+                       action_type="create_standard", payload=_VALID_STANDARD,
+                       content_hash="h")
+    assert client.post("/api/assistant/actions/a1/apply").status_code == 200
+    resp = client.post("/api/assistant/actions/a1/reject")
+    assert resp.status_code == 409
+    sess = repo.get_action("a1")
+    assert sess["status"] == "applied"  # apply outcome survives the replay

--- a/tests/api/test_assistant_routes.py
+++ b/tests/api/test_assistant_routes.py
@@ -548,3 +548,23 @@ def test_apply_verify_finding_writes_badge(client, app, tmp_path, monkeypatch):
     assert client.post("/api/assistant/actions/a1/apply").status_code == 200
     from quodeq.services.verified import verified_entries
     assert [e["note"] for e in verified_entries(evals / "proj")] == ["real: unsanitized input"]
+
+
+def test_apply_verify_finding_traversal_payload_400(client, app, tmp_path, monkeypatch):
+    """A drafted verify_finding whose stored payload has a traversal project must return 400
+    and must NOT create any actions.jsonl outside the evaluations root."""
+    evals = tmp_path / "evals"
+    evals.mkdir(parents=True)
+    monkeypatch.setitem(app.config, "EVALUATIONS_DIR", str(evals))
+    repo = _repo(app)
+    repo.create_session(session_id="s1", provider="ollama")
+    repo.create_action(action_id="a-traverse", session_id="s1",
+                       action_type="verify_finding",
+                       payload={"project": "../escape", "req": "r1", "file": "a.py",
+                                "line": 3, "note": "would escape"},
+                       content_hash="h")
+    resp = client.post("/api/assistant/actions/a-traverse/apply")
+    assert resp.status_code == 400
+    # The traversal target directory must not have been created.
+    escape_dir = tmp_path / "escape"
+    assert not escape_dir.exists()

--- a/tests/api/test_cluster6_projection_offthread.py
+++ b/tests/api/test_cluster6_projection_offthread.py
@@ -13,7 +13,8 @@ from unittest.mock import patch, MagicMock
 import pytest
 from flask import Flask
 
-from quodeq.api.routes_findings import register_findings_routes, _projection_locks
+from quodeq.api.routes_findings import register_findings_routes
+from quodeq.services.mutation_rescore import _projection_locks
 
 
 @pytest.fixture()
@@ -42,7 +43,7 @@ def test_dismiss_returns_without_waiting_for_projection(client, tmp_path):
         projection_may_finish.wait(timeout=5)
 
     with patch(
-        "quodeq.api.routes_findings._project_all_runs",
+        "quodeq.services.mutation_rescore._project_all_runs",
         side_effect=_slow_project,
     ):
         resp = client.post("/api/findings/dismiss", json={
@@ -95,7 +96,7 @@ def test_concurrent_dismisses_same_project_call_project_all_runs_once(
         projection_first_may_finish.wait(timeout=5)
 
     with patch(
-        "quodeq.api.routes_findings._project_all_runs",
+        "quodeq.services.mutation_rescore._project_all_runs",
         side_effect=_blocking_project,
     ):
         # Fire first request and wait until projection has started (lock held).

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -303,3 +303,25 @@ class TestListDismissedEndpoint:
         resp = client.get("/api/findings/dismissed?project=nonexistent")
         assert resp.status_code == 200
         assert resp.get_json() == []
+
+
+class TestVerifiedEndpoints:
+    def test_verified_list_and_unverify(self, client, tmp_path):
+        from quodeq.services.verified import verify_finding
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        verify_finding(project_dir, {"req": "r1", "file": "a.py", "line": 3, "note": "n"})
+
+        resp = client.get("/api/findings/verified?project=my-project")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert [(e["req"], e["file"], e["line"], e["note"]) for e in body] == [("r1", "a.py", 3, "n")]
+
+        resp = client.post("/api/findings/unverify",
+                           json={"project": "my-project", "req": "r1", "file": "a.py", "line": 3})
+        assert resp.status_code == 200
+        assert client.get("/api/findings/verified?project=my-project").get_json() == []
+
+    def test_unverify_requires_key_fields(self, client):
+        resp = client.post("/api/findings/unverify", json={"project": "p"})
+        assert resp.status_code == 400

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -325,3 +325,5 @@ class TestVerifiedEndpoints:
     def test_unverify_requires_key_fields(self, client):
         resp = client.post("/api/findings/unverify", json={"project": "p"})
         assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["code"] == "MISSING_PARAM"

--- a/tests/assistant/test_api_adapter.py
+++ b/tests/assistant/test_api_adapter.py
@@ -122,6 +122,20 @@ def test_iteration_cap_ends_turn():
     assert len(client.calls) == 6  # MAX_TOOL_ITERATIONS
 
 
+def test_iteration_cap_is_config_driven():
+    looping = [
+        _delta(tool_calls=[_tool_call_delta(0, "c1", "get_scores", "{}")]),
+        _delta(finish="tool_calls"),
+    ]
+    client = FakeClient([list(looping) for _ in range(10)])
+    config = ApiTurnConfig(api_base="http://x", api_key=None, model="m",
+                           native_tools=True, max_tool_iterations=2)
+    run_api_turn(messages=[{"role": "user", "content": "x"}],
+                 config=config, registry=_registry(),
+                 emit=lambda f: None, client_factory=lambda c: client)
+    assert len(client.calls) == 2
+
+
 def test_extra_body_disables_thinking_for_local_and_sets_ctx(monkeypatch):
     from quodeq.assistant.adapters._api import ApiTurnConfig, _extra_body
     monkeypatch.setenv("QUODEQ_CONTEXT_SIZE", "32768")

--- a/tests/assistant/test_orchestrator.py
+++ b/tests/assistant/test_orchestrator.py
@@ -282,3 +282,24 @@ def test_cli_config_skill_block_empty_without_skill(setup):
     run_turn(request, repository=repo, tool_ctx=ctx, cli_turn_fn=fake_cli)
     assert captured["config"].skill_block == ""
     assert captured["config"].system_prompt  # context always present
+
+
+def test_skill_turns_get_extra_iterations(setup):
+    repo, ctx = setup
+    captured = {}
+
+    def fake_api(*, messages, config, registry, emit):
+        captured["config"] = config
+        return "ok"
+
+    request = TurnRequest(session_id="s1", text="/explain-score security",
+                          ui_state=None, api_base="http://x", api_key=None,
+                          provider="ollama", model="m")
+    run_turn(request, repository=repo, tool_ctx=ctx, turn_fn=fake_api)
+    assert captured["config"].max_tool_iterations == 12
+
+    request = TurnRequest(session_id="s1", text="hello", ui_state=None,
+                          api_base="http://x", api_key=None,
+                          provider="ollama", model="m")
+    run_turn(request, repository=repo, tool_ctx=ctx, turn_fn=fake_api)
+    assert captured["config"].max_tool_iterations == 6

--- a/tests/assistant/test_skills.py
+++ b/tests/assistant/test_skills.py
@@ -51,3 +51,18 @@ def test_builtin_skills_have_views_and_hints():
     assert "overview" in skills["explain-score"].views
     assert "violations" in skills["explain-finding"].views
     assert "standards" in skills["create-standard"].views
+
+
+def test_verify_finding_skill_loads():
+    skill = load_skills()["verify-finding"]
+    assert skill.views == ("violations",)
+    assert skill.argument_hint
+
+
+def test_verify_finding_skill_is_card_gated():
+    body = load_skills()["verify-finding"].instructions
+    assert "FALSE POSITIVE" in body
+    assert "dismiss_finding" in body and "verify_finding" in body
+    # pinned: the skill must never claim or instruct direct application
+    assert "auto-apply" not in body.lower()
+    assert "never claim the action was applied" in body

--- a/tests/assistant/test_tools_actions.py
+++ b/tests/assistant/test_tools_actions.py
@@ -49,3 +49,10 @@ def test_draft_action_rejects_invalid_payload(ctx):
         "action_type": "create_standard", "payload": {"name": "no id"},
     })
     assert out["ok"] is False
+
+
+def test_actions_registry_covers_types(ctx):
+    from quodeq.assistant.tools._actions import ACTIONS, ACTION_TYPES
+    assert set(ACTIONS) == set(ACTION_TYPES)
+    for spec in ACTIONS.values():
+        assert callable(spec.validate) and callable(spec.summarize) and callable(spec.apply)

--- a/tests/assistant/test_tools_actions.py
+++ b/tests/assistant/test_tools_actions.py
@@ -56,3 +56,55 @@ def test_actions_registry_covers_types(ctx):
     assert set(ACTIONS) == set(ACTION_TYPES)
     for spec in ACTIONS.values():
         assert callable(spec.validate) and callable(spec.summarize) and callable(spec.apply)
+
+
+@pytest.fixture()
+def project_ctx(tmp_path):
+    store = AssistantRepository(tmp_path / "assistant_p.db")
+    store.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=store, session_id="s1", run_dir=None, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json",
+        project_id="proj", reports_dir=tmp_path / "evals",
+    )
+
+
+def test_draft_dismiss_requires_reason(project_ctx):
+    out = build_registry(project_ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": 3},
+    })
+    assert out["ok"] is False
+    assert "reason" in out["error"]
+
+
+def test_draft_dismiss_canonicalizes_from_session(project_ctx):
+    out = build_registry(project_ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": 3,
+                    "reason": "guarded two lines above",
+                    "project": "spoofed-by-model"},
+    })
+    assert out["ok"] is True
+    stored = project_ctx.repository.get_action(out["result"]["action_id"])
+    assert stored["payload"]["project"] == "proj"  # session wins over model payload
+    assert stored["payload"]["reason"] == "guarded two lines above"
+    frames = [f for _, f in project_ctx.repository.events_after("s1", 0)]
+    draft = next(f for f in frames if f["type"] == "action_draft")
+    assert draft["summary"] == {"req": "r1", "file": "a.py", "line": 3,
+                                "reason": "guarded two lines above"}
+
+
+def test_draft_verify_requires_note_and_project(ctx, project_ctx):
+    reg = build_registry(project_ctx)
+    out = reg.dispatch("draft_action", {
+        "action_type": "verify_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": 3},
+    })
+    assert out["ok"] is False and "note" in out["error"]
+    out = build_registry(ctx).dispatch("draft_action", {
+        "action_type": "verify_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": 3, "note": "n"},
+    })
+    assert out["ok"] is False  # ctx has no project_id -> actionable error

--- a/tests/assistant/test_tools_actions.py
+++ b/tests/assistant/test_tools_actions.py
@@ -108,3 +108,35 @@ def test_draft_verify_requires_note_and_project(ctx, project_ctx):
         "payload": {"req": "r1", "file": "a.py", "line": 3, "note": "n"},
     })
     assert out["ok"] is False  # ctx has no project_id -> actionable error
+
+
+@pytest.fixture()
+def evil_project_ctx(tmp_path):
+    store = AssistantRepository(tmp_path / "assistant_evil.db")
+    store.create_session(session_id="s1", provider="ollama")
+    return ToolContext(
+        repository=store, session_id="s1", run_dir=None, repo_root=None,
+        evaluators_dir=tmp_path / "e", compiled_dir=tmp_path / "c",
+        dimensions_file=tmp_path / "d.json",
+        project_id="../evil",
+        reports_dir=tmp_path / "evals",
+    )
+
+
+def test_draft_dismiss_rejects_evil_project_id(evil_project_ctx):
+    """draft_action for dismiss_finding must fail when project_id is a traversal path."""
+    out = build_registry(evil_project_ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": 3, "reason": "fp"},
+    })
+    assert out["ok"] is False
+    assert "invalid project" in out["error"].lower()
+
+
+def test_draft_dismiss_rejects_bool_line(project_ctx):
+    """line=True must be rejected (isinstance check tightened to exclude booleans)."""
+    out = build_registry(project_ctx).dispatch("draft_action", {
+        "action_type": "dismiss_finding",
+        "payload": {"req": "r1", "file": "a.py", "line": True, "reason": "fp"},
+    })
+    assert out["ok"] is False

--- a/tests/services/test_verified.py
+++ b/tests/services/test_verified.py
@@ -27,6 +27,11 @@ def test_verified_and_dismissed_coexist_in_one_log(tmp_path):
     assert [e["req"] for e in verified_entries(tmp_path)] == ["r1"]
 
 
+def test_verify_without_note_yields_empty_string(tmp_path):
+    verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3})
+    assert verified_entries(tmp_path)[0]["note"] == ""
+
+
 def test_reader_skips_unknown_event_types(tmp_path):
     verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3, "note": "n"})
     log = tmp_path / "actions.jsonl"

--- a/tests/services/test_verified.py
+++ b/tests/services/test_verified.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from quodeq.services.dismissed import dismissed_keys, dismiss_finding
+from quodeq.services.verified import unverify_finding, verified_entries, verify_finding
+
+
+def test_verify_then_list(tmp_path):
+    verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3, "note": "checked the guard"})
+    entries = verified_entries(tmp_path)
+    assert len(entries) == 1
+    e = entries[0]
+    assert (e["req"], e["file"], e["line"]) == ("r1", "a.py", 3)
+    assert e["note"] == "checked the guard"
+    assert e["verifiedAt"]  # ISO timestamp present
+
+
+def test_unverify_removes_key(tmp_path):
+    verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3, "note": "n"})
+    unverify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3})
+    assert verified_entries(tmp_path) == []
+
+
+def test_verified_and_dismissed_coexist_in_one_log(tmp_path):
+    dismiss_finding(tmp_path, {"req": "r2", "file": "b.py", "line": 9, "dismissReason": "fp"})
+    verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3, "note": "n"})
+    assert dismissed_keys(tmp_path) == {("r2", "b.py", 9)}
+    assert [e["req"] for e in verified_entries(tmp_path)] == ["r1"]
+
+
+def test_reader_skips_unknown_event_types(tmp_path):
+    verify_finding(tmp_path, {"req": "r1", "file": "a.py", "line": 3, "note": "n"})
+    log = tmp_path / "actions.jsonl"
+    log.write_text(
+        log.read_text(encoding="utf-8")
+        + '{"event_type": "FUTURE_EVENT", "payload": {}}\n',
+        encoding="utf-8",
+    )
+    assert len(verified_entries(tmp_path)) == 1  # unknown line ignored, no crash

--- a/tools/import_baseline.txt
+++ b/tools/import_baseline.txt
@@ -16,7 +16,6 @@ src/quodeq/api/import_project.py:30:data
 src/quodeq/api/import_project.py:31:data
 src/quodeq/api/import_project.py:32:data
 src/quodeq/api/llm_bridge_routes.py:8:llm_bridge
-src/quodeq/api/routes_findings.py:107:data
 src/quodeq/data/fs/project_resolver.py:17:services
 src/quodeq/data/fs/repo_clone.py:19:context
 src/quodeq/data/fs/report_parser/runs.py:190:services


### PR DESCRIPTION
## Summary

The `/verify-finding` skill: the assistant adversarially checks a finding against the requirement text and the actual code (including related files), argues REAL or FALSE POSITIVE with a confidence, and drafts exactly one card-gated action either way. The model can never apply anything: both verdicts end in the existing Apply/Reject preview card.

- **False positive -> `dismiss_finding` card.** Reason required (the skill's reasoning). Apply dismisses via the existing `services/dismissed` path, keyed on `(req, file, line)`, and rescores (same fallback projection the dismiss button uses).
- **Real -> `verify_finding` card.** Note required. Apply appends a `FindingVerified` event to the project's `actions.jsonl` (mirroring dismissals; old readers skip unknown event types, test-pinned). Badges never affect scores.
- **Verified chip.** Violation cards (explorer detail + the violations file drill-in) show a clickable "verified" chip with the note as tooltip; clicking clears it via `POST /api/findings/unverify`. `GET /api/findings/verified?project=` lists badges. After a card Apply the UI refreshes itself (badge appears / dismissed row refresh) via a window event bridge.
- **Action registry.** `_actions.py` is now the spec's Phase 2 `ActionSpec` shape (validate/summarize/apply per type); `create_standard` migrated behavior-preserving. The reject endpoint gained the same drafted-only 409 replay guard apply has (previously an applied action could be flipped to rejected).
- **Skill turns get 12 tool iterations** on the API-adapter path (default stays 6; CLI/MCP unchanged) so search -> standard -> code -> draft chains do not hit the cap.
- **Type-aware ActionPreviewCard**: per-type summaries (dismiss shows req, file:line, reason; verify shows the note); create_standard rendering unchanged.

Security notes: the canonical payload's `project` always comes from the session, never the model (spoof-tested); both new apply handlers validate the project path segment before touching the filesystem (draft-time and apply-time, traversal-tested), matching the jailing every sibling route uses.

## Verification

- TDD throughout; each task independently reviewed, plus a final whole-branch review whose findings (path jailing, apply-refresh bridge, drill-in chip, tidies) are fixed and re-reviewed on this branch.
- Backend: 1460 passed (`pytest tests/assistant tests/api tests/services -m "not integration"`). UI: 234 node:test + 720 vitest across 129 files; production build clean. Invariants re-checked: web-tool exclusion, orchestrator gating, catalog shape (81 tests).
- Live API smoke on the built app: catalog lists the skill and all three action types; a seeded `verify_finding` draft applied through the real endpoint produced the badge in the verified list; apply and reject both 409 on replay; unverify cleared it.
- Not exercised live: a full claude-CLI `/verify-finding` turn (needs a configured provider and spends tokens; the tool references and card gating are content-pinned by tests) and an in-browser screenshot of the chip (render logic unit-tested; a preview eval-context issue blocked the drill-in click-through). Recommend one manual `/verify-finding` on a real finding after merge.

## Spec deviations (documented)

- The dismiss card summary omits the optional severity lookup (spec marked it "when available, else omitted").
- Badge surfaces: explorer detail pages + violations file drill-in. Other listings (heat grid rows) intentionally unchanged in this slice.
