### PR TITLE
fix(dashboard): hold the Overview loading screen until scores resolve (first-load flicker)

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -170,7 +170,15 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     );
   }
 
-  const isLoading = loading && !dashboard;
+  // Run detail only needs the dashboard payload, so it can show as soon as that
+  // resolves (`&& !dashboard`). The Overview additionally needs the
+  // scores-derived `accumulated` block — DashboardContent returns a
+  // LoadingScreen without it — so it must stay in the loading state until the
+  // scores query resolves too. `loading` (dashboardQuery.isLoading ||
+  // scoresLoading) is already true until every required query has data; gating
+  // the Overview on it avoids fading to "ready" while still showing a spinner
+  // and then popping the real content in a beat later (the first-load flicker).
+  const isLoading = runMode ? (loading && !dashboard) : loading;
   // True while a *background* fetch is running but we're already showing
   // data (placeholderData kept the previous run on screen during a switch).
   // The page dims itself slightly so the user sees "still working" without

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DashboardPage from './DashboardPage.jsx';
+
+// First-load flicker guard. On a fresh (uncached) load the dashboard query
+// resolves a beat before the scores query. The Overview renders nothing until
+// `accumulated` (derived from scores) arrives — DashboardContent returns a
+// LoadingScreen without it. If the page drops its loading state the moment the
+// dashboard payload lands, it fades to `dashboard-ready` (a 400ms fade-in)
+// while still showing a spinner, then the real content pops in a beat later:
+// the "it refreshes again" flicker. So the Overview must stay in the loading
+// state until BOTH the dashboard and the accumulated block are present.
+const overviewLoading = {
+  projectsLoaded: true,
+  projects: [{ id: 'p1', name: 'p1' }],
+  selectedProject: 'p1',
+  // dashboard payload has already resolved...
+  dashboard: {
+    dimensions: [{ dimension: 'Security', overallScore: '7.0/10', violations: [], compliance: [], principles: [] }],
+    trend: [],
+    selectedRun: { runId: 'r1', dateLabel: '2026-05-01' },
+  },
+  // ...but the scores query has not, so accumulated is still null and `loading`
+  // (dashboardQuery.isLoading || scoresLoading) is still true.
+  accumulated: null,
+  loading: true,
+  isFetching: false,
+  error: null,
+  availableRuns: [{ runId: 'r1', status: 'complete' }],
+};
+
+describe('DashboardPage first-load loading gate', () => {
+  it('keeps the Overview in the loading state until accumulated (scores) is ready', () => {
+    const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    const page = container.querySelector('.dashboard-page');
+    expect(page).toBeTruthy();
+    // Must NOT flip to the ready fade before the data needed to render is present.
+    expect(page.className).toContain('dashboard-loading');
+    expect(page.className).not.toContain('dashboard-ready');
+  });
+});


### PR DESCRIPTION
## The flicker you actually see

On a fresh (uncached) open, the **Overview** and the **first entry into a history run** flicker "like it refreshes again." This is the real first-load flicker (distinct from the trend-identity re-render fixed in #740).

## Root cause

The dashboard query resolves a beat before the scores query. `DashboardPage` computed:

```js
const isLoading = loading && !dashboard;
```

`loading` (`dashboardQuery.isLoading || scoresLoading`) is correctly true until **both** queries have data — but `&& !dashboard` drops the loading state the instant the **dashboard** payload lands. The Overview renders nothing until `accumulated` (derived from the slower **scores** query) arrives — `DashboardContent` returns a `<LoadingScreen/>` without it. So the page fades to `dashboard-ready` (a 400ms `dashboard-fadein`) **while still showing a spinner**, then the real content pops in a beat later. That two-step is the flicker.

The `&& !dashboard` is a run-detail optimisation (run views only need the dashboard payload, so show them the moment it resolves) that leaked into the Overview.

## Fix

Make the gate view-aware:

```js
const isLoading = runMode ? (loading && !dashboard) : loading;
```

- **Run detail** keeps `loading && !dashboard` (unchanged — shows as soon as the dashboard payload resolves).
- **Overview** uses `loading`, which is already true until every required query has data, so it stays in the loading state until **both** resolve, then does a single fade-to-ready with the content already present.

Safe: on the Overview, `accumulated` becomes non-null exactly when the scores query resolves (which is also when `scoresLoading` clears), so `isLoading = loading` is equivalent to "wait for dashboard **and** accumulated." Cached re-entry and placeholder-backed run switches keep `loading === false`, so they still render instantly.

## Verification

- **Regression test** (`DashboardPage.test.jsx`): watched it **fail** on the old gate (page was `dashboard-ready` with `accumulated` still null) → **pass** after the fix (stays `dashboard-loading`).
- **In the browser** against the real 201-run project, with the `/scores` response delayed 1.5s and a MutationObserver logging every fade trigger:
  - Overview: `dashboard-loading` → *(dashboard resolves — page stays loading)* → `dashboard-ready` **and** the accumulated panel mount fire at the **same** timestamp. One clean transition, no ready-with-spinner intermediate.
  - History run entry (6-dimension project, uncached run): a single `LoadingScreen → content` transition; nothing repaints when the delayed scores resolve.
- Full UI vitest suite: **783 passed**. Production build compiles clean.

Together with #740 (stable dashboard object identity across the scores resolution), this removes the first-load flicker on both the Overview and run-detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)