### PR TITLE
fix(dashboard): run view applies dismissed and deleted filters

### DIFF
--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -22,7 +22,9 @@ from quodeq.services.ports import (
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services.deleted import filter_deleted_from_dimensions
 from quodeq.services.dim_resolution import is_eligible_for_default_view
+from quodeq.services.dismissed import filter_dismissed_from_dimensions
 
 _logger = logging.getLogger(__name__)
 
@@ -285,6 +287,22 @@ def _attach_exit_reason_to_dim(
     return out
 
 
+def _attach_dismissed_count_to_dim(
+    dim_dict: dict[str, Any], dismissed_counts: dict[str, int],
+) -> dict[str, Any]:
+    """Add ``dismissedCount`` to a serialized dimension dict when > 0.
+
+    The count says how many of the scan's re-found violations were hidden by
+    the project-level dismissed filter, so the UI can explain the gap between
+    "what the scan found" and "what the view shows". Omitted when nothing was
+    filtered, mirroring the exitReason convention.
+    """
+    count = dismissed_counts.get(dim_dict.get("dimension") or "", 0)
+    if count <= 0:
+        return dim_dict
+    return {**dim_dict, "dismissedCount": count}
+
+
 def _build_dashboard_result(
     project: str,
     runs: list[RunInfo],
@@ -292,10 +310,14 @@ def _build_dashboard_result(
     payload: _DashboardPayload,
     *,
     exit_reason: str | None = None,
+    dismissed_counts: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     """Assemble the final dashboard response dict from pre-computed parts."""
     dim_dicts = [
-        _attach_exit_reason_to_dim(to_camel_dict(d), exit_reason)
+        _attach_dismissed_count_to_dim(
+            _attach_exit_reason_to_dim(to_camel_dict(d), exit_reason),
+            dismissed_counts or {},
+        )
         for d in payload.dimensions_with_trend
     ]
     return {
@@ -453,10 +475,22 @@ def build_dashboard(
 
     selected_run, selected_index = _resolve_selected_run(runs, run)
     # read_run_data overlays the SQL grade tables for event-log runs, so the
-    # selected run's dims (and the summary derived from them) already reflect
-    # dismisses and any applied grade formula. Passing *params* keeps the
-    # aggregate threshold labels and dimension weights in sync.
+    # selected run's GRADES already reflect dismissals and any applied grade
+    # formula. The violations/totals, however, come verbatim from the frozen
+    # eval JSON, which by design keeps everything the scan found - including
+    # findings the user dismissed in an earlier run. Apply the same read-time
+    # dismissed/deleted filters as the dimension detail and the accumulated
+    # overview, or a long-dismissed critical resurfaces in the history run
+    # view with counts that contradict its own grade.
     selected_dims = read_run_data(reports_root, project, selected_run.run_id)
+    project_dir = reports_root / project
+    pre_filter_counts = {d.dimension: len(d.violations) for d in selected_dims}
+    selected_dims = filter_dismissed_from_dimensions(selected_dims, project_dir)
+    dismissed_counts = {
+        (d.dimension or ""): pre_filter_counts.get(d.dimension, 0) - len(d.violations)
+        for d in selected_dims
+    }
+    selected_dims = filter_deleted_from_dimensions(selected_dims, project_dir)
     ctx = _SelectedRunContext(
         run=selected_run,
         index=selected_index,
@@ -466,5 +500,6 @@ def build_dashboard(
     payload = _compute_dashboard_payload(reports_root, project, runs, ctx, cc, params)
     exit_reason = _read_run_exit_reason(reports_root, project, selected_run.run_id)
     return _build_dashboard_result(
-        project, runs, selected_run, payload, exit_reason=exit_reason,
+        project, runs, selected_run, payload,
+        exit_reason=exit_reason, dismissed_counts=dismissed_counts,
     )

--- a/src/quodeq/ui/src/features/dashboard/buildRunSummary.js
+++ b/src/quodeq/ui/src/features/dashboard/buildRunSummary.js
@@ -19,6 +19,7 @@ export default function buildRunSummary(dimensions, apiSummary) {
       totalCompliance: 0,
       dimensionCount: 0,
       severity: { critical: 0, major: 0, minor: 0 },
+      dismissed: 0,
     };
   }
 
@@ -29,13 +30,14 @@ export default function buildRunSummary(dimensions, apiSummary) {
       ? (scores.reduce((a, b) => a + b, 0) / scores.length).toFixed(1)
       : null;
 
-  let totalViolations = 0, totalCompliance = 0, critical = 0, major = 0, minor = 0;
+  let totalViolations = 0, totalCompliance = 0, critical = 0, major = 0, minor = 0, dismissed = 0;
   for (const d of dimensions) {
     totalViolations += d.totals?.violationCount || 0;
     totalCompliance += d.totals?.complianceCount || 0;
     critical += d.totals?.severity?.critical || 0;
     major += d.totals?.severity?.major || 0;
     minor += d.totals?.severity?.minor || 0;
+    dismissed += typeof d.dismissedCount === 'number' ? d.dismissedCount : 0;
   }
 
   return {
@@ -45,5 +47,6 @@ export default function buildRunSummary(dimensions, apiSummary) {
     totalCompliance,
     dimensionCount: dimensions.length,
     severity: { critical, major, minor },
+    dismissed,
   };
 }

--- a/src/quodeq/ui/src/features/dashboard/buildRunSummary.test.js
+++ b/src/quodeq/ui/src/features/dashboard/buildRunSummary.test.js
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import buildRunSummary from './buildRunSummary.js';
+
+const dim = (over = {}) => ({
+  dimension: 'maintainability',
+  overallGrade: 'Fair',
+  overallScore: '6.0',
+  totals: {
+    violationCount: 1,
+    complianceCount: 2,
+    severity: { critical: 0, major: 1, minor: 0 },
+  },
+  ...over,
+});
+
+// ---------------------------------------------------------------------------
+// dismissed aggregation
+// ---------------------------------------------------------------------------
+
+test('dismissed: sums dismissedCount across dimensions', () => {
+  const summary = buildRunSummary([
+    dim({ dismissedCount: 3 }),
+    dim({ dimension: 'security', dismissedCount: 2 }),
+  ]);
+  assert.equal(summary.dismissed, 5);
+});
+
+test('dismissed: 0 when no dimension carries dismissedCount', () => {
+  const summary = buildRunSummary([dim(), dim({ dimension: 'security' })]);
+  assert.equal(summary.dismissed, 0);
+});
+
+test('dismissed: 0 for the empty-dimensions fallback', () => {
+  const summary = buildRunSummary([]);
+  assert.equal(summary.dismissed, 0);
+});
+
+test('dismissed: ignores non-numeric dismissedCount', () => {
+  const summary = buildRunSummary([dim({ dismissedCount: 'nope' })]);
+  assert.equal(summary.dismissed, 0);
+});
+
+// ---------------------------------------------------------------------------
+// existing aggregation still intact
+// ---------------------------------------------------------------------------
+
+test('aggregates totals and severity as before', () => {
+  const summary = buildRunSummary([
+    dim({ dismissedCount: 1 }),
+    dim({ dimension: 'security' }),
+  ]);
+  assert.equal(summary.totalViolations, 2);
+  assert.equal(summary.totalCompliance, 4);
+  assert.equal(summary.severity.major, 2);
+  assert.equal(summary.dimensionCount, 2);
+});

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -53,13 +53,14 @@ function SeverityBadgeRow({ severity, onSeverityClick }) {
   );
 }
 
-function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNavigate }) {
+export function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNavigate }) {
   const dateLabel = dashboard?.selectedRun?.dateLabel || formatRunId(selectedRunId);
   const scoreNum = parseFloat(runSummary.numericAverage);
   const scoreDisplay = isNaN(scoreNum) ? '—' : scoreNum.toFixed(1);
   const grade = runSummary.overallGrade;
   const violations = runSummary.totalViolations || 0;
   const compliance = runSummary.totalCompliance || 0;
+  const dismissed = runSummary.dismissed || 0;
   const totalChecks = violations + compliance;
   const ratio = complianceRatio(violations, compliance);
 
@@ -81,7 +82,14 @@ function RunHeroSection({ dashboard, selectedRunId, runSummary, onCardNavigate }
         <Stat
           label="VIOLATIONS"
           value={violations}
-          hint={<SeverityBadgeRow severity={runSummary.severity} onSeverityClick={handleSeverity} />}
+          hint={
+            <>
+              <SeverityBadgeRow severity={runSummary.severity} onSeverityClick={handleSeverity} />
+              {dismissed > 0 && (
+                <span className="term-stat__dismissed-note">{dismissed} dismissed hidden</span>
+              )}
+            </>
+          }
           onClick={handleViolations}
           ariaLabel={violations > 0 ? 'Show all violations for this run' : undefined}
         />

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { RunHeroSection } from './RunOverviewPanel.jsx';
+
+const baseSummary = {
+  overallGrade: 'Fair',
+  numericAverage: '6.0',
+  totalViolations: 131,
+  totalCompliance: 175,
+  dimensionCount: 1,
+  severity: { critical: 0, major: 11, minor: 120 },
+  dismissed: 0,
+};
+
+const dashboard = { selectedRun: { runId: 'r1', dateLabel: '4 Jul 2026' } };
+
+describe('RunHeroSection dismissed note', () => {
+  it('shows how many findings the dismissed filter hid', () => {
+    render(
+      <RunHeroSection
+        dashboard={dashboard}
+        selectedRunId="r1"
+        runSummary={{ ...baseSummary, dismissed: 404 }}
+      />,
+    );
+    expect(screen.getByText(/404 dismissed hidden/)).toBeTruthy();
+  });
+
+  it('renders no note when nothing was dismissed', () => {
+    render(
+      <RunHeroSection
+        dashboard={dashboard}
+        selectedRunId="r1"
+        runSummary={baseSummary}
+      />,
+    );
+    expect(screen.queryByText(/dismissed hidden/)).toBeNull();
+  });
+
+  it('shows the note even when every violation was dismissed', () => {
+    render(
+      <RunHeroSection
+        dashboard={dashboard}
+        selectedRunId="r1"
+        runSummary={{
+          ...baseSummary,
+          totalViolations: 0,
+          severity: { critical: 0, major: 0, minor: 0 },
+          dismissed: 535,
+        }}
+      />,
+    );
+    expect(screen.getByText(/535 dismissed hidden/)).toBeTruthy();
+  });
+});

--- a/src/quodeq/ui/src/models/dimension.js
+++ b/src/quodeq/ui/src/models/dimension.js
@@ -33,6 +33,8 @@
  * @property {string|null}   [exitReason]        - per-dim or run-level exit signal.
  *   Values: "done" (success), "time_limit", "failure_streak", "cancelled",
  *   "error", or null/missing (legacy, treated as "done" by the UI).
+ * @property {number}        [dismissedCount]    - re-found violations hidden by the
+ *   project-level dismissed filter (dashboard run view). Missing when zero.
  *
  * @typedef {Object} DimensionEval
  * @property {string}           dimension

--- a/src/quodeq/ui/src/styles/terminal.css
+++ b/src/quodeq/ui/src/styles/terminal.css
@@ -493,6 +493,18 @@ button.term-sev-badge--clickable:focus-visible {
   gap: var(--term-space-1);
   align-items: center;
 }
+/* Quiet meta note beside the severity badges: how many re-found findings the
+   project-level dismissed filter hid from this run view. */
+.term-stat__dismissed-note {
+  font-family: var(--term-font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+}
+.acc-eval-sev-row + .term-stat__dismissed-note {
+  margin-left: var(--term-space-2);
+}
 
 /* ------------------------------------------------------------
    Violations (migrated) — terminal-style flag row & sev row

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -693,3 +693,99 @@ class TestDashboardSqlOverlayAfterConfidenceFix:
         sec = result["dimensions"][0]
         assert sec["overallScore"] == "7.7/10"
         assert sec["overallGrade"] == "Good"
+
+
+class TestBuildDashboardDismissedFiltering:
+    """The run-level dashboard payload must not resurface findings the user
+    dismissed or deleted at project level.
+
+    Regression for the 2026-07-04 report: run 03c99d26 showed "1 critical"
+    in the history run view for a finding dismissed on 2026-06-20, while the
+    dimension detail (which applies the dismissed-keys filter) correctly hid
+    it. The run view, the dimension detail, and the accumulated overview must
+    all read through the same dismissal semantics.
+    """
+
+    def _write_run(self, reports, project="proj", run_id="20260101T000000"):
+        """A legacy-style on-disk run with two violations in one dimension."""
+        import json as _json
+
+        run_dir = reports / project / run_id
+        eval_dir = run_dir / "evaluation"
+        eval_dir.mkdir(parents=True)
+        violations = [
+            {
+                "principle": "N/A", "req": "N/A",
+                "file": "src/a.py", "line": 73,
+                "title": "Arbitrary file read", "severity": "critical",
+            },
+            {
+                "principle": "Modularity", "req": "M-MOD-1",
+                "file": "src/b.py", "line": 5,
+                "title": "Oversized function", "severity": "major",
+            },
+        ]
+        (eval_dir / "maintainability.json").write_text(_json.dumps({
+            "dimension": "maintainability",
+            "overallScore": "6.0/10", "overallGrade": "Fair",
+            "principles": [], "violations": violations, "compliance": [],
+            "totals": {
+                "violationCount": 2, "complianceCount": 0,
+                "severity": {"critical": 1, "major": 1, "minor": 0},
+            },
+        }), encoding="utf-8")
+        evidence_dir = run_dir / "evidence"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "manifest.json").write_text('{"language_stats": {}}', encoding="utf-8")
+        return run_dir
+
+    def test_dismissed_finding_excluded_and_totals_recounted(self, tmp_path):
+        from quodeq.services.dismissed import dismiss_finding
+
+        self._write_run(tmp_path)
+        dismiss_finding(tmp_path / "proj", {"req": "N/A", "file": "src/a.py", "line": 73})
+
+        result = build_dashboard(str(tmp_path), "proj", "latest")
+
+        dim = result["dimensions"][0]
+        assert [v["file"] for v in dim["violations"]] == ["src/b.py"]
+        assert dim["totals"]["violationCount"] == 1
+        assert dim["totals"]["severity"]["critical"] == 0
+        assert dim["totals"]["severity"]["major"] == 1
+
+    def test_dismissed_count_attached_to_dimension(self, tmp_path):
+        from quodeq.services.dismissed import dismiss_finding
+
+        self._write_run(tmp_path)
+        dismiss_finding(tmp_path / "proj", {"req": "N/A", "file": "src/a.py", "line": 73})
+
+        result = build_dashboard(str(tmp_path), "proj", "latest")
+
+        assert result["dimensions"][0]["dismissedCount"] == 1
+
+    def test_no_dismissals_leaves_payload_unchanged(self, tmp_path):
+        self._write_run(tmp_path)
+
+        result = build_dashboard(str(tmp_path), "proj", "latest")
+
+        dim = result["dimensions"][0]
+        assert len(dim["violations"]) == 2
+        assert dim["totals"]["violationCount"] == 2
+        assert dim["totals"]["severity"]["critical"] == 1
+        assert "dismissedCount" not in dim
+
+    def test_deleted_finding_excluded_without_dismissed_count(self, tmp_path):
+        from quodeq.services.deleted import delete_finding
+
+        self._write_run(tmp_path)
+        delete_finding(tmp_path / "proj", {
+            "dimension": "maintainability", "principle": "Modularity", "file": "src/b.py",
+        })
+
+        result = build_dashboard(str(tmp_path), "proj", "latest")
+
+        dim = result["dimensions"][0]
+        assert [v["file"] for v in dim["violations"]] == ["src/a.py"]
+        assert dim["totals"]["violationCount"] == 1
+        # Deleted findings are suppressed, not "dismissed": no count is shown.
+        assert "dismissedCount" not in dim


### PR DESCRIPTION
## Problem

Opening a completed run from History showed findings the user had already dismissed. Run 03c99d26 (4 Jul, maintainability) displayed **1 critical / 535 violations** even though its only critical (\`src/quodeq/api/_llamacpp_log_routes.py:73\`) was dismissed as a verified FP on 20 June. The dimension detail correctly hid it, so the same run contradicted itself depending on which screen you looked at. The run view also showed a grade computed *excluding* dismissed findings (SQL overlay) next to counts computed *including* them.

## Root cause

\`build_dashboard\` reads the frozen \`evaluation/<dim>.json\`, which by design keeps everything a scan found. Dismissals are read-time state (project \`actions.jsonl\`), and the run view was the only surface that never applied them: \`filter_dismissed_from_dimensions\` existed but was wired only into the accumulated overview.

## Fix

- \`build_dashboard\` now applies \`filter_dismissed_from_dimensions\` + \`filter_deleted_from_dimensions\` to the selected run's dimensions, matching the accumulated overview. Totals are recounted by the filters, so badges, counts, grade, top-files, fix plan, and report all describe the same population.
- Each serialized dimension carries \`dismissedCount\` (omitted when zero, mirroring the \`exitReason\` convention).
- The run hero shows a quiet "N dismissed hidden" note beside the severity badges, so a re-scan that re-finds a pile of dismissed FPs does not look suspiciously clean and the gap to the scan log stays explainable.

## Verification

- TDD throughout: 4 new backend tests (on-disk fixture, real \`actions.jsonl\` events), 5 new \`buildRunSummary\` node tests, 3 new \`RunHeroSection\` component tests. All watched fail first.
- Full suites green: \`pytest -m "not integration"\` 4050 passed, UI node tests 245, vitest 717. Import-layer gate clean.
- Real-data E2E against run 03c99d26: served payload went from 535 violations / 1 critical to **114 open violations / 0 criticals / dismissedCount 404**, llamacpp finding absent.
- Verified in the browser through the real stack (scratch \`QUODEQ_EVALUATIONS_DIR\` fixture): run view shows VIOLATIONS 2, badges 1 maj / 1 min, note "1 dismissed hidden"; critical filtered from counts, badges, and violations-by-file.
- Adversarial review workflow (3 lenses, 7 raised findings): 0 confirmed; all refuted as unreachable or pre-existing.

## Known related issues (out of scope, filed separately)

- Dimension detail's *deleted*-filter is inert (reads \`principle\` from dicts that carry \`practiceId\`), so detail still serves 17 deleted-store findings this view now hides. Task filed.
- Assistant run-scoped tools and the exported run report still read/print unfiltered data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)