### PR TITLE
feat(ui): mutation-delta writer (slice 1 — dismiss path)

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -18,7 +18,7 @@ from flask import Flask, Response, abort, jsonify, request
 
 from quodeq.services.deleted import delete_all_dismissed, delete_finding
 from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
-from quodeq.services.mutation_rescore import rescore_with_fallback
+from quodeq.services.mutation_rescore import dismiss_delta, rescore_with_fallback
 from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
@@ -75,7 +75,10 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
         dismiss_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
-        return jsonify({"scores": scores}), 200
+        delta = dismiss_delta(
+            _eval_dir(), project, run_id, {"req": req, "file": file, "line": line},
+        )
+        return jsonify({"scores": scores, "delta": delta}), 200
 
     @app.post("/api/findings/restore")
     def restore() -> tuple[Response, int]:

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -153,6 +153,82 @@ def _rescore_run(
         return None
 
 
+def _resolve_default_run_id(evaluations_dir: str, project: str) -> str | None:
+    """Return the run_id the Overview lands on by default, or None.
+
+    Reuses the EXACT "latest completed run" rule the dashboard uses: pick the
+    first run in newest-first ``list_runs`` order whose status is eligible for
+    the default view (``complete`` only), falling back to the newest run when
+    none is complete. This mirrors ``dashboard._resolve_selected_run("latest")``
+    so ``isLatest`` matches what the Overview actually shows.
+    """
+    from quodeq.services.dim_resolution import is_eligible_for_default_view  # noqa: PLC0415
+    from quodeq.services.ports import list_runs  # noqa: PLC0415
+
+    reports_root = Path(evaluations_dir).resolve()
+    try:
+        runs = list_runs(reports_root, project)
+    except Exception:
+        return None
+    if not runs:
+        return None
+    selected = next(
+        (r for r in runs if is_eligible_for_default_view(r.status)),
+        runs[0],
+    )
+    return selected.run_id
+
+
+def _accumulated_payload(evaluations_dir: str, project: str) -> dict[str, Any] | None:
+    """Return the cache-backed accumulated payload, or None on any failure.
+
+    ``get_project_scores(reports_root, project, None)`` returns a dict with an
+    ``accumulated`` key ({dimensions, summary}); we surface just that so the
+    client can patch the accumulated (cross-run) scores cache.
+    """
+    from quodeq.services.scoring import get_project_scores  # noqa: PLC0415
+
+    reports_root = Path(evaluations_dir).resolve()
+    try:
+        payload = get_project_scores(reports_root, project, None)
+    except Exception:
+        _logger.warning("Accumulated fetch for delta failed for %s", project, exc_info=True)
+        return None
+    if not payload:
+        return None
+    return payload.get("accumulated")
+
+
+def dismiss_delta(
+    evaluations_dir: str, project: str, run_id: str | None, dismissed: dict[str, Any],
+) -> dict[str, Any]:
+    """Describe a dismiss mutation so the client can patch its caches.
+
+    ``isLatest`` is True when ``run_id`` is the run the Overview lands on by
+    default — the exact ``_resolve_default_run_id`` rule shared with the
+    dashboard. ``accumulated`` carries the (cache-backed) cross-run rollup so
+    the Overview's accumulated view updates without a refetch; it is None when
+    no ``run_id`` was supplied (the caller has no run to anchor the rollup to)
+    or when the fetch fails.
+    """
+    is_latest = False
+    accumulated: dict[str, Any] | None = None
+    if run_id:
+        is_latest = run_id == _resolve_default_run_id(evaluations_dir, project)
+        accumulated = _accumulated_payload(evaluations_dir, project)
+    return {
+        "kind": "dismiss",
+        "runId": run_id,
+        "isLatest": is_latest,
+        "dismissed": {
+            "req": dismissed.get("req"),
+            "file": dismissed.get("file"),
+            "line": dismissed.get("line"),
+        },
+        "accumulated": accumulated,
+    }
+
+
 def rescore_with_fallback(
     evaluations_dir: str, project: str, run_id: str | None,
 ) -> dict[str, Any] | None:

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -19,7 +19,9 @@ const HelpPage = lazy(() => import('./features/help/components/HelpPage.jsx'));
 const OnboardingWizard = lazy(() => import('./features/onboarding/components/OnboardingWizard.jsx'));
 import EmptyStateWithTour from './features/onboarding/components/EmptyStateWithTour.jsx';
 import ServerDisconnectedOverlay from './components/ServerDisconnectedOverlay.jsx';
+import { useQueryClient } from '@tanstack/react-query';
 import { useApi } from './api/ApiContext.jsx';
+import { applyMutationDelta } from './api/applyMutationDelta.js';
 import { getGradeFormula } from './api/index.js';
 import { setGradeThresholds } from './utils/gradeThresholds.js';
 import LoadingScreen from './components/LoadingScreen.jsx';
@@ -170,6 +172,7 @@ function renderEvalPrincipleDetail(params, props) {
         // accumulated (cross-run) rollup separately.
         const payload = { ...buildDismissPayload(v, evalPrincipal.dimension), run_id: evalPrincipal.runId };
         const result = await props.dismissFinding(selectedProject, payload);
+        props.applyDelta?.(selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -354,6 +357,7 @@ const ROUTE_RENDERERS = {
       onDismiss={async (v) => {
         const payload = { ...buildDismissPayload(v), run_id: params.runId };
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
+        props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -370,6 +374,7 @@ const ROUTE_RENDERERS = {
       onDismiss={async (v) => {
         const payload = { ...buildDismissPayload(v, params.dimension), run_id: params.runId };
         const result = await props.dismissFinding(props.navigation.selectedProject, payload);
+        props.applyDelta?.(props.navigation.selectedProject, result?.scores, result?.delta);
         props.refreshDashboard?.();
         props.bumpDismissRefresh?.();
         return result;
@@ -432,6 +437,7 @@ function AppShell({ sidebar, header, content, drawer }) {
 
 export default function App() {
   const { dismissFinding } = useApi();
+  const queryClient = useQueryClient();
   const state = useAppState();
   const APP_VERSION = state.serverVersion;
   const selectedProjectInfo = state.projects?.find((p) => (p.id || p.name) === state.selectedProject) || null;
@@ -635,6 +641,12 @@ export default function App() {
     settings: state.settings,
     refreshDashboard: state.refreshDashboard,
     dismissFinding,
+    // Patch the dashboard/scores caches from the dismiss response delta so the
+    // Overview updates instantly. Additive — the refreshDashboard /
+    // bumpDismissRefresh mechanisms below still run. The delta carries only the
+    // mutation shape; the caller folds in the rescored dims from result.scores.
+    applyDelta: (project, scores, delta) =>
+      applyMutationDelta(queryClient, project, delta && { ...delta, dimensions: scores?.dimensions }),
     bumpDismissRefresh,
     dismissRefreshKey,
   };

--- a/src/quodeq/ui/src/api/applyMutationDelta.js
+++ b/src/quodeq/ui/src/api/applyMutationDelta.js
@@ -1,0 +1,130 @@
+/**
+ * Patch the React Query dashboard/scores caches from a dismiss mutation delta.
+ *
+ * The dismiss endpoint returns a ``delta`` describing the mutation; this writer
+ * folds it into the cached dashboard/scores payloads so the Overview updates
+ * instantly, without waiting for a refetch. It is ADDITIVE — the existing
+ * refreshDashboard / bumpDismissRefresh mechanisms still run; they just no
+ * longer gate the perceived latency of a dismiss.
+ *
+ * Referential identity is a hard requirement: untouched dimensions must keep
+ * their object identity so downstream memoized selectors don't re-render the
+ * whole page. Only the patched/spliced dimension gets a new reference — we
+ * never map through model factories or deep-clone inside the updater.
+ */
+import { projectKeys } from "./queryKeys";
+
+// Same key convention as mergeRescoreIntoEval (explorerDataHooks.js): a
+// violation is identified by req|file|line, defaulting missing parts.
+function violationKey(v) {
+  return `${v?.req || ""}|${v?.file || ""}|${v?.line || 0}`;
+}
+
+function clampNonNegative(n) {
+  return Math.max(0, n | 0);
+}
+
+/**
+ * Remove the dismissed violation from a dimension and decrement its totals.
+ * Returns the SAME dimension object unchanged when the violation isn't present,
+ * preserving referential identity.
+ */
+function removeDismissed(dim, dismissed) {
+  const violations = dim?.violations;
+  if (!Array.isArray(violations)) return dim;
+  const targetKey = violationKey(dismissed);
+  const idx = violations.findIndex((v) => violationKey(v) === targetKey);
+  if (idx === -1) return dim;
+
+  const removed = violations[idx];
+  const nextViolations = violations.filter((_, i) => i !== idx);
+
+  const prevTotals = dim.totals || {};
+  const prevSeverity = prevTotals.severity || {};
+  const removedSeverity = (removed?.severity || "").toLowerCase();
+  const nextSeverity = { ...prevSeverity };
+  if (removedSeverity && nextSeverity[removedSeverity] != null) {
+    nextSeverity[removedSeverity] = clampNonNegative(nextSeverity[removedSeverity] - 1);
+  }
+  const nextTotals = {
+    ...prevTotals,
+    violationCount: clampNonNegative((prevTotals.violationCount || 0) - 1),
+    severity: nextSeverity,
+  };
+
+  return { ...dim, violations: nextViolations, totals: nextTotals };
+}
+
+/**
+ * Apply the rescored per-dimension score/grade to a dimension when present in
+ * scoreByDim. Returns the SAME object when there's nothing to patch.
+ */
+function patchDimScore(dim, scoreByDim) {
+  const resc = scoreByDim.get(dim?.dimension);
+  if (!resc) return dim;
+  return {
+    ...dim,
+    overallScore: resc.overallScore ?? dim.overallScore,
+    overallGrade: resc.overallGrade ?? dim.overallGrade,
+  };
+}
+
+export function applyMutationDelta(queryClient, projectId, delta) {
+  if (!queryClient || !projectId || !delta) return;
+  if (delta.kind !== "dismiss") return;
+
+  const dims = Array.isArray(delta.dimensions) ? delta.dimensions : [];
+  const scoreByDim = new Map(dims.map((d) => [d.dimension, d]));
+  const dismissed = delta.dismissed || {};
+
+  // Dashboard cache: patch score + splice the dismissed violation from totals.
+  const patchDashboard = (key) => {
+    const prev = queryClient.getQueryData(key);
+    if (!prev || !Array.isArray(prev.dimensions)) {
+      queryClient.invalidateQueries({ queryKey: key, refetchType: "none" });
+      return;
+    }
+    queryClient.setQueryData(key, (old) => ({
+      ...old,
+      dimensions: old.dimensions.map((dim) =>
+        removeDismissed(patchDimScore(dim, scoreByDim), dismissed),
+      ),
+    }));
+  };
+
+  // Per-run scores cache: slim violations, so just refresh the dim score/grade.
+  const patchRunScores = (key) => {
+    const prev = queryClient.getQueryData(key);
+    if (!prev || !Array.isArray(prev.dimensions)) {
+      queryClient.invalidateQueries({ queryKey: key, refetchType: "none" });
+      return;
+    }
+    queryClient.setQueryData(key, (old) => ({
+      ...old,
+      dimensions: old.dimensions.map((dim) => patchDimScore(dim, scoreByDim)),
+    }));
+  };
+
+  // Accumulated (cross-run) scores cache: the server sent the whole rollup, so
+  // swap it in wholesale; if absent, invalidate (it's small — a default refetch
+  // is fine).
+  const patchAccumulated = (key, accumulated) => {
+    const prev = queryClient.getQueryData(key);
+    if (!accumulated || !prev) {
+      queryClient.invalidateQueries({ queryKey: key });
+      return;
+    }
+    queryClient.setQueryData(key, (old) => ({ ...old, accumulated }));
+  };
+
+  const runId = delta.runId;
+  if (runId) {
+    patchDashboard(projectKeys.dashboard(projectId, runId));
+    patchRunScores(projectKeys.scores(projectId, runId));
+  }
+
+  if (delta.isLatest) {
+    patchDashboard(projectKeys.dashboard(projectId, "latest"));
+    patchAccumulated(projectKeys.scores(projectId, null), delta.accumulated);
+  }
+}

--- a/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
+++ b/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyMutationDelta } from "./applyMutationDelta";
+import { projectKeys } from "./queryKeys";
+
+// A mock queryClient backed by a Map keyed by JSON.stringify(key), so tests
+// can seed caches and assert on the patched result. getQueryData/setQueryData
+// mirror React Query's functional-updater contract.
+function makeClient(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  const getQueryData = vi.fn((key) => store.get(JSON.stringify(key)));
+  const setQueryData = vi.fn((key, updater) => {
+    const k = JSON.stringify(key);
+    const prev = store.get(k);
+    const next = typeof updater === "function" ? updater(prev) : updater;
+    store.set(k, next);
+    return next;
+  });
+  const invalidateQueries = vi.fn();
+  return {
+    client: { getQueryData, setQueryData, invalidateQueries },
+    store,
+    getQueryData,
+    setQueryData,
+    invalidateQueries,
+  };
+}
+
+const PROJECT = "p1";
+const RUN = "run-1";
+
+function seedDashboard(store, key, dimensions) {
+  store.set(JSON.stringify(key), { dimensions });
+}
+
+// A dashboard dimension carrying two violations + totals, so removal tests
+// have something to splice.
+function securityDim() {
+  return {
+    dimension: "security",
+    overallScore: "5.0",
+    overallGrade: "C",
+    violations: [
+      { req: "R1", file: "a.py", line: 10, severity: "critical" },
+      { req: "R2", file: "b.py", line: 20, severity: "major" },
+    ],
+    totals: {
+      violationCount: 2,
+      severity: { critical: 1, major: 1, minor: 0 },
+    },
+  };
+}
+
+function maintainabilityDim() {
+  return {
+    dimension: "maintainability",
+    overallScore: "7.0",
+    overallGrade: "B",
+    violations: [],
+    totals: { violationCount: 0, severity: { critical: 0, major: 0, minor: 0 } },
+  };
+}
+
+describe("applyMutationDelta", () => {
+  it("A: patches the dimension score from the rescored dims", () => {
+    const { client, store, setQueryData } = makeClient();
+    const key = projectKeys.dashboard(PROJECT, RUN);
+    seedDashboard(store, key, [securityDim(), maintainabilityDim()]);
+
+    const delta = {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [
+        { dimension: "security", overallScore: "6.5", overallGrade: "B" },
+      ],
+    };
+
+    applyMutationDelta(client, PROJECT, delta);
+
+    expect(setQueryData).toHaveBeenCalled();
+    const next = store.get(JSON.stringify(key));
+    const sec = next.dimensions.find((d) => d.dimension === "security");
+    expect(sec.overallScore).toBe("6.5");
+    expect(sec.overallGrade).toBe("B");
+  });
+
+  it("B: removes the dismissed finding and decrements totals", () => {
+    const { client, store } = makeClient();
+    const key = projectKeys.dashboard(PROJECT, RUN);
+    seedDashboard(store, key, [securityDim()]);
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [],
+    });
+
+    const sec = store.get(JSON.stringify(key)).dimensions[0];
+    expect(sec.violations.map((v) => v.req)).toEqual(["R2"]);
+    expect(sec.totals.violationCount).toBe(1);
+    expect(sec.totals.severity.critical).toBe(0);
+    expect(sec.totals.severity.major).toBe(1);
+  });
+
+  it("C: patches accumulated (not invalidate) when isLatest", () => {
+    const { client, store, invalidateQueries } = makeClient();
+    const scoresKey = projectKeys.scores(PROJECT, null);
+    store.set(JSON.stringify(scoresKey), { accumulated: { dimensions: [], summary: {} } });
+
+    const newAccumulated = { dimensions: [{ dimension: "security" }], summary: { overallGrade: "B" } };
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: true,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: newAccumulated,
+      dimensions: [],
+    });
+
+    expect(store.get(JSON.stringify(scoresKey)).accumulated).toBe(newAccumulated);
+    // Accumulated must be patched, not invalidated.
+    const accInvalidated = invalidateQueries.mock.calls.some(
+      ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(scoresKey),
+    );
+    expect(accInvalidated).toBe(false);
+  });
+
+  it("D: updates the per-run scores dim score", () => {
+    const { client, store } = makeClient();
+    const scoresKey = projectKeys.scores(PROJECT, RUN);
+    store.set(JSON.stringify(scoresKey), {
+      dimensions: [{ dimension: "security", overallScore: "5.0", overallGrade: "C" }],
+      summary: {},
+    });
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+    });
+
+    const dim = store.get(JSON.stringify(scoresKey)).dimensions[0];
+    expect(dim.overallScore).toBe("6.5");
+    expect(dim.overallGrade).toBe("B");
+  });
+
+  it("E: invalidates (refetchType none) when dashboard cache is absent, no setQueryData", () => {
+    const { client, setQueryData, invalidateQueries } = makeClient();
+    const dashKey = projectKeys.dashboard(PROJECT, RUN);
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+    });
+
+    // Dashboard was absent → invalidate with refetchType:"none".
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: dashKey, refetchType: "none" });
+    // No setQueryData for the dashboard key.
+    const setDash = setQueryData.mock.calls.some(
+      ([k]) => JSON.stringify(k) === JSON.stringify(dashKey),
+    );
+    expect(setDash).toBe(false);
+  });
+
+  it("F: invalidates accumulated when delta.accumulated is null", () => {
+    const { client, store, invalidateQueries, setQueryData } = makeClient();
+    const scoresKey = projectKeys.scores(PROJECT, null);
+    store.set(JSON.stringify(scoresKey), { accumulated: { dimensions: [] } });
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: true,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [],
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: scoresKey });
+    const setAcc = setQueryData.mock.calls.some(
+      ([k]) => JSON.stringify(k) === JSON.stringify(scoresKey),
+    );
+    expect(setAcc).toBe(false);
+  });
+
+  it("G: isLatest false leaves dashboard('latest') and scores(null) untouched", () => {
+    const { client, setQueryData, invalidateQueries } = makeClient();
+    const latestDashKey = projectKeys.dashboard(PROJECT, "latest");
+    const accKey = projectKeys.scores(PROJECT, null);
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: { dimensions: [] },
+      dimensions: [],
+    });
+
+    const touched = (key) =>
+      setQueryData.mock.calls.some(([k]) => JSON.stringify(k) === JSON.stringify(key)) ||
+      invalidateQueries.mock.calls.some(
+        ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(key),
+      );
+    expect(touched(latestDashKey)).toBe(false);
+    expect(touched(accKey)).toBe(false);
+  });
+
+  it("H: unknown dim in delta leaves existing dims unchanged and does not throw", () => {
+    const { client, store } = makeClient();
+    const key = projectKeys.dashboard(PROJECT, RUN);
+    seedDashboard(store, key, [securityDim(), maintainabilityDim()]);
+
+    expect(() =>
+      applyMutationDelta(client, PROJECT, {
+        kind: "dismiss",
+        runId: RUN,
+        isLatest: false,
+        dismissed: { req: "ZZZ", file: "nope.py", line: 999 },
+        accumulated: null,
+        dimensions: [{ dimension: "does-not-exist", overallScore: "9.9", overallGrade: "A" }],
+      }),
+    ).not.toThrow();
+
+    const next = store.get(JSON.stringify(key));
+    const sec = next.dimensions.find((d) => d.dimension === "security");
+    // Unknown-dim rescore doesn't touch security; no violation matched either.
+    expect(sec.overallScore).toBe("5.0");
+    expect(sec.violations).toHaveLength(2);
+  });
+
+  it("I: untouched dimension keeps referential identity", () => {
+    const { client, store } = makeClient();
+    const key = projectKeys.dashboard(PROJECT, RUN);
+    const prevDims = [securityDim(), maintainabilityDim()];
+    seedDashboard(store, key, prevDims);
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+    });
+
+    const next = store.get(JSON.stringify(key));
+    // maintainability was neither rescored nor had a violation removed →
+    // it must be the same object reference.
+    expect(next.dimensions[1]).toBe(prevDims[1]);
+  });
+});

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -1,6 +1,5 @@
 """Tests for the findings dismiss/restore API endpoints."""
 import json
-from pathlib import Path
 
 import pytest
 from flask import Flask
@@ -39,7 +38,9 @@ class TestDismissEndpoint:
             "reason": "False positive",
         })
         assert resp.status_code == 200
-        assert resp.get_json() == {"scores": None}
+        body = resp.get_json()
+        assert body["scores"] is None
+        assert "delta" in body
 
     def test_dismiss_appends_to_actions_log(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
@@ -103,6 +104,61 @@ class TestDismissEndpoint:
         # Payload shape mirrors GET /api/projects/<p>/scores/<run>.
         assert "dimensions" in body["scores"]
         assert "summary" in body["scores"]
+
+    def test_dismiss_with_run_id_returns_delta_envelope(self, client, tmp_path):
+        """The dismiss response carries a ``delta`` envelope so the client can
+        patch its dashboard/scores caches synchronously. With a run_id, the
+        delta describes the dismissed finding and carries the accumulated
+        rollup for the Overview.
+        """
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+        from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+        run_dir = tmp_path / "my-project" / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "evidence").mkdir()
+        (run_dir / "evidence" / "manifest.json").write_text("{}")
+        EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="Integrity", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1", severity="critical",
+        )))
+        SqliteFindingsRepository(run_dir).list_by_dimension("security")
+
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "R1", "file": "a.py", "line": 10,
+            "dimension": "security", "severity": "critical",
+            "run_id": "run-1",
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        delta = body["delta"]
+        assert delta["kind"] == "dismiss"
+        assert delta["runId"] == "run-1"
+        assert delta["dismissed"] == {"req": "R1", "file": "a.py", "line": 10}
+        assert "isLatest" in delta
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+        assert "summary" in delta["accumulated"]
+
+    def test_dismiss_without_run_id_delta_has_null_accumulated(self, client, tmp_path):
+        """Without a run_id, the delta still describes the dismissed finding but
+        carries no run anchor: runId is None and accumulated is None.
+        """
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/dismiss", json={
+            "project": "my-project",
+            "req": "M-MOD-4", "file": "foo.js", "line": 4,
+            "dimension": "maintainability", "severity": "minor",
+        })
+        assert resp.status_code == 200
+        delta = resp.get_json()["delta"]
+        assert delta["kind"] == "dismiss"
+        assert delta["runId"] is None
+        assert delta["accumulated"] is None
+        assert delta["dismissed"] == {"req": "M-MOD-4", "file": "foo.js", "line": 4}
 
 
 class TestRestoreEndpoint:
@@ -201,7 +257,9 @@ class TestListDismissedEndpoint:
             "dimension": "security", "severity": "critical",
         })
         assert resp.status_code == 200
-        assert resp.get_json() == {"scores": None}
+        body = resp.get_json()
+        assert body["scores"] is None
+        assert "delta" in body
 
         listed = client.get("/api/findings/dismissed?project=my-project").get_json()
         assert len(listed) == 1
@@ -236,7 +294,9 @@ class TestListDismissedEndpoint:
             "run_id": "latest",
         })
         assert resp.status_code == 200
-        assert resp.get_json() == {"scores": None}
+        body = resp.get_json()
+        assert body["scores"] is None
+        assert "delta" in body
 
         listed = client.get("/api/findings/dismissed?project=my-project").get_json()
         assert len(listed) == 1

--- a/tests/services/test_mutation_rescore_delta.py
+++ b/tests/services/test_mutation_rescore_delta.py
@@ -1,0 +1,74 @@
+"""Tests for ``dismiss_delta`` — the dismiss mutation-delta envelope.
+
+The dismiss endpoint returns a ``delta`` alongside the slim ``scores`` so the
+client can patch its React Query caches synchronously. ``isLatest`` MUST match
+the Overview's own latest-run resolution (``_resolve_selected_run("latest")``,
+which picks the first ``complete`` run in newest-first ``list_runs`` order).
+"""
+import os
+from pathlib import Path
+
+from quodeq.services.mutation_rescore import dismiss_delta
+
+_DISMISSED = {"req": "R1", "file": "a.py", "line": 10}
+
+
+def _make_run(root: Path, project: str, run_id: str, *, in_progress: bool = False) -> Path:
+    """Create a ``list_runs``-visible run dir under ``root/project/run_id``."""
+    run_dir = root / project / run_id
+    (run_dir / "evidence").mkdir(parents=True)
+    (run_dir / "evidence" / "manifest.json").write_text("{}")
+    if in_progress:
+        # Own PID passes the liveness check → list_runs marks it in_progress.
+        (run_dir / ".pid").write_text(str(os.getpid()))
+    return run_dir
+
+
+class TestDismissDeltaEnvelope:
+    def test_envelope_shape_with_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = dismiss_delta(str(tmp_path), "proj", "run-1", dict(_DISMISSED))
+        assert delta["kind"] == "dismiss"
+        assert delta["runId"] == "run-1"
+        assert delta["dismissed"] == {"req": "R1", "file": "a.py", "line": 10}
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_without_run_id_accumulated_is_none(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = dismiss_delta(str(tmp_path), "proj", None, dict(_DISMISSED))
+        assert delta["runId"] is None
+        assert delta["accumulated"] is None
+        assert delta["dismissed"] == {"req": "R1", "file": "a.py", "line": 10}
+        assert delta["isLatest"] is False
+
+    def test_accumulated_present_when_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = dismiss_delta(str(tmp_path), "proj", "run-1", dict(_DISMISSED))
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+        assert "summary" in delta["accumulated"]
+
+
+class TestDismissDeltaIsLatest:
+    def test_is_latest_true_on_latest_run(self, tmp_path):
+        # run-2 sorts newest-first (run_id desc) → it is the latest complete run.
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        delta = dismiss_delta(str(tmp_path), "proj", "run-2", dict(_DISMISSED))
+        assert delta["isLatest"] is True
+
+    def test_is_latest_false_on_older_run(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        delta = dismiss_delta(str(tmp_path), "proj", "run-1", dict(_DISMISSED))
+        assert delta["isLatest"] is False
+
+    def test_is_latest_resolves_to_last_complete_when_in_progress_exists(self, tmp_path):
+        # run-3 is in_progress → excluded from default view; the latest COMPLETE
+        # run is run-2. Dismissing on run-2 must read isLatest=True; run-3 False.
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        _make_run(tmp_path, "proj", "run-3", in_progress=True)
+        assert dismiss_delta(str(tmp_path), "proj", "run-2", dict(_DISMISSED))["isLatest"] is True
+        assert dismiss_delta(str(tmp_path), "proj", "run-3", dict(_DISMISSED))["isLatest"] is False


### PR DESCRIPTION
First slice of phase 2 of the UI data-loading architecture: replace the five tangled client mutation-propagation mechanisms (`refreshDashboard`, `dismissRefreshKey`, `refreshSignal`, the `quodeq:assistant-action-applied` DOM event, and the hand-written `mergeRescoreIntoEval`) with ONE `applyMutationDelta` writer driven by a server delta. This slice is **additive** — it introduces the writer and wires it to the dismiss path; none of the old mechanisms are removed yet (slices 2–4 peel them away).

## What landed
- **Server:** the dismiss endpoint returns a `delta` alongside `scores`: `{kind, runId, isLatest, dismissed:{req,file,line}, accumulated}`. `isLatest` reuses the exact "latest completed run" rule the dashboard uses (`list_runs` newest-first + `is_eligible_for_default_view` + `runs[0]` fallback). `accumulated` is the freshly-rescored, cache-backed Overview payload (never recomputed client-side — the formula-weighted summary can't be), or `null` (→ client falls back to invalidation).
- **Client:** `applyMutationDelta(queryClient, projectId, delta)` patches the dashboard/scores React Query caches via `setQueryData`: updates each affected dimension's score/grade, splices the dismissed finding out of the run-detail violations and decrements totals, and patches the Overview accumulated when the dismiss is on the latest run. Absent cache or missing field → invalidate that key (correctness never depends on delta completeness). **Untouched dimensions keep referential identity — no deep-clone of the multi-MB cache.**
- Wired into the three dismiss handlers (Principle/File/Finding detail), before the still-present mechanisms.

## Guarantees
- Table-driven writer tests (9 cases): score patch, finding removal + totals decrement, accumulated patch, all three fallback-to-invalidate paths, `isLatest:false` leaves the Overview untouched, and a referential-identity assertion.
- Additive + eventually consistent: `refreshDashboard` still fires, so any view the writer doesn't instantly patch (e.g. Overview after an older-run dismiss) is marked stale and refreshes normally.
- Full suites green: 755 UI, 245 node, 4148 Python (non-integration), ruff clean.

## Next slices
2. restore/delete deltas; remove `dismissRefreshKey` + `refreshSignal`.
3. verify/unverify + the assistant DOM event; remove the remaining mechanisms. (When `refreshDashboard` is removed, the writer patches accumulated whenever the delta carries it, not gated on `isLatest`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)