### PR TITLE
fix(dashboard): hoist grace hooks above early returns (React #310 crash on load)

### DIFF
--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.jsx
@@ -133,6 +133,21 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
   const focusedDimensionData = useMemo(() => focusedDimension ? (dashboard?.dimensions || []).find((d) => d.dimension === focusedDimension) || null : null, [focusedDimension, dashboard]);
   const handlers = useDashboardHandlers(onNavigate, dashboard);
 
+  // What each view needs before it can render real content: run detail only
+  // needs the dashboard payload; the Overview also needs the scores-derived
+  // `accumulated` block (DashboardContent returns a LoadingScreen without it).
+  // These hooks MUST stay above the early returns below — calling them after a
+  // conditional return changes the hook count between renders (React error
+  // #310, a blank-crash on load).
+  const contentReady = runMode ? !!dashboard : (!!dashboard && !!accumulated);
+  // Grace state for the slow/cold-load fallback (consumed by isLoading below).
+  const [graceElapsed, setGraceElapsed] = useState(false);
+  useEffect(() => {
+    if (contentReady || !dashboard) { setGraceElapsed(false); return undefined; }
+    const timer = setTimeout(() => setGraceElapsed(true), 700);
+    return () => clearTimeout(timer);
+  }, [contentReady, dashboard]);
+
   const { projectsLoaded } = data;
   if (!projectsLoaded) return <LoadingScreen />;
   if (projects.length === 0) {
@@ -170,25 +185,15 @@ export default function DashboardPage({ data = {}, callbacks = {}, runMode = fal
     );
   }
 
-  // What each view needs before it can render real content: run detail only
-  // needs the dashboard payload; the Overview also needs the scores-derived
-  // `accumulated` block (DashboardContent returns a LoadingScreen without it).
-  const contentReady = runMode ? !!dashboard : (!!dashboard && !!accumulated);
   // Hold the full LoadingScreen until the content is ready, so we don't fade in
   // a half-drawn page and then pop the real content in a beat later (the
   // first-load flicker). BUT a cold score cache can take several seconds to
   // rebuild (e.g. right after a dismiss/restore/formula change invalidates it);
   // sitting on a blank spinner that whole time reads as "not opening". So once
-  // the dashboard payload is in and a short grace has elapsed, fall back to the
-  // partial page (frame + a content spinner) so a slow load shows progress
-  // instead of a hang. The grace comfortably exceeds a warm load (both queries
-  // resolve in well under it), so the fast path still gets one clean transition.
-  const [graceElapsed, setGraceElapsed] = useState(false);
-  useEffect(() => {
-    if (contentReady || !dashboard) { setGraceElapsed(false); return undefined; }
-    const timer = setTimeout(() => setGraceElapsed(true), 700);
-    return () => clearTimeout(timer);
-  }, [contentReady, dashboard]);
+  // the dashboard payload is in and the grace has elapsed (graceElapsed, set
+  // above), fall back to the partial page (frame + a content spinner) so a slow
+  // load shows progress instead of a hang. The grace comfortably exceeds a warm
+  // load, so the fast path still gets one clean transition.
   const isLoading = loading && !contentReady && !(dashboard && graceElapsed);
   // True while a *background* fetch is running but we're already showing
   // data (placeholderData kept the previous run on screen during a switch).

--- a/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
+++ b/src/quodeq/ui/src/features/dashboard/components/DashboardPage.test.jsx
@@ -43,6 +43,20 @@ describe('DashboardPage first-load loading gate', () => {
   // must not sit on a blank full-screen spinner that whole time (reads as "the
   // project won't open"). Once the dashboard payload is in and a short grace
   // has elapsed, fall back to the partial page so a slow load shows progress.
+  // Rules-of-Hooks guard. On first load `projectsLoaded` is false, which hits
+  // an early return; a beat later it flips true and the page renders fully. If
+  // any hook (e.g. the grace state) lives BELOW the early returns, the hook
+  // count changes between those two renders and React throws #310 — a blank
+  // crash on load. This reproduces that transition.
+  it('does not change hook count across the projectsLoaded false -> true transition', () => {
+    const { rerender } = render(
+      <DashboardPage data={{ projectsLoaded: false }} callbacks={{}} runMode={false} />,
+    );
+    expect(() => {
+      rerender(<DashboardPage data={overviewLoading} callbacks={{}} runMode={false} />);
+    }).not.toThrow();
+  });
+
   it('falls back to the partial page after a grace period if scores stays slow', () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Critical: blank crash on load

`Uncaught Error: Minified React error #310` in `DashboardPage` — the app fails to load.

## Cause (regression from #743)

The grace-fallback added in #743 placed the `useState`/`useEffect` for the cold-load grace **below** `DashboardPage`'s early returns:

```jsx
if (!projectsLoaded) return <LoadingScreen />;   // + 3 more early returns
...
const [graceElapsed, setGraceElapsed] = useState(false);   // ❌ hook below early returns
useEffect(() => {...}, [contentReady, dashboard]);          // ❌
```

On first load `projectsLoaded` is false → the early return fires and those two hooks are **skipped**. A beat later it flips true → they run. The hook count changes between renders, so React throws **#310** (rendered more hooks than the previous render) and the page blank-crashes.

The pytest CI passed because this is a **frontend runtime** error, and #743's unit test only rendered the "past the early returns" state, never the `false → true` transition.

## Fix

Hoist `contentReady` + the grace `useState`/`useEffect` **above all early returns** (Rules of Hooks). Only the non-hook `isLoading` computation stays below. No behavior change to the grace logic itself.

## Verification

- New regression test renders with `projectsLoaded: false` (hits an early return), then rerenders with the full payload and asserts **no throw**. Confirmed it **fails on the pre-fix code** and **passes after**.
- Full UI suite: **785 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)