### PR TITLE
perf(dashboard): cache the history trend fetcher (run-detail entry 3.8x faster)

### DIFF
--- a/src/quodeq/services/_trend_fetcher.py
+++ b/src/quodeq/services/_trend_fetcher.py
@@ -1,0 +1,119 @@
+"""Shared cache-backed, dismiss-adjusted SCALAR trend fetcher.
+
+Extracted from ``scoring/__init__.py`` so both the ``/scores`` endpoint
+(``get_project_scores``) and the run-detail dashboard (``build_dashboard``)
+can build their history trend / previous-score / stale computations off the
+SAME fast, cache-backed, scalar-only fetcher instead of reading full run data
+(violations, multi-MB) for every historical run.
+
+This module depends only on leaf modules (``_cache``, ``score_cache``,
+``ports``, ``rescore``) so it can be imported by both ``dashboard.py`` and
+``scoring/__init__.py`` without a circular import.
+
+Dependency injection: the scalar reader and the dismissed/deleted lookups are
+parameters (defaulting to the real functions). ``scoring/__init__.py`` passes
+its own module-level references so its monkeypatch-based tests keep working;
+``dashboard.py`` uses the defaults.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from threading import Lock
+from typing import Callable
+
+from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams
+from quodeq.core.types import DimensionResult
+from quodeq.services._cache import make_lru_dimension_fetcher
+from quodeq.services.deleted import deleted_keys as _default_deleted_keys
+from quodeq.services.dismissed import dismissed_keys as _default_dismissed_keys
+from quodeq.services.ports import read_run_scalars as _default_read_run_scalars
+from quodeq.services.rescore import _rescore_dimension
+from quodeq.services.score_cache import make_cache_backed_fetcher, score_cache_version
+
+_Fetcher = Callable[[str], list[DimensionResult]]
+
+
+def make_rescoring_fetcher(
+    reports_root: Path,
+    project: str,
+    params: ScoringParams = DEFAULT_PARAMS,
+    *,
+    base_fetcher: _Fetcher,
+    dismissed_keys: Callable[[Path], set] = _default_dismissed_keys,
+    deleted_keys: Callable[[Path], set] = _default_deleted_keys,
+) -> _Fetcher:
+    """Return a dimension fetcher that applies dismiss/delete rescore to results.
+
+    Wraps *base_fetcher* (a full-data run-dimension fetcher) so consumers get
+    dismiss-adjusted data. Identity when the project has no active
+    dismissals/deletions.
+    """
+    project_dir = reports_root / project
+    dismissed = dismissed_keys(project_dir)
+    deleted = deleted_keys(project_dir)
+    if not dismissed and not deleted:
+        return base_fetcher
+
+    def rescoring_fetcher(run_id: str) -> list[DimensionResult]:
+        dims = base_fetcher(run_id)
+        return [_rescore_dimension(d, dismissed, deleted, params=params) for d in dims]
+
+    return rescoring_fetcher
+
+
+def make_trend_fetcher(
+    reports_root: Path,
+    project: str,
+    params: ScoringParams = DEFAULT_PARAMS,
+    cacheable_run_ids: set[str] | None = None,
+    *,
+    max_history: int,
+    base_fetcher_factory: Callable[[Path, str], _Fetcher],
+    read_run_scalars: Callable[[Path, str, str], list[DimensionResult]] = _default_read_run_scalars,
+    dismissed_keys: Callable[[Path], set] = _default_dismissed_keys,
+    deleted_keys: Callable[[Path], set] = _default_deleted_keys,
+) -> _Fetcher:
+    """Return the dimension fetcher for the history trend / previous / stale path.
+
+    Fast path (no active dismissals/deletions): read only per-run scalar grades
+    via *read_run_scalars* through a fresh per-call LRU cache, so scalar
+    (findings-less) results never collide with the shared full-data cache used
+    for the selected run.
+
+    Heavy path (dismissals/deletions active): wrap the findings-based rescoring
+    fetcher with the read-through score cache. The cache version is a content
+    hash of dismissals/deletions/params, so any change auto-invalidates.
+
+    ``cacheable_run_ids`` restricts which runs the heavy-path cache may
+    *persist*: only terminal (complete) runs are safe. An in-progress run's
+    scalar set grows as dims finish, and the version hash can't see that, so
+    persisting its partial set would strand a stale row. When ``None`` every run
+    is cacheable (fast path persists nothing anyway).
+
+    In-progress freshness: both paths read in-progress runs fresh every request.
+    Fast path uses a per-call cache (re-read next request); heavy path's
+    ``cacheable_run_ids`` guard makes in-progress runs compute-through without
+    persisting. Stale-partial detection is preserved inside ``read_run_scalars``,
+    which falls back to full ``read_run_data`` whenever the SQL scalar projection
+    disagrees with the on-disk ``evaluation/*.json`` count.
+    """
+    project_dir = reports_root / project
+    if dismissed_keys(project_dir) or deleted_keys(project_dir):
+        base = make_rescoring_fetcher(
+            reports_root, project, params=params,
+            base_fetcher=base_fetcher_factory(reports_root, project),
+            dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
+        )
+        version = score_cache_version(project_dir, params)
+        is_cacheable = (
+            None if cacheable_run_ids is None
+            else (lambda rid: rid in cacheable_run_ids)
+        )
+        return make_cache_backed_fetcher(project, version, base, is_cacheable=is_cacheable)
+
+    cache: OrderedDict = OrderedDict()
+    return make_lru_dimension_fetcher(
+        reports_root, project, cache, Lock(),
+        max_history, reader=read_run_scalars,
+    )

--- a/src/quodeq/services/dashboard.py
+++ b/src/quodeq/services/dashboard.py
@@ -22,6 +22,7 @@ from quodeq.services.ports import (
 from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_stale import collect_stale_dimensions
 from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services._trend_fetcher import make_trend_fetcher
 from quodeq.services.dim_resolution import is_eligible_for_default_view
 from quodeq.services.dismissed import filter_dismissed_from_dimensions
 
@@ -184,33 +185,6 @@ def _rescore_run_dimensions(
     if not dismissed and not deleted:
         return dims
     return [_rescore_dimension(d, dismissed, deleted, params=params) for d in dims]
-
-
-def _wrap_fetcher_with_rescore(
-    fetcher: Callable[[str], list[DimensionResult]],
-    reports_root: Path,
-    project: str,
-    params: ScoringParams,
-) -> Callable[[str], list[DimensionResult]]:
-    """Decorate a run-dimension fetcher with the project-wide dismiss/delete rescore.
-
-    Returns *fetcher* unchanged when the project has no active dismissals or
-    deletions (the common case, so the trend fast-path cost is unchanged).
-    Otherwise each fetched run's dimensions are rescored so the trend /
-    previous-score / stale computations show the dismiss-adjusted score rather
-    than the raw scan value.
-    """
-    from quodeq.services.deleted import deleted_keys  # noqa: PLC0415
-    from quodeq.services.dismissed import dismissed_keys  # noqa: PLC0415
-
-    project_dir = reports_root / project
-    if not dismissed_keys(project_dir) and not deleted_keys(project_dir):
-        return fetcher
-
-    def rescoring(run_id: str) -> list[DimensionResult]:
-        return _rescore_run_dimensions(fetcher(run_id), reports_root, project, params)
-
-    return rescoring
 
 
 def _count_eval_files(reports_root: Path, project: str, run_id: str) -> int:
@@ -484,20 +458,28 @@ def _compute_dashboard_payload(
     else:
         history_runs = scoreable_runs[:max(max_history, selected_in_scoreable + 1)]
         history_index = selected_in_scoreable
-    # Status-aware fetcher: bypass cache for in_progress runs whose on-disk
-    # evaluation/*.json set grows as dims finish mid-run. Without this,
-    # the History page renders the partial dim set from the first read
-    # forever -- new dims that complete later never surface.
-    get_run_dimensions = _make_status_aware_fetcher(
-        reports_root, project, history_runs,
-        cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
-    )
-    # Rescore each historical run's dims with the project-wide dismiss/delete
-    # set before they feed the trend / previous-score / stale computations, so
-    # the History chart and the previous-run deltas agree with the selected
-    # run's dismiss-adjusted score instead of showing the raw scan value.
-    get_run_dimensions = _wrap_fetcher_with_rescore(
-        get_run_dimensions, reports_root, project, params,
+    # History fetcher: cache-backed, dismiss-adjusted, SCALAR-only -- the same
+    # fetcher the /scores endpoint uses. The three consumers below
+    # (_collect_previous_scores, collect_stale_dimensions, build_accumulated_trend)
+    # read only per-run scalars (dimension + overallScore + overallGrade), not
+    # the full violations. Reading + rescoring FULL data for every history run
+    # (up to _max_history_runs()) was the ~2s cost this replaces.
+    #
+    # In-progress freshness is preserved: the fast path re-reads each request
+    # (fresh per-call cache), and the heavy path's cacheable_run_ids guard makes
+    # in-progress runs compute-through without persisting a partial set. Stale-
+    # partial detection is preserved inside read_run_scalars, which falls back to
+    # full read_run_data whenever the SQL scalar projection disagrees with the
+    # on-disk evaluation/*.json count -- the same self-heal the old status-aware
+    # fetcher did via _count_eval_files. The dismiss-adjustment (Bug B) stays;
+    # it is now cached rather than recomputed on every request.
+    cacheable_run_ids = {r.run_id for r in history_runs if r.status == "complete"}
+    get_run_dimensions = make_trend_fetcher(
+        reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
+        max_history=max_history,
+        base_fetcher_factory=lambda rr, proj: _make_run_dimension_fetcher(
+            rr, proj, cache=cc.cache, lock=cc.lock, max_size=cc.max_size,
+        ),
     )
     previous_by_dimension = _collect_previous_scores(
         history_runs, history_index, selected_dim_names, get_run_dimensions,

--- a/src/quodeq/services/scoring/__init__.py
+++ b/src/quodeq/services/scoring/__init__.py
@@ -32,14 +32,10 @@ from quodeq.core.scoring.internals import score_to_grade_label
 from quodeq.core.scoring.params import DEFAULT_PARAMS, ScoringParams, dimension_weighted_average
 from quodeq.core.types.report import PrincipleGrade
 from quodeq.core.types.dimension import DimensionResult, DimensionSummary, GradeBreakdown
-from quodeq.services._cache import make_lru_dimension_fetcher
 from quodeq.services._dashboard_trend import build_accumulated_trend
+from quodeq.services._trend_fetcher import make_rescoring_fetcher, make_trend_fetcher
 from quodeq.services.accumulated import compute_accumulated
-from quodeq.services.dashboard import (
-    DashboardCacheConfig,
-    _make_run_dimension_fetcher,
-    create_dimension_cache,
-)
+from quodeq.services.dashboard import _make_run_dimension_fetcher
 from quodeq.services.grade_formula import load_params
 from quodeq.services.deleted import deleted_keys
 from quodeq.services.dismissed import dismissed_keys
@@ -47,8 +43,6 @@ from quodeq.services._fs_projects import find_children
 from quodeq.services.score_cache import (
     accumulated_cache_version,
     cached_accumulated,
-    make_cache_backed_fetcher,
-    score_cache_version,
 )
 from quodeq.services.ports import RunInfo, list_runs, read_run_data, read_run_scalars
 from quodeq.services.rescore import _rescore_dimension, rescore_dimensions
@@ -407,21 +401,15 @@ def _make_rescoring_fetcher(
 ) -> Callable[[str], list[DimensionResult]]:
     """Return a dimension fetcher that applies rescore (dismissals) to results.
 
-    Wraps the standard cached fetcher so that build_accumulated_trend
-    automatically gets rescored data.
+    Thin seam over the shared :func:`make_rescoring_fetcher` factory. Passes the
+    scoring module's own ``dismissed_keys`` / ``deleted_keys`` references so
+    monkeypatch-based tests keep working, and the full-data base fetcher.
     """
-    base_fetcher = _make_run_dimension_fetcher(reports_root, project)
-    project_dir = reports_root / project
-    dismissed = dismissed_keys(project_dir)
-    deleted = deleted_keys(project_dir)
-    if not dismissed and not deleted:
-        return base_fetcher
-
-    def rescoring_fetcher(run_id: str) -> list[DimensionResult]:
-        dims = base_fetcher(run_id)
-        return [_rescore_dimension(d, dismissed, deleted, params=params) for d in dims]
-
-    return rescoring_fetcher
+    return make_rescoring_fetcher(
+        reports_root, project, params=params,
+        base_fetcher=_make_run_dimension_fetcher(reports_root, project),
+        dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
+    )
 
 
 def _make_trend_fetcher(
@@ -431,41 +419,18 @@ def _make_trend_fetcher(
 ) -> Callable[[str], list[DimensionResult]]:
     """Return the dimension fetcher for the trend chart.
 
-    Fast path: when the project has no active dismissals/deletions, read only
-    the per-run scalar grades (``read_run_scalars``) -- the trend needs nothing
-    else. Uses a fresh per-call LRU cache so scalar (findings-less) results
-    never collide with the shared full-data cache used elsewhere.
-
-    Heavy path: when dismissals/deletions are active, wrap the findings-based
-    rescoring fetcher with the read-through score cache. The cache version is a
-    content-hash of the project's dismissals/deletions/params, so any change
-    auto-invalidates without a write-path hook.
-
-    ``cacheable_run_ids`` restricts which runs the heavy-path cache may
-    *persist*: a run still scoring (in-progress) grows its dimension set as
-    dims finish, but the version hash can't see that, so persisting its partial
-    set would strand a stale row (fixed forever until dismissals/params change).
-    Only completed runs are safe to persist; when ``None`` every run is
-    cacheable (used by the fast path, which persists nothing anyway).
+    Thin seam over the shared :func:`make_trend_fetcher` factory, passing the
+    scoring module's own ``read_run_scalars`` / ``dismissed_keys`` /
+    ``deleted_keys`` references (so this module's monkeypatch-based tests keep
+    working) and the shared full-data base-fetcher factory. See
+    :func:`make_trend_fetcher` for the fast/heavy path and caching semantics.
     """
-    project_dir = reports_root / project
-    if dismissed_keys(project_dir) or deleted_keys(project_dir):
-        # Heavy path: wrap the findings-based rescoring fetcher with the
-        # read-through score cache. Version is a content hash of the project's
-        # dismissals/deletions/params, so any change auto-invalidates.
-        # dismissed/deleted are read here (branch test), in _make_rescoring_fetcher,
-        # and in score_cache_version -- three reads total, each ~0.01s, acceptable.
-        base = _make_rescoring_fetcher(reports_root, project, params=params)
-        version = score_cache_version(project_dir, params)
-        is_cacheable = (
-            None if cacheable_run_ids is None
-            else (lambda rid: rid in cacheable_run_ids)
-        )
-        return make_cache_backed_fetcher(project, version, base, is_cacheable=is_cacheable)
-    cache, lock = create_dimension_cache()
-    return make_lru_dimension_fetcher(
-        reports_root, project, cache, lock,
-        _max_history_runs(), reader=read_run_scalars,
+    return make_trend_fetcher(
+        reports_root, project, params=params, cacheable_run_ids=cacheable_run_ids,
+        max_history=_max_history_runs(),
+        base_fetcher_factory=_make_run_dimension_fetcher,
+        read_run_scalars=read_run_scalars,
+        dismissed_keys=dismissed_keys, deleted_keys=deleted_keys,
     )
 
 

--- a/tests/services/test_dashboard.py
+++ b/tests/services/test_dashboard.py
@@ -250,13 +250,13 @@ class TestBuildDashboard:
             result = build_dashboard(str(tmp_path), "proj", "r-cancelled")
         assert result["selectedRun"]["runId"] == "r-cancelled"
 
-    def test_shared_run_dim_cache_persists_across_calls(self, tmp_path):
-        # Regression: _make_run_dimension_fetcher used to create a fresh LRU
-        # cache per call (via create_dimension_cache()), so dashboard requests
-        # paid the read_run_data cost on every call — even when the same run
-        # had been read seconds earlier. This test asserts that the second
-        # build_dashboard call hits the shared module-level cache for at
-        # least one historical run, demonstrably eliminating that I/O.
+    def test_history_path_reads_scalars_not_full_data(self, tmp_path, monkeypatch):
+        # Trend-cache perf fix: the HISTORY trend/previous/stale path must read
+        # per-run SCALARS (read_run_scalars), NOT full run data (violations,
+        # multi-MB). Reading + rescoring full data for every history run was the
+        # ~2s cost this fix removes. The selected run still reads full data
+        # (its findings are always needed) via dashboard.read_run_data.
+        monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
         runs = [
             RunInfo(run_id=f"r{i}", date_iso=f"2024-{i:02d}-01", date_label=f"2024-{i:02d}-01", status="complete")
             for i in range(1, 6)
@@ -264,35 +264,42 @@ class TestBuildDashboard:
         dims = [_dim("security", "B", "7.0")]
         summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
 
-        # Track every read_run_data call across both invocations.
-        read_calls: list[tuple[str, str]] = []
+        # The history fetcher goes through read_run_scalars. For these tmp runs
+        # (no events.jsonl / evaluation.db) the scalar reader falls back to
+        # read_run_data at the runs-module level -- a distinct seam from the
+        # dashboard-scope read_run_data used for the SELECTED run. Tracking the
+        # two seams separately proves history never uses the full-data
+        # dashboard fetcher.
+        history_reads: list[str] = []
+        selected_full_reads: list[str] = []
 
-        def tracked_read(_root, project, run_id):
-            read_calls.append((project, run_id))
+        def tracked_history(_root, _project, run_id):
+            history_reads.append(run_id)
             return dims
 
-        # Reset the shared cache so this test starts from a clean state.
+        def tracked_selected(_root, _project, run_id):
+            selected_full_reads.append(run_id)
+            return dims
+
         from quodeq.services.dashboard import _SHARED_RUN_DIM_CACHE
         _SHARED_RUN_DIM_CACHE.clear()
 
         with (
             patch("quodeq.services.dashboard.list_runs", return_value=runs),
-            patch("quodeq.services._cache.read_run_data", side_effect=tracked_read),
-            patch("quodeq.services.dashboard.read_run_data", side_effect=tracked_read),
+            patch("quodeq.services.dashboard.read_run_data", side_effect=tracked_selected),
+            patch("quodeq.data.fs.report_parser.runs.read_run_data", side_effect=tracked_history),
             patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
         ):
             build_dashboard(str(tmp_path), "proj-shared", "r3")
-            calls_after_first = len(read_calls)
-            build_dashboard(str(tmp_path), "proj-shared", "r3")
-            calls_after_second = len(read_calls)
 
-        # If the cache were per-request (the bug), the second call would do
-        # ~the same number of reads as the first. With the shared cache, the
-        # second call's reads via _make_run_dimension_fetcher are eliminated.
-        assert calls_after_second < calls_after_first * 2, (
-            f"Expected shared cache to reduce reads on second call. "
-            f"After 1st: {calls_after_first}, after 2nd: {calls_after_second} "
-            f"(would be {calls_after_first * 2} with no caching)"
+        # History runs are read via the scalar reader (which fell back to the
+        # runs-module read_run_data for these no-db tmp runs).
+        assert history_reads, "expected history path to use the scalar reader"
+        # The selected run's full data is read via the dashboard fetcher; the
+        # history path must NOT touch that full-data seam.
+        assert selected_full_reads == ["r3"], (
+            f"selected run must read full data once via dashboard fetcher; "
+            f"got {selected_full_reads}"
         )
 
     def test_does_not_crash_when_cancelled_runs_precede_selected(self, tmp_path):
@@ -560,6 +567,62 @@ class TestStaleCacheSelfHeal:
         )
 
 
+class TestInProgressFreshnessThroughDashboard:
+    """After the trend-cache perf fix the History trend/previous/stale path is
+    served by the cache-backed SCALAR fetcher. This pins that an in_progress
+    history run is still read FRESH on every dashboard request: its scalar set
+    grows as dims finish mid-run, and the fix must NOT persist a partial set
+    (which would strand a stale trend point served forever after the run ends).
+    """
+
+    def test_in_progress_history_run_read_fresh_each_call(self, tmp_path, monkeypatch):
+        # Isolate the read-through score cache so a persisted row from another
+        # test can't mask a regression here.
+        monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
+
+        selected = RunInfo(run_id="r-sel", date_iso="2024-02-01", date_label="2024-02-01", status="complete")
+        running = RunInfo(run_id="r-run", date_iso="2024-01-01", date_label="2024-01-01", status="in_progress")
+        runs = [selected, running]
+        summary = DimensionSummary(dimensions_count=1, overall_grade="B", numeric_average=7.0)
+
+        # The in_progress run grows from 1 dim to 2 between the two dashboard
+        # calls (a dim finished mid-run). Scalar reads fall back to the runs-
+        # module read_run_data for these no-db tmp runs.
+        run_call_count = {"r-run": 0}
+
+        def history_read(_root, _project, run_id):
+            if run_id == "r-run":
+                run_call_count["r-run"] += 1
+                if run_call_count["r-run"] == 1:
+                    return [_dim("security", "B", "7.0")]
+                return [_dim("security", "B", "7.0"), _dim("performance", "A", "9.0")]
+            return [_dim("usability", "A", "9.5")]
+
+        from quodeq.services.dashboard import _SHARED_RUN_DIM_CACHE
+        _SHARED_RUN_DIM_CACHE.clear()
+
+        with (
+            patch("quodeq.services.dashboard.list_runs", return_value=runs),
+            patch("quodeq.services.dashboard.read_run_data", side_effect=history_read),
+            patch("quodeq.data.fs.report_parser.runs.read_run_data", side_effect=history_read),
+            patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
+        ):
+            first = build_dashboard(str(tmp_path), "proj-ip", "r-sel")
+            second = build_dashboard(str(tmp_path), "proj-ip", "r-sel")
+
+        # The in_progress run's trend point reflects the GROWN dim set on the
+        # second call -- proof it was re-read fresh, not served from a persisted
+        # partial (which would have frozen it at 1 dim forever).
+        def running_point(dash):
+            return next(p for p in dash["trend"] if p["runId"] == "r-run")
+
+        assert running_point(first)["dimensionsCount"] == 1
+        assert running_point(second)["dimensionsCount"] == 2, (
+            "in_progress history run must be re-read fresh each call, not "
+            "served from a stale persisted partial"
+        )
+        # And the in_progress run was read on BOTH calls (never cache-served).
+        assert run_call_count["r-run"] == 2
 
 
 # ============================================================
@@ -795,7 +858,21 @@ class TestHistoryContextSlimming:
     """previousByDimension / stalePreviousByDimension / staleDimensions must
     carry scores + provenance only. No consumer reads finding bodies from
     these keys, and on large projects the bodies dominated the payload
-    (~18.6 MB of a 19.9 MB old-run dashboard on a 201-run project)."""
+    (~18.6 MB of a 19.9 MB old-run dashboard on a 201-run project).
+
+    Since the trend-cache perf fix these keys are built by the cache-backed
+    SCALAR fetcher (the same one the /scores endpoint uses), so the guaranteed
+    contract is: bodies (violations/compliance) are empty, and
+    dimension/overallScore/overallGrade/provenance survive -- the scores and
+    grades the trend context exists to convey. The UI reads none of these three
+    keys directly (0 references in the frontend; it reads the scalar fields
+    inlined on the selected-run dimensions). For SQL-projected runs the scalar
+    reader also drops display-metadata (totals/principles/discipline/
+    evidenceDate/sourceFileCount/filesRead) that no consumer reads -- a strict
+    payload improvement; the load-bearing scores/grades/provenance stay
+    byte-identical (verified against a real 74-run project). For legacy/no-SQL
+    runs the reader falls back to full data, so those fields may still appear;
+    either way the bodies are dropped and the scalars/provenance match."""
 
     def _finding(self, i: int, verdict: str = "violation"):
         from quodeq.core.types.finding import Finding
@@ -836,8 +913,13 @@ class TestHistoryContextSlimming:
         _SHARED_RUN_DIM_CACHE.clear()
         with (
             patch("quodeq.services.dashboard.list_runs", return_value=runs),
+            # Selected-run path reads via dashboard.read_run_data; the history
+            # trend/previous/stale path reads via the scalar fetcher. In this
+            # no-events/no-db tmp project the scalar reader falls back to
+            # read_run_data at the runs-module level, so patch there too.
             patch("quodeq.services.dashboard.read_run_data", side_effect=read_by_run),
             patch("quodeq.services._cache.read_run_data", side_effect=read_by_run),
+            patch("quodeq.data.fs.report_parser.runs.read_run_data", side_effect=read_by_run),
             patch("quodeq.services.dashboard.summarize_dimensions", return_value=summary),
         ):
             result = build_dashboard(str(tmp_path), "proj-slim-history", "r-new")
@@ -846,11 +928,11 @@ class TestHistoryContextSlimming:
         assert result["dimensions"][0]["violations"][0]["reason"] == "a long explanation"
         assert result["dimensions"][0]["compliance"]
 
-        # previousByDimension: scores/grades/totals survive, bodies do not.
+        # previousByDimension: scores/grades/provenance survive, bodies do not.
         prev = result["previousByDimension"]["security"]
         assert prev["overallGrade"] == "C"
         assert prev["overallScore"] == "6.0/10"
-        assert prev["totals"]["violationCount"] == 1
+        assert prev["runId"] == "r-old"
         assert prev["violations"] == []
         assert prev["compliance"] == []
 
@@ -858,7 +940,8 @@ class TestHistoryContextSlimming:
         stale = [d for d in result["staleDimensions"] if d["dimension"] == "perf"]
         assert stale, f"expected perf in staleDimensions, got {result['staleDimensions']}"
         assert stale[0]["overallScore"] == "5.0/10"
-        assert stale[0]["totals"]["complianceCount"] == 1
+        assert stale[0]["stale"] is True
+        assert stale[0]["fromRunId"] == "r-old"
         assert stale[0]["violations"] == []
         assert stale[0]["compliance"] == []
 

--- a/tests/services/test_scoring_trend_fetcher.py
+++ b/tests/services/test_scoring_trend_fetcher.py
@@ -41,13 +41,15 @@ def test_active_dismissal_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     rescoring_calls: list[str] = []
 
-    def fake_rescoring_fetcher(rr, p, params=None):
+    def fake_rescoring_fetcher(rr, p, params=None, *, base_fetcher=None, **_kw):
         def fetch(run_id: str) -> list[DimensionResult]:
             rescoring_calls.append(run_id)
             return [DimensionResult(dimension="security", overall_score="7.0/10", overall_grade="Fair")]
         return fetch
 
-    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher", fake_rescoring_fetcher)
+    # The heavy-path rescoring fetcher is built by the shared _trend_fetcher
+    # factory (scoring._make_trend_fetcher delegates to it).
+    monkeypatch.setattr("quodeq.services._trend_fetcher.make_rescoring_fetcher", fake_rescoring_fetcher)
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active dismissals")
@@ -70,13 +72,13 @@ def test_active_deletion_uses_heavy_path(tmp_path: Path, monkeypatch) -> None:
 
     rescoring_calls: list[str] = []
 
-    def fake_rescoring_fetcher(rr, p, params=None):
+    def fake_rescoring_fetcher(rr, p, params=None, *, base_fetcher=None, **_kw):
         def fetch(run_id: str) -> list[DimensionResult]:
             rescoring_calls.append(run_id)
             return [DimensionResult(dimension="security", overall_score="6.0/10", overall_grade="Fair")]
         return fetch
 
-    monkeypatch.setattr("quodeq.services.scoring._make_rescoring_fetcher", fake_rescoring_fetcher)
+    monkeypatch.setattr("quodeq.services._trend_fetcher.make_rescoring_fetcher", fake_rescoring_fetcher)
 
     def boom(*_a):
         raise AssertionError("scalar reader used despite active deletions")


### PR DESCRIPTION
## Problem
Entering a run detail was slow (`build_dashboard` 1.5–3.4s on the 74-run project). Cause: the dashboard rebuilt the entire history — trend chart, previous-run deltas, and stale-detection — by reading the FULL run data (multi-MB violations) for every history run on every page load. PR #735's dismiss-consistency fix made it worse by re-applying the project's ~1800 dismissals to each of those runs, uncached.

Measured: reading+rescoring all 74 runs ≈ 2–2.5s. The three history consumers only need per-run SCALARS (dimension + score + grade), not violations.

## Fix
The `/scores` endpoint already solved this — it builds its trend from cache-backed, dismiss-adjusted, scalar-only reads (`_make_trend_fetcher`, ~377ms). This routes the dashboard's history computations through the same path.

- Extracted the fetcher factory into a new leaf module `services/_trend_fetcher.py` (`dashboard.py` couldn't import `scoring/__init__.py` — circular). Both consumers now delegate to it.
- The dashboard history path reads cache-backed rescored scalars (terminal runs cached, in-progress read fresh, dismissals still applied). The selected run's full-violations path is untouched.

## Guarantees
- **Parity — byte-identical.** Verified on the real 74-run project across 5 sampled runs: `trend` (all 74 points), `previousByDimension`, `staleDimensions`, `stalePreviousByDimension` — every scalar and provenance field matches. The only difference is a strict payload shrink: UI-unused metadata (`totals`/`principles`/`discipline`/…) is dropped from *history* dims (confirmed the frontend never reads those off history dims), consistent with the existing `_slim_history_dim` philosophy.
- **Values unchanged:** dismissals are still reflected in the trend (just cached now) — this is a pure speed fix, and it also corrects the regression #735 introduced.
- **Preserved:** in-progress freshness (new regression test — a growing in-progress history run surfaces its new dim on re-read) and stale-partial self-heal (`read_run_scalars` falls back to full read on eval-count mismatch).

## Numbers (real project, oldest run = worst case)
| | before | after |
|---|---|---|
| dashboard build warm | ~1730–1930ms | **~470ms** |
| dashboard build cold | ~4140ms | ~475ms |
| `GET /dashboard?run=` (HTTP, warm) | ~1.3–3.4s | **0.49s** |

Full non-integration suite: 4168 passed, 1 skipped. ruff clean. Backend-only.

## Note
This removes the dashboard *compute* bottleneck. The remaining run-detail latency is payload size (~7.7MB per response — the run's full violations feeding the detail + Violations/Map), which is the separate payload-slimming work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)