### PR TITLE
fix: 5 critical findings (fault tolerance + input hardening)

### DIFF
--- a/src/quodeq/analysis/_command.py
+++ b/src/quodeq/analysis/_command.py
@@ -243,6 +243,19 @@ def _resolve_language(config: AnalysisConfig) -> str:
     return ""
 
 
+def _is_known_cli_provider(cmd: str) -> bool:
+    """Return True only if *cmd* matches a registered provider of type 'cli'.
+
+    ``cmd`` ultimately comes from the user-controlled AI_CMD/AI_PROVIDER env
+    var (see ``quodeq.shared._env.get_ai_cmd``) with no prior validation. Gate
+    subprocess execution to the known provider registry so a typo'd or
+    unexpected value fails closed instead of shelling out to an arbitrary
+    program. Only ``type == "cli"`` providers reach this CLI-register path;
+    API-type providers (ollama, omlx, custom, ...) never do.
+    """
+    return _get_provider_configs().get(cmd, {}).get("type") == "cli"
+
+
 def _register_cli_mcp(cmd: str, config: AnalysisConfig, work_dir: Path | None = None) -> str | None:
     """Register the findings MCP server via `<cmd> mcp add`.
 
@@ -250,6 +263,9 @@ def _register_cli_mcp(cmd: str, config: AnalysisConfig, work_dir: Path | None = 
     the cached name immediately.  Removes any stale registration first.
     Returns the server name on success, None on failure.
     """
+    if not _is_known_cli_provider(cmd):
+        _log.warning("Refusing to register MCP server: unknown CLI provider %r", cmd)
+        return None
     name = _mcp_server_name(config)
     key = f"{cmd}:{name}"
     with _cli_mcp_lock:
@@ -278,6 +294,8 @@ def _register_cli_mcp(cmd: str, config: AnalysisConfig, work_dir: Path | None = 
 
 def _unregister_cli_mcp(cmd: str, name: str) -> None:
     """Remove the findings MCP server via `<cmd> mcp remove`."""
+    if not _is_known_cli_provider(cmd):
+        return
     try:
         subprocess.run(
             [cmd, "mcp", "remove", name],

--- a/src/quodeq/analysis/_config.py
+++ b/src/quodeq/analysis/_config.py
@@ -1,11 +1,11 @@
 """Analysis configuration dataclasses and type aliases."""
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
+from quodeq.shared._env import _env_int
 from quodeq.shared.constants import _DEFAULT_TIME_LIMIT
 
 if TYPE_CHECKING:
@@ -15,8 +15,8 @@ HeartbeatCallback = Callable[[int, dict], None]
 
 _DEFAULT_MAX_FILES_PER_AGENT = 30
 
-_DEFAULT_MAX_TURNS = int(os.environ.get("QUODEQ_DEFAULT_MAX_TURNS", "200"))
-_DEFAULT_MAX_DURATION = int(os.environ.get("QUODEQ_DEFAULT_MAX_DURATION", "1800"))  # 30 minutes
+_DEFAULT_MAX_TURNS = _env_int("QUODEQ_DEFAULT_MAX_TURNS", 200)
+_DEFAULT_MAX_DURATION = _env_int("QUODEQ_DEFAULT_MAX_DURATION", 1800)  # 30 minutes
 _MCP_TOOL_REPORT_FINDING = "mcp__findings__report_finding"
 _MCP_TOOL_GET_NEXT_FILES = "mcp__findings__get_next_files"
 _MCP_TOOL_MARK_FILE_DONE = "mcp__findings__mark_file_done"

--- a/src/quodeq/analysis/subprocess.py
+++ b/src/quodeq/analysis/subprocess.py
@@ -67,9 +67,9 @@ def _run_cli_analysis(
 ) -> None:
     """Run analysis via CLI subprocess."""
     ai_cmd = cfg.ai_cmd or get_ai_cmd()
-    # ai_cmd comes from provider config (not user input) and is executed via
-    # subprocess list (no shell injection). The command may not be on PATH in
-    # test/CI environments, so we skip shutil.which validation here.
+    # ai_cmd comes from the AI_CMD/AI_PROVIDER env var and is gated to known
+    # providers in _register_cli_mcp before any subprocess call; it runs via a
+    # subprocess list (no shell injection). Skipping shutil.which for CI/PATH.
     configs = get_provider_configs()
     provider_cfg = configs.get(ai_cmd, {})
     mcp_style = provider_cfg.get("mcp_style", "config-file")

--- a/src/quodeq/ci/export_cli.py
+++ b/src/quodeq/ci/export_cli.py
@@ -38,7 +38,7 @@ def _handle_sarif(args: argparse.Namespace) -> int:
         include_snippets=getattr(args, "with_snippets", False),
     )
 
-    out_path = Path(args.output)
+    out_path = Path(args.output).expanduser().resolve()
     try:
         out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.js
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.js
@@ -71,6 +71,7 @@ export function useAssistantStream(sessionId, { onDone } = {}) {
     es.onmessage = (e) => {
       resetInactivity();
       let frame; try { frame = JSON.parse(e.data); } catch { return; }
+      if (!frame || typeof frame !== 'object') return;
       if (frame.type === 'token') { beginContent(); pending.current += frame.text || ''; scheduleFlush(); }
       else if (frame.type === 'tool_call') { beginContent(); flushTokens(); append({ role: 'tool', name: frame.name, argsSummary: frame.argsSummary }); }
       else if (frame.type === 'action_draft') { beginContent(); flushTokens();

--- a/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
+++ b/src/quodeq/ui/src/features/assistant/useAssistantStream.test.jsx
@@ -150,3 +150,12 @@ it('a heartbeat data frame resets inactivity so a slow model does not time out',
   expect(result.current.messages.some((m) => m.role === 'heartbeat')).toBe(false);
   expect(result.current.messages.length).toBe(0);
 });
+
+it('a null JSON payload frame is ignored instead of crashing', () => {
+  // A `null` payload parses to `null`; accessing `frame.type` on it would throw.
+  const { result } = renderHook(() => useAssistantStream('s1'));
+  const es = MockES.instances[0];
+  expect(() => { act(() => { es.emit('message', null); }); }).not.toThrow();
+  expect(result.current.messages.length).toBe(0);
+  expect(result.current.error).toBe(null);
+});

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyView.jsx
@@ -56,6 +56,9 @@ function useGalaxyHandlers({ canvasRef, navRef, animRef, camRef, hoveredRef, mou
 }
 
 export default function GalaxyView({ dimensions, onNavigate, showLabels = true, setShowLabels, darkMode, resetKey = 0, projectName = '', standardTypes = {} }) {
+  // Guard against an omitted or null `dimensions` prop: normalize to an empty
+  // array so the memos below don't crash on `.map()`/`.length`.
+  const safeDimensions = dimensions ?? [];
   const canvasRef = useRef(null);
   const [size, setSize] = useState({ w: 800, h: 600 });
   const savedNavRef = useRef(null);
@@ -63,16 +66,16 @@ export default function GalaxyView({ dimensions, onNavigate, showLabels = true, 
 
   useEffect(() => { invalidateThemeColors(); }, [darkMode]);
 
-  const dimKey = useMemo(() => dimensions.map(d => d.dimension).sort().join('|'), [dimensions]);
+  const dimKey = useMemo(() => safeDimensions.map(d => d.dimension).sort().join('|'), [safeDimensions]);
   const typesKey = useMemo(() => Object.keys(standardTypes).sort().join('|'), [standardTypes]);
   const scene = useMemo(() => {
-    if (dimensions.length === 0) return null;
-    return buildScene(dimensions, 800, 600, standardTypes);
+    if (safeDimensions.length === 0) return null;
+    return buildScene(safeDimensions, 800, 600, standardTypes);
   }, [dimKey, typesKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useMemo(() => {
-    if (scene && dimensions.length > 0) updateSceneLiveData(scene, dimensions);
-  }, [dimensions, scene]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (scene && safeDimensions.length > 0) updateSceneLiveData(scene, safeDimensions);
+  }, [safeDimensions, scene]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const el = canvasRef.current?.parentElement;

--- a/src/quodeq/ui/src/features/map/viz/components/GalaxyView.test.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/GalaxyView.test.jsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import GalaxyView from './GalaxyView.jsx';
+
+// GalaxyView wires a ResizeObserver in a useEffect; jsdom does not provide one.
+// Stub it so the test exercises the real render path and isolates the bug under
+// test (a missing/null `dimensions` prop) rather than the environment gap.
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('GalaxyView', () => {
+  it('does not crash when dimensions is omitted', () => {
+    expect(() => render(<GalaxyView onNavigate={() => {}} />)).not.toThrow();
+  });
+
+  it('does not crash when dimensions is null', () => {
+    expect(() => render(<GalaxyView dimensions={null} onNavigate={() => {}} />)).not.toThrow();
+  });
+});

--- a/src/quodeq/ui/src/features/map/viz/components/galaxyViewInfo.jsx
+++ b/src/quodeq/ui/src/features/map/viz/components/galaxyViewInfo.jsx
@@ -39,6 +39,7 @@ export function LevelInfoPanel({ levelInfo }) {
  * @returns {object|null} { title, lines, hint, detailAction }
  */
 export function computeLevelInfo(scene, nav, projectName, onNavigate, navRef) {
+  if (!scene) return null;
   if (nav.depth === 0) {
     const clusterStars = nav.clusterCx != null
       ? scene.stars.filter(s => s._clusterCx === nav.clusterCx && s._clusterCy === nav.clusterCy)

--- a/tests/analysis/test_command.py
+++ b/tests/analysis/test_command.py
@@ -1,0 +1,39 @@
+"""Guards on AI_CMD-derived subprocess execution in analysis._command."""
+from quodeq.analysis._command import _register_cli_mcp, _unregister_cli_mcp
+from quodeq.analysis._config import AnalysisConfig
+
+
+def test_register_cli_mcp_rejects_unknown_provider(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "quodeq.analysis._command.subprocess.run",
+        lambda *a, **k: calls.append(a),
+    )
+    result = _register_cli_mcp("rm -rf /", AnalysisConfig())
+    assert result is None
+    assert calls == []
+
+
+def test_unregister_cli_mcp_rejects_unknown_provider(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "quodeq.analysis._command.subprocess.run",
+        lambda *a, **k: calls.append(a),
+    )
+    _unregister_cli_mcp("rm -rf /", "some-server-name")
+    assert calls == []
+
+
+def test_register_cli_mcp_allows_known_cli_provider(monkeypatch, tmp_path):
+    """A registered type='cli' provider (claude) still reaches subprocess.run."""
+    calls = []
+    monkeypatch.setattr(
+        "quodeq.analysis._command.subprocess.run",
+        lambda *a, **k: calls.append(a),
+    )
+    # Reset the module-level registration cache so this call is not short-circuited.
+    monkeypatch.setattr("quodeq.analysis._command._cli_mcp_registered", set())
+    config = AnalysisConfig(jsonl_file=tmp_path / "findings.jsonl")
+    result = _register_cli_mcp("claude", config)
+    assert result is not None
+    assert calls  # subprocess.run was invoked (register, and possibly unregister)

--- a/tests/analysis/test_config.py
+++ b/tests/analysis/test_config.py
@@ -1,0 +1,12 @@
+import importlib
+
+
+def test_invalid_max_turns_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("QUODEQ_DEFAULT_MAX_TURNS", "not-a-number")
+    import quodeq.analysis._config as config_mod
+    importlib.reload(config_mod)
+    try:
+        assert config_mod._DEFAULT_MAX_TURNS == 200
+    finally:
+        monkeypatch.delenv("QUODEQ_DEFAULT_MAX_TURNS", raising=False)
+        importlib.reload(config_mod)  # restore real env for subsequent tests

--- a/tests/analysis/test_mcp_registration.py
+++ b/tests/analysis/test_mcp_registration.py
@@ -27,7 +27,7 @@ class TestRegisterCliMcp:
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
-             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {}}):
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.return_value = MagicMock(returncode=0)
             name = _register_cli_mcp("mycli", config)
         assert name == "quodeq-findings"
@@ -36,7 +36,7 @@ class TestRegisterCliMcp:
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
-             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {}}):
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.return_value = MagicMock(returncode=0)
             _register_cli_mcp("mycli", config)
             _register_cli_mcp("mycli", config)
@@ -48,7 +48,7 @@ class TestRegisterCliMcp:
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
-             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {}}):
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.side_effect = [MagicMock(), subprocess.CalledProcessError(1, "mycli")]
             name = _register_cli_mcp("mycli", config)
         assert name is None
@@ -57,7 +57,7 @@ class TestRegisterCliMcp:
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
-             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {}}):
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.side_effect = [MagicMock(), subprocess.TimeoutExpired("mycli", 10)]
             name = _register_cli_mcp("mycli", config)
         assert name is None
@@ -66,7 +66,7 @@ class TestRegisterCliMcp:
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
-             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {}}):
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.side_effect = [MagicMock(), FileNotFoundError("mycli")]
             name = _register_cli_mcp("mycli", config)
         assert name is None
@@ -74,7 +74,7 @@ class TestRegisterCliMcp:
     def test_no_separator_when_configured(self, tmp_path):
         jsonl = tmp_path / "findings.jsonl"
         config = AnalysisConfig(jsonl_file=jsonl)
-        provider = {"gemini": {"mcp_add_separator": False}}
+        provider = {"gemini": {"mcp_add_separator": False, "type": "cli"}}
         with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
              patch("quodeq.analysis._command._get_provider_configs", return_value=provider):
             mock_run.return_value = MagicMock(returncode=0)
@@ -86,7 +86,8 @@ class TestRegisterCliMcp:
 
 class TestUnregisterCliMcp:
     def test_unregister_runs_command(self):
-        with patch("quodeq.analysis._command.subprocess.run") as mock_run:
+        with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.return_value = MagicMock()
             _unregister_cli_mcp("mycli", "quodeq-findings")
             mock_run.assert_called_once()
@@ -94,12 +95,14 @@ class TestUnregisterCliMcp:
             assert cmd == ["mycli", "mcp", "remove", "quodeq-findings"]
 
     def test_unregister_handles_timeout(self):
-        with patch("quodeq.analysis._command.subprocess.run") as mock_run:
+        with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.side_effect = subprocess.TimeoutExpired("mycli", 10)
             # Should not raise
             _unregister_cli_mcp("mycli", "quodeq-findings")
 
     def test_unregister_handles_file_not_found(self):
-        with patch("quodeq.analysis._command.subprocess.run") as mock_run:
+        with patch("quodeq.analysis._command.subprocess.run") as mock_run, \
+             patch("quodeq.analysis._command._get_provider_configs", return_value={"mycli": {"type": "cli"}}):
             mock_run.side_effect = FileNotFoundError("mycli")
             _unregister_cli_mcp("mycli", "quodeq-findings")

--- a/tests/ci/test_export_cli.py
+++ b/tests/ci/test_export_cli.py
@@ -42,6 +42,21 @@ def test_handle_export_writes_valid_sarif(tmp_path):
     assert len(doc["runs"][0]["results"]) == 1
 
 
+def test_handle_export_expands_user_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    eval_dir = tmp_path / "evaluation"
+    _write_report(eval_dir, "reliability", [
+        {"principle": "Fault Tolerance", "file": "app.py", "line": 1, "severity": "major",
+         "title": "t", "reason": "r", "req": "R-FT-1", "req_refs": []},
+    ])
+
+    code = handle_export(_args(evaluation_dir=str(eval_dir), output="~/out/report.sarif"))
+
+    assert code == 0
+    assert (tmp_path / "out" / "report.sarif").exists()
+
+
 def test_handle_export_missing_dir_returns_error(tmp_path, capsys):
     out = tmp_path / "out.sarif"
     code = handle_export(_args(evaluation_dir=str(tmp_path / "nope"), output=str(out)))

--- a/tests/ci/test_export_cli.py
+++ b/tests/ci/test_export_cli.py
@@ -43,7 +43,10 @@ def test_handle_export_writes_valid_sarif(tmp_path):
 
 
 def test_handle_export_expands_user_path(tmp_path, monkeypatch):
+    # `~` resolves via HOME on POSIX and USERPROFILE on Windows; set both so
+    # Path.expanduser() lands inside tmp_path on every platform.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.chdir(tmp_path)
     eval_dir = tmp_path / "evaluation"
     _write_report(eval_dir, "reliability", [


### PR DESCRIPTION
Fixes 5 critical scanner findings. Each is a minimal, surgical fix with a regression test; one commit per finding, all following TDD.

## What changed

| # | Finding | Fix |
|---|---------|-----|
| 1 | Env-var int parsing crashes at import (`analysis/_config.py`) | Reuse the existing `_env_int()` helper (warns + falls back instead of raising `ValueError`) |
| 2 | `GalaxyView` crashes on missing/null/empty `dimensions` | Normalize with `dimensions ?? []` **and** guard `computeLevelInfo` against a null scene |
| 3 | Assistant SSE handler crashes on a `null` JSON frame | `if (!frame \|\| typeof frame !== 'object') return;` before reading `frame.type` |
| 4 | `AI_CMD`-derived value shelled out unvalidated (`analysis/_command.py`) | Gate `_register/_unregister_cli_mcp` to providers registered as `type: "cli"` |
| 5 | Export output path used verbatim (`ci/export_cli.py`) | `Path(args.output).expanduser().resolve()` |

## Notes for the reviewer

**Finding 2 was deeper than the single flagged line.** Guarding only `dimensions.map()` just moves the crash ~70 lines down: with empty dimensions, `scene` becomes `null` and `computeLevelInfo` crashes (white screen). This is reachable in production — `MapPage` guards on the *unfiltered* `allDimensions` but passes the *filtered* `dimensions` to `GalaxyView`, so hiding all standard types yields an empty array. Both are fixed for genuine graceful degradation.

**Findings 4 and 5 are defensive hardening, not exploitable-vulnerability fixes.** `AI_CMD` and `--output` are both controlled by the same local user running this desktop CLI — no remote/privilege boundary is crossed, so the CWE-78/CWE-22 framing overstates real-world risk. The fixes are still worth having (fail-closed on typos, predictable `~` handling) and change nothing for legitimate callers.

**Task 4 test-fixture edits (`test_mcp_registration.py`):** those tests exercise the registration *machinery* using `mycli` with an under-specified mock config `{"mycli": {}}`. The new guard requires `type: "cli"`, so the mocks were updated to `{"mycli": {"type": "cli"}}` — preserving each test's original intent (a real CLI provider always has that type).

## Verification

- Python: `4090 passed, 1 skipped, 13 deselected` (`pytest -m "not integration"`)
- UI vitest: `739 passed (133 files)`; UI node `--test`: `245 passed`
- Production `vite build`: ✓ (`src/quodeq/static/` is gitignored, rebuilt at release — no stale bundle)
- Import-layer + working-tree gates: clean
