### PR TITLE
feat(evaluate): context-aware standard preselection on the Evaluate button

### DIFF
--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -24,6 +24,7 @@ import { useApi } from './api/ApiContext.jsx';
 import { applyMutationDelta } from './api/applyMutationDelta.js';
 import { getGradeFormula } from './api/index.js';
 import { setGradeThresholds } from './utils/gradeThresholds.js';
+import { deriveEvaluatePreselect } from './utils/evaluatePreselect.js';
 import LoadingScreen from './components/LoadingScreen.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import TopBar from './components/TopBar.jsx';
@@ -93,7 +94,7 @@ function useNativeTitlebarSync(effectiveDark) {
  * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
  * @returns {JSX.Element}
  */
-function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings }) {
+function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {
   const { connected, setConnected } = serverHealth;
   const { job, jobError, liveViolations, handleStartEvaluation, handleEvalDismiss, cancelEvaluation } = evaluation;
   const projectInfo = projects?.find(p => (p.id || p.name) === selectedProject) || null;
@@ -108,7 +109,7 @@ function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onG
       {!connected && <ServerDisconnectedOverlay onReconnect={() => setConnected(true)} />}
       <EvaluateScreen
         evaluation={{ job, jobError, liveViolations }}
-        context={{ selectedProject, projectInfo, jobProjectInfo }}
+        context={{ selectedProject, projectInfo, jobProjectInfo, preselectDims }}
         actions={{ onStart: handleStartEvaluation, onDismiss: handleEvalDismiss, onCancel: cancelEvaluation, onGoToProjects, onGoToSettings }}
       />
     </>
@@ -347,7 +348,7 @@ const ROUTE_RENDERERS = {
       trend={props.dashboardData.dashboard?.trend || []}
     />
   ),
-  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />,
+  evaluate: (params, props) => <EvaluateCase serverHealth={props.serverHealth} evaluation={props.evaluation} selectedProject={props.navigation.selectedProject} projects={props.navigation.projects} preselectDims={params.preselectDims} onGoToProjects={() => props.navigation.navTab('projects')} onGoToSettings={() => props.navigation.navTab('settings')} />,
   file: (params, props) => (
     <FileDetailPage
       file={params.file}
@@ -697,7 +698,7 @@ export default function App() {
               serverUrl={typeof window !== 'undefined' ? window.location.origin : null}
               provider={sidebarProvider}
               model={sidebarModel}
-              onEvaluate={state.projects?.length > 0 ? (() => navTab('evaluate')) : null}
+              onEvaluate={state.projects?.length > 0 ? (() => navTab('evaluate', { preselectDims: deriveEvaluatePreselect(activePage) })) : null}
               evaluating={state.evalLifecycle?.job?.status === 'running'}
               onProviderClick={() => navTab('settings')}
               onMenuToggle={() => setSidebarPinned((v) => !v)}

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -91,7 +91,7 @@ function useNativeTitlebarSync(effectiveDark) {
 }
 
 /**
- * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string, projects: Array, onGoToProjects: Function, onGoToSettings: Function, preselectDims: string[] }} props
+ * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string, projects: Array, onGoToProjects: Function, onGoToSettings: Function, preselectDims: string[]|undefined }} props
  * @returns {JSX.Element}
  */
 function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {

--- a/src/quodeq/ui/src/App.jsx
+++ b/src/quodeq/ui/src/App.jsx
@@ -91,7 +91,7 @@ function useNativeTitlebarSync(effectiveDark) {
 }
 
 /**
- * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string }} props
+ * @param {{ serverHealth: Object, evaluation: Object, selectedProject: string, projects: Array, onGoToProjects: Function, onGoToSettings: Function, preselectDims: string[] }} props
  * @returns {JSX.Element}
  */
 function EvaluateCase({ serverHealth, evaluation, selectedProject, projects, onGoToProjects, onGoToSettings, preselectDims }) {

--- a/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/EvaluateScreen.jsx
@@ -113,7 +113,7 @@ function NoProjectSelected({ onGoToProjects }) {
 
 export default function EvaluateScreen({ evaluation, context, actions }) {
   const { job, jobError, liveViolations } = evaluation;
-  const { selectedProject, projectInfo, jobProjectInfo } = context;
+  const { selectedProject, projectInfo, jobProjectInfo, preselectDims } = context;
   const { onStart: onStartEvaluation, onDismiss, onCancel, onGoToProjects, onGoToSettings } = actions;
   const [toastKey, setToastKey] = useState(0);
   const [toastVisible, setToastVisible] = useState(false);
@@ -134,7 +134,7 @@ export default function EvaluateScreen({ evaluation, context, actions }) {
 
       <div className="evaluate-content">
         {!job && selectedProject && (
-          <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={wrappedOnStart} disabled={false} />
+          <ReEvaluateCard project={selectedProject} projectInfo={projectInfo} onStart={wrappedOnStart} disabled={false} preselectDims={preselectDims} />
         )}
 
         {!job && !selectedProject && (

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useApi } from '../../../api/ApiContext.jsx';
 import { usePluginDimensions } from '../hooks/usePluginDimensions.js';
 import { useScanData } from '../hooks/useScanData.js';
@@ -73,9 +73,30 @@ function useReEvalInfo(project, initialInfo, { getProjectInfo, relocateProject }
   return { info, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore };
 }
 
-function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, onValidationFail) {
+function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, onValidationFail, preselectDims = []) {
   const [selectedDims, setSelectedDims] = useState(new Set());
   const [cleanScan, setCleanScan] = useState('off');
+
+  // Seed the selection once from the navigation context (e.g. arriving from a
+  // dimension or principle detail). Runs in an effect rather than the useState
+  // initializer because the chips (allDimensions) load asynchronously. The ref
+  // guards it to a single seed per mount so later re-renders never clobber the
+  // user's own toggles. Ids are matched case-insensitively and only kept when
+  // they map to a real (visible) chip.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current) return;
+    if (!preselectDims || preselectDims.length === 0) return;
+    if (allDimensions.length === 0) return;
+    const byLowerId = new Map(allDimensions.map((d) => [String(d.id).toLowerCase(), d.id]));
+    const seed = new Set();
+    for (const id of preselectDims) {
+      const match = byLowerId.get(String(id).toLowerCase());
+      if (match) seed.add(match);
+    }
+    seededRef.current = true;
+    if (seed.size > 0) setSelectedDims(seed);
+  }, [allDimensions, preselectDims]);
 
   const toggleDim = (id) => {
     setSelectedDims((prev) => {
@@ -99,7 +120,7 @@ function useDimensionSelection(allDimensions, info, branch, scopePath, onStart, 
   return { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan };
 }
 
-function useReEvaluateCard(project, onStart, projectInfo) {
+function useReEvaluateCard(project, onStart, projectInfo, preselectDims) {
   const api = useApi();
   const { getProjectInfo, relocateProject } = api;
   const { info, error, urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore } = useReEvalInfo(project, projectInfo, { getProjectInfo, relocateProject });
@@ -114,7 +135,7 @@ function useReEvaluateCard(project, onStart, projectInfo) {
   const { scanData } = useScanData(isLocal ? project : null);
 
   const { selectedDims, toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan } =
-    useDimensionSelection(allDimensions, info, branch, scopePath, onStart, showToast);
+    useDimensionSelection(allDimensions, info, branch, scopePath, onStart, showToast, preselectDims);
 
   return {
     info, error, allDimensions, selectedDims,
@@ -244,13 +265,13 @@ function ReEvaluateCardView({ info, project, disabled, dimensions, actions, scop
   );
 }
 
-export default function ReEvaluateCard({ project, projectInfo, onStart, disabled }) {
+export default function ReEvaluateCard({ project, projectInfo, onStart, disabled, preselectDims }) {
   const {
     info, error, allDimensions, selectedDims,
     toggleDim, selectAll, clearAll, handleScan, cleanScan, setCleanScan,
     urlInput, setUrlInput, urlError, urlSaving, handleUrlRestore,
     isLocal, scanData, branch, setBranch, scopePath, setScopePath,
-  } = useReEvaluateCard(project, onStart, projectInfo);
+  } = useReEvaluateCard(project, onStart, projectInfo, preselectDims);
 
   if (error) return null;
   if (!info) return (

--- a/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
+++ b/src/quodeq/ui/src/features/evaluation/components/ReEvaluateCard.test.jsx
@@ -82,7 +82,7 @@ const stubSidePane = {
   registerWindowSpec: vi.fn(),
 };
 
-function renderCard({ project, projectInfo, api, onStart = vi.fn(), disabled = false } = {}) {
+function renderCard({ project, projectInfo, api, onStart = vi.fn(), disabled = false, preselectDims = [] } = {}) {
   const QueryWrapper = withQueryClient();
   return render(
     <QueryWrapper>
@@ -93,6 +93,7 @@ function renderCard({ project, projectInfo, api, onStart = vi.fn(), disabled = f
             projectInfo={projectInfo}
             onStart={onStart}
             disabled={disabled}
+            preselectDims={preselectDims}
           />
         </SidePaneContext.Provider>
       </ApiProvider>
@@ -155,5 +156,38 @@ describe('ReEvaluateCard ephemeral gating', () => {
     // Scan button is not disabled
     const button = screen.getByRole('button', { name: /^▸\s*scan$|^scan$|running\.\.\./i });
     expect(button).not.toBeDisabled();
+  });
+});
+
+describe('ReEvaluateCard preselection seeding', () => {
+  beforeEach(() => { invalidateDimensionCache(); });
+
+  const localInfo = { name: 'demo', path: '/repos/myproj', location: 'local', ephemeral: false, evaluable: true };
+  const apiWithDims = () => makeFakeApi({
+    getProjectInfo: vi.fn().mockResolvedValue(localInfo),
+    listPlugins: vi.fn().mockResolvedValue([{ dimensions: [
+      { id: 'security', label: 'Security' },
+      { id: 'maintainability', label: 'Maintainability' },
+    ] }]),
+  });
+
+  it('preselects the matching chip from preselectDims (case-insensitive)', async () => {
+    renderCard({ project: 'p1', projectInfo: localInfo, api: apiWithDims(), preselectDims: ['Security'] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /maintainability/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('ignores ids with no matching chip and leaves selection empty', async () => {
+    renderCard({ project: 'p2', projectInfo: localInfo, api: apiWithDims(), preselectDims: ['nonexistent'] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /maintainability/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('leaves selection empty when preselectDims is empty (plain launch)', async () => {
+    renderCard({ project: 'p3', projectInfo: localInfo, api: apiWithDims(), preselectDims: [] });
+    await waitFor(() => expect(screen.getByRole('button', { name: /security/i })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /security/i })).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -50,11 +50,11 @@ function createNavActions(setNavStack, navStackRef, history) {
     if (stepsBack > 0) history.go(-stepsBack);
   }
 
-  function navTab(page) {
+  function navTab(page, params = {}) {
     const prev = navStackRef.current;
     const stepsBack = prev.length - 1;
     const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
-    const next = [{ page, _tabKey: prevKey + 1 }];
+    const next = [{ page, _tabKey: prevKey + 1, ...params }];
     setNavStack(next);
     if (stepsBack > 0) history.go(-stepsBack);
   }

--- a/src/quodeq/ui/src/hooks/useNavStack.js
+++ b/src/quodeq/ui/src/hooks/useNavStack.js
@@ -54,7 +54,9 @@ function createNavActions(setNavStack, navStackRef, history) {
     const prev = navStackRef.current;
     const stepsBack = prev.length - 1;
     const prevKey = prev.length === 1 && prev[0].page === page ? (prev[0]._tabKey || 0) : 0;
-    const next = [{ page, _tabKey: prevKey + 1, ...params }];
+    // Spread params first so page/_tabKey stay authoritative and can't be
+    // clobbered by a caller-supplied params key.
+    const next = [{ ...params, page, _tabKey: prevKey + 1 }];
     setNavStack(next);
     if (stepsBack > 0) history.go(-stepsBack);
   }

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -223,8 +223,15 @@ describe('useNavStack navTab params', () => {
     };
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('folds extra params into the single reset entry', () => {
-    const { result } = renderHook(() => useNavStack({ historyAdapter }));
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
 
     act(() => { result.current.navTab('evaluate', { preselectDims: ['security'] }); });
 
@@ -234,7 +241,10 @@ describe('useNavStack navTab params', () => {
   });
 
   it('still works with no params (backward compatible)', () => {
-    const { result } = renderHook(() => useNavStack({ historyAdapter }));
+    const { result } = renderHook(
+      () => useNavStack({ historyAdapter }),
+      { wrapper: strictWrapper },
+    );
 
     act(() => { result.current.navTab('projects'); });
 

--- a/src/quodeq/ui/src/hooks/useNavStack.test.jsx
+++ b/src/quodeq/ui/src/hooks/useNavStack.test.jsx
@@ -210,3 +210,36 @@ describe('useNavStack navTab purity (#363 follow-up)', () => {
     expect(historyAdapter.go).not.toHaveBeenCalled();
   });
 });
+
+describe('useNavStack navTab params', () => {
+  let historyAdapter;
+
+  beforeEach(() => {
+    historyAdapter = {
+      pushState: vi.fn(),
+      replaceState: vi.fn(),
+      back: vi.fn(),
+      go: vi.fn(),
+    };
+  });
+
+  it('folds extra params into the single reset entry', () => {
+    const { result } = renderHook(() => useNavStack({ historyAdapter }));
+
+    act(() => { result.current.navTab('evaluate', { preselectDims: ['security'] }); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('evaluate');
+    expect(result.current.navStack[0].preselectDims).toEqual(['security']);
+  });
+
+  it('still works with no params (backward compatible)', () => {
+    const { result } = renderHook(() => useNavStack({ historyAdapter }));
+
+    act(() => { result.current.navTab('projects'); });
+
+    expect(result.current.navStack).toHaveLength(1);
+    expect(result.current.navStack[0].page).toBe('projects');
+    expect(result.current.navStack[0].preselectDims).toBeUndefined();
+  });
+});

--- a/src/quodeq/ui/src/utils/evaluatePreselect.js
+++ b/src/quodeq/ui/src/utils/evaluatePreselect.js
@@ -1,0 +1,22 @@
+/**
+ * Maps the active nav-stack entry to the standard ids the evaluate screen
+ * should preselect. Returns [] for any page that carries no standard context
+ * (overview, violations, map, history, a plain sidebar/topbar launch).
+ *
+ * @param {{ page?: string, dimension?: string, evalPrincipal?: { dimension?: string } } | null | undefined} activePage
+ * @returns {string[]}
+ */
+export function deriveEvaluatePreselect(activePage) {
+  if (!activePage) return [];
+  const { page } = activePage;
+  if (page === 'explorer' && activePage.dimension) {
+    return [activePage.dimension];
+  }
+  if (
+    (page === 'evalprinciple' || page === 'eval-principle-detail') &&
+    activePage.evalPrincipal?.dimension
+  ) {
+    return [activePage.evalPrincipal.dimension];
+  }
+  return [];
+}

--- a/src/quodeq/ui/src/utils/evaluatePreselect.test.js
+++ b/src/quodeq/ui/src/utils/evaluatePreselect.test.js
@@ -34,3 +34,11 @@ test('missing fields are guarded', () => {
   assert.deepEqual(deriveEvaluatePreselect(null), []);
   assert.deepEqual(deriveEvaluatePreselect(undefined), []);
 });
+
+test('empty-string dimension is treated as no context', () => {
+  // buildEvalPrincipal (App.jsx) normalizes a missing dimension to '', and the
+  // explorer nav entry does the same, so the empty-string case is what
+  // production actually sends when there is no real dimension.
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'explorer', dimension: '' }), []);
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'evalprinciple', evalPrincipal: { dimension: '' } }), []);
+});

--- a/src/quodeq/ui/src/utils/evaluatePreselect.test.js
+++ b/src/quodeq/ui/src/utils/evaluatePreselect.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveEvaluatePreselect } from './evaluatePreselect.js';
+
+test('explorer page preselects its dimension', () => {
+  assert.deepEqual(
+    deriveEvaluatePreselect({ page: 'explorer', dimension: 'security' }),
+    ['security'],
+  );
+});
+
+test('evalprinciple page preselects the containing dimension', () => {
+  assert.deepEqual(
+    deriveEvaluatePreselect({ page: 'evalprinciple', evalPrincipal: { dimension: 'reliability' } }),
+    ['reliability'],
+  );
+});
+
+test('eval-principle-detail alias also preselects', () => {
+  assert.deepEqual(
+    deriveEvaluatePreselect({ page: 'eval-principle-detail', evalPrincipal: { dimension: 'reliability' } }),
+    ['reliability'],
+  );
+});
+
+test('overview and other pages preselect nothing', () => {
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'overview' }), []);
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'violations' }), []);
+});
+
+test('missing fields are guarded', () => {
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'explorer' }), []);
+  assert.deepEqual(deriveEvaluatePreselect({ page: 'evalprinciple', evalPrincipal: {} }), []);
+  assert.deepEqual(deriveEvaluatePreselect(null), []);
+  assert.deepEqual(deriveEvaluatePreselect(undefined), []);
+});


### PR DESCRIPTION
## Summary

The TopBar `+ Evaluate` button now preselects the relevant quality standard(s) on the evaluate screen based on where it was pressed, so you no longer re-pick a standard you just came from:

- **Dimension / standard detail** (explorer page) → that one standard is preselected.
- **Principle detail** (evalprinciple page) → the standard containing that principle is preselected.
- **Overview** or a **plain sidebar / topbar launch** → selection stays empty, exactly as before.

The nav stack already carries the context at click time, so this reuses the existing param-passing channel rather than adding new buttons or global state.

## How it works

- `deriveEvaluatePreselect(activePage)` (new pure helper) maps the active nav entry to the standard ids to preselect (`explorer` -> its dimension, `evalprinciple`/`eval-principle-detail` -> the principle's dimension, everything else -> `[]`).
- `navTab(page, params)` now folds params into the reset nav entry, so the `+ Evaluate` button can pass `preselectDims` while keeping the "tab switch resets the stack" behavior. Existing single-arg callers are unchanged.
- `ReEvaluateCard` seeds its selection once, after the standard chips finish loading, matching ids case-insensitively and keeping only ids that map to a real (visible) chip. It never clobbers later user edits.

## Test plan

- [x] Unit: derive-helper branches, `navTab` params + backward compatibility (StrictMode), and seeding (case-insensitive match / unknown-or-hidden id dropped / empty preselect). 781 vitest + 251 node tests pass; production build succeeds.
- [x] Manual (dev server against the demo project): dimension detail -> `+ Evaluate` preselects only that standard; principle detail -> preselects its parent standard; overview and plain sidebar launch -> empty.

Out of scope (deferred by request): overview multi-select preselection and any change to the plain-launch default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)