### PR TITLE
fix(dashboard): grace-fallback so a cold Overview load never blanks

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -170,15 +170,26 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     );
   }
 
-  // Run detail only needs the dashboard payload, so it can show as soon as that
-  // resolves (`&& !dashboard`). The Overview additionally needs the
-  // scores-derived `accumulated` block — DashboardContent returns a
-  // LoadingScreen without it — so it must stay in the loading state until the
-  // scores query resolves too. `loading` (dashboardQuery.isLoading ||
-  // scoresLoading) is already true until every required query has data; gating
-  // the Overview on it avoids fading to "ready" while still showing a spinner
-  // and then popping the real content in a beat later (the first-load flicker).
-  const isLoading = runMode ? (loading && !dashboard) : loading;
+  // What each view needs before it can render real content: run detail only
+  // needs the dashboard payload; the Overview also needs the scores-derived
+  // `accumulated` block (DashboardContent returns a LoadingScreen without it).
+  const contentReady = runMode ? !!dashboard : (!!dashboard && !!accumulated);
+  // Hold the full LoadingScreen until the content is ready, so we don't fade in
+  // a half-drawn page and then pop the real content in a beat later (the
+  // first-load flicker). BUT a cold score cache can take several seconds to
+  // rebuild (e.g. right after a dismiss/restore/formula change invalidates it);
+  // sitting on a blank spinner that whole time reads as "not opening". So once
+  // the dashboard payload is in and a short grace has elapsed, fall back to the
+  // partial page (frame + a content spinner) so a slow load shows progress
+  // instead of a hang. The grace comfortably exceeds a warm load (both queries
+  // resolve in well under it), so the fast path still gets one clean transition.
+  const [graceElapsed, setGraceElapsed] = useState(false);
+  useEffect(() => {
+    if (contentReady || !dashboard) { setGraceElapsed(false); return undefined; }
+    const timer = setTimeout(() => setGraceElapsed(true), 700);
+    return () => clearTimeout(timer);
+  }, [contentReady, dashboard]);
+  const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
   // True while a *background* fetch is running but we're already showing
   // data (placeholderData kept the previous run on screen during a switch).
   // The page dims itself slightly so the user sees "still working" without

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import DashboardPage from './DashboardPage.jsx';
 
 // First-load flicker guard. On a fresh (uncached) load the dashboard query
@@ -37,5 +37,23 @@ describe('DashboardPage first-load loading gate', () => {
     // Must NOT flip to the ready fade before the data needed to render is present.
     expect(page.className).toContain('dashboard-loading');
     expect(page.className).not.toContain('dashboard-ready');
+  });
+
+  // The flip side: a cold score cache can take several seconds to rebuild. We
+  // must not sit on a blank full-screen spinner that whole time (reads as "the
+  // project won't open"). Once the dashboard payload is in and a short grace
+  // has elapsed, fall back to the partial page so a slow load shows progress.
+  it('falls back to the partial page after a grace period if scores stays slow', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+      // Before the grace: still the full loading screen.
+      expect(container.querySelector('.dashboard-page').className).toContain('dashboard-loading');
+      // After the grace elapses with scores still pending: drop to the partial page.
+      act(() => { vi.advanceTimersByTime(800); });
+      expect(container.querySelector('.dashboard-page').className).toContain('dashboard-ready');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Regression from #742

#742 fixed the first-load flicker by gating the Overview on `loading` (wait for **both** the dashboard and scores queries). That's correct for a **warm** cache — but a **cold** score cache can take several seconds to rebuild, and gating on `loading` means the Overview sits on a **blank full-screen spinner** that whole time. That reads as "the project won't open."

This is exactly what happened after a *Restore all* invalidated a project's score cache: the next open recomputed cold and showed nothing until it finished.

**Measured** on the 201-run project: cold scores build **4.94s** vs warm **0.44s**.

## Fix

Add a **700ms grace**. Hold the full LoadingScreen until either the content is ready **or** the dashboard payload is in and the grace has elapsed — then fall back to the partial page (frame + a content spinner) so a slow load shows *progress* instead of a hang.

```js
const contentReady = runMode ? !!dashboard : (!!dashboard && !!accumulated);
const [graceElapsed, setGraceElapsed] = useState(false);
useEffect(() => {
  if (contentReady || !dashboard) { setGraceElapsed(false); return undefined; }
  const timer = setTimeout(() => setGraceElapsed(true), 700);
  return () => clearTimeout(timer);
}, [contentReady, dashboard]);
const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
```

A warm load resolves both queries well under 700ms, so the fast path still gets **one clean transition** — the #742 flicker fix is preserved.

## Verification (in the browser, MutationObserver logging fade triggers)

- **Warm** (no delay): `DASH-loading` → at **47ms** `DASH-ready` + content mount **together**. Single transition, no flicker.
- **Cold** (`/scores` delayed 3s): `DASH-loading` → dashboard resolves (~38ms, still loading) → at **742ms** `DASH-ready` = partial page (progress visible) → content at **3058ms**. No blank hang.
- Unit test covers both the hold-until-ready and grace-fallback branches. Full UI suite: **784 passed**. Build clean.

## Note

The deeper fix is the ~5s cold scores build itself (payload-slimming / cache work, tracked separately). This PR makes the UX resilient to it in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)