### PR TITLE
fix(scoring): scope grades to the current standard's dimensions (drop retired dims like clean-architecture)

### DIFF
--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -93,6 +93,16 @@ def _read_accumulated_summary(
                     if files_count is None and d.source_file_count:
                         files_count = d.source_file_count
             acc_dims = list(latest_by_dim.values())
+            # Scope the card summary to the dimensions the latest eligible run
+            # actually configured, dropping stale dims (e.g. clean-architecture)
+            # that linger via old runs / evaluation.db drift. ``runs`` arrive
+            # newest-first, so runs[0] is the latest. Fail-open when its config
+            # can't be read (empty set -> _scope_to_configured keeps everything).
+            if runs:
+                from quodeq.services._run_dimensions import configured_dimensions  # noqa: PLC0415
+                from quodeq.services.accumulated import _scope_to_configured  # noqa: PLC0415
+                configured = configured_dimensions(project_dir / runs[0].run_id)
+                acc_dims = _scope_to_configured(acc_dims, configured)
             if not acc_dims:
                 return {"grade": None, "score": None, "files": files_count}
             summary = summarize_dimensions(acc_dims, params)

--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -93,16 +93,17 @@ def _read_accumulated_summary(
                     if files_count is None and d.source_file_count:
                         files_count = d.source_file_count
             acc_dims = list(latest_by_dim.values())
-            # Scope the card summary to the dimensions the latest eligible run
-            # actually configured, dropping stale dims (e.g. clean-architecture)
-            # that linger via old runs / evaluation.db drift. ``runs`` arrive
-            # newest-first, so runs[0] is the latest. Fail-open when its config
-            # can't be read (empty set -> _scope_to_configured keeps everything).
-            if runs:
-                from quodeq.services._run_dimensions import configured_dimensions  # noqa: PLC0415
-                from quodeq.services.accumulated import _scope_to_configured  # noqa: PLC0415
-                configured = configured_dimensions(project_dir / runs[0].run_id)
-                acc_dims = _scope_to_configured(acc_dims, configured)
+            # Scope the card summary to the project's current dimension standard
+            # — the union of dimensions configured by the last few ELIGIBLE runs
+            # — dropping stale dims (e.g. clean-architecture) that linger via old
+            # runs / evaluation.db drift. ``runs`` here are NOT eligibility-
+            # filtered (runs[0] may be in_progress), so the helper's internal
+            # eligible filter keeps this symmetric with the accumulated path.
+            # Fail-open: an empty standard set keeps every dim.
+            from quodeq.services._run_dimensions import current_standard_dimensions  # noqa: PLC0415
+            from quodeq.services.accumulated import _scope_to_configured  # noqa: PLC0415
+            standard = current_standard_dimensions(reports_root, entry_name, runs)
+            acc_dims = _scope_to_configured(acc_dims, standard)
             if not acc_dims:
                 return {"grade": None, "score": None, "files": files_count}
             summary = summarize_dimensions(acc_dims, params)

--- a/src/quodeq/services/_run_dimensions.py
+++ b/src/quodeq/services/_run_dimensions.py
@@ -1,0 +1,50 @@
+"""Read the dimensions a run ACTUALLY configured.
+
+A run records the dimensions it configured in two authoritative places
+under its run dir:
+
+* ``dimensions.json`` (``{"schema_version":1, "dimensions": {...}}``) —
+  the keys are the configured dimensions. Preferred.
+* ``status.json`` (``{"dimensions": [...]}``) — the same list. Fallback
+  for runs whose per-dim sidecar is missing.
+
+This is the current-standard signal: a project that stopped evaluating
+a dimension (e.g. ``clean-architecture``) will not list it here even
+though old runs and ``evaluation.db`` drift still carry it. Scoping the
+accumulated grade and the project card to this set drops those stale
+dimensions.
+
+The read is fail-open: an unreadable/absent pair returns the empty set,
+and callers must treat that as "don't filter" rather than "no dims".
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.shared.dimensions_state import read_dimensions
+
+
+def configured_dimensions(run_dir: Path) -> set[str]:
+    """Return the set of dimension IDs *run_dir* configured.
+
+    Prefers ``dimensions.json`` keys; falls back to the ``dimensions``
+    list in ``status.json``. Returns an empty set when neither file is
+    present or parseable — callers must interpret that as "unknown, do
+    not filter" (fail-open), never as "no dimensions".
+    """
+    dims = read_dimensions(run_dir).get("dimensions")
+    if isinstance(dims, dict) and dims:
+        return set(dims.keys())
+
+    status_path = run_dir / "status.json"
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    status_dims = data.get("dimensions")
+    if isinstance(status_dims, list):
+        return {d for d in status_dims if isinstance(d, str)}
+    return set()

--- a/src/quodeq/services/_run_dimensions.py
+++ b/src/quodeq/services/_run_dimensions.py
@@ -16,13 +16,27 @@ dimensions.
 
 The read is fail-open: an unreadable/absent pair returns the empty set,
 and callers must treat that as "don't filter" rather than "no dims".
+
+The current standard is the UNION of configured dimensions over the last
+few ELIGIBLE runs (:func:`current_standard_dimensions`), not just the
+single latest run: a targeted subset re-run (e.g. one that scans only
+``maintainability``) must not collapse the standard to that one dimension.
 """
 from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from quodeq.shared.dimensions_state import read_dimensions
+
+if TYPE_CHECKING:
+    from quodeq.services.ports import RunInfo
+
+# Union the configured dimensions over the last N eligible runs so a subset
+# re-run doesn't collapse the standard, while dimensions retired more than N
+# eligible runs ago drop out.
+_STANDARD_WINDOW = 5
 
 
 def configured_dimensions(run_dir: Path) -> set[str]:
@@ -48,3 +62,32 @@ def configured_dimensions(run_dir: Path) -> set[str]:
     if isinstance(status_dims, list):
         return {d for d in status_dims if isinstance(d, str)}
     return set()
+
+
+def current_standard_dimensions(
+    reports_root: Path,
+    project: str,
+    run_infos: list["RunInfo"],
+    *,
+    window: int = _STANDARD_WINDOW,
+) -> set[str]:
+    """Return the project's current dimension standard.
+
+    The union of :func:`configured_dimensions` over the last *window*
+    ELIGIBLE runs (newest-first). Unioning over a window means a targeted
+    subset re-run (which configures only one dimension) does not collapse
+    the standard, while a dimension retired more than *window* eligible
+    runs ago drops out.
+
+    Filters to eligible runs internally so the result is correct
+    regardless of whether the caller pre-filtered. Returns the empty set
+    when there are no eligible runs or every config is unreadable — a
+    fail-open signal callers must treat as "don't filter".
+    """
+    from quodeq.services.dim_resolution import is_eligible_for_default_view  # noqa: PLC0415
+
+    eligible = [r for r in run_infos if is_eligible_for_default_view(r.status)]
+    standard: set[str] = set()
+    for run in eligible[:window]:
+        standard |= configured_dimensions(reports_root / project / run.run_id)
+    return standard

--- a/src/quodeq/services/_run_dimensions.py
+++ b/src/quodeq/services/_run_dimensions.py
@@ -85,9 +85,19 @@ def current_standard_dimensions(
     fail-open signal callers must treat as "don't filter".
     """
     from quodeq.services.dim_resolution import is_eligible_for_default_view  # noqa: PLC0415
+    from quodeq.shared.validation import validate_path_segment  # noqa: PLC0415
 
     eligible = [r for r in run_infos if is_eligible_for_default_view(r.status)]
     standard: set[str] = set()
     for run in eligible[:window]:
+        # Defense-in-depth: reject traversal in the path segments before
+        # building the run dir (mirrors read_run_data / parse_run_date). These
+        # segments are validated upstream and enumerated from disk, so a failure
+        # here is not expected — skip that run rather than crash the grade,
+        # honouring this module's fail-open contract.
+        try:
+            validate_path_segment(project, run.run_id)
+        except ValueError:
+            continue
         standard |= configured_dimensions(reports_root / project / run.run_id)
     return standard

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -11,6 +11,7 @@ from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams, dimension_weighted_average
 from quodeq.core.types import DimensionResult, to_camel_dict
 from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services._run_dimensions import configured_dimensions
 from quodeq.services.deleted import filter_deleted_from_dimensions
 from quodeq.services.dim_resolution import is_eligible_for_default_view
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
@@ -188,6 +189,22 @@ def _compute_result(
     return _build_accumulated_for_runs(reports_root, project, eligible_run_infos, cache_config, params)
 
 
+def _scope_to_configured(
+    all_dims: list[DimensionResult], configured: set[str],
+) -> list[DimensionResult]:
+    """Drop dimensions not in *configured*, the latest run's current standard.
+
+    Removes stale dimensions (e.g. ``clean-architecture``) that a project
+    no longer evaluates but that linger in old runs / ``evaluation.db``
+    drift. Fail-open: an empty *configured* set (unreadable dimensions.json
+    / status.json) means "unknown", so nothing is dropped — never return an
+    empty grade because a config file went missing.
+    """
+    if not configured:
+        return all_dims
+    return [d for d in all_dims if d.dimension in configured]
+
+
 def _build_accumulated_for_runs(
     reports_root: Path, project: str, run_infos: list[RunInfo],
     cache_config: AccumulatedCacheConfig | None,
@@ -203,6 +220,12 @@ def _build_accumulated_for_runs(
     project_dir = reports_root / project
     all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), project_dir)
     all_dims = filter_deleted_from_dimensions(all_dims, project_dir)
+    # Scope to the dimensions the latest eligible run actually configured,
+    # dropping stale dims (e.g. clean-architecture) that only survive via
+    # old runs / evaluation.db drift. run_infos arrive newest-first, so
+    # runs[0] is the latest. Fail-open when its config can't be read.
+    if runs:
+        all_dims = _scope_to_configured(all_dims, configured_dimensions(project_dir / runs[0]))
     dims_with_trend = _compute_accumulated_trends(all_dims, prev_occurrence)
     severity = _aggregate_severity_counts(all_dims)
     avg, prev_avg = _compute_accumulated_scores(all_dims, prev_run_latest, params)

--- a/src/quodeq/services/accumulated.py
+++ b/src/quodeq/services/accumulated.py
@@ -11,7 +11,7 @@ from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams, dimension_weighted_average
 from quodeq.core.types import DimensionResult, to_camel_dict
 from quodeq.services._cache import make_lru_dimension_fetcher
-from quodeq.services._run_dimensions import configured_dimensions
+from quodeq.services._run_dimensions import current_standard_dimensions
 from quodeq.services.deleted import filter_deleted_from_dimensions
 from quodeq.services.dim_resolution import is_eligible_for_default_view
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
@@ -192,7 +192,7 @@ def _compute_result(
 def _scope_to_configured(
     all_dims: list[DimensionResult], configured: set[str],
 ) -> list[DimensionResult]:
-    """Drop dimensions not in *configured*, the latest run's current standard.
+    """Drop dimensions not in *configured*, the project's current standard.
 
     Removes stale dimensions (e.g. ``clean-architecture``) that a project
     no longer evaluates but that linger in old runs / ``evaluation.db``
@@ -220,12 +220,14 @@ def _build_accumulated_for_runs(
     project_dir = reports_root / project
     all_dims = filter_dismissed_from_dimensions(list(latest_by_dim.values()), project_dir)
     all_dims = filter_deleted_from_dimensions(all_dims, project_dir)
-    # Scope to the dimensions the latest eligible run actually configured,
-    # dropping stale dims (e.g. clean-architecture) that only survive via
-    # old runs / evaluation.db drift. run_infos arrive newest-first, so
-    # runs[0] is the latest. Fail-open when its config can't be read.
-    if runs:
-        all_dims = _scope_to_configured(all_dims, configured_dimensions(project_dir / runs[0]))
+    # Scope to the project's current dimension standard — the union of the
+    # dimensions configured by the last few eligible runs — dropping stale
+    # dims (e.g. clean-architecture) that only survive via old runs /
+    # evaluation.db drift. Unioning over a window keeps a targeted subset
+    # re-run from collapsing the standard to its one dimension. Fail-open
+    # when no eligible config can be read.
+    standard = current_standard_dimensions(reports_root, project, run_infos)
+    all_dims = _scope_to_configured(all_dims, standard)
     dims_with_trend = _compute_accumulated_trends(all_dims, prev_occurrence)
     severity = _aggregate_severity_counts(all_dims)
     avg, prev_avg = _compute_accumulated_scores(all_dims, prev_run_latest, params)

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -28,7 +28,11 @@ _BUSY_TIMEOUT_MS = 5000
 # of 6 dims), which the content-hash version could never invalidate; the
 # write-guard now persists only completed runs, and this bump rebuilds the
 # stranded partial rows once.
-_CACHE_WRITER_EPOCH = "2"
+# "3": accumulated / project-summary payloads written before configured-dim
+# scoping carried stale dimensions (e.g. clean-architecture) that the project
+# no longer evaluates; the run-fingerprint could never invalidate them, so this
+# bump rebuilds them once against the latest run's configured-dimension set.
+_CACHE_WRITER_EPOCH = "3"
 _SCHEMA = (
     "CREATE TABLE IF NOT EXISTS run_scalars ("
     " project TEXT NOT NULL, run_id TEXT NOT NULL, version TEXT NOT NULL,"

--- a/tests/services/test_accumulated_configured_scope.py
+++ b/tests/services/test_accumulated_configured_scope.py
@@ -1,0 +1,120 @@
+"""The accumulated view is scoped to the latest run's configured dimensions.
+
+A project that stopped evaluating a dimension (e.g. clean-architecture)
+still carries it in old runs / evaluation.db drift. The accumulated grade
+must reflect the CURRENT standard — the dimensions the latest eligible run
+actually configured — and drop the stale ones.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from quodeq.core.types import DimensionResult
+from quodeq.core.types.mappers import parse_dimension_result
+from quodeq.services.accumulated import (
+    _build_accumulated_for_runs,
+    _scope_to_configured,
+)
+from quodeq.services.ports import RunInfo
+
+
+def _dim(name: str, score: str = "7.5", grade: str = "B") -> DimensionResult:
+    return parse_dimension_result({"dimension": name, "overallScore": score, "overallGrade": grade})
+
+
+# ---------------------------------------------------------------------------
+# _scope_to_configured (pure helper)
+# ---------------------------------------------------------------------------
+
+class TestScopeToConfigured:
+    def test_drops_dims_not_configured(self):
+        dims = [_dim("A"), _dim("B"), _dim("C")]
+        result = _scope_to_configured(dims, {"A", "B"})
+        assert sorted(d.dimension for d in result) == ["A", "B"]
+
+    def test_empty_configured_fails_open(self):
+        # Unknown config (empty set) -> never drop everything.
+        dims = [_dim("A"), _dim("B")]
+        result = _scope_to_configured(dims, set())
+        assert sorted(d.dimension for d in result) == ["A", "B"]
+
+    def test_keeps_all_when_all_configured(self):
+        dims = [_dim("A"), _dim("B")]
+        result = _scope_to_configured(dims, {"A", "B", "C"})
+        assert sorted(d.dimension for d in result) == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# _build_accumulated_for_runs — end-to-end scoping through the real reader
+# ---------------------------------------------------------------------------
+
+def _write_eval(run_dir: Path, name: str, score: str, grade: str) -> None:
+    eval_dir = run_dir / "evaluation"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "dimension": name, "overallScore": score, "overallGrade": grade,
+        "principles": [], "violations": [], "compliance": [],
+    }
+    (eval_dir / f"{name}.json").write_text(json.dumps(data), encoding="utf-8")
+    ev = run_dir / "evidence"
+    ev.mkdir(parents=True, exist_ok=True)
+    (ev / f"{name}_evidence.json").write_text(
+        json.dumps({"dimension": name, "discipline": "typescript"}), encoding="utf-8",
+    )
+
+
+def _setup_run(run_dir: Path, dims: list[tuple[str, str, str]], configured: list[str]) -> None:
+    for name, score, grade in dims:
+        _write_eval(run_dir, name, score, grade)
+    (run_dir / "evidence").mkdir(parents=True, exist_ok=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}", encoding="utf-8")
+    (run_dir / "scan.json").write_text("{}", encoding="utf-8")
+    (run_dir / "dimensions.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "dimensions": {d: {"state": "done"} for d in configured},
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_accumulated_excludes_stale_dimension(tmp_path: Path) -> None:
+    """Latest run configures {A,B}; an older run had C. C must be excluded."""
+    project = "proj"
+    reports_root = tmp_path / "evaluations"
+    latest = reports_root / project / "run-new"
+    old = reports_root / project / "run-old"
+    # Latest run: only A and B configured.
+    _setup_run(latest, [("A", "8.0", "A"), ("B", "6.0", "C")], configured=["A", "B"])
+    # Old run: A, B, and the now-retired C.
+    _setup_run(old, [("A", "8.0", "A"), ("B", "6.0", "C"), ("C", "9.0", "A")],
+               configured=["A", "B", "C"])
+
+    # run_infos arrive newest-first.
+    run_infos = [
+        RunInfo(run_id="run-new", date_iso="2026-07-05", date_label="Jul 5", status="complete"),
+        RunInfo(run_id="run-old", date_iso="2026-07-01", date_label="Jul 1", status="complete"),
+    ]
+    result = _build_accumulated_for_runs(reports_root, project, run_infos, None)
+    dims = sorted(d.dimension for d in result.all_dimensions)
+    assert dims == ["A", "B"], f"stale dim C should be dropped, got {dims}"
+
+
+def test_accumulated_fails_open_without_config(tmp_path: Path) -> None:
+    """No dimensions.json / status.json on the latest run -> do not filter."""
+    project = "proj"
+    reports_root = tmp_path / "evaluations"
+    latest = reports_root / project / "run-new"
+    # Set up run but then remove the config signal.
+    _setup_run(latest, [("A", "8.0", "A"), ("C", "9.0", "A")], configured=["A"])
+    (latest / "dimensions.json").unlink()
+
+    run_infos = [
+        RunInfo(run_id="run-new", date_iso="2026-07-05", date_label="Jul 5", status="complete"),
+    ]
+    result = _build_accumulated_for_runs(reports_root, project, run_infos, None)
+    dims = sorted(d.dimension for d in result.all_dimensions)
+    # Fail-open: both dims survive because config is unreadable.
+    assert dims == ["A", "C"], f"fail-open should keep all dims, got {dims}"

--- a/tests/services/test_accumulated_configured_scope.py
+++ b/tests/services/test_accumulated_configured_scope.py
@@ -81,25 +81,53 @@ def _setup_run(run_dir: Path, dims: list[tuple[str, str, str]], configured: list
 
 
 def test_accumulated_excludes_stale_dimension(tmp_path: Path) -> None:
-    """Latest run configures {A,B}; an older run had C. C must be excluded."""
+    """C was retired more than a window ago. It must be excluded even though it
+    still has findings in the old run."""
     project = "proj"
     reports_root = tmp_path / "evaluations"
-    latest = reports_root / project / "run-new"
+    run_infos = []
+    # 5 recent eligible runs configure only {A,B}; the 6th (oldest, outside the
+    # window of 5) still configured C and carries a C finding.
+    for i in range(5):
+        rd = reports_root / project / f"run-{i}"
+        _setup_run(rd, [("A", "8.0", "A"), ("B", "6.0", "C")], configured=["A", "B"])
+        run_infos.append(RunInfo(
+            run_id=f"run-{i}", date_iso=f"2026-07-{20 - i:02d}",
+            date_label="d", status="complete",
+        ))
     old = reports_root / project / "run-old"
-    # Latest run: only A and B configured.
-    _setup_run(latest, [("A", "8.0", "A"), ("B", "6.0", "C")], configured=["A", "B"])
-    # Old run: A, B, and the now-retired C.
     _setup_run(old, [("A", "8.0", "A"), ("B", "6.0", "C"), ("C", "9.0", "A")],
                configured=["A", "B", "C"])
+    run_infos.append(RunInfo(
+        run_id="run-old", date_iso="2026-07-01", date_label="d", status="complete",
+    ))
 
-    # run_infos arrive newest-first.
+    result = _build_accumulated_for_runs(reports_root, project, run_infos, None)
+    dims = sorted(d.dimension for d in result.all_dimensions)
+    assert dims == ["A", "B"], f"retired dim C should be dropped, got {dims}"
+
+
+def test_accumulated_subset_rerun_does_not_collapse(tmp_path: Path) -> None:
+    """The latest eligible run is a targeted subset re-run configuring only {A}.
+    The full standard {A,B,C} must survive because prior eligible runs configured
+    it — the accumulated grade must NOT collapse to a single dimension."""
+    project = "proj"
+    reports_root = tmp_path / "evaluations"
+    # Newest run: subset re-run, only A.
+    subset = reports_root / project / "run-subset"
+    _setup_run(subset, [("A", "8.0", "A")], configured=["A"])
+    # Prior eligible runs configured the full {A,B,C}, with findings for each.
+    prior = reports_root / project / "run-full"
+    _setup_run(prior, [("A", "8.0", "A"), ("B", "6.0", "C"), ("C", "7.0", "B")],
+               configured=["A", "B", "C"])
+
     run_infos = [
-        RunInfo(run_id="run-new", date_iso="2026-07-05", date_label="Jul 5", status="complete"),
-        RunInfo(run_id="run-old", date_iso="2026-07-01", date_label="Jul 1", status="complete"),
+        RunInfo(run_id="run-subset", date_iso="2026-07-05", date_label="d", status="complete"),
+        RunInfo(run_id="run-full", date_iso="2026-07-01", date_label="d", status="complete"),
     ]
     result = _build_accumulated_for_runs(reports_root, project, run_infos, None)
     dims = sorted(d.dimension for d in result.all_dimensions)
-    assert dims == ["A", "B"], f"stale dim C should be dropped, got {dims}"
+    assert dims == ["A", "B", "C"], f"subset re-run must not collapse standard, got {dims}"
 
 
 def test_accumulated_fails_open_without_config(tmp_path: Path) -> None:

--- a/tests/services/test_configured_dimensions.py
+++ b/tests/services/test_configured_dimensions.py
@@ -1,0 +1,66 @@
+"""Tests for quodeq.services._run_dimensions.configured_dimensions."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quodeq.services._run_dimensions import configured_dimensions
+
+
+def _write(path: Path, name: str, data: dict) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / name).write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_reads_dimensions_json_keys(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write(
+        run_dir,
+        "dimensions.json",
+        {
+            "schema_version": 1,
+            "dimensions": {
+                "security": {"state": "done"},
+                "performance": {"state": "done"},
+            },
+        },
+    )
+    assert configured_dimensions(run_dir) == {"security", "performance"}
+
+
+def test_prefers_dimensions_json_over_status(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write(
+        run_dir,
+        "dimensions.json",
+        {"schema_version": 1, "dimensions": {"security": {"state": "done"}}},
+    )
+    _write(run_dir, "status.json", {"dimensions": ["security", "reliability"]})
+    # dimensions.json wins when present and non-empty.
+    assert configured_dimensions(run_dir) == {"security"}
+
+
+def test_falls_back_to_status_json(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    # No dimensions.json — status.json list is the fallback signal.
+    _write(run_dir, "status.json", {"dimensions": ["security", "usability"]})
+    assert configured_dimensions(run_dir) == {"security", "usability"}
+
+
+def test_falls_back_when_dimensions_json_empty(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write(run_dir, "dimensions.json", {"schema_version": 1, "dimensions": {}})
+    _write(run_dir, "status.json", {"dimensions": ["security"]})
+    assert configured_dimensions(run_dir) == {"security"}
+
+
+def test_empty_set_when_absent(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    assert configured_dimensions(run_dir) == set()
+
+
+def test_empty_set_when_status_dimensions_not_a_list(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    _write(run_dir, "status.json", {"dimensions": "security"})
+    assert configured_dimensions(run_dir) == set()

--- a/tests/services/test_configured_dimensions.py
+++ b/tests/services/test_configured_dimensions.py
@@ -153,3 +153,15 @@ def test_current_standard_dimensions_empty_when_no_eligible_runs(tmp_path: Path)
     _make_run(reports_root, project, "r1", _FULL)
     run_infos = [_info("r0", status="in_progress"), _info("r1", status="failed")]
     assert current_standard_dimensions(reports_root, project, run_infos) == set()
+
+
+def test_current_standard_dimensions_rejects_traversal_segments(tmp_path: Path) -> None:
+    """A project/run_id with path-traversal is skipped (defense-in-depth, fail-open)."""
+    reports_root = tmp_path / "evaluations"
+    # A traversal project name must not build a path outside reports_root; the
+    # run is skipped and the result is the fail-open empty set.
+    assert current_standard_dimensions(reports_root, "../../etc", [_info("r0")]) == set()
+    # A traversal run_id is likewise skipped, so a well-formed sibling still counts.
+    _make_run(reports_root, "proj", "good", _FULL)
+    run_infos = [_info("../evil"), _info("good")]
+    assert current_standard_dimensions(reports_root, "proj", run_infos) == set(_FULL)

--- a/tests/services/test_configured_dimensions.py
+++ b/tests/services/test_configured_dimensions.py
@@ -1,15 +1,32 @@
-"""Tests for quodeq.services._run_dimensions.configured_dimensions."""
+"""Tests for quodeq.services._run_dimensions."""
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
-from quodeq.services._run_dimensions import configured_dimensions
+from quodeq.services._run_dimensions import (
+    configured_dimensions,
+    current_standard_dimensions,
+)
+from quodeq.services.ports import RunInfo
 
 
 def _write(path: Path, name: str, data: dict) -> None:
     path.mkdir(parents=True, exist_ok=True)
     (path / name).write_text(json.dumps(data), encoding="utf-8")
+
+
+def _make_run(reports_root: Path, project: str, run_id: str, dims: list[str]) -> None:
+    run_dir = reports_root / project / run_id
+    _write(
+        run_dir,
+        "dimensions.json",
+        {"schema_version": 1, "dimensions": {d: {"state": "done"} for d in dims}},
+    )
+
+
+def _info(run_id: str, status: str = "complete") -> RunInfo:
+    return RunInfo(run_id=run_id, date_iso="2026-07-01", date_label="d", status=status)
 
 
 def test_reads_dimensions_json_keys(tmp_path: Path) -> None:
@@ -64,3 +81,75 @@ def test_empty_set_when_status_dimensions_not_a_list(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
     _write(run_dir, "status.json", {"dimensions": "security"})
     assert configured_dimensions(run_dir) == set()
+
+
+# ---------------------------------------------------------------------------
+# current_standard_dimensions — union over the last N eligible runs
+# ---------------------------------------------------------------------------
+
+_FULL = ["A", "B", "C", "D", "E", "F"]
+
+
+def test_current_standard_dimensions_unions_recent_eligible_runs(tmp_path: Path) -> None:
+    """Latest eligible run is a subset re-run ({A} only), but prior eligible
+    runs configured the full set — the union must recover the full set."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj"
+    # newest-first: subset re-run, then full-set runs.
+    _make_run(reports_root, project, "r0", ["A"])  # subset re-run
+    _make_run(reports_root, project, "r1", _FULL)
+    _make_run(reports_root, project, "r2", ["A"])  # another subset re-run
+    _make_run(reports_root, project, "r3", _FULL)
+    run_infos = [_info("r0"), _info("r1"), _info("r2"), _info("r3")]
+
+    result = current_standard_dimensions(reports_root, project, run_infos)
+    assert result == set(_FULL), f"subset re-run must not collapse standard, got {sorted(result)}"
+
+
+def test_current_standard_dimensions_drops_retired_dim(tmp_path: Path) -> None:
+    """A dimension configured only in a run older than the window is excluded."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj"
+    # 5 recent runs in the window configure {A,B}; the 6th (oldest) had C.
+    for i in range(5):
+        _make_run(reports_root, project, f"r{i}", ["A", "B"])
+    _make_run(reports_root, project, "r5", ["A", "B", "C"])  # outside window of 5
+    run_infos = [_info(f"r{i}") for i in range(6)]
+
+    result = current_standard_dimensions(reports_root, project, run_infos, window=5)
+    assert result == {"A", "B"}, f"retired C should drop out, got {sorted(result)}"
+
+
+def test_current_standard_dimensions_excludes_in_progress(tmp_path: Path) -> None:
+    """An in_progress latest run is skipped for eligibility. With window=1, the
+    standard comes from the first ELIGIBLE run, not the in_progress one."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj"
+    # newest-first: in_progress run configures {A,B,C}; latest complete is {A,B}.
+    _make_run(reports_root, project, "live", ["A", "B", "C"])
+    _make_run(reports_root, project, "done", ["A", "B"])
+    run_infos = [_info("live", status="in_progress"), _info("done", status="complete")]
+
+    # window=1 makes the eligible filter observable: without it, "live" (in_progress)
+    # would seed C; with it, only "done" counts.
+    result = current_standard_dimensions(reports_root, project, run_infos, window=1)
+    assert result == {"A", "B"}, f"in_progress run must be skipped, got {sorted(result)}"
+
+
+def test_current_standard_dimensions_fails_open_when_all_unreadable(tmp_path: Path) -> None:
+    """No config files anywhere -> empty set (fail-open signal)."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj"
+    (reports_root / project / "r0").mkdir(parents=True)
+    run_infos = [_info("r0")]
+    assert current_standard_dimensions(reports_root, project, run_infos) == set()
+
+
+def test_current_standard_dimensions_empty_when_no_eligible_runs(tmp_path: Path) -> None:
+    """All runs are in_progress/failed -> no eligible runs -> empty set."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj"
+    _make_run(reports_root, project, "r0", _FULL)
+    _make_run(reports_root, project, "r1", _FULL)
+    run_infos = [_info("r0", status="in_progress"), _info("r1", status="failed")]
+    assert current_standard_dimensions(reports_root, project, run_infos) == set()

--- a/tests/services/test_fs_metadata.py
+++ b/tests/services/test_fs_metadata.py
@@ -169,6 +169,48 @@ class TestReadAccumulatedSummary:
         assert score is None
         assert files is None
 
+    @patch("quodeq.services._fs_metadata.summarize_dimensions")
+    @patch("quodeq.services._fs_metadata.read_run_data")
+    def test_card_summary_scoped_to_latest_configured_dims(
+        self, mock_read, mock_summarize, tmp_path, monkeypatch,
+    ):
+        """A stale dim (clean-architecture) not configured by the latest run
+        is dropped before summarize_dimensions sees it."""
+        from quodeq.core.types import DimensionResult
+        from quodeq.services.ports import RunInfo
+
+        # Bypass the persisted project-summary cache so we observe the fresh
+        # computation (the cache is keyed by project name, not reports_root).
+        monkeypatch.setenv("QUODEQ_DISABLE_SCORE_CACHE", "1")
+        reports_root = tmp_path / "evaluations"
+        project = "proj"
+        latest_dir = reports_root / project / "run-new"
+        latest_dir.mkdir(parents=True)
+        # Latest run configured only security + reliability.
+        (latest_dir / "dimensions.json").write_text(
+            json.dumps({
+                "schema_version": 1,
+                "dimensions": {"security": {"state": "done"}, "reliability": {"state": "done"}},
+            }),
+            encoding="utf-8",
+        )
+        mock_read.return_value = [
+            DimensionResult(dimension="security", overall_score="8.0", source_file_count=10),
+            DimensionResult(dimension="reliability", overall_score="7.0"),
+            DimensionResult(dimension="clean-architecture", overall_score="4.0"),
+        ]
+        mock_summarize.return_value = type(
+            "S", (), {"overall_grade": "A", "numeric_average": 7.5},
+        )()
+
+        runs = [RunInfo(run_id="run-new", date_iso="2026-01-02", date_label="Jan 02")]
+        _read_accumulated_summary(reports_root, project, runs)
+
+        # summarize_dimensions must be called WITHOUT clean-architecture.
+        called_dims = mock_summarize.call_args[0][0]
+        names = sorted(d.dimension for d in called_dims)
+        assert names == ["reliability", "security"], names
+
     def test_project_card_reflects_overlaid_sql_grades_and_loaded_params(
         self, tmp_path, monkeypatch,
     ):


### PR DESCRIPTION
## Problem
The accumulated grade and the project-card grade counted a stale `clean-architecture` dimension that the project no longer evaluates. Because the accumulated view takes latest-per-dimension across the whole run history, a dimension retired from the standard (last configured 7 runs ago) kept getting resurrected from an old run — and it also lingers via an `evaluation.db` projection even though the latest scans don't produce it. On the real quodeq project this dragged the grade from a correct ~7.7 down to 7.4, and the disparity was visible between the project card and the Overview.

## Fix
Scope the accumulated grade AND the card grade to the project's **current standard** — defined as the union of dimensions actually *configured* (per each run's `dimensions.json` / `status.json`) across the last 5 eligible (completed) runs.

- Drops dimensions retired more than the window ago (e.g. `clean-architecture`).
- **Robust to subset re-runs:** a targeted single-dimension re-run (you do these — e.g. a `maintainability`-only run) does NOT collapse the grade, because the union across recent runs still covers the full standard. Verified against production run `03c99d26` (maintainability-only).
- **Fail-open:** if no config is readable, nothing is filtered (never returns an empty grade).
- Card and accumulated paths both route through the same helper, so they stay symmetric (the card previously scoped off a possibly-in-progress run).
- Epoch bump invalidates caches that had already stored the stale dimension.

## Verification
- Real data (project d33f1fd0): accumulated dims = the 6 current ones, `clean-architecture` excluded; card grade corrected 7.4 → 7.6 (7.6 not 7.7 only because the very latest run is in-progress and excluded).
- Subset-re-run-as-newest scenario: still yields the full 6 dimensions (no collapse).
- New unit tests cover the union, retired-dim drop, in-progress exclusion, subset-re-run non-collapse, and fail-open. Full non-integration suite: 4134 passed, 1 skipped.

## Scope note
This fixes the *grade* disparity (accumulated + card). Making dismissals apply consistently across every view (the Overview 7.0 vs detail/history 6.6 issue) is a separate, larger change tracked next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)