### PR TITLE
fix(ui): stop the background-refetch dim on frozen historical runs

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -444,13 +444,21 @@ export default function App() {
   // fetched once on mount.
   const [dismissRefreshKey, setDismissRefreshKey] = useState(0);
   const bumpDismissRefresh = () => setDismissRefreshKey((k) => k + 1);
+  const { refreshDashboard: refreshDashboardForApply } = state;
   useEffect(() => {
     const handler = (event) => {
-      if (event.detail?.actionType === 'dismiss_finding') bumpDismissRefresh();
+      if (event.detail?.actionType === 'dismiss_finding') {
+        bumpDismissRefresh();
+        // Assistant-applied dismissals mutate the same payloads manual ones
+        // do; invalidate the project queries so frozen run views (staleTime
+        // Infinity) refetch on their next mount instead of showing the
+        // pre-dismiss counts forever.
+        refreshDashboardForApply?.();
+      }
     };
     window.addEventListener('quodeq:assistant-action-applied', handler);
     return () => window.removeEventListener('quodeq:assistant-action-applied', handler);
-  }, []);
+  }, [refreshDashboardForApply]);
   // Auto-open is a once-per-session decision. Without this guard, closing the
   // wizard sets wizardEntry → null, which re-fires this effect and re-opens
   // the wizard immediately because projects.length is still 0. The user's

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -25,18 +25,6 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
   const { getDashboard } = useApi();
   const queryClient = useQueryClient();
 
-  const dashboardQuery = useQuery({
-    queryKey: projectKeys.dashboard(selectedProject || "_none_", selectedRun),
-    queryFn: () => getDashboard(selectedProject, selectedRun),
-    enabled: !!selectedProject,
-    staleTime: 60_000,
-    // Keep showing the previous run's data while a new run loads — instant
-    // perceived navigation. isFetching toggles true during the background
-    // fetch, which the page reads to show a subtle indicator.
-    // Disabled when keepPlaceholder=false (History run details).
-    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
-  });
-
   const {
     scores,
     latestScores,
@@ -44,6 +32,30 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
     error: scoresError,
     availableRuns,
   } = useProjectScores({ selectedProject, selectedRun, keepPlaceholder });
+
+  // A completed historical run is immutable on disk: its payload only changes
+  // through explicit user actions (dismiss, delete, verify, grade formula,
+  // run deletion), and every one of those invalidates the project query
+  // subtree — which forces a refetch regardless of staleTime. Freezing the
+  // query here removes the routine time-based background refetch (and the
+  // dashboard-refreshing dim flash) on re-entering a run view. Unknown
+  // status counts as frozen: by the time a run detail is opened the runs
+  // list is already cached, and treating the brief unknown window as frozen
+  // avoids a spurious mount refetch.
+  const runStatus = (availableRuns || []).find((r) => r.runId === selectedRun)?.status;
+  const isFrozenRun = !!selectedRun && selectedRun !== "latest" && runStatus !== "in_progress";
+
+  const dashboardQuery = useQuery({
+    queryKey: projectKeys.dashboard(selectedProject || "_none_", selectedRun),
+    queryFn: () => getDashboard(selectedProject, selectedRun),
+    enabled: !!selectedProject,
+    staleTime: isFrozenRun ? Infinity : 60_000,
+    // Keep showing the previous run's data while a new run loads — instant
+    // perceived navigation. isFetching toggles true during the background
+    // fetch, which the page reads to show a subtle indicator.
+    // Disabled when keepPlaceholder=false (History run details).
+    placeholderData: keepPlaceholder ? (prev) => prev : undefined,
+  });
 
   const dashboardWithTrend = useMemo(() => {
     if (!dashboardQuery.data) return null;

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useDashboard } from "./useDashboard";
 import { withQueryClient } from "../../../test-utils/withQueryClient.jsx";
 import { ApiProvider } from "../../../api/ApiContext.jsx";
+import { projectKeys } from "../../../api/queryKeys.js";
+import { getProjectScores } from "../../../api/index.js";
 
 const fakeApi = {
   getDashboard: vi.fn(async (project, run) => ({
@@ -111,6 +114,99 @@ describe("useDashboard", () => {
       await result.current.refreshDashboardActive();
     });
     await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledTimes(2));
+  });
+});
+
+// A completed historical run's payload is immutable apart from explicit
+// mutations (dismiss/delete/formula), which invalidate the project subtree.
+// These tests pin the freeze contract: cached completed runs never refetch
+// on remount (no dashboard-refreshing dim flash), while 'latest',
+// in-progress runs, and invalidated entries still do.
+describe("useDashboard frozen historical runs", () => {
+  const OLD = () => Date.now() - 120_000; // well past the 60s staleTime
+
+  function seededClient({ runStatus = "complete" } = {}) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 60_000 }, mutations: { retry: false } },
+    });
+    // Fresh latest-scores entry: run statuses resolve synchronously, no fetch.
+    client.setQueryData(
+      projectKeys.scores("p1", null),
+      { accumulated: { score: 90 }, trend: [], availableRuns: [{ runId: "r1", status: runStatus }] },
+      { updatedAt: Date.now() },
+    );
+    // Stale entries for the run itself.
+    client.setQueryData(
+      projectKeys.dashboard("p1", "r1"),
+      { marker: "cached", trend: [], dimensions: [], selectedRun: { runId: "r1" } },
+      { updatedAt: OLD() },
+    );
+    client.setQueryData(
+      projectKeys.scores("p1", "r1"),
+      { accumulated: { score: 80 }, trend: [] },
+      { updatedAt: OLD() },
+    );
+    return client;
+  }
+
+  function wrapWith(client) {
+    return ({ children }) => (
+      <QueryClientProvider client={client}>
+        <ApiProvider value={fakeApi}>{children}</ApiProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it("serves a cached completed run without any refetch", async () => {
+    fakeApi.getDashboard.mockClear();
+    getProjectScores.mockClear();
+    const client = seededClient();
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: wrapWith(client) },
+    );
+    await waitFor(() => expect(result.current.dashboard).not.toBeNull());
+    expect(result.current.dashboard.marker).toBe("cached");
+    // Give any errant background refetch a chance to fire, then assert quiet.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fakeApi.getDashboard).not.toHaveBeenCalled();
+    expect(getProjectScores).not.toHaveBeenCalled();
+  });
+
+  it("still refetches a stale in-progress run", async () => {
+    fakeApi.getDashboard.mockClear();
+    const client = seededClient({ runStatus: "in_progress" });
+    renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: wrapWith(client) },
+    );
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledWith("p1", "r1"));
+  });
+
+  it("still refetches a stale latest selection", async () => {
+    fakeApi.getDashboard.mockClear();
+    const client = seededClient();
+    client.setQueryData(
+      projectKeys.dashboard("p1", null),
+      { marker: "cached-latest", trend: [], dimensions: [] },
+      { updatedAt: OLD() },
+    );
+    renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: null, keepPlaceholder: false }),
+      { wrapper: wrapWith(client) },
+    );
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledWith("p1", null));
+  });
+
+  it("refetches a frozen run after invalidation (dismiss/delete contract)", async () => {
+    fakeApi.getDashboard.mockClear();
+    const client = seededClient();
+    await client.invalidateQueries({ queryKey: projectKeys.project("p1"), refetchType: "none" });
+    renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: wrapWith(client) },
+    );
+    await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledWith("p1", "r1"));
   });
 });
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
@@ -21,18 +21,22 @@ export function usePrefetchRun(selectedProject) {
   return useCallback(
     (runId) => {
       if (!selectedProject || !runId) return;
+      // Historical runs are immutable (see useDashboard), so a cached entry
+      // is good until a mutation invalidates it — and prefetchQuery refetches
+      // invalidated entries regardless of staleTime.
+      const staleTime = runId !== "latest" ? Infinity : STALE_TIME_MS;
       // Dashboard payload (the main render).
       queryClient.prefetchQuery({
         queryKey: projectKeys.dashboard(selectedProject, runId),
         queryFn: () => getDashboard(selectedProject, runId),
-        staleTime: STALE_TIME_MS,
+        staleTime,
       });
       // Scores payload (drives accumulated + trend).
       const asOf = runId !== "latest" ? runId : null;
       queryClient.prefetchQuery({
         queryKey: projectKeys.scores(selectedProject, asOf),
         queryFn: () => getProjectScores(selectedProject, asOf),
-        staleTime: STALE_TIME_MS,
+        staleTime,
       });
     },
     [queryClient, getDashboard, selectedProject],

--- a/src/quodeq/ui/src/hooks/useProjectScores.js
+++ b/src/quodeq/ui/src/hooks/useProjectScores.js
@@ -57,7 +57,12 @@ export function useProjectScores({ selectedProject, selectedRun, keepPlaceholder
     // otherwise we'd briefly call with the raw selectedRun and only later
     // correct it, leaking a stale-asOf request.
     enabled: !!selectedProject && (isLatestSelection || latestQuery.isSuccess),
-    staleTime: 60_000,
+    // A non-null asOf always names a completed run (in-progress falls back
+    // to null above), and as-of scores for a completed run only change via
+    // explicit actions (dismiss/delete/formula) — all of which invalidate
+    // the project subtree and force a refetch regardless of staleTime.
+    // Freeze to skip the routine background refetch on re-entry.
+    staleTime: asOf ? Infinity : 60_000,
     // Keep prior scores visible while switching runs — see useDashboard for rationale.
     placeholderData: keepPlaceholder ? (prev) => prev : undefined,
   });

--- a/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
+++ b/src/quodeq/ui/src/hooks/useProjectScores.test.jsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useProjectScores } from "./useProjectScores";
 import { withQueryClient } from "../test-utils/withQueryClient.jsx";
 import { getProjectScores } from "../api/index.js";
+import { projectKeys } from "../api/queryKeys.js";
 
 vi.mock("../api/index.js", () => ({
   getProjectScores: vi.fn(async (project, asOf) => {
@@ -121,6 +124,32 @@ describe("useProjectScores", () => {
     });
     const asOfArgs = getProjectScores.mock.calls.map((c) => c[1]);
     expect(asOfArgs).toContain("r_old");
+  });
+
+  // As-of scores for a completed run are immutable apart from explicit
+  // mutations (which invalidate the project subtree), so a cached entry
+  // must be served without a background refetch — no dim flash on re-entry.
+  it("serves cached as-of scores for a completed run without refetching", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 60_000 } },
+    });
+    client.setQueryData(
+      projectKeys.scores("p1", null),
+      { accumulated: { score: 90 }, trend: [], availableRuns: [{ runId: "r1", status: "complete" }] },
+      { updatedAt: Date.now() },
+    );
+    client.setQueryData(
+      projectKeys.scores("p1", "r1"),
+      { accumulated: { score: 80 }, trend: [] },
+      { updatedAt: Date.now() - 120_000 }, // well past the old 60s staleTime
+    );
+    const { result } = renderHook(
+      () => useProjectScores({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: ({ children }) => <QueryClientProvider client={client}>{children}</QueryClientProvider> },
+    );
+    await waitFor(() => expect(result.current.scores?.accumulated?.score).toBe(80));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getProjectScores).not.toHaveBeenCalled();
   });
 
 });


### PR DESCRIPTION
Follow-up to #727. This commit was pushed to the #727 branch after it merged, so it never landed in develop; re-landed here via cherry-pick (original: 1fd11f74).

## Problem

Re-entering (or refocusing the window on) a run detail viewed more than a minute ago showed cached content instantly, then dimmed the page to 70% and back while a background refetch re-pulled multi-MB payloads. The dashboard and as-of scores queries carried a 60s staleTime that treated immutable historical data like live data.

## Change

Freeze the caches exactly where immutability holds, and nowhere else:

- `useDashboard`: staleTime Infinity when the selected run is a completed historical run (status from availableRuns; unknown counts as frozen since the runs list is cached by the time a run detail opens). `latest` and in-progress runs keep the 60s staleness.
- `useProjectScores`: the scoped as-of query freezes whenever `asOf` is set, which by construction names a completed run. The latest query keeps 60s.
- `usePrefetchRun`: hover prefetch of a historical run trusts any cached entry.

Correctness holds because every mutation that changes a run's payload (dismiss, delete, grade formula, run deletion) invalidates the project query subtree, and invalidation forces a refetch regardless of staleTime. The assistant card-apply dismiss path previously relied on the 60s staleness to propagate; it now calls `refreshDashboard` like the manual dismiss handlers.

The `dashboard-refreshing` dim now appears exactly when the run's content actually changed, instead of on every re-entry after a minute.

Known trade-off: a CLI-side dismissal made while the app sits open is not picked up by a frozen run view until an in-app action, project switch, or reload (previously the 60s clock caught it within a minute).

## Verification

- Live app against real project data: re-entering a cached run 75s later (past the old staleTime) renders instantly with zero network requests and no dim, and nothing fires in the following 2s; a never-visited run still fetches normally (skeleton + both requests).
- UI suite green: 741 tests, including freeze-contract tests: cached completed run never refetches on remount; stale `latest` and in-progress runs still do; an invalidated frozen run refetches (the dismiss/delete contract); cached as-of scores served without refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)