### PR TITLE
fix(scoring): apply dismiss/delete rescore to the project-card grade

### DIFF
--- a/src/quodeq/services/_fs_metadata.py
+++ b/src/quodeq/services/_fs_metadata.py
@@ -67,8 +67,9 @@ def _read_accumulated_summary(
 ) -> tuple[str | None, float | None, int | None]:
     """Compute accumulated grade and score across all runs. Returns (grade, score, files).
 
-    ``read_run_data`` overlays the SQL grade tables for event-log runs, so the
-    project-card summary reflects dismisses and any applied grade formula.
+    The card summary applies the same project-wide dismiss/delete rescore as
+    every other read path (see the ``_rescore_dimension`` step below), so the
+    repositories-screen grade agrees with the Overview / explorer / trend.
     *params* (loaded from the saved formula when None) keeps the aggregate
     threshold labels and dimension weights consistent with the dashboard.
     """
@@ -93,6 +94,25 @@ def _read_accumulated_summary(
                     if files_count is None and d.source_file_count:
                         files_count = d.source_file_count
             acc_dims = list(latest_by_dim.values())
+            # Apply the project-wide dismiss/delete rescore so the card agrees
+            # with every other read path (detail/explorer/dashboard/trend all
+            # route through ``scored_run_dimensions``, i.e. read_run_data +
+            # ``_rescore_dimension``). ``read_run_data`` returns the raw scan;
+            # its SQL grade overlay reflects dismisses only when the run is
+            # freshly projected, and NEVER reflects deletions. Without this the
+            # project-card grade kept a stale, too-low value for any project
+            # with deletions (or dismissals on a not-yet-reprojected run) —
+            # diverging from the score shown everywhere else.
+            from quodeq.services.deleted import deleted_keys  # noqa: PLC0415
+            from quodeq.services.dismissed import dismissed_keys  # noqa: PLC0415
+            from quodeq.services.rescore import _rescore_dimension  # noqa: PLC0415
+            dismissed = dismissed_keys(project_dir)
+            deleted = deleted_keys(project_dir)
+            if dismissed or deleted:
+                acc_dims = [
+                    _rescore_dimension(d, dismissed, deleted, params=params)
+                    for d in acc_dims
+                ]
             # Scope the card summary to the project's current dimension standard
             # — the union of dimensions configured by the last few ELIGIBLE runs
             # — dropping stale dims (e.g. clean-architecture) that linger via old

--- a/src/quodeq/services/score_cache.py
+++ b/src/quodeq/services/score_cache.py
@@ -208,6 +208,12 @@ def accumulated_cache_version(
     independence.
     """
     payload = json.dumps({
+        # Bump when the accumulated / project-card computation changes, so
+        # existing cache entries recompute on deploy instead of serving a stale
+        # value until the next scan/dismiss/delete. v2: the project-card summary
+        # now applies the dismiss/delete rescore (was raw read_run_data, which
+        # ignored deletions).
+        "algo": 2,
         "base": score_cache_version(project_dir, params),
         "runs": sorted(list(t) for t in run_fingerprint),
         "as_of": as_of or "",

--- a/tests/services/test_scoring_parity.py
+++ b/tests/services/test_scoring_parity.py
@@ -104,7 +104,10 @@ def _build_run_with_violations(reports_root: Path, project: str) -> Path:
         "principles": [{"name": "p1", "score": f"{row['score']}/10", "grade": row["grade"]}],
         "violations": [
             {
-                "practiceId": v.practice_id, "req": v.req, "file": v.file, "line": v.line,
+                # The parser maps ``practice_id`` from the ``principle`` key, so
+                # carry both — deletions key on (dimension, principle, file).
+                "practiceId": v.practice_id, "principle": v.practice_id,
+                "req": v.req, "file": v.file, "line": v.line,
                 "severity": v.severity, "title": v.title, "reason": v.reason,
             }
             for v in violations
@@ -186,6 +189,65 @@ def test_all_read_paths_agree_after_dismissal(tmp_path):
         d["overallGrade"] for d in gps["accumulated"]["dimensions"] if d["dimension"] == _DIM
     )
     assert overall_pg["grade"] == acc_grade
+
+
+def test_project_card_summary_applies_deletions(tmp_path, monkeypatch):
+    """The repositories-card grade must apply project-wide DELETIONS, agreeing
+    with the accumulated / scored per-run paths.
+
+    Regression: ``_read_accumulated_summary`` (the project-card path) read raw
+    ``read_run_data`` and never applied the project-wide dismiss/delete rescore
+    that every other read path routes through (``scored_run_dimensions``). So a
+    project with deletions showed a stale, too-low card grade on the
+    repositories screen while the Overview / explorer / trend showed the higher,
+    deletion-adjusted score. Deletions never appear in the SQL grade overlay, so
+    this path missed them entirely.
+    """
+    reports_root = tmp_path / "evaluations"
+    project = "proj-uuid"
+    _build_run_with_violations(reports_root, project)
+    project_dir = reports_root / project
+    # Isolate the project-summary cache so a real ~/.quodeq cache can't leak in.
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
+
+    from quodeq.services._fs_metadata import _read_accumulated_summary
+    from quodeq.services.deleted import delete_finding
+    from quodeq.services.ports import list_runs
+
+    # Delete the critical finding project-wide — this raises the score.
+    delete_finding(project_dir, {"dimension": _DIM, "principle": "p1", "file": "a.py"})
+    clear_shared_dimension_cache()
+
+    # Reference: the accumulated view is deletion-adjusted.
+    gps = get_project_scores(reports_root, project, None)
+    accumulated = _num(_perf_score(gps["accumulated"]["dimensions"]))
+    assert accumulated is not None
+
+    # The project-card summary must serve the SAME deletion-adjusted score.
+    runs = list_runs(reports_root, project)
+    _grade, card_score, _files = _read_accumulated_summary(reports_root, project, runs)
+    assert card_score == accumulated, f"card {card_score} != accumulated {accumulated}"
+
+
+def test_deletion_actually_moves_the_card_score(tmp_path, monkeypatch):
+    """Guard: the deletion genuinely raises the card score (else parity is trivial)."""
+    reports_root = tmp_path / "evaluations"
+    project = "proj-uuid2"
+    _build_run_with_violations(reports_root, project)
+    project_dir = reports_root / project
+    monkeypatch.setenv("QUODEQ_SCORE_CACHE_PATH", str(tmp_path / "score_cache.db"))
+
+    from quodeq.services._fs_metadata import _read_accumulated_summary
+    from quodeq.services.deleted import delete_finding
+    from quodeq.services.ports import list_runs
+
+    runs = list_runs(reports_root, project)
+    _g, before, _f = _read_accumulated_summary(reports_root, project, runs)
+    delete_finding(project_dir, {"dimension": _DIM, "principle": "p1", "file": "a.py"})
+    clear_shared_dimension_cache()
+    _g2, after, _f2 = _read_accumulated_summary(reports_root, project, runs)
+    assert before is not None and after is not None
+    assert after > before, f"deleting the critical should raise the card score; {before} -> {after}"
 
 
 def test_dismissal_actually_moves_the_score(tmp_path):


### PR DESCRIPTION
## Symptom

The repositories-screen grade disagrees with the score shown everywhere else. On a real project: **card = 5.8** but Overview / explorer / trend = **8.2 (Good)** — same runs, same dimensions.

## Root cause

`_read_accumulated_summary` (`src/quodeq/services/_fs_metadata.py`) — the project-card path — builds its accumulated grade from **raw `read_run_data`** and never applies the project-wide dismiss/**delete** rescore that every other read path routes through (`scored_run_dimensions`).

`read_run_data`'s SQL grade overlay reflects **dismisses only when a run is freshly projected**, and **never reflects deletions at all**. So a project with deletions (0 dismissals, 2,142 deleted findings in the observed case) kept a stale, too-low card grade while every other screen applied the deletions and showed the higher score. PRs #734/#735 routed the detail/explorer/dashboard/trend paths through the shared seam — the **project-card summary path was missed**, and the parity test only exercised dismisses so it never caught it.

## Fix

```python
# in _read_accumulated_summary._compute, after collecting latest-per-dim:
dismissed = dismissed_keys(project_dir)
deleted = deleted_keys(project_dir)
if dismissed or deleted:
    acc_dims = [_rescore_dimension(d, dismissed, deleted, params=params) for d in acc_dims]
```

- Applies the **same** `_rescore_dimension` transform the accumulated view uses, so the card agrees with everything else. Verified against the real project: card now serves **8.2**.
- **Bumps `accumulated_cache_version` (`algo: 2`)** so existing cached summaries recompute on deploy — otherwise the stale value lingers until the next scan/dismiss/delete for untouched projects.
- **Extends the cross-path parity test** to cover the project-card summary **and the DELETE path** (the gap that let this slip), plus a guard that the deletion actually moves the card score. TDD: both new tests watched fail → pass.

## Verification

- `tests/services/test_scoring_parity.py`: 4 passed (2 new, RED→GREEN).
- Full `tests/api` + `tests/services` (non-integration): **1367 passed**.
- Real-data check: `_read_accumulated_summary` for the affected project now returns 8.2 / Good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)