### PR TITLE
fix(ui): dwell-gate the History hover prefetch to kill the request storm

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchAdjacentRuns.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchAdjacentRuns.js
@@ -12,7 +12,7 @@ import { useCallback } from "react";
 import { usePrefetchRun } from "./usePrefetchRun.js";
 
 export function usePrefetchAdjacentRuns({ selectedProject, availableRuns, overviewRunIndex }) {
-  const prefetchRun = usePrefetchRun(selectedProject);
+  const { prefetchRun } = usePrefetchRun(selectedProject);
 
   const onPrevHover = useCallback(() => {
     const idx = Math.min(overviewRunIndex + 1, availableRuns.length - 1);

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.js
@@ -5,40 +5,65 @@
  * the time the user clicks, the data is often already there and the loading
  * state is skipped entirely. Shared by the overview run navigator
  * (usePrefetchAdjacentRuns) and the History table rows.
+ *
+ * The prefetch fires only after the pointer dwells PREFETCH_DWELL_MS on the
+ * same run. Both payloads are expensive to build server-side (seconds of CPU
+ * on large projects), so prefetching every row a mouse sweep crosses queued
+ * enough work to stall the click's own requests for tens of seconds. A dwell
+ * captures hover-then-click intent while a sweep across rows fires nothing:
+ * each new run resets the shared timer, and cancelPrefetch drops the pending
+ * one when the pointer leaves the rows entirely.
  */
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useApi } from "../../../api/ApiContext.jsx";
 import { getProjectScores } from "../../../api/index.js";
 import { projectKeys } from "../../../api/queryKeys.js";
 
 const STALE_TIME_MS = 60_000;
+export const PREFETCH_DWELL_MS = 150;
 
 export function usePrefetchRun(selectedProject) {
   const queryClient = useQueryClient();
   const { getDashboard } = useApi();
+  const timerRef = useRef(null);
 
-  return useCallback(
+  const cancelPrefetch = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancelPrefetch, [cancelPrefetch]);
+
+  const prefetchRun = useCallback(
     (runId) => {
+      cancelPrefetch();
       if (!selectedProject || !runId) return;
-      // Historical runs are immutable (see useDashboard), so a cached entry
-      // is good until a mutation invalidates it — and prefetchQuery refetches
-      // invalidated entries regardless of staleTime.
-      const staleTime = runId !== "latest" ? Infinity : STALE_TIME_MS;
-      // Dashboard payload (the main render).
-      queryClient.prefetchQuery({
-        queryKey: projectKeys.dashboard(selectedProject, runId),
-        queryFn: () => getDashboard(selectedProject, runId),
-        staleTime,
-      });
-      // Scores payload (drives accumulated + trend).
-      const asOf = runId !== "latest" ? runId : null;
-      queryClient.prefetchQuery({
-        queryKey: projectKeys.scores(selectedProject, asOf),
-        queryFn: () => getProjectScores(selectedProject, asOf),
-        staleTime,
-      });
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        // Historical runs are immutable (see useDashboard), so a cached entry
+        // is good until a mutation invalidates it — and prefetchQuery refetches
+        // invalidated entries regardless of staleTime.
+        const staleTime = runId !== "latest" ? Infinity : STALE_TIME_MS;
+        // Dashboard payload (the main render).
+        queryClient.prefetchQuery({
+          queryKey: projectKeys.dashboard(selectedProject, runId),
+          queryFn: () => getDashboard(selectedProject, runId),
+          staleTime,
+        });
+        // Scores payload (drives accumulated + trend).
+        const asOf = runId !== "latest" ? runId : null;
+        queryClient.prefetchQuery({
+          queryKey: projectKeys.scores(selectedProject, asOf),
+          queryFn: () => getProjectScores(selectedProject, asOf),
+          staleTime,
+        });
+      }, PREFETCH_DWELL_MS);
     },
-    [queryClient, getDashboard, selectedProject],
+    [queryClient, getDashboard, selectedProject, cancelPrefetch],
   );
+
+  return { prefetchRun, cancelPrefetch };
 }

--- a/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/usePrefetchRun.test.jsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { usePrefetchRun } from './usePrefetchRun.js';
+import { usePrefetchRun, PREFETCH_DWELL_MS } from './usePrefetchRun.js';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { getProjectScores } from '../../../api/index.js';
 import { projectKeys } from '../../../api/queryKeys.js';
@@ -24,6 +24,7 @@ describe('usePrefetchRun', () => {
   let getDashboard;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     getDashboard = vi.fn().mockResolvedValue({ dimensions: [] });
@@ -31,9 +32,16 @@ describe('usePrefetchRun', () => {
     getProjectScores.mockResolvedValue({ trend: [] });
   });
 
-  it('warms the dashboard and scores cache for a run', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('warms the dashboard and scores cache after the dwell delay', async () => {
     const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
-    result.current('r1');
+    result.current.prefetchRun('r1');
+
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS);
+    vi.useRealTimers();
 
     await waitFor(() => {
       expect(queryClient.getQueryData(projectKeys.dashboard('p1', 'r1'))).toBeTruthy();
@@ -43,9 +51,59 @@ describe('usePrefetchRun', () => {
     expect(getProjectScores).toHaveBeenCalledWith('p1', 'r1');
   });
 
+  it('does not prefetch a row the pointer merely crosses', async () => {
+    const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current.prefetchRun('r1');
+
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS - 1);
+    expect(getDashboard).not.toHaveBeenCalled();
+    expect(getProjectScores).not.toHaveBeenCalled();
+  });
+
+  it('a sweep across rows fires only the last row dwelled on', async () => {
+    // Regression: History rows prefetch on mouseenter. Sweeping the pointer
+    // across N rows used to fire 2N requests (~4s of backend CPU per row),
+    // queueing the actual click's fetches behind tens of seconds of work.
+    const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current.prefetchRun('r1');
+    await vi.advanceTimersByTimeAsync(80);
+    result.current.prefetchRun('r2');
+    await vi.advanceTimersByTimeAsync(80);
+    result.current.prefetchRun('r3');
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS);
+
+    expect(getDashboard).toHaveBeenCalledTimes(1);
+    expect(getDashboard).toHaveBeenCalledWith('p1', 'r3');
+    expect(getProjectScores).toHaveBeenCalledTimes(1);
+    expect(getProjectScores).toHaveBeenCalledWith('p1', 'r3');
+  });
+
+  it('cancelPrefetch drops a pending prefetch when the pointer leaves', async () => {
+    const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current.prefetchRun('r1');
+    result.current.cancelPrefetch();
+
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS * 4);
+    expect(getDashboard).not.toHaveBeenCalled();
+    expect(getProjectScores).not.toHaveBeenCalled();
+  });
+
+  it('unmount clears a pending dwell timer', async () => {
+    const { result, unmount } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
+    result.current.prefetchRun('r1');
+    unmount();
+
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS * 4);
+    expect(getDashboard).not.toHaveBeenCalled();
+    expect(getProjectScores).not.toHaveBeenCalled();
+  });
+
   it('maps the latest run to the null asOf scores key', async () => {
     const { result } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
-    result.current('latest');
+    result.current.prefetchRun('latest');
+
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS);
+    vi.useRealTimers();
 
     await waitFor(() => {
       expect(queryClient.getQueryData(projectKeys.scores('p1', null))).toBeTruthy();
@@ -53,13 +111,14 @@ describe('usePrefetchRun', () => {
     expect(getProjectScores).toHaveBeenCalledWith('p1', null);
   });
 
-  it('does nothing without a project or run id', () => {
+  it('does nothing without a project or run id', async () => {
     const { result } = renderHook(() => usePrefetchRun(null), { wrapper: makeWrapper(queryClient) });
-    result.current('r1');
+    result.current.prefetchRun('r1');
 
     const { result: withProject } = renderHook(() => usePrefetchRun('p1'), { wrapper: makeWrapper(queryClient) });
-    withProject.current(null);
+    withProject.current.prefetchRun(null);
 
+    await vi.advanceTimersByTimeAsync(PREFETCH_DWELL_MS * 4);
     expect(getDashboard).not.toHaveBeenCalled();
     expect(getProjectScores).not.toHaveBeenCalled();
   });

--- a/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
+++ b/src/quodeq/ui/src/features/history/components/HistoryPage.jsx
@@ -210,13 +210,15 @@ function InProgressHistoryRow({ entry, onClick, onNotReadyClick }) {
   );
 }
 
-function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onRunHover, onDeleteRun, onNotReadyClick }) {
+function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRunClick, onRunHover, onRunHoverEnd, onDeleteRun, onNotReadyClick }) {
   return (
     <section className="history-evaluations panel">
       <div className="history-evaluations__header">
         <span className="term-section-label__text">EVALUATIONS</span>
       </div>
-      <div className="history-table">
+      {/* Row-to-row movement resets the dwell timer inside usePrefetchRun;
+          leaving the table entirely must drop the pending prefetch too. */}
+      <div className="history-table" onMouseLeave={onRunHoverEnd} onBlur={onRunHoverEnd}>
         <HistoryRow
           className="history-row--header"
           cells={{
@@ -286,7 +288,7 @@ function EvaluationsTable({ visible, selectedRunId, deltas, statusByRunId, onRun
 
 function HistoryContent({ data, callbacks, runNav, languageSub }) {
   const { trend, selectedRunId, availableRuns } = data;
-  const { onRunClick, onRunHover, onRunChange, onDeleteRun } = callbacks;
+  const { onRunClick, onRunHover, onRunHoverEnd, onRunChange, onDeleteRun } = callbacks;
   const { runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest } = runNav;
   const inProgressStubs = useMemo(() => buildInProgressStubs(availableRuns, trend), [availableRuns, trend]);
   // Toast state for clicks on running runs that have no scored dimensions yet.
@@ -347,6 +349,7 @@ function HistoryContent({ data, callbacks, runNav, languageSub }) {
         statusByRunId={statusByRunId}
         onRunClick={onRunClick}
         onRunHover={onRunHover}
+        onRunHoverEnd={onRunHoverEnd}
         onDeleteRun={onDeleteRun}
         onNotReadyClick={handleNotReadyClick}
       />
@@ -371,7 +374,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   // page only — other tabs don't poll.
   useRunningRunsRefresh({ selectedProject, availableRuns });
   // Warm the run-detail cache on row hover so clicking through is instant.
-  const prefetchRun = usePrefetchRun(selectedProject);
+  const { prefetchRun, cancelPrefetch } = usePrefetchRun(selectedProject);
   const visibleSet = useMemo(() => new Set(readVisibleStandardIds()), []);
   const trend = useMemo(() => filterTrendByVisibleStandards(rawTrend || [], visibleSet), [rawTrend, visibleSet]);
 
@@ -464,7 +467,7 @@ export default function HistoryPage({ trend: rawTrend, selection, availableRuns,
   return (
     <HistoryContent
       data={{ trend, selectedRunId, availableRuns }}
-      callbacks={{ onRunClick, onRunHover: prefetchRun, onRunChange, onDeleteRun: handleDeleteRun }}
+      callbacks={{ onRunClick, onRunHover: prefetchRun, onRunHoverEnd: cancelPrefetch, onRunChange, onDeleteRun: handleDeleteRun }}
       runNav={{ runNavLabel, overviewRunIndex, currentOverviewRun, handleRunPrev, handleRunNext, handleRunLatest }}
       languageSub={languageSub}
     />


### PR DESCRIPTION
## Problem

Entering an old run from History regressed to tens of seconds on large projects after #727. Every History row the pointer crossed fired an immediate dashboard + scores?asOf prefetch, and on the 201-run quodeq project each pair costs seconds of GIL-serialized backend CPU (~2.3s + ~1.9s, ~7MB per uncached run). Reaching an old run means sweeping the pointer across many rows, so the click's own requests queued behind the storm.

Measured against real data with a browser-faithful harness (6-connection pool):

| Scenario | Run entry |
|---|---|
| Clean click, no sweep | 0.89s |
| Click after sweeping just 8 rows | **42.2s** |

Principles/explorer entry is cheap (~0.1s of requests) but queued behind the same drain, which is why both loading screens appeared to hang.

## Fix

`usePrefetchRun` now arms a shared 150ms dwell timer instead of prefetching immediately:

- Sweeping across rows keeps resetting the timer and fires nothing.
- Resting on a row (hover-then-click intent) fires exactly the two payloads the click needs, so #727's instant entry is preserved.
- `cancelPrefetch` drops the pending dwell when the pointer or focus leaves the History table; the hook clears the timer on unmount.
- `usePrefetchAdjacentRuns` inherits the same dwell for the run-navigator buttons.

## Verification (live dev UI, real 201-run project, full-fidelity mouseout/mouseover pairs)

- 13-row sweep: **0** API calls (was 26)
- 350ms dwell on a row: exactly **2** calls (dashboard + scores for that run)
- Click the dwelled run: enters in **26ms**, zero fetches
- Cold click on the oldest run (Apr 26), no hover: **1.86s** (intrinsic two ~7.7MB payloads, same as pre-#727)
- Re-entry of the same old run: **60ms**, zero fetches (frozen cache from #728 holds)
- Principles from the oldest run: **480ms**

Full UI suite green: 132 files / 746 tests. New regression tests cover dwell, sweep-reset, cancel, and unmount in `usePrefetchRun.test.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)