### PR TITLE
style(ui): verified badge as an accent check-circle, beside Fix plan

### DIFF
--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -90,9 +90,9 @@ export function EvalViolationCard({ v, principle, index, onDismiss }) {
     >
       <div className="vdetail-row-main">
         <SevBadge level={v.severity} format="long" />
-        <VerifiedChip v={v} />
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
+        <VerifiedChip v={v} />
         <button
           type="button"
           className="fix-plan-btn"

--- a/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/EvalCards.jsx
@@ -92,26 +92,28 @@ export function EvalViolationCard({ v, principle, index, onDismiss }) {
         <SevBadge level={v.severity} format="long" />
         <span className="vrow-label">[{v.principle || principle}]</span>
         {filename && <FileCopyBtn display={display} copyText={ref} />}
-        <VerifiedChip v={v} />
-        <button
-          type="button"
-          className="fix-plan-btn"
-          onClick={() => { const spec = violationFixPlanSpec(v, v.principle || principle); if (spec) addWindow(spec); }}
-        >
-          <SparkleIcon />
-          Fix plan
-        </button>
-        {onDismiss && (
+        <div className="vrow-actions">
+          <VerifiedChip v={v} />
           <button
             type="button"
-            className="dismiss-btn"
-            onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
-            title="Dismiss this finding (exclude from scoring)"
-            aria-label="Dismiss this finding (exclude from scoring)"
+            className="fix-plan-btn"
+            onClick={() => { const spec = violationFixPlanSpec(v, v.principle || principle); if (spec) addWindow(spec); }}
           >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            <SparkleIcon />
+            Fix plan
           </button>
-        )}
+          {onDismiss && (
+            <button
+              type="button"
+              className="dismiss-btn"
+              onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
+              title="Dismiss this finding (exclude from scoring)"
+              aria-label="Dismiss this finding (exclude from scoring)"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            </button>
+          )}
+        </div>
       </div>
       <ViolationDetail item={v} />
     </div>

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -43,26 +43,28 @@ const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
         {filename && (
           <FileCopyBtn display={display} copyText={ref} />
         )}
-        <VerifiedChip v={v} />
-        <button
-          type="button"
-          className="fix-plan-btn"
-          onClick={() => { const spec = violationFixPlanSpec(v); if (spec) addWindow(spec); }}
-        >
-          <SparkleIcon />
-          Fix plan
-        </button>
-        {onDismiss && (
+        <div className="vrow-actions">
+          <VerifiedChip v={v} />
           <button
             type="button"
-            className="dismiss-btn"
-            onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
-            title="Dismiss this finding (exclude from scoring)"
-            aria-label="Dismiss this finding (exclude from scoring)"
+            className="fix-plan-btn"
+            onClick={() => { const spec = violationFixPlanSpec(v); if (spec) addWindow(spec); }}
           >
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            <SparkleIcon />
+            Fix plan
           </button>
-        )}
+          {onDismiss && (
+            <button
+              type="button"
+              className="dismiss-btn"
+              onClick={(e) => { e.stopPropagation(); onDismiss(v); }}
+              title="Dismiss this finding (exclude from scoring)"
+              aria-label="Dismiss this finding (exclude from scoring)"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            </button>
+          )}
+        </div>
       </div>
       <div className="vlive-detail">
         {(v.title || v.reason) && (

--- a/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
+++ b/src/quodeq/ui/src/features/explorer/components/FileDetailPage.jsx
@@ -30,7 +30,6 @@ const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
     <div className={`vdetail-row vdetail-row--${v.severity}`}>
       <div className="vdetail-row-main">
         <span className={`severity-tag ${v.severity}`}>{v.severity}</span>
-        <VerifiedChip v={v} />
         {v.provenanceDowngrade && (
           <span
             className="provenance-downgrade-tag"
@@ -44,6 +43,7 @@ const ViolationCard = memo(function ViolationCard({ v, onDismiss }) {
         {filename && (
           <FileCopyBtn display={display} copyText={ref} />
         )}
+        <VerifiedChip v={v} />
         <button
           type="button"
           className="fix-plan-btn"

--- a/src/quodeq/ui/src/features/violations/components/VerifiedChip.jsx
+++ b/src/quodeq/ui/src/features/violations/components/VerifiedChip.jsx
@@ -10,17 +10,26 @@ export function VerifiedChip({ v }) {
   const verifiedCtx = useVerifiedFindings();
   const key = `${v.req || ''}|${v.file || ''}|${v.line || 0}`;
   if (!verifiedCtx?.keys?.has(key)) return null;
+  const note = verifiedCtx.noteFor(key);
+  // Icon-only badge: a filled accent circle with a check (theme-aligned, not
+  // a fixed blue). The tooltip carries the note; the aria-label always starts
+  // with "Verified" so the control is named for assistive tech and tests.
+  const hover = `${note || 'Verified by the assistant'}. Click to remove the badge.`;
+  const label = note
+    ? `Verified: ${note}. Click to remove the badge.`
+    : 'Verified by the assistant. Click to remove the badge.';
   return (
     <button
       type="button"
       className="verified-chip"
-      title={`${verifiedCtx.noteFor(key) || 'Verified by the assistant'}. Click to remove the badge.`}
+      title={hover}
+      aria-label={label}
       onClick={(e) => {
         e.stopPropagation();
         verifiedCtx.unverify(v).catch(() => {});
       }}
     >
-      verified
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12" /></svg>
     </button>
   );
 }

--- a/src/quodeq/ui/src/features/violations/components/VerifiedChip.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/VerifiedChip.test.jsx
@@ -20,13 +20,17 @@ it('renders nothing without a provider', () => {
   expect(container.firstChild).toBeNull();
 });
 
-it('renders the chip inside a provider when the key matches', async () => {
+it('renders an icon-only chip inside a provider when the key matches', async () => {
   render(
     <VerifiedFindingsProvider project="proj">
       <VerifiedChip v={{ req: 'r1', file: 'a.py', line: 3 }} />
     </VerifiedFindingsProvider>,
   );
-  await waitFor(() => expect(screen.getByRole('button', { name: /verified/i })).toBeInTheDocument());
+  const btn = await screen.findByRole('button', { name: /verified/i });
+  // Icon-only: named via aria-label (note included), no visible text, an svg check.
+  expect(btn).toHaveAccessibleName(/confirmed real/i);
+  expect(btn.textContent).toBe('');
+  expect(btn.querySelector('svg')).toBeInTheDocument();
 });
 
 it('renders nothing for an unmatched key', async () => {

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -3095,9 +3095,11 @@ button.eval-provider-badge--clickable:focus-visible {
   overflow-wrap: anywhere;
 }
 
-.verified-chip { border: 1px solid var(--color-accent); color: var(--color-accent); background: transparent; border-radius: 6px; padding: 1px 7px; font-size: 11px; font-family: var(--font-mono); cursor: pointer; }
-/* The chip sits on the right, against the Fix plan button: it takes over the
-   row's auto margin, and the button (which normally carries it) yields so the
-   container gap spaces the pair. Rows without a badge keep today's layout. */
-.vdetail-row-main .verified-chip { margin-left: auto; }
-.vdetail-row-main .verified-chip + .fix-plan-btn { margin-left: 0; }
+.verified-chip { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; padding: 0; border: none; border-radius: 50%; background: var(--color-accent); color: var(--color-on-accent); cursor: pointer; flex-shrink: 0; }
+.verified-chip:hover { opacity: 0.85; }
+/* Right-aligned action cluster: the verified chip (when present), fix plan,
+   and dismiss stay together and wrap as one unit. The group carries the auto
+   margin, so the inner fix plan yields its own. Rows keep today's layout when
+   the chip is absent. */
+.vdetail-row-main .vrow-actions { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; }
+.vdetail-row-main .vrow-actions .fix-plan-btn { margin-left: 0; }

--- a/src/quodeq/ui/src/styles/evaluation.css
+++ b/src/quodeq/ui/src/styles/evaluation.css
@@ -3096,3 +3096,8 @@ button.eval-provider-badge--clickable:focus-visible {
 }
 
 .verified-chip { border: 1px solid var(--color-accent); color: var(--color-accent); background: transparent; border-radius: 6px; padding: 1px 7px; font-size: 11px; font-family: var(--font-mono); cursor: pointer; }
+/* The chip sits on the right, against the Fix plan button: it takes over the
+   row's auto margin, and the button (which normally carries it) yields so the
+   container gap spaces the pair. Rows without a badge keep today's layout. */
+.vdetail-row-main .verified-chip { margin-left: auto; }
+.vdetail-row-main .verified-chip + .fix-plan-btn { margin-left: 0; }


### PR DESCRIPTION
## Summary

Follow-up polish to the verified badge shipped in #722, based on live design review. Two commits:

1. **Reposition** — the verified badge, Fix plan, and dismiss controls now live in a right-aligned `.vrow-actions` group, so the badge sits immediately left of Fix plan and the trio stays together and wraps as one unit. (The previous `margin-left:auto` on the badge alone was fragile: a narrow badge could slip onto the file-name line while Fix plan dropped below.) Rows without a badge keep their exact prior layout.
2. **Circle badge** — the badge is now an icon-only, accent-filled circle with a check (theme-aligned via `--color-accent`: cyan in the dark theme, the theme accent in each other theme), replacing the outlined lowercase `verified` text chip. Icon-only, so it names itself via `aria-label` (starts with "Verified", includes the note); the hover tooltip still carries the assistant's justification and the click-to-remove affordance is unchanged.

Surfaces: explorer finding/principle detail cards and the violations file drill-in (same three components the badge already rendered in).

## Verification

- `src/features/violations/` + `src/features/explorer/` suites green (50 tests); full UI build clean.
- Verified live in the running app in both dark and light themes: badge is an accent circle immediately left of Fix plan, on the same row, 8px gap; click still clears the badge.

## Note

Reviewed the light-theme rendering with the user: the default (crimson) theme makes the circle red. They chose to keep it following `--color-accent` for brand consistency rather than a fixed green, aware of the tradeoff.
