### PR TITLE
fix(dashboard): score cache stranded in-progress runs' partial dims

### DIFF
--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -22,6 +22,13 @@ from quodeq.shared._env import get_score_cache_path, score_cache_disabled
 
 _logger = logging.getLogger(__name__)
 _BUSY_TIMEOUT_MS = 5000
+# Bumped when the cache *writer* semantics change in a way that could have
+# produced bad rows, to invalidate everything written by the prior writer.
+# "2": earlier writers persisted in-progress runs' partial scalar sets (e.g. 1
+# of 6 dims), which the content-hash version could never invalidate; the
+# write-guard now persists only completed runs, and this bump rebuilds the
+# stranded partial rows once.
+_CACHE_WRITER_EPOCH = "2"
 _SCHEMA = (
     "CREATE TABLE IF NOT EXISTS run_scalars ("
     " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"
@@ -177,6 +184,7 @@ def score_cache_version(project_dir: Path, params: ScoringParams) -> str:
     rows without a write-path hook.
     """
     payload = json.dumps({
+        "epoch": _CACHE_WRITER_EPOCH,
         "dismissed": sorted(str(k) for k in dismissed_keys(project_dir)),
         "deleted": sorted(str(k) for k in deleted_keys(project_dir)),
         "params": _params_fingerprint(params),
@@ -230,6 +238,7 @@ def cached_accumulated(
 def make_cache_backed_fetcher(
     project: str, version: str,
     base_fetcher: Callable[[str], list[DimensionResult]],
+    is_cacheable: Callable[[str], bool] | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
     """Wrap *base_fetcher* (returns rescored dims) with the read-through cache.
 
@@ -238,6 +247,16 @@ def make_cache_backed_fetcher(
     them back, and returns the scalars. Returns scalar-only DimensionResults
     (dimension/overall_score/overall_grade). If the kill switch is set, returns
     *base_fetcher* unchanged.
+
+    ``is_cacheable`` gates *persistence* per run. The version hash covers only
+    dismissals/deletions/params, so it can't tell that an in-progress run's
+    scalar set grows as dimensions finish. Without a guard, opening History
+    mid-scan persists the run's partial set (e.g. only ``security`` of six) and
+    the run completing never invalidates it -- so the trend shows one dimension
+    forever while run-detail shows all six. Callers pass a predicate that is
+    True only for terminal (complete) runs; non-cacheable runs compute-through
+    and are served for the current build but never written to disk. Defaults to
+    "always cacheable" for backward compatibility.
     """
     if score_cache_disabled():
         return base_fetcher
@@ -264,11 +283,12 @@ def make_cache_backed_fetcher(
                                    overall_grade=d.overall_grade)
                    for d in dims if d.dimension]
         by_run[run_id] = scalars
-        try:
-            with open_score_cache() as conn:
-                write_cached_rows(conn, project, run_id, version, scalars)
-        except sqlite3.Error:
-            pass
+        if is_cacheable is None or is_cacheable(run_id):
+            try:
+                with open_score_cache() as conn:
+                    write_cached_rows(conn, project, run_id, version, scalars)
+            except sqlite3.Error:
+                pass
         return scalars
 
     return fetch

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -351,6 +351,7 @@ def _make_rescoring_fetcher(
 def _make_trend_fetcher(
     reports_root: Path, project: str,
     params: ScoringParams = DEFAULT_PARAMS,
+    cacheable_run_ids: set[str] | None = None,
 ) -> Callable[[str], list[DimensionResult]]:
     """Return the dimension fetcher for the trend chart.
 
@@ -363,6 +364,13 @@ def _make_trend_fetcher(
     rescoring fetcher with the read-through score cache. The cache version is a
     content-hash of the project's dismissals/deletions/params, so any change
     auto-invalidates without a write-path hook.
+
+    ``cacheable_run_ids`` restricts which runs the heavy-path cache may
+    *persist*: a run still scoring (in-progress) grows its dimension set as
+    dims finish, but the version hash can't see that, so persisting its partial
+    set would strand a stale row (fixed forever until dismissals/params change).
+    Only completed runs are safe to persist; when ``None`` every run is
+    cacheable (used by the fast path, which persists nothing anyway).
     """
     project_dir = reports_root / project
     if dismissed_keys(project_dir) or deleted_keys(project_dir):
@@ -373,7 +381,11 @@ def _make_trend_fetcher(
         # and in score_cache_version -- three reads total, each ~0.01s, acceptable.
         base = _make_rescoring_fetcher(reports_root, project, params=params)
         version = score_cache_version(project_dir, params)
-        return make_cache_backed_fetcher(project, version, base)
+        is_cacheable = (
+            None if cacheable_run_ids is None
+            else (lambda rid: rid in cacheable_run_ids)
+        )
+        return make_cache_backed_fetcher(project, version, base, is_cacheable=is_cacheable)
     cache, lock = create_dimension_cache()
     return make_lru_dimension_fetcher(
         reports_root, project, cache, lock,
@@ -513,7 +525,14 @@ def get_project_scores(
     # when the user asks for them explicitly.
     scoreable_runs = [r for r in all_runs if r.status not in ("cancelled", "failed")]
     history_runs = scoreable_runs[:_max_history_runs()]
-    trend_fetcher = _make_trend_fetcher(reports_root, project, params=params)
+    # Only completed runs may be persisted to the score cache: an in-progress
+    # run's scalar set is still growing, and the cache version can't see that,
+    # so caching its partial set would strand a stale row (e.g. 1 of 6 dims)
+    # served forever after the run finishes.
+    cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
+    trend_fetcher = _make_trend_fetcher(
+        reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
+    )
     trend = build_accumulated_trend(history_runs, trend_fetcher, params=params)
 
     # Build available runs list

--- a/tests/services/test_score_cache_fetcher.py
+++ b/tests/services/test_score_cache_fetcher.py
@@ -43,3 +43,51 @@ def test_kill_switch_returns_base_fetcher(tmp_path, monkeypatch):
     monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
     base = _rescored
     assert make_cache_backed_fetcher("proj", "v1", base) is base
+
+
+def _dims(*names):
+    return [DimensionResult(dimension=n, overall_score="8.0/10", overall_grade="Good") for n in names]
+
+
+def test_in_progress_run_is_not_persisted(tmp_path, monkeypatch):
+    """A run cached mid-flight must not permanently mask its completed result.
+
+    Regression: opening History while a scan runs (only the first dim scored)
+    used to persist that partial set. Because the cache version only hashes
+    dismissals/deletions/params, the run completing never invalidated it, so
+    the history trend showed 1 dim forever while run-detail showed all of them.
+    Non-cacheable (in-progress) runs must compute-through without persisting.
+    """
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+
+    # Build 1: run "r1" is in progress -- only "security" has scored so far.
+    partial_calls = []
+    def base_partial(rid):
+        partial_calls.append(rid)
+        return _dims("security")
+
+    f1 = make_cache_backed_fetcher("proj", "v1", base_partial, is_cacheable=lambda rid: False)
+    out1 = f1("r1")
+    assert [d.dimension for d in out1] == ["security"]   # still served this build
+    assert partial_calls == ["r1"]
+
+    # Build 2 (fresh bulk-load): the run has since completed all 6 dims. Because
+    # the partial set was never persisted, this is a MISS and re-fetches fresh.
+    full_calls = []
+    def base_full(rid):
+        full_calls.append(rid)
+        return _dims("security", "reliability", "maintainability",
+                     "performance", "usability", "flexibility")
+
+    f2 = make_cache_backed_fetcher("proj", "v1", base_full, is_cacheable=lambda rid: True)
+    out2 = f2("r1")
+    assert [d.dimension for d in out2] == sorted(
+        ["flexibility", "maintainability", "performance", "reliability", "security", "usability"]
+    ) or len(out2) == 6
+    assert full_calls == ["r1"]   # re-fetched, not served the stale 1-dim set
+
+    # Build 3: now the completed run IS persisted -> hit, base not called.
+    def boom(rid):
+        raise AssertionError("base fetcher called on a cache hit for a completed run")
+    f3 = make_cache_backed_fetcher("proj", "v1", boom, is_cacheable=lambda rid: True)
+    assert len(f3("r1")) == 6

--- a/tests/services/test_score_cache_in_progress.py
+++ b/tests/services/test_score_cache_in_progress.py
@@ -1,0 +1,67 @@
+"""Regression: an in-progress run must not be persisted to the score cache.
+
+Opening History (or its live refresh polling) while a scan is running used to
+persist the run's *partial* scalar set -- e.g. only ``security`` of six. The
+cache version hashes only dismissals/deletions/params, so the run completing
+never invalidated that row: the history trend showed one dimension forever
+while run-detail (which reads the run's evaluation output directly) showed all
+six. Only terminal (complete) runs may be persisted.
+"""
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from quodeq.services import _external_jobs
+from quodeq.services.dashboard import clear_shared_dimension_cache
+from quodeq.services.dismissed import dismiss_finding, dismissed_keys
+from quodeq.services.scoring import get_project_scores
+from tests.services._scalar_fixtures import build_projected_run
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "sc.db"))
+    clear_shared_dimension_cache()
+    yield
+    clear_shared_dimension_cache()
+
+
+def _cached_run_ids(cache_path: Path) -> dict[str, int]:
+    """Map run_id -> number of persisted scalar rows in the score cache."""
+    if not cache_path.exists():
+        return {}
+    conn = sqlite3.connect(cache_path)
+    try:
+        rows = conn.execute(
+            "SELECT run_id, COUNT(*) FROM run_scalars GROUP BY run_id"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {rid: n for rid, n in rows}
+
+
+def test_in_progress_run_not_persisted_but_complete_run_is(tmp_path, monkeypatch):
+    reports = tmp_path / "evaluations"
+    # A finished run (persists normally) and a still-running run (must not persist).
+    build_projected_run(reports, "proj", "20260101T000000", {"security": (7.0, "Fair")})
+    live_run = "20260102T000000"
+    build_projected_run(reports, "proj", live_run, {"security": (8.0, "Good")})
+    dismiss_finding(reports / "proj", {"req": "R1", "file": "a.py", "line": 1})
+    assert dismissed_keys(reports / "proj"), "heavy (cached) path not activated"
+
+    # Make the newer run look live: resolve_external_pid returns a pid for it.
+    def fake_pid(project, run_id, root):
+        return 4242 if run_id == live_run else None
+    monkeypatch.setattr(_external_jobs, "resolve_external_pid", fake_pid)
+
+    scores = get_project_scores(reports, "proj")
+    trend_ids = {e["runId"] for e in scores["trend"]}
+    assert live_run in trend_ids, "in-progress run should still be served in the trend"
+
+    cached = _cached_run_ids(tmp_path / "sc.db")
+    assert cached.get("20260101T000000") == 1, "completed run should be persisted"
+    assert live_run not in cached, (
+        "in-progress run must NOT be persisted -- its partial scalar set would be "
+        "served forever after the run completes"
+    )

--- a/tests/services/test_score_cache_version.py
+++ b/tests/services/test_score_cache_version.py
@@ -25,6 +25,22 @@ def test_changes_when_dismissals_change(tmp_path, monkeypatch):
     assert v1 != v2
 
 
+def test_changes_when_writer_epoch_changes(tmp_path, monkeypatch):
+    """The writer epoch participates in the version.
+
+    Bumping it invalidates every row written by a prior writer -- the one-time
+    repair for runs whose partial (in-progress) scalar set was persisted before
+    the write-guard existed. They miss on the next build and are rebuilt fresh.
+    """
+    pd = tmp_path / "proj"; pd.mkdir()
+    monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: set())
+    monkeypatch.setattr("quodeq.services.score_cache.deleted_keys", lambda _p: set())
+    v1 = score_cache_version(pd, DEFAULT_PARAMS)
+    monkeypatch.setattr("quodeq.services.score_cache._CACHE_WRITER_EPOCH", "different-epoch")
+    v2 = score_cache_version(pd, DEFAULT_PARAMS)
+    assert v1 != v2
+
+
 def test_changes_when_params_change(tmp_path, monkeypatch):
     pd = tmp_path / "proj"; pd.mkdir()
     monkeypatch.setattr("quodeq.services.score_cache.dismissed_keys", lambda _p: set())

--- a/tests/services/test_scoring_scalar_parity.py
+++ b/tests/services/test_scoring_scalar_parity.py
@@ -30,7 +30,9 @@ def test_trend_identical_between_fast_and_heavy_paths(tmp_path: Path, monkeypatc
     import quodeq.services.scoring as scoring
     monkeypatch.setattr(
         scoring, "_make_trend_fetcher",
-        lambda rr, p, params=scoring.DEFAULT_PARAMS: scoring._make_rescoring_fetcher(rr, p, params=params),
+        lambda rr, p, params=scoring.DEFAULT_PARAMS, cacheable_run_ids=None: (
+            scoring._make_rescoring_fetcher(rr, p, params=params)
+        ),
     )
     heavy = get_project_scores(reports, "proj")
 


### PR DESCRIPTION
## Symptom

In the run **history** list, the latest run's *dimensions* column showed only **security**, but opening that run's **detail** view showed all **6** dimensions analyzed.

## Root cause

The history "dims" column is built from the per-run **score cache** (`score_cache.db`), while run-detail reads the run's evaluation output directly.

For dismissal-heavy projects the trend uses the **heavy path** → `make_cache_backed_fetcher`, which persists per-run scalars to `score_cache.db`. When History (or its live refresh) was opened **while a scan was still running**, the fetcher read the run's then-current state (only the first dimension, `security`, had finished) and persisted that single row.

The cache `version` ([`score_cache_version`](../blob/develop/src/quodeq/services/score_cache.py)) hashes only dismissals/deletions/grade-params — **not run status/completeness** — so the run finishing all 6 dims never invalidated the row. `fetch()` treats "any rows exist for this run_id" as a hit and served the stale 1-dim set indefinitely.

(The *accumulated* cache already guards on run status via `accumulated_cache_version`; the per-run scalar cache simply omitted the same guard.)

## Fix

**Prevention** — `make_cache_backed_fetcher` gains an `is_cacheable(run_id)` predicate. `get_project_scores` passes only **completed** runs, so in-progress runs compute-through and are never persisted. Fully backward compatible (`is_cacheable=None` → cache everything, as before).

**Repair** — bump the cache **writer epoch** folded into `score_cache_version`, invalidating rows written by the old partial-persisting writer so they rebuild once under the write-guard.

## Verification on real data

Reproduced from the real cache: run `5e3b8a76` had `dimensions.json`/`evaluation/` with all 6 dims `done`, but `run_scalars` held only `security` (written mid-scan, never refreshed). Blast radius in that project: 2 runs (`5e3b8a76` 1/6, `a8815193` 1/7).

After the epoch bump + rebuild (tested against a copy of the real cache, real evaluations dir), the trend entry for `5e3b8a76` rebuilds to `dimensionsCount = 6` with all 6 dims. Real cache untouched during verification.

## Tests

- `test_score_cache_fetcher.py::test_in_progress_run_is_not_persisted` — mid-flight partial set is not persisted; re-fetches fresh once complete.
- `test_score_cache_in_progress.py` — end-to-end via `get_project_scores`: an in-progress run is served but not persisted; a completed run is.
- `test_score_cache_version.py::test_changes_when_writer_epoch_changes` — epoch participates in the version (repair mechanism).

Full non-integration suite green: **4085 passed, 1 skipped**.

## Notes

- Frontend `filterTrendByVisibleStandards`/`visibleSet` was investigated and ruled out: `DEFAULT_VISIBLE_STANDARDS` contains all 6 dims, so it hides nothing by default. The bug was entirely in the backend score cache.
- One-time cost: the epoch bump forces a single score-cache rebuild per project on next dashboard load (idiomatic for this content-hash-versioned, disposable cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)