### PR TITLE
fix(dashboard): stop run-detail flicker by keeping dashboard identity stable

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.js
@@ -59,7 +59,19 @@ export function useDashboard({ selectedProject, selectedRun, keepPlaceholder = t
 
   const dashboardWithTrend = useMemo(() => {
     if (!dashboardQuery.data) return null;
-    const trend = scores?.trend || latestScores?.trend || dashboardQuery.data.trend || [];
+    // The dashboard payload carries its OWN cache-backed, dismiss-adjusted
+    // trend that is byte-identical to scores.trend (tests/services/
+    // test_scoring_parity.py pins every read path to the same per-run score).
+    // Return the payload UNCHANGED when it has one: the scoped scores query
+    // resolves a beat AFTER the dashboard query, and folding scores.trend in
+    // then would mint a new `dashboard` object identity. RunOverviewPanel
+    // memoizes every derived value on the whole dashboard object and has a fade
+    // animation, so a new identity re-renders the panel and replays the fade —
+    // the run-detail entry "flicker". Fall back to the scores trend only when
+    // the payload lacks one (older cached payloads / the grade-formula
+    // early-return path).
+    if (dashboardQuery.data.trend?.length) return dashboardQuery.data;
+    const trend = scores?.trend || latestScores?.trend || [];
     return { ...dashboardQuery.data, trend };
   }, [dashboardQuery.data, scores, latestScores]);
 

--- a/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/hooks/useDashboard.test.jsx
@@ -208,6 +208,74 @@ describe("useDashboard frozen historical runs", () => {
     );
     await waitFor(() => expect(fakeApi.getDashboard).toHaveBeenCalledWith("p1", "r1"));
   });
+
+  // Run-detail flicker guard. The dashboard payload carries its OWN
+  // cache-backed, dismiss-adjusted trend (post-#738, byte-identical to
+  // scores.trend — see tests/services/test_scoring_parity.py). The scoped
+  // scores query resolves a beat AFTER the dashboard query; folding scores.trend
+  // in then would mint a new `dashboard` object identity. RunOverviewPanel
+  // memoizes every derived value on the whole dashboard object and has a fade
+  // animation, so a new identity re-renders the panel and replays the fade —
+  // the visible "flicker". The hook must therefore keep the dashboard object
+  // identity stable when the scores query resolves.
+  it("keeps a stable dashboard identity when the scores query resolves (no run-detail flicker)", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 60_000 }, mutations: { retry: false } },
+    });
+    const dashTrend = [
+      { runId: "r1", dimensionDetails: [{ dimension: "security", delta: 0.2, score: 7 }] },
+    ];
+    // Fresh + completed => frozen (staleTime Infinity), so no background
+    // refetch swaps the object out from under us.
+    client.setQueryData(
+      projectKeys.dashboard("p1", "r1"),
+      {
+        marker: "dash",
+        trend: dashTrend,
+        dimensions: [{ dimension: "Security", overallScore: "7.0/10", violations: [], compliance: [] }],
+        selectedRun: { runId: "r1", dateLabel: "2026-05-01" },
+      },
+      { updatedAt: Date.now() },
+    );
+    // Latest scores resolve first (its own distinct trend array) so the scoped
+    // asOf can resolve to the completed r1.
+    client.setQueryData(
+      projectKeys.scores("p1", null),
+      {
+        accumulated: { score: 90 },
+        trend: [{ runId: "r1", dimensionDetails: [{ dimension: "security", delta: 0.2, score: 7 }] }],
+        availableRuns: [{ runId: "r1", status: "complete" }],
+      },
+      { updatedAt: Date.now() },
+    );
+
+    const { result } = renderHook(
+      () => useDashboard({ selectedProject: "p1", selectedRun: "r1", keepPlaceholder: false }),
+      { wrapper: wrapWith(client) },
+    );
+
+    await waitFor(() => expect(result.current.dashboard?.marker).toBe("dash"));
+    const before = result.current.dashboard;
+    // Uses the dashboard payload's OWN trend, not the scores query's.
+    expect(before.trend).toBe(dashTrend);
+
+    // The scoped scores query resolves a beat later with its OWN trend array —
+    // a different reference, identical values. Must not mint a new dashboard.
+    await act(async () => {
+      client.setQueryData(
+        projectKeys.scores("p1", "r1"),
+        {
+          accumulated: { score: 90 },
+          trend: [{ runId: "r1", dimensionDetails: [{ dimension: "security", delta: 0.2, score: 7 }] }],
+        },
+        { updatedAt: Date.now() },
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.dashboard).toBe(before); // identity stable => no flicker
+    expect(result.current.dashboard.trend).toBe(dashTrend);
+  });
 });
 
 // Note: live grade SSE merging used to live here. It was deleted in the


### PR DESCRIPTION
## Problem

Opening a run in Overview flickers "like it refreshes again" a beat after entry. It is **not** a refetch and **not** Bug B (dismissal divergence) — it is a pre-existing two-phase paint.

## Cause

The dashboard query resolves (~0.5s) before the scoped scores query (~1s). `dashboardWithTrend` (`useDashboard.js`) preferred `scores.trend`, so when the slower scores query resolved it minted a **new `dashboard` object identity**. `RunOverviewPanel` memoizes *every* derived value (`runSummary`, `runTopFiles`, `trendDeltas`, `reportSpec`, `fixPlanSpec`, `onCardNavigate`) on the whole `dashboard` object and wraps its content in a `run-overview-fade` animation — so a new object identity re-renders the panel and replays the fade. That replay is the flicker.

## Fix

Post-#738 the dashboard payload carries its **own** cache-backed, dismiss-adjusted trend that is byte-identical to `scores.trend` — every read path is pinned to the same per-run score by `tests/services/test_scoring_parity.py`. So prefer the payload's own trend and **return the payload unchanged** when it has one, keeping React Query's stable reference across the scores resolution. Only fall back to `scores.trend` when the payload lacks a trend (older cached payloads / the grade-formula early-return path).

```diff
-    const trend = scores?.trend || latestScores?.trend || dashboardQuery.data.trend || [];
-    return { ...dashboardQuery.data, trend };
+    if (dashboardQuery.data.trend?.length) return dashboardQuery.data;
+    const trend = scores?.trend || latestScores?.trend || [];
+    return { ...dashboardQuery.data, trend };
```

Value-safe: for recent runs (the flicker window) both endpoints build trend via the same `build_accumulated_trend` over the same top-N window, so the values are identical; for older runs the dashboard's trend is a superset (has the selected-run entry `scores.trend` may omit), so preferring it is if anything more correct for `trendDeltas`.

## Verification

- **TDD regression test** (`useDashboard.test.jsx`) pins the invariant: watched it **fail** on the old code (trend folded from scores, `dashboard` identity flips when scores resolves) → **pass** after the fix (identity stable).
- Full UI vitest suite: **782 passed**.
- `tests/services/test_scoring_parity.py`: **2 passed** (the data-safety precondition the fix relies on).
- Production build compiles clean.

Note: the flicker is a sub-second render-identity artifact requiring the live backend + a real multi-run project to reproduce, so the deterministic identity-stability unit test is the reliable instrument here rather than a transient screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)