### PR TITLE
feat(ui): mutation-delta writer slice 2 — restore/delete/-all

### DIFF
--- a/src/quodeq/api/routes_findings.py
+++ b/src/quodeq/api/routes_findings.py
@@ -18,7 +18,14 @@ from flask import Flask, Response, abort, jsonify, request
 
 from quodeq.services.deleted import delete_all_dismissed, delete_finding
 from quodeq.services.dismissed import dismiss_finding, load_dismissed, restore_finding, restore_all_findings
-from quodeq.services.mutation_rescore import dismiss_delta, rescore_with_fallback
+from quodeq.services.mutation_rescore import (
+    delete_all_delta,
+    delete_delta,
+    dismiss_delta,
+    rescore_with_fallback,
+    restore_all_delta,
+    restore_delta,
+)
 from quodeq.services.verified import unverify_finding, verified_entries
 from quodeq.shared.utils import get_evaluations_dir
 from quodeq.shared.validation import validate_path_segment
@@ -92,7 +99,10 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project, req, file, and line are required", "code": "MISSING_PARAM"}), 400
         restore_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
-        return jsonify({"scores": scores}), 200
+        delta = restore_delta(
+            _eval_dir(), project, run_id, {"req": req, "file": file, "line": line},
+        )
+        return jsonify({"scores": scores, "delta": delta}), 200
 
     @app.post("/api/findings/restore-all")
     def restore_all() -> tuple[Response, int]:
@@ -103,7 +113,8 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project is required", "code": "MISSING_PARAM"}), 400
         count = restore_all_findings(_project_dir(_eval_dir(), project))
         scores = _scores_with_fallback(project, run_id)
-        return jsonify({"ok": True, "restored": count, "scores": scores}), 200
+        delta = restore_all_delta(_eval_dir(), project, run_id)
+        return jsonify({"ok": True, "restored": count, "scores": scores, "delta": delta}), 200
 
     @app.post("/api/findings/delete")
     def delete() -> tuple[Response, int]:
@@ -117,7 +128,11 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project, dimension, principle, and file are required", "code": "MISSING_PARAM"}), 400
         swept = delete_finding(_project_dir(_eval_dir(), project), body)
         scores = _scores_with_fallback(project, run_id)
-        return jsonify({"ok": True, "swept": swept, "scores": scores}), 200
+        delta = delete_delta(
+            _eval_dir(), project, run_id,
+            {"dimension": dimension, "principle": principle, "file": file},
+        )
+        return jsonify({"ok": True, "swept": swept, "scores": scores, "delta": delta}), 200
 
     @app.post("/api/findings/delete-all")
     def delete_all() -> tuple[Response, int]:
@@ -128,7 +143,8 @@ def register_findings_routes(app: Flask) -> None:
             return jsonify({"error": "project is required", "code": "MISSING_PARAM"}), 400
         count = delete_all_dismissed(_project_dir(_eval_dir(), project))
         scores = _scores_with_fallback(project, run_id)
-        return jsonify({"ok": True, "deleted": count, "scores": scores}), 200
+        delta = delete_all_delta(_eval_dir(), project, run_id)
+        return jsonify({"ok": True, "deleted": count, "scores": scores, "delta": delta}), 200
 
     @app.get("/api/findings/verified")
     def list_verified() -> Response:

--- a/src/quodeq/services/mutation_rescore.py
+++ b/src/quodeq/services/mutation_rescore.py
@@ -199,17 +199,19 @@ def _accumulated_payload(evaluations_dir: str, project: str) -> dict[str, Any] |
     return payload.get("accumulated")
 
 
-def dismiss_delta(
-    evaluations_dir: str, project: str, run_id: str | None, dismissed: dict[str, Any],
+def _mutation_envelope(
+    evaluations_dir: str, project: str, run_id: str | None, kind: str,
 ) -> dict[str, Any]:
-    """Describe a dismiss mutation so the client can patch its caches.
+    """Shared delta scaffold: kind/runId/isLatest/accumulated.
 
     ``isLatest`` is True when ``run_id`` is the run the Overview lands on by
     default — the exact ``_resolve_default_run_id`` rule shared with the
     dashboard. ``accumulated`` carries the (cache-backed) cross-run rollup so
     the Overview's accumulated view updates without a refetch; it is None when
     no ``run_id`` was supplied (the caller has no run to anchor the rollup to)
-    or when the fetch fails.
+    or when the fetch fails. Per-kind finding fields (``dismissed`` /
+    ``restored`` / ``deleted``) are folded in by the caller — bulk kinds
+    (``restore_all`` / ``delete_all``) carry none.
     """
     is_latest = False
     accumulated: dict[str, Any] | None = None
@@ -217,16 +219,78 @@ def dismiss_delta(
         is_latest = run_id == _resolve_default_run_id(evaluations_dir, project)
         accumulated = _accumulated_payload(evaluations_dir, project)
     return {
-        "kind": "dismiss",
+        "kind": kind,
         "runId": run_id,
         "isLatest": is_latest,
-        "dismissed": {
-            "req": dismissed.get("req"),
-            "file": dismissed.get("file"),
-            "line": dismissed.get("line"),
-        },
         "accumulated": accumulated,
     }
+
+
+def dismiss_delta(
+    evaluations_dir: str, project: str, run_id: str | None, dismissed: dict[str, Any],
+) -> dict[str, Any]:
+    """Describe a dismiss mutation so the client can patch its caches.
+
+    The client splices the dismissed finding out of the run-detail violation
+    list locally (it has the full key) and patches scores + accumulated.
+    """
+    envelope = _mutation_envelope(evaluations_dir, project, run_id, "dismiss")
+    envelope["dismissed"] = {
+        "req": dismissed.get("req"),
+        "file": dismissed.get("file"),
+        "line": dismissed.get("line"),
+    }
+    return envelope
+
+
+def restore_delta(
+    evaluations_dir: str, project: str, run_id: str | None, restored: dict[str, Any],
+) -> dict[str, Any]:
+    """Describe a restore mutation so the client can patch its caches.
+
+    Unlike dismiss, the client can't reconstruct the restored violation body,
+    so it patches scores + accumulated and INVALIDATES the run-detail violation
+    source (refetch on next view). ``restored`` carries the finding key.
+    """
+    envelope = _mutation_envelope(evaluations_dir, project, run_id, "restore")
+    envelope["restored"] = {
+        "req": restored.get("req"),
+        "file": restored.get("file"),
+        "line": restored.get("line"),
+    }
+    return envelope
+
+
+def delete_delta(
+    evaluations_dir: str, project: str, run_id: str | None, deleted: dict[str, Any],
+) -> dict[str, Any]:
+    """Describe a delete mutation so the client can patch its caches.
+
+    Delete sweeps every finding sharing (dimension, principle, file), so the
+    client can't cheaply mirror the batch removal — it patches scores +
+    accumulated and INVALIDATES the run-detail violation source.
+    """
+    envelope = _mutation_envelope(evaluations_dir, project, run_id, "delete")
+    envelope["deleted"] = {
+        "dimension": deleted.get("dimension"),
+        "principle": deleted.get("principle"),
+        "file": deleted.get("file"),
+    }
+    return envelope
+
+
+def restore_all_delta(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any]:
+    """Describe a bulk restore-all mutation (no single finding key)."""
+    return _mutation_envelope(evaluations_dir, project, run_id, "restore_all")
+
+
+def delete_all_delta(
+    evaluations_dir: str, project: str, run_id: str | None,
+) -> dict[str, Any]:
+    """Describe a bulk delete-all mutation (no single finding key)."""
+    return _mutation_envelope(evaluations_dir, project, run_id, "delete_all")
 
 
 def rescore_with_fallback(

--- a/src/quodeq/ui/src/api/applyMutationDelta.js
+++ b/src/quodeq/ui/src/api/applyMutationDelta.js
@@ -69,16 +69,28 @@ function patchDimScore(dim, scoreByDim) {
   };
 }
 
+// Kinds this writer understands. dismiss splices the violation locally; the
+// rest (restore/delete and their -all bulk forms) can't cheaply/correctly
+// reconstruct the violation-list change, so they invalidate the run-detail
+// violation source and let it refetch on next view.
+const KNOWN_KINDS = new Set(["dismiss", "restore", "delete", "restore_all", "delete_all"]);
+
 export function applyMutationDelta(queryClient, projectId, delta) {
   if (!queryClient || !projectId || !delta) return;
-  if (delta.kind !== "dismiss") return;
+  if (!KNOWN_KINDS.has(delta.kind)) return;
 
   const dims = Array.isArray(delta.dimensions) ? delta.dimensions : [];
   const scoreByDim = new Map(dims.map((d) => [d.dimension, d]));
   const dismissed = delta.dismissed || {};
+  // Only dismiss can splice locally — it carries the full violation key and is
+  // a single-finding removal. Every other kind invalidates instead.
+  const splices = delta.kind === "dismiss";
 
-  // Dashboard cache: patch score + splice the dismissed violation from totals.
-  const patchDashboard = (key) => {
+  // Patch dim score/grade in place, preserving referential identity for
+  // untouched dims. ``spliceDismissed`` additionally removes the dismissed
+  // violation from the dashboard cache (which carries full violation arrays);
+  // the per-run scores cache is slim so it never splices.
+  const patchScores = (key, { spliceDismissed = false } = {}) => {
     const prev = queryClient.getQueryData(key);
     if (!prev || !Array.isArray(prev.dimensions)) {
       queryClient.invalidateQueries({ queryKey: key, refetchType: "none" });
@@ -86,22 +98,10 @@ export function applyMutationDelta(queryClient, projectId, delta) {
     }
     queryClient.setQueryData(key, (old) => ({
       ...old,
-      dimensions: old.dimensions.map((dim) =>
-        removeDismissed(patchDimScore(dim, scoreByDim), dismissed),
-      ),
-    }));
-  };
-
-  // Per-run scores cache: slim violations, so just refresh the dim score/grade.
-  const patchRunScores = (key) => {
-    const prev = queryClient.getQueryData(key);
-    if (!prev || !Array.isArray(prev.dimensions)) {
-      queryClient.invalidateQueries({ queryKey: key, refetchType: "none" });
-      return;
-    }
-    queryClient.setQueryData(key, (old) => ({
-      ...old,
-      dimensions: old.dimensions.map((dim) => patchDimScore(dim, scoreByDim)),
+      dimensions: old.dimensions.map((dim) => {
+        const scored = patchDimScore(dim, scoreByDim);
+        return spliceDismissed ? removeDismissed(scored, dismissed) : scored;
+      }),
     }));
   };
 
@@ -117,14 +117,31 @@ export function applyMutationDelta(queryClient, projectId, delta) {
     queryClient.setQueryData(key, (old) => ({ ...old, accumulated }));
   };
 
+  // Invalidate the run-detail violation source so lists refetch on next view.
+  // refetchType:"none" keeps it lazy — no eager network churn while scores
+  // already updated instantly via the score-patch above.
+  const invalidateViolations = (key) => {
+    queryClient.invalidateQueries({ queryKey: key, refetchType: "none" });
+  };
+
   const runId = delta.runId;
   if (runId) {
-    patchDashboard(projectKeys.dashboard(projectId, runId));
-    patchRunScores(projectKeys.scores(projectId, runId));
+    const dashKey = projectKeys.dashboard(projectId, runId);
+    const scoresKey = projectKeys.scores(projectId, runId);
+    // Score-patch is shared across all kinds; dashboard additionally splices
+    // for dismiss.
+    patchScores(dashKey, { spliceDismissed: splices });
+    patchScores(scoresKey);
+    // Non-dismiss kinds can't mirror the violation-list change locally →
+    // invalidate the run-detail sources so they refetch (scores already patched).
+    if (!splices) {
+      invalidateViolations(dashKey);
+      invalidateViolations(scoresKey);
+    }
   }
 
   if (delta.isLatest) {
-    patchDashboard(projectKeys.dashboard(projectId, "latest"));
+    patchScores(projectKeys.dashboard(projectId, "latest"), { spliceDismissed: splices });
     patchAccumulated(projectKeys.scores(projectId, null), delta.accumulated);
   }
 }

--- a/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
+++ b/src/quodeq/ui/src/api/applyMutationDelta.test.jsx
@@ -262,3 +262,160 @@ describe("applyMutationDelta", () => {
     expect(next.dimensions[1]).toBe(prevDims[1]);
   });
 });
+
+// Slice 2: restore / delete / restore_all / delete_all all patch dim SCORES
+// (like dismiss) but, because the client can't cheaply reconstruct the
+// violation-list change, INVALIDATE the run-detail violation source instead of
+// splicing. dismiss must keep splicing (regression).
+describe("applyMutationDelta — restore/delete/bulk kinds (slice 2)", () => {
+  function invalidatedNoRefetch(invalidateQueries, key) {
+    return invalidateQueries.mock.calls.some(
+      ([arg]) =>
+        JSON.stringify(arg?.queryKey) === JSON.stringify(key) &&
+        arg?.refetchType === "none",
+    );
+  }
+
+  for (const kind of ["restore", "delete", "restore_all", "delete_all"]) {
+    it(`${kind}: patches dashboard dim score`, () => {
+      const { client, store } = makeClient();
+      const key = projectKeys.dashboard(PROJECT, RUN);
+      seedDashboard(store, key, [securityDim(), maintainabilityDim()]);
+
+      applyMutationDelta(client, PROJECT, {
+        kind,
+        runId: RUN,
+        isLatest: false,
+        accumulated: null,
+        dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+      });
+
+      const sec = store
+        .get(JSON.stringify(key))
+        .dimensions.find((d) => d.dimension === "security");
+      expect(sec.overallScore).toBe("6.5");
+      expect(sec.overallGrade).toBe("B");
+    });
+
+    it(`${kind}: patches per-run scores dim score`, () => {
+      const { client, store } = makeClient();
+      const scoresKey = projectKeys.scores(PROJECT, RUN);
+      store.set(JSON.stringify(scoresKey), {
+        dimensions: [{ dimension: "security", overallScore: "5.0", overallGrade: "C" }],
+        summary: {},
+      });
+
+      applyMutationDelta(client, PROJECT, {
+        kind,
+        runId: RUN,
+        isLatest: false,
+        accumulated: null,
+        dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+      });
+
+      const dim = store.get(JSON.stringify(scoresKey)).dimensions[0];
+      expect(dim.overallScore).toBe("6.5");
+      expect(dim.overallGrade).toBe("B");
+    });
+
+    it(`${kind}: INVALIDATES the run-detail violation source (does not splice)`, () => {
+      const { client, store, invalidateQueries } = makeClient();
+      const dashKey = projectKeys.dashboard(PROJECT, RUN);
+      const scoresKey = projectKeys.scores(PROJECT, RUN);
+      seedDashboard(store, dashKey, [securityDim()]);
+      store.set(JSON.stringify(scoresKey), {
+        dimensions: [{ dimension: "security", overallScore: "5.0", overallGrade: "C" }],
+        summary: {},
+      });
+
+      applyMutationDelta(client, PROJECT, {
+        kind,
+        runId: RUN,
+        isLatest: false,
+        accumulated: null,
+        dimensions: [],
+      });
+
+      // Both the dashboard and per-run scores violation sources are invalidated
+      // with refetchType:"none" so lists refetch on next view.
+      expect(invalidatedNoRefetch(invalidateQueries, dashKey)).toBe(true);
+      expect(invalidatedNoRefetch(invalidateQueries, scoresKey)).toBe(true);
+
+      // The dashboard violation list is NOT spliced in place — both violations
+      // remain until the refetch replaces them.
+      const sec = store.get(JSON.stringify(dashKey)).dimensions[0];
+      expect(sec.violations).toHaveLength(2);
+    });
+
+    it(`${kind}: patches accumulated when isLatest`, () => {
+      const { client, store, invalidateQueries } = makeClient();
+      const accKey = projectKeys.scores(PROJECT, null);
+      store.set(JSON.stringify(accKey), { accumulated: { dimensions: [], summary: {} } });
+
+      const newAccumulated = {
+        dimensions: [{ dimension: "security" }],
+        summary: { overallGrade: "B" },
+      };
+      applyMutationDelta(client, PROJECT, {
+        kind,
+        runId: RUN,
+        isLatest: true,
+        accumulated: newAccumulated,
+        dimensions: [],
+      });
+
+      expect(store.get(JSON.stringify(accKey)).accumulated).toBe(newAccumulated);
+      const accInvalidated = invalidateQueries.mock.calls.some(
+        ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(accKey),
+      );
+      expect(accInvalidated).toBe(false);
+    });
+
+    it(`${kind}: untouched dimension keeps referential identity in score-patch`, () => {
+      const { client, store } = makeClient();
+      const scoresKey = projectKeys.scores(PROJECT, RUN);
+      const prevDims = [
+        { dimension: "security", overallScore: "5.0", overallGrade: "C" },
+        { dimension: "maintainability", overallScore: "7.0", overallGrade: "B" },
+      ];
+      store.set(JSON.stringify(scoresKey), { dimensions: prevDims, summary: {} });
+
+      applyMutationDelta(client, PROJECT, {
+        kind,
+        runId: RUN,
+        isLatest: false,
+        accumulated: null,
+        dimensions: [{ dimension: "security", overallScore: "6.5", overallGrade: "B" }],
+      });
+
+      const next = store.get(JSON.stringify(scoresKey));
+      // maintainability was not rescored → same object reference.
+      expect(next.dimensions[1]).toBe(prevDims[1]);
+    });
+  }
+
+  it("dismiss still SPLICES the violation (regression, not invalidate)", () => {
+    const { client, store, invalidateQueries } = makeClient();
+    const dashKey = projectKeys.dashboard(PROJECT, RUN);
+    seedDashboard(store, dashKey, [securityDim()]);
+
+    applyMutationDelta(client, PROJECT, {
+      kind: "dismiss",
+      runId: RUN,
+      isLatest: false,
+      dismissed: { req: "R1", file: "a.py", line: 10 },
+      accumulated: null,
+      dimensions: [],
+    });
+
+    const sec = store.get(JSON.stringify(dashKey)).dimensions[0];
+    // Spliced in place, not left for a refetch.
+    expect(sec.violations.map((v) => v.req)).toEqual(["R2"]);
+    expect(sec.totals.violationCount).toBe(1);
+    // dismiss must NOT invalidate the dashboard violation source.
+    const dashInvalidated = invalidateQueries.mock.calls.some(
+      ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(dashKey),
+    );
+    expect(dashInvalidated).toBe(false);
+  });
+});

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   listDismissedFindings,
   restoreFinding,
@@ -6,10 +7,25 @@ import {
   deleteFinding,
   deleteAllFindings,
 } from '../../../api/index.js';
+import { applyMutationDelta } from '../../../api/applyMutationDelta.js';
 import { confirmDialog } from '../../../utils/confirmDialog.js';
 
 export function useDismissedFindings(selectedProject, onRefresh, setRestoreError, refreshKey = 0) {
   const [dismissed, setDismissed] = useState([]);
+  const queryClient = useQueryClient();
+
+  // Fold the mutation-delta from a restore/delete response into the React Query
+  // caches so dimension scores/grades update instantly and the run-detail
+  // violation lists get invalidated for a lazy refetch. Additive — the local
+  // setDismissed splices and onRefresh below still run.
+  const applyDelta = useCallback((result) => {
+    const delta = result?.delta;
+    if (!delta) return;
+    applyMutationDelta(queryClient, selectedProject, {
+      ...delta,
+      dimensions: result?.scores?.dimensions,
+    });
+  }, [queryClient, selectedProject]);
 
   // refreshKey lets the parent force a refetch when something dismissed an
   // entry elsewhere (e.g. the principle-detail page). Without it, the
@@ -22,33 +38,36 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
 
   const handleRestore = useCallback(async (d) => {
     try {
-      await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
+      const result = await restoreFinding(selectedProject, { req: d.req, file: d.file, line: d.line });
+      applyDelta(result);
       setDismissed((prev) => prev.filter((item) => !(item.req === d.req && item.file === d.file && item.line === d.line)));
       onRefresh?.();
     } catch (err) {
       console.error('Failed to restore finding:', err);
       setRestoreError?.('Failed to restore finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError]);
+  }, [selectedProject, onRefresh, setRestoreError, applyDelta]);
 
   const handleRestoreAll = useCallback(async () => {
     try {
-      await restoreAllFindings(selectedProject);
+      const result = await restoreAllFindings(selectedProject);
+      applyDelta(result);
       setDismissed([]);
       onRefresh?.();
     } catch (err) {
       console.error('Failed to restore all findings:', err);
       setRestoreError?.('Failed to restore all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError]);
+  }, [selectedProject, onRefresh, setRestoreError, applyDelta]);
 
   const handleDelete = useCallback(async (d) => {
     try {
-      await deleteFinding(selectedProject, {
+      const result = await deleteFinding(selectedProject, {
         dimension: d.dimension,
         principle: d.principle,
         file: d.file,
       });
+      applyDelta(result);
       // Sweep every dismissed entry that shares the same (dimension, principle, file),
       // matching the backend sweep so the local list stays in sync without a refetch.
       setDismissed((prev) => prev.filter((item) => !(
@@ -61,7 +80,7 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
       console.error('Failed to delete finding:', err);
       setRestoreError?.('Failed to delete finding. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError]);
+  }, [selectedProject, onRefresh, setRestoreError, applyDelta]);
 
   const handleDeleteAll = useCallback(async () => {
     const count = dismissed.length;
@@ -74,14 +93,15 @@ export function useDismissedFindings(selectedProject, onRefresh, setRestoreError
     });
     if (!ok) return;
     try {
-      await deleteAllFindings(selectedProject);
+      const result = await deleteAllFindings(selectedProject);
+      applyDelta(result);
       setDismissed([]);
       onRefresh?.();
     } catch (err) {
       console.error('Failed to delete all findings:', err);
       setRestoreError?.('Failed to delete all findings. Please try again.');
     }
-  }, [selectedProject, onRefresh, setRestoreError, dismissed.length]);
+  }, [selectedProject, onRefresh, setRestoreError, dismissed.length, applyDelta]);
 
   return { dismissed, handleRestore, handleRestoreAll, handleDelete, handleDeleteAll };
 }

--- a/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
+++ b/src/quodeq/ui/src/features/violations/components/useDismissedFindings.test.jsx
@@ -1,7 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useDismissedFindings } from './useDismissedFindings.js';
+
+// useDismissedFindings now reads useQueryClient() to fold restore/delete deltas
+// into the RQ caches. Wrap renderHook in a provider so the hook has a client.
+function withQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+}
 
 vi.mock('../../../api/index.js', () => ({
   listDismissedFindings: vi.fn(),
@@ -44,7 +57,7 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreFinding.mockResolvedValueOnce({ ok: true });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleRestore(sampleA); });
@@ -60,7 +73,7 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
     await act(async () => { await result.current.handleRestore(sampleA); });
@@ -75,7 +88,7 @@ describe('useDismissedFindings — restore handlers', () => {
     restoreAllFindings.mockResolvedValueOnce({ ok: true, restored: 2 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleRestoreAll(); });
@@ -92,7 +105,7 @@ describe('useDismissedFindings — handleDelete', () => {
     deleteFinding.mockResolvedValueOnce({ ok: true, swept: 1 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleDelete(sampleA); });
@@ -112,7 +125,7 @@ describe('useDismissedFindings — handleDelete', () => {
     const dupA = { ...sampleA, line: 99 };
     listDismissedFindings.mockResolvedValueOnce([sampleA, dupA, sampleB]);
     deleteFinding.mockResolvedValueOnce({ ok: true, swept: 2 });
-    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), vi.fn()));
+    const { result } = renderHook(() => useDismissedFindings('proj', vi.fn(), vi.fn()), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(3));
 
     await act(async () => { await result.current.handleDelete(sampleA); });
@@ -125,7 +138,7 @@ describe('useDismissedFindings — handleDelete', () => {
     deleteFinding.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
     await act(async () => { await result.current.handleDelete(sampleA); });
@@ -143,7 +156,7 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     deleteAllFindings.mockResolvedValueOnce({ ok: true, deleted: 2 });
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleDeleteAll(); });
@@ -165,7 +178,7 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     confirmDialog.mockResolvedValueOnce(false);
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(2));
 
     await act(async () => { await result.current.handleDeleteAll(); });
@@ -182,7 +195,7 @@ describe('useDismissedFindings — handleDeleteAll', () => {
     deleteAllFindings.mockRejectedValueOnce(new Error('boom'));
     const onRefresh = vi.fn();
     const setRestoreError = vi.fn();
-    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError));
+    const { result } = renderHook(() => useDismissedFindings('proj', onRefresh, setRestoreError), withQueryClient());
     await waitFor(() => expect(result.current.dismissed).toHaveLength(1));
 
     await act(async () => { await result.current.handleDeleteAll(); });

--- a/tests/api/test_routes_findings.py
+++ b/tests/api/test_routes_findings.py
@@ -183,7 +183,46 @@ class TestRestoreEndpoint:
             "req": "M-MOD-4", "file": "foo.js", "line": 4,
         })
         assert resp.status_code == 200
-        assert resp.get_json() == {"scores": None}
+        body = resp.get_json()
+        assert body["scores"] is None
+        assert "delta" in body
+
+    def test_restore_with_run_id_returns_delta_envelope(self, client, tmp_path):
+        """The restore response carries a ``delta`` (kind=restore) with the
+        restored finding key + accumulated rollup so the client patches scores
+        instantly and invalidates the run-detail violation source.
+        """
+        from quodeq.core.events.models import JudgmentCreatedEvent, JudgmentPayload
+        from quodeq.core.events.writer import EventLogWriter
+        from quodeq.data.sqlite.findings_repository import SqliteFindingsRepository
+
+        run_dir = tmp_path / "my-project" / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "evidence").mkdir()
+        (run_dir / "evidence" / "manifest.json").write_text("{}")
+        EventLogWriter(run_dir / "events.jsonl").emit(JudgmentCreatedEvent(payload=JudgmentPayload(
+            practice_id="Integrity", verdict="violation", dimension="security",
+            file="a.py", line=10, reason="r", req="R1", severity="critical",
+        )))
+        SqliteFindingsRepository(run_dir).list_by_dimension("security")
+
+        client.post("/api/findings/dismiss", json={
+            "project": "my-project", "req": "R1", "file": "a.py", "line": 10,
+            "dimension": "security", "severity": "critical", "run_id": "run-1",
+        })
+        resp = client.post("/api/findings/restore", json={
+            "project": "my-project", "req": "R1", "file": "a.py", "line": 10,
+            "run_id": "run-1",
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert "scores" in body
+        delta = body["delta"]
+        assert delta["kind"] == "restore"
+        assert delta["runId"] == "run-1"
+        assert delta["restored"] == {"req": "R1", "file": "a.py", "line": 10}
+        assert "isLatest" in delta
+        assert delta["accumulated"] is not None
 
     def test_restore_appends_undismiss_event(self, client, tmp_path):
         project_dir = tmp_path / "my-project"
@@ -201,6 +240,81 @@ class TestRestoreEndpoint:
         assert "FINDING_DISMISSED" in text
         assert "FINDING_UNDISMISSED" in text
         assert not (project_dir / "dismissed.json").exists()
+
+
+class TestRestoreAllEndpoint:
+    def test_restore_all_returns_delta_envelope(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/restore-all", json={
+            "project": "my-project", "run_id": "run-1",
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert "restored" in body
+        assert "scores" in body
+        delta = body["delta"]
+        assert delta["kind"] == "restore_all"
+        assert delta["runId"] == "run-1"
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_restore_all_missing_project_returns_400(self, client):
+        resp = client.post("/api/findings/restore-all", json={})
+        assert resp.status_code == 400
+
+
+class TestDeleteEndpoint:
+    def test_delete_returns_delta_envelope(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/delete", json={
+            "project": "my-project",
+            "dimension": "security", "principle": "Integrity", "file": "a.py",
+            "run_id": "run-1",
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert "swept" in body
+        assert "scores" in body
+        delta = body["delta"]
+        assert delta["kind"] == "delete"
+        assert delta["runId"] == "run-1"
+        assert delta["deleted"] == {
+            "dimension": "security", "principle": "Integrity", "file": "a.py",
+        }
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_delete_missing_fields_returns_400(self, client):
+        resp = client.post("/api/findings/delete", json={"project": "x"})
+        assert resp.status_code == 400
+        assert resp.get_json()["code"] == "MISSING_PARAM"
+
+
+class TestDeleteAllEndpoint:
+    def test_delete_all_returns_delta_envelope(self, client, tmp_path):
+        project_dir = tmp_path / "my-project"
+        project_dir.mkdir()
+        resp = client.post("/api/findings/delete-all", json={
+            "project": "my-project", "run_id": "run-1",
+        })
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert "deleted" in body
+        assert "scores" in body
+        delta = body["delta"]
+        assert delta["kind"] == "delete_all"
+        assert delta["runId"] == "run-1"
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_delete_all_missing_project_returns_400(self, client):
+        resp = client.post("/api/findings/delete-all", json={})
+        assert resp.status_code == 400
 
 
 class TestListDismissedEndpoint:

--- a/tests/services/test_mutation_rescore_delta.py
+++ b/tests/services/test_mutation_rescore_delta.py
@@ -8,9 +8,17 @@ which picks the first ``complete`` run in newest-first ``list_runs`` order).
 import os
 from pathlib import Path
 
-from quodeq.services.mutation_rescore import dismiss_delta
+from quodeq.services.mutation_rescore import (
+    delete_all_delta,
+    delete_delta,
+    dismiss_delta,
+    restore_all_delta,
+    restore_delta,
+)
 
 _DISMISSED = {"req": "R1", "file": "a.py", "line": 10}
+_RESTORED = {"req": "R1", "file": "a.py", "line": 10}
+_DELETED = {"dimension": "security", "principle": "Integrity", "file": "a.py"}
 
 
 def _make_run(root: Path, project: str, run_id: str, *, in_progress: bool = False) -> Path:
@@ -72,3 +80,108 @@ class TestDismissDeltaIsLatest:
         _make_run(tmp_path, "proj", "run-3", in_progress=True)
         assert dismiss_delta(str(tmp_path), "proj", "run-2", dict(_DISMISSED))["isLatest"] is True
         assert dismiss_delta(str(tmp_path), "proj", "run-3", dict(_DISMISSED))["isLatest"] is False
+
+
+class TestRestoreDeltaEnvelope:
+    def test_envelope_shape_with_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = restore_delta(str(tmp_path), "proj", "run-1", dict(_RESTORED))
+        assert delta["kind"] == "restore"
+        assert delta["runId"] == "run-1"
+        assert delta["restored"] == {"req": "R1", "file": "a.py", "line": 10}
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_accumulated_present_when_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = restore_delta(str(tmp_path), "proj", "run-1", dict(_RESTORED))
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+        assert "summary" in delta["accumulated"]
+
+    def test_without_run_id_accumulated_is_none(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = restore_delta(str(tmp_path), "proj", None, dict(_RESTORED))
+        assert delta["runId"] is None
+        assert delta["accumulated"] is None
+        assert delta["isLatest"] is False
+        assert delta["restored"] == {"req": "R1", "file": "a.py", "line": 10}
+
+    def test_is_latest_true_on_latest_run(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        assert restore_delta(str(tmp_path), "proj", "run-2", dict(_RESTORED))["isLatest"] is True
+        assert restore_delta(str(tmp_path), "proj", "run-1", dict(_RESTORED))["isLatest"] is False
+
+
+class TestDeleteDeltaEnvelope:
+    def test_envelope_shape_with_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = delete_delta(str(tmp_path), "proj", "run-1", dict(_DELETED))
+        assert delta["kind"] == "delete"
+        assert delta["runId"] == "run-1"
+        assert delta["deleted"] == {
+            "dimension": "security", "principle": "Integrity", "file": "a.py",
+        }
+        assert "isLatest" in delta
+        assert "accumulated" in delta
+
+    def test_accumulated_present_when_run_id(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = delete_delta(str(tmp_path), "proj", "run-1", dict(_DELETED))
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+        assert "summary" in delta["accumulated"]
+
+    def test_without_run_id_accumulated_is_none(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = delete_delta(str(tmp_path), "proj", None, dict(_DELETED))
+        assert delta["runId"] is None
+        assert delta["accumulated"] is None
+        assert delta["isLatest"] is False
+        assert delta["deleted"] == {
+            "dimension": "security", "principle": "Integrity", "file": "a.py",
+        }
+
+    def test_is_latest_true_on_latest_run(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        assert delete_delta(str(tmp_path), "proj", "run-2", dict(_DELETED))["isLatest"] is True
+        assert delete_delta(str(tmp_path), "proj", "run-1", dict(_DELETED))["isLatest"] is False
+
+
+class TestBulkDeltaEnvelopes:
+    """restore_all / delete_all carry no single finding — just kind/run/isLatest/accumulated."""
+
+    def test_restore_all_envelope_shape(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = restore_all_delta(str(tmp_path), "proj", "run-1")
+        assert delta["kind"] == "restore_all"
+        assert delta["runId"] == "run-1"
+        assert "isLatest" in delta
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+        assert "restored" not in delta
+        assert "deleted" not in delta
+
+    def test_delete_all_envelope_shape(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        delta = delete_all_delta(str(tmp_path), "proj", "run-1")
+        assert delta["kind"] == "delete_all"
+        assert delta["runId"] == "run-1"
+        assert "isLatest" in delta
+        assert delta["accumulated"] is not None
+        assert "dimensions" in delta["accumulated"]
+
+    def test_bulk_without_run_id_accumulated_is_none(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        r = restore_all_delta(str(tmp_path), "proj", None)
+        d = delete_all_delta(str(tmp_path), "proj", None)
+        assert r["runId"] is None and r["accumulated"] is None and r["isLatest"] is False
+        assert d["runId"] is None and d["accumulated"] is None and d["isLatest"] is False
+
+    def test_bulk_is_latest_true_on_latest_run(self, tmp_path):
+        _make_run(tmp_path, "proj", "run-1")
+        _make_run(tmp_path, "proj", "run-2")
+        assert restore_all_delta(str(tmp_path), "proj", "run-2")["isLatest"] is True
+        assert delete_all_delta(str(tmp_path), "proj", "run-1")["isLatest"] is False


### PR DESCRIPTION
Slice 2 of phase 2. Extends the `applyMutationDelta` writer + server delta to the remaining mutations: `restore`, `restore-all`, `delete`, `delete-all`. Still **additive** — no propagation mechanism removed yet.

## What landed
- **Server:** a shared `_mutation_envelope(evaluations_dir, project, run_id, kind)` computes `kind`/`runId`/`isLatest` (reusing slice 1's exact latest-run rule) + `accumulated`; `dismiss_delta` refactored onto it (behavior unchanged). The four endpoints now return a `delta`: `restore` (`restored:{req,file,line}`), `delete` (`deleted:{dimension,principle,file}`), and the bulk `restore_all`/`delete_all` (no single-finding field).
- **Client:** the writer's score-patch is now shared across all kinds (`patchScores`), preserving referential identity for untouched dimensions. Per kind: dismiss splices the finding locally (unchanged); restore/delete/-all patch scores + accumulated instantly, then lazily invalidate the run-detail violation lists (`refetchType:'none'`) — because re-inserting (restore needs the body) / batch removal (delete) / bulk (-all) can't be cheaply spliced client-side. An unknown `kind` is a safe no-op (`KNOWN_KINDS` gate).
- Wired into the four `useDismissedFindings` handlers (restore/restore-all/delete/delete-all), additive to their existing local splice + refresh.

## Verification
- Writer table tests extended (30 cases): each new kind patches scores + accumulated, invalidates the violation source with `refetchType:'none'`, keeps referential identity; a regression test confirms dismiss still splices.
- Server delta-shape + `isLatest` true/false tests for all four kinds.
- Green: 776 UI, 4167 Python (non-integration), 42 targeted server, ruff clean.

## Deferred (for the mechanism-removal slice)
Non-dismiss kinds don't yet invalidate the `dashboard(latest)` violation list — currently covered by the still-firing `refreshDashboard`. When that mechanism is removed, the writer becomes self-contained there (one-line hardening). Next slices migrate the Violations dismissed-list and Explorer onto React Query so the five mechanisms can finally be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)