### PR TITLE
fix(services): match deleted-finding keys against camelCase practiceId

### DIFF
--- a/src/quodeq/services/violations.py
+++ b/src/quodeq/services/violations.py
@@ -58,12 +58,19 @@ def _dismissed_key_for_violation(v: dict) -> tuple:
     return (req, raw_file, 0)
 
 
-def _deleted_key_for_violation(v: dict, dimension: str) -> tuple:
-    """Build a (dimension, principle, file) suppression key from a violation dict."""
+def _deleted_key_for_violation(v: dict, dimension: str, principle: str | None = None) -> tuple:
+    """Build a (dimension, principle, file) suppression key from a violation dict.
+
+    Parsed eval violations are camelCase (``practiceId``); ``principle`` is
+    kept as a fallback for pre-camelCase dicts. Principle-group entries carry
+    no principle field at all, so callers pass the group name as *principle*.
+    """
     raw_file = v.get("file", "")
     if v.get("line") is None and ":" in raw_file:
         raw_file = raw_file.rsplit(":", 1)[0]
-    return (dimension or "", v.get("principle", "") or "", raw_file)
+    if principle is None:
+        principle = v.get("practiceId") or v.get("principle") or ""
+    return (dimension or "", principle or "", raw_file)
 
 
 def _filter_dismissed_from_result(
@@ -84,10 +91,11 @@ def _filter_dismissed_from_result(
             ]
         for p in result.get("principles", []):
             if "violations" in p:
+                group_principle = p.get("name", "") or ""
                 p["violations"] = [
                     v for v in p["violations"]
                     if _dismissed_key_for_violation(v) not in dkeys
-                    and (not delkeys or _deleted_key_for_violation(v, dimension) not in delkeys)
+                    and (not delkeys or _deleted_key_for_violation(v, dimension, group_principle) not in delkeys)
                 ]
     return result
 

--- a/tests/services/test_violations_coverage.py
+++ b/tests/services/test_violations_coverage.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from quodeq.services.violations import (
+    _deleted_key_for_violation,
     _dismissed_key_for_violation,
     _filter_dismissed_from_result,
     _max_violation_files,
@@ -42,6 +43,27 @@ class TestDismissedKeyForViolation:
     def test_line_zero_explicit(self):
         v = {"req": "R", "file": "f.py", "line": 0}
         assert _dismissed_key_for_violation(v) == ("R", "f.py", 0)
+
+
+class TestDeletedKeyForViolation:
+    def test_camel_case_practice_id(self):
+        v = {"practiceId": "Modularity", "file": "a.py", "line": 3}
+        assert _deleted_key_for_violation(v, "maintainability") == ("maintainability", "Modularity", "a.py")
+
+    def test_legacy_principle_fallback(self):
+        v = {"principle": "Modularity", "file": "a.py", "line": 3}
+        assert _deleted_key_for_violation(v, "maintainability") == ("maintainability", "Modularity", "a.py")
+
+    def test_explicit_principle_override(self):
+        v = {"file": "a.py:3"}
+        assert _deleted_key_for_violation(v, "maintainability", "Modularity") == ("maintainability", "Modularity", "a.py")
+
+    def test_combined_file_line_stripped(self):
+        v = {"practiceId": "Modularity", "file": "a.py:3"}
+        assert _deleted_key_for_violation(v, "maintainability") == ("maintainability", "Modularity", "a.py")
+
+    def test_empty_dict(self):
+        assert _deleted_key_for_violation({}, "") == ("", "", "")
 
 
 class TestFilterDismissedFromResult:
@@ -85,6 +107,67 @@ class TestFilterDismissedFromResult:
         dkeys = {("R1", "a.py", 1)}
         # Should return result unchanged
         assert _filter_dismissed_from_result(result, dkeys) is result
+
+
+class TestDeletedFilteredFromDimensionEval:
+    """Permanently-deleted findings must not survive into the served dimension eval.
+
+    The JSON eval parser emits camelCase violation dicts (``practiceId``, not
+    ``principle``), so the deletion key must be built from ``practiceId``.
+    Regression test for the dimension-detail view showing deleted findings.
+    """
+
+    def test_deleted_key_matches_practice_id_violation(self, tmp_path):
+        project_dir = tmp_path / "project"
+        base = project_dir / "run"
+        (base / "evaluation").mkdir(parents=True)
+        eval_data = {
+            "dimension": "testdim",
+            "principles": [{"name": "Clear Naming", "score": 5, "grade": "C"}],
+            "violations": [
+                {"principle": "Clear Naming", "file": "src/app.py", "line": 12,
+                 "title": "t", "reason": "r", "severity": "major"},
+                {"principle": "Clear Naming", "file": "src/other.py", "line": 3,
+                 "title": "t2", "reason": "r2", "severity": "minor"},
+            ],
+        }
+        (base / "evaluation" / "testdim.json").write_text(json.dumps(eval_data))
+        (project_dir / "deleted.json").write_text(json.dumps([
+            {"dimension": "testdim", "principle": "Clear Naming", "file": "src/app.py"},
+        ]))
+
+        result = resolve_dimension_eval(base, "proj", "run", "testdim")
+
+        files = [v["file"] for v in result["violations"]]
+        assert "src/app.py" not in files
+        assert "src/other.py" in files
+
+    def test_deleted_key_matches_principle_group_violations(self, tmp_path):
+        """Group entries carry no principle field; the group name is the principle."""
+        project_dir = tmp_path / "project"
+        base = project_dir / "run"
+        (base / "evaluation").mkdir(parents=True)
+        eval_data = {
+            "dimension": "testdim",
+            "principles": [{"name": "Clear Naming", "score": 5, "grade": "C"}],
+            "violations": [
+                {"principle": "Clear Naming", "file": "src/app.py", "line": 12,
+                 "title": "t", "reason": "r", "severity": "major"},
+                {"principle": "Clear Naming", "file": "src/other.py", "line": 3,
+                 "title": "t2", "reason": "r2", "severity": "minor"},
+            ],
+        }
+        (base / "evaluation" / "testdim.json").write_text(json.dumps(eval_data))
+        (project_dir / "deleted.json").write_text(json.dumps([
+            {"dimension": "testdim", "principle": "Clear Naming", "file": "src/app.py"},
+        ]))
+
+        result = resolve_dimension_eval(base, "proj", "run", "testdim")
+
+        group = next(p for p in result["principles"] if p["name"] == "Clear Naming")
+        group_files = [v["file"] for v in group["violations"]]
+        assert "src/app.py:12" not in group_files
+        assert "src/other.py:3" in group_files
 
 
 class TestMaxViolationFiles:


### PR DESCRIPTION
## Problem

The dimension-detail read path applies the permanent-deletion filter with a key that can never match, so user-deleted findings still render in the dimension detail view while the accumulated overview (and, since the run-dashboard dismissal fix, the history run view) correctly hide them.

`_deleted_key_for_violation` in `services/violations.py` built the suppression key from `v.get("principle")`, but the violation dicts it receives come from `parse_eval_from_json`, which runs `to_camel_dict(build_finding(...))` — the principle lives under `practiceId`. The key was always `(dimension, "", file)` and only matched deleted entries with an empty stored principle.

The second filter site (violations inside principle groups) was doubly broken: group entries built by `_collect_findings` carry **no principle field at all** — the principle is the group's `name`.

## Fix

- `_deleted_key_for_violation` reads `practiceId` with a `principle` fallback for pre-camelCase dicts.
- The principle-group filter passes the group's `name` explicitly as the principle.

## Verification

- TDD: both integration tests (through `resolve_dimension_eval` with real tmp files: camelCase eval JSON + matching `deleted.json` entry) written first and confirmed failing, then fixed to green. Unit tests pin the key-building variants (camelCase, legacy fallback, group override, combined `file:line`).
- Real data: run `03c99d26` maintainability now serves **114** violations instead of **131** — exactly the 17 deleted-key matches identified in the trace, and top-level and group counts agree.
- `pytest -m "not integration"`: 4078 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)