### PR TITLE
feat(ui): instant run-detail entry via hover prefetch + skeleton

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -332,7 +332,7 @@ const ROUTE_RENDERERS = {
       />
     );
   },
-  'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} />,
+  'history-run': (params, props) => <DashboardPage data={props.dashboardData} callbacks={{ onNavigate: props.navigation.handleNavigate }} runMode={true} pendingDateLabel={params.dateLabel} />,
   explorer: (params, props) => (
     <ExplorerPage
       project={params.fromProject || props.navigation.selectedProject}

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import DimensionCard from './DimensionCard.jsx';
 import AccumulatedOverviewPanel from './AccumulatedOverviewPanel.jsx';
 import RunOverviewPanel from './RunOverviewPanel.jsx';
+import RunOverviewSkeleton from './RunOverviewSkeleton.jsx';
 import IncompleteSetupCard from './IncompleteSetupCard.jsx';
 import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import EmptyState from '../../../components/EmptyState.jsx';
@@ -106,7 +107,7 @@ function useDashboardHandlers(onNavigate, dashboard) {
   }), [onNavigate, dashboard]);
 }
 
-export default function DashboardPage({ data = {}, callbacks = {}, runMode = false }) {
+export default function DashboardPage({ data = {}, callbacks = {}, runMode = false, pendingDateLabel = null }) {
   const { selectedProject, selectedRun, projects = [], dashboard, accumulated, loading, isFetching, error, availableRuns = [], dailyRuns, overviewRunIndex = 0, granularity = 'day', onGranularityChange } = data;
   const projectInfo = projects.find((p) => (p.id || p.name) === selectedProject) || null;
   const { onNavigate, onRunSelect, onProjectsReload } = callbacks;
@@ -176,12 +177,15 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   // The page dims itself slightly so the user sees "still working" without
   // the jarring full-screen LoadingScreen.
   const isRefreshing = isFetching && !!dashboard && !isLoading;
+  // Run mode renders a structural skeleton while loading, so the page keeps
+  // its own loading affordance and the wrapper skips the dimmed state.
+  const showSkeleton = isLoading && runMode;
 
   return (
-    <div className={`dashboard-page dashboard-fade ${isLoading ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
+    <div className={`dashboard-page dashboard-fade ${isLoading && !showSkeleton ? 'dashboard-loading' : 'dashboard-ready'}${isRefreshing ? ' dashboard-refreshing' : ''}`}>
       <IncompleteSetupCard projectInfo={projectInfo} onComplete={handleSetupComplete} />
       {error && <p className="inline-error">Failed to load dashboard data. Please try again.</p>}
-      {isLoading && <LoadingScreen />}
+      {isLoading && (showSkeleton ? <RunOverviewSkeleton dateLabel={pendingDateLabel} /> : <LoadingScreen />)}
       {dashboard && (
         <DashboardContent
           runMode={runMode}

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewPanel.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import LoadingScreen from '../../../components/LoadingScreen.jsx';
 import TopOffendingFilesTable from './TopOffendingFilesTable.jsx';
 import DimensionGaugeCard from './DimensionGaugeCard.jsx';
+import RunOverviewSkeleton from './RunOverviewSkeleton.jsx';
 import { TermHeader, StatStrip, Stat, SevBadge, SectionLabel } from '../../../components/terminal/index.js';
 
 import { buildTopOffendingFiles, buildDimensionPlanFromViolations, buildProjectRootFile } from '../../../utils/explorerUtils.js';
@@ -190,26 +190,21 @@ export default function RunOverviewPanel({ dashboard, selectedRunId, projectName
   }, [dashboard]);
 
   const isLoading = !dashboard || !dashboard.dimensions;
+  if (isLoading) return <RunOverviewSkeleton dateLabel={runDateLabel} />;
   const dimCount = (dashboard?.dimensions || []).length;
 
   return (
-    <div className={`run-overview-fade ${isLoading ? 'run-overview-loading' : 'run-overview-ready'}`}>
-      {isLoading ? (
-        <div className="run-overview-spinner"><LoadingScreen /></div>
-      ) : (
-        <>
-          <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} runSummary={runSummary} onCardNavigate={onCardNavigate} />
-          <section className="quality-dimensions" aria-label="Quality dimensions">
-            <div className="quality-dimensions__head">
-              <SectionLabel>quality_dimensions · {dimCount}</SectionLabel>
-            </div>
-            <div className="dimensions-panel">
-              <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} trendDeltas={trendDeltas} />
-            </div>
-          </section>
-          <RunFileViolations runTopFiles={runTopFiles} onFileClick={onFileClick} />
-        </>
-      )}
+    <div className="run-overview-fade run-overview-ready">
+      <RunHeroSection dashboard={dashboard} selectedRunId={selectedRunId} runSummary={runSummary} onCardNavigate={onCardNavigate} />
+      <section className="quality-dimensions" aria-label="Quality dimensions">
+        <div className="quality-dimensions__head">
+          <SectionLabel>quality_dimensions · {dimCount}</SectionLabel>
+        </div>
+        <div className="dimensions-panel">
+          <RunDimensionsGrid dimensions={dashboard?.dimensions || []} selectedRunId={selectedRunId} dateLabel={dashboard?.selectedRun?.dateLabel} onDimensionClick={onDimensionClick} trendDeltas={trendDeltas} />
+        </div>
+      </section>
+      <RunFileViolations runTopFiles={runTopFiles} onFileClick={onFileClick} />
     </div>
   );
 }

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewSkeleton.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewSkeleton.jsx
@@ -1,0 +1,45 @@
+import { TermHeader, StatStrip, Stat, SectionLabel } from '../../../components/terminal/index.js';
+
+const STAT_LABELS = ['SCORE', 'VIOLATIONS', 'COMPLIANCE', 'RATIO'];
+const DIMENSION_CARD_COUNT = 6;
+
+function Block({ width }) {
+  return <span className="run-skel__block" style={{ width }} aria-hidden="true" />;
+}
+
+/**
+ * Loading placeholder for the run detail view.
+ *
+ * Mirrors the RunOverviewPanel layout (hero header + stat cards + dimension
+ * grid) so entering a run keeps the page structure stable instead of
+ * blanking to a full-screen spinner. The run date is already known from the
+ * navigation params, so the header renders it immediately.
+ */
+export default function RunOverviewSkeleton({ dateLabel }) {
+  return (
+    <div className="run-overview-fade run-overview-ready run-skel" role="status" aria-label="Loading run details">
+      <section className="acc-eval-panel acc-eval-panel--terminal">
+        <div className="acc-eval-panel__top">
+          <TermHeader name="run" sub={dateLabel || <Block width="10ch" />} />
+        </div>
+        <StatStrip cards>
+          {STAT_LABELS.map((label) => (
+            <Stat key={label} label={label} value={<Block width="3ch" />} hint={<Block width="9ch" />} />
+          ))}
+        </StatStrip>
+      </section>
+      <section className="quality-dimensions" aria-hidden="true">
+        <div className="quality-dimensions__head">
+          <SectionLabel>quality_dimensions</SectionLabel>
+        </div>
+        <div className="dimensions-panel">
+          <div className="dimensions-grid">
+            {Array.from({ length: DIMENSION_CARD_COUNT }, (_, i) => (
+              <div key={i} className="run-skel__card" />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/quodeq/ui/src/features/dashboard/components/RunOverviewSkeleton.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/RunOverviewSkeleton.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import RunOverviewSkeleton from './RunOverviewSkeleton.jsx';
+
+describe('RunOverviewSkeleton', () => {
+  it('shows the run date immediately while the payload loads', () => {
+    render(<RunOverviewSkeleton dateLabel="Jul 4, 2026" />);
+    expect(screen.getByText('Jul 4, 2026')).toBeTruthy();
+  });
+
+  it('mirrors the hero stat layout', () => {
+    render(<RunOverviewSkeleton dateLabel="Jul 4, 2026" />);
+    for (const label of ['SCORE', 'VIOLATIONS', 'COMPLIANCE', 'RATIO']) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it('is announced as a loading status', () => {
+    render(<RunOverviewSkeleton />);
+    expect(screen.getByRole('status', { name: /loading run details/i })).toBeTruthy();
+  });
+
+  it('renders placeholder blocks without a date label', () => {
+    const { container } = render(<RunOverviewSkeleton />);
+    expect(container.querySelectorAll('.run-skel__block').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('.run-skel__card').length).toBe(6);
+  });
+});

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchAdjacentRuns.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchAdjacentRuns.js
@@ -9,36 +9,10 @@
  * The hook is no-op when the project or runs list is empty.
  */
 import { useCallback } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { useApi } from "../../../api/ApiContext.jsx";
-import { getProjectScores } from "../../../api/index.js";
-import { projectKeys } from "../../../api/queryKeys.js";
-
-const STALE_TIME_MS = 60_000;
+import { usePrefetchRun } from "./usePrefetchRun.js";
 
 export function usePrefetchAdjacentRuns({ selectedProject, availableRuns, overviewRunIndex }) {
-  const queryClient = useQueryClient();
-  const { getDashboard } = useApi();
-
-  const prefetchRun = useCallback(
-    (runId) => {
-      if (!selectedProject || !runId) return;
-      // Dashboard payload (the main render).
-      queryClient.prefetchQuery({
-        queryKey: projectKeys.dashboard(selectedProject, runId),
-        queryFn: () => getDashboard(selectedProject, runId),
-        staleTime: STALE_TIME_MS,
-      });
-      // Scores payload (drives accumulated + trend).
-      const asOf = runId !== "latest" ? runId : null;
-      queryClient.prefetchQuery({
-        queryKey: projectKeys.scores(selectedProject, asOf),
-        queryFn: () => getProjectScores(selectedProject, asOf),
-        staleTime: STALE_TIME_MS,
-      });
-    },
-    [queryClient, getDashboard, selectedProject],
-  );
+  const prefetchRun = usePrefetchRun(selectedProject);
 
   const onPrevHover = useCallback(() => {
     const idx = Math.min(overviewRunIndex + 1, availableRuns.length - 1);

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
@@ -1,0 +1,40 @@
+/**
+ * Prefetch a single run's dashboard + scores payloads into the query cache.
+ *
+ * Pairs with the run-detail views: warming the cache on hover means that by
+ * the time the user clicks, the data is often already there and the loading
+ * state is skipped entirely. Shared by the overview run navigator
+ * (usePrefetchAdjacentRuns) and the History table rows.
+ */
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useApi } from "../../../api/ApiContext.jsx";
+import { getProjectScores } from "../../../api/index.js";
+import { projectKeys } from "../../../api/queryKeys.js";
+
+const STALE_TIME_MS = 60_000;
+
+export function usePrefetchRun(selectedProject) {
+  const queryClient = useQueryClient();
+  const { getDashboard } = useApi();
+
+  return useCallback(
+    (runId) => {
+      if (!selectedProject || !runId) return;
+      // Dashboard payload (the main render).
+      queryClient.prefetchQuery({
+        queryKey: projectKeys.dashboard(selectedProject, runId),
+        queryFn: () => getDashboard(selectedProject, runId),
+        staleTime: STALE_TIME_MS,
+      });
+      // Scores payload (drives accumulated + trend).
+      const asOf = runId !== "latest" ? runId : null;
+      queryClient.prefetchQuery({
+        queryKey: projectKeys.scores(selectedProject, asOf),
+        queryFn: () => getProjectScores(selectedProject, asOf),
+        staleTime: STALE_TIME_MS,
+      });
+    },
+    [queryClient, getDashboard, selectedProject],
+  );
+}

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.test.jsx
@@ -1,0 +1,66 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { usePrefetchRun } from './usePrefetchRun.js';
+import { useApi } from '../../../api/ApiContext.jsx';
+import { getProjectScores } from '../../../api/index.js';
+import { projectKeys } from '../../../api/queryKeys.js';
+
+vi.mock('../../../api/ApiContext.jsx', () => ({
+  useApi: vi.fn(),
+}));
+vi.mock('../../../api/index.js', () => ({
+  getProjectScores: vi.fn(),
+}));
+
+function makeWrapper(queryClient) {
+  return function Wrapper({ children }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('usePrefetchRun', () => {
+  let queryClient;
+  let getDashboard;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    getDashboard = vi.fn().mockResolvedValue({ dimensions: [] });
+    useApi.mockReturnValue({ getDashboard });
+    getProjectScores.mockResolvedValue({ trend: [] });
+  });
+
+  it('warms the dashboard and scores cache for a run', async () => {
+    const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current('r1');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(projectKeys.dashboard('p1', 'r1'))).toBeTruthy();
+      expect(queryClient.getQueryData(projectKeys.scores('p1', 'r1'))).toBeTruthy();
+    });
+    expect(getDashboard).toHaveBeenCalledWith('p1', 'r1');
+    expect(getProjectScores).toHaveBeenCalledWith('p1', 'r1');
+  });
+
+  it('maps the latest run to the null asOf scores key', async () => {
+    const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current('latest');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(projectKeys.scores('p1', null))).toBeTruthy();
+    });
+    expect(getProjectScores).toHaveBeenCalledWith('p1', null);
+  });
+
+  it('does nothing without a project or run id', () => {
+    const { result } = renderHook(() => usePrefetchRun(null), { wrapper: makeWrapper(queryClient) });
+    result.current('r1');
+
+    const { result: withProject } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    withProject.current(null);
+
+    expect(getDashboard).not.toHaveBeenCalled();
+    expect(getProjectScores).not.toHaveBeenCalled();
+  });
+});

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -9,6 +9,7 @@ const HistoryChartPanel = lazy(() => import('./HistoryChartPanel.jsx'));
 
 import RunNavigator from '../../dashboard/components/RunNavigator.jsx';
 import { useRunNavigator } from '../../../hooks/useRunNavigator.js';
+import { usePrefetchRun } from '../../dashboard/hooks/usePrefetchRun.js';
 import { readVisibleStandardIds } from '../../../utils/visibleStandards.js';
 import { filterTrendByVisibleStandards } from '../../../utils/scoreFiltering.js';
 import { TermHeader } from '../../../components/terminal/index.js';
@@ -130,7 +131,7 @@ function NotReadyToast({ message, onDismiss }) {
  *
  *   [ DATE ][ TIME ][ GRADE ][ SCORE ][ Δ ][ DIMENSIONS (flex) ]
  */
-function HistoryRow({ className = '', onClick, cells, onDelete, title }) {
+function HistoryRow({ className = '', onClick, onHover, cells, onDelete, title }) {
   const common = `history-row ${className}`.trim();
   const isHeader = className.includes('history-row--header');
   function handleDeleteClick(e) {
@@ -138,7 +139,7 @@ function HistoryRow({ className = '', onClick, cells, onDelete, title }) {
     onDelete?.();
   }
   return (
-    <div className={common} onClick={onClick} role={onClick ? 'button' : 'row'} tabIndex={onClick ? 0 : undefined} title={title}>
+    <div className={common} onClick={onClick} onMouseEnter={onHover} onFocus={onHover} role={onClick ? 'button' : 'row'} tabIndex={onClick ? 0 : undefined} title={title}>
       <div className="history-row__col history-row__col--date">{cells.date}</div>
       <div className="history-row__col history-row__col--time">{cells.time}</div>
       <div className="history-row__col history-row__col--grade">{cells.grade}</div>
@@ -209,7 +210,7 @@ function InProgressHistoryRow({ entry, onClick, onNotReadyClick }) {
   );
 }
 
-function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onDeleteRun, onNotReadyClick }) {
+function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onRunHover, onDeleteRun, onNotReadyClick }) {
   return (
     <section className="history-evaluations panel">
       <div className="history-evaluations__header">
@@ -249,6 +250,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
               key={entry.runId}
               className={`${isSelected ? 'history-row--selected' : ''}${isPartial ? ' history-row--partial' : ''}`.trim()}
               onClick={() => onRunClick(entry.runId, entry.dateLabel)}
+              onHover={onRunHover ? () => onRunHover(entry.runId) : undefined}
               onDelete={onDeleteRun ? () => onDeleteRun(entry.runId, entry.dateLabel || date) : undefined}
               cells={{
                 date,
@@ -284,7 +286,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
 
 function HistoryContent({ data, callbacks, runNav, languageSub }) {
   const { trend, selectedRunId, availableRuns } = data;
-  const { onRunClick, onRunChange, onDeleteRun } = callbacks;
+  const { onRunClick, onRunHover, onRunChange, onDeleteRun } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
   const inProgressStubs = useMemo(() => buildInProgressStubs(availableRuns, trend), [availableRuns, trend]);
   // Toast state for clicks on running runs that have no scored dimensions yet.
@@ -344,6 +346,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
         deltas={deltas}
         statusByRunId={statusByRunId}
         onRunClick={onRunClick}
+        onRunHover={onRunHover}
         onDeleteRun={onDeleteRun}
         onNotReadyClick={handleNotReadyClick}
       />
@@ -367,6 +370,8 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   // to "complete" without the user manually reloading. Scoped to this
   // page only — other tabs don't poll.
   useRunningRunsRefresh({ selectedProject, availableRuns });
+  // Warm the run-detail cache on row hover so clicking through is instant.
+  const prefetchRun = usePrefetchRun(selectedProject);
   const visibleSet = useMemo(() => new Set(readVisibleStandardIds()), []);
   const trend = useMemo(() => filterTrendByVisibleStandards(rawTrend || [], visibleSet), [rawTrend, visibleSet]);
 
@@ -459,7 +464,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   return (
     <HistoryContent
       data={{ trend, selectedRunId, availableRuns }}
-      callbacks={{ onRunClick, onRunChange, onDeleteRun: handleDeleteRun }}
+      callbacks={{ onRunClick, onRunHover: prefetchRun, onRunChange, onDeleteRun: handleDeleteRun }}
       runNav={{ runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest }}
       languageSub={languageSub}
     />

--- a/src/quodeq/ui/src/styles/dashboard.css
+++ b/src/quodeq/ui/src/styles/dashboard.css
@@ -40,32 +40,46 @@
   transition: opacity 250ms ease;
 }
 
-.run-overview-loading {
-  opacity: 0.4;
-}
-
 .run-overview-ready {
   animation: run-overview-fadein 300ms ease;
-}
-
-.run-overview-spinner {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 60vh;
-}
-
-.run-overview-spinner .loading-screen {
-  position: static;
-  inset: auto;
-  z-index: auto;
-  width: auto;
-  height: auto;
 }
 
 @keyframes run-overview-fadein {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+/* ── Run overview skeleton ────────────────────────────── */
+/* Placeholder shown while the run payload loads. Mirrors the hero +
+   dimension-grid layout so the page structure stays stable; blocks pulse
+   to signal loading without a full-screen spinner. */
+
+.run-skel__block {
+  display: inline-block;
+  height: 1em;
+  border-radius: 3px;
+  background: var(--color-border);
+  animation: run-skel-pulse 1.2s ease-in-out infinite;
+}
+
+.run-skel__card {
+  height: 180px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  animation: run-skel-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes run-skel-pulse {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 0.25; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .run-skel__block,
+  .run-skel__card {
+    animation: none;
+    opacity: 0.4;
+  }
 }
 
 /* ── Stat cards ───────────────────────────────────────── */


### PR DESCRIPTION
## Problem

Entering a run detail from History always blanked the page behind a full-screen spinner for 1-3 seconds. Measured in the live app: the `/dashboard?run=` payload is ~8MB (~430ms server-side warm, ~2.2s cold), History views deliberately keep no placeholder data (PR #338, to avoid flashing another run's numbers), and nothing prefetched on row hover.

## Changes

**1. Hover prefetch on History rows.** `usePrefetchRun` (extracted from `usePrefetchAdjacentRuns`, which now shares it) warms the dashboard + scores query cache on row `mouseenter`/`focus`. React Query dedupes by key with a 60s staleTime, so repeated hovers don't refire.

**2. Run-detail skeleton instead of the full-screen spinner.** While the payload loads, `RunOverviewSkeleton` mirrors the real layout: the hero header renders the run date immediately (threaded from the `history-run` nav params via `pendingDateLabel`), with pulsing stat/dimension placeholders (`prefers-reduced-motion` respected). It replaces both the DashboardPage run-mode `LoadingScreen` and the RunOverviewPanel internal spinner; the unused spinner CSS is removed.

Note: a third commit (frozen staleTime for completed historical runs, killing the background-refetch dim on re-entry) was pushed to this branch after the merge and did not land here. It ships in #728.

## Verification

- Live app against real project data (dev UI + running backend):
  - Hovering a History row fires both `/dashboard?run=` and `/scores?asOf=` prefetches.
  - Hover-then-click: content mounts in under 150ms with zero fetches and no loading state.
  - Cold click (no hover): skeleton visible at 120ms with the real run date, no spinner; swaps atomically to content when the payload lands.
- UI suite green: 132 files / 736 tests, including new tests for `usePrefetchRun` and `RunOverviewSkeleton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)