### PR TITLE
perf(api): slim run-detail payloads + gzip large JSON responses

### DIFF
--- a/src/quodeq/api/_compression.py
+++ b/src/quodeq/api/_compression.py
@@ -1,0 +1,67 @@
+"""Opt-in gzip for large JSON responses.
+
+The score/dashboard endpoints return multi-megabyte JSON on long-lived
+projects. Slimming (dashboard history keys, explorer identity-only violations)
+removed the avoidable bulk, but the accumulated scores payload
+(``/scores?asOf=``) is still large because its violation/compliance bodies
+feed the Overview drill-in and the Violations/Map pages. gzip is the cheap
+catch-all for what can't be slimmed without a UI-side lazy-load refactor.
+
+Deliberately narrow to stay safe:
+
+* Only ``application/json`` above ``_MIN_SIZE`` bytes — small responses gain
+  nothing and pay compression latency.
+* Never streamed or ``direct_passthrough`` responses: SSE log/event streams
+  (``text/event-stream`` generators) and ``send_file`` downloads (the project
+  ZIP export) must reach the client byte-for-byte, unbuffered.
+* Only when the client advertised ``Accept-Encoding: gzip`` and the response
+  isn't already encoded.
+
+This runs as an ``after_request`` hook, so it composes with the security-header
+hook without ordering constraints (each only mutates the response it's handed).
+"""
+from __future__ import annotations
+
+import gzip
+
+from flask import Flask, Response, request
+
+# Below this, gzip's CPU + latency outweighs the transfer saving. The score
+# endpoints clear it by orders of magnitude; typical CRUD/status JSON won't.
+_MIN_SIZE = 500_000
+# Level 6 is zlib's default: ~5x on these payloads at a fraction of the cost of
+# level 9, which buys little on already-repetitive JSON.
+_LEVEL = 6
+
+
+def configure_compression(app: Flask) -> None:
+    """Register the size-gated gzip ``after_request`` hook on *app*."""
+
+    @app.after_request
+    def _gzip_large_json(response: Response) -> Response:
+        # Streamed (SSE) and passthrough (send_file) responses have no
+        # in-memory body to compress and must not be buffered here.
+        if response.direct_passthrough or response.is_streamed:
+            return response
+        if response.mimetype != "application/json":
+            return response
+        if response.headers.get("Content-Encoding"):
+            return response
+        # request.accept_encodings honours q-values: `gzip;q=0` is an explicit
+        # refusal and an absent header means "don't compress". A plain
+        # substring test would wrongly compress for `gzip;q=0`.
+        if not request.accept_encodings.quality("gzip"):
+            return response
+        # Reading .data on a non-streamed response is the already-materialized
+        # body; no extra buffering beyond what Flask holds.
+        body = response.get_data()
+        if len(body) < _MIN_SIZE:
+            return response
+        compressed = gzip.compress(body, _LEVEL)
+        response.set_data(compressed)
+        response.headers["Content-Encoding"] = "gzip"
+        response.headers["Content-Length"] = str(len(compressed))
+        # Caches must key on Accept-Encoding so a gzip body isn't served to a
+        # client that didn't ask for it.
+        response.headers.add("Vary", "Accept-Encoding")
+        return response

--- a/src/quodeq/api/_scores_routes.py
+++ b/src/quodeq/api/_scores_routes.py
@@ -16,7 +16,7 @@ from flask import Flask, Response, jsonify, request
 
 from quodeq.api.helpers import error_response
 from quodeq.api.routes_common import reports_dir
-from quodeq.services.scoring import get_project_scores, get_scores_raw
+from quodeq.services.scoring import get_project_scores, get_scores_slim
 from quodeq.shared.validation import validate_path_segment
 
 _logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ def register_scores_routes(app: Flask) -> None:
             return err
         eval_dir = reports_dir()
         try:
-            result = get_scores_raw(Path(eval_dir), project, run_id)
+            result = get_scores_slim(Path(eval_dir), project, run_id)
         except FileNotFoundError:
             body, status = error_response("Run not found", HTTPStatus.NOT_FOUND, "NOT_FOUND")
             return jsonify(body), status

--- a/src/quodeq/api/app.py
+++ b/src/quodeq/api/app.py
@@ -119,6 +119,8 @@ def create_app(
         )
 
     configure_security(app, store, api_key)
+    from quodeq.api._compression import configure_compression
+    configure_compression(app)
     app.config["QUODEQ_API_KEY"] = api_key
     from quodeq.shared.utils import get_action_api_host as _gah
     app.config["QUODEQ_BIND_HOST"] = _gah()

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -303,6 +303,21 @@ def _attach_dismissed_count_to_dim(
     return {**dim_dict, "dismissedCount": count}
 
 
+def _slim_history_dim(dim: DimensionResult) -> dict[str, Any]:
+    """Serialize a history-context dimension without its finding bodies.
+
+    The previousByDimension / stalePreviousByDimension / staleDimensions keys
+    exist to carry scores, grades, and provenance (run id, dates) for trend
+    context; the UI reads only the scalar fields inlined on each selected-run
+    dimension (previousScore, trend, stale, fromRunId). No consumer reads the
+    violations/compliance arrays from these keys, yet on large projects they
+    dominated the payload: for a 201-run project, an old run's dashboard was
+    19.9 MB of which these three keys carried 18.6 MB of finding bodies.
+    Totals keep the counts; only the bodies are dropped.
+    """
+    return to_camel_dict(replace(dim, violations=[], compliance=[]))
+
+
 def _build_dashboard_result(
     project: str,
     runs: list[RunInfo],
@@ -339,9 +354,9 @@ def _build_dashboard_result(
         },
         "trend": payload.trend,
         "dimensions": dim_dicts,
-        "previousByDimension": {k: to_camel_dict(v) for k, v in payload.previous_by_dimension.items()},
-        "stalePreviousByDimension": {k: to_camel_dict(v) for k, v in payload.stale_previous_by_dimension.items()},
-        "staleDimensions": [to_camel_dict(d) for d in payload.stale_dimensions],
+        "previousByDimension": {k: _slim_history_dim(v) for k, v in payload.previous_by_dimension.items()},
+        "stalePreviousByDimension": {k: _slim_history_dim(v) for k, v in payload.stale_previous_by_dimension.items()},
+        "staleDimensions": [_slim_history_dim(d) for d in payload.stale_dimensions],
     }
 
 

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -325,6 +325,31 @@ def get_scores_raw(
     return _build_response_from_eval_files(reports_root, project, run_id, params=params)
 
 
+def get_scores_slim(
+    reports_root: Path, project: str, run_id: str,
+) -> dict:
+    """``get_scores_raw`` with finding bodies stripped for the run-scores route.
+
+    The Explorer (the endpoint's only consumer) uses the response to overlay
+    dismissal-aware scores onto the eval payload it fetched separately: it
+    reads per-dimension/per-principle score + grade + totals, and uses each
+    violation solely as a ``req|file|line`` identity key to filter dismissed
+    findings out of the eval data. Returning full bodies made the response
+    7+ MB on finding-heavy runs; the slim form carries the same information
+    the merge needs at a fraction of the size. Compliance bodies are never
+    read from this payload, so the list is emptied (counts live in totals).
+    """
+    raw = get_scores_raw(reports_root, project, run_id)
+    slim_dims = []
+    for dim in raw.get("dimensions", []) or []:
+        slim_violations = [
+            {"req": v.get("req"), "file": v.get("file"), "line": v.get("line")}
+            for v in (dim.get("violations") or [])
+        ]
+        slim_dims.append({**dim, "violations": slim_violations, "compliance": []})
+    return {**raw, "dimensions": slim_dims}
+
+
 def _make_rescoring_fetcher(
     reports_root: Path, project: str,
     params: ScoringParams = DEFAULT_PARAMS,
@@ -550,5 +575,6 @@ def get_project_scores(
 
 __all__ = [
     "get_scores_raw",
+    "get_scores_slim",
     "get_project_scores",
 ]

--- a/tests/api/test_compression.py
+++ b/tests/api/test_compression.py
@@ -1,0 +1,81 @@
+"""gzip after-request hook: compress large JSON, leave everything else alone."""
+from __future__ import annotations
+
+import gzip
+import json
+
+import pytest
+from flask import Flask, Response, jsonify, stream_with_context
+
+from quodeq.api._compression import _MIN_SIZE, configure_compression
+
+
+@pytest.fixture
+def app() -> Flask:
+    app = Flask(__name__)
+    configure_compression(app)
+
+    @app.get("/big")
+    def big() -> Response:
+        # Comfortably over the threshold once serialized.
+        return jsonify({"items": [{"i": i, "pad": "x" * 64} for i in range(20_000)]})
+
+    @app.get("/small")
+    def small() -> Response:
+        return jsonify({"ok": True})
+
+    @app.get("/stream")
+    def stream() -> Response:
+        def gen():
+            for i in range(50_000):
+                yield f"data: {i}\n\n"
+        return Response(stream_with_context(gen()), mimetype="text/event-stream")
+
+    @app.get("/plaintext-big")
+    def plaintext_big() -> Response:
+        return Response("z" * (_MIN_SIZE + 10), mimetype="text/plain")
+
+    return app
+
+
+def test_large_json_is_gzipped_and_roundtrips(app: Flask) -> None:
+    client = app.test_client()
+    resp = client.get("/big", headers={"Accept-Encoding": "gzip"})
+    assert resp.headers["Content-Encoding"] == "gzip"
+    assert "Accept-Encoding" in resp.headers["Vary"]
+    # Content-Length must describe the compressed body actually sent.
+    assert int(resp.headers["Content-Length"]) == len(resp.get_data())
+    decoded = json.loads(gzip.decompress(resp.get_data()))
+    assert len(decoded["items"]) == 20_000
+
+
+def test_no_gzip_without_accept_encoding(app: Flask) -> None:
+    resp = app.test_client().get("/big")  # no Accept-Encoding
+    assert "Content-Encoding" not in resp.headers
+    json.loads(resp.get_data())  # still valid, uncompressed
+
+
+def test_small_json_is_not_gzipped(app: Flask) -> None:
+    resp = app.test_client().get("/small", headers={"Accept-Encoding": "gzip"})
+    assert "Content-Encoding" not in resp.headers
+
+
+def test_streamed_response_is_never_touched(app: Flask) -> None:
+    """SSE streams must stay unbuffered and unencoded — compressing here would
+    collect the whole generator into memory and break incremental delivery."""
+    resp = app.test_client().get("/stream", headers={"Accept-Encoding": "gzip"})
+    assert "Content-Encoding" not in resp.headers
+    assert resp.mimetype == "text/event-stream"
+
+
+def test_non_json_is_not_gzipped(app: Flask) -> None:
+    resp = app.test_client().get("/plaintext-big", headers={"Accept-Encoding": "gzip"})
+    assert "Content-Encoding" not in resp.headers
+
+
+def test_explicit_gzip_refusal_is_honored(app: Flask) -> None:
+    """``gzip;q=0`` is an explicit refusal — the body must go out uncompressed
+    even though it clears the size threshold."""
+    resp = app.test_client().get("/big", headers={"Accept-Encoding": "gzip;q=0"})
+    assert "Content-Encoding" not in resp.headers
+    json.loads(resp.get_data())  # valid, uncompressed

--- a/tests/api/test_scores_routes.py
+++ b/tests/api/test_scores_routes.py
@@ -13,7 +13,7 @@ from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
 from quodeq.core.events.writer import EventLogWriter
 from quodeq.data.projection.projector import Projector
 from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
-from quodeq.services.scoring import get_scores_raw
+from quodeq.services.scoring import get_scores_raw, get_scores_slim
 
 
 # ---------------------------------------------------------------------------
@@ -318,3 +318,44 @@ def test_get_scores_raw_summary_has_required_fields(tmp_path: Path) -> None:
     assert "dimensionsCount" in summary
     assert summary["dimensionsCount"] == 1
     assert "overallGrade" in summary
+
+
+# ---------------------------------------------------------------------------
+# Slim variant (GET /scores/<runId> payload diet)
+# ---------------------------------------------------------------------------
+
+def test_get_scores_slim_reduces_violations_to_identity_keys(tmp_path: Path) -> None:
+    """The run-scores route serves ``get_scores_slim``: each violation keeps
+    only the ``req``/``file``/``line`` fields the Explorer's rescore merge
+    uses as identity keys — heavy fields (reason, snippet, context) are gone.
+    """
+    _seed_run(tmp_path, "myproject", "r1", violations=_scorable_violations())
+
+    result = get_scores_slim(tmp_path, "myproject", "r1")
+
+    dim = next(d for d in result["dimensions"] if d["dimension"] == "Security")
+    assert dim["violations"], "slim payload must still carry violation keys"
+    for v in dim["violations"]:
+        assert set(v.keys()) == {"req", "file", "line"}
+        assert v["file"] and v["line"] is not None
+
+
+def test_get_scores_slim_drops_compliance_but_keeps_scores(tmp_path: Path) -> None:
+    """Compliance bodies are never read from this payload — the list is
+    emptied while grades, principles, totals, and summary stay identical to
+    the raw payload.
+    """
+    _seed_run(tmp_path, "myproject", "r1", violations=_scorable_violations())
+
+    raw = get_scores_raw(tmp_path, "myproject", "r1")
+    slim = get_scores_slim(tmp_path, "myproject", "r1")
+
+    assert slim["summary"] == raw["summary"]
+    for raw_dim, slim_dim in zip(raw["dimensions"], slim["dimensions"]):
+        assert slim_dim["compliance"] == []
+        assert slim_dim["dimension"] == raw_dim["dimension"]
+        assert slim_dim["overallScore"] == raw_dim["overallScore"]
+        assert slim_dim["overallGrade"] == raw_dim["overallGrade"]
+        assert slim_dim["principles"] == raw_dim["principles"]
+        assert slim_dim["totals"] == raw_dim["totals"]
+        assert len(slim_dim["violations"]) == len(raw_dim["violations"])

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -789,3 +789,80 @@ class TestBuildDashboardDismissedFiltering:
         assert dim["totals"]["violationCount"] == 1
         # Deleted findings are suppressed, not "dismissed": no count is shown.
         assert "dismissedCount" not in dim
+
+
+class TestHistoryContextSlimming:
+    """previousByDimension / stalePreviousByDimension / staleDimensions must
+    carry scores + provenance only. No consumer reads finding bodies from
+    these keys, and on large projects the bodies dominated the payload
+    (~18.6 MB of a 19.9 MB old-run dashboard on a 201-run project)."""
+
+    def _finding(self, i: int, verdict: str = "violation"):
+        from quodeq.core.types.finding import Finding
+        return Finding(
+            practice_id="P1", verdict=verdict, file=f"f{i}.py", line=i,
+            reason="a long explanation", snippet="offending()", context="ctx",
+            req=f"R{i}",
+        )
+
+    def test_history_keys_drop_finding_bodies_but_keep_scores(self, tmp_path):
+        from quodeq.core.types.finding import Totals
+        runs = [
+            RunInfo(run_id="r-new", date_iso="2024-02-01", date_label="2024-02-01", status="complete"),
+            RunInfo(run_id="r-old", date_iso="2024-01-01", date_label="2024-01-01", status="complete"),
+        ]
+        selected_dims = [DimensionResult(
+            dimension="security", overall_grade="B", overall_score="7.0/10",
+            violations=[self._finding(1)], compliance=[self._finding(2, "compliance")],
+        )]
+        old_dims = [
+            DimensionResult(
+                dimension="security", overall_grade="C", overall_score="6.0/10",
+                violations=[self._finding(3)],
+                totals=Totals(violation_count=1, compliance_count=0),
+            ),
+            DimensionResult(
+                dimension="perf", overall_grade="C", overall_score="5.0/10",
+                violations=[self._finding(4)], compliance=[self._finding(5, "compliance")],
+                totals=Totals(violation_count=1, compliance_count=1),
+            ),
+        ]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+
+        def read_by_run(_root, _project, run_id):
+            return selected_dims if run_id == "r-new" else old_dims
+
+        from quodeq.services.dashboard import _SHARED_RUN_DIM_CACHE
+        _SHARED_RUN_DIM_CACHE.clear()
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=runs),
+            patch("quodeq.services.dashboard.read_run_data", side_effect=read_by_run),
+            patch("quodeq.services._cache.read_run_data", side_effect=read_by_run),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            result = build_dashboard(str(tmp_path), "proj-slim-history", "r-new")
+
+        # The selected run's own dimensions keep their full finding bodies.
+        assert result["dimensions"][0]["violations"][0]["reason"] == "a long explanation"
+        assert result["dimensions"][0]["compliance"]
+
+        # previousByDimension: scores/grades/totals survive, bodies do not.
+        prev = result["previousByDimension"]["security"]
+        assert prev["overallGrade"] == "C"
+        assert prev["overallScore"] == "6.0/10"
+        assert prev["totals"]["violationCount"] == 1
+        assert prev["violations"] == []
+        assert prev["compliance"] == []
+
+        # staleDimensions (perf is missing from the selected run): same rule.
+        stale = [d for d in result["staleDimensions"] if d["dimension"] == "perf"]
+        assert stale, f"expected perf in staleDimensions, got {result['staleDimensions']}"
+        assert stale[0]["overallScore"] == "5.0/10"
+        assert stale[0]["totals"]["complianceCount"] == 1
+        assert stale[0]["violations"] == []
+        assert stale[0]["compliance"] == []
+
+        # stalePreviousByDimension follows the same serialization path.
+        for dim in result["stalePreviousByDimension"].values():
+            assert dim["violations"] == []
+            assert dim["compliance"] == []


### PR DESCRIPTION
## Problem

Run-detail entry for old historical runs cost ~1.9s cold even against an idle backend, dominated by JSON payload size. On the 201-run `quodeq` project, an old run's `GET /dashboard?run=<id>` returned **19.9MB** and the explorer's `GET /scores/<runId>` **up to 7.6MB** — almost entirely full violation/compliance finding bodies (`context`, `reason`, `snippet`, `reqRefs`) duplicated across payloads.

## What dominates the JSON

Measured field-by-field against the real project:

- **Dashboard:** 93% of the payload lived in three keys — `previousByDimension`, `stalePreviousByDimension`, `staleDimensions` — that carry full finding bodies **no consumer reads**. The UI reads trend context from the scalar fields (`previousScore`, `trend`, `stale`, `fromRunId`) inlined onto each `dimensions[]` entry, never from those maps.
- **Explorer `/scores/<runId>`:** its only consumer (`explorerDataHooks.js` → `mergeRescoreIntoEval`) uses violations solely as a `req|file|line` identity key to filter the separately-fetched dimension eval, and reads compliance from `getDimensionEval`, not this route.

## Changes (serialization + transport only)

1. **`_slim_history_dim()`** (`services/dashboard.py`) — serializes the three dashboard history keys with empty `violations`/`compliance`; scalars, principles, and totals kept. The main `dimensions[]` array is unchanged (full bodies).
2. **`get_scores_slim()`** (`services/scoring/__init__.py`) — reduces each violation to `{req,file,line}` and empties compliance; scores/grades/principles/totals kept. Wired only into the `/scores/<run_id>` route; `get_scores_raw` is unchanged for its other callers (`mutation_rescore`, `_sql_grade_overlay`).
3. **gzip** (`api/_compression.py`, wired in `create_app`) — size-gated `after_request` hook: `application/json` over 500KB, honors `Accept-Encoding` (incl. `gzip;q=0` refusal), skips streamed (SSE) and `direct_passthrough` (`send_file`) responses. This is the catch-all for the accumulated `/scores?asOf=` payload (~9.7MB), which still needs its bodies for the Overview drill-in and Violations/Map pages.

## Measured impact (old run, 201-run project)

| Endpoint | Before | After slim | + gzip |
|---|---|---|---|
| `dashboard?run=` | 19.9 MB | 1.33 MB | 280 KB |
| `scores/<runId>` (explorer) | 1.3–5.5 MB | 27–101 KB | (under threshold) |
| `scores?asOf=` (accumulated) | 9.77 MB | unchanged | 1.93 MB, 1.45s → 0.57s |

## Safety

- Does **not** touch the frozen-cache semantics (#728/#730) or the dwell-gated prefetch (#731) — changes are payload-shape and transport only.
- Full non-integration suite passes (4099), plus new coverage for the slimmed shapes, the gzip hook, the SSE-passthrough guard, and `gzip;q=0` refusal. Import-layer and bare-text-IO architecture gates stay green.
- A 4-lens adversarial review (hunting for any broken consumer, key-field mismatch, gzip corruption, or cache-aliasing bug) returned no blockers.

## Follow-up

`scores?asOf=` accumulated bodies aren't slimmed because they feed the Overview drill-in and Violations/Map. Slimming them safely needs a UI-side lazy-load change; gzip covers the transfer cost meanwhile.