### PR TITLE
perf(api): cache project-card summary (7x) + runs unit endpoint with ETag

### DIFF
--- a/src/quodeq/api/_http_cache.py
+++ b/src/quodeq/api/_http_cache.py
@@ -1,0 +1,37 @@
+"""Reusable HTTP-cache helpers for UI data-unit endpoints.
+
+etag_for / conditional_json: strong ETag + 304 handling so an unchanged unit
+costs a bodyless 304 and no client re-parse. gzip is handled separately and
+app-wide by ``_compression.configure_compression`` — not here.
+"""
+from __future__ import annotations
+
+import hashlib
+import json as _json
+
+from flask import Response, request
+
+
+def etag_for(payload_bytes: bytes) -> str:
+    """Strong, quoted ETag from the exact response bytes."""
+    digest = hashlib.sha256(payload_bytes).hexdigest()[:32]
+    return f'"{digest}"'
+
+
+def conditional_json(payload: object, *, max_age: int = 0) -> Response:
+    """Serialize *payload* to JSON with an ETag; 304 when If-None-Match matches.
+
+    The ETag is computed over compact JSON bytes; the same encoding is used for
+    the body so the tag always matches what we send.
+    """
+    body = _json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    tag = etag_for(body)
+    if request.headers.get("If-None-Match") == tag:
+        resp = Response(status=304)
+        resp.headers["ETag"] = tag
+        return resp
+    resp = Response(body, mimetype="application/json")
+    resp.headers["ETag"] = tag
+    if max_age > 0:
+        resp.headers["Cache-Control"] = f"private, max-age={max_age}"
+    return resp

--- a/src/quodeq/api/routes_registry.py
+++ b/src/quodeq/api/routes_registry.py
@@ -28,6 +28,7 @@ from quodeq.api.llm_bridge_routes import register_llm_bridge_routes
 from quodeq.api.routes_rescore import register_rescore_routes
 from quodeq.api.routes_update import register_update_routes
 from quodeq.api._scores_routes import register_scores_routes
+from quodeq.api.routes_runs import register_runs_routes
 from quodeq.api._grade_formula_routes import register_grade_formula_routes
 from quodeq.services.base import ActionProvider
 
@@ -60,6 +61,7 @@ def register_all_routes(
     register_findings_routes(app)
     register_rescore_routes(app)
     register_scores_routes(app)
+    register_runs_routes(app)
     register_grade_formula_routes(app)
     register_llm_bridge_routes(app)
     if log_buffer:

--- a/src/quodeq/api/routes_runs.py
+++ b/src/quodeq/api/routes_runs.py
@@ -1,0 +1,34 @@
+"""GET /api/projects/<project>/runs — the `runs` UI data unit."""
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from pathlib import Path
+
+from flask import Flask, Response, jsonify
+
+from quodeq.api._http_cache import conditional_json
+from quodeq.api.helpers import error_response
+from quodeq.api.routes_common import reports_dir
+from quodeq.services._runs_unit import build_runs_unit
+from quodeq.shared._env import get_index_db_path
+from quodeq.shared.validation import validate_path_segment
+
+_logger = logging.getLogger(__name__)
+
+
+def register_runs_routes(app: Flask) -> None:
+    @app.get("/api/projects/<project>/runs")
+    def project_runs(project: str) -> Response | tuple[Response, int]:
+        try:
+            validate_path_segment(project)
+        except ValueError:
+            body, status = error_response("Invalid parameter", HTTPStatus.BAD_REQUEST, "INVALID_INPUT")
+            return jsonify(body), status
+        try:
+            runs = build_runs_unit(Path(reports_dir()), Path(get_index_db_path()), project)
+        except Exception:
+            _logger.exception("Failed to build runs unit for %s", project)
+            body, status = error_response("Failed to load runs", HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR")
+            return jsonify(body), status
+        return conditional_json({"runs": runs}, max_age=0)

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -75,23 +75,33 @@ def _read_accumulated_summary(
     if params is None:
         from quodeq.services import grade_formula  # noqa: PLC0415
         params = grade_formula.load_params()
-    try:
-        latest_by_dim: dict[str, object] = {}
-        files_count: int | None = None
-        for run in runs:
-            dims = read_run_data(reports_root, entry_name, run.run_id)
-            for d in dims:
-                if d.dimension and d.dimension not in latest_by_dim:
-                    latest_by_dim[d.dimension] = d
-                if files_count is None and d.source_file_count:
-                    files_count = d.source_file_count
-        acc_dims = list(latest_by_dim.values())
-        if not acc_dims:
-            return None, None, files_count
-        summary = summarize_dimensions(acc_dims, params)
-        return summary.overall_grade, summary.numeric_average, files_count
-    except (OSError, json.JSONDecodeError, KeyError):
-        return None, None, None
+
+    from quodeq.services.score_cache import accumulated_cache_version, cached_project_summary  # noqa: PLC0415
+    project_dir = reports_root / entry_name
+    run_fingerprint = [(r.run_id, r.status) for r in runs]
+    version = accumulated_cache_version(project_dir, params, run_fingerprint, as_of=None)
+
+    def _compute() -> dict:
+        try:
+            latest_by_dim: dict[str, object] = {}
+            files_count: int | None = None
+            for run in runs:
+                dims = read_run_data(reports_root, entry_name, run.run_id)
+                for d in dims:
+                    if d.dimension and d.dimension not in latest_by_dim:
+                        latest_by_dim[d.dimension] = d
+                    if files_count is None and d.source_file_count:
+                        files_count = d.source_file_count
+            acc_dims = list(latest_by_dim.values())
+            if not acc_dims:
+                return {"grade": None, "score": None, "files": files_count}
+            summary = summarize_dimensions(acc_dims, params)
+            return {"grade": summary.overall_grade, "score": summary.numeric_average, "files": files_count}
+        except (OSError, json.JSONDecodeError, KeyError):
+            return {"grade": None, "score": None, "files": None}
+
+    payload = cached_project_summary(entry_name, version, _compute)
+    return payload["grade"], payload["score"], payload["files"]
 
 
 def _read_language_stats(reports_root: Path, entry_name: str, runs: list[RunInfo]) -> dict[str, int]:

--- a/src/quodeq/services/_runs_unit.py
+++ b/src/quodeq/services/_runs_unit.py
@@ -7,6 +7,9 @@ multi-MB dashboard payload.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
+from quodeq.services.ports import most_frequent_grade, parse_numeric_score, read_run_scalars
 from quodeq.services.run_index import RunRow
 
 _INDEX_STATE_TO_UI_STATUS = {
@@ -32,3 +35,34 @@ def _row_to_run_entry(row: RunRow) -> dict:
         "overallGrade": None,
         "dimensionScores": {},
     }
+
+
+_TERMINAL = {"complete", "cancelled", "failed"}
+
+
+def _fill_scores(entry: dict, reports_root: Path, project: str, run_id: str) -> None:
+    """Populate dimensionScores/overallScore/overallGrade in place.
+
+    Terminal runs only; failures leave placeholders untouched. read_run_scalars
+    is score-cache backed for terminal runs, so this is cheap. DimensionResult
+    carries overall_score as a string ("7.5/10"); parse_numeric_score turns it
+    into a float, matching every production caller (see _dashboard_trend.py).
+    """
+    if entry["status"] not in _TERMINAL:
+        return
+    try:
+        dims = read_run_scalars(reports_root, project, run_id)
+    except (OSError, ValueError):
+        return
+    scores = {}
+    for d in dims:
+        raw = getattr(d, "overall_score", None)
+        s = parse_numeric_score(raw) if raw else None
+        if s is not None:
+            scores[d.dimension] = s
+    if not scores:
+        return
+    entry["dimensionScores"] = scores
+    entry["overallScore"] = round(sum(scores.values()) / len(scores), 1)
+    grades = [d.overall_grade for d in dims if getattr(d, "overall_grade", None)]
+    entry["overallGrade"] = most_frequent_grade(grades) if grades else None

--- a/src/quodeq/services/_runs_unit.py
+++ b/src/quodeq/services/_runs_unit.py
@@ -1,0 +1,34 @@
+"""Builder for the `runs` UI data unit.
+
+Assembles one project's run list from the SQLite run index (status + dates)
+plus per-dimension scalar scores from the score cache. Returns camelCase dicts
+sized for History rows, the trend chart, and the run navigator — NOT the
+multi-MB dashboard payload.
+"""
+from __future__ import annotations
+
+from quodeq.services.run_index import RunRow
+
+_INDEX_STATE_TO_UI_STATUS = {
+    "done": "complete", "complete": "complete", "finished": "complete",
+    "running": "in_progress", "in_progress": "in_progress",
+    "cancelled": "cancelled", "canceled": "cancelled",
+    "failed": "failed", "error": "failed",
+}
+
+
+def _ui_status(state: str) -> str:
+    """Map an index `state` to the UI's run status vocabulary."""
+    return _INDEX_STATE_TO_UI_STATUS.get((state or "").lower(), "complete")
+
+
+def _row_to_run_entry(row: RunRow) -> dict:
+    """One index row → a runs-unit entry with score placeholders."""
+    return {
+        "runId": row.run_id,
+        "status": _ui_status(row.state),
+        "dateISO": row.started_at,
+        "overallScore": None,
+        "overallGrade": None,
+        "dimensionScores": {},
+    }

--- a/src/quodeq/services/_runs_unit.py
+++ b/src/quodeq/services/_runs_unit.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from quodeq.services.ports import most_frequent_grade, parse_numeric_score, read_run_scalars
-from quodeq.services.run_index import RunRow
+from quodeq.services.run_index import (
+    RunRow,
+    list_runs_for_project,
+    open_index,
+    sync_index,
+)
 
 _INDEX_STATE_TO_UI_STATUS = {
     "done": "complete", "complete": "complete", "finished": "complete",
@@ -66,3 +71,21 @@ def _fill_scores(entry: dict, reports_root: Path, project: str, run_id: str) -> 
     entry["overallScore"] = round(sum(scores.values()) / len(scores), 1)
     grades = [d.overall_grade for d in dims if getattr(d, "overall_grade", None)]
     entry["overallGrade"] = most_frequent_grade(grades) if grades else None
+
+
+def build_runs_unit(reports_root: Path, index_db_path: Path, project: str) -> list[dict]:
+    """Assemble the `runs` unit for one project.
+
+    Status + dates from the index (synced first so freshly-written runs appear);
+    scalar scores from the score cache.
+    """
+    db = open_index(index_db_path)
+    try:
+        sync_index(db, reports_root)
+        rows = list_runs_for_project(db, project)
+    finally:
+        db.close()
+    entries = [_row_to_run_entry(r) for r in rows]
+    for entry in entries:
+        _fill_scores(entry, reports_root, project, entry["runId"])
+    return entries

--- a/src/quodeq/services/run_index.py
+++ b/src/quodeq/services/run_index.py
@@ -243,6 +243,22 @@ def list_runs(db: sqlite3.Connection, *, limit: int = 0) -> list[RunRow]:
     return [_row_to_runrow(r) for r in db.execute(sql).fetchall()]
 
 
+def list_runs_for_project(
+    db: sqlite3.Connection, project_uuid: str, *, limit: int = 0,
+) -> list[RunRow]:
+    """Return one project's runs ordered by started_at DESC. limit=0 = no limit.
+
+    Native indexed query — the replacement for walking the project's run dirs.
+    """
+    sql = (
+        f"SELECT {_LIST_COLS} FROM runs WHERE project_uuid = ? "
+        "ORDER BY started_at DESC"
+    )
+    if limit > 0:
+        sql += f" LIMIT {int(limit)}"
+    return [_row_to_runrow(r) for r in db.execute(sql, (project_uuid,)).fetchall()]
+
+
 def get_run(db: sqlite3.Connection, job_id: str) -> RunRow | None:
     row = db.execute(
         f"SELECT {_LIST_COLS} FROM runs WHERE job_id = ?", (job_id,),

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -40,6 +40,8 @@ _SCHEMA = (
     " project TEXT NOT NULL, version TEXT NOT NULL, payload TEXT NOT NULL,"
     " updated_at TEXT NOT NULL DEFAULT (datetime('now')),"
     " PRIMARY KEY (project, version));"
+    "CREATE TABLE IF NOT EXISTS project_summary_cache ("
+    " project TEXT PRIMARY KEY, version TEXT NOT NULL, payload TEXT NOT NULL);"
 )
 
 
@@ -230,6 +232,66 @@ def cached_accumulated(
     try:
         with open_score_cache() as conn:
             write_cached_accumulated(conn, project, version, result)
+    except sqlite3.Error:
+        pass
+    return result
+
+
+def read_cached_project_summary(
+    conn: sqlite3.Connection, project: str, version: str,
+) -> dict | None:
+    """Return the cached project-card summary for (project, version), or None."""
+    try:
+        row = conn.execute(
+            "SELECT payload FROM project_summary_cache WHERE project=? AND version=?",
+            (project, version),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    try:
+        return json.loads(row[0])
+    except (ValueError, TypeError):
+        return None
+
+
+def write_cached_project_summary(
+    conn: sqlite3.Connection, project: str, version: str, payload: dict,
+) -> None:
+    """Single-slot-per-project write for the project-card summary."""
+    try:
+        blob = json.dumps(payload)
+    except (TypeError, ValueError):
+        return
+    try:
+        conn.execute("DELETE FROM project_summary_cache WHERE project=?", (project,))
+        conn.execute(
+            "INSERT OR REPLACE INTO project_summary_cache (project, version, payload) VALUES (?, ?, ?)",
+            (project, version, blob),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        _logger.warning("project summary cache write failed for %s", project, exc_info=True)
+
+
+def cached_project_summary(
+    project: str, version: str, compute: Callable[[], dict],
+) -> dict:
+    """Read-through cache for the project-card summary (mirrors cached_accumulated)."""
+    if score_cache_disabled():
+        return compute()
+    try:
+        with open_score_cache() as conn:
+            hit = read_cached_project_summary(conn, project, version)
+        if hit is not None:
+            return hit
+    except sqlite3.Error:
+        return compute()
+    result = compute()
+    try:
+        with open_score_cache() as conn:
+            write_cached_project_summary(conn, project, version, result)
     except sqlite3.Error:
         pass
     return result

--- a/tests/api/test_http_cache.py
+++ b/tests/api/test_http_cache.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+from flask import Flask
+
+from quodeq.api._http_cache import etag_for, conditional_json
+
+
+def test_etag_is_stable_and_quoted():
+    a = etag_for(b'{"x":1}')
+    b = etag_for(b'{"x":1}')
+    c = etag_for(b'{"x":2}')
+    assert a == b and a != c
+    assert a.startswith('"') and a.endswith('"')
+
+
+def _compact(payload):
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def test_conditional_json_returns_304_on_match():
+    app = Flask(__name__)
+    with app.test_request_context(headers={"If-None-Match": etag_for(_compact({"k": 1}))}):
+        resp = conditional_json({"k": 1})
+        assert resp.status_code == 304
+        assert resp.get_data() == b""
+
+
+def test_conditional_json_returns_200_with_etag_on_miss():
+    app = Flask(__name__)
+    with app.test_request_context(headers={"If-None-Match": '"stale"'}):
+        resp = conditional_json({"k": 1})
+        assert resp.status_code == 200
+        assert resp.headers["ETag"] == etag_for(_compact({"k": 1}))
+        assert json.loads(resp.get_data()) == {"k": 1}

--- a/tests/api/test_runs_endpoint.py
+++ b/tests/api/test_runs_endpoint.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from quodeq.api.app import create_app
+from quodeq.services.run_index import open_index
+
+
+@pytest.fixture(autouse=True)
+def _no_auth(monkeypatch):
+    monkeypatch.delenv("QUODEQ_API_KEY", raising=False)
+
+
+def _seed_index(index_db_path):
+    db = open_index(index_db_path)
+    with db:
+        db.execute(
+            "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+            "started_at, updated_at, status_mtime) VALUES "
+            "('ext-a','proj','a','/x/a','done','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z',0)"
+        )
+    db.close()
+
+
+def test_runs_endpoint_returns_unit(tmp_path, monkeypatch):
+    evals = tmp_path / "evaluations"
+    (evals / "proj").mkdir(parents=True)
+    index_db = tmp_path / "index.db"
+    _seed_index(index_db)
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(evals))
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(index_db))
+    import quodeq.services._runs_unit as ru
+    monkeypatch.setattr(ru, "read_run_scalars", lambda *a, **k: [])
+
+    app = create_app(static_dist=None, api_key=None)
+    client = app.test_client()
+    resp = client.get("/api/projects/proj/runs")
+    assert resp.status_code == 200
+    body = json.loads(resp.get_data())
+    assert body["runs"][0]["runId"] == "a"
+    assert body["runs"][0]["status"] == "complete"
+    assert "ETag" in resp.headers
+
+
+def test_runs_endpoint_304_on_matching_etag(tmp_path, monkeypatch):
+    evals = tmp_path / "evaluations"
+    (evals / "proj").mkdir(parents=True)
+    index_db = tmp_path / "index.db"
+    _seed_index(index_db)
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(evals))
+    monkeypatch.setenv("QUODEQ_INDEX_DB_PATH", str(index_db))
+    import quodeq.services._runs_unit as ru
+    monkeypatch.setattr(ru, "read_run_scalars", lambda *a, **k: [])
+
+    app = create_app(static_dist=None, api_key=None)
+    client = app.test_client()
+    first = client.get("/api/projects/proj/runs")
+    etag = first.headers["ETag"]
+    second = client.get("/api/projects/proj/runs", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+
+
+def test_runs_endpoint_rejects_bad_project(tmp_path, monkeypatch):
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+    app = create_app(static_dist=None, api_key=None)
+    client = app.test_client()
+    resp = client.get("/api/projects/..%2f..%2fetc/runs")
+    assert resp.status_code in (400, 404)
+
+
+def test_runs_endpoint_400_on_invalid_segment(tmp_path, monkeypatch):
+    # 'a..b' is a single routable path segment (no encoded slash), so it reaches
+    # the handler and must fail validate_path_segment → 400 INVALID_INPUT.
+    monkeypatch.setenv("QUODEQ_EVALUATIONS_DIR", str(tmp_path))
+    app = create_app(static_dist=None, api_key=None)
+    client = app.test_client()
+    resp = client.get("/api/projects/a..b/runs")
+    assert resp.status_code == 400
+    assert json.loads(resp.get_data())["code"] == "INVALID_INPUT"

--- a/tests/services/test_project_summary_cache.py
+++ b/tests/services/test_project_summary_cache.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from quodeq.core.types import DimensionResult
+from quodeq.services import _fs_metadata as md
+from quodeq.services.score_cache import (
+    open_score_cache, read_cached_project_summary, write_cached_project_summary,
+)
+
+
+def test_project_summary_roundtrip_and_versioning(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
+    with open_score_cache() as conn:
+        assert read_cached_project_summary(conn, "P", "v1") is None
+        write_cached_project_summary(conn, "P", "v1", {"grade": "Good", "score": 7.3, "files": 1538})
+    with open_score_cache() as conn:
+        assert read_cached_project_summary(conn, "P", "v1") == {"grade": "Good", "score": 7.3, "files": 1538}
+        assert read_cached_project_summary(conn, "P", "v2") is None
+        write_cached_project_summary(conn, "P", "v2", {"grade": "Adequate", "score": 6.1, "files": 900})
+    with open_score_cache() as conn:
+        assert read_cached_project_summary(conn, "P", "v1") is None  # evicted (single slot)
+        assert read_cached_project_summary(conn, "P", "v2")["grade"] == "Adequate"
+
+
+def test_read_accumulated_summary_is_cached(monkeypatch, tmp_path):
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
+
+    calls = {"n": 0}
+    def _read(root, proj, run_id):
+        calls["n"] += 1
+        return [DimensionResult(dimension="security", overall_score="7.0/10",
+                                overall_grade="Good", source_file_count=10)]
+    monkeypatch.setattr(md, "read_run_data", _read)
+
+    class _Run:
+        def __init__(self, rid):
+            self.run_id = rid
+            self.status = "complete"
+    runs = [_Run("a"), _Run("b")]
+
+    first = md._read_accumulated_summary(tmp_path, "proj", runs)
+    n_after_first = calls["n"]
+    second = md._read_accumulated_summary(tmp_path, "proj", runs)
+    assert first == second
+    assert first == ("Good", 7.0, 10)  # grade, numeric_average, files_count
+    assert calls["n"] == n_after_first  # second call served from cache, no re-read

--- a/tests/services/test_run_index_project_query.py
+++ b/tests/services/test_run_index_project_query.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from quodeq.services.run_index import open_index, list_runs_for_project
+
+def _insert(db, *, job_id, project, run_id, state, started_at):
+    db.execute(
+        "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+        "started_at, updated_at, status_mtime) VALUES (?,?,?,?,?,?,?,?)",
+        (job_id, project, run_id, f"/x/{run_id}", state, started_at, started_at, 0),
+    )
+
+def test_list_runs_for_project_filters_and_orders(tmp_path):
+    db = open_index(tmp_path / "index.db")
+    with db:
+        _insert(db, job_id="ext-a", project="P1", run_id="a", state="done", started_at="2026-01-01T00:00:00Z")
+        _insert(db, job_id="ext-b", project="P1", run_id="b", state="done", started_at="2026-03-01T00:00:00Z")
+        _insert(db, job_id="ext-c", project="P2", run_id="c", state="done", started_at="2026-02-01T00:00:00Z")
+    rows = list_runs_for_project(db, "P1")
+    assert [r.run_id for r in rows] == ["b", "a"]
+    assert all(r.project_uuid == "P1" for r in rows)
+
+def test_list_runs_for_project_empty(tmp_path):
+    db = open_index(tmp_path / "index.db")
+    assert list_runs_for_project(db, "nope") == []

--- a/tests/services/test_runs_unit.py
+++ b/tests/services/test_runs_unit.py
@@ -28,3 +28,39 @@ def test_row_to_run_entry_shape_is_camel_and_score_placeholders():
     assert entry["overallGrade"] is None
     assert entry["dimensionScores"] == {}
     assert not any("_" in k for k in entry)
+
+
+from quodeq.services import _runs_unit as ru
+
+class _Dim:
+    def __init__(self, dimension, overall_score, overall_grade):
+        self.dimension = dimension
+        self.overall_score = overall_score
+        self.overall_grade = overall_grade
+
+def test_fill_scores_averages_dimensions(monkeypatch, tmp_path):
+    monkeypatch.setattr(ru, "read_run_scalars",
+        lambda root, proj, rid: [_Dim("security", "6.0/10", "GOOD"), _Dim("performance", "8.0/10", "GOOD")])
+    entry = ru._row_to_run_entry(_row(run_id="r1", state="done"))
+    ru._fill_scores(entry, tmp_path, "P", "r1")
+    assert entry["dimensionScores"] == {"security": 6.0, "performance": 8.0}
+    assert entry["overallScore"] == 7.0
+    assert entry["overallGrade"] is not None
+
+def test_fill_scores_skips_in_progress(monkeypatch, tmp_path):
+    called = False
+    def _boom(*a, **k):
+        nonlocal called
+        called = True
+        return []
+    monkeypatch.setattr(ru, "read_run_scalars", _boom)
+    entry = ru._row_to_run_entry(_row(run_id="r1", state="running"))
+    ru._fill_scores(entry, tmp_path, "P", "r1")
+    assert called is False
+    assert entry["overallScore"] is None
+
+def test_fill_scores_tolerates_read_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(ru, "read_run_scalars", lambda *a, **k: (_ for _ in ()).throw(OSError("gone")))
+    entry = ru._row_to_run_entry(_row(run_id="r1", state="done"))
+    ru._fill_scores(entry, tmp_path, "P", "r1")
+    assert entry["overallScore"] is None

--- a/tests/services/test_runs_unit.py
+++ b/tests/services/test_runs_unit.py
@@ -64,3 +64,23 @@ def test_fill_scores_tolerates_read_error(monkeypatch, tmp_path):
     entry = ru._row_to_run_entry(_row(run_id="r1", state="done"))
     ru._fill_scores(entry, tmp_path, "P", "r1")
     assert entry["overallScore"] is None
+
+
+from quodeq.services.run_index import open_index
+
+def test_build_runs_unit_end_to_end(monkeypatch, tmp_path):
+    db_path = tmp_path / "index.db"
+    db = open_index(db_path)
+    with db:
+        db.execute(
+            "INSERT INTO runs (job_id, project_uuid, run_id, run_dir, state, "
+            "started_at, updated_at, status_mtime) VALUES "
+            "('ext-a','P','a','/x/a','done','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z',0),"
+            "('ext-b','P','b','/x/b','done','2026-02-01T00:00:00Z','2026-02-01T00:00:00Z',0)"
+        )
+    db.close()
+    monkeypatch.setattr(ru, "read_run_scalars", lambda root, proj, rid: [_Dim("security", "5.0/10", "ADEQUATE")])
+    rows = ru.build_runs_unit(tmp_path, db_path, "P")
+    assert [r["runId"] for r in rows] == ["b", "a"]
+    assert rows[0]["overallScore"] == 5.0
+    assert rows[0]["dimensionScores"] == {"security": 5.0}

--- a/tests/services/test_runs_unit.py
+++ b/tests/services/test_runs_unit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from quodeq.services._runs_unit import _ui_status, _row_to_run_entry
+from quodeq.services.run_index import RunRow
+
+def _row(run_id="r1", state="done", started_at="2026-01-02T03:04:05Z"):
+    return RunRow(
+        job_id=f"ext-{run_id}", project_uuid="P", run_id=run_id, run_dir=f"/x/{run_id}",
+        state=state, phase=None, current_dimension=None, started_at=started_at,
+        updated_at=started_at, finalized_at=None, heartbeat_at=None, pid=None,
+        exit_reason=None, status_mtime=0,
+    )
+
+def test_ui_status_mapping():
+    assert _ui_status("done") == "complete"
+    assert _ui_status("complete") == "complete"
+    assert _ui_status("running") == "in_progress"
+    assert _ui_status("in_progress") == "in_progress"
+    assert _ui_status("cancelled") == "cancelled"
+    assert _ui_status("failed") == "failed"
+    assert _ui_status("weird-unknown") == "complete"
+
+def test_row_to_run_entry_shape_is_camel_and_score_placeholders():
+    entry = _row_to_run_entry(_row(run_id="abc", state="done"))
+    assert entry["runId"] == "abc"
+    assert entry["status"] == "complete"
+    assert entry["dateISO"] == "2026-01-02T03:04:05Z"
+    assert entry["overallScore"] is None
+    assert entry["overallGrade"] is None
+    assert entry["dimensionScores"] == {}
+    assert not any("_" in k for k in entry)


### PR DESCRIPTION
Phase 1 of the UI data-loading architecture (spec + plan are local-only under docs/superpowers/). Executed subagent-driven with two-stage review per unit. Backend-only; the frontend still consumes the old endpoints unchanged.

## What landed

**1. Cache the per-project accumulated card summary — the headline win.**
`/api/projects` was dominated by `_read_accumulated_summary`, which reads *every* run's data to compute each project card's grade/score (the accumulated rollup takes latest-per-dimension across the whole run history, so it can't early-break). It's now wrapped in a read-through cache in `score_cache.db` (new isolated `project_summary_cache` table), keyed by the existing `accumulated_cache_version` (dismissals + deletions + grade-formula params + run-set), so a dismiss / formula change / new scan invalidates it automatically.

Measured on real data (12 projects, ~340 runs) — `build_project_list`:

| | time |
|---|---|
| cold (summary cache empty) | 3254 ms |
| warm (cache hit) | 467 ms |

**7.0x**, and the output is byte-identical to before (the compute logic is unchanged, only wrapped). The cache persists across launches, so a typical relaunch with unchanged data is warm. A separate table is used deliberately: the existing `accumulated_cache` is single-slot-per-project and owned by the dashboard view — sharing it would make the card and dashboard evict each other.

**2. New `GET /api/projects/<project>/runs` unit endpoint** (~42 KB vs the 2.5 MB `scores` monolith it will eventually replace): status + dates from `~/.quodeq/index.db`, per-dimension scalar scores from the score cache. Additive; not yet wired into the UI.

**3. Reusable ETag helper** (`api/_http_cache.py`, `conditional_json`): a matching `If-None-Match` returns a bodyless 304. gzip is **not** re-added here — it's already app-wide via #732's `_compression.py` (500 KB gate); this branch merged post-#732 develop cleanly.

## Deferred: index-backed project-list enumeration

I implemented and reviewed replacing the per-project `list_runs` disk walk (the residual ~356 ms) with an index query, then **reverted it** after a real-data parity check found it is *not* a faithful drop-in — all 12 projects diverged:
- disk `list_runs` caps at `_DEFAULT_RUN_LIMIT=100`; the index returns all runs (quodeq 100→201)
- disk requires `evidence/manifest.json` per run; the index counts incomplete/no-manifest runs (quodeq-qwen 22→28)
- disk orders by evidence `date_iso` (artifact date); the index by `started_at` (scan wall-clock) → the index picked a **cancelled** run as one project's "latest"
- date format `Z` vs `+00:00`

Reconciling the run-set and date-source differences needs per-run disk reads, which defeats the purpose. Preserved on branch `defer/index-backed-enum`; a proper version must first extend `index.db` to carry the evidence date + manifest-validity.

## Known follow-ups (phase 2)
- `/runs` is ~1.5 s cold because `build_runs_unit` calls `sync_index` over the whole evaluations tree per call — scope the sync to the target project before wiring `/runs` into History.
- `/runs` `overallScore` uses an unweighted mean of dimension scores, whereas the project card uses the formula-weighted `numeric_average`; reconcile if the two surfaces must match exactly.

## Verification
- Full non-integration suite: **4118 passed, 1 skipped**.
- Real-data: the 7x measurement above; `/runs` returns the unit + ETag, and a matching `If-None-Match` replays as a 0-byte 304.
- Every unit passed independent spec-compliance + code-quality review; the whole branch passed a final coherence review (no residue from the reverted enumeration; the three enumeration files are byte-identical to develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)